### PR TITLE
Mock react-dom in snapshot tests

### DIFF
--- a/packages/wonder-blocks-button/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/generated-snapshot.test.js
@@ -6,6 +6,9 @@
 //   2. Run `yarn run gen-snapshot-tests`.
 import React from "react";
 import renderer from "react-test-renderer";
+
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
 import Button from "./components/button.js";
 
 describe("wonder-blocks-button", () => {

--- a/packages/wonder-blocks-color/generated-snapshot.test.js
+++ b/packages/wonder-blocks-color/generated-snapshot.test.js
@@ -7,6 +7,9 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
+
 describe("wonder-blocks-color", () => {
     it("example 1", () => {
         const {StyleSheet} = require("aphrodite");

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -6,6 +6,9 @@
 //   2. Run `yarn run gen-snapshot-tests`.
 import React from "react";
 import renderer from "react-test-renderer";
+
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
 import ClickableBehavior from "./components/clickable-behavior.js";
 import MediaLayout from "./components/media-layout.js";
 import Text from "./components/text.js";

--- a/packages/wonder-blocks-grid/generated-snapshot.test.js
+++ b/packages/wonder-blocks-grid/generated-snapshot.test.js
@@ -6,6 +6,9 @@
 //   2. Run `yarn run gen-snapshot-tests`.
 import React from "react";
 import renderer from "react-test-renderer";
+
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
 import Cell from "./components/cell.js";
 import FixedWidthCell from "./components/fixed-width-cell.js";
 import FlexCell from "./components/flex-cell.js";

--- a/packages/wonder-blocks-icon-button/generated-snapshot.test.js
+++ b/packages/wonder-blocks-icon-button/generated-snapshot.test.js
@@ -6,6 +6,9 @@
 //   2. Run `yarn run gen-snapshot-tests`.
 import React from "react";
 import renderer from "react-test-renderer";
+
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
 import IconButton from "./components/icon-button.js";
 
 describe("wonder-blocks-icon-button", () => {

--- a/packages/wonder-blocks-layout/generated-snapshot.test.js
+++ b/packages/wonder-blocks-layout/generated-snapshot.test.js
@@ -7,6 +7,9 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
+
 describe("wonder-blocks-layout", () => {
     it("example 1", () => {
         const {StyleSheet} = require("aphrodite");

--- a/packages/wonder-blocks-link/generated-snapshot.test.js
+++ b/packages/wonder-blocks-link/generated-snapshot.test.js
@@ -6,6 +6,9 @@
 //   2. Run `yarn run gen-snapshot-tests`.
 import React from "react";
 import renderer from "react-test-renderer";
+
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
 import Link from "./components/link.js";
 
 describe("wonder-blocks-link", () => {

--- a/packages/wonder-blocks-modal/generated-snapshot.test.js
+++ b/packages/wonder-blocks-modal/generated-snapshot.test.js
@@ -6,6 +6,9 @@
 //   2. Run `yarn run gen-snapshot-tests`.
 import React from "react";
 import renderer from "react-test-renderer";
+
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
 import ModalLauncher from "./components/modal-launcher.js";
 import StandardModal from "./components/standard-modal.js";
 import TwoColumnModal from "./components/two-column-modal.js";

--- a/packages/wonder-blocks-progress-spinner/generated-snapshot.test.js
+++ b/packages/wonder-blocks-progress-spinner/generated-snapshot.test.js
@@ -6,6 +6,9 @@
 //   2. Run `yarn run gen-snapshot-tests`.
 import React from "react";
 import renderer from "react-test-renderer";
+
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
 import CircularSpinner from "./components/circular-spinner.js";
 
 describe("wonder-blocks-progress-spinner", () => {

--- a/packages/wonder-blocks-spacing/generated-snapshot.test.js
+++ b/packages/wonder-blocks-spacing/generated-snapshot.test.js
@@ -7,6 +7,9 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
+
 describe("wonder-blocks-spacing", () => {
     it("example 1", () => {
         const {StyleSheet} = require("aphrodite");

--- a/packages/wonder-blocks-typography/generated-snapshot.test.js
+++ b/packages/wonder-blocks-typography/generated-snapshot.test.js
@@ -6,6 +6,9 @@
 //   2. Run `yarn run gen-snapshot-tests`.
 import React from "react";
 import renderer from "react-test-renderer";
+
+// Mock react-dom as jest doesn't like findDOMNode.
+jest.mock("react-dom");
 import BodyMonospace from "./components/body-monospace.js";
 import BodySerifBlock from "./components/body-serif-block.js";
 import BodySerif from "./components/body-serif.js";

--- a/utils/gen-snapshot-tests.js
+++ b/utils/gen-snapshot-tests.js
@@ -44,6 +44,9 @@ function generateTestFile(root, examples, componentFileMap) {
         "//   2. Run `yarn run gen-snapshot-tests`.",
         `import React from "react";`,
         `import renderer from "react-test-renderer";`,
+        ``,
+        `// Mock react-dom as jest doesn't like findDOMNode.`,
+        `jest.mock("react-dom");`,
     ];
 
     const modName = root.split("/")[1];


### PR DESCRIPTION
This is needed for when we use things like `ReactDOM.findDOMNode` in our components, as they will cause jest to fail the test.

While no components do this yet, there are some coming (like the `Tooltip`: #140 ) that will require this change.