### PR TITLE
add CODEOWNERS file and make myself a global owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @kevinbarabash

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @kevinbarabash
+*   @kevinbarabash @jeresig


### PR DESCRIPTION
This in combination with enabling the "Require review from Code Owners" setting on the `master` protected branch is equivalent to Phabricator's "add required reviewer" herald system.