### PR TITLE
[Button v1] Allow custom styling for Buttons

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -68,10 +68,29 @@ exports[`wonder-blocks-button example 1 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_r594hu"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#1865f2",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -94,10 +113,41 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_r594hu-o_O-focus_653n95"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              ":before": Object {
+                "borderColor": "#1865f2",
+                "borderRadius": 7,
+                "borderStyle": "solid",
+                "borderWidth": 2,
+                "bottom": -3,
+                "content": "''",
+                "left": -3,
+                "position": "absolute",
+                "right": -3,
+                "top": -3,
+              },
+              "alignItems": "center",
+              "background": "#1865f2",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -120,10 +170,29 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_r594hu-o_O-active_ggw6ry"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#1b50b3",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#b5cefb",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -146,10 +215,29 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_r594hu-o_O-disabled_1w7pcko"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "rgba(33,36,44,0.32)",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "rgba(255,255,255,0.64)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -184,10 +272,32 @@ exports[`wonder-blocks-button example 1 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_nhzqyc"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(33,36,44,0.50)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -210,10 +320,32 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_nhzqyc-o_O-focus_1tokxmj"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#ffffff",
+              "border": "none",
+              "borderColor": "#1865f2",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 14,
+              "paddingRight": 14,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -236,10 +368,32 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_nhzqyc-o_O-active_1r3agrx"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#b5cefb",
+              "border": "none",
+              "borderColor": "#1b50b3",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#1b50b3",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -262,10 +416,32 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_nhzqyc-o_O-disabled_1rke1mr"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(33,36,44,0.32)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "rgba(33,36,44,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -300,10 +476,29 @@ exports[`wonder-blocks-button example 1 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1hnxdow"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -326,10 +521,32 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1hnxdow-o_O-focus_1xgwdxn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "#1865f2",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -352,10 +569,29 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1hnxdow-o_O-active_1udmvi8"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#1b50b3",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -378,10 +614,29 @@ exports[`wonder-blocks-button example 1 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_1hnxdow-o_O-disabled_ehqzfp"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "rgba(33,36,44,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -476,10 +731,29 @@ exports[`wonder-blocks-button example 2 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1imy9aa"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#ffffff",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -502,10 +776,41 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1imy9aa-o_O-focus_1a3epdz"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              ":before": Object {
+                "borderColor": "#ffffff",
+                "borderRadius": 7,
+                "borderStyle": "solid",
+                "borderWidth": 2,
+                "bottom": -3,
+                "content": "''",
+                "left": -3,
+                "position": "absolute",
+                "right": -3,
+                "top": -3,
+              },
+              "alignItems": "center",
+              "background": "#ffffff",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -528,10 +833,29 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1imy9aa-o_O-active_rhtw9a"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#b5cefb",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#1b50b3",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -554,10 +878,29 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_1imy9aa-o_O-disabled_1bghbg4"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "rgba(255,255,255,0.64)",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -592,10 +935,32 @@ exports[`wonder-blocks-button example 2 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1shc7ui"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(255,255,255,0.64)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -618,10 +983,32 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1shc7ui-o_O-focus_gvewhn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#1865f2",
+              "border": "none",
+              "borderColor": "#ffffff",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 14,
+              "paddingRight": 14,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -644,10 +1031,32 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1shc7ui-o_O-active_1bd05sv"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#1b50b3",
+              "border": "none",
+              "borderColor": "#b5cefb",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#b5cefb",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -670,10 +1079,32 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_1shc7ui-o_O-disabled_1rprq5f"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(255,255,255,0.32)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "rgba(255,255,255,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -708,10 +1139,29 @@ exports[`wonder-blocks-button example 2 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_t7qze6"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -734,10 +1184,32 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_t7qze6-o_O-focus_pqzh2t"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "#ffffff",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -760,10 +1232,29 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_t7qze6-o_O-active_169x9f6"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#b5cefb",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -786,10 +1277,29 @@ exports[`wonder-blocks-button example 2 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_t7qze6-o_O-disabled_1p0v4sy"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "rgba(255,255,255,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -883,10 +1393,29 @@ exports[`wonder-blocks-button example 3 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_tdur71"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#d92916",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -909,10 +1438,41 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_tdur71-o_O-focus_1aqalti"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              ":before": Object {
+                "borderColor": "#d92916",
+                "borderRadius": 7,
+                "borderStyle": "solid",
+                "borderWidth": 2,
+                "bottom": -3,
+                "content": "''",
+                "left": -3,
+                "position": "absolute",
+                "right": -3,
+                "top": -3,
+              },
+              "alignItems": "center",
+              "background": "#d92916",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -935,10 +1495,29 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_tdur71-o_O-active_o202oj"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#9e271d",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#f3bbb4",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -961,10 +1540,29 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_tdur71-o_O-disabled_1w7pcko"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "rgba(33,36,44,0.32)",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "rgba(255,255,255,0.64)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -999,10 +1597,32 @@ exports[`wonder-blocks-button example 3 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_jnoznf"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(33,36,44,0.50)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#d92916",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1025,10 +1645,32 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_jnoznf-o_O-focus_oj5g4"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#ffffff",
+              "border": "none",
+              "borderColor": "#d92916",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#d92916",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 14,
+              "paddingRight": 14,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1051,10 +1693,32 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_jnoznf-o_O-active_16aybtn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#f3bbb4",
+              "border": "none",
+              "borderColor": "#9e271d",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#9e271d",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1077,10 +1741,32 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_jnoznf-o_O-disabled_1rke1mr"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(33,36,44,0.32)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "rgba(33,36,44,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1115,10 +1801,29 @@ exports[`wonder-blocks-button example 3 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1mhrujj"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#d92916",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1141,10 +1846,32 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1mhrujj-o_O-focus_flt1z8"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "#d92916",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#d92916",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1167,10 +1894,29 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1mhrujj-o_O-active_esl9fv"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#9e271d",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1193,10 +1939,29 @@ exports[`wonder-blocks-button example 3 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_1mhrujj-o_O-disabled_ehqzfp"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "rgba(33,36,44,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1291,10 +2056,29 @@ exports[`wonder-blocks-button example 4 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_d2y3ot"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#ffffff",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#d92916",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1317,10 +2101,41 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_d2y3ot-o_O-focus_1a3epdz"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              ":before": Object {
+                "borderColor": "#ffffff",
+                "borderRadius": 7,
+                "borderStyle": "solid",
+                "borderWidth": 2,
+                "bottom": -3,
+                "content": "''",
+                "left": -3,
+                "position": "absolute",
+                "right": -3,
+                "top": -3,
+              },
+              "alignItems": "center",
+              "background": "#ffffff",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#d92916",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1343,10 +2158,29 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_d2y3ot-o_O-active_1h9ov83"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#f3bbb4",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#9e271d",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1369,10 +2203,29 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_d2y3ot-o_O-disabled_qkki4b"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "rgba(255,255,255,0.64)",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#d92916",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1407,10 +2260,32 @@ exports[`wonder-blocks-button example 4 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1shc7ui"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(255,255,255,0.64)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1433,10 +2308,32 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1shc7ui-o_O-focus_cyoct0"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#d92916",
+              "border": "none",
+              "borderColor": "#ffffff",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 14,
+              "paddingRight": 14,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1459,10 +2356,32 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1shc7ui-o_O-active_yk48z8"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#9e271d",
+              "border": "none",
+              "borderColor": "#f3bbb4",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#f3bbb4",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1485,10 +2404,32 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_1shc7ui-o_O-disabled_1rprq5f"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(255,255,255,0.32)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "rgba(255,255,255,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1523,10 +2464,29 @@ exports[`wonder-blocks-button example 4 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_t7qze6"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1549,10 +2509,32 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_t7qze6-o_O-focus_pqzh2t"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "#ffffff",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1575,10 +2557,29 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_t7qze6-o_O-active_pekw78"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#f3bbb4",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1601,10 +2602,29 @@ exports[`wonder-blocks-button example 4 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_t7qze6-o_O-disabled_1p0v4sy"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "rgba(255,255,255,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 40,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1698,10 +2718,29 @@ exports[`wonder-blocks-button example 5 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_r594hu-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#1865f2",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1724,10 +2763,41 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_r594hu-o_O-focus_653n95-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              ":before": Object {
+                "borderColor": "#1865f2",
+                "borderRadius": 7,
+                "borderStyle": "solid",
+                "borderWidth": 2,
+                "bottom": -3,
+                "content": "''",
+                "left": -3,
+                "position": "absolute",
+                "right": -3,
+                "top": -3,
+              },
+              "alignItems": "center",
+              "background": "#1865f2",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#ffffff",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1750,10 +2820,29 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_r594hu-o_O-active_ggw6ry-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#1b50b3",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#b5cefb",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1776,10 +2865,29 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_r594hu-o_O-disabled_1w7pcko-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "rgba(33,36,44,0.32)",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "rgba(255,255,255,0.64)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1814,10 +2922,32 @@ exports[`wonder-blocks-button example 5 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_nhzqyc-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(33,36,44,0.50)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1840,10 +2970,32 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_nhzqyc-o_O-focus_1tokxmj-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#ffffff",
+              "border": "none",
+              "borderColor": "#1865f2",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 14,
+              "paddingRight": 14,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1866,10 +3018,32 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_nhzqyc-o_O-active_1r3agrx-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "#b5cefb",
+              "border": "none",
+              "borderColor": "#1b50b3",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "#1b50b3",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1892,10 +3066,32 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_nhzqyc-o_O-disabled_1rke1mr-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "rgba(33,36,44,0.32)",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "boxSizing": "border-box",
+              "color": "rgba(33,36,44,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1930,10 +3126,29 @@ exports[`wonder-blocks-button example 5 1`] = `
       </th>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1hnxdow-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1956,10 +3171,32 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1hnxdow-o_O-focus_1xgwdxn-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderColor": "#1865f2",
