### PR TITLE
Add TooltipAnchor component

### DIFF
--- a/packages/wonder-blocks-tooltip/components/tooltip-anchor.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-anchor.js
@@ -1,0 +1,169 @@
+// @flow
+/**
+ * This component turns the given content into an accessible anchor for
+ * positioning and displaying tooltips.
+ */
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+import TooltipPortalMounter from "./tooltip-portal-mounter.js";
+
+type Props = {|
+    // A method that renders the content for anchoring the tooltip.
+    // This must return a TooltipPortalMounter component.
+    children: (active: boolean) => React.Element<typeof TooltipPortalMounter>,
+
+    // Callback to be invoked when the anchored content is mounted.
+    // This provides a reference to the anchored content, which can then be
+    // used for calculating tooltip bubble positioning.
+    anchorRef: (?Element) => mixed,
+
+    // When true, if a tabindex attribute is not already present on the element
+    // wrapped by the anchor, the element will be given tabindex=0 to make it
+    // keyboard focusable; otherwise, does not attempt to change the ability to
+    // focus the anchor element.
+    //
+    // Defaults to true.
+    //
+    // One might set this to false in circumstances where the wrapped component
+    // already can receive focus or contains an element that can.
+    // Use good judgement when overriding this value, the tooltip content should
+    // be accessible via keyboard in all circumstances where the tooltip would
+    // appear using the mouse, so verify those use-cases.
+    forceAnchorFocusivity?: boolean,
+|};
+
+type State = {|
+    active: boolean,
+|};
+
+export default class TooltipAnchor extends React.Component<Props, State> {
+    _weSetFocusivity: ?boolean;
+    _anchorNode: ?Element;
+    _focused: boolean;
+    _hovered: boolean;
+
+    static defaultProps = {
+        forceAnchorFocusivity: true,
+    };
+
+    state = {
+        active: false,
+    };
+
+    componentDidMount() {
+        const anchorNode = ReactDOM.findDOMNode(this);
+
+        // This should never happen, but we have this check here to make flow
+        // happy and ensure that if this does happen, we'll know about it.
+        if (anchorNode instanceof Text) {
+            throw new Error(
+                "TooltipAnchor must be applied to an Element. Text content is not supported.",
+            );
+        }
+
+        this._anchorNode = anchorNode;
+        this._updateFocusivity();
+        if (anchorNode) {
+            // TODO(somewhatabstract): Detect ESC key to deactivate
+            /**
+             * TODO(somewhatabstract): Work out how to allow pointer to go over
+             * the tooltip content to keep it active. This likely requires
+             * pointer events but that would break the obscurement checks we do.
+             * So, careful consideration required.
+             */
+
+            anchorNode.addEventListener("focusin", this._handleFocusIn);
+            anchorNode.addEventListener("focusout", this._handleFocusOut);
+            anchorNode.addEventListener("mouseenter", this._handleMouseEnter);
+            anchorNode.addEventListener("mouseleave", this._handleMouseLeave);
+
+            this.props.anchorRef(this._anchorNode);
+        }
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (
+            prevProps.forceAnchorFocusivity !==
+                this.props.forceAnchorFocusivity ||
+            prevProps.children !== this.props.children
+        ) {
+            this._updateFocusivity();
+        }
+    }
+
+    componentWillUnmount() {
+        const anchorNode = this._anchorNode;
+        if (anchorNode) {
+            anchorNode.removeEventListener("focusin", this._handleFocusIn);
+            anchorNode.removeEventListener("focusout", this._handleFocusOut);
+            anchorNode.removeEventListener(
+                "mouseenter",
+                this._handleMouseEnter,
+            );
+            anchorNode.removeEventListener(
+                "mouseleave",
+                this._handleMouseLeave,
+            );
+        }
+    }
+
+    _updateFocusivity() {
+        const anchorNode = this._anchorNode;
+        if (!anchorNode) {
+            return;
+        }
+        const {forceAnchorFocusivity} = this.props;
+        const currentTabIndex = anchorNode.getAttribute("tabindex");
+
+        if (forceAnchorFocusivity && !currentTabIndex) {
+            // Ensure that the anchor point is keyboard focusable so that
+            // we can show the tooltip for visually impaired users that don't
+            // use pointer devices nor assistive technology like screen readers.
+            anchorNode.setAttribute("tabindex", "0");
+            this._weSetFocusivity = true;
+        } else if (!forceAnchorFocusivity && currentTabIndex) {
+            // We may not be forcing it, but we also want to ensure that if we
+            // did before, we remove it.
+            if (this._weSetFocusivity) {
+                anchorNode.removeAttribute("tabindex");
+                this._weSetFocusivity = false;
+            }
+        }
+    }
+
+    _updateActiveState(hovered: boolean, focused: boolean) {
+        // Take a snapshot of the old and new state.
+        const oldState = this.state.active;
+        const newState = hovered || focused;
+
+        // Update our stored values.
+        this._hovered = hovered;
+        this._focused = focused;
+
+        // If we changed state, call our subscriber and let them know.
+        if (oldState !== newState) {
+            this.setState({active: newState});
+        }
+    }
+
+    _handleFocusIn = () => {
+        this._updateActiveState(this._hovered, true);
+    };
+
+    _handleFocusOut = () => {
+        this._updateActiveState(this._hovered, false);
+    };
+
+    _handleMouseEnter = () => {
+        this._updateActiveState(true, this._focused);
+    };
+
+    _handleMouseLeave = () => {
+        this._updateActiveState(false, this._focused);
+    };
+
+    render() {
+        return this.props.children(this.state.active);
+    }
+}

