### PR TITLE
Add "light red" to available wonder blocks colors

### DIFF
--- a/packages/wonder-blocks-color/index.js
+++ b/packages/wonder-blocks-color/index.js
@@ -11,6 +11,7 @@ const Color = {
     green: "#00a60e",
     gold: "#ffb100",
     red: "#d92916",
+    lightRed: "#fd6c6e",
 
     // Neutral
     offBlack,
@@ -34,6 +35,7 @@ const Color = {
 const SemanticColor = {
     controlDefault: Color.blue,
     controlDestructive: Color.red,
+    struggling: Color.lightRed,
 };
 
 export {Color as default, SemanticColor, mix, fade};


### PR DESCRIPTION
This color is currently used in the struggling indicator in webapp.

See: https://github.com/Khan/webapp/blob/ddf131365eb7823a00da5944ad559b872e9018c8/javascript/mastery-package/struggling-indicator.jsx#L35