### PR TITLE
[typography] Type components now accept an `id` prop

### DIFF
--- a/packages/wonder-blocks-typography/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-typography/__snapshots__/generated-snapshot.test.js.snap
@@ -7,6 +7,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
 >
   <h1
     className=""
+    id="example-Title"
     style={
       Object {
         "@media (max-width: 1023px)": Object {
@@ -31,6 +32,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </h1>
   <h2
     className=""
+    id="example-HeadingLarge"
     style={
       Object {
         "@media (max-width: 1023px)": Object {
@@ -55,6 +57,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </h2>
   <h3
     className=""
+    id="example-HeadingMedium"
     style={
       Object {
         "@media (max-width: 1023px)": Object {
@@ -79,6 +82,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </h3>
   <h4
     className=""
+    id="example-HeadingSmall"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -97,6 +101,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </h4>
   <h4
     className=""
+    id="example-HeadingXSmall"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -117,6 +122,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </h4>
   <span
     className=""
+    id="example-BodySerifBlock"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -133,6 +139,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-BodySerif"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -149,6 +156,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-BodyMonospace"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -165,6 +173,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-Body"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -181,6 +190,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-LabelLarge"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -197,6 +207,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-LabelMedium"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -213,6 +224,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-LabelSmall"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -229,6 +241,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-LabelXSmall"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -245,6 +258,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-Tagline"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -261,6 +275,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-Caption"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -277,6 +292,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
   </span>
   <span
     className=""
+    id="example-Footnote"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -297,6 +313,7 @@ exports[`wonder-blocks-typography example 1 1`] = `
 exports[`wonder-blocks-typography example 2 1`] = `
 <h1
   className=""
+  id={undefined}
   style={
     Object {
       "@media (max-width: 1023px)": Object {

--- a/packages/wonder-blocks-typography/components/body-monospace.js
+++ b/packages/wonder-blocks-typography/components/body-monospace.js
@@ -12,9 +12,9 @@ export default class BodyMonospace extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.BodyMonospace, style]}>
+            <Text id={id} tag={tag} style={[styles.BodyMonospace, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/body-serif-block.js
+++ b/packages/wonder-blocks-typography/components/body-serif-block.js
@@ -12,9 +12,9 @@ export default class BodySerifBlock extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.BodySerifBlock, style]}>
+            <Text id={id} tag={tag} style={[styles.BodySerifBlock, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/body-serif.js
+++ b/packages/wonder-blocks-typography/components/body-serif.js
@@ -12,9 +12,9 @@ export default class BodySerif extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.BodySerif, style]}>
+            <Text id={id} tag={tag} style={[styles.BodySerif, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/body.js
+++ b/packages/wonder-blocks-typography/components/body.js
@@ -12,9 +12,9 @@ export default class Body extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.Body, style]}>
+            <Text id={id} tag={tag} style={[styles.Body, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/caption.js
+++ b/packages/wonder-blocks-typography/components/caption.js
@@ -12,9 +12,9 @@ export default class Caption extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.Caption, style]}>
+            <Text id={id} tag={tag} style={[styles.Caption, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/footnote.js
+++ b/packages/wonder-blocks-typography/components/footnote.js
@@ -12,9 +12,9 @@ export default class Footnote extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.Footnote, style]}>
+            <Text id={id} tag={tag} style={[styles.Footnote, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/heading-large.js
+++ b/packages/wonder-blocks-typography/components/heading-large.js
@@ -12,9 +12,9 @@ export default class HeadingLarge extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.HeadingLarge, style]}>
+            <Text id={id} tag={tag} style={[styles.HeadingLarge, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/heading-medium.js
+++ b/packages/wonder-blocks-typography/components/heading-medium.js
@@ -12,9 +12,9 @@ export default class HeadingMedium extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.HeadingMedium, style]}>
+            <Text id={id} tag={tag} style={[styles.HeadingMedium, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/heading-small.js
+++ b/packages/wonder-blocks-typography/components/heading-small.js
@@ -12,9 +12,9 @@ export default class HeadingSmall extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.HeadingSmall, style]}>
+            <Text id={id} tag={tag} style={[styles.HeadingSmall, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/heading-xsmall.js
+++ b/packages/wonder-blocks-typography/components/heading-xsmall.js
@@ -12,9 +12,9 @@ export default class HeadingXSmall extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.HeadingXSmall, style]}>
+            <Text id={id} tag={tag} style={[styles.HeadingXSmall, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/label-large.js
+++ b/packages/wonder-blocks-typography/components/label-large.js
@@ -12,9 +12,9 @@ export default class LabelLarge extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.LabelLarge, style]}>
+            <Text id={id} tag={tag} style={[styles.LabelLarge, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/label-medium.js
+++ b/packages/wonder-blocks-typography/components/label-medium.js
@@ -12,9 +12,9 @@ export default class LabelMedium extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.LabelMedium, style]}>
+            <Text id={id} tag={tag} style={[styles.LabelMedium, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/label-small.js
+++ b/packages/wonder-blocks-typography/components/label-small.js
@@ -12,9 +12,9 @@ export default class LabelSmall extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.LabelSmall, style]}>
+            <Text id={id} tag={tag} style={[styles.LabelSmall, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/label-xsmall.js
+++ b/packages/wonder-blocks-typography/components/label-xsmall.js
@@ -12,9 +12,9 @@ export default class LabelXSmall extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.LabelXSmall, style]}>
+            <Text id={id} tag={tag} style={[styles.LabelXSmall, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/tagline.js
+++ b/packages/wonder-blocks-typography/components/tagline.js
@@ -12,9 +12,9 @@ export default class Tagline extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.Tagline, style]}>
+            <Text id={id} tag={tag} style={[styles.Tagline, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/components/title.js
+++ b/packages/wonder-blocks-typography/components/title.js
@@ -14,9 +14,9 @@ export default class Title extends Component<Props> {
     };
 
     render() {
-        const {tag, style, children} = this.props;
+        const {id, tag, style, children} = this.props;
         return (
-            <Text tag={tag} style={[styles.Title, style]}>
+            <Text id={id} tag={tag} style={[styles.Title, style]}>
                 {children}
             </Text>
         );

--- a/packages/wonder-blocks-typography/docs.md
+++ b/packages/wonder-blocks-typography/docs.md
@@ -1,27 +1,30 @@
 ```js
 const {View} = require("wonder-blocks-core");
 
+// NOTE(mdr): I added an `id` attribute to each of these tags, to ensure that
+//     they all pass the `id` attribute correctly. This fact will be saved in
+//     snapshot tests.
 <View>
-    <Title>Title</Title>
-    <HeadingLarge>HeadingLarge</HeadingLarge>
-    <HeadingMedium>HeadingMedium</HeadingMedium>
-    <HeadingSmall>HeadingSmall</HeadingSmall>
-    <HeadingXSmall>HeadingXSmall</HeadingXSmall>
-    <BodySerifBlock>BodySerifBlock</BodySerifBlock>
-    <BodySerif>BodySerif</BodySerif>
-    <BodyMonospace>BodyMonospace</BodyMonospace>
-    <Body>Body</Body>
-    <LabelLarge>LabelLarge</LabelLarge>
-    <LabelMedium>LabelMedium</LabelMedium>
-    <LabelSmall>LabelSmall</LabelSmall>
-    <LabelXSmall>LabelXSmall</LabelXSmall>
-    <Tagline>Tagline</Tagline>
-    <Caption>Caption</Caption>
-    <Footnote>Footnote</Footnote>
+    <Title id="example-Title">Title</Title>
+    <HeadingLarge id="example-HeadingLarge">HeadingLarge</HeadingLarge>
+    <HeadingMedium id="example-HeadingMedium">HeadingMedium</HeadingMedium>
+    <HeadingSmall id="example-HeadingSmall">HeadingSmall</HeadingSmall>
+    <HeadingXSmall id="example-HeadingXSmall">HeadingXSmall</HeadingXSmall>
+    <BodySerifBlock id="example-BodySerifBlock">BodySerifBlock</BodySerifBlock>
+    <BodySerif id="example-BodySerif">BodySerif</BodySerif>
+    <BodyMonospace id="example-BodyMonospace">BodyMonospace</BodyMonospace>
+    <Body id="example-Body">Body</Body>
+    <LabelLarge id="example-LabelLarge">LabelLarge</LabelLarge>
+    <LabelMedium id="example-LabelMedium">LabelMedium</LabelMedium>
+    <LabelSmall id="example-LabelSmall">LabelSmall</LabelSmall>
+    <LabelXSmall id="example-LabelXSmall">LabelXSmall</LabelXSmall>
+    <Tagline id="example-Tagline">Tagline</Tagline>
+    <Caption id="example-Caption">Caption</Caption>
+    <Footnote id="example-Footnote">Footnote</Footnote>
 </View>
 ```
 
-You can change the color of text with the `color` prop:
+You can change the color of text with the `style` prop:
 
 ```js
 const Color = require("wonder-blocks-color").default;

--- a/packages/wonder-blocks-typography/generated-snapshot.test.js
+++ b/packages/wonder-blocks-typography/generated-snapshot.test.js
@@ -23,39 +23,56 @@ import Title from "./components/title.js";
 describe("wonder-blocks-typography", () => {
     it("example 1", () => {
         const {View} = require("wonder-blocks-core");
-        
-        const example = <View>
-            <Title>Title</Title>
-            <HeadingLarge>HeadingLarge</HeadingLarge>
-            <HeadingMedium>HeadingMedium</HeadingMedium>
-            <HeadingSmall>HeadingSmall</HeadingSmall>
-            <HeadingXSmall>HeadingXSmall</HeadingXSmall>
-            <BodySerifBlock>BodySerifBlock</BodySerifBlock>
-            <BodySerif>BodySerif</BodySerif>
-            <BodyMonospace>BodyMonospace</BodyMonospace>
-            <Body>Body</Body>
-            <LabelLarge>LabelLarge</LabelLarge>
-            <LabelMedium>LabelMedium</LabelMedium>
-            <LabelSmall>LabelSmall</LabelSmall>
-            <LabelXSmall>LabelXSmall</LabelXSmall>
-            <Tagline>Tagline</Tagline>
-            <Caption>Caption</Caption>
-            <Footnote>Footnote</Footnote>
-        </View>
+
+        // NOTE(mdr): I added an `id` attribute to each of these tags, to ensure that
+        //     they all pass the `id` attribute correctly. This fact will be saved in
+        //     snapshot tests.
+        const example = (
+            <View>
+                <Title id="example-Title">Title</Title>
+                <HeadingLarge id="example-HeadingLarge">
+                    HeadingLarge
+                </HeadingLarge>
+                <HeadingMedium id="example-HeadingMedium">
+                    HeadingMedium
+                </HeadingMedium>
+                <HeadingSmall id="example-HeadingSmall">
+                    HeadingSmall
+                </HeadingSmall>
+                <HeadingXSmall id="example-HeadingXSmall">
+                    HeadingXSmall
+                </HeadingXSmall>
+                <BodySerifBlock id="example-BodySerifBlock">
+                    BodySerifBlock
+                </BodySerifBlock>
+                <BodySerif id="example-BodySerif">BodySerif</BodySerif>
+                <BodyMonospace id="example-BodyMonospace">
+                    BodyMonospace
+                </BodyMonospace>
+                <Body id="example-Body">Body</Body>
+                <LabelLarge id="example-LabelLarge">LabelLarge</LabelLarge>
+                <LabelMedium id="example-LabelMedium">LabelMedium</LabelMedium>
+                <LabelSmall id="example-LabelSmall">LabelSmall</LabelSmall>
+                <LabelXSmall id="example-LabelXSmall">LabelXSmall</LabelXSmall>
+                <Tagline id="example-Tagline">Tagline</Tagline>
+                <Caption id="example-Caption">Caption</Caption>
+                <Footnote id="example-Footnote">Footnote</Footnote>
+            </View>
+        );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
     it("example 2", () => {
         const Color = require("wonder-blocks-color").default;
         const {StyleSheet} = require("aphrodite");
-        
+
         const styles = StyleSheet.create({
             blueText: {
                 color: Color.blue,
             },
         });
-        
-        const example = <Title style={styles.blueText}>Blue Title</Title>
+
+        const example = <Title style={styles.blueText}>Blue Title</Title>;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-typography/util/types.js
+++ b/packages/wonder-blocks-typography/util/types.js
@@ -5,5 +5,6 @@ import type {TextTag} from "wonder-blocks-core";
 export type Props = {
     style?: any,
     children?: string,
+    id?: string,
     tag: TextTag,
 };


### PR DESCRIPTION
In this change, we add an `id` prop to typography components. This enables us to identify these nodes to screen readers, for cases like `aria-labelledby`.

Depends on #68, which enables `Text` to accept arbitrary props.

# Test Plan:
Open the typography section in styleguidist. Confirm that all typography tags in the first example have their `id` set correctly.