### PR TITLE
Use the Grid for the one and two-column modal dialogs.

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-footer.js
+++ b/packages/wonder-blocks-modal/components/modal-footer.js
@@ -1,0 +1,47 @@
+// @flow
+import * as React from "react";
+import {StyleSheet, css} from "aphrodite";
+
+import Color from "wonder-blocks-color";
+import {View} from "wonder-blocks-core";
+
+/**
+ * A modal footer.
+ */
+export default class ModalFooter extends React.Component<{
+    /** The footer to show under the content. */
+    children: React.Node,
+
+    /** Styles to apply to the footer */
+    style?: any,
+}> {
+    render() {
+        const {children, style} = this.props;
+
+        return <View style={[styles.footer, style]}>{children}</View>;
+    }
+}
+
+const styles = StyleSheet.create({
+    footer: {
+        flex: "0 0 auto",
+        boxSizing: "border-box",
+        minHeight: 64,
+        paddingLeft: 16,
+        paddingRight: 16,
+        paddingTop: 8,
+        paddingBottom: 8,
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "flex-end",
+
+        borderTopStyle: "solid",
+        borderTopColor: Color.offBlack16,
+        borderTopWidth: 1,
+
+        backgroundColor: Color.white,
+        width: "100%",
+    },
+});

--- a/packages/wonder-blocks-modal/components/modal-launcher.md
+++ b/packages/wonder-blocks-modal/components/modal-launcher.md
@@ -57,7 +57,7 @@ const standardModal = ({closeModal}) => (
 );
 
 const twoColumnModal = ({closeModal}) => <TwoColumnModal
