### PR TITLE
Adding the ability to have a `tag` in all typography components

### DIFF
--- a/__snapshots__/story-shots.test.js.snap
+++ b/__snapshots__/story-shots.test.js.snap
@@ -310,6 +310,15 @@ exports[`Storyshots Typography all 1`] = `
 </div>
 `;
 
+exports[`Storyshots Typography/Body as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-Body_aye3wz"
+  style={Object {}}
+>
+  Body
+</h5>
+`;
+
 exports[`Storyshots Typography/Body default 1`] = `
 <span
   className="text_f1191h-o_O-Body_aye3wz"
@@ -326,6 +335,15 @@ exports[`Storyshots Typography/Body light on dark 1`] = `
 >
   Body
 </span>
+`;
+
+exports[`Storyshots Typography/BodyMonospace as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-BodyMonospace_1s34hz9"
+  style={Object {}}
+>
+  BodyMonospace
+</h5>
 `;
 
 exports[`Storyshots Typography/BodyMonospace default 1`] = `
@@ -346,6 +364,15 @@ exports[`Storyshots Typography/BodyMonospace light on dark 1`] = `
 </span>
 `;
 
+exports[`Storyshots Typography/BodySerif as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-BodySerif_czdgjk"
+  style={Object {}}
+>
+  BodySerif
+</h5>
+`;
+
 exports[`Storyshots Typography/BodySerif default 1`] = `
 <span
   className="text_f1191h-o_O-BodySerif_czdgjk"
@@ -362,6 +389,15 @@ exports[`Storyshots Typography/BodySerif light on dark 1`] = `
 >
   BodySerif
 </span>
+`;
+
+exports[`Storyshots Typography/BodySerifBlock as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-BodySerifBlock_1q1y0lf"
+  style={Object {}}
+>
+  BodySerifBlock
+</h5>
 `;
 
 exports[`Storyshots Typography/BodySerifBlock default 1`] = `
@@ -382,6 +418,15 @@ exports[`Storyshots Typography/BodySerifBlock light on dark 1`] = `
 </span>
 `;
 
+exports[`Storyshots Typography/Caption as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-Caption_1d6h637"
+  style={Object {}}
+>
+  Caption
+</h5>
+`;
+
 exports[`Storyshots Typography/Caption default 1`] = `
 <span
   className="text_f1191h-o_O-Caption_1d6h637"
@@ -398,6 +443,15 @@ exports[`Storyshots Typography/Caption light on dark 1`] = `
 >
   Caption
 </span>
+`;
+
+exports[`Storyshots Typography/Footnote as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-Footnote_1h6ehge"
+  style={Object {}}
+>
+  Footnote
+</h5>
 `;
 
 exports[`Storyshots Typography/Footnote default 1`] = `
@@ -526,6 +580,15 @@ exports[`Storyshots Typography/HeadingXSmall light on dark 1`] = `
 </h4>
 `;
 
+exports[`Storyshots Typography/LabelLarge as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-LabelLarge_19qk49e"
+  style={Object {}}
+>
+  LabelLarge
+</h5>
+`;
+
 exports[`Storyshots Typography/LabelLarge default 1`] = `
 <span
   className="text_f1191h-o_O-LabelLarge_19qk49e"
@@ -542,6 +605,15 @@ exports[`Storyshots Typography/LabelLarge light on dark 1`] = `
 >
   LabelLarge
 </span>
+`;
+
+exports[`Storyshots Typography/LabelMedium as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-LabelMedium_1y2bm6p"
+  style={Object {}}
+>
+  LabelMedium
+</h5>
 `;
 
 exports[`Storyshots Typography/LabelMedium default 1`] = `
@@ -562,6 +634,15 @@ exports[`Storyshots Typography/LabelMedium light on dark 1`] = `
 </span>
 `;
 
+exports[`Storyshots Typography/LabelSmall as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-LabelSmall_xwaspk"
+  style={Object {}}
+>
+  LabelSmall
+</h5>
+`;
+
 exports[`Storyshots Typography/LabelSmall default 1`] = `
 <span
   className="text_f1191h-o_O-LabelSmall_xwaspk"
@@ -580,6 +661,15 @@ exports[`Storyshots Typography/LabelSmall light on dark 1`] = `
 </span>
 `;
 
+exports[`Storyshots Typography/LabelXSmall as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-LabelXSmall_1ot4900"
+  style={Object {}}
+>
+  LabelXSmall
+</h5>
+`;
+
 exports[`Storyshots Typography/LabelXSmall default 1`] = `
 <span
   className="text_f1191h-o_O-LabelXSmall_1ot4900"
@@ -596,6 +686,15 @@ exports[`Storyshots Typography/LabelXSmall light on dark 1`] = `
 >
   LabelXSmall
 </span>
+`;
+
+exports[`Storyshots Typography/Tagline as an h5 tag 1`] = `
+<h5
+  className="text_f1191h-o_O-header_1sc4ubv-o_O-Tagline_13wg9ps"
+  style={Object {}}
+>
+  Tagline
+</h5>
 `;
 
 exports[`Storyshots Typography/Tagline default 1`] = `

--- a/packages/wonder-blocks-button/package-lock.json
+++ b/packages/wonder-blocks-button/package-lock.json
@@ -21,9 +21,6 @@
         "wonder-blocks-core": {
           "version": "file:../wonder-blocks-core",
           "bundled": true,
-          "requires": {
-            "wonder-blocks-color": "file:../wonder-blocks-color"
-          },
           "dependencies": {
             "wonder-blocks-color": {
               "version": "file:../wonder-blocks-color",

--- a/packages/wonder-blocks-core/package-lock.json
+++ b/packages/wonder-blocks-core/package-lock.json
@@ -1,11 +1,5 @@
 {
   "name": "wonder-blocks-core",
   "version": "0.0.1",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "wonder-blocks-color": {
-      "version": "file:../wonder-blocks-color"
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/packages/wonder-blocks-typography/index.stories.js
+++ b/packages/wonder-blocks-typography/index.stories.js
@@ -43,14 +43,10 @@ for (const componentName of componentNames) {
         .addWithJSX("default", () => <Component>{componentName}</Component>)
         .addWithJSX("light on dark", () => (
             <Component style={styles.lightOnDark}>{componentName}</Component>
+        ))
+        .addWithJSX("as an h5 tag", () => (
+            <Component tag="h5">{componentName}</Component>
         ));
-
-    if (componentName === "Title" || componentName.includes("Heading")) {
-        storiesOf(`Typography/${componentName}`, module)
-            .addWithJSX("as an h5 tag", () => (
-                <Component tag="h5">{componentName}</Component>
-            ));
-    }
 }
 
 const styles = StyleSheet.create({

--- a/packages/wonder-blocks-typography/package-lock.json
+++ b/packages/wonder-blocks-typography/package-lock.json
@@ -9,9 +9,6 @@
     },
     "wonder-blocks-core": {
       "version": "file:../wonder-blocks-core",
-      "requires": {
-        "wonder-blocks-color": "file:../wonder-blocks-color"
-      },
       "dependencies": {
         "wonder-blocks-color": {
           "version": "file:../wonder-blocks-color",

--- a/packages/wonder-blocks-typography/src/typography.js
+++ b/packages/wonder-blocks-typography/src/typography.js
@@ -26,12 +26,17 @@ export class Title extends Component {
 }
 
 export class Tagline extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.Tagline, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.Tagline, style]}>
+                {children}
             </Text>
         );
     }
@@ -106,48 +111,68 @@ export class HeadingXSmall extends Component {
 }
 
 export class BodySerifBlock extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.BodySerifBlock, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.BodySerifBlock, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class BodySerif extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.BodySerif, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.BodySerif, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class BodyMonospace extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.BodyMonospace, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.BodyMonospace, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class Body extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.Body, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.Body, style]}>
+                {children}
             </Text>
         );
     }
@@ -155,72 +180,102 @@ export class Body extends Component {
 
 // TODO(kevinb): consider making labels block level elements
 export class LabelLarge extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.LabelLarge, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.LabelLarge, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class LabelMedium extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.LabelMedium, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.LabelMedium, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class LabelSmall extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.LabelSmall, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.LabelSmall, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class LabelXSmall extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.LabelXSmall, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.LabelXSmall, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class Caption extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.Caption, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.Caption, style]}>
+                {children}
             </Text>
         );
     }
 }
 
 export class Footnote extends Component {
-    props: Props;
+    props: HeadingProps;
+
+    static defaultProps = {
+        tag: "span",
+    };
 
     render() {
+        const {tag, style, children} = this.props;
         return (
-            <Text style={[styles.Footnote, this.props.style]}>
-                {this.props.children}
+            <Text tag={tag} style={[styles.Footnote, style]}>
+                {children}
             </Text>
         );
     }


### PR DESCRIPTION
Alex created a PR which allows the `tag` property on all `Title` and `Heading` components, but we really need this ability on all components.  I have a case where the text is a `LabelMedium` but it needs to be an H3 in the view hierarchy.  

Test Plan:
Use any typography component with a `tag` property and see it wrapped appropriately