### PR TITLE
Add TooltipContent component

### DIFF
--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -145,6 +145,30 @@ exports[`wonder-blocks-tooltip example 5 1`] = `
     }
   }
 >
+  <div
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 4,
+        "MsFlexPreferredSize": 4,
+        "WebkitFlexBasis": 4,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 4,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  />
   <span
     className=""
     style={
@@ -202,6 +226,30 @@ exports[`wonder-blocks-tooltip example 6 1`] = `
   >
     Title text!
   </h4>
+  <div
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 4,
+        "MsFlexPreferredSize": 4,
+        "WebkitFlexBasis": 4,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 4,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  />
   <span
     className=""
     style={
@@ -257,6 +305,30 @@ exports[`wonder-blocks-tooltip example 7 1`] = `
   >
     Body text title!
   </span>
+  <div
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 4,
+        "MsFlexPreferredSize": 4,
+        "WebkitFlexBasis": 4,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 4,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  />
   <span
     className=""
     style={

--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -124,3 +124,170 @@ exports[`wonder-blocks-tooltip example 4 1`] = `
   </button>
 </div>
 `;
+
+exports[`wonder-blocks-tooltip example 5 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "20px",
+      }
+    }
+  >
+    Just the content
+  </span>
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 6 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <h4
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 20,
+        "fontWeight": 700,
+        "lineHeight": "24px",
+        "marginBottom": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    Title text!
+  </h4>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "20px",
+      }
+    }
+  >
+    Some content in my content
+  </span>
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 7 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    Body text title!
+  </span>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    Body text content!
+  </span>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 14,
+        "fontWeight": 400,
+        "lineHeight": "18px",
+      }
+    }
+  >
+    And LabelSmall!
+  </span>
+</div>
+`;

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
@@ -3,6 +3,7 @@ import {css, StyleSheet} from "aphrodite";
 import * as React from "react";
 import {Popper} from "react-popper";
 
+import TooltipContent from "./tooltip-content.js";
 import visibilityModifierDefaultConfig from "../util/visibility-modifier.js";
 
 import type {PopperChildrenProps} from "react-popper";
@@ -10,8 +11,7 @@ import type {Placement} from "../util/types.js";
 
 type Props = {|
     // The content to be shown in the bubble.
-    // TODO(somewhatabstract): Make this the TooltipContent type.
-    children: string,
+    children: React.Element<typeof TooltipContent>,
 
     // The element that anchors the tooltip bubble.
     // This is used to position the bubble.

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
@@ -5,6 +5,7 @@ import {mount} from "enzyme";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import TooltipBubble from "./tooltip-bubble.js";
+import TooltipContent from "./tooltip-content.js";
 
 /**
  * A little wrapper for the TooltipBubble so that we can provide an anchor
@@ -23,12 +24,6 @@ class BubbleTest extends React.Component<*, {ref: ?HTMLElement}> {
     }
 
     render() {
-        const resultRef = (((
-            <View ref={(ref) => this.props.resultRef(ref)}>
-                This is a pretend string with a ref so we can detect it being
-                rendered
-            </View>
-        ): any): string);
         return (
             <View>
                 <View ref={(ref) => this.updateRef(ref)}>Anchor</View>
@@ -36,7 +31,10 @@ class BubbleTest extends React.Component<*, {ref: ?HTMLElement}> {
                     placement={this.props.placement}
                     anchorElement={this.state.ref}
                 >
-                    {resultRef}
+                    <TooltipContent ref={(ref) => this.props.resultRef(ref)}>
+                        This is a pretend string with a ref so we can detect it
+                        being rendered
+                    </TooltipContent>
                 </TooltipBubble>
             </View>
         );

--- a/packages/wonder-blocks-tooltip/components/tooltip-content.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-content.js
@@ -1,6 +1,8 @@
 // @flow
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {HeadingSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 
@@ -42,6 +44,7 @@ export default class TooltipContent extends React.Component<Props> {
         return (
             <View>
                 {this._renderTitle()}
+                <Strut size={Spacing.xxxSmall} />
                 {this._renderChildren()}
             </View>
         );

--- a/packages/wonder-blocks-tooltip/components/tooltip-content.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-content.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from "react";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {HeadingSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import type {Typography} from "@khanacademy/wonder-blocks-typography";
+
+type Props = {|
+    title?: string | React.Element<Typography>,
+    children:
+        | string
+        | React.Element<Typography>
+        | Array<React.Element<Typography>>,
+|};
+
+/**
+ * This component is used to provide the content that is to be rendered in the
+ * tooltip bubble.
+ */
+export default class TooltipContent extends React.Component<Props> {
+    _renderTitle() {
+        const {title} = this.props;
+        if (title) {
+            if (typeof title === "string") {
+                return <HeadingSmall>{title}</HeadingSmall>;
+            } else {
+                return title;
+            }
+        }
+        return null;
+    }
+
+    _renderChildren() {
+        const {children} = this.props;
+        if (typeof children === "string") {
+            return <LabelMedium>{children}</LabelMedium>;
+        } else {
+            return children;
+        }
+    }
+
+    render() {
+        return (
+            <View>
+                {this._renderTitle()}
+                {this._renderChildren()}
+            </View>
+        );
+    }
+}

--- a/packages/wonder-blocks-tooltip/components/tooltip-content.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip-content.md
@@ -1,0 +1,34 @@
+The `TooltipContent` component is provided for situations where the `Tooltip` needs to be customized beyond the default stylings. `TooltipContent` supports all `wonder-blocks-typography` components.
+
+### Just text content
+
+This shows the default which is text rendered using `LabelMedium`.
+
+```jsx
+<TooltipContent>
+    Just the content
+</TooltipContent>
+```
+
+### Titled content
+
+This shows the default with a title; the title is rendered using `HeadingSmall`.
+
+```jsx
+<TooltipContent title="Title text!">
+    Some content in my content
+</TooltipContent>
+```
+
+### Custom title and custom content
+
+This shows how we can customize both the title and the content.
+
+```jsx
+const {Body, LabelSmall} = require("@khanacademy/wonder-blocks-typography");
+
+<TooltipContent title={<Body>Body text title!</Body>}>
+    <Body>Body text content!</Body>
+    <LabelSmall>And LabelSmall!</LabelSmall>
+</TooltipContent>
+```

--- a/packages/wonder-blocks-tooltip/components/tooltip-content.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-content.test.js
@@ -1,0 +1,4 @@
+// @flow
+describe("TooltipContent", () => {
+    test("TODO");
+});

--- a/packages/wonder-blocks-tooltip/components/tooltip-content.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-content.test.js
@@ -1,4 +1,0 @@
-// @flow
-describe("TooltipContent", () => {
-    test("TODO");
-});

--- a/packages/wonder-blocks-tooltip/components/tooltip-portal-mounter.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-portal-mounter.test.js
@@ -13,6 +13,7 @@ import {
 import {TooltipPortalAttributeName} from "../util/constants.js";
 import TooltipPortalMounter from "./tooltip-portal-mounter.js";
 import TooltipBubble from "./tooltip-bubble.js";
+import TooltipContent from "./tooltip-content.js";
 
 import type {Placement} from "../util/types.js";
 
@@ -59,7 +60,7 @@ class TestHarness extends React.Component<TestHarnessProps, TestHarnessState> {
                         ref={(r) => this.props.refChild(r)}
                         anchorElement={this.state.anchor}
                     >
-                        Tooltip!
+                        <TooltipContent>Tooltip!</TooltipContent>
                     </TooltipBubble>
                 ) : null}
             </TooltipPortalMounter>

--- a/packages/wonder-blocks-tooltip/components/tooltip.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip.js
@@ -6,17 +6,22 @@ import {Text} from "@khanacademy/wonder-blocks-core";
 import TooltipPortalMounter from "./tooltip-portal-mounter";
 import TooltipAnchor from "./tooltip-anchor.js";
 import TooltipBubble from "./tooltip-bubble.js";
+import TooltipContent from "./tooltip-content.js";
 
 import type {Placement} from "../util/types.js";
+import type {Typography} from "@khanacademy/wonder-blocks-typography";
 
 type Props = {|
     // The content for anchoring the tooltip.
     // This component will be used to position the tooltip.
     children: React.Element<any> | string,
 
+    // The title of the tooltip.
+    // Optional.
+    title?: string | React.Element<Typography>,
+
     // The content to render in the tooltip.
-    // TODO(somewhatabstract): Update to allow TooltipContent or string
-    content: string,
+    content: string | React.Element<typeof TooltipContent>,
 
     // When true, the child element will be given tabindex=0
     // to make it keyboard focusable. This value defaults to true. One might set
@@ -64,8 +69,19 @@ export default class Tooltip extends React.Component<Props, State> {
         }
     }
 
+    _renderBubbleContent() {
+        const {title, content} = this.props;
+        if (typeof content === "string") {
+            return <TooltipContent title={title}>{content}</TooltipContent>;
+        } else if (title) {
+            return React.cloneElement(content, {title});
+        } else {
+            return content;
+        }
+    }
+
     render() {
-        const {forceAnchorFocusivity, placement, content} = this.props;
+        const {forceAnchorFocusivity, placement} = this.props;
         return (
             <TooltipAnchor
                 forceAnchorFocusivity={forceAnchorFocusivity}
@@ -80,7 +96,7 @@ export default class Tooltip extends React.Component<Props, State> {
                                 }
                                 anchorElement={this.state.anchorElement}
                             >
-                                {content}
+                                {this._renderBubbleContent()}
                             </TooltipBubble>
                         ) : null}
                     </TooltipPortalMounter>

--- a/packages/wonder-blocks-tooltip/components/tooltip.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip.md
@@ -2,7 +2,6 @@
 
 ```js
 const React = require("react");