+              "borderRadius": 4,
+              "borderStyle": "solid",
+              "borderWidth": 2,
+              "boxSizing": "border-box",
+              "color": "#1865f2",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -1982,10 +3219,29 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-default_1hnxdow-o_O-active_1udmvi8-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={false}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "#1b50b3",
+              "cursor": "pointer",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""
@@ -2008,10 +3264,29 @@ exports[`wonder-blocks-button example 5 1`] = `
       </td>
       <td>
         <button
-          className="shared_ew9he-o_O-disabled_mqm918-o_O-default_1hnxdow-o_O-disabled_ehqzfp-o_O-small_xwkmkn"
+          className=""
           data-test-id={undefined}
           disabled={true}
           href={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "none",
+              "border": "none",
+              "borderRadius": 4,
+              "boxSizing": "border-box",
+              "color": "rgba(33,36,44,0.32)",
+              "cursor": "auto",
+              "display": "inline-flex",
+              "height": 32,
+              "justifyContent": "center",
+              "outline": "none",
+              "paddingLeft": 4,
+              "paddingRight": 4,
+              "position": "relative",
+              "textDecoration": "none",
+            }
+          }
         >
           <span
             className=""

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -1,11 +1,12 @@
 // @flow
 import React from "react";
-import {StyleSheet, css} from "aphrodite";
+import {StyleSheet} from "aphrodite";
 
 import {LabelLarge} from "wonder-blocks-typography";
 import Color, {mix, fade} from "wonder-blocks-color";
 import type {SharedProps} from "./button.js";
 import type {Handlers} from "./clickable-behavior.js";
+import {processStyleList} from "../../wonder-blocks-core/util/util.js";
 
 type Props = SharedProps &
     Handlers & {
@@ -19,7 +20,7 @@ export default class ButtonCore extends React.Component<Props> {
     render() {
         const {
             children,
-            icon,
+            icon, // eslint-disable-line no-unused-vars
             color,
             kind,
             light,
@@ -36,19 +37,25 @@ export default class ButtonCore extends React.Component<Props> {
 
         const buttonStyles = _generateStyles(color, kind, light);
         const Tag = href ? "a" : "button";
+
+        const styleAttributes = processStyleList([
+            sharedStyles.shared,
+            disabled && sharedStyles.disabled,
+            buttonStyles.default,
+            disabled && buttonStyles.disabled,
+            !disabled &&
+                (pressed
+                    ? buttonStyles.active
+                    : (hovered || focused) && buttonStyles.focus),
+            size === "small" && sharedStyles.small,
+            overridableStyles,
+            style,
+        ]);
+
         return (
             <Tag
-                className={css(
-                    sharedStyles.shared,
-                    disabled && sharedStyles.disabled,
-                    buttonStyles.default,
-                    disabled && buttonStyles.disabled,
-                    !disabled &&
-                        (pressed
-                            ? buttonStyles.active
-                            : (hovered || focused) && buttonStyles.focus),
-                    size === "small" && sharedStyles.small,
-                )}
+                style={styleAttributes.style}
+                className={styleAttributes.className}
                 href={href}
                 disabled={disabled}
                 data-test-id={testId}
@@ -60,11 +67,15 @@ export default class ButtonCore extends React.Component<Props> {
     }
 }
 
+const overridableStyles = {
+    position: "relative",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+};
+
 const sharedStyles = StyleSheet.create({
     shared: {
-        position: "relative",
-        display: "inline-flex",
-        alignItems: "center",
         height: 40,
         paddingLeft: 16,
         paddingRight: 16,

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -1,7 +1,6 @@
 // @flow
 import React from "react";
 
-import {View} from "wonder-blocks-core";
 import Color from "wonder-blocks-color";
 import type {ValidTints} from "wonder-blocks-color";
 import ClickableBehavior from "./clickable-behavior.js";

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -20,3 +20,127 @@ Disabled button example:
     disabled={true}
 >Label</Button>
 ```
