### PR TITLE
Re-implement modals to use low-level building blocks.

### DIFF
--- a/packages/wonder-blocks-modal/building-blocks.md
+++ b/packages/wonder-blocks-modal/building-blocks.md
@@ -1,0 +1,1 @@
+Use these low-level building blocks to build your own modal dialog, instead of using StandardModal, TwoColumnModal, or OneColumnModal. This should happen very rarely and only when a specific exception is required.

--- a/packages/wonder-blocks-modal/components/modal-content-pane.js
+++ b/packages/wonder-blocks-modal/components/modal-content-pane.js
@@ -1,0 +1,121 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import Color from "wonder-blocks-color";
+import {View} from "wonder-blocks-core";
+
+import ModalCloseButton from "./modal-close-button.js";
+
+import typeof ModalContent from "./modal-content.js";
+import typeof ModalTitleBar from "./modal-title-bar.js";
+import typeof ModalHeader from "./modal-header.js";
+import typeof ModalFooter from "./modal-footer.js";
+
+export default class ModalContentPane extends React.Component<{
+    content: React.Element<ModalContent>,
+    titlebar?: React.Element<ModalTitleBar>,
+    header?: React.Element<ModalHeader>,
+    footer?: React.Element<ModalFooter>,
+    showCloseButton: boolean,
+    color: "light" | "dark",
+    style?: any,
+
+    /**
+     * Called when the close button is clicked.
+     *
+     * If you're using `ModalLauncher`, you probably shouldn't use this prop!
+     * Instead, to listen for when the modal closes, add an `onClose` handler
+     * to the `ModalLauncher`.
+     *
+     * This defaults to a no-op via `defaultProps`. (When used in a
+     * `ModalLauncher`, we'll automatically add an extra listener here via
+     * `cloneElement`, so that the `ModalLauncher` can listen for close button
+     * clicks too.)
+     */
+    onClickCloseButton: () => void,
+}> {
+    static defaultProps = {
+        showCloseButton: false,
+        color: "light",
+        onClickCloseButton: () => {},
+    };
+
+    render() {
+        const {
+            content,
+            titlebar,
+            header,
+            footer,
+            showCloseButton,
+            onClickCloseButton,
+            color,
+            style,
+        } = this.props;
+
+        const mainContent =
+            titlebar || footer
+                ? React.cloneElement(content, {
+                      style: [
+                          titlebar && styles.hasTitle,
+                          footer && styles.hasFooter,
+                          content.props.style,
+                      ],
+                  })
+                : content;
+
+        return (
+            <View
+                style={[styles.wrapper, color === "dark" && styles.dark, style]}
+            >
+                {showCloseButton && (
+                    <View style={styles.closeButton}>
+                        <ModalCloseButton
+                            color={
+                                color === "dark" ||
+                                (titlebar && titlebar.props.color === "dark")
+                                    ? "light"
+                                    : "dark"
+                            }
+                            onClick={onClickCloseButton}
+                        />
+                    </View>
+                )}
+                {titlebar}
+                {header}
+                {mainContent}
+                {footer}
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    wrapper: {
+        flex: "1 1 auto",
+        position: "relative",
+        display: "flex",
+        flexDirection: "column",
+        background: "white",
+        boxSizing: "border-box",
+    },
+
+    closeButton: {
+        position: "absolute",
+        left: 4,
+        top: 8,
+    },
+
+    dark: {
+        background: Color.darkBlue,
+        color: Color.white,
+    },
+
+    hasTitle: {
+        paddingTop: 32,
+    },
+
+    hasFooter: {
+        paddingBottom: 32,
+    },
+});

--- a/packages/wonder-blocks-modal/components/modal-content.js
+++ b/packages/wonder-blocks-modal/components/modal-content.js
@@ -4,19 +4,39 @@ import {StyleSheet} from "aphrodite";
 
 import {View} from "wonder-blocks-core";
 
-export default class ModalContent extends React.Component<{
+import ModalHeader from "./modal-header.js";
+
+type Props = {
+    header?: React.Element<typeof ModalHeader> | React.Node,
     children: React.Node,
     style?: any,
-}> {
+};
+
+export default class ModalContent extends React.Component<Props> {
     render() {
-        const {style, children} = this.props;
-        return <View style={[styles.content, style]}>{children}</View>;
+        const {header, style, children} = this.props;
+
+        return (
+            <View style={styles.wrapper}>
+                {!header || header.type === ModalHeader ? (
+                    header
+                ) : (
+                    <ModalHeader>{header}</ModalHeader>
+                )}
+                <View style={[styles.content, style]}>{children}</View>
+            </View>
+        );
     }
 }
 
 const styles = StyleSheet.create({
+    wrapper: {
+        flex: 1,
+        overflow: "auto",
+    },
+
     content: {
-        flex: "1",
+        flex: 1,
         padding: 64,
         overflow: "auto",
         boxSizing: "border-box",

--- a/packages/wonder-blocks-modal/components/modal-content.js
+++ b/packages/wonder-blocks-modal/components/modal-content.js
@@ -33,6 +33,10 @@ const styles = StyleSheet.create({
     wrapper: {
         flex: 1,
         overflow: "auto",
+
+        // This helps to ensure that the paddingBottom is preserved when
+        // the contents start to overflow, this goes away on display: flex
+        display: "block",
     },
 
     content: {

--- a/packages/wonder-blocks-modal/components/modal-content.js
+++ b/packages/wonder-blocks-modal/components/modal-content.js
@@ -1,0 +1,24 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {View} from "wonder-blocks-core";
+
+export default class ModalContent extends React.Component<{
+    children: React.Node,
+    style?: any,
+}> {
+    render() {
+        const {style, children} = this.props;
+        return <View style={[styles.content, style]}>{children}</View>;
+    }
+}
+
+const styles = StyleSheet.create({
+    content: {
+        flex: "1",
+        padding: 64,
+        overflow: "auto",
+        boxSizing: "border-box",
+    },
+});

--- a/packages/wonder-blocks-modal/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/components/modal-dialog.js
@@ -1,0 +1,48 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {View} from "wonder-blocks-core";
+
+import typeof ModalContentPane from "./modal-content-pane.js";
+
+export default class ModalDialog extends React.Component<{
+    children: React.ChildrenArray<React.Element<
+        ModalContentPane,
+    > | null | void>,
+    style?: any,
+}> {
+    render() {
+        const {style, children} = this.props;
+        return (
+            <View
+                style={[styles.wrapper, style]}
+                role="dialog"
+                aria-labelledby="wb-modal-title"
+            >
+                {children}
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    wrapper: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "stretch",
+        position: "relative",
+
+        borderRadius: 4,
+        overflow: "hidden",
+
+        /*
+		// On mobile, we consume the full screen size.
+		[smOrSmaller]: {
+		    width: "100%",
+		    height: "100%",
+		    borderRadius: 0,
+		},
+		*/
+    },
+});

--- a/packages/wonder-blocks-modal/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/components/modal-dialog.js
@@ -6,12 +6,12 @@ import {View} from "wonder-blocks-core";
 
 import typeof ModalContentPane from "./modal-content-pane.js";
 
-export default class ModalDialog extends React.Component<{
-    children: React.ChildrenArray<React.Element<
-        ModalContentPane,
-    > | null | void>,
+type Props = {
+    children: React.ChildrenArray<?React.Element<ModalContentPane>>,
     style?: any,
-}> {
+};
+
+export default class ModalDialog extends React.Component<Props> {
     render() {
         const {style, children} = this.props;
         return (
@@ -37,12 +37,12 @@ const styles = StyleSheet.create({
         overflow: "hidden",
 
         /*
-		// On mobile, we consume the full screen size.
-		[smOrSmaller]: {
-		    width: "100%",
-		    height: "100%",
-		    borderRadius: 0,
-		},
-		*/
+        // On mobile, we consume the full screen size.
+        [smOrSmaller]: {
+            width: "100%",
+            height: "100%",
+            borderRadius: 0,
+        },
+        */
     },
 });

--- a/packages/wonder-blocks-modal/components/modal-footer.js
+++ b/packages/wonder-blocks-modal/components/modal-footer.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import Color from "wonder-blocks-color";
+import {View} from "wonder-blocks-core";
+
+export default class ModalFooter extends React.Component<{
+    children: React.Node,
+    style?: any,
+}> {
+    render() {
+        const {style, children} = this.props;
+        return <View style={[styles.footer, style]}>{children}</View>;
+    }
+}
+
+const styles = StyleSheet.create({
+    footer: {
+        flex: "0 0 auto",
+        boxSizing: "border-box",
+        minHeight: 64,
+        paddingLeft: 16,
+        paddingRight: 16,
+        paddingTop: 8,
+        paddingBottom: 8,
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "flex-end",
+
+        borderTopStyle: "solid",
+        borderTopColor: Color.offBlack16,
+        borderTopWidth: 1,
+    },
+});

--- a/packages/wonder-blocks-modal/components/modal-footer.js
+++ b/packages/wonder-blocks-modal/components/modal-footer.js
@@ -5,10 +5,12 @@ import {StyleSheet} from "aphrodite";
 import Color from "wonder-blocks-color";
 import {View} from "wonder-blocks-core";
 
-export default class ModalFooter extends React.Component<{
+type Props = {
     children: React.Node,
     style?: any,
-}> {
+};
+
+export default class ModalFooter extends React.Component<Props> {
     render() {
         const {style, children} = this.props;
         return <View style={[styles.footer, style]}>{children}</View>;

--- a/packages/wonder-blocks-modal/components/modal-header.js
+++ b/packages/wonder-blocks-modal/components/modal-header.js
@@ -1,0 +1,48 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import Color from "wonder-blocks-color";
+import {View} from "wonder-blocks-core";
+
+export default class ModalHeader extends React.Component<{
+    children: React.Node,
+    style?: any,
+    color: "light" | "dark",
+}> {
+    static defaultProps = {
+        color: "dark",
+    };
+
+    render() {
+        const {style, color, children} = this.props;
+        return (
+            <View
+                style={[styles.header, color === "dark" && styles.dark, style]}
+            >
+                {children}
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    header: {
+        flex: "0 0 auto",
+        boxSizing: "border-box",
+        maxHeight: 108,
+        paddingLeft: 64,
+        paddingRight: 64,
+        paddingTop: 8,
+        paddingBottom: 8,
+
+        display: "flex",
+        flexDirection: "row",
+        overflow: "auto",
+    },
+
+    dark: {
+        background: Color.darkBlue,
+        color: Color.white,
+    },
+});

--- a/packages/wonder-blocks-modal/components/modal-header.js
+++ b/packages/wonder-blocks-modal/components/modal-header.js
@@ -5,11 +5,13 @@ import {StyleSheet} from "aphrodite";
 import Color from "wonder-blocks-color";
 import {View} from "wonder-blocks-core";
 
-export default class ModalHeader extends React.Component<{
+type Props = {
     children: React.Node,
     style?: any,
     color: "light" | "dark",
-}> {
+};
+
+export default class ModalHeader extends React.Component<Props> {
     static defaultProps = {
         color: "dark",
     };
@@ -38,7 +40,6 @@ const styles = StyleSheet.create({
 
         display: "flex",
         flexDirection: "row",
-        overflow: "auto",
     },
 
     dark: {

--- a/packages/wonder-blocks-modal/components/modal-launcher.md
+++ b/packages/wonder-blocks-modal/components/modal-launcher.md
@@ -12,7 +12,7 @@ const {smOrSmaller} = require("../util/util.js");
 const styles = StyleSheet.create({
     example: {
         padding: 32,
-        textAlign: "center",
+        alignItems: "center",
     },
 
     title: {

--- a/packages/wonder-blocks-modal/components/modal-launcher.md
+++ b/packages/wonder-blocks-modal/components/modal-launcher.md
@@ -6,6 +6,7 @@ const {View} = require("wonder-blocks-core");
 const {Title, Body} = require("wonder-blocks-typography");
 const ModalLauncher = require("./modal-launcher.js").default;
 const TwoColumnModal = require("./two-column-modal.js").default;
+const OneColumnModal = require("./one-column-modal.js").default;
 const {smOrSmaller} = require("../util/util.js");
 
 const styles = StyleSheet.create({
@@ -20,16 +21,7 @@ const styles = StyleSheet.create({
 
     modalContent: {
         margin: "0 auto",
-        marginTop: 40,
-        marginBottom: 40,
-        paddingLeft: 32,
-        paddingRight: 32,
         maxWidth: 544,
-
-        [smOrSmaller]: {
-            paddingLeft: 16,
-            paddingRight: 16,
-        },
     },
 });
 
@@ -66,9 +58,9 @@ const standardModal = ({closeModal}) => (
 );
 
 const twoColumnModal = ({closeModal}) => <TwoColumnModal
-    leftContent={
+    sidebar={
         <View>
-            <Title style={styles.title}>Left column</Title>
+            <Title style={styles.title}>Sidebar</Title>
             <Body>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
                 do eiusmod tempor incididunt ut labore et dolore magna
@@ -77,9 +69,44 @@ const twoColumnModal = ({closeModal}) => <TwoColumnModal
             </Body>
         </View>
     }
-    rightContent={
+    content={
         <View>
-            <Title style={styles.title}>Right column</Title>
+            <Title style={styles.title}>Contents</Title>
+            <View>
+                <label>
+                    <LabelSmall>Username:</LabelSmall>
+                    <input type="text" />
+                </label>
+            </View>
+            <View>
+                <label>
+                    <LabelSmall>Password:</LabelSmall>
+                    <input type="password" />
+                </label>
+            </View>
+            <View>
+                {/* TODO(mdr): Use Wonder Blocks Button. */}
+                <button
+                    onClick={closeModal}
+                    style={{marginTop: 16}}
+                >
+                    Go back
+                </button>
+                <button
+                    onClick={() => alert("Just kidding, no-op!")}
+                    style={{marginTop: 16}}
+                >
+                    Log in
+                </button>
+            </View>
+        </View>
+    }
+/>;
+
+const oneColumnModal = ({closeModal}) => <OneColumnModal
+    content={
+        <View>
+            <Title style={styles.title}>Title</Title>
             <View>
                 <label>
                     <LabelSmall>Username:</LabelSmall>
@@ -118,6 +145,9 @@ const twoColumnModal = ({closeModal}) => <TwoColumnModal
     </ModalLauncher>
     <ModalLauncher modal={twoColumnModal}>
         {({openModal}) => <button onClick={openModal}>Two-column modal</button>}
+    </ModalLauncher>
+    <ModalLauncher modal={oneColumnModal}>
+        {({openModal}) => <button onClick={openModal}>One-column modal</button>}
     </ModalLauncher>
 </View>;
 ```

--- a/packages/wonder-blocks-modal/components/modal-title-bar.js
+++ b/packages/wonder-blocks-modal/components/modal-title-bar.js
@@ -10,7 +10,7 @@ import {
     LabelSmall,
 } from "wonder-blocks-typography";
 
-export default class ModalTitleBar extends React.Component<{
+type Props = {
     /**
      * The title of the modal, appearing in the titlebar.
      *
@@ -26,7 +26,9 @@ export default class ModalTitleBar extends React.Component<{
 
     color: "light" | "dark",
     style?: any,
-}> {
+};
+
+export default class ModalTitleBar extends React.Component<Props> {
     static defaultProps = {
         color: "light",
     };

--- a/packages/wonder-blocks-modal/components/modal-title-bar.js
+++ b/packages/wonder-blocks-modal/components/modal-title-bar.js
@@ -1,0 +1,106 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import Color from "wonder-blocks-color";
+import {View} from "wonder-blocks-core";
+import {
+    HeadingMedium,
+    HeadingSmall,
+    LabelSmall,
+} from "wonder-blocks-typography";
+
+export default class ModalTitleBar extends React.Component<{
+    /**
+     * The title of the modal, appearing in the titlebar.
+     *
+     * If a subtitle is also present, this becomes smaller to accommodate both
+     * within the title bar.
+     */
+    title: string,
+
+    /**
+     * The subtitle of the modal, appearing in the titlebar, below the title.
+     */
+    subtitle?: string,
+
+    color: "light" | "dark",
+    style?: any,
+}> {
+    static defaultProps = {
+        color: "light",
+    };
+
+    _renderTitleAndSubtitle() {
+        const {title, subtitle} = this.props;
+
+        if (subtitle) {
+            return (
+                <View>
+                    <HeadingSmall id="wb-modal-title">{title}</HeadingSmall>
+                    <LabelSmall>{subtitle}</LabelSmall>
+                </View>
+            );
+        } else {
+            return <HeadingMedium id="wb-modal-title">{title}</HeadingMedium>;
+        }
+    }
+
+    render() {
+        const {color, style} = this.props;
+        return (
+            <View
+                style={[
+                    styles.titlebar,
+                    color === "dark" && styles.dark,
+                    style,
+                ]}
+            >
+                <View style={styles.titleAndSubtitle}>
+                    {this._renderTitleAndSubtitle()}
+                </View>
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    titlebar: {
+        flex: "0 0 auto",
+        boxSizing: "border-box",
+        minHeight: 64,
+        paddingLeft: 4,
+        paddingRight: 4,
+        paddingTop: 8,
+        paddingBottom: 8,
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+
+        borderBottomStyle: "solid",
+        borderBottomColor: Color.offBlack16,
+        borderBottomWidth: 1,
+
+        // On mobile, the titlebar is more compact.
+        //[smOrSmaller]: {
+        //    minHeight: 56,
+        //    paddingTop: 4,
+        //    paddingBottom: 4,
+        //    paddingLeft: 64,
+        //    paddingRight: 16,
+        //},
+    },
+
+    // This element is centered within the titlebar
+    titleAndSubtitle: {
+        flex: "1",
+        textAlign: "center",
+    },
+
+    dark: {
+        background: Color.darkBlue,
+        color: Color.white,
+        borderBottomColor: Color.white64,
+    },
+});

--- a/packages/wonder-blocks-modal/components/one-column-modal.js
+++ b/packages/wonder-blocks-modal/components/one-column-modal.js
@@ -4,8 +4,6 @@ import {StyleSheet} from "aphrodite";
 
 import ModalDialog from "./modal-dialog.js";
 import ModalContentPane from "./modal-content-pane.js";
-import ModalFooter from "./modal-footer.js";
-import ModalContent from "./modal-content.js";
 
 type Props = {
     /** The modal's content. */
@@ -45,10 +43,8 @@ export default class OneColumnModal extends React.Component<Props> {
                 <ModalContentPane
                     showCloseButton
                     onClickCloseButton={onClickCloseButton}
-                    content={<ModalContent>{content}</ModalContent>}
-                    footer={
-                        footer ? <ModalFooter>{footer}</ModalFooter> : undefined
-                    }
+                    content={content}
+                    footer={footer}
                 />
             </ModalDialog>
         );

--- a/packages/wonder-blocks-modal/components/one-column-modal.js
+++ b/packages/wonder-blocks-modal/components/one-column-modal.js
@@ -8,13 +8,10 @@ import ModalFooter from "./modal-footer.js";
 import ModalContent from "./modal-content.js";
 
 type Props = {
-    /** The sidebar contents (which becomes the header on mobile screens). */
-    sidebar: React.Node,
-
-    /** The main contents. */
+    /** The modal's content. */
     content: React.Node,
 
-    /** The optional footer to display beneath the content. */
+    /** The optional footer to display beneath the contents. */
     footer?: React.Node,
 
     /**
@@ -33,27 +30,21 @@ type Props = {
 };
 
 /**
- * A two-column modal layout.
+ * A one-column modal layout.
  */
-export default class TwoColumnModal extends React.Component<Props> {
+export default class OneColumnModal extends React.Component<Props> {
     static defaultProps = {
         onClickCloseButton: () => {},
     };
 
     render() {
-        const {onClickCloseButton, sidebar, content, footer} = this.props;
+        const {onClickCloseButton, content, footer} = this.props;
 
         return (
             <ModalDialog style={styles.wrapper}>
                 <ModalContentPane
                     showCloseButton
-                    color="dark"
                     onClickCloseButton={onClickCloseButton}
-                    style={styles.column}
-                    content={<ModalContent>{sidebar}</ModalContent>}
-                />
-                <ModalContentPane
-                    style={styles.column}
                     content={<ModalContent>{content}</ModalContent>}
                     footer={
                         footer ? <ModalFooter>{footer}</ModalFooter> : undefined
@@ -66,12 +57,6 @@ export default class TwoColumnModal extends React.Component<Props> {
 
 const styles = StyleSheet.create({
     wrapper: {
-        width: "86.72%",
-        height: "60.42%",
-        minHeight: 464,
-    },
-
-    column: {
-        flex: "0 0 50%",
+        width: "64.65%",
     },
 });

--- a/packages/wonder-blocks-modal/components/one-column-modal.md
+++ b/packages/wonder-blocks-modal/components/one-column-modal.md
@@ -2,76 +2,7 @@
 const {StyleSheet, css} = require("aphrodite");
 const {View} = require("wonder-blocks-core");
 const {Title, Body} = require("wonder-blocks-typography");
-const TwoColumnModal = require("./two-column-modal.js").default;
-
-const styles = StyleSheet.create({
-    previewSizer: {
-        height: 512,
-    },
-
-    modalPositioner: {
-        // Checkerboard background
-        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-
-        position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-    },
-
-    title: {
-        marginBottom: 16,
-    },
-});
-
-<View style={styles.previewSizer}>
-    <View style={styles.modalPositioner}>
-        <TwoColumnModal
-            sidebar={
-                <View>
-                    <Title style={styles.title}>Sidebar</Title>
-                    <Body>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-                        sed do eiusmod tempor incididunt ut labore et dolore
-                        magna aliqua. Ut enim ad minim veniam, quis nostrud
-                        exercitation ullamco laboris.
-                    </Body>
-                </View>
-            }
-            content={
-                <View>
-                    <Title style={styles.title}>Contents</Title>
-                    <Body>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-                        sed do eiusmod tempor incididunt ut labore et dolore
-                        magna aliqua. Ut enim ad minim veniam, quis nostrud
-                        exercitation ullamco laboris nisi ut aliquip ex ea
-                        commodo consequat. Duis aute irure dolor in
-                        reprehenderit in voluptate velit esse cillum dolore eu
-                        fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-                        non proident, sunt in culpa qui officia deserunt mollit
-                        anim id est.
-                    </Body>
-                </View>
-            }
-            onClickCloseButton={() => alert("This would close the modal.")}
-        />
-    </View>
-</View>;
-```
-
-```js
-const {StyleSheet, css} = require("aphrodite");
-const {View} = require("wonder-blocks-core");
-const {Title, Body} = require("wonder-blocks-typography");
-const TwoColumnModal = require("./two-column-modal.js").default;
+const OneColumnModal = require("./one-column-modal.js").default;
 
 const styles = StyleSheet.create({
     previewSizer: {
@@ -103,21 +34,69 @@ const styles = StyleSheet.create({
 
 <View style={styles.previewSizer}>
     <View style={styles.modalPositioner}>
-        <TwoColumnModal
-            sidebar={
+        <OneColumnModal
+            content={
                 <View>
-                    <Title style={styles.title}>Sidebar</Title>
+                    <Title style={styles.title}>Title</Title>
                     <Body>
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                         sed do eiusmod tempor incididunt ut labore et dolore
                         magna aliqua. Ut enim ad minim veniam, quis nostrud
-                        exercitation ullamco laboris.
+                        exercitation ullamco laboris nisi ut aliquip ex ea
+                        commodo consequat. Duis aute irure dolor in
+                        reprehenderit in voluptate velit esse cillum dolore eu
+                        fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                        non proident, sunt in culpa qui officia deserunt mollit
+                        anim id est.
                     </Body>
                 </View>
             }
+            onClickCloseButton={() => alert("This would close the modal.")}
+        />
+    </View>
+</View>;
+```
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const {Title, Body} = require("wonder-blocks-typography");
+const OneColumnModal = require("./one-column-modal.js").default;
+
+const styles = StyleSheet.create({
+    previewSizer: {
+        height: 512,
+    },
+
+    modalPositioner: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+
+        position: "absolute",
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+    },
+
+    title: {
+        marginBottom: 16,
+    },
+});
+
+<View style={styles.previewSizer}>
+    <View style={styles.modalPositioner}>
+        <OneColumnModal
             content={
                 <View>
-                    <Title style={styles.title}>Contents</Title>
+                    <Title style={styles.title}>Title</Title>
                     <Body>
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                         sed do eiusmod tempor incididunt ut labore et dolore

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -4,8 +4,6 @@ import {StyleSheet} from "aphrodite";
 
 import ModalDialog from "./modal-dialog.js";
 import ModalContentPane from "./modal-content-pane.js";
-import ModalHeader from "./modal-header.js";
-import ModalFooter from "./modal-footer.js";
 import ModalContent from "./modal-content.js";
 import ModalTitleBar from "./modal-title-bar.js";
 
@@ -81,20 +79,16 @@ export default class StandardModal extends React.Component<Props> {
                 <ModalContentPane
                     showCloseButton
                     onClickCloseButton={onClickCloseButton}
-                    titlebar={
+                    titleBar={
                         <ModalTitleBar
                             title={title}
                             subtitle={subtitle}
                             color={header ? "dark" : "light"}
                         />
                     }
-                    header={
-                        header ? <ModalHeader>{header}</ModalHeader> : undefined
-                    }
-                    content={<ModalContent>{content}</ModalContent>}
-                    footer={
-                        footer ? <ModalFooter>{footer}</ModalFooter> : undefined
-                    }
+                    header={header}
+                    content={content}
+                    footer={footer}
                 />
                 {preview ? (
                     <ModalContentPane

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -2,16 +2,12 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color from "wonder-blocks-color";
-import {View} from "wonder-blocks-core";
-import {
-    HeadingMedium,
-    HeadingSmall,
-    LabelSmall,
-} from "wonder-blocks-typography";
-
-import ModalCloseButton from "./modal-close-button.js";
-import {smOrSmaller, generateUniqueId} from "../util/util.js";
+import ModalDialog from "./modal-dialog.js";
+import ModalContentPane from "./modal-content-pane.js";
+import ModalHeader from "./modal-header.js";
+import ModalFooter from "./modal-footer.js";
+import ModalContent from "./modal-content.js";
+import ModalTitleBar from "./modal-title-bar.js";
 
 type Props = {
     /**
@@ -40,6 +36,13 @@ type Props = {
      */
     footer: React.Node,
 
+    header?: React.Node,
+
+    /**
+     * An optional preview area to show on the right-hand-side of the modal.
+     */
+    preview?: React.Node,
+
     /**
      * Called when the close button is clicked.
      *
@@ -59,159 +62,73 @@ type Props = {
  * The "standard" modal layout: a titlebar, a content area, and a footer.
  */
 export default class StandardModal extends React.Component<Props> {
-    /** A unique HTML ID for the title element. */
-    _titleId: string;
-
     static defaultProps = {
         onClickCloseButton: () => {},
     };
-
-    constructor(props: Props) {
-        super(props);
-
-        // Generate a unique ID for this modal.
-        //
-        // TODO(mdr): Once we add snapshot tests for modals, we'll need to
-        //     ensure that this function is deterministic, perhaps by mocking
-        //     it during the snapshot test.
-        const modalId = generateUniqueId();
-
-        // Use that unique ID number to generate unique ID strings for this
-        // modal's elements.
-        const idPrefix = `wonder-blocks-standard-modal-${modalId}`;
-        this._titleId = `${idPrefix}-title`;
-    }
-
-    _renderTitleAndSubtitle() {
-        const {title, subtitle} = this.props;
-
-        if (subtitle) {
-            return (
-                <View>
-                    <HeadingSmall id={this._titleId}>{title}</HeadingSmall>
-                    <LabelSmall>{subtitle}</LabelSmall>
-                </View>
-            );
-        } else {
-            return <HeadingMedium id={this._titleId}>{title}</HeadingMedium>;
-        }
-    }
-
     render() {
+        const {
+            onClickCloseButton,
+            title,
+            subtitle,
+            header,
+            footer,
+            content,
+            preview,
+        } = this.props;
+
         return (
-            <View
-                style={styles.container}
-                role="dialog"
-                aria-labelledby={this._titleId}
-            >
-                <View style={styles.titlebar}>
-                    <View style={styles.closeButton}>
-                        <ModalCloseButton
-                            color="dark"
-                            onClick={this.props.onClickCloseButton}
+            <ModalDialog style={styles.wrapper}>
+                <ModalContentPane
+                    showCloseButton
+                    onClickCloseButton={onClickCloseButton}
+                    titlebar={
+                        <ModalTitleBar
+                            title={title}
+                            subtitle={subtitle}
+                            color={header ? "dark" : "light"}
                         />
-                    </View>
-                    <View style={styles.titleAndSubtitle}>
-                        {this._renderTitleAndSubtitle()}
-                    </View>
-                    <View style={styles.titleBarSpacer} />
-                </View>
-                <View style={styles.content}>{this.props.content}</View>
-                <View style={styles.footer}>{this.props.footer}</View>
-            </View>
+                    }
+                    header={
+                        header ? <ModalHeader>{header}</ModalHeader> : undefined
+                    }
+                    content={<ModalContent>{content}</ModalContent>}
+                    footer={
+                        footer ? <ModalFooter>{footer}</ModalFooter> : undefined
+                    }
+                />
+                {preview ? (
+                    <ModalContentPane
+                        color="dark"
+                        style={styles.preview}
+                        content={
+                            <ModalContent style={styles.previewContent}>
+                                {preview}
+                            </ModalContent>
+                        }
+                    />
+                ) : (
+                    undefined
+                )}
+            </ModalDialog>
         );
     }
 }
 
 const styles = StyleSheet.create({
-    container: {
-        alignItems: "stretch",
-
+    wrapper: {
         width: "93.75%",
         maxWidth: 960,
         height: "81.25%",
         minHeight: 200,
         maxHeight: 624,
-
-        background: Color.white,
-        borderRadius: 4,
-        overflow: "hidden",
-
-        // On mobile, we consume the full screen size.
-        [smOrSmaller]: {
-            width: "100%",
-            height: "100%",
-            maxWidth: "none",
-            minHeight: 0,
-            maxHeight: "none",
-            borderRadius: 0,
-        },
     },
 
-    titlebar: {
-        flex: "0 0 auto",
-        boxSizing: "border-box",
-        minHeight: 64,
-        paddingLeft: 4,
-        paddingRight: 4,
-        paddingTop: 8,
-        paddingBottom: 8,
-
-        flexDirection: "row",
-        alignItems: "center",
-
-        borderBottomStyle: "solid",
-        borderBottomColor: Color.offBlack16,
-        borderBottomWidth: 1,
-
-        // On mobile, the titlebar is more compact.
-        [smOrSmaller]: {
-            minHeight: 56,
-            paddingTop: 4,
-            paddingBottom: 4,
-        },
+    preview: {
+        maxWidth: 392,
+        flex: "1 0 auto",
     },
 
-    content: {
-        flex: "1 1 auto",
-        overflow: "auto",
-    },
-
-    footer: {
-        flex: "0 0 auto",
-        boxSizing: "border-box",
-        minHeight: 64,
-        paddingLeft: 16,
-        paddingRight: 16,
-        paddingTop: 8,
-        paddingBottom: 8,
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "flex-end",
-
-        borderTopStyle: "solid",
-        borderTopColor: Color.offBlack16,
-        borderTopWidth: 1,
-    },
-
-    // This element is centered within the titlebar, despite the presence of
-    // the close button, because there's an additional right-hand spacer
-    // element that grows at the same rate.
-    titleAndSubtitle: {
-        flex: "0 1 auto",
-        textAlign: "center",
-    },
-
-    closeButton: {
-        flex: "1 0 0",
-    },
-
-    titleBarSpacer: {
-        flex: "1 0 0",
-
-        // When the modal gets small, provide some minimal space here, to
-        // prevent the text from running up against the edge.
-        minWidth: 16,
+    previewContent: {
+        padding: "0 64px 0 0",
     },
 });

--- a/packages/wonder-blocks-modal/components/standard-modal.md
+++ b/packages/wonder-blocks-modal/components/standard-modal.md
@@ -244,13 +244,7 @@ const styles = StyleSheet.create({
             header={
                 <View>
                     <Body tag="p">
-                        {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."}
-                    </Body>
-                    <Body tag="p">
-                        {"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
-                    </Body>
-                    <Body tag="p">
-                        {"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                        {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."}
                     </Body>
                 </View>
             }

--- a/packages/wonder-blocks-modal/components/standard-modal.md
+++ b/packages/wonder-blocks-modal/components/standard-modal.md
@@ -31,16 +31,7 @@ const styles = StyleSheet.create({
 
     modalContent: {
         margin: "0 auto",
-        marginTop: 40,
-        marginBottom: 40,
-        paddingLeft: 32,
-        paddingRight: 32,
         maxWidth: 544,
-
-        [smOrSmaller]: {
-            paddingLeft: 16,
-            paddingRight: 16,
-        },
     },
 });
 
@@ -95,19 +86,66 @@ const styles = StyleSheet.create({
         top: 0,
         bottom: 0,
     },
+});
 
-    modalContent: {
-        margin: "0 auto",
-        marginTop: 40,
-        marginBottom: 40,
-        paddingLeft: 32,
-        paddingRight: 32,
-        maxWidth: 544,
+<View style={styles.previewSizer}>
+    <View style={styles.modalPositioner}>
+        <StandardModal
+            title="Title"
+            subtitle="Wow, look at all this content!"
+            content={
+                <View>
+                    <Body tag="p">
+                        {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."}
+                    </Body>
+                    <Body tag="p">
+                        {"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                    <Body tag="p">
+                        {"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                </View>
+            }
+            footer={<View>
+                {/* TODO(mdr): Use Wonder Blocks button. */}
+                <button type="button">Button (no-op)</button>
+            </View>}
+            onClickCloseButton={() => alert("This would close the modal.")}
+        />
+    </View>
+</View>;
+```
 
-        [smOrSmaller]: {
-            paddingLeft: 16,
-            paddingRight: 16,
-        },
+### Example: Preview Area
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const {Title, Body} = require("wonder-blocks-typography");
+const StandardModal = require("./standard-modal.js").default;
+const {smOrSmaller} = require("../util/util.js");
+
+const styles = StyleSheet.create({
+    previewSizer: {
+        height: 512,
+    },
+
+    modalPositioner: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+
+        position: "absolute",
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
     },
 });
 
@@ -117,7 +155,94 @@ const styles = StyleSheet.create({
             title="Title"
             subtitle="Wow, look at all this content!"
             content={
-                <View style={styles.modalContent}>
+                <View>
+                    <Body tag="p">
+                        {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."}
+                    </Body>
+                    <Body tag="p">
+                        {"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                    <Body tag="p">
+                        {"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                </View>
+            }
+            preview={
+                <View>
+                    <Body tag="p">
+                        {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."}
+                    </Body>
+                    <Body tag="p">
+                        {"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                    <Body tag="p">
+                        {"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                </View>
+            }
+            footer={<View>
+                {/* TODO(mdr): Use Wonder Blocks button. */}
+                <button type="button">Button (no-op)</button>
+            </View>}
+            onClickCloseButton={() => alert("This would close the modal.")}
+        />
+    </View>
+</View>;
+```
+
+### Example: With Header
+
+```js
+const {StyleSheet, css} = require("aphrodite");
+const {View} = require("wonder-blocks-core");
+const {Title, Body} = require("wonder-blocks-typography");
+const StandardModal = require("./standard-modal.js").default;
+const {smOrSmaller} = require("../util/util.js");
+
+const styles = StyleSheet.create({
+    previewSizer: {
+        height: 512,
+    },
+
+    modalPositioner: {
+        // Checkerboard background
+        backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundSize: "20px 20px",
+        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+
+        position: "absolute",
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+    },
+});
+
+<View style={styles.previewSizer}>
+    <View style={styles.modalPositioner}>
+        <StandardModal
+            title="Title"
+            subtitle="Wow, look at all this content!"
+            content={
+                <View>
+                    <Body tag="p">
+                        {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."}
+                    </Body>
+                    <Body tag="p">
+                        {"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                    <Body tag="p">
+                        {"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."}
+                    </Body>
+                </View>
+            }
+            header={
+                <View>
                     <Body tag="p">
                         {"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est."}
                     </Body>

--- a/packages/wonder-blocks-modal/components/standard-modal.test.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.test.js
@@ -6,18 +6,10 @@ import StandardModal from "./standard-modal.js";
 
 describe("StandardModal", () => {
     test("Clicking the close button triggers `onClickCloseButton`", () => {
-        const onClickCloseButton = jest.fn();
         const wrapper = shallow(
-            <StandardModal
-                title="Title"
-                content="Content"
-                footer="Footer"
-                onClickCloseButton={onClickCloseButton}
-            />,
+            <StandardModal title="Title" content="Content" footer="Footer" />,
         );
 
-        expect(onClickCloseButton).not.toHaveBeenCalled();
-        wrapper.find("ModalCloseButton").simulate("click");
-        expect(onClickCloseButton).toHaveBeenCalled();
+        expect(wrapper.find("ModalCloseButton").exists()).toBeFalsy();
     });
 });

--- a/packages/wonder-blocks-modal/components/standard-modal.test.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.test.js
@@ -5,7 +5,7 @@ import {shallow} from "enzyme";
 import StandardModal from "./standard-modal.js";
 
 describe("StandardModal", () => {
-    test("Clicking the close button triggers `onClickCloseButton`", () => {
+    test("Ensure the ModalCloseButton isn't inside.", () => {
         const wrapper = shallow(
             <StandardModal title="Title" content="Content" footer="Footer" />,
         );

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -4,8 +4,6 @@ import {StyleSheet} from "aphrodite";
 
 import ModalDialog from "./modal-dialog.js";
 import ModalContentPane from "./modal-content-pane.js";
-import ModalFooter from "./modal-footer.js";
-import ModalContent from "./modal-content.js";
 
 type Props = {
     /** The sidebar contents (which becomes the header on mobile screens). */
@@ -50,14 +48,12 @@ export default class TwoColumnModal extends React.Component<Props> {
                     color="dark"
                     onClickCloseButton={onClickCloseButton}
                     style={styles.column}
-                    content={<ModalContent>{sidebar}</ModalContent>}
+                    content={sidebar}
                 />
                 <ModalContentPane
                     style={styles.column}
-                    content={<ModalContent>{content}</ModalContent>}
-                    footer={
-                        footer ? <ModalFooter>{footer}</ModalFooter> : undefined
-                    }
+                    content={content}
+                    footer={footer}
                 />
             </ModalDialog>
         );

--- a/packages/wonder-blocks-modal/components/two-column-modal.test.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.test.js
@@ -5,7 +5,7 @@ import {shallow} from "enzyme";
 import TwoColumnModal from "./two-column-modal.js";
 
 describe("TwoColumnModal", () => {
-    test("Has no ModalCloseButton as a direct child", () => {
+    test("Ensure the ModalCloseButton isn't inside.", () => {
         const wrapper = shallow(
             <TwoColumnModal sidebar="Sidebar" content="Contents" />,
         );

--- a/packages/wonder-blocks-modal/components/two-column-modal.test.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.test.js
@@ -5,18 +5,11 @@ import {shallow} from "enzyme";
 import TwoColumnModal from "./two-column-modal.js";
 
 describe("TwoColumnModal", () => {
-    test("Clicking the close button triggers `onClickCloseButton`", () => {
-        const onClickCloseButton = jest.fn();
+    test("Has no ModalCloseButton as a direct child", () => {
         const wrapper = shallow(
-            <TwoColumnModal
-                leftContent="Left content"
-                rightContent="Right content"
-                onClickCloseButton={onClickCloseButton}
-            />,
+            <TwoColumnModal sidebar="Sidebar" content="Contents" />,
         );
 
-        expect(onClickCloseButton).not.toHaveBeenCalled();
-        wrapper.find("ModalCloseButton").simulate("click");
-        expect(onClickCloseButton).toHaveBeenCalled();
+        expect(wrapper.find("ModalCloseButton").exists()).toBeFalsy();
     });
 });

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -30,13 +30,33 @@ module.exports = {
         {
             name: "Modal",
             content: "packages/wonder-blocks-modal/docs.md",
-            components: "packages/wonder-blocks-modal/components/*.js",
-            ignore: [
-                "**/components/focus-trap.js",
-                "**/components/modal-backdrop.js",
-                "**/components/modal-close-button.js",
-                "**/components/modal-launcher-portal.js",
-                "**/components/scroll-disabler.js",
+            sections: [
+                {
+                    name: "Launcher",
+                    components: [
+                        "packages/wonder-blocks-modal/components/modal-launcher.js",
+                    ],
+                },
+                {
+                    name: "Modals",
+                    components: [
+                        "packages/wonder-blocks-modal/components/standard-modal.js",
+                        "packages/wonder-blocks-modal/components/two-column-modal.js",
+                        "packages/wonder-blocks-modal/components/one-column-modal.js",
+                    ],
+                },
+                {
+                    name: "Building Blocks",
+                    content: "packages/wonder-blocks-modal/building-blocks.md",
+                    components: [
+                        "packages/wonder-blocks-modal/components/modal-dialog.js",
+                        "packages/wonder-blocks-modal/components/modal-content-pane.js",
+                        "packages/wonder-blocks-modal/components/modal-content.js",
+                        "packages/wonder-blocks-modal/components/modal-title-bar.js",
+                        "packages/wonder-blocks-modal/components/modal-header.js",
+                        "packages/wonder-blocks-modal/components/modal-footer.js",
+                    ],
+                },
             ],
         },
         {


### PR DESCRIPTION
Now that we're free from our Grid restrictions it's really easy to build up a series of low-level building blocks to construct our modals! I built a collection of these components to build all of our modals, and to give users the power to construct their own and potentially override specific aspects of the layout, if need be.

Looking at an existing set of modals:

![screenshot 2018-05-09 17 10 56](https://user-images.githubusercontent.com/1615/39840293-e3e35e5e-53ac-11e8-8976-dea94d0c9e99.jpg)

* ModalDialog (red): Holds the entire modal and all of the contents (a set of ModalContentPanes).
* ModalContentPane (orange): Holds a set of ModalTitleBar, ModalHeader, ModalContent, and ModalFooter and renders them all. Additionally is responsible for rendering the ModalCloseButton.
* ModalTitleBar (green): Renders the Title and Subtitle.
* ModalHeader (teal): Renders the section displayed beneath the titlebar and above the contents.
* ModalContent (purple): The main contents of the ModalContentPane (and the only required part of the content pane).
* ModalFooter (blue): An optional footer to display beneath the contents.

This diff also implements the following new additions to the existing modals:
* OneColumnModal is now available!
* StandardModal Headers are now available (they are dark and if provided cause the titlebar to turn dark too).
* StandardModal Preview (displayed next to the main contents and have less padding than a normal contents).

I think you'll find that by breaking everything up all of the components are much simpler now. All of the main modals are quite small and (IMO) easy to understand. If someone wanted to build a similar one they could easily copy the contents of an existing modal and modify it.

Not done yet and will do in a following diff:
* Get mobile support working.
* Write documentation for all of this!

