### PR TITLE
important-ify inline styles

### DIFF
--- a/packages/wonder-blocks-core/util/util.js
+++ b/packages/wonder-blocks-core/util/util.js
@@ -33,6 +33,8 @@ export function processStyleList<T: Object>(style?: StyleType<T>) {
     flatten(style).forEach((child: T) => {
         // Check for aphrodite internal property
         if ((child: any)._definition) {
+            // TODO(kevinb): figure out how to test this with
+            // process.env.SNAPSHOT_INLINE_APHRODITE=0
             if (
                 typeof process !== "undefined" &&
                 process.env.SNAPSHOT_INLINE_APHRODITE
@@ -42,6 +44,18 @@ export function processStyleList<T: Object>(style?: StyleType<T>) {
                 stylesheetStyles.push(child);
             }
         } else {
+            // All of our aphrodite styles use !important so we need to add
+            // !important to all of our inline styles so that they can actually
+            // override aphrodite styles.
+            Object.keys(child).forEach((key) => {
+                const value = child[key];
+                if (typeof value === "string" && value.endsWith("!important")) {
+                    // skip
+                } else {
+                    child[key] = stringifyAndImportantifyValue(key, value);
+                }
+            });
+
             inlineStyles.push(child);
         }
     });
@@ -51,3 +65,108 @@ export function processStyleList<T: Object>(style?: StyleType<T>) {
         className: css(...stylesheetStyles),
     };
 }
+
+// TODO(kevinb): extract into a separate file
+
+/**
+ * CSS properties which accept numbers but are not in units of "px".
+ * Taken from React's CSSProperty.js
+ */
+const isUnitlessNumber = {
+    animationIterationCount: true,
+    borderImageOutset: true,
+    borderImageSlice: true,
+    borderImageWidth: true,
+    boxFlex: true,
+    boxFlexGroup: true,
+    boxOrdinalGroup: true,
+    columnCount: true,
+    flex: true,
+    flexGrow: true,
+    flexPositive: true,
+    flexShrink: true,
+    flexNegative: true,
+    flexOrder: true,
+    gridRow: true,
+    gridColumn: true,
+    fontWeight: true,
+    lineClamp: true,
+    lineHeight: true,
+    opacity: true,
+    order: true,
+    orphans: true,
+    tabSize: true,
+    widows: true,
+    zIndex: true,
+    zoom: true,
+
+    // SVG-related properties
+    fillOpacity: true,
+    floodOpacity: true,
+    stopOpacity: true,
+    strokeDasharray: true,
+    strokeDashoffset: true,
+    strokeMiterlimit: true,
+    strokeOpacity: true,
+    strokeWidth: true,
+};
+
+/**
+ * Taken from React's CSSProperty.js
+ *
+ * @param {string} prefix vendor-specific prefix, eg: Webkit
+ * @param {string} key style name, eg: transitionDuration
+ * @return {string} style name prefixed with `prefix`, properly camelCased, eg:
+ * WebkitTransitionDuration
+ */
+function prefixKey(prefix, key) {
+    return prefix + key.charAt(0).toUpperCase() + key.substring(1);
+}
+
+/**
+ * Support style names that may come passed in prefixed by adding permutations
+ * of vendor prefixes.
+ * Taken from React's CSSProperty.js
+ */
+const prefixes = ["Webkit", "ms", "Moz", "O"];
+
+// Using Object.keys here, or else the vanilla for-in loop makes IE8 go into an
+// infinite loop, because it iterates over the newly added props too.
+// Taken from React's CSSProperty.js
+Object.keys(isUnitlessNumber).forEach(function(prop) {
+    prefixes.forEach(function(prefix) {
+        isUnitlessNumber[prefixKey(prefix, prop)] = isUnitlessNumber[prop];
+    });
+});
+
+export const stringifyValue = (
+    key /*: string */,
+    prop /*: any */,
+) /*: string */ => {
+    if (typeof prop === "number") {
+        if (isUnitlessNumber[key]) {
+            return "" + prop;
+        } else {
+            return prop + "px";
+        }
+    } else {
+        return "" + prop;
+    }
+};
+
+export const stringifyAndImportantifyValue = (
+    key /*: string */,
+    prop /*: any */,
+) /*: string */ => importantify(stringifyValue(key, prop));
+
+// Given a single style value string like the "b" from "a: b;", adds !important
+// to generate "b !important".
+const importantify = (string /*: string */) /*: string */ =>
+    // Bracket string character access is very fast, and in the default case we
+    // normally don't expect there to be "!important" at the end of the string
+    // so we can use this simple check to take an optimized path. If there
+    // happens to be a "!" in this position, we follow up with a more thorough
+    // check.
+    string[string.length - 10] === "!" && string.slice(-11) === " !important"
+        ? string
+        : `${string} !important`;

--- a/packages/wonder-blocks-core/util/util.test.js
+++ b/packages/wonder-blocks-core/util/util.test.js
@@ -1,0 +1,79 @@
+// @flow
+import {processStyleList} from "./util.js";
+
+describe("processStyleList", () => {
+    it("no inline styles", () => {
+        const {style} = processStyleList([]);
+        expect(style).toEqual({});
+    });
+
+    it("one inline style", () => {
+        const {style} = processStyleList({
+            WebkitFlex: 1,
+            backgroundColor: "red",
+            padding: 12,
+        });
+        expect(style).toEqual({
+            WebkitFlex: "1 !important",
+            backgroundColor: "red !important",
+            padding: "12px !important",
+        });
+    });
+
+    it("reused inline style", () => {
+        const {style} = processStyleList([
+            {
+                WebkitFlex: 1,
+                backgroundColor: "red",
+                padding: 12,
+            },
+            {
+                WebkitFlex: 1,
+                backgroundColor: "red",
+                padding: 12,
+            },
+        ]);
+        expect(style).toEqual({
+            WebkitFlex: "1 !important",
+            backgroundColor: "red !important",
+            padding: "12px !important",
+        });
+    });
+
+    it("mixed inline style", () => {
+        const {style} = processStyleList([
+            {
+                WebkitFlex: 1,
+                backgroundColor: "red",
+                padding: 12,
+            },
+            {
+                flex: 1,
+                backgroundColor: "blue",
+                padding: 12,
+            },
+        ]);
+        expect(style).toEqual({
+            WebkitFlex: "1 !important",
+            backgroundColor: "blue !important",
+            flex: "1 !important",
+            padding: "12px !important",
+        });
+    });
+
+    it("falsy inline style", () => {
+        const {style} = processStyleList([
+            {
+                WebkitFlex: 1,
+                backgroundColor: "red",
+                padding: 12,
+            },
+            false,
+        ]);
+        expect(style).toEqual({
+            WebkitFlex: "1 !important",
+            backgroundColor: "red !important",
+            padding: "12px !important",
+        });
+    });
+});

--- a/packages/wonder-blocks-grid/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-grid/__snapshots__/generated-snapshot.test.js.snap
@@ -39,10 +39,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -95,7 +95,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
             className=""
             style={
               Object {
-                "textAlign": "right",
+                "textAlign": "right !important",
               }
             }
           >
@@ -116,10 +116,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 32,
-              "MsFlexPreferredSize": 32,
-              "WebkitFlexBasis": 32,
-              "flexBasis": 32,
+              "MsFlexBasis": "32px !important",
+              "MsFlexPreferredSize": "32px !important",
+              "WebkitFlexBasis": "32px !important",
+              "flexBasis": "32px !important",
               "flexShrink": 0,
             }
           }
