### PR TITLE
[modal] Trap focus in the modal, and wrap tab button presses

### DIFF
--- a/packages/wonder-blocks-modal/components/focus-trap.js
+++ b/packages/wonder-blocks-modal/components/focus-trap.js
@@ -1,0 +1,143 @@
+// @flow
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+/**
+ * This component ensures that focus stays within itself. If the user uses Tab
+ * at the end of the modal, or Shift-Tab at the start of the modal, then this
+ * component wraps focus to the start/end respectively.
+ *
+ * We use this in `ModalBackdrop` to ensure that focus stays within the launched
+ * modal.
+ *
+ * Adapted from the WAI-ARIA dialog behavior example.
+ * https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/dialog-modal/dialog.html
+ *
+ * NOTE(mdr): This component frequently references the "modal" and the "modal
+ *     root", to aid readability in this package. But this component isn't
+ *     actually coupled to the modal, and these could be renamed "children"
+ *     instead if we were to generalize!
+ */
+export default class FocusTrap extends React.Component<{children: React.Node}> {
+    /** The most recent node _inside this component_ to receive focus. */
+    _lastNodeFocusedInModal: ?Node = null;
+
+    /**
+     * Whether we're currently applying programmatic focus, and should therefore
+     * ignore focus change events.
+     */
+    _ignoreFocusChanges: boolean = false;
+
+    componentDidMount() {
+        window.addEventListener("focus", this._handleGlobalFocus, true);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("focus", this._handleGlobalFocus, true);
+    }
+
+    /** Get the outermost DOM node of our children. */
+    _getModalRoot(): Node {
+        const modalRoot = ReactDOM.findDOMNode(this);
+        if (!modalRoot) {
+            throw new Error(
+                "Assertion error: modal root should exist after mount",
+            );
+        }
+        return modalRoot;
+    }
+
+    /** Try to focus the given node. Return true iff successful. */
+    _tryToFocus(node: Node) {
+        if (typeof node.focus !== "function") {
+            return;
+        }
+
+        this._ignoreFocusChanges = true;
+        try {
+            node.focus();
+        } catch (e) {}
+        this._ignoreFocusChanges = false;
+
+        return document.activeElement === node;
+    }
+
+    /**
+     * Focus the first focusable descendant of the given node.
+     *
+     * Return true if we succeed. Or, if the given node has no focusable
+     * descendants, return false.
+     */
+    _focusFirstElementIn(currentParent: Node) {
+        const children = currentParent.childNodes;
+        for (let i = 0; i < children.length; i++) {
+            const child = children[i];
+            if (this._tryToFocus(child) || this._focusFirstElementIn(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Focus the last focusable descendant of the given node.
+     *
+     * Return true if we succeed. Or, if the given node has no focusable
+     * descendants, return false.
+     */
+    _focusLastElementIn(currentParent: Node) {
+        const children = currentParent.childNodes;
+        for (let i = children.length - 1; i >= 0; i--) {
+            const child = children[i];
+            if (this._tryToFocus(child) || this._focusLastElementIn(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** This method is called when any node on the page is focused. */
+    _handleGlobalFocus = (e: FocusEvent) => {
+        // If we're busy applying our own programmatic focus, we ignore focus
+        // changes, to avoid an infinite loop.
+        if (this._ignoreFocusChanges) {
+            return;
+        }
+
+        const target = e.target;
+        if (!(target instanceof Node)) {
+            // Sometimes focus events trigger on the document itself. Ignore!
+            return;
+        }
+
+        const modalRoot = this._getModalRoot();
+        if (modalRoot.contains(target)) {
+            // If the newly focused node is inside the modal, we just keep track
+            // of that.
+            this._lastNodeFocusedInModal = target;
+        } else {
+            // If the newly focused node is outside the modal, we try refocusing
+            // the first focusable node of the modal. (This could be the user
+            // pressing Tab on the last node of the modal, or focus escaping in
+            // some other way.)
+            this._focusFirstElementIn(modalRoot);
+
+            // But, if it turns out that the first focusable node of the modal
+            // was what we were previously focusing, then this is probably the
+            // user pressing Shift-Tab on the first node, wanting to go to the
+            // end. So, we instead try focusing the last focusable node of the
+            // modal.
+            if (document.activeElement === this._lastNodeFocusedInModal) {
+                this._focusLastElementIn(modalRoot);
+            }
+
+            // Focus should now be inside the modal, so record the newly-focused
+            // node as the last node focused in the modal.
+            this._lastNodeFocusedInModal = document.activeElement;
+        }
+    };
+
+    render() {
+        return this.props.children;
+    }
+}

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -71,13 +71,15 @@ export default class ModalBackdrop extends React.Component<Props> {
 
         return (
             <View style={styles.modalPositioner} onClick={this._handleClick}>
-                {/* To ensure that tab wrapping happens inside the modal area,
-                  * even if the modal is mounted at the start/end of the
-                  * document (end is likely in practice!), we add focusable
-                  * sentinel nodes. That way, tabbing out of the modal is more
-                  * likely to hit a sentinel node. They're not critical to
-                  * focus wrapping, though; we're resilient to any kind of focus
-                  * shift, whether they hit the sentinels or not! */}
+                {/* When you press Tab on the last focusable node of the
+                  * document, some browsers will move your tab focus outside of
+                  * the document. But we want to capture that as a focus event,
+                  * and move focus back into the modal! So, we add focusable
+                  * sentinel nodes. That way, tabbing out of the modal should
+                  * take you to a sentinel node, rather than taking you out of
+                  * the document. These sentinels aren't critical to focus
+                  * wrapping, though; we're resilient to any kind of focus
+                  * shift, whether it's to the sentinels or somewhere else! */}
                 <div tabIndex="0" />
                 <FocusTrap>{clonedChildren}</FocusTrap>
                 <div tabIndex="0" />

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -113,7 +113,13 @@ class FocusTrap extends React.Component<{children: React.Node}> {
 
     /** Get the outermost DOM node of our children. */
     _getModalRoot(): Node {
-        return (ReactDOM.findDOMNode(this): any);
+        const modalRoot = ReactDOM.findDOMNode(this);
+        if (!modalRoot) {
+            throw new Error(
+                "Assertion error: modal root should exist after mount",
+            );
+        }
+        return modalRoot;
     }
 
     /** Try to focus the given node. Return true iff successful. */

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -6,6 +6,7 @@ import {StyleSheet} from "aphrodite";
 import Color from "wonder-blocks-color";
 import {View} from "wonder-blocks-core";
 
+import FocusTrap from "./focus-trap.js";
 import type {ModalElement} from "../util/types.js";
 
 type Props = {
@@ -82,138 +83,6 @@ export default class ModalBackdrop extends React.Component<Props> {
                 <div tabIndex="0" />
             </View>
         );
-    }
-}
-
-/**
- * This component ensures that focus stays within itself. If the user uses Tab
- * at the end of the modal, or Shift-Tab at the start of the modal, then this
- * component wraps focus to the start/end respectively.
- *
- * Adapted from the WAI-ARIA dialog behavior example.
- * https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/dialog-modal/dialog.html
- */
-class FocusTrap extends React.Component<{children: React.Node}> {
-    /** The most recent node _inside this component_ to receive focus. */
-    _lastNodeFocusedInModal: ?Node = null;
-
-    /**
-     * Whether we're currently applying programmatic focus, and should therefore
-     * ignore focus change events.
-     */
-    _ignoreFocusChanges: boolean = false;
-
-    componentDidMount() {
-        window.addEventListener("focus", this._handleGlobalFocus, true);
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener("focus", this._handleGlobalFocus, true);
-    }
-
-    /** Get the outermost DOM node of our children. */
-    _getModalRoot(): Node {
-        const modalRoot = ReactDOM.findDOMNode(this);
-        if (!modalRoot) {
-            throw new Error(
-                "Assertion error: modal root should exist after mount",
-            );
-        }
-        return modalRoot;
-    }
-
-    /** Try to focus the given node. Return true iff successful. */
-    _tryToFocus(node: Node) {
-        if (typeof node.focus !== "function") {
-            return;
-        }
-
-        this._ignoreFocusChanges = true;
-        try {
-            node.focus();
-        } catch (e) {}
-        this._ignoreFocusChanges = false;
-
-        return document.activeElement === node;
-    }
-
-    /**
-     * Focus the first focusable descendant of the given node.
-     *
-     * Return true if we succeed. Or, if the given node has no focusable
-     * descendants, return false.
-     */
-    _focusFirstElementIn(currentParent: Node) {
-        const children = currentParent.childNodes;
-        for (let i = 0; i < children.length; i++) {
-            const child = children[i];
-            if (this._tryToFocus(child) || this._focusFirstElementIn(child)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Focus the last focusable descendant of the given node.
-     *
-     * Return true if we succeed. Or, if the given node has no focusable
-     * descendants, return false.
-     */
-    _focusLastElementIn(currentParent: Node) {
-        const children = currentParent.childNodes;
-        for (let i = children.length - 1; i >= 0; i--) {
-            const child = children[i];
-            if (this._tryToFocus(child) || this._focusLastElementIn(child)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /** This method is called when any node on the page is focused. */
-    _handleGlobalFocus = (e: FocusEvent) => {
-        // If we're busy applying our own programmatic focus, we ignore focus
-        // changes, to avoid an infinite loop.
-        if (this._ignoreFocusChanges) {
-            return;
-        }
-
-        const target = e.target;
-        if (!(target instanceof Node)) {
-            // Sometimes focus events trigger on the document itself. Ignore!
-            return;
-        }
-
-        const modalRoot = this._getModalRoot();
-        if (modalRoot.contains(target)) {
-            // If the newly focused node is inside the modal, we just keep track
-            // of that.
-            this._lastNodeFocusedInModal = target;
-        } else {
-            // If the newly focused node is outside the modal, we try refocusing
-            // the first focusable node of the modal. (This could be the user
-            // pressing Tab on the last node of the modal, or focus escaping in
-            // some other way.)
-            this._focusFirstElementIn(modalRoot);
-
-            // But, if it turns out that the first focusable node of the modal
-            // was what we were previously focusing, then this is probably the
-            // user pressing Shift-Tab on the first node, wanting to go to the
-            // end. So, we instead try focusing the last focusable node of the
-            // modal.
-            if (document.activeElement === this._lastNodeFocusedInModal) {
-                this._focusLastElementIn(modalRoot);
-            }
-
-            // Focus should now be inside the modal, so record the newly-focused
-            // node as the last node focused in the modal.
-            this._lastNodeFocusedInModal = document.activeElement;
-        }
-    };
-
-    render() {
-        return this.props.children;
     }
 }
 

--- a/packages/wonder-blocks-modal/components/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.test.js
@@ -177,8 +177,57 @@ describe("ModalBackdrop", () => {
             </ModalBackdrop>,
         );
 
-        const focusedElement: HTMLElement = (document.activeElement: any);
-        expect(focusedElement).toBeTruthy();
-        expect(focusedElement.hasAttribute("data-last-button")).toBe(true);
+        const lastButton = wrapper.find("[data-last-button]").getDOMNode();
+        expect(document.activeElement).toBe(lastButton);
+    });
+
+    // TODO(mdr): I haven't figured out how to actually simulate tab keystrokes
+    //     or focus events in a way that JSDOM will recognize, so triggering the
+    //     global focus handler isn't feasible. I had to do manual testing
+    //     instead :( Here's what I had, though!
+    test.skip("Tabbing inside the modal wraps around", () => {
+        const wrapper = mount(
+            <div>
+                <button data-button-id="A" />
+                <ModalBackdrop onCloseModal={() => {}}>
+                    <div>
+                        <button data-button-id="1" />
+                        <button data-button-id="2" />
+                        <button data-button-id="3" />
+                    </div>
+                </ModalBackdrop>
+                <button data-button-id="Z" />
+            </div>,
+        );
+
+        const buttonA = wrapper.find('[data-button-id="A"]').getDOMNode();
+        const button1 = wrapper.find('[data-button-id="1"]').getDOMNode();
+        const button2 = wrapper.find('[data-button-id="2"]').getDOMNode();
+        const button3 = wrapper.find('[data-button-id="3"]').getDOMNode();
+        const buttonZ = wrapper.find('[data-button-id="Z"]').getDOMNode();
+
+        // First, go forward. Confirm that, when we get to button Z, we wrap
+        // back to button 1. (I wish we could just simulate tab keypresses!
+        // Instead, we depend on the implementation detail that _which_ node you
+        // exit from determines where you'll end up.)
+        button1.focus();
+        expect(document.activeElement).toBe(button1);
+        button2.focus();
+        expect(document.activeElement).toBe(button2);
+        button3.focus();
+        expect(document.activeElement).toBe(button3);
+        buttonZ.focus();
+        expect(document.activeElement).toBe(button1);
+
+        // Then, go backward. Confirm that, when we get to button A, we wrap
+        // back to button 3.
+        button3.focus();
+        expect(document.activeElement).toBe(button3);
+        button2.focus();
+        expect(document.activeElement).toBe(button2);
+        button1.focus();
+        expect(document.activeElement).toBe(button1);
+        buttonA.focus();
+        expect(document.activeElement).toBe(button3);
     });
 });

--- a/packages/wonder-blocks-modal/components/modal-launcher.md
+++ b/packages/wonder-blocks-modal/components/modal-launcher.md
@@ -1,3 +1,5 @@
+Once the modal is launched, tab focus wraps inside the modal content. Pressing Tab at the end of the modal will focus the modal's first element, and pressing Shift-Tab at the start of the modal will focus the modal's last element.
+
 ```js
 const {StyleSheet, css} = require("aphrodite");
 const {View} = require("wonder-blocks-core");
@@ -78,23 +80,33 @@ const twoColumnModal = ({closeModal}) => <TwoColumnModal
     rightContent={
         <View>
             <Title style={styles.title}>Right column</Title>
-            <Body>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-                do eiusmod tempor incididunt ut labore et dolore magna
-                aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                Duis aute irure dolor in reprehenderit in voluptate velit
-                esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-                occaecat cupidatat non proident, sunt in culpa qui officia
-                deserunt mollit anim id est.
-            </Body>
-            {/* TODO(mdr): Use Wonder Blocks Button. */}
-            <button
-                onClick={closeModal}
-                style={{marginTop: 16}}
-            >
-                Close modal
-            </button>
+            <View>
+                <label>
+                    <LabelSmall>Username:</LabelSmall>
+                    <input type="text" />
+                </label>
+            </View>
+            <View>
+                <label>
+                    <LabelSmall>Password:</LabelSmall>
+                    <input type="password" />
+                </label>
+            </View>
+            <View>
+                {/* TODO(mdr): Use Wonder Blocks Button. */}
+                <button
+                    onClick={closeModal}
+                    style={{marginTop: 16}}
+                >
+                    Go back
+                </button>
+                <button
+                    onClick={() => alert("Just kidding, no-op!")}
+                    style={{marginTop: 16}}
+                >
+                    Log in
+                </button>
+            </View>
         </View>
     }
 />;

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -28,6 +28,7 @@ module.exports = {
             content: "packages/wonder-blocks-modal/docs.md",
             components: "packages/wonder-blocks-modal/components/*.js",
             ignore: [
+                "**/components/focus-trap.js",
                 "**/components/modal-backdrop.js",
                 "**/components/modal-close-button.js",
                 "**/components/modal-launcher-portal.js",


### PR DESCRIPTION
In this change, we ensure that tab focus stays within the modal. If the user attempts to tab beyond the modal's boundaries, their tab focus wraps back around.

The general approach was adapted from the WAI-ARIA dialog behavior example, in which they implemented similar behavior for their modal.

Unfortunately, I couldn't get an automated test working :( I left my WIP version of the test in the suite as a `test.skip`, and performed testing manually.

This new login-form example showcases that maybe we want cleverer auto-focus behavior than #70 gives us. (We auto-focus the "log in" button, but we should probably auto-focus the username field.) Will try something cleverer in a later change!

Depends on #70, which added basic auto-focus behavior for ARIA's sake.

https://khanacademy.atlassian.net/browse/WB-132

# Test Plan:
In Styleguidist, launch the `TwoColumnModal`, which now has a login form in the right-hand column.

Observe that, as in #70, focus is automatically moved inside the modal.

Then, use Tab and Shift-Tab to rotate through the form fields, form buttons, and modal close button. Observe that they are a cycle: pressing Tab when "Log in" is focused takes you to the modal close button, and pressing Shift-Tab when the close button is focused takes you to "Log in", despite them being at start and end of the modal.