-const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 
 <Tooltip content={"The tooltip text"}>
     Some text
@@ -16,7 +15,6 @@ In this example, we're no longer forcing the anchor root to be focusable, since 
 ```js
 const React = require("react");
 const {View} = require("@khanacademy/wonder-blocks-core");
-const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 
 <Tooltip forceAnchorFocusivity={false} content={"The tooltip text"}>
     <View>
@@ -31,7 +29,6 @@ const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 ```js
 const React = require("react");
 const {View, Text} = require("@khanacademy/wonder-blocks-core");
-const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 
 <div>
     <div style={{height: 100, overflow: "auto", border: "1px solid", margin: 10,}}>
@@ -51,7 +48,6 @@ const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 ```js
 const React = require("react");
 const {View, Text} = require("@khanacademy/wonder-blocks-core");
-const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 const {StandardModal, ModalLauncher} = require("@khanacademy/wonder-blocks-modal");
 
 const scrollyContent = (

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -10,11 +10,11 @@ import renderer from "react-test-renderer";
 // Mock react-dom as jest doesn't like findDOMNode.
 jest.mock("react-dom");
 import Tooltip from "./components/tooltip.js";
+import TooltipContent from "./components/tooltip-content.js";
 
 describe("wonder-blocks-tooltip", () => {
     it("example 1", () => {
         const React = require("react");
-        const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 
         const example = (
             <Tooltip content={"The tooltip text"}>Some text</Tooltip>
@@ -25,7 +25,6 @@ describe("wonder-blocks-tooltip", () => {
     it("example 2", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
-        const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 
         const example = (
             <Tooltip forceAnchorFocusivity={false} content={"The tooltip text"}>
@@ -41,7 +40,6 @@ describe("wonder-blocks-tooltip", () => {
     it("example 3", () => {
         const React = require("react");
         const {View, Text} = require("@khanacademy/wonder-blocks-core");
-        const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
 
         const example = (
             <div>
@@ -69,7 +67,6 @@ describe("wonder-blocks-tooltip", () => {
     it("example 4", () => {
         const React = require("react");
         const {View, Text} = require("@khanacademy/wonder-blocks-core");
-        const {Tooltip} = require("@khanacademy/wonder-blocks-tooltip");
         const {
             StandardModal,
             ModalLauncher,
@@ -112,6 +109,35 @@ describe("wonder-blocks-tooltip", () => {
                     <button onClick={openModal}>Click here!</button>
                 )}
             </ModalLauncher>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 5", () => {
+        const example = <TooltipContent>Just the content</TooltipContent>;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 6", () => {
+        const example = (
+            <TooltipContent title="Title text!">
+                Some content in my content
+            </TooltipContent>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 7", () => {
+        const {
+            Body,
+            LabelSmall,
+        } = require("@khanacademy/wonder-blocks-typography");
+
+        const example = (
+            <TooltipContent title={<Body>Body text title!</Body>}>
+                <Body>Body text content!</Body>
+                <LabelSmall>And LabelSmall!</LabelSmall>
+            </TooltipContent>
         );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();

--- a/packages/wonder-blocks-tooltip/index.js
+++ b/packages/wonder-blocks-tooltip/index.js
@@ -1,4 +1,5 @@
 // @flow
 import Tooltip from "./components/tooltip.js";
+import TooltipContent from "./components/tooltip-content.js";
 
-export {Tooltip};
+export {Tooltip as default, TooltipContent};

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -18,7 +18,9 @@
     "react-popper": "^1.0.0-beta.6",
     "@khanacademy/wonder-blocks-color": "^1.0.2",
     "@khanacademy/wonder-blocks-core": "^1.0.2",
+    "@khanacademy/wonder-blocks-layout": "^0.0.2",
     "@khanacademy/wonder-blocks-modal": "^0.0.3",
+    "@khanacademy/wonder-blocks-spacing": "^2.0.0",
     "@khanacademy/wonder-blocks-typography": "^1.0.2"
   }
 }

--- a/packages/wonder-blocks-typography/index.js
+++ b/packages/wonder-blocks-typography/index.js
@@ -18,6 +18,45 @@ import Tagline from "./components/tagline.js";
 import Caption from "./components/caption.js";
 import Footnote from "./components/footnote.js";
 
+/**
+ * Typography components for headings or titles.
+ */
+export type Heading =
+    | typeof Title
+    | typeof HeadingLarge
+    | typeof HeadingMedium
+    | typeof HeadingSmall
+    | typeof HeadingXSmall;
+
+/**
+ * Typography components for representing body text.
+ */
+export type BodyText =
+    | typeof Body
+    | typeof BodySerif
+    | typeof BodySerifBlock
+    | typeof BodyMonospace;
+
+/**
+ * Typography components for labels.
+ */
+export type Label =
+    | typeof LabelLarge
+    | typeof LabelMedium
+    | typeof LabelSmall
+    | typeof LabelXSmall;
+
+/**
+ * All typography components.
+ */
+export type Typography =
+    | Heading
+    | BodyText
+    | Label
+    | typeof Tagline
+    | typeof Caption
+    | typeof Footnote;
+
 export {
     Title,
     HeadingLarge,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -99,7 +99,10 @@ module.exports = {
         {
             name: "Tooltip",
             content: "packages/wonder-blocks-tooltip/docs.md",
-            components: "packages/wonder-blocks-tooltip/components/tooltip.js",
+            components: [
+                "packages/wonder-blocks-tooltip/components/tooltip.js",
+                "packages/wonder-blocks-tooltip/components/tooltip-content.js",
+            ],
         },
     ],
 


### PR DESCRIPTION
This PR implements the `TooltipContent` component that is used to render the content of the `TooltipBubble`. In this change, we add the new component and some test documentation for it, as well as update the other components to support it.

We also add some helper types to `wonder-blocks-typography` to simplify how we specify what elements are valid.