@@ -137,10 +137,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "@media (min-width: 768px) and (max-width: 1023px)": Object {
                 "background": "#00a60e",
               },
-              "MsFlexBasis": 100,
-              "MsFlexPreferredSize": 100,
-              "WebkitFlexBasis": 100,
-              "flexBasis": 100,
+              "MsFlexBasis": "100px !important",
+              "MsFlexPreferredSize": "100px !important",
+              "WebkitFlexBasis": "100px !important",
+              "flexBasis": "100px !important",
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
@@ -164,7 +164,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
             className=""
             style={
               Object {
-                "textAlign": "center",
+                "textAlign": "center !important",
               }
             }
           >
@@ -185,10 +185,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 32,
-              "MsFlexPreferredSize": 32,
-              "WebkitFlexBasis": 32,
-              "flexBasis": 32,
+              "MsFlexBasis": "32px !important",
+              "MsFlexPreferredSize": "32px !important",
+              "WebkitFlexBasis": "32px !important",
+              "flexBasis": "32px !important",
               "flexShrink": 0,
             }
           }
@@ -206,10 +206,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "@media (min-width: 768px) and (max-width: 1023px)": Object {
                 "background": "#00a60e",
               },
-              "MsFlexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
-              "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
-              "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
-              "flexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
+              "MsFlexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px) !important",
+              "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px) !important",
+              "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px) !important",
+              "flexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px) !important",
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
@@ -233,7 +233,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
             className=""
             style={
               Object {
-                "textAlign": "center",
+                "textAlign": "center !important",
               }
             }
           >
@@ -254,10 +254,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 32,
-              "MsFlexPreferredSize": 32,
-              "WebkitFlexBasis": 32,
-              "flexBasis": 32,
+              "MsFlexBasis": "32px !important",
+              "MsFlexPreferredSize": "32px !important",
+              "WebkitFlexBasis": "32px !important",
+              "flexBasis": "32px !important",
               "flexShrink": 0,
             }
           }
@@ -275,10 +275,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "@media (min-width: 768px) and (max-width: 1023px)": Object {
                 "background": "#00a60e",
               },
-              "MsFlexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
-              "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
-              "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
-              "flexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
+              "MsFlexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px) !important",
+              "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px) !important",
+              "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px) !important",
+              "flexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px) !important",
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
@@ -321,7 +321,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               className=""
               style={
                 Object {
-                  "textAlign": "right",
+                  "textAlign": "right !important",
                 }
               }
             >
