### PR TITLE
[modal] First draft of ARIA dialog behavior

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import {StyleSheet} from "aphrodite";
 
 import Color from "wonder-blocks-color";
@@ -35,6 +36,26 @@ export default class ModalBackdrop extends React.Component<Props> {
             this.props.onCloseModal();
         }
     };
+
+    componentDidMount() {
+        // Focus the last button in the modal, on the assumption that it'll be
+        // a sensible default action.
+        //
+        // TODO(mdr): Not sure how robust this is; or whether we'll sometimes
+        //     want the default to be something in the modal content, or a
+        //     different button, or something else.
+        const node: HTMLElement = (ReactDOM.findDOMNode(this): any);
+        if (!node) {
+            return;
+        }
+
+        const buttons = node.querySelectorAll("button");
+        const lastButton = buttons[buttons.length - 1];
+        if (!lastButton) {
+            return;
+        }
+        lastButton.focus();
+    }
 
     render() {
         const children = this.props.children;

--- a/packages/wonder-blocks-modal/components/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.test.js
@@ -165,4 +165,20 @@ describe("ModalBackdrop", () => {
             expect(customOnClickCloseButton).toHaveBeenCalled();
         },
     );
+
+    test("On mount, we focus the last button in the modal", () => {
+        const wrapper = mount(
+            <ModalBackdrop onCloseModal={() => {}}>
+                <div>
+                    <button />
+                    <button />
+                    <button data-last-button />
+                </div>
+            </ModalBackdrop>,
+        );
+
+        const focusedElement: HTMLElement = (document.activeElement: any);
+        expect(focusedElement).toBeTruthy();
+        expect(focusedElement.hasAttribute("data-last-button")).toBe(true);
+    });
 });

