### PR TITLE
Update View and Text to pass along unknown props

### DIFF
--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -3,7 +3,6 @@
 exports[`wonder-blocks-core example 1 1`] = `
 <div
   className=""
-  onClick={undefined}
   style={
     Object {
       "backgroundColor": "plum",
@@ -23,6 +22,33 @@ exports[`wonder-blocks-core example 1 1`] = `
     }
   >
     Hello, world!
+  </span>
+</div>
+`;
+
+exports[`wonder-blocks-core example 2 1`] = `
+<div
+  className=""
+  style={Object {}}
+>
+  <div
+    className=""
+    onClick={[Function]}
+    style={Object {}}
+  >
+    Click me!
+  </div>
+  <span
+    aria-hidden={true}
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+      }
+    }
+  >
+    This text is hidden from screen readers.
   </span>
 </div>
 `;

--- a/packages/wonder-blocks-core/components/text.js
+++ b/packages/wonder-blocks-core/components/text.js
@@ -9,6 +9,7 @@ type Props = {
     style?: any,
     tag: TextTag,
     children?: any,
+    [otherProp: string]: any,
 };
 
 const isHeaderRegex = /^h[1-6]$/;
@@ -35,17 +36,21 @@ export default class Text extends React.Component<Props> {
     };
 
     render() {
-        const isHeader = isHeaderRegex.test(this.props.tag);
-        const {className, style} = processStyleList([
+        const {children, style, tag: Tag, ...otherProps} = this.props;
+
+        const isHeader = isHeaderRegex.test(Tag);
+        const styleAttributes = processStyleList([
             styles.text,
             isHeader && styles.header,
             this.props.style,
         ]);
 
-        const Tag = this.props.tag;
-
         return (
-            <Tag style={style} className={className}>
+            <Tag
+                {...otherProps}
+                style={styleAttributes.style}
+                className={styleAttributes.className}
+            >
                 {this.props.children}
             </Tag>
         );

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -9,15 +9,16 @@ export default class View extends React.Component<Props> {
     props: Props;
 
     render() {
-        const {className, style} = processStyleList(this.props.style);
+        const {children, style, ...otherProps} = this.props;
+        const styleAttributes = processStyleList(style);
 
         return (
             <div
-                style={style}
-                className={className}
-                onClick={this.props.onClick}
+                {...otherProps}
+                style={styleAttributes.style}
+                className={styleAttributes.className}
             >
-                {this.props.children}
+                {children}
             </div>
         );
     }

--- a/packages/wonder-blocks-core/docs.md
+++ b/packages/wonder-blocks-core/docs.md
@@ -24,3 +24,17 @@ const styles = StyleSheet.create({
     </Text>
 </View>
 ```
