### PR TITLE
ignore changes to tests and documentation when publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,14 @@
   "packages": [
     "packages/*"
   ],
+  "command": {
+    "publish": {
+      "ignore": [
+        "*.test.js",
+        "*.md"
+      ]
+    }
+  },
   "version": "independent",
   "npmClient": "yarn",
   "useWorkspaces": true


### PR DESCRIPTION
Unfortunately, this change doesn't impact any of the packages that lerna wants to bump since it still checks to see if devDependencies have changed when decided whether or not to bump a package's version.