### PR TITLE
make wonder-blocks-core a dependency of wonder-blocks-spacing, add prop-types as a project-wide dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "aphrodite": "^1.2.5",
+    "prop-types": "^15.6.1",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-router-dom": "^4.2.2"

--- a/packages/wonder-blocks-spacing/package.json
+++ b/packages/wonder-blocks-spacing/package.json
@@ -7,8 +7,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "wonder-blocks-core": "0.0.1"
+  },
   "devDependencies": {
-    "wonder-blocks-core": "0.0.1",
     "wonder-blocks-color": "0.0.1"
   },
   "author": "",


### PR DESCRIPTION
The addition of `prop-types` is b/c in a few places we were using it was being included in built files.  The webpack.config.js looks at package.json so if something's not explicitly listed but imported as a sub dependency of something else we don't mark it as external.  Adding an explicit dep for it to the root package.json avoid bundling prop-types in each of the packages.