### PR TITLE
Add TooltipArrow component

### DIFF
--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -40,21 +40,63 @@ exports[`wonder-blocks-tooltip example 2 1`] = `
 `;
 
 exports[`wonder-blocks-tooltip example 3 1`] = `
-<div>
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
   <div
+    className=""
     style={
       Object {
-        "border": "1px solid",
+        "alignItems": "stretch",
+        "border": "1px solid black",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
         "height": 100,
         "margin": 10,
+        "minHeight": 0,
+        "minWidth": 0,
         "overflow": "auto",
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
       }
     }
   >
     <div
+      className=""
       style={
         Object {
-          "height": "200vh",
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": "200vh",
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
         }
       }
     >
@@ -64,33 +106,30 @@ exports[`wonder-blocks-tooltip example 3 1`] = `
           Object {
             "MozOsxFontSmoothing": "grayscale",
             "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "22px",
           }
         }
       >
-        This is a big long piece of text with a 
-      </span>
-      <span
-        className=""
-        style={
-          Object {
-            "MozOsxFontSmoothing": "grayscale",
-            "WebkitFontSmoothing": "antialiased",
-            "color": "red",
+        This is a big long piece of text with a
+        <span
+          className=""
+          style={
+            Object {
+              "MozOsxFontSmoothing": "grayscale",
+              "WebkitFontSmoothing": "antialiased",
+            }
           }
-        }
-      >
-        tooltip
-      </span>
-      <span
-        className=""
-        style={
-          Object {
-            "MozOsxFontSmoothing": "grayscale",
-            "WebkitFontSmoothing": "antialiased",
-          }
-        }
-      >
-         in the middle.
+        >
+          [tooltip]
+        </span>
+        <span>
+           
+        </span>
+        in the middle.
       </span>
     </div>
   </div>
@@ -374,9 +413,27 @@ exports[`wonder-blocks-tooltip example 8 1`] = `
   }
 >
   <div
-    className="arrowContainer_jqq9v4-o_O-container-top_15ku1de"
+    className=""
     data-placement="top"
-    style={undefined}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "height": 20,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "relative",
+        "width": 24,
+        "zIndex": 0,
+      }
+    }
   >
     <svg
       className="arrow_oo4scr-o_O-arrow-top_1itpe9r"
@@ -445,9 +502,27 @@ exports[`wonder-blocks-tooltip example 9 1`] = `
   }
 >
   <div
-    className="arrowContainer_jqq9v4-o_O-container-right_8hn242"
+    className=""
     data-placement="right"
-    style={undefined}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "height": 24,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "relative",
+        "width": 20,
+        "zIndex": 0,
+      }
+    }
   >
     <svg
       className="arrow_oo4scr-o_O-arrow-right_14846yz"
