### PR TITLE
Debug your tests in VS Code and more

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,22 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+        // This configuration is for debugging the currently open test file.
+        {
+            "type": "node",
+            "name": "vscode-jest-tests",
+            "request": "launch",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": [
+                "--runInBand",
+                "${file}"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        },
+
+        // This is for debugging node scripts.
         {
             "type": "node",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,9 +14,7 @@
                 "--runInBand",
                 "${file}"
             ],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
+            "cwd": "${workspaceFolder}"
         },
 
         // This is for debugging node scripts.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,95 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        // Using the Quick Open (Cmd+P), these can be run by typing
+        // "task <task label>"
+        //
+        // Default build task.
+        // Shift+Cmd+B will run this.
+        {
+            "label": "build",
+            "type": "npm",
+            "script": "build:all",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        // This is the "yarn watch:all" task
+        {
+            "identifier": "watch",
+            "type": "npm",
+            "script": "watch:all",
+            "problemMatcher": [],
+            "group": "build",
+            "isBackground": true,
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "dedicated"
+            }
+        },
+        // This is the "yarn start" task
+        {
+            "identifier": "start",
+            "type": "npm",
+            "script": "start",
+            "isBackground": true,
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "dedicated"
+            },
+            "problemMatcher": [],
+            "group": "test"
+        },
+        // This combines the "watch" and "start" tasks.
+        // By running both, the dev server will properly update docs for a
+        // package when a dependency of that package is changed and rebuilt.
+        {
+            "label": "start dev server with watch",
+            "group": "test",
+            "dependsOn": [
+                "watch",
+                "start"
+            ],
+            "problemMatcher": []
+        },
+
+        // This is the default test task.
+        // This runs "yarn test"
+        {
+            "label": "run tests",
+            "type": "npm",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "dedicated"
+            },
+            "script": "test",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
+        // This task runs "yarn build:coverage" for updating coverage data.
+        {
+            "label": "refresh coverage",
+            "type": "npm",
+            "script": "build:coverage",
+            "problemMatcher": [],
+            "group": "test",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This adds a few things to our VS Code setup:

1. Some tasks that wrap our common `package.json` tasks. This sets up a default build task, a default test task, and provides a combined task that will watch and start the dev server, allowing us to have live update of the dev server when package dependencies are changed
2. A new debug configuration specifically for debugging jest test files. The Jest extension provides some great support for jest, but even without it, this will allow us to set breakpoints in our tests and step through them.