### PR TITLE
Update View to have to have display: flex; flexDirection: column

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 docs/* linguist-generated
-**/__snapshots__/** linguist-generated
 package-lock.json linguist-generated
+**/generated-snapshot.test.js

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 docs/* linguist-generated
 **/__snapshots__/** linguist-generated
 package-lock.json linguist-generated
-**/generated-snapshot.test.js

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -6,6 +6,8 @@ exports[`wonder-blocks-core example 1 1`] = `
   style={
     Object {
       "backgroundColor": "plum",
+      "display": "flex",
+      "flexDirection": "column",
       "padding": 32,
     }
   }
@@ -29,12 +31,22 @@ exports[`wonder-blocks-core example 1 1`] = `
 exports[`wonder-blocks-core example 2 1`] = `
 <div
   className=""
-  style={Object {}}
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "column",
+    }
+  }
 >
   <div
     className=""
     onClick={[Function]}
-    style={Object {}}
+    style={
+      Object {
+        "display": "flex",
+        "flexDirection": "column",
+      }
+    }
   >
     Click me!
   </div>

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -1,11 +1,19 @@
 // @flow
 import React from "react";
+import {StyleSheet} from "aphrodite";
 
 import {addStyle} from "../util/add-style.js";
 
 import type {Props} from "../util/types.js";
 
-const StyledDiv = addStyle("div");
+const styles = StyleSheet.create({
+    default: {
+        display: "flex",
+        flexDirection: "column",
+    },
+});
+
+const StyledDiv = addStyle("div", styles.default);
 
 export default class View extends React.Component<Props> {
     props: Props;

--- a/packages/wonder-blocks-grid/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-grid/__snapshots__/generated-snapshot.test.js.snap
@@ -6,12 +6,19 @@ exports[`wonder-blocks-grid example 1 1`] = `
   style={
     Object {
       "background": "#21242c",
+      "display": "flex",
+      "flexDirection": "column",
     }
   }
 >
   <div
     className=""
-    style={Object {}}
+    style={
+      Object {
+        "display": "flex",
+        "flexDirection": "column",
+      }
+    }
   >
     <div
       className=""
@@ -19,6 +26,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
         Object {
           "alignItems": "center",
           "display": "flex",
+          "flexDirection": "row",
         }
       }
     >
@@ -30,6 +38,7 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "flexDirection": "row",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -42,7 +51,9 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -60,6 +71,8 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "@media (min-width: 768px) and (max-width: 1023px)": Object {
                 "background": "#00a60e",
               },
+              "display": "flex",
+              "flexDirection": "column",
               "flexGrow": 1,
               "height": 100,
               "padding": 5,
@@ -95,6 +108,8 @@ exports[`wonder-blocks-grid example 1 1`] = `
             className=""
             style={
               Object {
+                "display": "flex",
+                "flexDirection": "column",
                 "textAlign": "right",
               }
             }
@@ -119,7 +134,9 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "MsFlexBasis": 32,
               "MsFlexPreferredSize": 32,
               "WebkitFlexBasis": 32,
+              "display": "flex",
               "flexBasis": 32,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -140,7 +157,9 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "MsFlexBasis": 100,
               "MsFlexPreferredSize": 100,
               "WebkitFlexBasis": 100,
+              "display": "flex",
               "flexBasis": 100,
+              "flexDirection": "column",
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
@@ -164,6 +183,8 @@ exports[`wonder-blocks-grid example 1 1`] = `
             className=""
             style={
               Object {
+                "display": "flex",
+                "flexDirection": "column",
                 "textAlign": "center",
               }
             }
@@ -188,7 +209,9 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "MsFlexBasis": 32,
               "MsFlexPreferredSize": 32,
               "WebkitFlexBasis": 32,
+              "display": "flex",
               "flexBasis": 32,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -209,7 +232,9 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "MsFlexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
               "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
               "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
+              "display": "flex",
               "flexBasis": "calc((100% - 352px - 48px) * 0.16666666666666666 + 32px)",
