### PR TITLE
Get Grid ready for Modals.

### DIFF
--- a/packages/wonder-blocks-grid/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-grid/__snapshots__/generated-snapshot.test.js.snap
@@ -30,6 +30,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "height": "100%",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -44,6 +45,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -121,6 +123,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "WebkitFlexBasis": 32,
               "flexBasis": 32,
               "flexShrink": 0,
+              "width": 32,
             }
           }
         />
@@ -144,6 +147,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
+              "width": 100,
             }
           }
         >
@@ -190,6 +194,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "WebkitFlexBasis": 32,
               "flexBasis": 32,
               "flexShrink": 0,
+              "width": 32,
             }
           }
         />
@@ -213,6 +218,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
+              "width": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
             }
           }
         >
@@ -259,6 +265,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "WebkitFlexBasis": 32,
               "flexBasis": 32,
               "flexShrink": 0,
+              "width": 32,
             }
           }
         />
@@ -282,6 +289,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
+              "width": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
             }
           }
         >
@@ -348,6 +356,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -390,6 +399,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "height": "100%",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -404,6 +414,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -428,6 +439,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -452,6 +464,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "height": "100%",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -466,6 +479,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -489,6 +503,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -514,6 +529,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "height": "100%",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -528,6 +544,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -540,6 +557,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
               "flexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
               "flexShrink": 0,
+              "width": "calc((100% - 352px - 48px) * 0.25 + 64px)",
             }
           }
         >
@@ -554,6 +572,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 32,
               "flexBasis": 32,
               "flexShrink": 0,
+              "width": 32,
             }
           }
         />
@@ -572,6 +591,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -595,6 +615,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "height": "100%",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -609,6 +630,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />
@@ -621,6 +643,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
               "flexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
               "flexShrink": 0,
+              "width": "calc((100% - 352px - 48px) * 0.25 + 64px)",
             }
           }
         >
@@ -643,6 +666,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 32,
               "flexBasis": 32,
               "flexShrink": 0,
+              "width": 32,
             }
           }
         />
@@ -691,6 +715,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "WebkitFlexBasis": 24,
               "flexBasis": 24,
               "flexShrink": 0,
+              "width": 24,
             }
           }
         />

--- a/packages/wonder-blocks-grid/components/fixed-width-cell.js
+++ b/packages/wonder-blocks-grid/components/fixed-width-cell.js
@@ -117,7 +117,7 @@ export default class FixedWidthCell extends React.Component<Props> {
         }
 
         return (
-            <View style={[styles.cellFixed, flexBasis(width), style]}>
+            <View style={[styles.cellFixed, flexBasis(width), {width}, style]}>
                 {contents}
             </View>
         );