+
+Button examples, `style` specified (Support width, position, margin, and flex styles):
+```js
+const {View} = require("wonder-blocks-core");
+<table>
+    <thead>
+        <tr>
+            <th style={{minWidth: '250px'}}>Styles</th>
+            <th style={{width: '100%'}}>Buttons</th>
+        </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>width: '200px'</td>
+        <td>
+            <Button
+                onClick={(e) => console.log("Hello, world!")}
+                style={{width: '200px'}}
+            >Label</Button>
+        </td>
+    </tr>
+    <tr>
+        <td>width: '75%'</td>
+        <td>
+            <Button
+                onClick={(e) => console.log("Hello, world!")}
+                style={{width: '75%'}}
+            >Label</Button>
+        </td>
+    </tr>
+    <tr>
+        <td>display: 'block', margin: '0 auto'</td>
+        <td>
+            <Button
+                onClick={(e) => console.log("Hello, world!")}
+                style={{display: 'block', margin: '0 auto'}}
+            >Label</Button>
+        </td>
+    </tr>
+    <tr>
+        <td>flexGrow: 1</td>
+        <td>
+            <div style={{display: 'flex'}}>
+                <Button
+                    onClick={(e) => console.log("Hello, world!")}
+                    style={{flexGrow: 1}}
+                >Label</Button>
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td>flexShrink: 2, width: '300px'</td>
+        <td>
+            <div style={{display: 'flex'}}>
+                <Button
+                    onClick={(e) => console.log("Hello, world!")}
+                    style={{flexShrink: 2, width: '300px'}}
+                >Label</Button>
+                <div
+                    onClick={(e) => console.log("Hello, world!")}
+                    style={
+                        {
+                            width: '100%',
+                            background: '#d92916',
+                            textAlign: 'center',
+                            lineHeight: '40px',
+                            borderRadius: '4px',
+                            color: 'white',
+                        }
+                    }
+                >A wide div</div>
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td>alignSelf: 'flex-end'</td>
+        <td>
+            <div style={{display: 'flex'}}>
+                <Button
+                    onClick={(e) => console.log("Hello, world!")}
+                    style={{alignSelf: 'flex-end'}}
+                >Label</Button>
+                <div
+                    onClick={(e) => console.log("Hello, world!")}
+                    style={
+                        {
+                            background: '#d92916',
+                            textAlign: 'center',
+                            lineHeight: '100px',
+                            height: '100px',
+                            borderRadius: '4px',
+                            padding: '0px 4px',
+                            color: 'white',
+                        }
+                    }
+                >A tall div</div>
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td>justifySelf: 'flex-end'</td>
+        <td>
+            <div style={{display: 'flex'}}>
+                <div style={{display: 'grid', width: '100%'}}>
+                <Button
+                    onClick={(e) => console.log("Hello, world!")}
+                    style={{justifySelf: 'flex-end'}}
+                >Label</Button>
+                </div>
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td>background: 'green'</td>
+        <td>
+            <Button
+                onClick={(e) => console.log("Hello, world!")}
+                style={{background: 'green'}}
+            >Label</Button>
+        </td>
+    </tr>
+    </tbody>
+</table>
+```