+
+Other props can be passed through `View` or `Text`, as if they were normal tags.
+
+```js
+<View>
+    <View onClick={() => alert("Clicked!")}>
+        Click me!
+    </View>
+
+    <Text aria-hidden>
+        This text is hidden from screen readers.
+    </Text>
+</View>
+```

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -9,7 +9,7 @@ import View from "./components/view.js";
 describe("wonder-blocks-core", () => {
     it("example 1", () => {
         const {StyleSheet} = require("aphrodite");
-        
+
         const styles = StyleSheet.create({
             container: {
                 padding: 32,
@@ -20,12 +20,25 @@ describe("wonder-blocks-core", () => {
                 fontSize: 24,
             },
         });
-        
-        const example = <View style={styles.container}>
-            <Text style={styles.text}>
-                Hello, world!
-            </Text>
-        </View>
+
+        const example = (
+            <View style={styles.container}>
+                <Text style={styles.text}>Hello, world!</Text>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 2", () => {
+        const example = (
+            <View>
+                <View onClick={() => alert("Clicked!")}>Click me!</View>
+
+                <Text aria-hidden>
+                    This text is hidden from screen readers.
+                </Text>
+            </View>
+        );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -11,9 +11,8 @@ export type StyleType<T: Object> = any; // eslint-disable-line no-unused-vars
 
 export type Props = {
     style?: any,
-    tag?: string,
     children?: any,
-    onClick?: (e: SyntheticEvent<HTMLDivElement>) => mixed,
+    [otherProp: string]: any,
 };
 
 export type TextTag = "span" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";

--- a/packages/wonder-blocks-grid/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-grid/__snapshots__/generated-snapshot.test.js.snap
@@ -3,7 +3,6 @@
 exports[`wonder-blocks-grid example 1 1`] = `
 <div
   className=""
-  onClick={undefined}
   style={
     Object {
       "background": "#21242c",
@@ -12,12 +11,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
 >
   <div
     className=""
-    onClick={undefined}
     style={Object {}}
   >
     <div
       className=""
-      onClick={undefined}
       style={
         Object {
           "alignItems": "center",
@@ -27,7 +24,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
     >
       <div
         className=""
-        onClick={undefined}
         style={
           Object {
             "@media (min-width: 1168px)": Object {
@@ -41,7 +37,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
       >
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -54,7 +49,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "@media (max-width: 767px)": Object {
@@ -99,7 +93,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
           <br />
           <div
             className=""
-            onClick={undefined}
             style={
               Object {
                 "textAlign": "right",
@@ -121,7 +114,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 32,
@@ -134,7 +126,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "@media (max-width: 767px)": Object {
@@ -171,7 +162,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
           <br />
           <div
             className=""
-            onClick={undefined}
             style={
               Object {
                 "textAlign": "center",
@@ -193,7 +183,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 32,
@@ -206,7 +195,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "@media (max-width: 767px)": Object {
@@ -243,7 +231,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
           <br />
           <div
             className=""
-            onClick={undefined}
             style={
               Object {
                 "textAlign": "center",
@@ -265,7 +252,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 32,
@@ -278,7 +264,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "@media (max-width: 767px)": Object {
@@ -302,7 +287,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         >
           <div
             className=""
-            onClick={undefined}
             style={Object {}}
           >
             <span
@@ -335,7 +319,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
             <br />
             <div
               className=""
-              onClick={undefined}
               style={
                 Object {
                   "textAlign": "right",
@@ -358,7 +341,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -378,7 +360,6 @@ exports[`wonder-blocks-grid example 1 1`] = `
 exports[`wonder-blocks-grid example 2 1`] = `
 <div
   className=""
-  onClick={undefined}
   style={
     Object {
       "background": "#f7f8fa",
@@ -387,12 +368,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
 >
   <div
     className=""
-    onClick={undefined}
     style={Object {}}
   >
     <div
       className=""
-      onClick={undefined}
       style={
         Object {
           "alignItems": "center",
@@ -405,7 +384,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
     >
       <div
         className=""
-        onClick={undefined}
         style={
           Object {
             "@media (min-width: 1168px)": Object {
@@ -419,7 +397,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
       >
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -432,7 +409,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "color": "#ffffff",
@@ -445,7 +421,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -460,7 +435,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
     </div>
     <div
       className=""
-      onClick={undefined}
       style={
         Object {
           "alignItems": "center",
@@ -472,7 +446,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
     >
       <div
         className=""
-        onClick={undefined}
         style={
           Object {
             "@media (min-width: 1168px)": Object {
@@ -486,7 +459,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
       >
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -499,7 +471,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "color": "#ffffff",
@@ -511,7 +482,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -526,7 +496,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
     </div>
     <div
       className=""
-      onClick={undefined}
       style={
         Object {
           "alignItems": "center",
@@ -539,7 +508,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
     >
       <div
         className=""
-        onClick={undefined}
         style={
           Object {
             "@media (min-width: 1168px)": Object {
@@ -553,7 +521,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
       >
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -566,7 +533,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
@@ -581,7 +547,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 32,
@@ -594,14 +559,12 @@ exports[`wonder-blocks-grid example 2 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={Object {}}
         >
           Beginner / Points to Apprentice
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -616,7 +579,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
     </div>
     <div
       className=""
-      onClick={undefined}
       style={
         Object {
           "alignItems": "center",
@@ -627,7 +589,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
     >
       <div
         className=""
-        onClick={undefined}
         style={
           Object {
             "@media (min-width: 1168px)": Object {
@@ -641,7 +602,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
       >
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,
@@ -654,7 +614,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
@@ -677,7 +636,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 32,
@@ -690,7 +648,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         />
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "flexGrow": 1,
@@ -699,7 +656,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         >
           <div
             className=""
-            onClick={undefined}
             style={
               Object {
                 "background": "#ffffff",
@@ -713,7 +669,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
           </div>
           <div
             className=""
-            onClick={undefined}
             style={
               Object {
                 "background": "#ffffff",
@@ -729,7 +684,6 @@ exports[`wonder-blocks-grid example 2 1`] = `
         </div>
         <div
           className=""
-          onClick={undefined}
           style={
             Object {
               "MsFlexBasis": 24,

--- a/packages/wonder-blocks-typography/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-typography/__snapshots__/generated-snapshot.test.js.snap
@@ -3,7 +3,6 @@
 exports[`wonder-blocks-typography example 1 1`] = `
 <div
   className=""
-  onClick={undefined}
   style={Object {}}
 >
   <h1


### PR DESCRIPTION
In this change, we allow `View` and `Text` to accept arbitrary props to pass along to the wrapper HTML element. This enables event handlers like `onClick`, and accessibility features like `id` and `aria-hidden`.

# Test Plan:
In Styleguidist, look at the new example in the "Core" section.

Click the words "Click me!", and see an alert appear.

Use a screen reader (I used VoiceOver in Safari), and observe that the screen reader does not recognize the text "This text is hidden from screen readers.".