### PR TITLE
[modal] Add close button to modal layouts

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-close-button.js
+++ b/packages/wonder-blocks-modal/components/modal-close-button.js
@@ -1,0 +1,69 @@
+// @flow
+import * as React from "react";
+import {StyleSheet, css} from "aphrodite";
+
+import Color from "wonder-blocks-color";
+
+type Props = {
+    /**
+     * Whether the button icon should be dark (for light backgrounds), or light
+     * (for dark backgrounds).
+     */
+    color: "dark" | "light",
+
+    /** Called when the button is clicked. */
+    onClick?: () => void,
+};
+
+/** A close button for modals. */
+export default class ModalCloseButton extends React.Component<Props> {
+    static defaultProps = {
+        color: "dark",
+    };
+
+    render() {
+        return (
+            // TODO(mdr): This should be a Wonder Blocks `IconButton`, with the
+            //     cross icon. Instead, I'm just using a plain text
+            //     multiplication sign.
+            <button
+                type="button"
+                className={css(
+                    styles.button,
+                    this.props.color === "dark" && styles.dark,
+                    this.props.color === "light" && styles.light,
+                )}
+                // TODO(mdr): Translate this string for i18n.
+                aria-label="Close modal"
+                onClick={this.props.onClick}
+            >
+                {"\xd7"}
+            </button>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    button: {
+        // Reset <button> styles to be more like <div>.
+        background: "none",
+        border: "none",
+        font: "inherit",
+        padding: 0,
+
+        cursor: "pointer",
+
+        // TODO(mdr): The modal should specify light or dark.
+        color: Color.white,
+        fontSize: 24,
+        lineHeight: 1,
+    },
+
+    dark: {
+        color: Color.offBlack50,
+    },
+
+    light: {
+        color: Color.white,
+    },
+});

--- a/packages/wonder-blocks-modal/components/modal-close-button.js
+++ b/packages/wonder-blocks-modal/components/modal-close-button.js
@@ -12,7 +12,7 @@ type Props = {
     color: "dark" | "light",
 
     /** Called when the button is clicked. */
-    onClick?: () => void,
+    onClick: () => void,
 };
 
 /** A close button for modals. */

--- a/packages/wonder-blocks-modal/components/modal-close-button.js
+++ b/packages/wonder-blocks-modal/components/modal-close-button.js
@@ -53,7 +53,9 @@ const styles = StyleSheet.create({
 
         cursor: "pointer",
         fontSize: 24,
-        lineHeight: 1,
+        lineHeight: "48px",
+        width: 48,
+        height: 48,
     },
 
     dark: {

--- a/packages/wonder-blocks-modal/components/modal-close-button.js
+++ b/packages/wonder-blocks-modal/components/modal-close-button.js
@@ -52,9 +52,6 @@ const styles = StyleSheet.create({
         padding: 0,
 
         cursor: "pointer",
-
-        // TODO(mdr): The modal should specify light or dark.
-        color: Color.white,
         fontSize: 24,
         lineHeight: 1,
     },

--- a/packages/wonder-blocks-modal/components/modal-close-button.test.js
+++ b/packages/wonder-blocks-modal/components/modal-close-button.test.js
@@ -1,0 +1,16 @@
+// @flow
+import React from "react";
+import {shallow} from "enzyme";
+
+import ModalCloseButton from "./modal-close-button.js";
+
+describe("ModalCloseButton", () => {
+    test("Clicking the button triggers `onClick`", () => {
+        const onClick = jest.fn();
+        const wrapper = shallow(<ModalCloseButton onClick={onClick} />);
+
+        expect(onClick).not.toHaveBeenCalled();
+        wrapper.find("button").simulate("click");
+        expect(onClick).toHaveBeenCalled();
+    });
+});

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -33,10 +33,10 @@ type Props = {
     children: ({openModal: () => void}) => React.Node,
 
     /**
-     * If the parent needs to be notified when the modal is closed use
-     * this prop.  Do not use `onClose` on the modals themselves as this
-     * is used by ModalNavigator to determine when to remove the modal
-     * the backdrop from the screen.
+     * If the parent needs to be notified when the modal is closed, use
+     * this prop. You probably want to use this instead of `onClickCloseButton`
+     * on the modals themselves, since this will capture a more complete set of
+     * close events.
      */
     onClose?: () => void,
 };

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -113,8 +113,8 @@ const styles = StyleSheet.create({
         flex: "0 0 auto",
         boxSizing: "border-box",
         minHeight: 64,
-        paddingLeft: 16,
-        paddingRight: 16,
+        paddingLeft: 4,
+        paddingRight: 4,
         paddingTop: 8,
         paddingBottom: 8,
 
@@ -155,10 +155,8 @@ const styles = StyleSheet.create({
     // the close button, because there's an additional right-hand spacer
     // element that grows at the same rate.
     titleAndSubtitle: {
-        flex: "0 0 auto",
+        flex: "0 1 auto",
         textAlign: "center",
-        paddingLeft: 16,
-        paddingRight: 16,
     },
 
     closeButton: {
@@ -167,5 +165,9 @@ const styles = StyleSheet.create({
 
     titleBarSpacer: {
         flex: "1 0 0",
+
+        // When the modal gets small, provide some minimal space here, to
+        // prevent the text from running up against the edge.
+        minWidth: 16,
     },
 });

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -10,6 +10,8 @@ import {
     LabelSmall,
 } from "wonder-blocks-typography";
 
+import ModalCloseButton from "./modal-close-button.js";
+
 type Props = {
     /**
      * The content of the modal, appearing between the titlebar and footer.
@@ -36,35 +38,45 @@ type Props = {
      * provide a container element with 100% width.
      */
     footer: React.Node,
+
+    /** Called when the close button is clicked. */
+    onClickCloseButton?: () => void,
 };
 
 /**
  * The "standard" modal layout: a titlebar, a content area, and a footer.
  */
 export default class StandardModal extends React.Component<Props> {
-    _renderTitlebar() {
+    _renderTitleAndSubtitle() {
         const {title, subtitle} = this.props;
 
         if (subtitle) {
             return (
-                <View style={[styles.titlebar]}>
+                <View>
                     <HeadingSmall>{title}</HeadingSmall>
                     <LabelSmall>{subtitle}</LabelSmall>
                 </View>
             );
         } else {
-            return (
-                <View style={[styles.titlebar]}>
-                    <HeadingMedium>{title}</HeadingMedium>
-                </View>
-            );
+            return <HeadingMedium>{title}</HeadingMedium>;
         }
     }
 
     render() {
         return (
             <View style={styles.container}>
-                {this._renderTitlebar()}
+                <View style={styles.titlebar}>
+                    <View style={styles.closeButton}>
+                        <ModalCloseButton
+                            color="dark"
+                            onClick={this.props.onClickCloseButton}
+                        />
+                    </View>
+                    <View style={styles.titleAndSubtitle}>
+                        {this._renderTitleAndSubtitle()}
+                    </View>
+                    <View style={styles.titleBarSpacer} />
+                </View>
                 <View style={styles.content}>{this.props.content}</View>
                 <View style={styles.footer}>{this.props.footer}</View>
             </View>
@@ -99,10 +111,8 @@ const styles = StyleSheet.create({
         paddingBottom: 8,
 
         display: "flex",
-        flexDirection: "column",
+        flexDirection: "row",
         alignItems: "center",
-        justifyContent: "center",
-        textAlign: "center",
 
         borderBottomStyle: "solid",
         borderBottomColor: Color.offBlack16,
@@ -133,10 +143,21 @@ const styles = StyleSheet.create({
         borderTopWidth: 1,
     },
 
+    // This element is centered within the titlebar, despite the presence of
+    // the close button, because there's an additional right-hand spacer
+    // element that grows at the same rate.
     titleAndSubtitle: {
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
+        flex: "0 0 auto",
         textAlign: "center",
+        paddingLeft: 16,
+        paddingRight: 16,
+    },
+
+    closeButton: {
+        flex: "1 0 0",
+    },
+
+    titleBarSpacer: {
+        flex: "1 0 0",
     },
 });

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -42,7 +42,14 @@ type Props = {
     /**
      * Called when the close button is clicked.
      *
-     * This defaults to a no-op via `defaultProps`.
+     * If you're using `ModalLauncher`, you probably shouldn't use this prop!
+     * Instead, to listen for when the modal closes, add an `onClose` handler
+     * to the `ModalLauncher`.
+     *
+     * This defaults to a no-op via `defaultProps`. (When used in a
+     * `ModalLauncher`, we'll automatically add an extra listener here via
+     * `cloneElement`, so that the `ModalLauncher` can listen for close button
+     * clicks too.)
      */
     onClickCloseButton: () => void,
 };

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -39,14 +39,22 @@ type Props = {
      */
     footer: React.Node,
 
-    /** Called when the close button is clicked. */
-    onClickCloseButton?: () => void,
+    /**
+     * Called when the close button is clicked.
+     *
+     * This defaults to a no-op via `defaultProps`.
+     */
+    onClickCloseButton: () => void,
 };
 
 /**
  * The "standard" modal layout: a titlebar, a content area, and a footer.
  */
 export default class StandardModal extends React.Component<Props> {
+    static defaultProps = {
+        onClickCloseButton: () => {},
+    };
+
     _renderTitleAndSubtitle() {
         const {title, subtitle} = this.props;
 

--- a/packages/wonder-blocks-modal/components/standard-modal.md
+++ b/packages/wonder-blocks-modal/components/standard-modal.md
@@ -55,6 +55,7 @@ const styles = StyleSheet.create({
                 {/* TODO(mdr): Use Wonder Blocks button. */}
                 <button type="button">Button (no-op)</button>
             </View>}
+            onClickCloseButton={() => alert("This would close the modal.")}
         />
     </View>
 </View>;
@@ -124,6 +125,7 @@ const styles = StyleSheet.create({
                 {/* TODO(mdr): Use Wonder Blocks button. */}
                 <button type="button">Button (no-op)</button>
             </View>}
+            onClickCloseButton={() => alert("This would close the modal.")}
         />
     </View>
 </View>;

--- a/packages/wonder-blocks-modal/components/standard-modal.test.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.test.js
@@ -1,0 +1,23 @@
+// @flow
+import * as React from "react";
+import {shallow} from "enzyme";
+
+import StandardModal from "./standard-modal.js";
+
+describe("StandardModal", () => {
+    test("Clicking the close button triggers `onClickCloseButton`", () => {
+        const onClickCloseButton = jest.fn();
+        const wrapper = shallow(
+            <StandardModal
+                title="Title"
+                content="Content"
+                footer="Footer"
+                onClickCloseButton={onClickCloseButton}
+            />,
+        );
+
+        expect(onClickCloseButton).not.toHaveBeenCalled();
+        wrapper.find("ModalCloseButton").simulate("click");
+        expect(onClickCloseButton).toHaveBeenCalled();
+    });
+});

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -5,12 +5,17 @@ import {StyleSheet, css} from "aphrodite";
 import Color from "wonder-blocks-color";
 import {View} from "wonder-blocks-core";
 
+import ModalCloseButton from "./modal-close-button.js";
+
 type Props = {
     /** The left-hand column's content. */
     leftContent: React.Node,
 
     /** The right-hand column's content. */
     rightContent: React.Node,
+
+    /** Called when the close button is clicked. */
+    onClickCloseButton?: () => void,
 };
 
 /**
@@ -20,6 +25,12 @@ export default class TwoColumnModal extends React.Component<Props> {
     render() {
         return (
             <View style={styles.container}>
+                <View style={styles.closeButton}>
+                    <ModalCloseButton
+                        color="light"
+                        onClick={this.props.onClickCloseButton}
+                    />
+                </View>
                 <View style={[styles.column, styles.leftColumn]}>
                     {this.props.leftContent}
                 </View>
@@ -36,6 +47,7 @@ const styles = StyleSheet.create({
         display: "flex",
         flexDirection: "row",
         alignItems: "stretch",
+        position: "relative",
 
         width: "86.72%",
         height: "60.42%",
@@ -43,6 +55,12 @@ const styles = StyleSheet.create({
 
         borderRadius: 4,
         overflow: "hidden",
+    },
+
+    closeButton: {
+        position: "absolute",
+        left: 24,
+        top: 16,
     },
 
     column: {

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -68,8 +68,8 @@ const styles = StyleSheet.create({
 
     closeButton: {
         position: "absolute",
-        left: 24,
-        top: 16,
+        left: 4,
+        top: 8,
     },
 
     column: {

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -14,14 +14,23 @@ type Props = {
     /** The right-hand column's content. */
     rightContent: React.Node,
 
-    /** Called when the close button is clicked. */
-    onClickCloseButton?: () => void,
+    /**
+     * Called when the close button is clicked.
+     *
+     * This defaults to a no-op via `defaultProps`.
+     */
+    onClickCloseButton: () => void,
+    onClickCloseButton: () => void,
 };
 
 /**
  * A two-column modal layout.
  */
 export default class TwoColumnModal extends React.Component<Props> {
+    static defaultProps = {
+        onClickCloseButton: () => {},
+    };
+
     render() {
         return (
             <View style={styles.container}>

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -17,9 +17,15 @@ type Props = {
     /**
      * Called when the close button is clicked.
      *
-     * This defaults to a no-op via `defaultProps`.
+     * If you're using `ModalLauncher`, you probably shouldn't use this prop!
+     * Instead, to listen for when the modal closes, add an `onClose` handler
+     * to the `ModalLauncher`.
+     *
+     * This defaults to a no-op via `defaultProps`. (When used in a
+     * `ModalLauncher`, we'll automatically add an extra listener here via
+     * `cloneElement`, so that the `ModalLauncher` can listen for close button
+     * clicks too.)
      */
-    onClickCloseButton: () => void,
     onClickCloseButton: () => void,
 };
 

--- a/packages/wonder-blocks-modal/components/two-column-modal.md
+++ b/packages/wonder-blocks-modal/components/two-column-modal.md
@@ -50,6 +50,7 @@ const styles = StyleSheet.create({
                 </Body>
             </View>
         }
+        onClickCloseButton={() => alert("This would close the modal.")}
     />
 </View>;
 ```

--- a/packages/wonder-blocks-modal/components/two-column-modal.test.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.test.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from "react";
+import {shallow} from "enzyme";
+
+import TwoColumnModal from "./two-column-modal.js";
+
+describe("TwoColumnModal", () => {
+    test("Clicking the close button triggers `onClickCloseButton`", () => {
+        const onClickCloseButton = jest.fn();
+        const wrapper = shallow(
+            <TwoColumnModal
+                leftContent="Left content"
+                rightContent="Right content"
+                onClickCloseButton={onClickCloseButton}
+            />,
+        );
+
+        expect(onClickCloseButton).not.toHaveBeenCalled();
+        wrapper.find("ModalCloseButton").simulate("click");
+        expect(onClickCloseButton).toHaveBeenCalled();
+    });
+});

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -28,8 +28,9 @@ module.exports = {
             content: "packages/wonder-blocks-modal/docs.md",
             components: "packages/wonder-blocks-modal/components/*.js",
             ignore: [
-                "**/components/modal-launcher-portal.js",
                 "**/components/modal-backdrop.js",
+                "**/components/modal-close-button.js",
+                "**/components/modal-launcher-portal.js",
             ],
         },
     ],


### PR DESCRIPTION
In this change, we create a `ModalCloseButton` component, and add it to the modal layout components.

This close button doesn't control modal launcher state yet; it just triggers the public callback `onClickCloseButton` on the modal layout component. (We'll probably need to set up some wires via context, in order to control the modal launcher. Coming soon!)

Some modals will not want to provide default close behavior at all, but that's not part of the scope of this change. (See WB-134.)

Test Plan:
Open Styleguidist, and take a look at those cute close buttons!
![StandardModal screenshot](https://user-images.githubusercontent.com/59218/39440118-c3667986-4c5e-11e8-8a9a-b23ed83f8036.png)
![TwoColumnModal screenshot](https://user-images.githubusercontent.com/59218/39440121-c9b287d0-4c5e-11e8-8038-f855f2aa05a9.png)

Click them, and see an alert, because the Styleguidist examples have an alert handler hooked up to `onClickCloseButton`.
<img width="916" alt="Alert screenshot" src="https://user-images.githubusercontent.com/59218/39440145-d7c3505c-4c5e-11e8-9adc-a9df04d7b633.png">

Additionally, use a ruler to confirm that the title and subtitle are indeed centered in the title bar, despite the addition of the close button.

Finally, use the resize handle to confirm that, when the viewport becomes small, the `StandardModal` title and subtitle text still wrap naturally.
<img width="380" alt="Small StandardModal screenshot" src="https://user-images.githubusercontent.com/59218/39440170-eb8366e0-4c5e-11e8-9f20-38accf02651b.png">