--- a/packages/wonder-blocks-modal/components/modal-launcher.md
+++ b/packages/wonder-blocks-modal/components/modal-launcher.md
@@ -34,6 +34,7 @@ const styles = StyleSheet.create({
 const standardModal = ({closeModal}) => (
     <StandardModal
         title="Title"
+        subtitle="You're reading the subtitle!"
         content={
             <View style={styles.modalContent}>
                 <Body tag="p">

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -74,6 +74,10 @@ export default class StandardModal extends React.Component<Props> {
 
         // Generate a unique ID for this modal. Math.random() isn't great, but
         // collisions on the same page should be pretty unlikely.
+        //
+        // TODO(mdr): Once we add snapshot testing, will this break it? We might
+        //     need to figure out how to seed the PRNG, or mock Math.random, or
+        //     find a different approach altogether.
         const modalId = Math.random()
             .toString(36)
             .substr(2);

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -11,7 +11,7 @@ import {
 } from "wonder-blocks-typography";
 
 import ModalCloseButton from "./modal-close-button.js";
-import {smOrSmaller} from "../util/util.js";
+import {smOrSmaller, generateUniqueId} from "../util/util.js";
 
 type Props = {
     /**
@@ -72,15 +72,12 @@ export default class StandardModal extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        // Generate a unique ID for this modal. Math.random() isn't great, but
-        // collisions on the same page should be pretty unlikely.
+        // Generate a unique ID for this modal.
         //
-        // TODO(mdr): Once we add snapshot testing, will this break it? We might
-        //     need to figure out how to seed the PRNG, or mock Math.random, or
-        //     find a different approach altogether.
-        const modalId = Math.random()
-            .toString(36)
-            .substr(2);
+        // TODO(mdr): Once we add snapshot tests for modals, we'll need to
+        //     ensure that this function is deterministic, perhaps by mocking
+        //     it during the snapshot test.
+        const modalId = generateUniqueId();
 
         // Use that unique ID number to generate unique ID strings for this
         // modal's elements.

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -62,9 +62,6 @@ export default class StandardModal extends React.Component<Props> {
     /** A unique HTML ID for the title element. */
     _titleId: string;
 
-    /** A unique HTML ID for the subtitle element. */
-    _subtitleId: string;
-
     static defaultProps = {
         onClickCloseButton: () => {},
     };
@@ -83,7 +80,6 @@ export default class StandardModal extends React.Component<Props> {
         // modal's elements.
         const idPrefix = `wonder-blocks-standard-modal-${modalId}`;
         this._titleId = `${idPrefix}-title`;
-        this._subtitleId = `${idPrefix}-title`;
     }
 
     _renderTitleAndSubtitle() {
@@ -93,7 +89,7 @@ export default class StandardModal extends React.Component<Props> {
             return (
                 <View>
                     <HeadingSmall id={this._titleId}>{title}</HeadingSmall>
-                    <LabelSmall id={this._subtitleId}>{subtitle}</LabelSmall>
+                    <LabelSmall>{subtitle}</LabelSmall>
                 </View>
             );
         } else {
@@ -107,10 +103,6 @@ export default class StandardModal extends React.Component<Props> {
                 style={styles.container}
                 role="dialog"
                 aria-labelledby={this._titleId}
-                // TODO(mdr): Is the subtitle a reliable "description" of the
-                //     modal? Or is it often used to convey more specific
-                //     information?
-                aria-describedby={this._subtitleId}
             >
                 <View style={styles.titlebar}>
                     <View style={styles.closeButton}>

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -59,9 +59,31 @@ type Props = {
  * The "standard" modal layout: a titlebar, a content area, and a footer.
  */
 export default class StandardModal extends React.Component<Props> {
+    /** A unique HTML ID for the title element. */
+    _titleId: string;
+
+    /** A unique HTML ID for the subtitle element. */
+    _subtitleId: string;
+
     static defaultProps = {
         onClickCloseButton: () => {},
     };
+
+    constructor(props: Props) {
+        super(props);
+
+        // Generate a unique ID for this modal. Math.random() isn't great, but
+        // collisions on the same page should be pretty unlikely.
+        const modalId = Math.random()
+            .toString(36)
+            .substr(2);
+
+        // Use that unique ID number to generate unique ID strings for this
+        // modal's elements.
+        const idPrefix = `wonder-blocks-standard-modal-${modalId}`;
+        this._titleId = `${idPrefix}-title`;
+        this._subtitleId = `${idPrefix}-title`;
+    }
 
     _renderTitleAndSubtitle() {
         const {title, subtitle} = this.props;
@@ -69,18 +91,41 @@ export default class StandardModal extends React.Component<Props> {
         if (subtitle) {
             return (
                 <View>
-                    <HeadingSmall>{title}</HeadingSmall>
-                    <LabelSmall>{subtitle}</LabelSmall>
+                    {/* TODO(mdr): Should typography components be able to
+                      *     accept `id` directly? */}
+                    <View id={this._titleId}>
+                        <HeadingSmall>{title}</HeadingSmall>
+                    </View>
+
+                    {/* TODO(mdr): Should typography components be able to
+                      *     accept `id` directly? */}
+                    <View id={this._subtitleId}>
+                        <LabelSmall>{subtitle}</LabelSmall>
+                    </View>
                 </View>
             );
         } else {
-            return <HeadingMedium>{title}</HeadingMedium>;
+            return (
+                // TODO(mdr): Should typography components be able to accept
+                //     `id` directly?
+                <View id={this._titleId}>
+                    <HeadingMedium>{title}</HeadingMedium>
+                </View>
+            );
         }
     }
 
     render() {
         return (
-            <View style={styles.container}>
+            <View
+                style={styles.container}
+                role="dialog"
+                aria-labelledby={this._titleId}
+                // TODO(mdr): Is the subtitle a reliable "description" of the
+                //     modal? Or is it often used to convey more specific
+                //     information?
+                aria-describedby={this._subtitleId}
+            >
                 <View style={styles.titlebar}>
                     <View style={styles.closeButton}>
                         <ModalCloseButton

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -91,27 +91,12 @@ export default class StandardModal extends React.Component<Props> {
         if (subtitle) {
             return (
                 <View>
-                    {/* TODO(mdr): Should typography components be able to
-                      *     accept `id` directly? */}
-                    <View id={this._titleId}>
-                        <HeadingSmall>{title}</HeadingSmall>
-                    </View>
-
-                    {/* TODO(mdr): Should typography components be able to
-                      *     accept `id` directly? */}
-                    <View id={this._subtitleId}>
-                        <LabelSmall>{subtitle}</LabelSmall>
-                    </View>
+                    <HeadingSmall id={this._titleId}>{title}</HeadingSmall>
+                    <LabelSmall id={this._subtitleId}>{subtitle}</LabelSmall>
                 </View>
             );
         } else {
-            return (
-                // TODO(mdr): Should typography components be able to accept
-                //     `id` directly?
-                <View id={this._titleId}>
-                    <HeadingMedium>{title}</HeadingMedium>
-                </View>
-            );
+            return <HeadingMedium id={this._titleId}>{title}</HeadingMedium>;
         }
     }
 

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -39,7 +39,12 @@ export default class TwoColumnModal extends React.Component<Props> {
 
     render() {
         return (
-            <View style={styles.container}>
+            <View
+                style={styles.container}
+                // TODO(mdr): How can we identify an appropriate aria-labelledby
+                //     node, if it's somewhere in the monolith of modal content?
+                role="dialog"
+            >
                 <View style={styles.closeButton}>
                     <ModalCloseButton
                         color="light"

--- a/packages/wonder-blocks-modal/util/util.js
+++ b/packages/wonder-blocks-modal/util/util.js
@@ -1,3 +1,21 @@
-// TODO(mdr): What's our media query story in Wonder Blocks? For now, I just
-//     copied the `smOrSmaller` breakpoint from the Khan Academy webapp.
+// @flow
+/**
+ * A media query matching mobile-ish screens.
+ *
+ * TODO(mdr): What's our media query story in Wonder Blocks? For now, I just
+ *     copied the `smOrSmaller` breakpoint from the Khan Academy webapp.
+ */
 export const smOrSmaller = "@media (max-width: 767px)";
+
+/**
+ * Creates a random unique ID string. Helpful for creating unique `id`
+ * attributes for a11y purposes, while avoiding conflicts with other mounted
+ * components.
+ */
+export function generateUniqueId() {
+    // Generate a random float, output it to a base-36 string, and remove the
+    // leading "0." characters.
+    return Math.random()
+        .toString(36)
+        .substr(2);
+}


### PR DESCRIPTION
In this change, we add basic screen reader support for our modal. In particular, we give it the "dialog" ARIA role, mark its title+subtitle nodes as a label and description respectively, and we add very basic focus management.

I only added an ARIA label and description in the `StandardModal`, since `title` and `subtitle` are its props. For the `TwoColumnModal`, I only applied `role="dialog"`, since identifying the appropriate label is trickier. (We just receive a monolith of content as our props.)

Depends on #69, which enables typography components to accept `id`.

https://khanacademy.atlassian.net/browse/WB-138

# Test Plan:
Using VoiceOver in Safari, open the standard modal in the `ModalLauncher` example. Confirm that focus shifts to its "Close modal" button, and that VoiceOver reports that the user is currently in a dialog named "Title".