+              "flexDirection": "column",
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
@@ -233,6 +258,8 @@ exports[`wonder-blocks-grid example 1 1`] = `
             className=""
             style={
               Object {
+                "display": "flex",
+                "flexDirection": "column",
                 "textAlign": "center",
               }
             }
@@ -257,7 +284,9 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "MsFlexBasis": 32,
               "MsFlexPreferredSize": 32,
               "WebkitFlexBasis": 32,
+              "display": "flex",
               "flexBasis": 32,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -278,7 +307,9 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "MsFlexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
               "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
               "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
+              "display": "flex",
               "flexBasis": "calc((100% - 352px - 48px) * 0.4166666666666667 + 128px)",
+              "flexDirection": "column",
               "flexShrink": 0,
               "height": 100,
               "padding": 5,
@@ -287,7 +318,12 @@ exports[`wonder-blocks-grid example 1 1`] = `
         >
           <div
             className=""
-            style={Object {}}
+            style={
+              Object {
+                "display": "flex",
+                "flexDirection": "column",
+              }
+            }
           >
             <span
               className=""
@@ -321,6 +357,8 @@ exports[`wonder-blocks-grid example 1 1`] = `
               className=""
               style={
                 Object {
+                  "display": "flex",
+                  "flexDirection": "column",
                   "textAlign": "right",
                 }
               }
@@ -346,7 +384,9 @@ exports[`wonder-blocks-grid example 1 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -363,12 +403,19 @@ exports[`wonder-blocks-grid example 2 1`] = `
   style={
     Object {
       "background": "#f7f8fa",
+      "display": "flex",
+      "flexDirection": "column",
     }
   }
 >
   <div
     className=""
-    style={Object {}}
+    style={
+      Object {
+        "display": "flex",
+        "flexDirection": "column",
+      }
+    }
   >
     <div
       className=""
@@ -378,6 +425,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
           "background": "#0a2a66",
           "borderBottom": "1px solid rgba(255,255,255,0.64)",
           "display": "flex",
+          "flexDirection": "row",
           "height": 64,
         }
       }
@@ -390,6 +438,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "flexDirection": "row",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -402,7 +451,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -412,6 +463,8 @@ exports[`wonder-blocks-grid example 2 1`] = `
           style={
             Object {
               "color": "#ffffff",
+              "display": "flex",
+              "flexDirection": "column",
               "flexGrow": 1,
               "textAlign": "center",
             }
@@ -426,7 +479,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -440,6 +495,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
           "alignItems": "center",
           "background": "#0a2a66",
           "display": "flex",
+          "flexDirection": "row",
           "height": 136,
         }
       }
@@ -452,6 +508,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "flexDirection": "row",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -464,7 +521,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -474,6 +533,8 @@ exports[`wonder-blocks-grid example 2 1`] = `
           style={
             Object {
               "color": "#ffffff",
+              "display": "flex",
+              "flexDirection": "column",
               "flexGrow": 1,
             }
           }
@@ -487,7 +548,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -502,6 +565,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
           "background": "#ffffff",
           "borderBottom": "1px solid rgba(33,36,44,0.08)",
           "display": "flex",
+          "flexDirection": "row",
           "height": 71,
         }
       }
@@ -514,6 +578,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "flexDirection": "row",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -526,7 +591,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -538,7 +605,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
               "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.25 + 64px)",
               "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
+              "display": "flex",
               "flexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -552,14 +621,21 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 32,
               "MsFlexPreferredSize": 32,
               "WebkitFlexBasis": 32,
+              "display": "flex",
               "flexBasis": 32,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
         />
         <div
           className=""
-          style={Object {}}
+          style={
+            Object {
+              "display": "flex",
+              "flexDirection": "column",
+            }
+          }
         >
           Beginner / Points to Apprentice
         </div>
@@ -570,7 +646,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -583,6 +661,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
         Object {
           "alignItems": "center",
           "display": "flex",
+          "flexDirection": "row",
           "padding": "17px 0",
         }
       }
@@ -595,6 +674,7 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "margin": "0 auto",
             },
             "display": "flex",
+            "flexDirection": "row",
             "maxWidth": 1120,
             "width": "100%",
           }
@@ -607,7 +687,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -619,7 +701,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
               "MsFlexPreferredSize": "calc((100% - 352px - 48px) * 0.25 + 64px)",
               "WebkitFlexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
+              "display": "flex",
               "flexBasis": "calc((100% - 352px - 48px) * 0.25 + 64px)",
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -641,7 +725,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 32,
               "MsFlexPreferredSize": 32,
               "WebkitFlexBasis": 32,
+              "display": "flex",
               "flexBasis": 32,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }
@@ -650,6 +736,8 @@ exports[`wonder-blocks-grid example 2 1`] = `
           className=""
           style={
             Object {
+              "display": "flex",
+              "flexDirection": "column",
               "flexGrow": 1,
             }
           }