@@ -515,9 +590,27 @@ exports[`wonder-blocks-tooltip example 10 1`] = `
   }
 >
   <div
-    className="arrowContainer_jqq9v4-o_O-container-bottom_15ku1de"
+    className=""
     data-placement="bottom"
-    style={undefined}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "height": 20,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "relative",
+        "width": 24,
+        "zIndex": 0,
+      }
+    }
   >
     <svg
       className="arrow_oo4scr-o_O-arrow-bottom_v72lrv"
@@ -585,9 +678,27 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
   }
 >
   <div
-    className="arrowContainer_jqq9v4-o_O-container-left_8hn242"
+    className=""
     data-placement="left"
-    style={undefined}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "height": 24,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "relative",
+        "width": 20,
+        "zIndex": 0,
+      }
+    }
   >
     <svg
       className="arrow_oo4scr-o_O-arrow-left_sdqx8w"

--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -363,3 +363,284 @@ exports[`wonder-blocks-tooltip example 7 1`] = `
   </span>
 </div>
 `;
+
+exports[`wonder-blocks-tooltip example 8 1`] = `
+<div
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "column",
+    }
+  }
+>
+  <div
+    className="arrowContainer_jqq9v4-o_O-container-top_15ku1de"
+    data-placement="top"
+    style={undefined}
+  >
+    <svg
+      className="arrow_oo4scr-o_O-arrow-top_1itpe9r"
+      height={12}
+      width={24}
+    >
+      <filter
+        height="150%"
+        id="tooltip-dropshadow-top"
+      >
+        <feOffset
+          dx={8}
+          dy={8}
+          result="offsetblur"
+        />
+        <feGaussianBlur
+          in="SourceAlpha"
+          stdDeviation={3}
+        />
+        <feComponentTransfer>
+          <feFuncA
+            slope={0.16}
+            type="linear"
+          />
+        </feComponentTransfer>
+        <feMerge>
+          <feMergeNode />
+          <feMergeNode
+            in="SourceGraphic"
+          />
+        </feMerge>
+      </filter>
+      <polyline
+        fill="#ffffff"
+        points="0,0 12,12 24,0"
+        stroke="#ffffff"
+      />
+      <polyline
+        fill="#ffffff"
+        filter="url(#tooltip-dropshadow-top)"
+        points="0,0 12,12 24,0"
+        stroke="rgba(33,36,44,0.16)"
+      />
+    </svg>
+  </div>
+  <div
+    style={
+      Object {
+        "backgroundColor": "red",
+        "height": 4,
+        "width": 24,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 9 1`] = `
+<div
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "row-reverse",
+      "justifyContent": "flex-end",
+    }
+  }
+>
+  <div
+    className="arrowContainer_jqq9v4-o_O-container-right_8hn242"
+    data-placement="right"
+    style={undefined}
+  >
+    <svg
+      className="arrow_oo4scr-o_O-arrow-right_14846yz"
+      height={24}
+      width={12}
+    >
+      <filter
+        height="150%"
+        id="tooltip-dropshadow-right"
+      >
+        <feOffset
+          dx={8}
+          dy={8}
+          result="offsetblur"
+        />
+        <feGaussianBlur
+          in="SourceAlpha"
+          stdDeviation={3}
+        />
+        <feComponentTransfer>
+          <feFuncA
+            slope={0.16}
+            type="linear"
+          />
+        </feComponentTransfer>
+        <feMerge>
+          <feMergeNode />
+          <feMergeNode
+            in="SourceGraphic"
+          />
+        </feMerge>
+      </filter>
+      <polyline
+        fill="#ffffff"
+        points="12,0 0,12 12,24"
+        stroke="#ffffff"
+      />
+      <polyline
+        fill="#ffffff"
+        filter="url(#tooltip-dropshadow-right)"
+        points="12,0 0,12 12,24"
+        stroke="rgba(33,36,44,0.16)"
+      />
+    </svg>
+  </div>
+  <div
+    style={
+      Object {
+        "backgroundColor": "red",
+        "height": 24,
+        "width": 4,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 10 1`] = `
+<div
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "column-reverse",
+    }
+  }
+>
+  <div
+    className="arrowContainer_jqq9v4-o_O-container-bottom_15ku1de"
+    data-placement="bottom"
+    style={undefined}
+  >
+    <svg
+      className="arrow_oo4scr-o_O-arrow-bottom_v72lrv"
+      height={12}
+      width={24}
+    >
+      <filter
+        height="150%"
+        id="tooltip-dropshadow-bottom"
+      >
+        <feOffset
+          dx={8}
+          dy={8}
+          result="offsetblur"
+        />
+        <feGaussianBlur
+          in="SourceAlpha"
+          stdDeviation={3}
+        />
+        <feComponentTransfer>
+          <feFuncA
+            slope={0.16}
+            type="linear"
+          />
+        </feComponentTransfer>
+        <feMerge>
+          <feMergeNode />
+          <feMergeNode
+            in="SourceGraphic"
+          />
+        </feMerge>
+      </filter>
+      <polyline
+        fill="#ffffff"
+        points="0, 12 12,0 24,12"
+        stroke="#ffffff"
+      />
+      <polyline
+        fill="#ffffff"
+        filter="url(#tooltip-dropshadow-bottom)"
+        points="0, 12 12,0 24,12"
+        stroke="rgba(33,36,44,0.16)"
+      />
+    </svg>
+  </div>
+  <div
+    style={
+      Object {
+        "backgroundColor": "red",
+        "height": 4,
+        "width": 24,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 11 1`] = `
+<div
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "row",
+    }
+  }
+>
+  <div
+    className="arrowContainer_jqq9v4-o_O-container-left_8hn242"
+    data-placement="left"
+    style={undefined}
+  >
+    <svg
+      className="arrow_oo4scr-o_O-arrow-left_sdqx8w"
+      height={24}
+      width={12}
+    >
+      <filter
+        height="150%"
+        id="tooltip-dropshadow-left"
+      >
+        <feOffset
+          dx={8}
+          dy={8}
+          result="offsetblur"
+        />
+        <feGaussianBlur
+          in="SourceAlpha"
+          stdDeviation={3}
+        />
+        <feComponentTransfer>
+          <feFuncA
+            slope={0.16}
+            type="linear"
+          />
+        </feComponentTransfer>
+        <feMerge>
+          <feMergeNode />
+          <feMergeNode
+            in="SourceGraphic"
+          />
+        </feMerge>
+      </filter>
+      <polyline
+        fill="#ffffff"
+        points="0,0 12,12 0,24"
+        stroke="#ffffff"
+      />
+      <polyline
+        fill="#ffffff"
+        filter="url(#tooltip-dropshadow-left)"
+        points="0,0 12,12 0,24"
+        stroke="rgba(33,36,44,0.16)"
+      />
+    </svg>
+  </div>
+  <div
+    style={
+      Object {
+        "backgroundColor": "red",
+        "height": 24,
+        "width": 4,
+      }
+    }
+  />
+</div>
+`;

--- a/packages/wonder-blocks-tooltip/components/tooltip-arrow.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-arrow.js
@@ -1,8 +1,10 @@
 // @flow
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import {css, StyleSheet} from "aphrodite";
 
 import Colors from "@khanacademy/wonder-blocks-color";
+import {View} from "@khanacademy/wonder-blocks-core";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {Placement} from "../util/types.js";
@@ -14,16 +16,19 @@ type Props = {
 };
 
 export default class TooltipArrow extends React.Component<Props> {
-    lastRef: ?HTMLElement;
+    _lastRef: ?HTMLElement;
 
-    updateRef(ref: ?HTMLElement) {
+    updateRef(ref: ?(React.Component<*> | Element)) {
         const {popperArrowProps} = this.props;
         // We only want to update the popper's arrow reference if it is
         // actually changed. Otherwise, we end up in an endless loop of updates
         // as every render would trigger yet another render.
-        if (popperArrowProps && ref && ref !== this.lastRef) {
-            this.lastRef = ref;
-            popperArrowProps.ref(ref);
+        if (popperArrowProps && ref) {
+            const domNode = ReactDOM.findDOMNode(ref);
+            if (domNode instanceof HTMLElement && domNode !== this._lastRef) {
+                this._lastRef = domNode;
+                popperArrowProps.ref(domNode);
+            }
         }
     }
 
@@ -165,17 +170,17 @@ export default class TooltipArrow extends React.Component<Props> {
         const {placement, popperArrowProps} = this.props;
         const {style} = popperArrowProps || {};
         return (
-            <div
-                className={css(
+            <View
+                style={[
                     styles.arrowContainer,
                     styles[`container-${placement}`],
-                )}
-                style={style}
+                    style,
+                ]}
                 data-placement={placement}
                 ref={(r) => this.updateRef(r)}
             >
                 {this._renderArrow()}
-            </div>
+            </View>
         );
     }
 }

--- a/packages/wonder-blocks-tooltip/components/tooltip-arrow.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-arrow.js
@@ -96,6 +96,10 @@ export default class TooltipArrow extends React.Component<Props> {
             height,
             width,
         } = this._calculateDimensionsFromPlacement();
+
+        // TODO(somewhatabstract): Use unique IDs!
+        const dropShadowFilterId = `tooltip-dropshadow-${placement}`;
+
         return (
             <svg
                 className={css(styles.arrow, styles[`arrow-${placement}`])}
@@ -115,7 +119,7 @@ export default class TooltipArrow extends React.Component<Props> {
                   * same side will yield ID conflicts... but at least they'll
                   * be the same filter, so it doesn't matter which one we
                   * reference, so long as it's for the correct side. */}
-                <filter id={`tooltip-dropshadow-${placement}`} height="150%">
+                <filter id={dropShadowFilterId} height="150%">
                     <feOffset
                         dx={Spacing.xSmall}
                         dy={Spacing.xSmall}
@@ -151,7 +155,7 @@ export default class TooltipArrow extends React.Component<Props> {
                     fill={Colors.white}
                     points={points.join(" ")}
                     stroke={Colors.offBlack16}
-                    filter={`url(#tooltip-dropshadow-${placement})`}
+                    filter={`url(#${dropShadowFilterId})`}
                 />
             </svg>
         );

