### PR TITLE
Allow tag overrides for Title and Heading____ typography components

### DIFF
--- a/__snapshots__/story-shots.test.js.snap
+++ b/__snapshots__/story-shots.test.js.snap
@@ -402,6 +402,15 @@ exports[`Storyshots Typography/Footnote light on dark 1`] = `
 </span>
 `;
 
+exports[`Storyshots Typography/HeadingLarge as an h5 tag 1`] = `
+<h5
+  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6"
+  style={Object {}}
+>
+  HeadingLarge
+</h5>
+`;
+
 exports[`Storyshots Typography/HeadingLarge default 1`] = `
 <h2
   className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6"
@@ -418,6 +427,15 @@ exports[`Storyshots Typography/HeadingLarge light on dark 1`] = `
 >
   HeadingLarge
 </h2>
+`;
+
+exports[`Storyshots Typography/HeadingMedium as an h5 tag 1`] = `
+<h5
+  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23"
+  style={Object {}}
+>
+  HeadingMedium
+</h5>
 `;
 
 exports[`Storyshots Typography/HeadingMedium default 1`] = `
@@ -438,6 +456,15 @@ exports[`Storyshots Typography/HeadingMedium light on dark 1`] = `
 </h3>
 `;
 
+exports[`Storyshots Typography/HeadingSmall as an h5 tag 1`] = `
+<h5
+  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj"
+  style={Object {}}
+>
+  HeadingSmall
+</h5>
+`;
+
 exports[`Storyshots Typography/HeadingSmall default 1`] = `
 <h4
   className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj"
@@ -454,6 +481,15 @@ exports[`Storyshots Typography/HeadingSmall light on dark 1`] = `
 >
   HeadingSmall
 </h4>
+`;
+
+exports[`Storyshots Typography/HeadingXSmall as an h5 tag 1`] = `
+<h5
+  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f"
+  style={Object {}}
+>
+  HeadingXSmall
+</h5>
 `;
 
 exports[`Storyshots Typography/HeadingXSmall default 1`] = `
