### PR TITLE
experimental flow library definition for wonder-blocks-core (don't merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 coverage
-dist
+**/dist/index.js

--- a/packages/wonder-blocks-core/dist/index.js.flow
+++ b/packages/wonder-blocks-core/dist/index.js.flow
@@ -1,0 +1,190 @@
+// @flow
+export type ClickableHandlers = {
+    onClick: (e: SyntheticMouseEvent<>) => void,
+    onMouseEnter: () => void,
+    onMouseLeave: () => void,
+    onMouseDown: () => void,
+    onMouseUp: (e: SyntheticMouseEvent<>) => void,
+    onTouchStart: () => void,
+    onTouchEnd: () => void,
+    onTouchCancel: () => void,
+    onKeyDown: (e: SyntheticKeyboardEvent<*>) => void,
+    onKeyUp: (e: SyntheticKeyboardEvent<*>) => void,
+    onBlur: (e: SyntheticFocusEvent<*>) => void,
+};
+
+// Source: https://www.w3.org/WAI/PF/aria-1.1/roles#role_definitions
+declare type roles = [
+    "alert",
+    "alertdialog",
+    "application",
+    "article",
+    "banner",
+    "button",
+    "checkbox",
+    "columnheader",
+    "combobox",
+    "command", // abstract role
+    "complementary",
+    "composite", // abstract role
+    "contentinfo",
+    "dialog",
+    "directory",
+    "document",
+    "form",
+    "grid",
+    "gridcell",
+    "group",
+    "heading",
+    "img",
+    "input", // abstract role
+    "landmark", // abstract role
+    "link",
+    "list",
+    "listbox",
+    "listitem",
+    "log",
+    "main",
+    "marquee",
+    "math",
+    "menu",
+    "menubar",
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+    "navigation",
+    "note",
+    "option",
+    "presentation",
+    "progressbar",
+    "radio",
+    "radiogroup",
+    "range", // abstract role
+    "region",
+    "reletype", // abstract role
+    "row",
+    "rowgroup",
+    "rowheader",
+    "scrollbar",
+    "search",
+    "section", // abstract role
+    "sectionhead", // abstract role
+    "select", // abstract role
+    "separator",
+    "slider",
+    "spinbutton",
+    "status",
+    "structure", // abstract role
+    "tab",
+    "tablist",
+    "tabpanel",
+    "textbox",
+    "timer",
+    "toolbar",
+    "tooltip",
+    "tree",
+    "treegrid",
+    "treeitem",
+    "widget", // abstract role
+    "window", // abstract role
+];
+
+declare type IdRef = string;
+declare type IdRefList = IdRef | Array<IdRef>;
+
+// Source: https://www.w3.org/WAI/PF/aria-1.1/states_and_properties
+// TODO(kevinb): figure out how to type ID ref lists
+export type AriaProps = {
+    role?: roles,
+    "aria-activedescendant"?: IdRef,
+    "aria-atomic"?: "false" | "true",
+    "aria-autocomplete"?: "both" | "inline" | "list" | "none",
+    "aria-busy"?: "true" | "false",
+    "aria-checked"?: "false" | "mixed" | "true" | "undefined",
+    "aria-controls"?: IdRefList,
+    "aria-describedat"?: string, // URI
+    "aria-describedby"?: IdRefList,
+    "aria-disabled"?: "false" | "true",
+    "aria-dropeffect"?: "copy" | "execute" | "link" | "move" | "none" | "popup",
+    "aria-expanded"?: "false" | "true" | "undefined",
+    "aria-flowto"?: IdRefList,
+    "aria-grabbed"?: "false" | "true" | "undefined",
+    "aria-haspopup"?: "false" | "true",
+    "aria-hidden"?: "false" | "true",
+    "aria-invalid"?: "grammar" | "false" | "spelling" | "true",
+    "aria-label"?: string,
+    "aria-labelledby"?: IdRefList,
+    "aria-level"?: number, // integer
+    "aria-live"?: "assertive" | "off" | "polite",
+    "aria-multiline"?: "false" | "true",
+    "aria-multiselectable"?: "false" | "true",
+    "aria-orientation"?: "horizontal" | "vertical",
+    "aria-owns"?: IdRefList,
+    "aria-posinset"?: number, // integer
+    "aria-pressed"?: "false" | "mixed" | "true" | "undefined",
+    "aria-readonly"?: "false" | "true",
+    "aria-relevant"?: void, // Not using aria-relevant is a best practice
+    "aria-required"?: "false" | "true",
+    "aria-selected"?: "false" | "true" | "undefined",
+    "aria-setsize"?: number, // integer
+    "aria-sort"?: "ascending" | "descending" | "none" | "other",
+    "aria-valuemax"?: number,
+    "aria-valuemin"?: number,
+    "aria-valuenow"?: number,
+    "aria-valuetext"?: string,
+};
+
+export type TextTag = "span" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+declare type TextProps = AriaProps & {
+    style?: any,
+    tag: TextTag,
+    children?: any,
+    [otherProp: string]: any,
+};
+
+declare export class Text extends React$Component<TextProps> {
+    static defaultProps: {
+        tag: TextTag,
+    };
+}
+
+declare type ViewProps = AriaProps & {
+    style?: any,
+    children?: any,
+    [otherProp: string]: any,
+};
+
+declare export class View extends React$Component<ViewProps> {
+}
+
+type State = {
+    hovered: boolean,
+    focused: boolean,
+    pressed: boolean,
+};
+
+type ClickableBehaviorProps = {
+    children: (state: State, handlers: ClickableHandlers) => React$Element<*>,
+    disabled: boolean,
+    href?: string,
+    onClick?: (e: SyntheticEvent<>) => void,
+    history?: any,
+};
+
+declare export class ClickableBehavior extends React$Component<ClickableBehaviorProps, State> {
+}
+
+declare export function addStyle<T: Object>(
+    Component: React$ComponentType<T> | string,
+    defaultStyle?: any,
+): React$ComponentType<T & {style: any}>;
+
+declare export function getClickableBehavior(
+    href?: string,
+    clientNav?: boolean,
+    /**
+     * router object added to the React context object by react-router-dom.
+     */
+    router: any,
+): typeof ClickableBehavior;


### PR DESCRIPTION
This is experimental.  `.js.flow` files should be generated as part of the build process automatically and not be checked in.  I'm going to try https://github.com/AgentME/flow-copy-source since `flow`'s built-in `gen-flow-files` command doesn't work.