### PR TITLE
Add path for coverage gutter to find coverage info

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,5 @@
     "files.trimTrailingWhitespace": true,
     "flow.useNPMPackagedFlow": true,
     "javascript.validate.enable": false,
+    "coverage-gutters.lcovname": "./coverage/lcov.info"
 }


### PR DESCRIPTION
If you add the coverage gutter extension, this means you can see our coverage results inside the code, and other useful things.