### PR TITLE
Remove default text color from Text component

### DIFF
--- a/__snapshots__/story-shots.test.js.snap
+++ b/__snapshots__/story-shots.test.js.snap
@@ -6,7 +6,7 @@ exports[`Storyshots Button blue button 1`] = `
   onClick={undefined}
 >
   <span
-    className="text_1asggzd-o_O-LabelLarge_19qk49e"
+    className="text_f1191h-o_O-LabelLarge_19qk49e"
     style={Object {}}
   >
     Hello, world!
@@ -20,7 +20,7 @@ exports[`Storyshots Button gold button 1`] = `
   onClick={undefined}
 >
   <span
-    className="text_1asggzd-o_O-LabelLarge_19qk49e"
+    className="text_f1191h-o_O-LabelLarge_19qk49e"
     style={Object {}}
   >
     Hello, world!
@@ -34,7 +34,7 @@ exports[`Storyshots Button green button 1`] = `
   onClick={undefined}
 >
   <span
-    className="text_1asggzd-o_O-LabelLarge_19qk49e"
+    className="text_f1191h-o_O-LabelLarge_19qk49e"
     style={Object {}}
   >
     Hello, world!
@@ -48,7 +48,7 @@ exports[`Storyshots Button red button 1`] = `
   onClick={undefined}
 >
   <span
-    className="text_1asggzd-o_O-LabelLarge_19qk49e"
+    className="text_f1191h-o_O-LabelLarge_19qk49e"
     style={Object {}}
   >
     Hello, world!
@@ -59,7 +59,7 @@ exports[`Storyshots Button red button 1`] = `
 exports[`Storyshots Core all 1`] = `
 <div>
   <span
-    className="text_1asggzd"
+    className="text_f1191h"
     style={Object {}}
   >
     Text
@@ -73,9 +73,25 @@ exports[`Storyshots Core all 1`] = `
 </div>
 `;
 
+exports[`Storyshots Core nested text inherits color 1`] = `
+<div>
+  <div
+    className="blue_1tsdo2i"
+    style={Object {}}
+  >
+    <span
+      className="text_f1191h"
+      style={Object {}}
+    >
+      Text
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Core/Text aphrodite styles 1`] = `
 <span
-  className="text_1asggzd-o_O-pink_th4aeu"
+  className="text_f1191h-o_O-pink_th4aeu"
   style={Object {}}
 >
   Text
@@ -84,7 +100,7 @@ exports[`Storyshots Core/Text aphrodite styles 1`] = `
 
 exports[`Storyshots Core/Text multiple Aphrodite styles 1`] = `
 <span
-  className="text_1asggzd-o_O-pink_th4aeu-o_O-bold_hq5slr"
+  className="text_f1191h-o_O-pink_th4aeu-o_O-bold_hq5slr"
   style={Object {}}
 >
   Text
@@ -94,13 +110,13 @@ exports[`Storyshots Core/Text multiple Aphrodite styles 1`] = `
 exports[`Storyshots Core/Text multiple text elements 1`] = `
 <div>
   <span
-    className="text_1asggzd-o_O-bold_hq5slr"
+    className="text_f1191h-o_O-bold_hq5slr"
     style={Object {}}
   >
     Text
   </span>
   <span
-    className="text_1asggzd-o_O-pink_th4aeu"
+    className="text_f1191h-o_O-pink_th4aeu"
     style={Object {}}
   >
     Text
@@ -110,7 +126,7 @@ exports[`Storyshots Core/Text multiple text elements 1`] = `
 
 exports[`Storyshots Core/Text text 1`] = `
 <span
-  className="text_1asggzd"
+  className="text_f1191h"
   style={Object {}}
 >
   Text
@@ -165,7 +181,7 @@ exports[`Storyshots Typography all 1`] = `
 <div>
   <div>
     <h1
