### PR TITLE
[modal] Create basic StandardModal component

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-launcher.md
+++ b/packages/wonder-blocks-modal/components/modal-launcher.md
@@ -14,9 +14,49 @@ const styles = StyleSheet.create({
     title: {
         marginBottom: 16,
     },
+
+    modalContent: {
+        margin: "0 auto",
+        marginTop: 40,
+        marginBottom: 40,
+        paddingLeft: 32,
+        paddingRight: 32,
+        maxWidth: 544,
+    },
 });
 
-const modal = ({closeModal}) => <TwoColumnModal
+const standardModal = ({closeModal}) => (
+    <StandardModal
+        title="Title"
+        content={
+            <View style={styles.modalContent}>
+                <Body tag="p">
+                    {
+                        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."
+                    }
+                </Body>
+                <Body tag="p">
+                    {
+                        "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                    }
+                </Body>
+                <Body tag="p">
+                    {
+                        "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                    }
+                </Body>
+            </View>
+        }
+        footer={
+            // TODO(mdr): Use Wonder Blocks Button.
+            <button onClick={closeModal}>
+                Close modal
+            </button>
+        }
+    />
+);
+
+const twoColumnModal = ({closeModal}) => <TwoColumnModal
     leftContent={
         <View>
             <Title style={styles.title}>Left column</Title>
@@ -54,8 +94,11 @@ const modal = ({closeModal}) => <TwoColumnModal
 
 // TODO(mdr): Use Wonder Blocks Button.
 <View style={styles.example}>
-    <ModalLauncher modal={modal}>
-        {({openModal}) => <button onClick={openModal}>Learn more!</button>}
+    <ModalLauncher modal={standardModal}>
+        {({openModal}) => <button onClick={openModal}>Standard modal</button>}
+    </ModalLauncher>
+    <ModalLauncher modal={twoColumnModal}>
+        {({openModal}) => <button onClick={openModal}>Two-column modal</button>}
     </ModalLauncher>
 </View>;
 ```

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -47,14 +47,14 @@ export default class StandardModal extends React.Component<Props> {
 
         if (subtitle) {
             return (
-                <View style={[styles.titlebar, styles.titlebarWithSubtitle]}>
+                <View style={[styles.titlebar]}>
                     <HeadingSmall>{title}</HeadingSmall>
                     <LabelSmall>{subtitle}</LabelSmall>
                 </View>
             );
         } else {
             return (
-                <View style={[styles.titlebar, styles.titlebarWithoutSubtitle]}>
+                <View style={[styles.titlebar]}>
                     <HeadingMedium>{title}</HeadingMedium>
                 </View>
             );
@@ -91,26 +91,22 @@ const styles = StyleSheet.create({
 
     titlebar: {
         flex: "0 0 auto",
+        boxSizing: "border-box",
+        minHeight: 64,
+        paddingLeft: 16,
+        paddingRight: 16,
+        paddingTop: 8,
+        paddingBottom: 8,
 
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-
-        paddingLeft: 16,
-        paddingRight: 16,
+        textAlign: "center",
 
         borderBottomStyle: "solid",
         borderBottomColor: Color.offBlack16,
         borderBottomWidth: 1,
-    },
-
-    titlebarWithSubtitle: {
-        height: 72,
-    },
-
-    titlebarWithoutSubtitle: {
-        height: 64,
     },
 
     content: {
@@ -119,15 +115,18 @@ const styles = StyleSheet.create({
     },
 
     footer: {
-        flex: "0 0 64px",
+        flex: "0 0 auto",
+        boxSizing: "border-box",
+        minHeight: 64,
+        paddingLeft: 16,
+        paddingRight: 16,
+        paddingTop: 8,
+        paddingBottom: 8,
 
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "flex-end",
-
-        paddingLeft: 16,
-        paddingRight: 16,
 
         borderTopStyle: "solid",
         borderTopColor: Color.offBlack16,

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -1,0 +1,113 @@
+// @flow
+import * as React from "react";
+import {StyleSheet, css} from "aphrodite";
+
+import Color from "wonder-blocks-color";
+import {View} from "wonder-blocks-core";
+import {HeadingMedium} from "wonder-blocks-typography";
+
+type Props = {
+    /**
+     * The content of the modal, appearing between the header and footer.
+     */
+    content: React.Node,
+
+    /**
+     * The title of the modal, appearing in the header.
+     *
+     * If a subtitle is also present, this becomes smaller to accommodate both
+     * within the title bar.
+     */
+    title: string,
+
+    /**
+     * The subtitle of the modal, appearing in the header, below the title.
+     */
+    subtitle?: string,
+
+    /**
+     * The content of the modal's footer. A great place for buttons!
+     *
+     * Content is right-aligned by default. To control alignment yourself,
+     * provide a container element with 100% width.
+     */
+    footer?: React.Node,
+};
+
+/**
+ * The "standard" modal layout: a header, a content area, and a footer.
+ */
+export default class StandardModal extends React.Component<Props> {
+    render() {
+        return (
+            <View style={styles.container}>
+                <View style={styles.header}>
+                    <HeadingMedium style={styles.title}>
+                        {this.props.title}
+                    </HeadingMedium>
+                </View>
+                <View style={styles.content}>{this.props.content}</View>
+                <View style={styles.footer}>{this.props.footer}</View>
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    container: {
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+
+        width: "93.75%",
+        maxWidth: 960,
+        height: "81.25%",
+        minHeight: 200,
+        maxHeight: 624,
+
+        background: Color.white,
+        borderRadius: 4,
+        overflow: "hidden",
+    },
+
+    header: {
+        flex: "0 0 64px",
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+
+        paddingLeft: 16,
+        paddingRight: 16,
+
+        borderBottomStyle: "solid",
+        borderBottomColor: Color.offBlack16,
+        borderBottomWidth: 1,
+    },
+
+    title: {
+        flex: "1 0 0",
+        textAlign: "center",
+    },
+
+    content: {
+        flex: "1 1 auto",
+        overflow: "auto",
+    },
+
+    footer: {
+        flex: "0 0 64px",
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "flex-end",
+
+        paddingLeft: 16,
+        paddingRight: 16,
+
+        borderTopStyle: "solid",
+        borderTopColor: Color.offBlack16,
+        borderTopWidth: 1,
+    },
+});

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -12,12 +12,12 @@ import {
 
 type Props = {
     /**
-     * The content of the modal, appearing between the header and footer.
+     * The content of the modal, appearing between the titlebar and footer.
      */
     content: React.Node,
 
     /**
-     * The title of the modal, appearing in the header.
+     * The title of the modal, appearing in the titlebar.
      *
      * If a subtitle is also present, this becomes smaller to accommodate both
      * within the title bar.
@@ -25,7 +25,7 @@ type Props = {
     title: string,
 
     /**
-     * The subtitle of the modal, appearing in the header, below the title.
+     * The subtitle of the modal, appearing in the titlebar, below the title.
      */
     subtitle?: string,
 
@@ -39,30 +39,32 @@ type Props = {
 };
 
 /**
- * The "standard" modal layout: a header, a content area, and a footer.
+ * The "standard" modal layout: a titlebar, a content area, and a footer.
  */
 export default class StandardModal extends React.Component<Props> {
-    _renderTitleAndSubtitle() {
+    _renderTitlebar() {
         const {title, subtitle} = this.props;
 
         if (subtitle) {
             return (
-                <View style={styles.titleAndSubtitle}>
+                <View style={[styles.titlebar, styles.titlebarWithSubtitle]}>
                     <HeadingSmall>{title}</HeadingSmall>
                     <LabelSmall>{subtitle}</LabelSmall>
                 </View>
             );
         } else {
-            return <HeadingMedium>{title}</HeadingMedium>;
+            return (
+                <View style={[styles.titlebar, styles.titlebarWithoutSubtitle]}>
+                    <HeadingMedium>{title}</HeadingMedium>
+                </View>
+            );
         }
     }
 
     render() {
         return (
             <View style={styles.container}>
-                <View style={styles.header}>
-                    {this._renderTitleAndSubtitle()}
-                </View>
+                {this._renderTitlebar()}
                 <View style={styles.content}>{this.props.content}</View>
                 <View style={styles.footer}>{this.props.footer}</View>
             </View>
@@ -87,11 +89,11 @@ const styles = StyleSheet.create({
         overflow: "hidden",
     },
 
-    header: {
-        flex: "0 0 64px",
+    titlebar: {
+        flex: "0 0 auto",
 
         display: "flex",
-        flexDirection: "row",
+        flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
 
@@ -101,6 +103,14 @@ const styles = StyleSheet.create({
         borderBottomStyle: "solid",
         borderBottomColor: Color.offBlack16,
         borderBottomWidth: 1,
+    },
+
+    titlebarWithSubtitle: {
+        height: 72,
+    },
+
+    titlebarWithoutSubtitle: {
+        height: 64,
     },
 
     content: {

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -4,7 +4,11 @@ import {StyleSheet, css} from "aphrodite";
 
 import Color from "wonder-blocks-color";
 import {View} from "wonder-blocks-core";
-import {HeadingMedium} from "wonder-blocks-typography";
+import {
+    HeadingMedium,
+    HeadingSmall,
+    LabelSmall,
+} from "wonder-blocks-typography";
 
 type Props = {
     /**
@@ -31,20 +35,33 @@ type Props = {
      * Content is right-aligned by default. To control alignment yourself,
      * provide a container element with 100% width.
      */
-    footer?: React.Node,
+    footer: React.Node,
 };
 
 /**
  * The "standard" modal layout: a header, a content area, and a footer.
  */
 export default class StandardModal extends React.Component<Props> {
+    _renderTitleAndSubtitle() {
+        const {title, subtitle} = this.props;
+
+        if (subtitle) {
+            return (
+                <View style={styles.titleAndSubtitle}>
+                    <HeadingSmall>{title}</HeadingSmall>
+                    <LabelSmall>{subtitle}</LabelSmall>
+                </View>
+            );
+        } else {
+            return <HeadingMedium>{title}</HeadingMedium>;
+        }
+    }
+
     render() {
         return (
             <View style={styles.container}>
                 <View style={styles.header}>
-                    <HeadingMedium style={styles.title}>
-                        {this.props.title}
-                    </HeadingMedium>
+                    {this._renderTitleAndSubtitle()}
                 </View>
                 <View style={styles.content}>{this.props.content}</View>
                 <View style={styles.footer}>{this.props.footer}</View>
@@ -76,6 +93,7 @@ const styles = StyleSheet.create({
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
+        justifyContent: "center",
 
         paddingLeft: 16,
         paddingRight: 16,
@@ -83,11 +101,6 @@ const styles = StyleSheet.create({
         borderBottomStyle: "solid",
         borderBottomColor: Color.offBlack16,
         borderBottomWidth: 1,
-    },
-
-    title: {
-        flex: "1 0 0",
-        textAlign: "center",
     },
 
     content: {
@@ -109,5 +122,12 @@ const styles = StyleSheet.create({
         borderTopStyle: "solid",
         borderTopColor: Color.offBlack16,
         borderTopWidth: 1,
+    },
+
+    titleAndSubtitle: {
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        textAlign: "center",
     },
 });

--- a/packages/wonder-blocks-modal/components/standard-modal.md
+++ b/packages/wonder-blocks-modal/components/standard-modal.md
@@ -106,6 +106,7 @@ const styles = StyleSheet.create({
     <View style={styles.modalPositioner}>
         <StandardModal
             title="Title"
+            subtitle="Wow, look at all this content!"
             content={
                 <View style={styles.modalContent}>
                     <Body tag="p">

--- a/packages/wonder-blocks-modal/components/standard-modal.md
+++ b/packages/wonder-blocks-modal/components/standard-modal.md
@@ -1,0 +1,129 @@
+### Example: Short content
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const {Title, Body} = require("wonder-blocks-typography");
+const StandardModal = require("./standard-modal.js").default;
+
+const styles = StyleSheet.create({
+    previewSizer: {
+        height: 512,
+    },
+
+    modalPositioner: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 32,
+
+        position: "absolute",
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+    },
+
+    modalContent: {
+        margin: "0 auto",
+        marginTop: 40,
+        marginBottom: 40,
+        paddingLeft: 32,
+        paddingRight: 32,
+        maxWidth: 544,
+    },
+});
+
+<View style={styles.previewSizer}>
+    <View style={styles.modalPositioner}>
+        <StandardModal
+            title="Title"
+            content={
+                <View style={styles.modalContent}>
+                    <Body tag="p">
+                        {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."}
+                    </Body>
+                </View>
+            }
+            footer={<View>
+                {/* TODO(mdr): Use Wonder Blocks button. */}
+                <button type="button">Button (no-op)</button>
+            </View>}
+        />
+    </View>
+</View>;
+```
+
+### Example: Long content (overflows)
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const {Title, Body} = require("wonder-blocks-typography");
+const StandardModal = require("./standard-modal.js").default;
+
+const styles = StyleSheet.create({
+    previewSizer: {
+        height: 512,
+    },
+
+    modalPositioner: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 32,
+
+        position: "absolute",
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+    },
+
+    modalContent: {
+        margin: "0 auto",
+        marginTop: 40,
+        marginBottom: 40,
+        paddingLeft: 32,
+        paddingRight: 32,
+        maxWidth: 544,
+    },
+});
+
+<View style={styles.previewSizer}>
+    <View style={styles.modalPositioner}>
+        <StandardModal
+            title="Title"
+            content={
+                <View style={styles.modalContent}>
+                    <Body tag="p">
+                        {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."}
+                    </Body>
+                    <Body tag="p">
+                        {"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                    <Body tag="p">
+                        {"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                </View>
+            }
+            footer={<View>
+                {/* TODO(mdr): Use Wonder Blocks button. */}
+                <button type="button">Button (no-op)</button>
+            </View>}
+        />
+    </View>
+</View>;
+```

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -61,6 +61,10 @@ module.exports = {
                 // Make the preview area resizable.
                 resize: "both",
                 overflow: "auto",
+
+                // Allow the preview content to grow to the full size, using
+                // absolute-positioning, and left/right/top/bottom all set to 0.
+                position: "relative",
             },
         },
     },


### PR DESCRIPTION
In this change, we implement the basics of the "standard overflow" modal layout, by creating the `StandardModal` component.

I also added a `position: relative` style to our Styleguidist preview areas, to enable the example container to take the full height of the preview area. This means that, when using the resize handle to increase the size of the preview area, the space available to the modal will now correctly increase. (It also introduces an awkward issue, in which decreasing the height of the preview area will add a scrollbar, to help you see the rest of the sizer element that I used to set the preview's initial height. Womp, womp! I think it's a net better experience, since you actually _can_ test height changes now, even though parts of the experience are clunky.)

Test Plan:
[Uploaded to my personal Wonder Blocks fork!](https://matchu.github.io/wonder-blocks/#standardmodal)

In Styleguidist, you can see some inline examples of the standard modal layout:
![screenshot](https://user-images.githubusercontent.com/59218/39387910-36f1b242-4a31-11e8-86b7-240c7717373c.png)

Additionally, there's a button to launch a standard modal. It plays well out of the box!
![animated screenshot](https://user-images.githubusercontent.com/59218/39380130-5e88d890-4a12-11e8-969c-86a26109d581.gif)

Finally, use the resize handle to confirm that long text wraps well, increasing the size of the header/footer if necessary.
![screenshot](https://user-images.githubusercontent.com/59218/39388228-504febee-4a33-11e8-8e33-671f1f289641.png)