--- a/packages/wonder-blocks-tooltip/components/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-anchor.test.js
@@ -23,9 +23,9 @@ describe("TooltipAnchor", () => {
     test("on mount, subscribes to focus and hover events", () => {
         // Arrange
         const getFakeTooltipPortalMounter = (active) =>
-            (((
-                <View id="anchor">{active ? "true" : "false"}</View>
-            ): any): React.Element<typeof TooltipPortalMounter>);
+            ((<View>{active ? "true" : "false"}</View>: any): React.Element<
+                typeof TooltipPortalMounter,
+            >);
         const nodes = (
             <View>
                 <TooltipAnchor anchorRef={() => {}}>
@@ -64,9 +64,9 @@ describe("TooltipAnchor", () => {
     test("on unmount, unsubscribes from focus and hover events", () => {
         // Arrange
         const getFakeTooltipPortalMounter = (active) =>
-            (((
-                <View id="anchor">{active ? "true" : "false"}</View>
-            ): any): React.Element<typeof TooltipPortalMounter>);
+            ((<View>{active ? "true" : "false"}</View>: any): React.Element<
+                typeof TooltipPortalMounter,
+            >);
         const nodes = (
             <View>
                 <TooltipAnchor anchorRef={() => {}}>
@@ -222,6 +222,9 @@ describe("TooltipAnchor", () => {
 
             const actAndAssert = (ref) => {
                 // Act
+                const tabindex = ref && ref.getAttribute("tabindex");
+                expect(tabindex).toBe("0");
+
                 // Need to do a timeout so that the mount can return and the
                 // wrapper can change the force prop to false.
                 setTimeout(() => {
@@ -278,9 +281,9 @@ describe("TooltipAnchor", () => {
         // Arrange
         const arrange = (actAndAssert) => {
             const getFakeTooltipPortalMounter = (active) =>
-                (((
-                    <View id="anchor">{active ? "true" : "false"}</View>
-                ): any): React.Element<typeof TooltipPortalMounter>);
+                ((<View>{active ? "true" : "false"}</View>: any): React.Element<
+                    typeof TooltipPortalMounter,
+                >);
             const nodes = (
                 <View>
                     <TooltipAnchor anchorRef={actAndAssert}>
@@ -318,7 +321,7 @@ describe("TooltipAnchor", () => {
             const arrange = (actAndAssert) => {
                 const getFakeTooltipPortalMounter = (active) =>
                     (((
-                        <View id="anchor">{active ? "true" : "false"}</View>
+                        <View>{active ? "true" : "false"}</View>
                     ): any): React.Element<typeof TooltipPortalMounter>);
                 const nodes = (
                     <View>
@@ -352,7 +355,7 @@ describe("TooltipAnchor", () => {
             const arrange = (actAndAssert) => {
                 const getFakeTooltipPortalMounter = (active) =>
                     (((
-                        <View id="anchor">{active ? "true" : "false"}</View>
+                        <View>{active ? "true" : "false"}</View>
                     ): any): React.Element<typeof TooltipPortalMounter>);
                 const nodes = (
                     <View>
@@ -386,9 +389,9 @@ describe("TooltipAnchor", () => {
         // Arrange
         const arrange = (actAndAssert) => {
             const getFakeTooltipPortalMounter = (active) =>
-                (((
-                    <View id="anchor">{active ? "true" : "false"}</View>
-                ): any): React.Element<typeof TooltipPortalMounter>);
+                ((<View>{active ? "true" : "false"}</View>: any): React.Element<
+                    typeof TooltipPortalMounter,
+                >);
             const nodes = (
                 <View>
                     <TooltipAnchor anchorRef={actAndAssert}>
@@ -422,7 +425,7 @@ describe("TooltipAnchor", () => {
             const arrange = (actAndAssert) => {
                 const getFakeTooltipPortalMounter = (active) =>
                     (((
-                        <View id="anchor">{active ? "true" : "false"}</View>
+                        <View>{active ? "true" : "false"}</View>
                     ): any): React.Element<typeof TooltipPortalMounter>);
                 const nodes = (
                     <View>
@@ -456,7 +459,7 @@ describe("TooltipAnchor", () => {
             const arrange = (actAndAssert) => {
                 const getFakeTooltipPortalMounter = (active) =>
                     (((
-                        <View id="anchor">{active ? "true" : "false"}</View>
+                        <View>{active ? "true" : "false"}</View>
                     ): any): React.Element<typeof TooltipPortalMounter>);
                 const nodes = (
                     <View>

--- a/packages/wonder-blocks-tooltip/components/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-anchor.test.js
@@ -1,0 +1,488 @@
+// @flow
+import * as React from "react";
+import {mount} from "enzyme";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+
+import TooltipAnchor from "./tooltip-anchor.js";
+import TooltipPortalMounter from "./tooltip-portal-mounter.js";
+
+// Helper for chaining event handlings.
+const doEvent = (ref, event) => {
+    if (!ref) {
+        throw new Error("No element");
+    }
+    ref.dispatchEvent(event);
+
+    return new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+};
+
+describe("TooltipAnchor", () => {
+    test("on mount, subscribes to focus and hover events", () => {
+        // Arrange
+        const getFakeTooltipPortalMounter = (active) =>
+            (((
+                <View id="anchor">{active ? "true" : "false"}</View>
+            ): any): React.Element<typeof TooltipPortalMounter>);
+        const nodes = (
+            <View>
+                <TooltipAnchor anchorRef={() => {}}>
+                    {getFakeTooltipPortalMounter}
+                </TooltipAnchor>
+            </View>
+        );
+        const addEventListenerSpy = jest.spyOn(
+            HTMLElement.prototype,
+            "addEventListener",
+        );
+        addEventListenerSpy.mockClear();
+
+        // Act
+        mount(nodes);
+
+        // Assert
+        expect(addEventListenerSpy).toHaveBeenCalledWith(
+            "focusin",
+            expect.any(Function),
+        );
+        expect(addEventListenerSpy).toHaveBeenCalledWith(
+            "focusout",
+            expect.any(Function),
+        );
+        expect(addEventListenerSpy).toHaveBeenCalledWith(
+            "mouseenter",
+            expect.any(Function),
+        );
+        expect(addEventListenerSpy).toHaveBeenCalledWith(
+            "mouseleave",
+            expect.any(Function),
+        );
+    });
+
+    test("on unmount, unsubscribes from focus and hover events", () => {
+        // Arrange
+        const getFakeTooltipPortalMounter = (active) =>
+            (((
+                <View id="anchor">{active ? "true" : "false"}</View>
+            ): any): React.Element<typeof TooltipPortalMounter>);
+        const nodes = (
+            <View>
+                <TooltipAnchor anchorRef={() => {}}>
+                    {getFakeTooltipPortalMounter}
+                </TooltipAnchor>
+            </View>
+        );
+        const removeEventListenerSpy = jest.spyOn(
+            HTMLElement.prototype,
+            "removeEventListener",
+        );
+        removeEventListenerSpy.mockClear();
+        const wrapper = mount(nodes);
+
+        // Act
+        wrapper.unmount();
+
+        // Assert
+        expect(removeEventListenerSpy).toHaveBeenCalledWith(
+            "focusin",
+            expect.any(Function),
+        );
+        expect(removeEventListenerSpy).toHaveBeenCalledWith(
+            "focusout",
+            expect.any(Function),
+        );
+        expect(removeEventListenerSpy).toHaveBeenCalledWith(
+            "mouseenter",
+            expect.any(Function),
+        );
+        expect(removeEventListenerSpy).toHaveBeenCalledWith(
+            "mouseleave",
+            expect.any(Function),
+        );
+    });
+
+    describe("forceAnchorFocusivity is true", () => {
+        test("if not set, sets tabindex on anchor target", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const fakeTooltipPortalMounter = (((
+                    <View>This is the anchor</View>
+                ): any): React.Element<typeof TooltipPortalMounter>);
+                const nodes = (
+                    <View>
+                        <TooltipAnchor
+                            forceAnchorFocusivity={true}
+                            anchorRef={actAndAssert}
+                        >
+                            {(active) => fakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                mount(nodes);
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                const result = ref && ref.getAttribute("tabindex");
+
+                // Assert
+                expect(result).toBe("0");
+                done();
+            };
+
+            arrange(actAndAssert);
+        });
+
+        test("if tabindex already set, leaves it as-is", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const fakeTooltipPortalMounter = (((
+                    <View tabIndex="-1">This is the anchor</View>
+                ): any): React.Element<typeof TooltipPortalMounter>);
+                const nodes = (
+                    <View>
+                        <TooltipAnchor
+                            forceAnchorFocusivity={true}
+                            anchorRef={actAndAssert}
+                        >
+                            {(active) => fakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                mount(nodes);
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                const result = ref && ref.getAttribute("tabindex");
+
+                // Assert
+                expect(result).toBe("-1");
+                done();
+            };
+
+            arrange(actAndAssert);
+        });
+    });
+
+    describe("forceAnchorFocusivity is false", () => {
+        test("does not set tabindex on anchor target", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const fakeTooltipPortalMounter = (((
+                    <View>This is the anchor</View>
+                ): any): React.Element<typeof TooltipPortalMounter>);
+                const nodes = (
+                    <View>
+                        <TooltipAnchor
+                            forceAnchorFocusivity={false}
+                            anchorRef={actAndAssert}
+                        >
+                            {(active) => fakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                mount(nodes);
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                const result = ref && ref.getAttribute("tabindex");
+
+                // Assert
+                expect(result).toBeNull();
+                done();
+            };
+
+            arrange(actAndAssert);
+        });
+
+        test("if we had added tabindex, removes it", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const fakeTooltipPortalMounter = (((
+                    <View>This is the anchor</View>
+                ): any): React.Element<typeof TooltipPortalMounter>);
+
+                const TestFixture = (props: any) => (
+                    <View>
+                        <TooltipAnchor
+                            forceAnchorFocusivity={props.force}
+                            anchorRef={actAndAssert}
+                        >
+                            {(active) => fakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                const wrapper = mount(<TestFixture force={true} />);
+                wrapper.setProps({force: false});
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                // Need to do a timeout so that the mount can return and the
+                // wrapper can change the force prop to false.
+                setTimeout(() => {
+                    const result = ref && ref.getAttribute("tabindex");
+
+                    // Assert
+                    expect(result).toBeNull();
+                    done();
+                }, 0);
+            };
+
+            arrange(actAndAssert);
+        });
+
+        test("if we had not added tabindex, leaves it", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const fakeTooltipPortalMounter = (((
+                    <View tabIndex="-1">This is the anchor</View>
+                ): any): React.Element<typeof TooltipPortalMounter>);
+
+                const TestFixture = (props: any) => (
+                    <View>
+                        <TooltipAnchor
+                            forceAnchorFocusivity={props.force}
+                            anchorRef={actAndAssert}
+                        >
+                            {(active) => fakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                const wrapper = mount(<TestFixture force={true} />);
+                wrapper.setProps({force: false});
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                // Need to do a timeout so that the mount can return and the
+                // wrapper can change the force prop to false.
+                setTimeout(() => {
+                    const result = ref && ref.getAttribute("tabindex");
+
+                    // Assert
+                    expect(result).not.toBeNull();
+                    done();
+                }, 0);
+            };
+
+            arrange(actAndAssert);
+        });
+    });
+
+    test("receives keyboard focus, is active", (done) => {
+        // Arrange
+        const arrange = (actAndAssert) => {
+            const getFakeTooltipPortalMounter = (active) =>
+                (((
+                    <View id="anchor">{active ? "true" : "false"}</View>
+                ): any): React.Element<typeof TooltipPortalMounter>);
+            const nodes = (
+                <View>
+                    <TooltipAnchor anchorRef={actAndAssert}>
+                        {getFakeTooltipPortalMounter}
+                    </TooltipAnchor>
+                </View>
+            );
+            mount(nodes);
+        };
+
+        const actAndAssert = (ref) => {
+            // Act
+            // Let's fake a focusin (this is the event that the anchor gets
+            // whether focused directly or a child is focused). We have to
+            // fake directly because there's no real browser here handling
+            // focus and real events.
+            const act = doEvent(ref, new FocusEvent("focusin"));
+
+            // Need a timeout here so that the event handling can occur.
+            act.then(() => {
+                const result = ref && ref.innerHTML;
+
+                // Assert
+                expect(result).toBe("true");
+                done();
+            });
+        };
+
+        arrange(actAndAssert);
+    });
+
+    describe("loses keyboard focus", () => {
+        test("active is set to false", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const getFakeTooltipPortalMounter = (active) =>
+                    (((
+                        <View id="anchor">{active ? "true" : "false"}</View>
+                    ): any): React.Element<typeof TooltipPortalMounter>);
+                const nodes = (
+                    <View>
+                        <TooltipAnchor anchorRef={actAndAssert}>
+                            {getFakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                mount(nodes);
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                const act = doEvent(ref, new FocusEvent("focusin")).then(() =>
+                    doEvent(ref, new FocusEvent("focusout")),
+                );
+
+                // Assert
+                act.then(() => {
+                    const result = ref && ref.innerHTML;
+                    expect(result).toBe("false");
+                    done();
+                });
+            };
+
+            arrange(actAndAssert);
+        });
+
+        test("if hovered, remains active", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const getFakeTooltipPortalMounter = (active) =>
+                    (((
+                        <View id="anchor">{active ? "true" : "false"}</View>
+                    ): any): React.Element<typeof TooltipPortalMounter>);
+                const nodes = (
+                    <View>
+                        <TooltipAnchor anchorRef={actAndAssert}>
+                            {getFakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                mount(nodes);
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                const act = doEvent(ref, new FocusEvent("focusin"))
+                    .then(() => doEvent(ref, new MouseEvent("mouseenter")))
+                    .then(() => doEvent(ref, new FocusEvent("focusout")));
+
+                // Assert
+                act.then(() => {
+                    const result = ref && ref.innerHTML;
+                    expect(result).toBe("true");
+                    done();
+                });
+            };
+
+            arrange(actAndAssert);
+        });
+    });
+
+    test("is hovered, is active", (done) => {
+        // Arrange
+        const arrange = (actAndAssert) => {
+            const getFakeTooltipPortalMounter = (active) =>
+                (((
+                    <View id="anchor">{active ? "true" : "false"}</View>
+                ): any): React.Element<typeof TooltipPortalMounter>);
+            const nodes = (
+                <View>
+                    <TooltipAnchor anchorRef={actAndAssert}>
+                        {getFakeTooltipPortalMounter}
+                    </TooltipAnchor>
+                </View>
+            );
+            mount(nodes);
+        };
+
+        const actAndAssert = (ref) => {
+            // Act
+            const act = doEvent(ref, new MouseEvent("mouseenter"));
+
+            // Assert
+            act.then(() => {
+                const result = ref && ref.innerHTML;
+
+                // Assert
+                expect(result).toBe("true");
+                done();
+            });
+        };
+
+        arrange(actAndAssert);
+    });
+
+    describe("is unhovered", () => {
+        test("active is set to false", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const getFakeTooltipPortalMounter = (active) =>
+                    (((
+                        <View id="anchor">{active ? "true" : "false"}</View>
+                    ): any): React.Element<typeof TooltipPortalMounter>);
+                const nodes = (
+                    <View>
+                        <TooltipAnchor anchorRef={actAndAssert}>
+                            {getFakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                mount(nodes);
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                const act = doEvent(ref, new MouseEvent("mouseenter")).then(
+                    () => doEvent(ref, new MouseEvent("mouseleave")),
+                );
+
+                // Assert
+                act.then(() => {
+                    const result = ref && ref.innerHTML;
+                    expect(result).toBe("false");
+                    done();
+                });
+            };
+
+            arrange(actAndAssert);
+        });
+
+        test("if focused, remains active", (done) => {
+            // Arrange
+            const arrange = (actAndAssert) => {
+                const getFakeTooltipPortalMounter = (active) =>
+                    (((
+                        <View id="anchor">{active ? "true" : "false"}</View>
+                    ): any): React.Element<typeof TooltipPortalMounter>);
+                const nodes = (
+                    <View>
+                        <TooltipAnchor anchorRef={actAndAssert}>
+                            {getFakeTooltipPortalMounter}
+                        </TooltipAnchor>
+                    </View>
+                );
+                mount(nodes);
+            };
+
+            const actAndAssert = (ref) => {
+                // Act
+                const act = doEvent(ref, new MouseEvent("mouseenter"))
+                    .then(() => doEvent(ref, new FocusEvent("focusin")))
+                    .then(() => doEvent(ref, new MouseEvent("mouseleave")));
+
+                // Assert
+                act.then(() => {
+                    const result = ref && ref.innerHTML;
+                    expect(result).toBe("true");
+                    done();
+                });
+            };
+
+            arrange(actAndAssert);
+        });
+    });
+});


### PR DESCRIPTION
This extends #149 to add the `TooltipAnchor` component. This component is responsible for controlling the active state of the tooltip so that we know when to show or hide the tooltip bubble.

This is another piece of #140.