### PR TITLE
only publish packages with explicit updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:styleguidist": "styleguidist build",
     "git-add-snapshot-tests": "git add packages/*/generated-snapshot.test.js",
     "pretty-quick": "pretty-quick --staged",
-    "publish": "git diff --stat --exit-code HEAD && yarn build:all && lerna publish"
+    "publish": "git diff --stat --exit-code HEAD && yarn build:all && lerna publish --only-explicit-updates"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
I'm going to give this a try.  It should prevent situations where we bump the version of a package and then any other package using that gets auto-bumped.