### PR TITLE
ensure all relative imports have a file extension

### DIFF
--- a/packages/wonder-blocks-typography/index.js
+++ b/packages/wonder-blocks-typography/index.js
@@ -1,22 +1,22 @@
 // @flow
 import styles from "./util/styles.js";
 
-import Title from "./components/title";
-import HeadingLarge from "./components/heading-large";
-import HeadingMedium from "./components/heading-medium";
-import HeadingSmall from "./components/heading-small";
-import HeadingXSmall from "./components/heading-xsmall";
-import BodySerifBlock from "./components/body-serif-block";
-import BodySerif from "./components/body-serif";
-import BodyMonospace from "./components/body-monospace";
-import Body from "./components/body";
-import LabelLarge from "./components/label-large";
-import LabelMedium from "./components/label-medium";
-import LabelSmall from "./components/label-small";
-import LabelXSmall from "./components/label-xsmall";
-import Tagline from "./components/tagline";
-import Caption from "./components/caption";
-import Footnote from "./components/footnote";
+import Title from "./components/title.js";
+import HeadingLarge from "./components/heading-large.js";
+import HeadingMedium from "./components/heading-medium.js";
+import HeadingSmall from "./components/heading-small.js";
+import HeadingXSmall from "./components/heading-xsmall.js";
+import BodySerifBlock from "./components/body-serif-block.js";
+import BodySerif from "./components/body-serif.js";
+import BodyMonospace from "./components/body-monospace.js";
+import Body from "./components/body.js";
+import LabelLarge from "./components/label-large.js";
+import LabelMedium from "./components/label-medium.js";
+import LabelSmall from "./components/label-small.js";
+import LabelXSmall from "./components/label-xsmall.js";
+import Tagline from "./components/tagline.js";
+import Caption from "./components/caption.js";
+import Footnote from "./components/footnote.js";
 
 export {
     Title,


### PR DESCRIPTION
Webapp doesn't understand files without extensions so we need to ensure that all local requires have one.