-    leftContent={
+    sidebar={
         <View>
             <Title style={styles.title}>Left column</Title>
             <Body>
@@ -68,7 +68,7 @@ const twoColumnModal = ({closeModal}) => <TwoColumnModal
             </Body>
         </View>
     }
-    rightContent={
+    contents={
         <View>
             <Title style={styles.title}>Right column</Title>
             <Body>
@@ -81,14 +81,13 @@ const twoColumnModal = ({closeModal}) => <TwoColumnModal
                 occaecat cupidatat non proident, sunt in culpa qui officia
                 deserunt mollit anim id est.
             </Body>
-            {/* TODO(mdr): Use Wonder Blocks Button. */}
-            <button
-                onClick={closeModal}
-                style={{marginTop: 16}}
-            >
-                Close modal
-            </button>
         </View>
+    }
+    footer={
+        // TODO(mdr): Use Wonder Blocks Button.
+        <button onClick={closeModal}>
+            Close modal
+        </button>
     }
 />;
 

--- a/packages/wonder-blocks-modal/components/modal-launcher.md
+++ b/packages/wonder-blocks-modal/components/modal-launcher.md
@@ -3,6 +3,7 @@ const {StyleSheet, css} = require("aphrodite");
 const {View} = require("wonder-blocks-core");
 const {Title, Body} = require("wonder-blocks-typography");
 const ModalLauncher = require("./modal-launcher.js").default;
+const OneColumnModal = require("./one-column-modal.js").default;
 const TwoColumnModal = require("./two-column-modal.js").default;
 
 const styles = StyleSheet.create({
@@ -56,6 +57,30 @@ const standardModal = ({closeModal}) => (
     />
 );
 
+const oneColumnModal = ({closeModal}) => <OneColumnModal
+    content={
+        <View>
+            <Title style={styles.title}>Contents</Title>
+            <Body>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                do eiusmod tempor incididunt ut labore et dolore magna
+                aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                Duis aute irure dolor in reprehenderit in voluptate velit
+                esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                occaecat cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est.
+            </Body>
+        </View>
+    }
+    footer={
+        // TODO(mdr): Use Wonder Blocks Button.
+        <button onClick={closeModal}>
+            Close modal
+        </button>
+    }
+/>;
+
 const twoColumnModal = ({closeModal}) => <TwoColumnModal
     sidebar={
         <View>
@@ -68,7 +93,7 @@ const twoColumnModal = ({closeModal}) => <TwoColumnModal
             </Body>
         </View>
     }
-    contents={
+    content={
         <View>
             <Title style={styles.title}>Right column</Title>
             <Body>
@@ -95,6 +120,9 @@ const twoColumnModal = ({closeModal}) => <TwoColumnModal
 <View style={styles.example}>
     <ModalLauncher modal={standardModal}>
         {({openModal}) => <button onClick={openModal}>Standard modal</button>}
+    </ModalLauncher>
+    <ModalLauncher modal={oneColumnModal}>
+        {({openModal}) => <button onClick={openModal}>One-column modal</button>}
     </ModalLauncher>
     <ModalLauncher modal={twoColumnModal}>
         {({openModal}) => <button onClick={openModal}>Two-column modal</button>}

--- a/packages/wonder-blocks-modal/components/one-column-modal.js
+++ b/packages/wonder-blocks-modal/components/one-column-modal.js
@@ -10,12 +10,9 @@ import ModalCloseButton from "./modal-close-button.js";
 import ModalFooter from "./modal-footer.js";
 
 /**
- * A two-column modal layout.
+ * A one-column modal layout.
  */
-export default class TwoColumnModal extends React.Component<{
-    /** The sidebar column's content. */
-    sidebar: React.Node,
-
+export default class OneColumnModal extends React.Component<{
     /**
      * Called when the close button is clicked.
      *
@@ -30,57 +27,27 @@ export default class TwoColumnModal extends React.Component<{
      */
     onClickCloseButton: () => void,
 
-    /** The footer to show under the main column's content. */
+    /** The footer to show under the contents. */
     footer?: React.Node,
 
-    /** The main column's content. */
+    /** The contents of the modal. */
     content: React.Node,
-
-    /** Should the sidebar be made smaller? (e.g. 1 column wide) */
-    smallSidebar: boolean,
 }> {
     static defaultProps = {
         onClickCloseButton: () => {},
-        smallSidebar: false,
     };
 
-    renderSidebar(sidebar: React.Node, smallSidebar: boolean) {
-        if (smallSidebar) {
-            return (
-                <Cell
-                    smCols={4}
-                    largeCols={1}
-                    style={[
-                        styles.column,
-                        styles.bgSidebar,
-                        styles.bgSidebarSmall,
-                    ]}
-                >
-                    {sidebar}
-                </Cell>
-            );
-        }
-
-        return (
-            <FlexCell style={[styles.column, styles.bgSidebar]}>
-                <View style={styles.sidebar}>{sidebar}</View>
-            </FlexCell>
-        );
-    }
-
     render() {
-        const {sidebar, footer, content, smallSidebar} = this.props;
+        const {footer, content} = this.props;
 
         return (
             <View style={styles.container}>
                 <Grid spec={GRID_MODAL_SPEC}>
                     <Row flush>
-                        {this.renderSidebar(sidebar, smallSidebar)}
                         <FlexCell style={[styles.column, styles.bgContents]}>
                             <View
                                 style={[
                                     styles.contents,
-                                    smallSidebar && styles.contentsSmall,
                                     footer && styles.contentsHasFooter,
                                 ]}
                             >
@@ -96,7 +63,7 @@ export default class TwoColumnModal extends React.Component<{
                 </Grid>
                 <View style={styles.closeButton}>
                     <ModalCloseButton
-                        color="light"
+                        color="dark"
                         onClick={this.props.onClickCloseButton}
                     />
                 </View>
@@ -110,13 +77,10 @@ const styles = StyleSheet.create({
         margin: "0 auto",
         position: "relative",
 
-        width: "86.72%",
+        width: "64.65%",
 
         borderRadius: 4,
         overflow: "hidden",
-
-        // For sidebar
-        minHeight: 464,
     },
 
     closeButton: {
@@ -130,54 +94,21 @@ const styles = StyleSheet.create({
         paddingBottom: 64,
         flex: "1 1 50%",
         boxSizing: "border-box",
-
-        // For sidebar
-        minHeight: 464,
-    },
-
-    bgSidebar: {
-        background: Color.darkBlue,
-        color: Color.white,
-    },
-
-    bgSidebarSmall: {
-        flex: "0",
     },
 
     bgContents: {
         background: Color.white,
         position: "relative",
         flexDirection: "column",
-
-        // For sidebar
-        display: "flex",
-    },
-
-    sidebar: {
-        marginRight: 32,
     },
 
     contents: {
         overflow: "auto",
         flex: "1 0 0",
-
-        // For sidebar
-        marginLeft: 64,
-        maxWidth: 472,
     },
 
     contentsHasFooter: {
         paddingBottom: 48,
-    },
-
-    contentsSmall: {
-        // Center the contents when the sidebar is small
-        margin: "0 auto",
-
-        // Add in some extra padding to the contents to
-        // simulate the extra gutters used for spacing
-        paddingLeft: 64,
-        paddingRight: 32,
     },
 
     footer: {

--- a/packages/wonder-blocks-modal/components/one-column-modal.md
+++ b/packages/wonder-blocks-modal/components/one-column-modal.md
@@ -1,0 +1,119 @@
+**One-Column, with footer:**
+
+A one-column modal dialog with a footer on the contents. The contents expand to fill the container and it continues to grow in size. There is no minimum height to the modal.
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const {Title, Body} = require("wonder-blocks-typography");
+const OneColumnModal = require("./one-column-modal.js").default;
+
+const styles = StyleSheet.create({
+    example: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        padding: 32,
+    },
+
+    title: {
+        marginBottom: 16,
+    },
+});
+
+const content = <View>
+    <Title style={styles.title}>Contents</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+</View>;
+
+const footer = <View>
+    {/* TODO(jeresig): Use Wonder Blocks button. */}
+    <button type="button">Button (no-op)</button>
+</View>;
+
+<View style={styles.example}>
+    <OneColumnModal
+        content={content}
+        footer={footer}
+        onClickCloseButton={() => alert("This would close the modal.")}
+    />
+</View>;
+```
+
+**One-Column, no footer:**
+
+A one-column modal dialog with no footer on the contents. The contents expand to fill the container and it continues to grow in size. There is no minimum height to the modal.
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const {Title, Body} = require("wonder-blocks-typography");
+const OneColumnModal = require("./one-column-modal.js").default;
+
+const styles = StyleSheet.create({
+    example: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        padding: 32,
+    },
+
+    title: {
+        marginBottom: 16,
+    },
+});
+
+const content = <View>
+    <Title style={styles.title}>Contents</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+</View>;
+
+<View style={styles.example}>
+    <OneColumnModal
+        content={content}
+        onClickCloseButton={() => alert("This would close the modal.")}
+    />
+</View>;
+```

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -4,15 +4,13 @@ import {StyleSheet, css} from "aphrodite";
 
 import Color from "wonder-blocks-color";
 import {View} from "wonder-blocks-core";
+import {Grid, Row, Cell, FlexCell, GRID_MODAL_SPEC} from "wonder-blocks-grid";
 
 import ModalCloseButton from "./modal-close-button.js";
 
 type Props = {
-    /** The left-hand column's content. */
-    leftContent: React.Node,
-
-    /** The right-hand column's content. */
-    rightContent: React.Node,
+    /** The sidebar column's content. */
+    sidebar?: React.Node,
 
     /**
      * Called when the close button is clicked.
@@ -27,6 +25,15 @@ type Props = {
      * clicks too.)
      */
     onClickCloseButton: () => void,
+
+    /** The footer to show under the main column's content. */
+    footer?: React.Node,
+
+    /** The main column's content. */
+    contents: React.Node,
+
+    /** Should the sidebar be made smaller? (e.g. 1 column wide) */
+    smallSidebar: boolean,
 };
 
 /**
@@ -35,22 +42,64 @@ type Props = {
 export default class TwoColumnModal extends React.Component<Props> {
     static defaultProps = {
         onClickCloseButton: () => {},
+        smallSidebar: false,
     };
 
     render() {
+        const {sidebar, footer, contents, smallSidebar} = this.props;
+
+        const sidebarView = smallSidebar ? (
+            <Cell
+                smCols={4}
+                largeCols={1}
+                style={[styles.column, styles.bgSidebar, styles.bgSidebarSmall]}
+            >
+                {sidebar}
+            </Cell>
+        ) : (
+            <FlexCell style={[styles.column, styles.bgSidebar]}>
+                <View style={styles.sidebar}>{sidebar}</View>
+            </FlexCell>
+        );
+
         return (
-            <View style={styles.container}>
+            <View
+                style={[
+                    styles.container,
+                    !sidebar && styles.containerNoSidebar,
+                ]}
+            >
+                <Grid spec={GRID_MODAL_SPEC}>
+                    <Row flush>
+                        {sidebar && sidebarView}
+                        <FlexCell
+                            style={[
+                                styles.column,
+                                styles.bgContents,
+                                !sidebar && styles.bgContentsNoSidebar,
+                            ]}
+                        >
+                            <View
+                                style={[
+                                    styles.contents,
+                                    smallSidebar && styles.contentsSmall,
+                                    !!footer && styles.contentsHasFooter,
+                                    !sidebar && styles.contentsNoSidebar,
+                                ]}
+                            >
+                                {contents}
+                            </View>
+                            {footer && (
+                                <View style={styles.footer}>{footer}</View>
+                            )}
+                        </FlexCell>
+                    </Row>
+                </Grid>
                 <View style={styles.closeButton}>
                     <ModalCloseButton
-                        color="light"
+                        color={sidebar ? "light" : "dark"}
                         onClick={this.props.onClickCloseButton}
                     />
-                </View>
-                <View style={[styles.column, styles.leftColumn]}>
-                    {this.props.leftContent}
-                </View>
-                <View style={[styles.column, styles.rightColumn]}>
-                    {this.props.rightContent}
                 </View>
             </View>
         );
@@ -59,9 +108,7 @@ export default class TwoColumnModal extends React.Component<Props> {
 
 const styles = StyleSheet.create({
     container: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "stretch",
+        margin: "0 auto",
         position: "relative",
 
         width: "86.72%",
@@ -78,32 +125,85 @@ const styles = StyleSheet.create({
         top: 8,
     },
 
-    column: {
-        boxSizing: "border-box",
-        flex: "0 0 50%",
+    containerNoSidebar: {
+        minHeight: "auto",
+    },
 
-        // TODO(mdr): Some call sites probably won't want built-in padding. How
-        //     should we handle that possibility?
+    column: {
         paddingTop: 64,
         paddingBottom: 64,
+        minHeight: 464,
+        flex: "1 1 50%",
+        boxSizing: "border-box",
     },
 
-    leftColumn: {
+    bgSidebar: {
         background: Color.darkBlue,
         color: Color.white,
-
-        // TODO(mdr): Some call sites probably won't want built-in padding. How
-        //     should we handle that possibility?
-        paddingLeft: 64,
-        paddingRight: 52,
     },
 
-    rightColumn: {
-        background: Color.white,
+    bgSidebarSmall: {
+        flex: "0",
+    },
 
-        // TODO(mdr): Some call sites probably won't want built-in padding. How
-        //     should we handle that possibility?
-        paddingLeft: 52,
-        paddingRight: 64,
+    bgContents: {
+        background: Color.white,
+        position: "relative",
+        display: "flex",
+        flexDirection: "column",
+    },
+
+    bgContentsNoSidebar: {
+        minHeight: "auto",
+        display: "block",
+    },
+
+    sidebar: {
+        marginRight: 32,
+    },
+
+    contents: {
+        marginLeft: 64,
+        overflow: "auto",
+        flex: "1 0 0",
+        maxWidth: 472,
+    },
+
+    contentsHasFooter: {
+        paddingBottom: 48,
+    },
+
+    contentsNoSidebar: {
+        marginLeft: 0,
+        maxWidth: "auto",
+    },
+
+    contentsSmall: {
+        margin: "0 auto",
+    },
+
+    footer: {
+        flex: "0 0 auto",
+        boxSizing: "border-box",
+        minHeight: 64,
+        paddingLeft: 16,
+        paddingRight: 16,
+        paddingTop: 8,
+        paddingBottom: 8,
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "flex-end",
+
+        borderTopStyle: "solid",
+        borderTopColor: Color.offBlack16,
+        borderTopWidth: 1,
+
+        backgroundColor: Color.white,
+        width: "100%",
+        position: "absolute",
+        left: 0,
+        bottom: 0,
     },
 });

--- a/packages/wonder-blocks-modal/components/two-column-modal.md
+++ b/packages/wonder-blocks-modal/components/two-column-modal.md
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const contents = <View>
+const content = <View>
     <Title style={styles.title}>Contents</Title>
     <Body>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
@@ -49,7 +49,7 @@ const sidebar = <View>
 
 <View style={styles.example}>
     <TwoColumnModal
-        contents={contents}
+        content={content}
         sidebar={sidebar}
         onClickCloseButton={() => alert("This would close the modal.")}
     />
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const contents = <View>
+const content = <View>
     <Title style={styles.title}>Contents</Title>
     <Body>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
@@ -124,7 +124,7 @@ const footer = <View>
 
 <View style={styles.example}>
     <TwoColumnModal
-        contents={contents}
+        content={content}
         footer={footer}
         sidebar={sidebar}
         onClickCloseButton={() => alert("This would close the modal.")}
@@ -159,7 +159,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const contents = <View>
+const content = <View>
     <Title style={styles.title}>Contents</Title>
     <Body>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
@@ -202,134 +202,10 @@ const footer = <View>
 
 <View style={styles.example}>
     <TwoColumnModal
-        contents={contents}
+        content={content}
         footer={footer}
         smallSidebar
         sidebar={sidebar}
-        onClickCloseButton={() => alert("This would close the modal.")}
-    />
-</View>;
-```
-
-**One-Column, with footer:**
-
-A one-column modal dialog with a footer on the contents. The contents expand to fill the container and it continues to grow in size. There is no minimum height to the modal.
-
-```js
-const {StyleSheet, css} = require("aphrodite");
-const {View} = require("wonder-blocks-core");
-const Color = require("wonder-blocks-color").default;
-const {Title, Body} = require("wonder-blocks-typography");
-const {Row, FlexCell} = require("wonder-blocks-grid");
-const TwoColumnModal = require("./two-column-modal.js").default;
-
-const styles = StyleSheet.create({
-    example: {
-        // Checkerboard background
-        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        padding: 32,
-    },
-
-    title: {
-        marginBottom: 16,
-    },
-});
-
-const contents = <View>
-    <Title style={styles.title}>Contents</Title>
-    <Body>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-        do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-        ullamco laboris nisi ut aliquip ex ea commodo consequat.
-        Duis aute irure dolor in reprehenderit in voluptate velit
-        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia
-        deserunt mollit anim id est.
-    </Body>
-    <Body>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-        do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-        ullamco laboris nisi ut aliquip ex ea commodo consequat.
-        Duis aute irure dolor in reprehenderit in voluptate velit
-        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia
-        deserunt mollit anim id est.
-    </Body>
-    <Body>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-        do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-        ullamco laboris nisi ut aliquip ex ea commodo consequat.
-        Duis aute irure dolor in reprehenderit in voluptate velit
-        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia
-        deserunt mollit anim id est.
-    </Body>
-</View>;
-
-const footer = <View>
-    {/* TODO(jeresig): Use Wonder Blocks button. */}
-    <button type="button">Button (no-op)</button>
-</View>;
-
-<View style={styles.example}>
-    <TwoColumnModal
-        contents={contents}
-        footer={footer}
-        onClickCloseButton={() => alert("This would close the modal.")}
-    />
-</View>;
-```
-
-**One-Column, no footer:**
-
-A one-column modal dialog with no footer on the contents. The contents expand to fill the container and it continues to grow in size. There is no minimum height to the modal.
-
-```js
-const {StyleSheet, css} = require("aphrodite");
-const {View} = require("wonder-blocks-core");
-const Color = require("wonder-blocks-color").default;
-const {Title, Body} = require("wonder-blocks-typography");
-const {Row, FlexCell} = require("wonder-blocks-grid");
-const TwoColumnModal = require("./two-column-modal.js").default;
-
-const styles = StyleSheet.create({
-    example: {
-        // Checkerboard background
-        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        padding: 32,
-    },
-
-    title: {
-        marginBottom: 16,
-    },
-});
-
-const contents = <View>
-    <Title style={styles.title}>Contents</Title>
-    <Body>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-        do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-        ullamco laboris nisi ut aliquip ex ea commodo consequat.
-        Duis aute irure dolor in reprehenderit in voluptate velit
-        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia
-        deserunt mollit anim id est.
-    </Body>
-</View>;
-
-<View style={styles.example}>
-    <TwoColumnModal
-        contents={contents}
         onClickCloseButton={() => alert("This would close the modal.")}
     />
 </View>;

--- a/packages/wonder-blocks-modal/components/two-column-modal.md
+++ b/packages/wonder-blocks-modal/components/two-column-modal.md
@@ -1,7 +1,13 @@
+**Two-Columns, No Footer:**
+
+A two-column modal dialog, with no footer. The height will be a ratio of the window height and the contents will expand to fill the space. If the contents become too large then it'll become scrollable.
+
 ```js
 const {StyleSheet, css} = require("aphrodite");
 const {View} = require("wonder-blocks-core");
+const Color = require("wonder-blocks-color").default;
 const {Title, Body} = require("wonder-blocks-typography");
+const {Row, FlexCell} = require("wonder-blocks-grid");
 const TwoColumnModal = require("./two-column-modal.js").default;
 
 const styles = StyleSheet.create({
@@ -11,9 +17,6 @@ const styles = StyleSheet.create({
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 
-        display: "flex",
-        flexDirection: "row",
-        justifyContent: "center",
         padding: 32,
     },
 
@@ -22,34 +25,311 @@ const styles = StyleSheet.create({
     },
 });
 
+const contents = <View>
+    <Title style={styles.title}>Contents</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur.
+    </Body>
+</View>;
+
+const sidebar = <View>
+    <Title style={styles.title}>Sidebar</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris.
+    </Body>
+</View>;
+
 <View style={styles.example}>
     <TwoColumnModal
-        leftContent={
-            <View>
-                <Title style={styles.title}>Left column</Title>
-                <Body>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-                    do eiusmod tempor incididunt ut labore et dolore magna
-                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                    ullamco laboris.
-                </Body>
-            </View>
-        }
-        rightContent={
-            <View>
-                <Title style={styles.title}>Right column</Title>
-                <Body>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-                    do eiusmod tempor incididunt ut labore et dolore magna
-                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                    Duis aute irure dolor in reprehenderit in voluptate velit
-                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-                    occaecat cupidatat non proident, sunt in culpa qui officia
-                    deserunt mollit anim id est.
-                </Body>
-            </View>
-        }
+        contents={contents}
+        sidebar={sidebar}
+        onClickCloseButton={() => alert("This would close the modal.")}
+    />
+</View>;
+```
+
+**Two-Columns, with Footer:**
+
+A two-column modal dialog with a footer on the contents. On overflow the contents will scroll beneath the toolbar.
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const Color = require("wonder-blocks-color").default;
+const {Title, Body} = require("wonder-blocks-typography");
+const {Row, FlexCell} = require("wonder-blocks-grid");
+const TwoColumnModal = require("./two-column-modal.js").default;
+
+const styles = StyleSheet.create({
+    example: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        padding: 32,
+    },
+
+    title: {
+        marginBottom: 16,
+    },
+});
+
+const contents = <View>
+    <Title style={styles.title}>Contents</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+</View>;
+
+const sidebar = <View>
+    <Title style={styles.title}>Sidebar</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris.
+    </Body>
+</View>;
+
+const footer = <View>
+    {/* TODO(jeresig): Use Wonder Blocks button. */}
+    <button type="button">Button (no-op)</button>
+</View>;
+
+<View style={styles.example}>
+    <TwoColumnModal
+        contents={contents}
+        footer={footer}
+        sidebar={sidebar}
+        onClickCloseButton={() => alert("This would close the modal.")}
+    />
+</View>;
+```
+
+**Two-Columns, with footer, small sidebar:**
+
+A two-column modal dialog with a footer on the contents. On overflow the contents will scroll beneath the toolbar. Additionally, the sidebar is very small (only a single column).
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const Color = require("wonder-blocks-color").default;
+const {Title, Body} = require("wonder-blocks-typography");
+const {Row, FlexCell} = require("wonder-blocks-grid");
+const TwoColumnModal = require("./two-column-modal.js").default;
+
+const styles = StyleSheet.create({
+    example: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        padding: 32,
+    },
+
+    title: {
+        marginBottom: 16,
+    },
+});
+
+const contents = <View>
+    <Title style={styles.title}>Contents</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+</View>;
+
+const sidebar = <View></View>;
+
+const footer = <View>
+    {/* TODO(jeresig): Use Wonder Blocks button. */}
+    <button type="button">Button (no-op)</button>
+</View>;
+
+<View style={styles.example}>
+    <TwoColumnModal
+        contents={contents}
+        footer={footer}
+        smallSidebar
+        sidebar={sidebar}
+        onClickCloseButton={() => alert("This would close the modal.")}
+    />
+</View>;
+```
+
+**One-Column, with footer:**
+
+A one-column modal dialog with a footer on the contents. The contents expand to fill the container and it continues to grow in size. There is no minimum height to the modal.
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const Color = require("wonder-blocks-color").default;
+const {Title, Body} = require("wonder-blocks-typography");
+const {Row, FlexCell} = require("wonder-blocks-grid");
+const TwoColumnModal = require("./two-column-modal.js").default;
+
+const styles = StyleSheet.create({
+    example: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        padding: 32,
+    },
+
+    title: {
+        marginBottom: 16,
+    },
+});
+
+const contents = <View>
+    <Title style={styles.title}>Contents</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+</View>;
+
+const footer = <View>
+    {/* TODO(jeresig): Use Wonder Blocks button. */}
+    <button type="button">Button (no-op)</button>
+</View>;
+
+<View style={styles.example}>
+    <TwoColumnModal
+        contents={contents}
+        footer={footer}
+        onClickCloseButton={() => alert("This would close the modal.")}
+    />
+</View>;
+```
+
+**One-Column, no footer:**
+
+A one-column modal dialog with no footer on the contents. The contents expand to fill the container and it continues to grow in size. There is no minimum height to the modal.
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const Color = require("wonder-blocks-color").default;
+const {Title, Body} = require("wonder-blocks-typography");
+const {Row, FlexCell} = require("wonder-blocks-grid");
+const TwoColumnModal = require("./two-column-modal.js").default;
+
+const styles = StyleSheet.create({
+    example: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        padding: 32,
+    },
+
+    title: {
+        marginBottom: 16,
+    },
+});
+
+const contents = <View>
+    <Title style={styles.title}>Contents</Title>
+    <Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+        do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia
+        deserunt mollit anim id est.
+    </Body>
+</View>;
+
+<View style={styles.example}>
+    <TwoColumnModal
+        contents={contents}
         onClickCloseButton={() => alert("This would close the modal.")}
     />
 </View>;

--- a/packages/wonder-blocks-modal/components/two-column-modal.test.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.test.js
@@ -9,8 +9,8 @@ describe("TwoColumnModal", () => {
         const onClickCloseButton = jest.fn();
         const wrapper = shallow(
             <TwoColumnModal
-                leftContent="Left content"
-                rightContent="Right content"
+                sidebar="Sidebar"
+                contents="Contents"
                 onClickCloseButton={onClickCloseButton}
             />,
         );

--- a/packages/wonder-blocks-modal/components/two-column-modal.test.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.test.js
@@ -10,7 +10,7 @@ describe("TwoColumnModal", () => {
         const wrapper = shallow(
             <TwoColumnModal
                 sidebar="Sidebar"
-                contents="Contents"
+                content="Contents"
                 onClickCloseButton={onClickCloseButton}
             />,
         );

--- a/packages/wonder-blocks-modal/package-lock.json
+++ b/packages/wonder-blocks-modal/package-lock.json
@@ -10,6 +10,23 @@
     "wonder-blocks-core": {
       "version": "file:../wonder-blocks-core"
     },
+    "wonder-blocks-grid": {
+      "version": "file:../wonder-blocks-grid",
+      "requires": {
+        "wonder-blocks-color": "file:../wonder-blocks-color",
+        "wonder-blocks-core": "file:../wonder-blocks-core"
+      },
+      "dependencies": {
+        "wonder-blocks-color": {
+          "version": "file:../wonder-blocks-color",
+          "bundled": true
+        },
+        "wonder-blocks-core": {
+          "version": "file:../wonder-blocks-core",
+          "bundled": true
+        }
+      }
+    },
     "wonder-blocks-typography": {
       "version": "file:../wonder-blocks-typography",
       "requires": {

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "wonder-blocks-color": "../wonder-blocks-color",
     "wonder-blocks-core": "../wonder-blocks-core",
+    "wonder-blocks-grid": "../wonder-blocks-grid",
     "wonder-blocks-typography": "../wonder-blocks-typography"
   }
 }

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -30,6 +30,7 @@ module.exports = {
             ignore: [
                 "**/components/modal-backdrop.js",
                 "**/components/modal-close-button.js",
+                "**/components/modal-footer.js",
                 "**/components/modal-launcher-portal.js",
             ],
         },


### PR DESCRIPTION
This diff adds in support for the one and two-column modal dialogs, using the new grid system. See #65 for the details of how the grid is ready.

A couple things that had fuzzy definitions in the design that I made a decision on:
* I added a 64px margin to the top and bottom of the modal, which seems to match the current design.
* I used a single 12-column grid for all two-column modals (which will be the same one I use for the standard modal, too).
* For the "11-column" modal the new design calls for a 128px space between the two pieces of text. I implemented that as: (in Sidebar: 32px space + 32px gutter + in Content: 64px space). This helps us to avoid having to implement a brand new type of grid just for this one modal.
* If the contents have a footer then I add a 48px padding to the bottom so that when the content scrolls up it looks nice (Zeplin shows it as 40px, but that's not one of our standard spacing sizes).

I haven't implemented mobile support yet, I'll handle that in a follow-up diff.