--- a/packages/wonder-blocks-tooltip/components/tooltip-arrow.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-arrow.js
@@ -1,0 +1,228 @@
+// @flow
+import * as React from "react";
+import {css, StyleSheet} from "aphrodite";
+
+import Colors from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+
+import type {Placement} from "../util/types.js";
+import type {PopperArrowProps} from "react-popper";
+
+type Props = {
+    placement: Placement,
+    popperArrowProps?: PopperArrowProps,
+};
+
+export default class TooltipArrow extends React.Component<Props> {
+    lastRef: ?HTMLElement;
+
+    updateRef(ref: ?HTMLElement) {
+        const {popperArrowProps} = this.props;
+        // We only want to update the popper's arrow reference if it is
+        // actually changed. Otherwise, we end up in an endless loop of updates
+        // as every render would trigger yet another render.
+        if (popperArrowProps && ref && ref !== this.lastRef) {
+            this.lastRef = ref;
+            popperArrowProps.ref(ref);
+        }
+    }
+
+    _calculateDimensionsFromPlacement() {
+        const {placement} = this.props;
+        const arrowWidth = Spacing.large;
+        const arrowHeight = Spacing.small;
+
+        // Calculate the three points of the arrow. Depending on the arrow's
+        // direction (i.e., the tooltip's "side"), we choose different points,
+        // and set our SVG's bounds differently.
+        //
+        // Note that `arrowWidth` and `arrowHeight` refer to the
+        // downward-pointing arrow (i.e. side="top"). When the arrow points to
+        // the left or right instead, the width/height are inverted.
+        switch (placement) {
+            case "top":
+                return {
+                    points: [
+                        "0,0",
+                        `${arrowWidth / 2},${arrowHeight}`,
+                        `${arrowWidth},0`,
+                    ],
+                    height: arrowHeight,
+                    width: arrowWidth,
+                };
+
+            case "right":
+                return {
+                    points: [
+                        `${arrowHeight},0`,
+                        `0,${arrowWidth / 2}`,
+                        `${arrowHeight},${arrowWidth}`,
+                    ],
+                    width: arrowHeight,
+                    height: arrowWidth,
+                };
+
+            case "bottom":
+                return {
+                    points: [
+                        `0, ${arrowHeight}`,
+                        `${arrowWidth / 2},0`,
+                        `${arrowWidth},${arrowHeight}`,
+                    ],
+                    width: arrowWidth,
+                    height: arrowHeight,
+                };
+
+            case "left":
+                return {
+                    points: [
+                        `0,0`,
+                        `${arrowHeight},${arrowWidth / 2}`,
+                        `0,${arrowWidth}`,
+                    ],
+                    width: arrowHeight,
+                    height: arrowWidth,
+                };
+
+            default:
+                throw new Error(`Unknown placement: ${placement}`);
+        }
+    }
+
+    _renderArrow() {
+        const {placement} = this.props;
+        const {
+            points,
+            height,
+            width,
+        } = this._calculateDimensionsFromPlacement();
+        return (
+            <svg
+                className={css(styles.arrow, styles[`arrow-${placement}`])}
+                width={width}
+                height={height}
+            >
+                {/* Create an SVG filter that applies a blur to an element.
+                  * We'll apply it to a dark shape outlining the tooltip, which
+                  * will produce the overall effect of a drop-shadow.
+                  *
+                  * Also, scope its ID by side, so that tooltips with other
+                  * "side" values don't end up using the wrong filter from
+                  * elsewhere in the document. (The `height` value depends on
+                  * which way the arrow is turned!)
+                  *
+                  * In general, it's not *great* that multiple tooltips of the
+                  * same side will yield ID conflicts... but at least they'll
+                  * be the same filter, so it doesn't matter which one we
+                  * reference, so long as it's for the correct side. */}
+                <filter id={`tooltip-dropshadow-${placement}`} height="150%">
+                    <feOffset
+                        dx={Spacing.xSmall}
+                        dy={Spacing.xSmall}
+                        result="offsetblur"
+                    />
+                    <feGaussianBlur
+                        in="SourceAlpha"
+                        stdDeviation={Spacing.xxSmall / 2}
+                    />
+                    <feComponentTransfer>
+                        <feFuncA type="linear" slope={0.16} />
+                    </feComponentTransfer>
+                    <feMerge>
+                        <feMergeNode />
+                        <feMergeNode in="SourceGraphic" />
+                    </feMerge>
+                </filter>
+
+                {/* Draw the background of the tooltip arrow. */}
+                <polyline
+                    fill={Colors.white}
+                    stroke={Colors.white}
+                    points={points.join(" ")}
+                />
+
+                {/* Draw an outline around the tooltip arrow, and apply the
+                  * blur filter we created above, to produce a drop shadow
+                  * effect. */}
+                <polyline
+                    // Redraw the stroke on top of the background color,
+                    // so that the ends aren't extra dark where they meet
+                    // the border of the tooltip.
+                    fill={Colors.white}
+                    points={points.join(" ")}
+                    stroke={Colors.offBlack16}
+                    filter={`url(#tooltip-dropshadow-${placement})`}
+                />
+            </svg>
+        );
+    }
+
+    render() {
+        const {placement, popperArrowProps} = this.props;
+        const {style} = popperArrowProps || {};
+        return (
+            <div
+                className={css(
+                    styles.arrowContainer,
+                    styles[`container-${placement}`],
+                )}
+                style={style}
+                data-placement={placement}
+                ref={(r) => this.updateRef(r)}
+            >
+                {this._renderArrow()}
+            </div>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    /**
+     * Container
+     */
+    arrowContainer: {
+        position: "relative",
+        width: Spacing.large,
+        height: Spacing.small,
+        pointerEvents: "none",
+    },
+
+    // Ensure the container is sized properly for us to be placed correctly
+    // by the Popper.js code.
+    "container-top": {
+        width: Spacing.large,
+        height: Spacing.small + Spacing.xSmall,
+    },
+    "container-right": {
+        width: Spacing.small + Spacing.xSmall,
+        height: Spacing.large,
+    },
+    "container-bottom": {
+        width: Spacing.large,
+        height: Spacing.small + Spacing.xSmall,
+    },
+    "container-left": {
+        width: Spacing.small + Spacing.xSmall,
+        height: Spacing.large,
+    },
+
+    /**
+     * Arrow
+     */
+    arrow: {
+        // Ensure the dropshadow bleeds outside our bounds.
+        overflow: "visible",
+    },
+    "arrow-top": {
+        paddingBottom: Spacing.xSmall,
+    },
+    "arrow-right": {
+        paddingLeft: Spacing.xSmall,
+    },
+    "arrow-bottom": {
+        paddingTop: Spacing.xSmall,
+    },
+    "arrow-left": {
+        paddingRight: Spacing.xSmall,
+    },
+});

--- a/packages/wonder-blocks-tooltip/components/tooltip-arrow.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip-arrow.md
@@ -1,0 +1,39 @@
+The `TooltipArrow` renders the arrow, including appropriate padding from the anchor location.
+
+In these examples, a red bar has been added to show how the arrow is distanced from the target elements.
+
+### Placement top
+
+```jsx
+<div style={{display: "flex", flexDirection: "column"}}>
+    <TooltipArrow placement="top" />
+    <div style={{backgroundColor: "red", width: 24, height: 4}} />
+</div>
+```
+
+### Placement right
+
+```jsx
+<div style={{display: "flex", flexDirection: "row-reverse", justifyContent: "flex-end"}}>
+    <TooltipArrow placement="right" />
+    <div style={{backgroundColor: "red", width: 4, height: 24}} />
+</div>
+```
+
+### Placement bottom
+
+```jsx
+<div style={{display: "flex", flexDirection: "column-reverse"}}>
+    <TooltipArrow placement="bottom" />
+    <div style={{backgroundColor: "red", width: 24, height: 4}} />
+</div>
+```
+
+### Placement left
+
+```jsx
+<div style={{display: "flex", flexDirection: "row"}}>
+    <TooltipArrow placement="left" />
+    <div style={{backgroundColor: "red", width: 4, height: 24}} />
+</div>
+```

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
@@ -3,7 +3,9 @@ import {css, StyleSheet} from "aphrodite";
 import * as React from "react";
 import {Popper} from "react-popper";
 
+import {View} from "@khanacademy/wonder-blocks-core";
 import TooltipContent from "./tooltip-content.js";
+import TooltipArrow from "./tooltip-arrow.js";
 import visibilityModifierDefaultConfig from "../util/visibility-modifier.js";
 
 import type {PopperChildrenProps} from "react-popper";
@@ -22,15 +24,10 @@ type Props = {|
 |};
 
 export default class TooltipBubble extends React.Component<Props> {
-    _renderContent(childrenProps: PopperChildrenProps) {
-        const {children} = this.props;
-        const {
-            ref,
-            outOfBoundaries,
-            style,
-            placement,
-            //  arrowProps,
-        } = childrenProps;
+    _renderBubble(childrenProps: PopperChildrenProps) {
+        const {children, placement} = this.props;
+        const {ref, outOfBoundaries, style, arrowProps} = childrenProps;
+        const actualPlacement = childrenProps.placement || placement;
 
         // Here we take the props provided to us by popper.js and use them
         // to position ourselves. We don't use a View because the ref callback
@@ -39,12 +36,18 @@ export default class TooltipBubble extends React.Component<Props> {
         // gain over just using a div.
         return (
             <div
-                data-placement={placement}
+                data-placement={actualPlacement}
                 ref={ref}
                 className={css(styles.bubble, outOfBoundaries && styles.hide)}
                 style={style}
             >
-                {children}
+                <View style={styles[`content-${actualPlacement}`]}>
+                    {children}
+                    <TooltipArrow
+                        placement={actualPlacement}
+                        popperArrowProps={arrowProps}
+                    />
+                </View>
             </div>
         );
     }
@@ -54,15 +57,13 @@ export default class TooltipBubble extends React.Component<Props> {
         return (
             <Popper
                 referenceElement={anchorElement}
-                //TODO(somewhatabstract): Expose placement as a prop
                 placement={placement}
                 modifiers={{
                     wbVisibility: visibilityModifierDefaultConfig,
-                    flip: {behavior: "clockwise"},
                     preventOverflow: {boundariesElement: "viewport"},
                 }}
             >
-                {(props) => this._renderContent(props)}
+                {(props) => this._renderBubble(props)}
             </Popper>
         );
     }
@@ -72,6 +73,7 @@ const styles = StyleSheet.create({
     bubble: {
         pointerEvents: "none",
     },
+
     /**
      * The hide style ensures that the bounds of the bubble stay unchanged.
      * This is because popper.js calculates the bubble position based off its
@@ -79,8 +81,25 @@ const styles = StyleSheet.create({
      * place it when it reappeared.
      */
     hide: {
+        pointerEvents: "none",
         opacity: 0,
         backgroundColor: "transparent",
         color: "transparent",
+    },
+
+    /**
+     * Ensure the content and arrow are properly arranged.
+     */
+    "content-top": {
+        flexDirection: "column",
+    },
+    "content-right": {
+        flexDirection: "row-reverse",
+    },
+    "content-bottom": {
+        flexDirection: "column-reverse",
+    },
+    "content-left": {
+        flexDirection: "row",
     },
 });

--- a/packages/wonder-blocks-tooltip/components/tooltip.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip.md
@@ -1,14 +1,14 @@
-### Text anchor & text tooltip
+### Text anchor & text tooltip & placement right
 
 ```js
 const React = require("react");
 
-<Tooltip content={"The tooltip text"}>
+<Tooltip content={"I'm on the right!"} placement="right">
     Some text
 </Tooltip>
 ```
 
-### Complex anchor & text tooltip
+### Complex anchor & text tooltip & placement default (top)
 
 In this example, we're no longer forcing the anchor root to be focusable, since the text input can take focus.
 
@@ -16,7 +16,7 @@ In this example, we're no longer forcing the anchor root to be focusable, since 
 const React = require("react");
 const {View} = require("@khanacademy/wonder-blocks-core");
 
-<Tooltip forceAnchorFocusivity={false} content={"The tooltip text"}>
+<Tooltip forceAnchorFocusivity={false} content={"I'm at the top!"}>
     <View>
         Some text
         <input />
@@ -24,7 +24,7 @@ const {View} = require("@khanacademy/wonder-blocks-core");
 </Tooltip>
 ```
 
-### Substring anchor in scrollable parent
+### Substring anchor in scrollable parent & placement bottom
 
 ```js
 const React = require("react");
@@ -34,7 +34,7 @@ const {View, Text} = require("@khanacademy/wonder-blocks-core");
     <div style={{height: 100, overflow: "auto", border: "1px solid", margin: 10,}}>
         <div style={{height: "200vh"}}>
             <Text>This is a big long piece of text with a </Text>
-            <Tooltip content={"Some long text"}>
+            <Tooltip content={"I'm on the bottom!"} placement={"bottom"}>
                 <Text style={{color: "red"}}>tooltip</Text>
             </Tooltip>
             <Text> in the middle.</Text>
@@ -43,7 +43,7 @@ const {View, Text} = require("@khanacademy/wonder-blocks-core");
 </div>
 ```
 
-### Tooltip in a modal
+### Tooltip in a modal & placement left
 
 ```js
 const React = require("react");
@@ -53,11 +53,9 @@ const {StandardModal, ModalLauncher} = require("@khanacademy/wonder-blocks-modal
 const scrollyContent = (
      <div style={{height: 100, overflow: "auto", border: "1px solid", margin: 10,}}>
         <div style={{height: "200vh"}}>
-            <Text>This is a big long piece of text with a </Text>
-            <Tooltip content={"Some long text"}>
+            <Tooltip content={"I'm on the left!"} placement="left">
                 <Text style={{color: "red"}}>tooltip</Text>
             </Tooltip>
-            <Text> in the middle.</Text>
         </div>
      </div>
 );

--- a/packages/wonder-blocks-tooltip/components/tooltip.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip.md
@@ -27,43 +27,75 @@ const {View} = require("@khanacademy/wonder-blocks-core");
 ### Substring anchor in scrollable parent & placement bottom
 
 ```js
+const {StyleSheet} = require("aphrodite");
 const React = require("react");
-const {View, Text} = require("@khanacademy/wonder-blocks-core");
+const {View} = require("@khanacademy/wonder-blocks-core");
+const {Body} = require("@khanacademy/wonder-blocks-typography");
 
-<div>
-    <div style={{height: 100, overflow: "auto", border: "1px solid", margin: 10,}}>
-        <div style={{height: "200vh"}}>
-            <Text>This is a big long piece of text with a </Text>
-            <Tooltip content={"I'm on the bottom!"} placement={"bottom"}>
-                <Text style={{color: "red"}}>tooltip</Text>
-            </Tooltip>
-            <Text> in the middle.</Text>
-        </div>
-    </div>
-</div>
+const styles = StyleSheet.create({
+    scrollbox: {
+        height: 100,
+        overflow: "auto",
+        border: "1px solid black",
+        margin: 10,
+    },
+    hostbox: {
+        minHeight: "200vh",
+    },
+});
+
+<View>
+    <View style={styles.scrollbox}>
+        <View style={styles.hostbox}>
+            <Body>
+                This is a big long piece of text with a
+                <Tooltip content={"I'm on the bottom!"} placement={"bottom"}>
+                    [tooltip]
+                </Tooltip>
+                <span> </span>in the middle.
+            </Body>
+        </View>
+    </View>
+</View>
 ```
 
 ### Tooltip in a modal & placement left
 
 ```js
+const {StyleSheet} = require("aphrodite");
 const React = require("react");
 const {View, Text} = require("@khanacademy/wonder-blocks-core");
 const {StandardModal, ModalLauncher} = require("@khanacademy/wonder-blocks-modal");
 
+const styles = StyleSheet.create({
+    scrollbox: {
+        height: 100,
+        overflow: "auto",
+        border: "1px solid black",
+        margin: 10,
+    },
+    hostbox: {
+        minHeight: "200vh",
+    },
+    modalbox: {
+        height: "200vh",
+    },
+});
+
 const scrollyContent = (
-     <div style={{height: 100, overflow: "auto", border: "1px solid", margin: 10,}}>
-        <div style={{height: "200vh"}}>
+     <View style={styles.scrollbox}>
+        <View style={styles.hostbox}>
             <Tooltip content={"I'm on the left!"} placement="left">
-                <Text style={{color: "red"}}>tooltip</Text>
+                tooltip
             </Tooltip>
-        </div>
-     </div>
+        </View>
+     </View>
 );
 
 const modalContent = (
-    <div style={{height: "200vh"}}>
+    <View style={styles.modalbox}>
         {scrollyContent}
-    </div>
+    </View>
 );
 
 const modal = (

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -41,36 +41,46 @@ describe("wonder-blocks-tooltip", () => {
         expect(tree).toMatchSnapshot();
     });
     it("example 3", () => {
+        const {StyleSheet} = require("aphrodite");
         const React = require("react");
-        const {View, Text} = require("@khanacademy/wonder-blocks-core");
+        const {View} = require("@khanacademy/wonder-blocks-core");
+        const {Body} = require("@khanacademy/wonder-blocks-typography");
+
+        const styles = StyleSheet.create({
+            scrollbox: {
+                height: 100,
+                overflow: "auto",
+                border: "1px solid black",
+                margin: 10,
+            },
+            hostbox: {
+                minHeight: "200vh",
+            },
+        });
 
         const example = (
-            <div>
-                <div
-                    style={{
-                        height: 100,
-                        overflow: "auto",
-                        border: "1px solid",
-                        margin: 10,
-                    }}
-                >
-                    <div style={{height: "200vh"}}>
-                        <Text>This is a big long piece of text with a </Text>
-                        <Tooltip
-                            content={"I'm on the bottom!"}
-                            placement={"bottom"}
-                        >
-                            <Text style={{color: "red"}}>tooltip</Text>
-                        </Tooltip>
-                        <Text> in the middle.</Text>
-                    </div>
-                </div>
-            </div>
+            <View>
+                <View style={styles.scrollbox}>
+                    <View style={styles.hostbox}>
+                        <Body>
+                            This is a big long piece of text with a
+                            <Tooltip
+                                content={"I'm on the bottom!"}
+                                placement={"bottom"}
+                            >
+                                [tooltip]
+                            </Tooltip>
+                            <span> </span>in the middle.
+                        </Body>
+                    </View>
+                </View>
+            </View>
         );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
     it("example 4", () => {
+        const {StyleSheet} = require("aphrodite");
         const React = require("react");
         const {View, Text} = require("@khanacademy/wonder-blocks-core");
         const {
@@ -78,25 +88,33 @@ describe("wonder-blocks-tooltip", () => {
             ModalLauncher,
         } = require("@khanacademy/wonder-blocks-modal");
 
+        const styles = StyleSheet.create({
+            scrollbox: {
+                height: 100,
+                overflow: "auto",
+                border: "1px solid black",
+                margin: 10,
+            },
+            hostbox: {
+                minHeight: "200vh",
+            },
+            modalbox: {
+                height: "200vh",
+            },
+        });
+
         const scrollyContent = (
-            <div
-                style={{
-                    height: 100,
-                    overflow: "auto",
-                    border: "1px solid",
-                    margin: 10,
-                }}
-            >
-                <div style={{height: "200vh"}}>
+            <View style={styles.scrollbox}>
+                <View style={styles.hostbox}>
                     <Tooltip content={"I'm on the left!"} placement="left">
-                        <Text style={{color: "red"}}>tooltip</Text>
+                        tooltip
                     </Tooltip>
-                </div>
-            </div>
+                </View>
+            </View>
         );
 
         const modalContent = (
-            <div style={{height: "200vh"}}>{scrollyContent}</div>
+            <View style={styles.modalbox}>{scrollyContent}</View>
         );
 
         const modal = (

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -11,13 +11,16 @@ import renderer from "react-test-renderer";
 jest.mock("react-dom");
 import Tooltip from "./components/tooltip.js";
 import TooltipContent from "./components/tooltip-content.js";
+import TooltipArrow from "./components/tooltip-arrow.js";
 
 describe("wonder-blocks-tooltip", () => {
     it("example 1", () => {
         const React = require("react");
 
         const example = (
-            <Tooltip content={"The tooltip text"}>Some text</Tooltip>
+            <Tooltip content={"I'm on the right!"} placement="right">
+                Some text
+            </Tooltip>
         );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
@@ -27,7 +30,7 @@ describe("wonder-blocks-tooltip", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
 
         const example = (
-            <Tooltip forceAnchorFocusivity={false} content={"The tooltip text"}>
+            <Tooltip forceAnchorFocusivity={false} content={"I'm at the top!"}>
                 <View>
                     Some text
                     <input />
@@ -53,7 +56,10 @@ describe("wonder-blocks-tooltip", () => {
                 >
                     <div style={{height: "200vh"}}>
                         <Text>This is a big long piece of text with a </Text>
-                        <Tooltip content={"Some long text"}>
+                        <Tooltip
+                            content={"I'm on the bottom!"}
+                            placement={"bottom"}
+                        >
                             <Text style={{color: "red"}}>tooltip</Text>
                         </Tooltip>
                         <Text> in the middle.</Text>
@@ -82,11 +88,9 @@ describe("wonder-blocks-tooltip", () => {
                 }}
             >
                 <div style={{height: "200vh"}}>
-                    <Text>This is a big long piece of text with a </Text>
-                    <Tooltip content={"Some long text"}>
+                    <Tooltip content={"I'm on the left!"} placement="left">
                         <Text style={{color: "red"}}>tooltip</Text>
                     </Tooltip>
-                    <Text> in the middle.</Text>
                 </div>
             </div>
         );
@@ -138,6 +142,52 @@ describe("wonder-blocks-tooltip", () => {
                 <Body>Body text content!</Body>
                 <LabelSmall>And LabelSmall!</LabelSmall>
             </TooltipContent>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 8", () => {
+        const example = (
+            <div style={{display: "flex", flexDirection: "column"}}>
+                <TooltipArrow placement="top" />
+                <div style={{backgroundColor: "red", width: 24, height: 4}} />
+            </div>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 9", () => {
+        const example = (
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "row-reverse",
+                    justifyContent: "flex-end",
+                }}
+            >
+                <TooltipArrow placement="right" />
+                <div style={{backgroundColor: "red", width: 4, height: 24}} />
+            </div>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 10", () => {
+        const example = (
+            <div style={{display: "flex", flexDirection: "column-reverse"}}>
+                <TooltipArrow placement="bottom" />
+                <div style={{backgroundColor: "red", width: 24, height: 4}} />
+            </div>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 11", () => {
+        const example = (
+            <div style={{display: "flex", flexDirection: "row"}}>
+                <TooltipArrow placement="left" />
+                <div style={{backgroundColor: "red", width: 4, height: 24}} />
+            </div>
         );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -15,12 +15,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "react-popper": "^1.0.0-beta.6",
     "@khanacademy/wonder-blocks-color": "^1.0.2",
     "@khanacademy/wonder-blocks-core": "^1.0.2",
     "@khanacademy/wonder-blocks-layout": "^0.0.2",
     "@khanacademy/wonder-blocks-modal": "^0.0.3",
     "@khanacademy/wonder-blocks-spacing": "^2.0.0",
-    "@khanacademy/wonder-blocks-typography": "^1.0.2"
+    "@khanacademy/wonder-blocks-typography": "^1.0.2",
+    "react-popper": "^1.0.0"
   }
 }

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -103,6 +103,15 @@ module.exports = {
                 "packages/wonder-blocks-tooltip/components/tooltip.js",
                 "packages/wonder-blocks-tooltip/components/tooltip-content.js",
             ],
+            sections: [
+                {
+                    name: "Internal Components",
+                    private: true,
+                    components: [
+                        "packages/wonder-blocks-tooltip/components/tooltip-arrow.js",
+                    ],
+                },
+            ],
         },
     ],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7763,7 +7763,7 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
-react-popper@^1.0.0-beta.6:
+react-popper@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.0.tgz#b99452144e8fe4acc77fa3d959a8c79e07a65084"
   dependencies:


### PR DESCRIPTION
This PR builds on #152 to add the `TooltipArrow` component.

In this work, we extend the `TooltipBubble` component to render the arrow, including style changes to ensure the arrow appears where we need it relative to the content.

Now that we know the overall structure, the next PR after this one will split the `TooltipBubble` into a rendering component and a positioning component. This should allow us to have some rendering docs for the entire bubble outside of the positioning code. This will also be when we add styling for the tooltip bubble.

The SVG code for drawing the arrow may need some tweaks to get the drop shadow radius looking like our designs. This can be done once the overall tooltip styling is done in the next PR.

## Appearance
Docs have been added for this internal component. These internal component docs are marked private in anticipation of #130.