### PR TITLE
Make jest work idiomatically and add extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,19 +1,19 @@
 {
-	// See http://go.microsoft.com/fwlink/?LinkId=827846
-	// for the documentation about the extensions.json format
-	"recommendations": [
-		// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
-		// Coverage Gutters for code coverage inside editor
-		"ryanluker.vscode-coverage-gutters",
+        // Coverage Gutters for code coverage inside editor
+        "ryanluker.vscode-coverage-gutters",
 
-		// ESLint for eslint error and suppression support
-		"dbaeumer.vscode-eslint",
+        // ESLint for eslint error and suppression support
+        "dbaeumer.vscode-eslint",
 
-		// GitLens because it is awesome
-		"eamodio.gitlens",
+        // GitLens because it is awesome
+        "eamodio.gitlens",
 
-		// FlowType for flow support
-		"flowtype.flow-for-vscode",
-	]
+        // FlowType for flow support
+        "flowtype.flow-for-vscode",
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,19 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+		// Coverage Gutters for code coverage inside editor
+		"ryanluker.vscode-coverage-gutters",
+
+		// ESLint for eslint error and suppression support
+		"dbaeumer.vscode-eslint",
+
+		// GitLens because it is awesome
+		"eamodio.gitlens",
+
+		// FlowType for flow support
+		"flowtype.flow-for-vscode",
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "files.trimTrailingWhitespace": true,
     "flow.useNPMPackagedFlow": true,
     "javascript.validate.enable": false,
-    "coverage-gutters.lcovname": "./coverage/lcov.info"
+    "coverage-gutters.lcovname": "./coverage/lcov.info",
+    "jest.enableSnapshotUpdateMessages": false,
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "watch:all": "webpack -w",
     "flow": "flow",
     "gen-snapshot-tests": "node utils/gen-snapshot-tests.js && prettier --write packages/*/generated-snapshot.test.js",
-    "jest": "SNAPSHOT_INLINE_APHRODITE=1 jest",
+    "jest": "jest",
     "test": "yarn run lint && yarn run gen-snapshot-tests && yarn run build:all && yarn run flow && yarn run jest",
-    "build:coverage": "SNAPSHOT_INLINE_APHRODITE=1 jest --coverage",
+    "build:coverage": "yarn run jest --coverage",
     "coverage": "yarn run build:coverage && open coverage/lcov-report/index.html",
     "styleguidist": "styleguidist server",
     "start": "yarn run styleguidist",
@@ -71,6 +71,9 @@
     "packages/*"
   ],
   "jest": {
+    "globals": {
+      "SNAPSHOT_INLINE_APHRODITE": true
+    },
     "testRegex": ".test\\.jsx?$",
     "setupTestFrameworkScriptFile": "./test-setup.js",
     "transform": {

--- a/packages/wonder-blocks-core/util/util.js
+++ b/packages/wonder-blocks-core/util/util.js
@@ -47,8 +47,8 @@ export function processStyleList<T: Object>(
         // Check for aphrodite internal property
         if ((child: any)._definition) {
             if (
-                typeof process !== "undefined" &&
-                process.env.SNAPSHOT_INLINE_APHRODITE
+                typeof global !== "undefined" &&
+                global.SNAPSHOT_INLINE_APHRODITE
             ) {
                 inlineStyles.push(child._definition);
             } else {


### PR DESCRIPTION
This is a tooling-only PR.

In this PR there are two main changes:
1. `jest` now uses `globals` in the jest configuration to control aphrodite style flattening, rather than an environment variable. This allows us to use idiomatic jest tooling like the VS Code jest extension.
1. Adds an `extensions.json` file to recommend a few extensions to use when developing for Wonder Blocks. This adds a "star" swatch to the extensions in the extensions explorer to indicate they are recommend; they can also be viewed by searching extensions for `@recommended` and expanding the "Workspace Recommendations" section.