@@ -562,6 +598,15 @@ exports[`Storyshots Typography/Tagline light on dark 1`] = `
 >
   Tagline
 </span>
+`;
+
+exports[`Storyshots Typography/Title as an h5 tag 1`] = `
+<h5
+  className="text_1asggzd-o_O-header_1sc4ubv-o_O-Title_pg0x2d"
+  style={Object {}}
+>
+  Title
+</h5>
 `;
 
 exports[`Storyshots Typography/Title default 1`] = `

--- a/__snapshots__/story-shots.test.js.snap
+++ b/__snapshots__/story-shots.test.js.snap
@@ -420,7 +420,7 @@ exports[`Storyshots Typography/Footnote light on dark 1`] = `
 
 exports[`Storyshots Typography/HeadingLarge as an h5 tag 1`] = `
 <h5
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6"
   style={Object {}}
 >
   HeadingLarge
@@ -447,7 +447,7 @@ exports[`Storyshots Typography/HeadingLarge light on dark 1`] = `
 
 exports[`Storyshots Typography/HeadingMedium as an h5 tag 1`] = `
 <h5
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23"
   style={Object {}}
 >
   HeadingMedium
@@ -474,7 +474,7 @@ exports[`Storyshots Typography/HeadingMedium light on dark 1`] = `
 
 exports[`Storyshots Typography/HeadingSmall as an h5 tag 1`] = `
 <h5
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj"
   style={Object {}}
 >
   HeadingSmall
@@ -501,7 +501,7 @@ exports[`Storyshots Typography/HeadingSmall light on dark 1`] = `
 
 exports[`Storyshots Typography/HeadingXSmall as an h5 tag 1`] = `
 <h5
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f"
   style={Object {}}
 >
   HeadingXSmall
@@ -618,7 +618,7 @@ exports[`Storyshots Typography/Tagline light on dark 1`] = `
 
 exports[`Storyshots Typography/Title as an h5 tag 1`] = `
 <h5
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-Title_pg0x2d"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-Title_pg0x2d"
   style={Object {}}
 >
   Title

--- a/packages/wonder-blocks-core/index.js
+++ b/packages/wonder-blocks-core/index.js
@@ -1,5 +1,7 @@
 // @flow
 import Text from "./src/text.js";
 import View from "./src/view.js";
+import type TextTag from "./src/types.js";
 
 export {Text, View};
+export type {TextTag};

--- a/packages/wonder-blocks-core/src/text.js
+++ b/packages/wonder-blocks-core/src/text.js
@@ -4,10 +4,11 @@ import {StyleSheet} from "aphrodite";
 import Color from "wonder-blocks-color";
 
 import {processStyleList} from "./util.js";
+import type TextTag from "./types.js";
 
 type Props = {
     style?: any,
-    tag: "span" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6",
+    tag: TextTag,
     children?: any,
 };
 

--- a/packages/wonder-blocks-core/src/types.js
+++ b/packages/wonder-blocks-core/src/types.js
@@ -14,3 +14,5 @@ export type Props = {
     tag?: string,
     children?: any,
 };
+
+export type TextTag = "span" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";

--- a/packages/wonder-blocks-typography/index.stories.js
+++ b/packages/wonder-blocks-typography/index.stories.js
@@ -44,6 +44,13 @@ for (const componentName of componentNames) {
         .addWithJSX("light on dark", () => (
             <Component style={styles.lightOnDark}>{componentName}</Component>
         ));
+
+    if (componentName === "Title" || componentName.includes("Heading")) {
+        storiesOf(`Typography/${componentName}`, module)
+            .addWithJSX("as an h5 tag", () => (
+                <Component tag="h5">{componentName}</Component>
+            ));
+    }
 }
 
 const styles = StyleSheet.create({

--- a/packages/wonder-blocks-typography/src/types.js
+++ b/packages/wonder-blocks-typography/src/types.js
@@ -1,7 +1,12 @@
 // @flow
+import type TextTag from "wonder-blocks-core";
 
 // TODO(kevinb): fix style type after upgrading flow
 export type Props = {
     style?: any,
     children?: string,
 };
+
+export type HeadingProps = Props & {
+    tag: TextTag,
+}

--- a/packages/wonder-blocks-typography/src/typography.js
+++ b/packages/wonder-blocks-typography/src/typography.js
@@ -4,17 +4,22 @@ import {Text} from "wonder-blocks-core";
 
 import styles from "./styles.js";
 
-import type {Props} from "./types.js";
+import type {Props, HeadingProps} from "./types.js";
 
 // TODO(alex): Once style prop validation works, if all of the style prop flow
 //             types are the same then switch to using functional components.
 export class Title extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "h1",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text tag="h1" style={[styles.Title, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.Title, style]}>
+                {children}
             </Text>
         );
     }
@@ -33,48 +38,68 @@ export class Tagline extends Component {
 }
 
 export class HeadingLarge extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "h2",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text tag="h2" style={[styles.HeadingLarge, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.HeadingLarge, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class HeadingMedium extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "h3",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text tag="h3" style={[styles.HeadingMedium, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.HeadingMedium, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class HeadingSmall extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "h4",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text tag="h4" style={[styles.HeadingSmall, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.HeadingSmall, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class HeadingXSmall extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "h4",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text tag="h4" style={[styles.HeadingXSmall, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.HeadingXSmall, style]}>
+                {children}
             </Text>
         );
     }


### PR DESCRIPTION
This is necessary for a11y best practices: Headings on a page should
form a hierarchy.

Test Plan:
npm test

<img width="745" alt="heading large as an h5 tag" src="https://user-images.githubusercontent.com/238458/38153097-d02c70f0-341f-11e8-89f2-cacb3d312887.png">

Reviewers: briangenisio