--- a/packages/wonder-blocks-grid/components/flex-cell.js
+++ b/packages/wonder-blocks-grid/components/flex-cell.js
@@ -9,11 +9,11 @@ import type {GridSize} from "../util/types.js";
 
 type Props = {
     /** Should this cell be shown on a Small Grid? */
-    small?: boolean,
+    small: boolean,
     /** Should this cell be shown on a Medium Grid? */
-    medium?: boolean,
+    medium: boolean,
     /** Should this cell be shown on a Large Grid? */
-    large?: boolean,
+    large: boolean,
     /**
      * The child components to populate inside the cell. Can also accept a
      * function which receives the `gridSize` and `totalColumns` and should

--- a/packages/wonder-blocks-grid/components/grid.js
+++ b/packages/wonder-blocks-grid/components/grid.js
@@ -30,7 +30,7 @@ type Props = {
     spec: GridSpec,
 
     /** The `<Row>` components that will make up the grid */
-    children: React.ChildrenArray<Row>,
+    children: React.Node,
 };
 
 /**
@@ -66,7 +66,7 @@ export default class Grid extends React.Component<
     },
 > {
     static WATCHERS: {
-        [size: GridSize]: any,
+        [query: string]: any,
     } = {};
 
     static defaultProps = {
@@ -104,6 +104,11 @@ export default class Grid extends React.Component<
         this.watchHandlers = {};
 
         for (const size of VALID_GRID_SIZES) {
+            // Skip sizes that aren't defined
+            if (!spec[size]) {
+                continue;
+            }
+
             const {query} = spec[size];
 
             // Don't watch sizes that don't have an associated query
@@ -112,11 +117,11 @@ export default class Grid extends React.Component<
             }
 
             // Create a new matchMedia watcher if one doesn't exist yet
-            if (!Grid.WATCHERS[size]) {
-                Grid.WATCHERS[size] = window.matchMedia(query);
+            if (!Grid.WATCHERS[query]) {
+                Grid.WATCHERS[query] = window.matchMedia(query);
             }
 
-            const watcher = Grid.WATCHERS[size];
+            const watcher = Grid.WATCHERS[query];
 
             // Attach a handler that watches for the change, saving a
             // references to it so we can remove it later
@@ -154,7 +159,14 @@ export default class Grid extends React.Component<
         // We go through the component and remove all of the listeners
         // that this Grid attached.
         for (const size of VALID_GRID_SIZES) {
-            const watcher = Grid.WATCHERS[size];
+            // Skip sizes that aren't defined
+            if (!spec[size]) {
+                continue;
+            }
+
+            const {query} = spec[size];
+            const watcher = Grid.WATCHERS[query];
+
             if (watcher) {
                 const handler = this.watchHandlers[size];
                 watcher.removeListener(handler);
@@ -185,7 +197,7 @@ class GridContext extends React.Component<{
     spec: GridSpec,
 
     // The Row components that will make up the grid
-    children: React.ChildrenArray<Row>,
+    children: React.Node,
 }> {
     static childContextTypes = gridContextTypes;
 

--- a/packages/wonder-blocks-grid/components/gutter.js
+++ b/packages/wonder-blocks-grid/components/gutter.js
@@ -22,11 +22,11 @@ import FixedWidthCell from "./fixed-width-cell.js";
  */
 export default class Gutter extends React.Component<{
     /** Should this gutter be shown on a Small Grid? */
-    small?: boolean,
+    small: boolean,
     /** Should this gutter be shown on a Medium Grid? */
-    medium?: boolean,
+    medium: boolean,
     /** Should this gutter be shown on a Large Grid? */
-    large?: boolean,
+    large: boolean,
 }> {
     static contextTypes = gridContextTypes;
     static defaultProps = {

--- a/packages/wonder-blocks-grid/index.js
+++ b/packages/wonder-blocks-grid/index.js
@@ -1,10 +1,10 @@
 // @flow
-export * from "./components/cell.js";
-export * from "./components/fixed-width-cell.js";
-export * from "./components/flex-cell.js";
-export * from "./components/grid.js";
-export * from "./components/gutter.js";
-export * from "./components/row.js";
+export {default as Cell} from "./components/cell.js";
+export {default as FixedWidthCell} from "./components/fixed-width-cell.js";
+export {default as FlexCell} from "./components/flex-cell.js";
+export {default as Grid} from "./components/grid.js";
+export {default as Gutter} from "./components/gutter.js";
+export {default as Row} from "./components/row.js";
 
 export * from "./util/specs.js";
 

--- a/packages/wonder-blocks-grid/util/specs.js
+++ b/packages/wonder-blocks-grid/util/specs.js
@@ -39,8 +39,8 @@ export const GRID_INTERNAL_SPEC: GridSpec = {
     },
 };
 
-// The default used for modals
-export const GRID_MODAL_12_SPEC: GridSpec = {
+// The default grid used for modals
+export const GRID_MODAL_SPEC: GridSpec = {
     small: {
         query: "(max-width: 767px)",
         totalColumns: 4,
@@ -50,38 +50,6 @@ export const GRID_MODAL_12_SPEC: GridSpec = {
     large: {
         query: "(min-width: 768px)",
         totalColumns: 12,
-        gutterWidth: 32,
-        marginWidth: 64,
-    },
-};
-
-// The odd-sized modal
-export const GRID_MODAL_11_SPEC: GridSpec = {
-    small: {
-        query: "(max-width: 767px)",
-        totalColumns: 4,
-        gutterWidth: 16,
-        marginWidth: 16,
-    },
-    large: {
-        query: "(min-width: 768px)",
-        totalColumns: 11,
-        gutterWidth: 32,
-        marginWidth: 64,
-    },
-};
-
-// Smaller modal
-export const GRID_MODAL_8_SPEC: GridSpec = {
-    small: {
-        query: "(max-width: 767px)",
-        totalColumns: 4,
-        gutterWidth: 16,
-        marginWidth: 16,
-    },
-    large: {
-        query: "(min-width: 768px)",
-        totalColumns: 8,
         gutterWidth: 32,
         marginWidth: 64,
     },

--- a/packages/wonder-blocks-grid/util/styles.js
+++ b/packages/wonder-blocks-grid/util/styles.js
@@ -12,6 +12,7 @@ const styles = StyleSheet.create({
     row: {
         display: "flex",
         width: "100%",
+        height: "100%",
     },
 
     rowMaxWidth: {

--- a/packages/wonder-blocks-grid/util/utils.js
+++ b/packages/wonder-blocks-grid/util/utils.js
@@ -4,11 +4,7 @@ import propTypes from "prop-types";
 import type {GridSize} from "./types.js";
 
 export const matchesSize = (
-    {
-        small,
-        medium,
-        large,
-    }: {small?: boolean, medium?: boolean, large?: boolean},
+    {small, medium, large}: {small: boolean, medium: boolean, large: boolean},
     gridSize: GridSize,
 ) =>
     (!small && !medium && !large) ||


### PR DESCRIPTION
This diff includes a number of changes related to grids to get them ready for modals. See #62 for the details of how it will be used.

Major changes:

* Improved the handling of fixed-width cells in the Grid so that they wouldn't forcefully grow if their contents were larger than the cell.
* Added a new `flush` property to Rows to make the contents do a couple things: 1) Margins are removed and the first and last cells expand to consume the margins (adding padding inside of them automatically). 2) Gutters are removed and the width of the gutter is added to the cell before as padding.
* Fixed a bug with modal grids where their "small" size wasn't being detected as the naming of the different grids conflicted with each other.
* Reduced the number of modal grid layouts down to just one.