### PR TITLE
[modal] Pressing Escape closes a launched modal

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -101,7 +101,33 @@ export default class ModalLauncher extends React.Component<Props, State> {
                         </ModalBackdrop>
                     </ModalLauncherPortal>
                 )}
+                {this.state.opened && (
+                    <ModalLauncherKeypressListener onClose={this._closeModal} />
+                )}
             </View>
         );
+    }
+}
+
+/** A component that, when mounted, calls `onClose` when Escape is pressed. */
+class ModalLauncherKeypressListener extends React.Component<{
+    onClose: () => void,
+}> {
+    componentDidMount() {
+        window.addEventListener("keyup", this._handleKeyup);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("keyup", this._handleKeyup);
+    }
+
+    _handleKeyup = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+            this.props.onClose();
+        }
+    };
+
+    render() {
+        return null;
     }
 }

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react";
-import {shallow} from "enzyme";
+import {shallow, mount} from "enzyme";
 
 import ModalLauncher from "./modal-launcher.js";
 
@@ -58,5 +58,35 @@ describe("ModalLauncher", () => {
         opened = true;
         wrapper.find("button").simulate("click");
         expect(wrapper.find("ModalLauncherPortal")).toHaveLength(1);
+    });
+
+    test("Pressing Escape closes the modal", (done) => {
+        let pressedEscape = false;
+
+        // On close, assert that this function was triggered _after_ Escape was
+        // pressed, and finish the test.
+        const onClose = () => {
+            expect(pressedEscape).toBe(true);
+            done();
+        };
+
+        // We mount into a real DOM, in order to simulate and capture real key
+        // presses anywhere in the document.
+        const wrapper = mount(
+            <ModalLauncher modal={<div />} onClose={onClose}>
+                {({openModal}) => <button onClick={openModal} />}
+            </ModalLauncher>,
+        );
+
+        // Launch the modal.
+        wrapper.find("button").simulate("click");
+
+        // Simulate an Escape keypress. This should call `onClose`, which is
+        // where the test continues.
+        pressedEscape = true;
+        const event: KeyboardEvent = (document.createEvent("Event"): any);
+        event.key = "Escape";
+        event.initEvent("keyup", true, true);
+        document.dispatchEvent(event);
     });
 });

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -60,33 +60,31 @@ describe("ModalLauncher", () => {
         expect(wrapper.find("ModalLauncherPortal")).toHaveLength(1);
     });
 
-    test("Pressing Escape closes the modal", (done) => {
-        let pressedEscape = false;
-
-        // On close, assert that this function was triggered _after_ Escape was
-        // pressed, and finish the test.
-        const onClose = () => {
-            expect(pressedEscape).toBe(true);
-            done();
-        };
-
+    test("Pressing Escape closes the modal", () => {
         // We mount into a real DOM, in order to simulate and capture real key
         // presses anywhere in the document.
         const wrapper = mount(
-            <ModalLauncher modal={<div />} onClose={onClose}>
+            <ModalLauncher modal={<div data-modal-child />}>
                 {({openModal}) => <button onClick={openModal} />}
             </ModalLauncher>,
         );
 
         // Launch the modal.
         wrapper.find("button").simulate("click");
+        expect(document.querySelector("[data-modal-child]")).toBeTruthy();
 
-        // Simulate an Escape keypress. This should call `onClose`, which is
-        // where the test continues.
-        pressedEscape = true;
+        // Simulate an Escape keypress. This will happen synchronously, because
+        // we're using `dispatchEvent`.
         const event: KeyboardEvent = (document.createEvent("Event"): any);
         event.key = "Escape";
         event.initEvent("keyup", true, true);
         document.dispatchEvent(event);
+
+        // Confirm that the modal is no longer mounted.
+        //
+        // NOTE(mdr): This might be fragile once React's async rendering lands.
+        //     I wonder if we'll be able to force synchronous rendering in unit
+        //     tests?
+        expect(document.querySelector("[data-modal-child]")).toBeFalsy();
     });
 });


### PR DESCRIPTION
In this change, we add keyboard listeners to `ModalLauncher` to close the modal when Escape is pressed.

Test Plan:
```npm test```

In Styleguidist, use the `ModalLauncher` example to launch a standard modal and a two-column modal. For each, confirm that pressing Escape closes the modal.