-      className="text_1asggzd-o_O-header_1sc4ubv-o_O-Title_pg0x2d"
+      className="text_f1191h-o_O-header_1sc4ubv-o_O-Title_pg0x2d"
       style={Object {}}
     >
       Title
@@ -173,7 +189,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-Tagline_13wg9ps"
+      className="text_f1191h-o_O-Tagline_13wg9ps"
       style={Object {}}
     >
       Tagline
@@ -181,7 +197,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <h2
-      className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6"
+      className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6"
       style={Object {}}
     >
       HeadingLarge
@@ -189,7 +205,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <h3
-      className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23"
+      className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23"
       style={Object {}}
     >
       HeadingMedium
@@ -197,7 +213,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <h4
-      className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj"
+      className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj"
       style={Object {}}
     >
       HeadingSmall
@@ -205,7 +221,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <h4
-      className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f"
+      className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f"
       style={Object {}}
     >
       HeadingXSmall
@@ -213,7 +229,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-BodySerifBlock_1q1y0lf"
+      className="text_f1191h-o_O-BodySerifBlock_1q1y0lf"
       style={Object {}}
     >
       BodySerifBlock
@@ -221,7 +237,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-BodySerif_czdgjk"
+      className="text_f1191h-o_O-BodySerif_czdgjk"
       style={Object {}}
     >
       BodySerif
@@ -229,7 +245,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-BodyMonospace_1s34hz9"
+      className="text_f1191h-o_O-BodyMonospace_1s34hz9"
       style={Object {}}
     >
       BodyMonospace
@@ -237,7 +253,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-Body_aye3wz"
+      className="text_f1191h-o_O-Body_aye3wz"
       style={Object {}}
     >
       Body
@@ -245,7 +261,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-LabelLarge_19qk49e"
+      className="text_f1191h-o_O-LabelLarge_19qk49e"
       style={Object {}}
     >
       LabelLarge
@@ -253,7 +269,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-LabelMedium_1y2bm6p"
+      className="text_f1191h-o_O-LabelMedium_1y2bm6p"
       style={Object {}}
     >
       LabelMedium
@@ -261,7 +277,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-LabelSmall_xwaspk"
+      className="text_f1191h-o_O-LabelSmall_xwaspk"
       style={Object {}}
     >
       LabelSmall
@@ -269,7 +285,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-LabelXSmall_1ot4900"
+      className="text_f1191h-o_O-LabelXSmall_1ot4900"
       style={Object {}}
     >
       LabelXSmall
@@ -277,7 +293,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-Caption_1d6h637"
+      className="text_f1191h-o_O-Caption_1d6h637"
       style={Object {}}
     >
       Caption
