### PR TITLE
[modal] Whoops, override `minHeight` in mobile view

### DIFF
--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -144,6 +144,7 @@ const styles = StyleSheet.create({
             width: "100%",
             height: "100%",
             maxWidth: "none",
+            minHeight: 0,
             maxHeight: "none",
             borderRadius: 0,
         },


### PR DESCRIPTION
I mentioned this in code review for #64, but forgot to change it! In addition to resetting our `maxWidth` and `maxHeight` rules, we also need to reset our `minHeight`. Otherwise, the modal will overflow the screen when it's <200px tall.

Test Plan:
Launch a `StandardModal`, then manually resize the window to be quite narrow and quite short. Confirm that the modal continues to be full-screen, without overflowing.
![image](https://user-images.githubusercontent.com/59218/39648272-89c99c40-4f96-11e8-8dad-6841272e7fc1.png)
