### PR TITLE
Avoid recursive imports

### DIFF
--- a/packages/wonder-blocks-core/components/media-layout.js
+++ b/packages/wonder-blocks-core/components/media-layout.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import {View} from "@khanacademy/wonder-blocks-core";
+import View from "./view.js";
 
 import {MEDIA_DEFAULT_SPEC, VALID_MEDIA_SIZES} from "../util/specs.js";
 import {mediaContextTypes} from "../util/util.js";

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -12,7 +12,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@khanacademy/wonder-blocks-core": "^1.0.0"
+    "@khanacademy/wonder-blocks-spacing": "^1.0.0"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "@khanacademy/wonder-blocks-core": "^1.0.0"
+  },
   "author": "",
   "license": "MIT"
 }

--- a/packages/wonder-blocks-grid/package.json
+++ b/packages/wonder-blocks-grid/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@khanacademy/wonder-blocks-color": "^1.0.0",
     "@khanacademy/wonder-blocks-core": "^1.0.0",
-    "@khanacademy/wonder-blocks-spacing": "^0.0.1"
+    "@khanacademy/wonder-blocks-spacing": "^1.0.0"
   }
 }

--- a/packages/wonder-blocks-progress-spinner/package.json
+++ b/packages/wonder-blocks-progress-spinner/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@khanacademy/wonder-blocks-color": "^1.0.0",
     "@khanacademy/wonder-blocks-core": "^1.0.0",
-    "@khanacademy/wonder-blocks-spacing": "^0.0.1"
+    "@khanacademy/wonder-blocks-spacing": "^1.0.0"
   }
 }

--- a/packages/wonder-blocks-spacing/package.json
+++ b/packages/wonder-blocks-spacing/package.json
@@ -1,7 +1,6 @@
 {
-  "private": true,
   "name": "@khanacademy/wonder-blocks-spacing",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "design": "v1",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
We had an issue where `yarn run watch:all` resulting in an ever growing dist/index.js for `wonder-blocks-core`.  This PR fixes that by ensuring that `wonder-blocks-core` has the prop dependencies specified and that internal dependencies are imported directly.  This fix will also require us to publish `wonder-blocks-spacing` which is a dependency of `wonder-blocks-core`.