@@ -660,6 +748,8 @@ exports[`wonder-blocks-grid example 2 1`] = `
               Object {
                 "background": "#ffffff",
                 "border": "1px solid rgba(33,36,44,0.08)",
+                "display": "flex",
+                "flexDirection": "column",
                 "height": 360,
                 "padding": 24,
               }
@@ -673,6 +763,8 @@ exports[`wonder-blocks-grid example 2 1`] = `
               Object {
                 "background": "#ffffff",
                 "border": "1px solid rgba(33,36,44,0.08)",
+                "display": "flex",
+                "flexDirection": "column",
                 "height": 360,
                 "marginTop": 16,
                 "padding": 24,
@@ -689,7 +781,9 @@ exports[`wonder-blocks-grid example 2 1`] = `
               "MsFlexBasis": 24,
               "MsFlexPreferredSize": 24,
               "WebkitFlexBasis": 24,
+              "display": "flex",
               "flexBasis": 24,
+              "flexDirection": "column",
               "flexShrink": 0,
             }
           }

--- a/packages/wonder-blocks-grid/util/styles.js
+++ b/packages/wonder-blocks-grid/util/styles.js
@@ -5,12 +5,12 @@ const WIDE_SCREEN = "@media (min-width: 1168px)";
 
 const styles = StyleSheet.create({
     rowWrap: {
-        display: "flex",
+        flexDirection: "row",
         alignItems: "center",
     },
 
     row: {
-        display: "flex",
+        flexDirection: "row",
         width: "100%",
     },
 

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -104,7 +104,6 @@ const styles = StyleSheet.create({
         width: "100%",
         height: "100%",
 
-        display: "flex",
         alignItems: "center",
         justifyContent: "center",
 

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -125,8 +125,6 @@ export default class StandardModal extends React.Component<Props> {
 
 const styles = StyleSheet.create({
     container: {
-        display: "flex",
-        flexDirection: "column",
         alignItems: "stretch",
 
         width: "93.75%",
@@ -159,7 +157,6 @@ const styles = StyleSheet.create({
         paddingTop: 8,
         paddingBottom: 8,
 
-        display: "flex",
         flexDirection: "row",
         alignItems: "center",
 
@@ -189,7 +186,6 @@ const styles = StyleSheet.create({
         paddingTop: 8,
         paddingBottom: 8,
 
-        display: "flex",
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "flex-end",

--- a/packages/wonder-blocks-modal/components/standard-modal.md
+++ b/packages/wonder-blocks-modal/components/standard-modal.md
@@ -18,7 +18,6 @@ const styles = StyleSheet.create({
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 
-        display: "flex",
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",
@@ -86,7 +85,6 @@ const styles = StyleSheet.create({
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 
-        display: "flex",
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -64,7 +64,6 @@ export default class TwoColumnModal extends React.Component<Props> {
 
 const styles = StyleSheet.create({
     container: {
-        display: "flex",
         flexDirection: "row",
         alignItems: "stretch",
         position: "relative",

--- a/packages/wonder-blocks-modal/components/two-column-modal.md
+++ b/packages/wonder-blocks-modal/components/two-column-modal.md
@@ -15,7 +15,6 @@ const styles = StyleSheet.create({
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 
-        display: "flex",
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",

--- a/packages/wonder-blocks-typography/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-typography/__snapshots__/generated-snapshot.test.js.snap
@@ -3,7 +3,12 @@
 exports[`wonder-blocks-typography example 1 1`] = `
 <div
   className=""
-  style={Object {}}
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "column",
+    }
+  }
 >
   <h1
     className=""


### PR DESCRIPTION
The rationale for this change is:
- flex-box layouts can break when a <div> is inserted in the layout
  without setting display: flex;
- by default flexDirection is "row" on the web, but this is quite
  different from the default layout of children when display: flex
  isn't set
- these are defaults for React Native's View component after which
  our View component is modelled so it makes sense have similar
  defaults

I've also re-enabled display of .snap files in github reviews.

Test Plan:
- npm test
- npm run styleguidist, look at all of the components to verify that
  nothing's broken after this change