@@ -285,7 +301,7 @@ exports[`Storyshots Typography all 1`] = `
   </div>
   <div>
     <span
-      className="text_1asggzd-o_O-Footnote_1h6ehge"
+      className="text_f1191h-o_O-Footnote_1h6ehge"
       style={Object {}}
     >
       Footnote
@@ -296,7 +312,7 @@ exports[`Storyshots Typography all 1`] = `
 
 exports[`Storyshots Typography/Body default 1`] = `
 <span
-  className="text_1asggzd-o_O-Body_aye3wz"
+  className="text_f1191h-o_O-Body_aye3wz"
   style={Object {}}
 >
   Body
@@ -305,7 +321,7 @@ exports[`Storyshots Typography/Body default 1`] = `
 
 exports[`Storyshots Typography/Body light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-Body_aye3wz-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-Body_aye3wz-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   Body
@@ -314,7 +330,7 @@ exports[`Storyshots Typography/Body light on dark 1`] = `
 
 exports[`Storyshots Typography/BodyMonospace default 1`] = `
 <span
-  className="text_1asggzd-o_O-BodyMonospace_1s34hz9"
+  className="text_f1191h-o_O-BodyMonospace_1s34hz9"
   style={Object {}}
 >
   BodyMonospace
@@ -323,7 +339,7 @@ exports[`Storyshots Typography/BodyMonospace default 1`] = `
 
 exports[`Storyshots Typography/BodyMonospace light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-BodyMonospace_1s34hz9-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-BodyMonospace_1s34hz9-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   BodyMonospace
@@ -332,7 +348,7 @@ exports[`Storyshots Typography/BodyMonospace light on dark 1`] = `
 
 exports[`Storyshots Typography/BodySerif default 1`] = `
 <span
-  className="text_1asggzd-o_O-BodySerif_czdgjk"
+  className="text_f1191h-o_O-BodySerif_czdgjk"
   style={Object {}}
 >
   BodySerif
@@ -341,7 +357,7 @@ exports[`Storyshots Typography/BodySerif default 1`] = `
 
 exports[`Storyshots Typography/BodySerif light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-BodySerif_czdgjk-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-BodySerif_czdgjk-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   BodySerif
@@ -350,7 +366,7 @@ exports[`Storyshots Typography/BodySerif light on dark 1`] = `
 
 exports[`Storyshots Typography/BodySerifBlock default 1`] = `
 <span
-  className="text_1asggzd-o_O-BodySerifBlock_1q1y0lf"
+  className="text_f1191h-o_O-BodySerifBlock_1q1y0lf"
   style={Object {}}
 >
   BodySerifBlock
@@ -359,7 +375,7 @@ exports[`Storyshots Typography/BodySerifBlock default 1`] = `
 
 exports[`Storyshots Typography/BodySerifBlock light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-BodySerifBlock_1q1y0lf-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-BodySerifBlock_1q1y0lf-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   BodySerifBlock
@@ -368,7 +384,7 @@ exports[`Storyshots Typography/BodySerifBlock light on dark 1`] = `
 
 exports[`Storyshots Typography/Caption default 1`] = `
 <span
-  className="text_1asggzd-o_O-Caption_1d6h637"
+  className="text_f1191h-o_O-Caption_1d6h637"
   style={Object {}}
 >
   Caption
@@ -377,7 +393,7 @@ exports[`Storyshots Typography/Caption default 1`] = `
 
 exports[`Storyshots Typography/Caption light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-Caption_1d6h637-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-Caption_1d6h637-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   Caption
@@ -386,7 +402,7 @@ exports[`Storyshots Typography/Caption light on dark 1`] = `
 
 exports[`Storyshots Typography/Footnote default 1`] = `
 <span
-  className="text_1asggzd-o_O-Footnote_1h6ehge"
+  className="text_f1191h-o_O-Footnote_1h6ehge"
   style={Object {}}
 >
   Footnote
@@ -395,7 +411,7 @@ exports[`Storyshots Typography/Footnote default 1`] = `
 
 exports[`Storyshots Typography/Footnote light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-Footnote_1h6ehge-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-Footnote_1h6ehge-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   Footnote
@@ -404,7 +420,7 @@ exports[`Storyshots Typography/Footnote light on dark 1`] = `
 
 exports[`Storyshots Typography/HeadingLarge default 1`] = `
 <h2
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6"
   style={Object {}}
 >
   HeadingLarge
@@ -413,7 +429,7 @@ exports[`Storyshots Typography/HeadingLarge default 1`] = `
 
 exports[`Storyshots Typography/HeadingLarge light on dark 1`] = `
 <h2
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingLarge_1y2mmy6-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   HeadingLarge
@@ -422,7 +438,7 @@ exports[`Storyshots Typography/HeadingLarge light on dark 1`] = `
 
 exports[`Storyshots Typography/HeadingMedium default 1`] = `
 <h3
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23"
   style={Object {}}
 >
   HeadingMedium
@@ -431,7 +447,7 @@ exports[`Storyshots Typography/HeadingMedium default 1`] = `
 
 exports[`Storyshots Typography/HeadingMedium light on dark 1`] = `
 <h3
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingMedium_17b4v23-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   HeadingMedium
@@ -440,7 +456,7 @@ exports[`Storyshots Typography/HeadingMedium light on dark 1`] = `
 
 exports[`Storyshots Typography/HeadingSmall default 1`] = `
 <h4
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj"
   style={Object {}}
 >
   HeadingSmall
@@ -449,7 +465,7 @@ exports[`Storyshots Typography/HeadingSmall default 1`] = `
 
 exports[`Storyshots Typography/HeadingSmall light on dark 1`] = `
 <h4
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingSmall_1vtz1kj-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   HeadingSmall
@@ -458,7 +474,7 @@ exports[`Storyshots Typography/HeadingSmall light on dark 1`] = `
 
 exports[`Storyshots Typography/HeadingXSmall default 1`] = `
 <h4
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f"
   style={Object {}}
 >
   HeadingXSmall
@@ -467,7 +483,7 @@ exports[`Storyshots Typography/HeadingXSmall default 1`] = `
 
 exports[`Storyshots Typography/HeadingXSmall light on dark 1`] = `
 <h4
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-HeadingXSmall_3f6s5f-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   HeadingXSmall
@@ -476,7 +492,7 @@ exports[`Storyshots Typography/HeadingXSmall light on dark 1`] = `
 
 exports[`Storyshots Typography/LabelLarge default 1`] = `
 <span
-  className="text_1asggzd-o_O-LabelLarge_19qk49e"
+  className="text_f1191h-o_O-LabelLarge_19qk49e"
   style={Object {}}
 >
   LabelLarge
@@ -485,7 +501,7 @@ exports[`Storyshots Typography/LabelLarge default 1`] = `
 
 exports[`Storyshots Typography/LabelLarge light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-LabelLarge_19qk49e-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-LabelLarge_19qk49e-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   LabelLarge
@@ -494,7 +510,7 @@ exports[`Storyshots Typography/LabelLarge light on dark 1`] = `
 
 exports[`Storyshots Typography/LabelMedium default 1`] = `
 <span
-  className="text_1asggzd-o_O-LabelMedium_1y2bm6p"
+  className="text_f1191h-o_O-LabelMedium_1y2bm6p"
   style={Object {}}
 >
   LabelMedium
@@ -503,7 +519,7 @@ exports[`Storyshots Typography/LabelMedium default 1`] = `
 
 exports[`Storyshots Typography/LabelMedium light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-LabelMedium_1y2bm6p-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-LabelMedium_1y2bm6p-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   LabelMedium
@@ -512,7 +528,7 @@ exports[`Storyshots Typography/LabelMedium light on dark 1`] = `
 
 exports[`Storyshots Typography/LabelSmall default 1`] = `
 <span
-  className="text_1asggzd-o_O-LabelSmall_xwaspk"
+  className="text_f1191h-o_O-LabelSmall_xwaspk"
   style={Object {}}
 >
   LabelSmall
@@ -521,7 +537,7 @@ exports[`Storyshots Typography/LabelSmall default 1`] = `
 
 exports[`Storyshots Typography/LabelSmall light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-LabelSmall_xwaspk-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-LabelSmall_xwaspk-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   LabelSmall
@@ -530,7 +546,7 @@ exports[`Storyshots Typography/LabelSmall light on dark 1`] = `
 
 exports[`Storyshots Typography/LabelXSmall default 1`] = `
 <span
-  className="text_1asggzd-o_O-LabelXSmall_1ot4900"
+  className="text_f1191h-o_O-LabelXSmall_1ot4900"
   style={Object {}}
 >
   LabelXSmall
@@ -539,7 +555,7 @@ exports[`Storyshots Typography/LabelXSmall default 1`] = `
 
 exports[`Storyshots Typography/LabelXSmall light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-LabelXSmall_1ot4900-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-LabelXSmall_1ot4900-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   LabelXSmall
@@ -548,7 +564,7 @@ exports[`Storyshots Typography/LabelXSmall light on dark 1`] = `
 
 exports[`Storyshots Typography/Tagline default 1`] = `
 <span
-  className="text_1asggzd-o_O-Tagline_13wg9ps"
+  className="text_f1191h-o_O-Tagline_13wg9ps"
   style={Object {}}
 >
   Tagline
@@ -557,7 +573,7 @@ exports[`Storyshots Typography/Tagline default 1`] = `
 
 exports[`Storyshots Typography/Tagline light on dark 1`] = `
 <span
-  className="text_1asggzd-o_O-Tagline_13wg9ps-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-Tagline_13wg9ps-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   Tagline
@@ -566,7 +582,7 @@ exports[`Storyshots Typography/Tagline light on dark 1`] = `
 
 exports[`Storyshots Typography/Title default 1`] = `
 <h1
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-Title_pg0x2d"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-Title_pg0x2d"
   style={Object {}}
 >
   Title
@@ -575,7 +591,7 @@ exports[`Storyshots Typography/Title default 1`] = `
 
 exports[`Storyshots Typography/Title light on dark 1`] = `
 <h1
-  className="text_1asggzd-o_O-header_1sc4ubv-o_O-Title_pg0x2d-o_O-lightOnDark_lsccso"
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-Title_pg0x2d-o_O-lightOnDark_lsccso"
   style={Object {}}
 >
   Title

--- a/packages/wonder-blocks-core/index.stories.js
+++ b/packages/wonder-blocks-core/index.stories.js
@@ -6,12 +6,18 @@ import {StyleSheet} from "aphrodite";
 
 import {Text, View} from "./index.js";
 
-storiesOf("Core", module).addWithJSX("all", () => (
-    <div>
-        <Text>Text</Text>
-        <View>View</View>
-    </div>
-));
+storiesOf("Core", module)
+    .addWithJSX("all", () => (
+        <div>
+            <Text>Text</Text>
+            <View>View</View>
+        </div>
+    ))
+    .addWithJSX("nested text inherits color", () => (
+        <div>
+            <View style={styles.blue}><Text>Text</Text></View>
+        </div>
+    ));
 
 storiesOf("Core/Text", module)
     .addWithJSX("text", () => <Text>Text</Text>)
@@ -40,6 +46,9 @@ storiesOf("Core/View", module)
     ));
 
 const styles = StyleSheet.create({
+    blue: {
+        color: "blue",
+    },
     pink: {
         backgroundColor: "pink",
     },

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -7,8 +7,5 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "MIT",
-  "dependencies": {
-    "wonder-blocks-color": "../wonder-blocks-color"
-  }
+  "license": "MIT"
 }

--- a/packages/wonder-blocks-core/src/text.js
+++ b/packages/wonder-blocks-core/src/text.js
@@ -1,7 +1,6 @@
 // @flow
 import React, {Component} from "react";
 import {StyleSheet} from "aphrodite";
-import Color from "wonder-blocks-color";
 
 import {processStyleList} from "./util.js";
 
@@ -15,11 +14,6 @@ const isHeaderRegex = /^h[1-6]$/;
 
 const styles = StyleSheet.create({
     text: {
-        // Our primary text color, off-black, looks a lot like pure black.
-        // We set it to be the default text color so that we don't ever
-        // have to worry about trying to visually distinguish the two.
-        color: Color.offBlack,
-
         // Disable subpixel antialiasing on Mac desktop for consistency of
         // rendering with mobile and Sketch (neither of which support it).
         // See https://bjango.com/articles/subpixeltext/ for more details.


### PR DESCRIPTION
This was a good idea but in practice it turns out that it prevents
colors from cascading, which is really annoying. This commit reverts
us back to the previous behavior, which was fine. Ideally we'll just
set the default text color in a css reset somewhere instead

Test Plan:
npm test

<img width="493" alt="nested text inherits color" src="https://user-images.githubusercontent.com/238458/38153473-d922fa06-3421-11e8-86b0-203eeabcadc6.png">

Reviewers: briangenisio