--- a/packages/wonder-blocks-button/components/clickable-behavior.js
+++ b/packages/wonder-blocks-button/components/clickable-behavior.js
@@ -63,7 +63,7 @@ type State = {
 };
 
 export type Handlers = {
-    // onClick: (e: SyntheticMouseEvent<>) => void,
+    onClick: (e: SyntheticMouseEvent<>) => void,
     onMouseEnter: () => void,
     onMouseLeave: () => void,
     onMouseDown: () => void,

--- a/packages/wonder-blocks-button/components/clickable-behavior.js
+++ b/packages/wonder-blocks-button/components/clickable-behavior.js
@@ -63,7 +63,7 @@ type State = {
 };
 
 export type Handlers = {
-    onClick: (e: SyntheticMouseEvent<>) => void,
+    // onClick: (e: SyntheticMouseEvent<>) => void,
     onMouseEnter: () => void,
     onMouseLeave: () => void,
     onMouseDown: () => void,
@@ -77,7 +77,7 @@ export type Handlers = {
 };
 
 const disabledHandlers = {
-    onClick: () => void 0,
+    // onClick: () => void 0,
     onMouseEnter: () => void 0,
     onMouseLeave: () => void 0,
     onMouseDown: () => void 0,
@@ -97,6 +97,8 @@ const keyCodes = {
 };
 
 export default class ClickableBehavior extends React.Component<Props, State> {
+    waitingForClick: boolean;
+
     static defaultProps = {
         disabled: false,
     };
@@ -111,12 +113,10 @@ export default class ClickableBehavior extends React.Component<Props, State> {
         };
     }
 
-    waitingForClick: boolean;
-
     handleClick = (e: SyntheticMouseEvent<>) => {
         if (this.props.onClick) {
             this.waitingForClick = false;
-            this.props.onClick(e);
+            // this.props.onClick(e);
         }
     };
 
@@ -188,7 +188,7 @@ export default class ClickableBehavior extends React.Component<Props, State> {
         const handlers = this.state.disabled
             ? disabledHandlers
             : {
-                  onClick: this.handleClick,
+                  // onClick: this.handleClick,
                   onMouseEnter: this.handleMouseEnter,
                   onMouseLeave: this.handleMouseLeave,
                   onMouseDown: this.handleMouseDown,

--- a/packages/wonder-blocks-button/components/clickable-behavior.js
+++ b/packages/wonder-blocks-button/components/clickable-behavior.js
@@ -77,7 +77,7 @@ export type Handlers = {
 };
 
 const disabledHandlers = {
-    // onClick: () => void 0,
+    onClick: () => void 0,
     onMouseEnter: () => void 0,
     onMouseLeave: () => void 0,
     onMouseDown: () => void 0,
@@ -116,7 +116,7 @@ export default class ClickableBehavior extends React.Component<Props, State> {
     handleClick = (e: SyntheticMouseEvent<>) => {
         if (this.props.onClick) {
             this.waitingForClick = false;
-            // this.props.onClick(e);
+            this.props.onClick(e);
         }
     };
 
@@ -188,7 +188,7 @@ export default class ClickableBehavior extends React.Component<Props, State> {
         const handlers = this.state.disabled
             ? disabledHandlers
             : {
-                  // onClick: this.handleClick,
+                  onClick: this.handleClick,
                   onMouseEnter: this.handleMouseEnter,
                   onMouseLeave: this.handleMouseLeave,
                   onMouseDown: this.handleMouseDown,


### PR DESCRIPTION
Allow width, position, margin, and flex styles to be passed in to Buttons. Styles that are not defined in ButtonCore may also be passed in, though we don't explicitly support this, and will be removing this once we strictly type the styles that are passed in.

Test Plan:
View on styleguidist