### PR TITLE
[modal] Mobile-optimized design for standard modal

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-launcher.md
+++ b/packages/wonder-blocks-modal/components/modal-launcher.md
@@ -4,6 +4,7 @@ const {View} = require("wonder-blocks-core");
 const {Title, Body} = require("wonder-blocks-typography");
 const ModalLauncher = require("./modal-launcher.js").default;
 const TwoColumnModal = require("./two-column-modal.js").default;
+const {smOrSmaller} = require("../util/util.js");
 
 const styles = StyleSheet.create({
     example: {
@@ -22,6 +23,11 @@ const styles = StyleSheet.create({
         paddingLeft: 32,
         paddingRight: 32,
         maxWidth: 544,
+
+        [smOrSmaller]: {
+            paddingLeft: 16,
+            paddingRight: 16,
+        },
     },
 });
 

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -11,6 +11,7 @@ import {
 } from "wonder-blocks-typography";
 
 import ModalCloseButton from "./modal-close-button.js";
+import {smOrSmaller} from "../util/util.js";
 
 type Props = {
     /**
@@ -114,6 +115,15 @@ const styles = StyleSheet.create({
         background: Color.white,
         borderRadius: 4,
         overflow: "hidden",
+
+        // On mobile, we consume the full screen size.
+        [smOrSmaller]: {
+            width: "100%",
+            height: "100%",
+            maxWidth: "none",
+            maxHeight: "none",
+            borderRadius: 0,
+        },
     },
 
     titlebar: {
@@ -132,6 +142,13 @@ const styles = StyleSheet.create({
         borderBottomStyle: "solid",
         borderBottomColor: Color.offBlack16,
         borderBottomWidth: 1,
+
+        // On mobile, the titlebar is more compact.
+        [smOrSmaller]: {
+            minHeight: 56,
+            paddingTop: 4,
+            paddingBottom: 4,
+        },
     },
 
     content: {

--- a/packages/wonder-blocks-modal/components/standard-modal.md
+++ b/packages/wonder-blocks-modal/components/standard-modal.md
@@ -5,6 +5,7 @@ const {StyleSheet, css} = require("aphrodite");
 const {View} = require("wonder-blocks-core");
 const {Title, Body} = require("wonder-blocks-typography");
 const StandardModal = require("./standard-modal.js").default;
+const {smOrSmaller} = require("../util/util.js");
 
 const styles = StyleSheet.create({
     previewSizer: {
@@ -21,7 +22,6 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",
-        padding: 32,
 
         position: "absolute",
         left: 0,
@@ -37,6 +37,11 @@ const styles = StyleSheet.create({
         paddingLeft: 32,
         paddingRight: 32,
         maxWidth: 544,
+
+        [smOrSmaller]: {
+            paddingLeft: 16,
+            paddingRight: 16,
+        },
     },
 });
 
@@ -68,6 +73,7 @@ const {StyleSheet, css} = require("aphrodite");
 const {View} = require("wonder-blocks-core");
 const {Title, Body} = require("wonder-blocks-typography");
 const StandardModal = require("./standard-modal.js").default;
+const {smOrSmaller} = require("../util/util.js");
 
 const styles = StyleSheet.create({
     previewSizer: {
@@ -84,7 +90,6 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",
-        padding: 32,
 
         position: "absolute",
         left: 0,
@@ -100,6 +105,11 @@ const styles = StyleSheet.create({
         paddingLeft: 32,
         paddingRight: 32,
         maxWidth: 544,
+
+        [smOrSmaller]: {
+            paddingLeft: 16,
+            paddingRight: 16,
+        },
     },
 });
 

--- a/packages/wonder-blocks-modal/components/two-column-modal.md
+++ b/packages/wonder-blocks-modal/components/two-column-modal.md
@@ -5,7 +5,11 @@ const {Title, Body} = require("wonder-blocks-typography");
 const TwoColumnModal = require("./two-column-modal.js").default;
 
 const styles = StyleSheet.create({
-    example: {
+    previewSizer: {
+        height: 512,
+    },
+
+    modalPositioner: {
         // Checkerboard background
         backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
         backgroundSize: "20px 20px",
@@ -13,8 +17,14 @@ const styles = StyleSheet.create({
 
         display: "flex",
         flexDirection: "row",
+        alignItems: "center",
         justifyContent: "center",
-        padding: 32,
+
+        position: "absolute",
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
     },
 
     title: {
@@ -22,35 +32,38 @@ const styles = StyleSheet.create({
     },
 });
 
-<View style={styles.example}>
-    <TwoColumnModal
-        leftContent={
-            <View>
-                <Title style={styles.title}>Left column</Title>
-                <Body>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-                    do eiusmod tempor incididunt ut labore et dolore magna
-                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                    ullamco laboris.
-                </Body>
-            </View>
-        }
-        rightContent={
-            <View>
-                <Title style={styles.title}>Right column</Title>
-                <Body>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-                    do eiusmod tempor incididunt ut labore et dolore magna
-                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                    Duis aute irure dolor in reprehenderit in voluptate velit
-                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-                    occaecat cupidatat non proident, sunt in culpa qui officia
-                    deserunt mollit anim id est.
-                </Body>
-            </View>
-        }
-        onClickCloseButton={() => alert("This would close the modal.")}
-    />
+<View style={styles.previewSizer}>
+    <View style={styles.modalPositioner}>
+        <TwoColumnModal
+            leftContent={
+                <View>
+                    <Title style={styles.title}>Left column</Title>
+                    <Body>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod tempor incididunt ut labore et dolore
+                        magna aliqua. Ut enim ad minim veniam, quis nostrud
+                        exercitation ullamco laboris.
+                    </Body>
+                </View>
+            }
+            rightContent={
+                <View>
+                    <Title style={styles.title}>Right column</Title>
+                    <Body>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod tempor incididunt ut labore et dolore
+                        magna aliqua. Ut enim ad minim veniam, quis nostrud
+                        exercitation ullamco laboris nisi ut aliquip ex ea
+                        commodo consequat. Duis aute irure dolor in
+                        reprehenderit in voluptate velit esse cillum dolore eu
+                        fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                        non proident, sunt in culpa qui officia deserunt mollit
+                        anim id est.
+                    </Body>
+                </View>
+            }
+            onClickCloseButton={() => alert("This would close the modal.")}
+        />
+    </View>
 </View>;
 ```

--- a/packages/wonder-blocks-modal/util/util.js
+++ b/packages/wonder-blocks-modal/util/util.js
@@ -1,0 +1,3 @@
+// TODO(mdr): What's our media query story in Wonder Blocks? For now, I just
+//     copied the `smOrSmaller` breakpoint from the Khan Academy webapp.
+export const smOrSmaller = "@media (max-width: 767px)";


### PR DESCRIPTION
In this change, we add mobile-optimized styles to `StandardModal`. We also tweak the example styles, to more accurately showcase mobile design.

We're not tackling other modal layouts yet; that's WB-130. Instead, we're producing one mobile layout, to showcase overall mobile behavior and get high-level design feedback, without slowing down iteration on the other modal layouts with this additional layer of complexity.

We also don't yet prevent the document from scrolling when this modal is open. That's up next, in WB-149.

(When tweaking the examples, I noticed that callers are currently responsible for a number of content style decisions, like content area padding on desktop and mobile, which we might want to standardize. We _don't_ want to include this padding in _all_ modals, because many modals don't need it and want to be full-bleed—but maybe it should be a default padding controlled by a flag, or there should be a `ModalContent` component? Long-term food for thought!)

# Test Plan:
Styleguidist examples for `StandardModal` look great on mobile!
![screenshot](https://user-images.githubusercontent.com/59218/39539682-310652da-4df5-11e8-92a0-2b9ca3308e03.png)

Here it is launched on the page.
![screenshot](https://user-images.githubusercontent.com/59218/39539714-482bb8b0-4df5-11e8-9122-9b2354f0c231.png)

Also, confirm that all the examples still look as expected on desktop.
![screenshot](https://user-images.githubusercontent.com/59218/39539752-61187ff2-4df5-11e8-9167-162b6a5ba1e3.png)