@@ -343,10 +343,10 @@ exports[`wonder-blocks-grid example 1 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -362,7 +362,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
   className=""
   style={
     Object {
-      "background": "#f7f8fa",
+      "background": "#f7f8fa !important",
     }
   }
 >
@@ -375,10 +375,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "background": "#0a2a66",
-          "borderBottom": "1px solid rgba(255,255,255,0.64)",
+          "background": "#0a2a66 !important",
+          "borderBottom": "1px solid rgba(255,255,255,0.64) !important",
           "display": "flex",
-          "height": 64,
+          "height": "64px !important",
         }
       }
     >
@@ -399,10 +399,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -411,9 +411,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "color": "#ffffff",
+              "color": "#ffffff !important",
               "flexGrow": 1,
-              "textAlign": "center",
+              "textAlign": "center !important",
             }
           }
         >
@@ -423,10 +423,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -438,9 +438,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "background": "#0a2a66",
+          "background": "#0a2a66 !important",
           "display": "flex",
-          "height": 136,
+          "height": "136px !important",
         }
       }
     >
@@ -461,10 +461,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -473,7 +473,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "color": "#ffffff",
+              "color": "#ffffff !important",
               "flexGrow": 1,
             }
           }
@@ -484,10 +484,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -499,10 +499,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "background": "#ffffff",
-          "borderBottom": "1px solid rgba(33,36,44,0.08)",
+          "background": "#ffffff !important",
+          "borderBottom": "1px solid rgba(33,36,44,0.08) !important",
           "display": "flex",
-          "height": 71,
+          "height": "71px !important",
         }
       }
     >
@@ -523,10 +523,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -535,10 +535,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
-              "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.25 + 64px)",
-              "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
-              "flexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
+              "MsFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px) !important",
+              "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.25 + 64px) !important",
+              "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px) !important",
+              "flexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px) !important",
               "flexShrink": 0,
             }
           }
@@ -549,10 +549,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 32,
-              "MsFlexPreferredSize": 32,
-              "WebkitFlexBasis": 32,
-              "flexBasis": 32,
+              "MsFlexBasis": "32px !important",
+              "MsFlexPreferredSize": "32px !important",
+              "WebkitFlexBasis": "32px !important",
+              "flexBasis": "32px !important",
               "flexShrink": 0,
             }
           }
@@ -567,10 +567,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -583,7 +583,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
         Object {
           "alignItems": "center",
           "display": "flex",
-          "padding": "17px 0",
+          "padding": "17px 0 !important",
         }
       }
     >
@@ -604,10 +604,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }
@@ -616,10 +616,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
-              "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.25 + 64px)",
-              "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
-              "flexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
+              "MsFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px) !important",
+              "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.25 + 64px) !important",
+              "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px) !important",
+              "flexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px) !important",
               "flexShrink": 0,
             }
           }
@@ -638,10 +638,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 32,
-              "MsFlexPreferredSize": 32,
-              "WebkitFlexBasis": 32,
-              "flexBasis": 32,
+              "MsFlexBasis": "32px !important",
+              "MsFlexPreferredSize": "32px !important",
+              "WebkitFlexBasis": "32px !important",
+              "flexBasis": "32px !important",
               "flexShrink": 0,
             }
           }
@@ -658,10 +658,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
             className=""
             style={
               Object {
-                "background": "#ffffff",
-                "border": "1px solid rgba(33,36,44,0.08)",
-                "height": 360,
-                "padding": 24,
+                "background": "#ffffff !important",
+                "border": "1px solid rgba(33,36,44,0.08) !important",
+                "height": "360px !important",
+                "padding": "24px !important",
               }
             }
           >
@@ -671,11 +671,11 @@ exports[`wonder-blocks-grid example 2 1`] = `
             className=""
             style={
               Object {
-                "background": "#ffffff",
-                "border": "1px solid rgba(33,36,44,0.08)",
-                "height": 360,
-                "marginTop": 16,
-                "padding": 24,
+                "background": "#ffffff !important",
+                "border": "1px solid rgba(33,36,44,0.08) !important",
+                "height": "360px !important",
+                "marginTop": "16px !important",
+                "padding": "24px !important",
               }
             }
           >
@@ -686,10 +686,10 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
-              "MsFlexBasis": 24,
-              "MsFlexPreferredSize": 24,
-              "WebkitFlexBasis": 24,
-              "flexBasis": 24,
+              "MsFlexBasis": "24px !important",
+              "MsFlexPreferredSize": "24px !important",
+              "WebkitFlexBasis": "24px !important",
+              "flexBasis": "24px !important",
               "flexShrink": 0,
             }
           }


### PR DESCRIPTION
`aphrodite` adds `!important` to all its styles by default so in order for inline styles to override `aphrodite` styles we need to make the inline styles `!important` as well.