### PR TITLE
Split TooltipBubble into TooltipBubble and TooltipPopper

### DIFF
--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -755,3 +755,979 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
   />
 </div>
 `;
+
+exports[`wonder-blocks-tooltip example 12 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "height": 50,
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    data-placement="top"
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "left": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      />
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+          }
+        }
+      >
+        I'm on the top!
+      </span>
+    </div>
+    <div
+      className="arrowContainer_jqq9v4-o_O-container-top_15ku1de"
+      data-placement="top"
+      style={
+        Object {
+          "left": 0,
+          "top": 0,
+        }
+      }
+    >
+      <svg
+        className="arrow_oo4scr-o_O-arrow-top_1itpe9r"
+        height={12}
+        width={24}
+      >
+        <filter
+          height="150%"
+          id="tooltip-dropshadow-top"
+        >
+          <feOffset
+            dx={8}
+            dy={8}
+            result="offsetblur"
+          />
+          <feGaussianBlur
+            in="SourceAlpha"
+            stdDeviation={3}
+          />
+          <feComponentTransfer>
+            <feFuncA
+              slope={0.16}
+              type="linear"
+            />
+          </feComponentTransfer>
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode
+              in="SourceGraphic"
+            />
+          </feMerge>
+        </filter>
+        <polyline
+          fill="#ffffff"
+          points="0,0 12,12 24,0"
+          stroke="#ffffff"
+        />
+        <polyline
+          fill="#ffffff"
+          filter="url(#tooltip-dropshadow-top)"
+          points="0,0 12,12 24,0"
+          stroke="rgba(33,36,44,0.16)"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 13 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row-reverse",
+      "height": 50,
+      "justifyContent": "flex-end",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    data-placement="right"
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "row-reverse",
+        "left": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      />
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+          }
+        }
+      >
+        I'm on the right!
+      </span>
+    </div>
+    <div
+      className="arrowContainer_jqq9v4-o_O-container-right_8hn242"
+      data-placement="right"
+      style={
+        Object {
+          "left": 0,
+          "top": 0,
+        }
+      }
+    >
+      <svg
+        className="arrow_oo4scr-o_O-arrow-right_14846yz"
+        height={24}
+        width={12}
+      >
+        <filter
+          height="150%"
+          id="tooltip-dropshadow-right"
+        >
+          <feOffset
+            dx={8}
+            dy={8}
+            result="offsetblur"
+          />
+          <feGaussianBlur
+            in="SourceAlpha"
+            stdDeviation={3}
+          />
+          <feComponentTransfer>
+            <feFuncA
+              slope={0.16}
+              type="linear"
+            />
+          </feComponentTransfer>
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode
+              in="SourceGraphic"
+            />
+          </feMerge>
+        </filter>
+        <polyline
+          fill="#ffffff"
+          points="12,0 0,12 12,24"
+          stroke="#ffffff"
+        />
+        <polyline
+          fill="#ffffff"
+          filter="url(#tooltip-dropshadow-right)"
+          points="12,0 0,12 12,24"
+          stroke="rgba(33,36,44,0.16)"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 14 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column-reverse",
+      "height": 50,
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    data-placement="bottom"
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column-reverse",
+        "left": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      />
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+          }
+        }
+      >
+        I'm on the bottom!
+      </span>
+    </div>
+    <div
+      className="arrowContainer_jqq9v4-o_O-container-bottom_15ku1de"
+      data-placement="bottom"
+      style={
+        Object {
+          "left": 0,
+          "top": 0,
+        }
+      }
+    >
+      <svg
+        className="arrow_oo4scr-o_O-arrow-bottom_v72lrv"
+        height={12}
+        width={24}
+      >
+        <filter
+          height="150%"
+          id="tooltip-dropshadow-bottom"
+        >
+          <feOffset
+            dx={8}
+            dy={8}
+            result="offsetblur"
+          />
+          <feGaussianBlur
+            in="SourceAlpha"
+            stdDeviation={3}
+          />
+          <feComponentTransfer>
+            <feFuncA
+              slope={0.16}
+              type="linear"
+            />
+          </feComponentTransfer>
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode
+              in="SourceGraphic"
+            />
+          </feMerge>
+        </filter>
+        <polyline
+          fill="#ffffff"
+          points="0, 12 12,0 24,12"
+          stroke="#ffffff"
+        />
+        <polyline
+          fill="#ffffff"
+          filter="url(#tooltip-dropshadow-bottom)"
+          points="0, 12 12,0 24,12"
+          stroke="rgba(33,36,44,0.16)"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 15 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "height": 50,
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    data-placement="left"
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "row",
+        "left": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      />
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+          }
+        }
+      >
+        I'm on the left!
+      </span>
+    </div>
+    <div
+      className="arrowContainer_jqq9v4-o_O-container-left_8hn242"
+      data-placement="left"
+      style={
+        Object {
+          "left": 0,
+          "top": 0,
+        }
+      }
+    >
+      <svg
+        className="arrow_oo4scr-o_O-arrow-left_sdqx8w"
+        height={24}
+        width={12}
+      >
+        <filter
+          height="150%"
+          id="tooltip-dropshadow-left"
+        >
+          <feOffset
+            dx={8}
+            dy={8}
+            result="offsetblur"
+          />
+          <feGaussianBlur
+            in="SourceAlpha"
+            stdDeviation={3}
+          />
+          <feComponentTransfer>
+            <feFuncA
+              slope={0.16}
+              type="linear"
+            />
+          </feComponentTransfer>
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode
+              in="SourceGraphic"
+            />
+          </feMerge>
+        </filter>
+        <polyline
+          fill="#ffffff"
+          points="0,0 12,12 0,24"
+          stroke="#ffffff"
+        />
+        <polyline
+          fill="#ffffff"
+          filter="url(#tooltip-dropshadow-left)"
+          points="0,0 12,12 0,24"
+          stroke="rgba(33,36,44,0.16)"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 16 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "height": 50,
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    data-placement="top"
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "left": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      />
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+          }
+        }
+      >
+        I'm on the left!
+      </span>
+    </div>
+    <div
+      className="arrowContainer_jqq9v4-o_O-container-top_15ku1de"
+      data-placement="top"
+      style={
+        Object {
+          "left": 50,
+          "top": 0,
+        }
+      }
+    >
+      <svg
+        className="arrow_oo4scr-o_O-arrow-top_1itpe9r"
+        height={12}
+        width={24}
+      >
+        <filter
+          height="150%"
+          id="tooltip-dropshadow-top"
+        >
+          <feOffset
+            dx={8}
+            dy={8}
+            result="offsetblur"
+          />
+          <feGaussianBlur
+            in="SourceAlpha"
+            stdDeviation={3}
+          />
+          <feComponentTransfer>
+            <feFuncA
+              slope={0.16}
+              type="linear"
+            />
+          </feComponentTransfer>
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode
+              in="SourceGraphic"
+            />
+          </feMerge>
+        </filter>
+        <polyline
+          fill="#ffffff"
+          points="0,0 12,12 24,0"
+          stroke="#ffffff"
+        />
+        <polyline
+          fill="#ffffff"
+          filter="url(#tooltip-dropshadow-top)"
+          points="0,0 12,12 24,0"
+          stroke="rgba(33,36,44,0.16)"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 17 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "height": 50,
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    data-placement="top"
+    style={
+      Object {
+        "alignItems": "stretch",
+        "backgroundColor": "transparent",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "color": "transparent",
+        "display": "flex",
+        "flexDirection": "column",
+        "left": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "opacity": 0,
+        "padding": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      />
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+          }
+        }
+      >
+        I'm on the left!
+      </span>
+    </div>
+    <div
+      className="arrowContainer_jqq9v4-o_O-container-top_15ku1de"
+      data-placement="top"
+      style={
+        Object {
+          "left": 0,
+          "top": 0,
+        }
+      }
+    >
+      <svg
+        className="arrow_oo4scr-o_O-arrow-top_1itpe9r"
+        height={12}
+        width={24}
+      >
+        <filter
+          height="150%"
+          id="tooltip-dropshadow-top"
+        >
+          <feOffset
+            dx={8}
+            dy={8}
+            result="offsetblur"
+          />
+          <feGaussianBlur
+            in="SourceAlpha"
+            stdDeviation={3}
+          />
+          <feComponentTransfer>
+            <feFuncA
+              slope={0.16}
+              type="linear"
+            />
+          </feComponentTransfer>
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode
+              in="SourceGraphic"
+            />
+          </feMerge>
+        </filter>
+        <polyline
+          fill="#ffffff"
+          points="0,0 12,12 24,0"
+          stroke="#ffffff"
+        />
+        <polyline
+          fill="#ffffff"
+          filter="url(#tooltip-dropshadow-top)"
+          points="0,0 12,12 24,0"
+          stroke="rgba(33,36,44,0.16)"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -1506,7 +1506,7 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
           }
         }
       >
-        I'm on the left!
+        I'm on the bottom with an arrow 50px in!
       </span>
     </div>
     <div
@@ -1671,7 +1671,7 @@ exports[`wonder-blocks-tooltip example 17 1`] = `
           }
         }
       >
-        I'm on the left!
+        I'm hidden. So hidden. Shhhhh!
       </span>
     </div>
     <div

--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -861,12 +861,27 @@ exports[`wonder-blocks-tooltip example 12 1`] = `
       </span>
     </div>
     <div
-      className="arrowContainer_jqq9v4-o_O-container-top_15ku1de"
+      className=""
       data-placement="top"
       style={
         Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 20,
           "left": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "pointerEvents": "none",
+          "position": "relative",
           "top": 0,
+          "width": 24,
+          "zIndex": 0,
         }
       }
     >
@@ -928,9 +943,8 @@ exports[`wonder-blocks-tooltip example 13 1`] = `
       "borderWidth": 0,
       "boxSizing": "border-box",
       "display": "flex",
-      "flexDirection": "row-reverse",
+      "flexDirection": "column",
       "height": 50,
-      "justifyContent": "flex-end",
       "margin": 0,
       "minHeight": 0,
       "minWidth": 0,
@@ -1024,12 +1038,27 @@ exports[`wonder-blocks-tooltip example 13 1`] = `
       </span>
     </div>
     <div
-      className="arrowContainer_jqq9v4-o_O-container-right_8hn242"
+      className=""
       data-placement="right"
       style={
         Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 24,
           "left": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "pointerEvents": "none",
+          "position": "relative",
           "top": 0,
+          "width": 20,
+          "zIndex": 0,
         }
       }
     >
@@ -1091,7 +1120,7 @@ exports[`wonder-blocks-tooltip example 14 1`] = `
       "borderWidth": 0,
       "boxSizing": "border-box",
       "display": "flex",
-      "flexDirection": "column-reverse",
+      "flexDirection": "column",
       "height": 50,
       "margin": 0,
       "minHeight": 0,
@@ -1186,12 +1215,27 @@ exports[`wonder-blocks-tooltip example 14 1`] = `
       </span>
     </div>
     <div
-      className="arrowContainer_jqq9v4-o_O-container-bottom_15ku1de"
+      className=""
       data-placement="bottom"
       style={
         Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 20,
           "left": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "pointerEvents": "none",
+          "position": "relative",
           "top": 0,
+          "width": 24,
+          "zIndex": 0,
         }
       }
     >
@@ -1348,12 +1392,27 @@ exports[`wonder-blocks-tooltip example 15 1`] = `
       </span>
     </div>
     <div
-      className="arrowContainer_jqq9v4-o_O-container-left_8hn242"
+      className=""
       data-placement="left"
       style={
         Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 24,
           "left": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "pointerEvents": "none",
+          "position": "relative",
           "top": 0,
+          "width": 20,
+          "zIndex": 0,
         }
       }
     >
@@ -1415,7 +1474,7 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
       "borderWidth": 0,
       "boxSizing": "border-box",
       "display": "flex",
-      "flexDirection": "row",
+      "flexDirection": "column",
       "height": 50,
       "margin": 0,
       "minHeight": 0,
@@ -1510,12 +1569,27 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
       </span>
     </div>
     <div
-      className="arrowContainer_jqq9v4-o_O-container-top_15ku1de"
+      className=""
       data-placement="top"
       style={
         Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 20,
           "left": 50,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "pointerEvents": "none",
+          "position": "relative",
           "top": 0,
+          "width": 24,
+          "zIndex": 0,
         }
       }
     >
@@ -1675,12 +1749,27 @@ exports[`wonder-blocks-tooltip example 17 1`] = `
       </span>
     </div>
     <div
-      className="arrowContainer_jqq9v4-o_O-container-top_15ku1de"
+      className=""
       data-placement="top"
       style={
         Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 20,
           "left": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "pointerEvents": "none",
+          "position": "relative",
           "top": 0,
+          "width": 24,
+          "zIndex": 0,
         }
       }
     >

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
@@ -63,7 +63,7 @@ export default class TooltipBubble extends React.Component<Props> {
 const styles = StyleSheet.create({
     bubble: {
         pointerEvents: "none",
-        position: "absolte",
+        position: "absolute",
     },
 
     /**

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
@@ -1,70 +1,61 @@
 // @flow
-import {css, StyleSheet} from "aphrodite";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
-import {Popper} from "react-popper";
+import * as ReactDOM from "react-dom";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import TooltipContent from "./tooltip-content.js";
 import TooltipArrow from "./tooltip-arrow.js";
-import visibilityModifierDefaultConfig from "../util/visibility-modifier.js";
 
-import type {PopperChildrenProps} from "react-popper";
-import type {Placement} from "../util/types.js";
+import type {PopperChildrenProps} from "./tooltip-popper.js";
 
 type Props = {|
     // The content to be shown in the bubble.
     children: React.Element<typeof TooltipContent>,
 
-    // The element that anchors the tooltip bubble.
-    // This is used to position the bubble.
-    anchorElement: ?HTMLElement,
-
-    // Where should the bubble try to go with respect to its anchor.
-    placement: Placement,
+    // The props provided by TooltipPopper, which are used to position
+    // and manage the bubble contents.
+    popperProps: PopperChildrenProps,
 |};
 
 export default class TooltipBubble extends React.Component<Props> {
-    _renderBubble(childrenProps: PopperChildrenProps) {
-        const {children, placement} = this.props;
-        const {ref, outOfBoundaries, style, arrowProps} = childrenProps;
-        const actualPlacement = childrenProps.placement || placement;
+    _lastRef: ?HTMLElement;
 
-        // Here we take the props provided to us by popper.js and use them
-        // to position ourselves. We don't use a View because the ref callback
-        // for the react-popper integration expects an HTMLElement and coercing
-        // a View ref to the right type is a lot of extra lifting for little
-        // gain over just using a div.
-        return (
-            <div
-                data-placement={actualPlacement}
-                ref={ref}
-                className={css(styles.bubble, outOfBoundaries && styles.hide)}
-                style={style}
-            >
-                <View style={styles[`content-${actualPlacement}`]}>
-                    {children}
-                    <TooltipArrow
-                        placement={actualPlacement}
-                        popperArrowProps={arrowProps}
-                    />
-                </View>
-            </div>
-        );
+    _updateRef(ref: ?(React.Component<*> | Element)) {
+        const {popperProps} = this.props;
+        // We only want to update the popper's arrow reference if it is
+        // actually changed. Otherwise, we end up in an endless loop of updates
+        // as every render would trigger yet another render.
+        if (popperProps && ref) {
+            const domNode = ReactDOM.findDOMNode(ref);
+            if (domNode instanceof HTMLElement && domNode !== this._lastRef) {
+                this._lastRef = domNode;
+                popperProps.ref(domNode);
+            }
+        }
     }
 
     render() {
-        const {anchorElement, placement} = this.props;
+        const {children, popperProps} = this.props;
+        const {placement, outOfBoundaries, style, arrowProps} = popperProps;
+
         return (
-            <Popper
-                referenceElement={anchorElement}
-                placement={placement}
-                modifiers={{
-                    wbVisibility: visibilityModifierDefaultConfig,
-                    preventOverflow: {boundariesElement: "viewport"},
-                }}
+            <View
+                data-placement={placement}
+                ref={(r) => this._updateRef(r)}
+                style={[
+                    style,
+                    outOfBoundaries && styles.hide,
+                    styles.bubble,
+                    styles[`content-${placement}`],
+                ]}
             >
-                {(props) => this._renderBubble(props)}
-            </Popper>
+                {children}
+                <TooltipArrow
+                    placement={placement}
+                    popperArrowProps={arrowProps}
+                />
+            </View>
         );
     }
 }
@@ -72,6 +63,7 @@ export default class TooltipBubble extends React.Component<Props> {
 const styles = StyleSheet.create({
     bubble: {
         pointerEvents: "none",
+        position: "absolte",
     },
 
     /**

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.md
@@ -26,7 +26,11 @@ const popperProps = {
     outOfBoundaries: false,
 };
 
-<View style={{height: 50, flexDirection: "column"}}>
+/**
+ * NOTE: We give height because TooltipBubble is positioned absolute and due
+ * to aphrodite styles being "important" we can't override that.
+ */
+<View style={{height: 50}}>
     <TooltipBubble popperProps={popperProps}>
         <TooltipContent>I'm on the top!</TooltipContent>
     </TooltipBubble>
@@ -57,7 +61,11 @@ const popperProps = {
     outOfBoundaries: false,
 };
 
-<View style={{height: 50, flexDirection: "row-reverse", justifyContent: "flex-end"}}>
+/**
+ * NOTE: We give height because TooltipBubble is positioned absolute and due
+ * to aphrodite styles being "important" we can't override that.
+ */
+<View style={{height: 50}}>
     <TooltipBubble popperProps={popperProps}>
         <TooltipContent>I'm on the right!</TooltipContent>
     </TooltipBubble>
@@ -88,7 +96,11 @@ const popperProps = {
     outOfBoundaries: false,
 };
 
-<View style={{height: 50, display: "flex", flexDirection: "column-reverse"}}>
+/**
+ * NOTE: We give height because TooltipBubble is positioned absolute and due
+ * to aphrodite styles being "important" we can't override that.
+ */
+<View style={{height: 50}}>
     <TooltipBubble popperProps={popperProps}>
         <TooltipContent>I'm on the bottom!</TooltipContent>
     </TooltipBubble>
@@ -119,7 +131,11 @@ const popperProps = {
     outOfBoundaries: false,
 };
 
-<View style={{height: 50, display: "flex", flexDirection: "row"}}>
+/**
+ * NOTE: We give height because TooltipBubble is positioned absolute and due
+ * to aphrodite styles being "important" we can't override that.
+ */
+<View style={{height: 50, flexDirection: "row"}}>
     <TooltipBubble popperProps={popperProps}>
         <TooltipContent>I'm on the left!</TooltipContent>
     </TooltipBubble>
@@ -152,7 +168,11 @@ const popperProps = {
     outOfBoundaries: false,
 };
 
-<View style={{height: 50, display: "flex", flexDirection: "row"}}>
+/**
+ * NOTE: We give height because TooltipBubble is positioned absolute and due
+ * to aphrodite styles being "important" we can't override that.
+ */
+<View style={{height: 50}}>
     <TooltipBubble popperProps={popperProps}>
         <TooltipContent>I'm on the bottom with an arrow 50px in!</TooltipContent>
     </TooltipBubble>
@@ -184,6 +204,10 @@ const popperProps = {
     outOfBoundaries: true,
 };
 
+/**
+ * NOTE: We give height because TooltipBubble is positioned absolute and due
+ * to aphrodite styles being "important" we can't override that.
+ */
 <View style={{height: 50}}>
     <TooltipBubble popperProps={popperProps}>
         <TooltipContent>I'm hidden. So hidden. Shhhhh!</TooltipContent>

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.md
@@ -1,0 +1,192 @@
+This is an internal component that we use to render the stuff that appears when a tooltip shows.
+
+Note that without explicit positioning, the arrow will not be centered.
+
+### Placement top
+
+```jsx
+const {View} = require("@khanacademy/wonder-blocks-core");
+
+const popperProps = {
+    style: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+    },
+    placement: "top",
+    ref: () => {},
+    scheduleUpdate: () => {},
+    arrowProps: {
+        style: {
+            left: 0,
+            top: 0,
+        },
+        ref: () => {},
+    },
+    outOfBoundaries: false,
+};
+
+<View style={{height: 50, flexDirection: "column"}}>
+    <TooltipBubble popperProps={popperProps}>
+        <TooltipContent>I'm on the top!</TooltipContent>
+    </TooltipBubble>
+</View>
+```
+
+### Placement right
+
+```jsx
+const {View} = require("@khanacademy/wonder-blocks-core");
+
+const popperProps = {
+    style: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+    },
+    placement: "right",
+    ref: () => {},
+    scheduleUpdate: () => {},
+    arrowProps: {
+        style: {
+            left: 0,
+            top: 0,
+        },
+        ref: () => {},
+    },
+    outOfBoundaries: false,
+};
+
+<View style={{height: 50, flexDirection: "row-reverse", justifyContent: "flex-end"}}>
+    <TooltipBubble popperProps={popperProps}>
+        <TooltipContent>I'm on the right!</TooltipContent>
+    </TooltipBubble>
+</View>
+```
+
+### Placement bottom
+
+```jsx
+const {View} = require("@khanacademy/wonder-blocks-core");
+
+const popperProps = {
+    style: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+    },
+    placement: "bottom",
+    ref: () => {},
+    scheduleUpdate: () => {},
+    arrowProps: {
+        style: {
+            left: 0,
+            top: 0,
+        },
+        ref: () => {},
+    },
+    outOfBoundaries: false,
+};
+
+<View style={{height: 50, display: "flex", flexDirection: "column-reverse"}}>
+    <TooltipBubble popperProps={popperProps}>
+        <TooltipContent>I'm on the bottom!</TooltipContent>
+    </TooltipBubble>
+</View>
+```
+
+### Placement left
+
+```jsx
+const {View} = require("@khanacademy/wonder-blocks-core");
+
+const popperProps = {
+    style: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+    },
+    placement: "left",
+    ref: () => {},
+    scheduleUpdate: () => {},
+    arrowProps: {
+        style: {
+            left: 0,
+            top: 0,
+        },
+        ref: () => {},
+    },
+    outOfBoundaries: false,
+};
+
+<View style={{height: 50, display: "flex", flexDirection: "row"}}>
+    <TooltipBubble popperProps={popperProps}>
+        <TooltipContent>I'm on the left!</TooltipContent>
+    </TooltipBubble>
+</View>
+```
+
+### Positioning the arrow
+Here we tell the arrow that it's lefthand side is at 50px.
+
+```jsx
+const {View} = require("@khanacademy/wonder-blocks-core");
+const Spacing = require("@khanacademy/wonder-blocks-spacing");
+
+const popperProps = {
+    placement: "top",
+    style: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+    },
+    ref: () => {},
+    scheduleUpdate: () => {},
+    arrowProps: {
+        style: {
+            left: 50,
+            top: 0,
+        },
+        ref: () => {},
+    },
+    outOfBoundaries: false,
+};
+
+<View style={{height: 50, display: "flex", flexDirection: "row"}}>
+    <TooltipBubble popperProps={popperProps}>
+        <TooltipContent>I'm on the left!</TooltipContent>
+    </TooltipBubble>
+</View>
+```
+
+### Hidden because outOfBoundaries is true
+
+```jsx
+const {View} = require("@khanacademy/wonder-blocks-core");
+const Spacing = require("@khanacademy/wonder-blocks-spacing");
+
+const popperProps = {
+    placement: "top",
+    style: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+    },
+    ref: () => {},
+    scheduleUpdate: () => {},
+    arrowProps: {
+        style: {
+            left: 0,
+            top: 0,
+        },
+        ref: () => {},
+    },
+    outOfBoundaries: true,
+};
+
+<View style={{height: 50}}>
+    <TooltipBubble popperProps={popperProps}>
+        <TooltipContent>I'm on the left!</TooltipContent>
+    </TooltipBubble>
+</View>
+```

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.md
@@ -154,7 +154,7 @@ const popperProps = {
 
 <View style={{height: 50, display: "flex", flexDirection: "row"}}>
     <TooltipBubble popperProps={popperProps}>
-        <TooltipContent>I'm on the left!</TooltipContent>
+        <TooltipContent>I'm on the bottom with an arrow 50px in!</TooltipContent>
     </TooltipBubble>
 </View>
 ```
@@ -186,7 +186,7 @@ const popperProps = {
 
 <View style={{height: 50}}>
     <TooltipBubble popperProps={popperProps}>
-        <TooltipContent>I'm on the left!</TooltipContent>
+        <TooltipContent>I'm hidden. So hidden. Shhhhh!</TooltipContent>
     </TooltipBubble>
 </View>
 ```

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
@@ -1,0 +1,70 @@
+// @flow
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import {mount} from "enzyme";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import TooltipBubble from "./tooltip-bubble.js";
+import TooltipContent from "./tooltip-content.js";
+
+describe("TooltipBubble", () => {
+    test("updates reference to bubble container", (done) => {
+        // Arrange
+        const arrangeAct = (assert) => {
+            const popperProps = {
+                placement: "top",
+                style: {
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                },
+                ref: assert,
+                scheduleUpdate: () => {},
+                arrowProps: {
+                    style: {
+                        left: 50,
+                        top: 0,
+                    },
+                    ref: () => {},
+                },
+                outOfBoundaries: false,
+            };
+            const fakeContent = (((
+                <View id="content">Some content</View>
+            ): any): React.Element<typeof TooltipContent>);
+            const nodes = (
+                <View>
+                    <TooltipBubble popperProps={popperProps}>
+                        {fakeContent}
+                    </TooltipBubble>
+                </View>
+            );
+
+            // Act
+            mount(nodes);
+        };
+
+        const andAssert = (bubbleNode) => {
+            /**
+             * All we're doing is making sure we got called and verifying that
+             * we got called with an element we expect.
+             */
+            // Assert
+            expect(bubbleNode).toBeDefined();
+
+            const realElement = ReactDOM.findDOMNode(bubbleNode);
+            expect(realElement instanceof Element).toBeTruthy();
+            if (realElement instanceof Element) {
+                expect(realElement.getAttribute("data-placement")).toBe("top");
+
+                const contentElement = realElement.firstElementChild;
+                expect(
+                    contentElement && contentElement.getAttribute("id"),
+                ).toBe("content");
+            }
+            done();
+        };
+
+        arrangeAct(andAssert);
+    });
+});

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
@@ -8,27 +8,36 @@ import TooltipBubble from "./tooltip-bubble.js";
 import TooltipContent from "./tooltip-content.js";
 
 describe("TooltipBubble", () => {
+    // A little helper method to make the actual test more readable.
+    const makePopperProps = () => ({
+        placement: "top",
+        style: {
+            position: "absolute",
+            top: 0,
+            left: 0,
+        },
+        ref: () => {},
+        scheduleUpdate: () => {},
+        arrowProps: {
+            style: {
+                left: 50,
+                top: 0,
+            },
+            ref: () => {},
+        },
+        outOfBoundaries: false,
+    });
+
     test("updates reference to bubble container", (done) => {
         // Arrange
         const arrangeAct = (assert) => {
-            const popperProps = {
-                placement: "top",
-                style: {
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                },
-                ref: assert,
-                scheduleUpdate: () => {},
-                arrowProps: {
-                    style: {
-                        left: 50,
-                        top: 0,
-                    },
-                    ref: () => {},
-                },
-                outOfBoundaries: false,
-            };
+            // Get some props and set the ref to our assert, that way we assert
+            // when the bubble component is mounted.
+            const popperProps = makePopperProps();
+            popperProps.ref = assert;
+
+            // Do some casting to pretend this is `TooltipContent`. That way
+            // we are isolating behaviors a bit more.
             const fakeContent = (((
                 <View id="content">Some content</View>
             ): any): React.Element<typeof TooltipContent>);
@@ -50,13 +59,19 @@ describe("TooltipBubble", () => {
              * we got called with an element we expect.
              */
             // Assert
+            // Did we get a node?
             expect(bubbleNode).toBeDefined();
 
+            // Is the node a mounted element?
             const realElement = ReactDOM.findDOMNode(bubbleNode);
             expect(realElement instanceof Element).toBeTruthy();
+
+            // Keep flow happy...
             if (realElement instanceof Element) {
+                // Did we apply our data attribute?
                 expect(realElement.getAttribute("data-placement")).toBe("top");
 
+                // Did we render our content?
                 const contentElement = realElement.firstElementChild;
                 expect(
                     contentElement && contentElement.getAttribute("id"),

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.js
@@ -1,0 +1,62 @@
+// @flow
+/**
+ * This component is a light wrapper for react-popper, allowing us to position
+ * and control the tooltip bubble location and visibility as we need.
+ */
+import * as React from "react";
+import {Popper} from "react-popper";
+
+import TooltipBubble from "./tooltip-bubble.js";
+import visibilityModifierDefaultConfig from "../util/visibility-modifier.js";
+
+import type {PopperChildrenProps as PopperJSChildrenProps} from "react-popper";
+import type {Placement} from "../util/types.js";
+
+/**
+ * Equivalent to PopperChildrenProps from the react-popper package but provided
+ * as our own type to abstract away react-popper so we can isolate it's
+ * inclusion to this file.
+ */
+export type PopperChildrenProps = PopperJSChildrenProps;
+
+type Props = {|
+    // This uses the children-as-a-function approach, mirroring react-popper's
+    // implementation, except we enforce the return type to be our TooltipBubble
+    // component.
+    children: (PopperChildrenProps) => React.Element<typeof TooltipBubble>,
+
+    // The element that anchors the tooltip bubble.
+    // This is used to position the bubble.
+    anchorElement: ?HTMLElement,
+
+    // Where should the bubble try to go with respect to its anchor.
+    placement: Placement,
+|};
+
+export default class TooltipPopper extends React.Component<Props> {
+    _renderPositionedContent(childrenProps: PopperJSChildrenProps) {
+        const {children, placement} = this.props;
+
+        // We'll hide some complexity from the children here and ensure
+        // that our placement always has a value.
+        childrenProps.placement = childrenProps.placement || placement;
+
+        return children(childrenProps);
+    }
+
+    render() {
+        const {anchorElement, placement} = this.props;
+        return (
+            <Popper
+                referenceElement={anchorElement}
+                placement={placement}
+                modifiers={{
+                    wbVisibility: visibilityModifierDefaultConfig,
+                    preventOverflow: {boundariesElement: "viewport"},
+                }}
+            >
+                {(props) => this._renderPositionedContent(props)}
+            </Popper>
+        );
+    }
+}

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.js
@@ -16,6 +16,9 @@ import type {Placement} from "../util/types.js";
  * Equivalent to PopperChildrenProps from the react-popper package but provided
  * as our own type to abstract away react-popper so we can isolate it's
  * inclusion to this file.
+ *
+ * TODO(somewhatabstract): More carefully curate the props so that we can have
+ * idiomatic wonderblocks styles, for example.
  */
 export type PopperChildrenProps = PopperJSChildrenProps;
 

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
@@ -5,13 +5,13 @@ import {mount} from "enzyme";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import TooltipBubble from "./tooltip-bubble.js";
-import TooltipContent from "./tooltip-content.js";
+import TooltipPopper from "./tooltip-popper.js";
 
 /**
- * A little wrapper for the TooltipBubble so that we can provide an anchor
+ * A little wrapper for the TooltipPopper so that we can provide an anchor
  * element reference and test that the children get rendered.
  */
-class BubbleTest extends React.Component<*, {ref: ?HTMLElement}> {
+class TestHarness extends React.Component<*, {ref: ?HTMLElement}> {
     state = {
         ref: null,
     };
@@ -24,25 +24,25 @@ class BubbleTest extends React.Component<*, {ref: ?HTMLElement}> {
     }
 
     render() {
+        const fakeBubble = (((
+            <View ref={(ref) => this.props.resultRef(ref)}>Fake bubble</View>
+        ): any): React.Element<typeof TooltipBubble>);
         return (
             <View>
                 <View ref={(ref) => this.updateRef(ref)}>Anchor</View>
-                <TooltipBubble
+                <TooltipPopper
                     placement={this.props.placement}
                     anchorElement={this.state.ref}
                 >
-                    <TooltipContent ref={(ref) => this.props.resultRef(ref)}>
-                        This is a pretend string with a ref so we can detect it
-                        being rendered
-                    </TooltipContent>
-                </TooltipBubble>
+                    {(props) => fakeBubble}
+                </TooltipPopper>
             </View>
         );
     }
 }
 
-describe("TooltipBubble", () => {
-    // The TooltipBubble component is just a wrapper around react-popper.
+describe("TooltipPopper", () => {
+    // The TooltipPopper component is just a wrapper around react-popper.
     // PopperJS requires full visual rendering and we don't do that here as
     // we're not in a browser.
     // So, let's do a test that we at least render the content how we expect
@@ -52,7 +52,7 @@ describe("TooltipBubble", () => {
         const arrange = (actAssert) => {
             const nodes = (
                 <View>
-                    <BubbleTest placement={"bottom"} resultRef={actAssert} />
+                    <TestHarness placement={"bottom"} resultRef={actAssert} />
                 </View>
             );
             mount(nodes);

--- a/packages/wonder-blocks-tooltip/components/tooltip-portal-mounter.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-portal-mounter.js
@@ -5,7 +5,7 @@ import * as ReactDOM from "react-dom";
 import {maybeGetPortalMountedModalHostElement} from "@khanacademy/wonder-blocks-modal";
 
 import {TooltipPortalAttributeName} from "../util/constants.js";
-import TooltipBubble from "./tooltip-bubble.js";
+import TooltipPopper from "./tooltip-popper.js";
 
 type Props = {|
     // The child element to be rendered within the main React tree.
@@ -13,7 +13,7 @@ type Props = {|
     anchor: React.Element<*>,
 
     // The tooltip that will be rendered in the portal.
-    children: ?React.Element<typeof TooltipBubble>,
+    children: ?React.Element<typeof TooltipPopper>,
 |};
 
 /**
@@ -77,8 +77,8 @@ export default class TooltipPortalMounter extends React.Component<Props> {
         }
 
         // Create a new destination node, and add it to the root.
-        // The data attribute is used in unit tests, to identify which
-        // ancestors of `children` were created by `TooltipPortal`.
+        // The data attribute is to identify which the mounted portal in
+        // unit tests.
         const destination = document.createElement("div");
         destination.setAttribute(TooltipPortalAttributeName, "");
         root.appendChild(destination);

--- a/packages/wonder-blocks-tooltip/components/tooltip-portal-mounter.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-portal-mounter.test.js
@@ -12,8 +12,7 @@ import {
 
 import {TooltipPortalAttributeName} from "../util/constants.js";
 import TooltipPortalMounter from "./tooltip-portal-mounter.js";
-import TooltipBubble from "./tooltip-bubble.js";
-import TooltipContent from "./tooltip-content.js";
+import TooltipPopper from "./tooltip-popper.js";
 
 import type {Placement} from "../util/types.js";
 
@@ -52,17 +51,12 @@ class TestHarness extends React.Component<TestHarnessProps, TestHarnessState> {
 
     render() {
         const anchor = <View ref={(r) => this.updateAnchorRef(r)}>Anchor</View>;
+        const fakePopper = (((
+            <View ref={(r) => this.props.refChild(r)}>Popper</View>
+        ): any): React.Element<typeof TooltipPopper>);
         return (
             <TooltipPortalMounter anchor={anchor}>
-                {this.props.hasBubble ? (
-                    <TooltipBubble
-                        placement={this.props.placement}
-                        ref={(r) => this.props.refChild(r)}
-                        anchorElement={this.state.anchor}
-                    >
-                        <TooltipContent>Tooltip!</TooltipContent>
-                    </TooltipBubble>
-                ) : null}
+                {this.props.hasBubble ? fakePopper : null}
             </TooltipPortalMounter>
         );
     }

--- a/packages/wonder-blocks-tooltip/components/tooltip.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip.js
@@ -7,6 +7,7 @@ import TooltipPortalMounter from "./tooltip-portal-mounter";
 import TooltipAnchor from "./tooltip-anchor.js";
 import TooltipBubble from "./tooltip-bubble.js";
 import TooltipContent from "./tooltip-content.js";
+import TooltipPopper from "./tooltip-popper.js";
 
 import type {Placement} from "../util/types.js";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
@@ -80,8 +81,28 @@ export default class Tooltip extends React.Component<Props, State> {
         }
     }
 
+    _renderPopper(active: boolean) {
+        if (!active) {
+            return null;
+        }
+
+        const {placement} = this.props;
+        return (
+            <TooltipPopper
+                anchorElement={this.state.anchorElement}
+                placement={placement || Tooltip.defaultProps.placement}
+            >
+                {(props) => (
+                    <TooltipBubble popperProps={props}>
+                        {this._renderBubbleContent()}
+                    </TooltipBubble>
+                )}
+            </TooltipPopper>
+        );
+    }
+
     render() {
-        const {forceAnchorFocusivity, placement} = this.props;
+        const {forceAnchorFocusivity} = this.props;
         return (
             <TooltipAnchor
                 forceAnchorFocusivity={forceAnchorFocusivity}
@@ -89,16 +110,7 @@ export default class Tooltip extends React.Component<Props, State> {
             >
                 {(active) => (
                     <TooltipPortalMounter anchor={this._renderAnchorElement()}>
-                        {active ? (
-                            <TooltipBubble
-                                placement={
-                                    placement || Tooltip.defaultProps.placement
-                                }
-                                anchorElement={this.state.anchorElement}
-                            >
-                                {this._renderBubbleContent()}
-                            </TooltipBubble>
-                        ) : null}
+                        {this._renderPopper(active)}
                     </TooltipPortalMounter>
                 )}
             </TooltipAnchor>

--- a/packages/wonder-blocks-tooltip/components/tooltip.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip.js
@@ -1,4 +1,23 @@
 // @flow
+/**
+ * The Tooltip component provides the means to anchor some additional
+ * information to some content. The additional information is shown in a
+ * callout that hovers above the page content. This additional information is
+ * invoked by hovering over the anchored content, or focusing all or part of the
+ * anchored content.
+ *
+ * This component is structured as follows:
+ *
+ * Tooltip (this component)
+ * - TooltipAnchor (provides hover/focus behaviors on anchored content)
+ *   - TooltipPortalMounter (creates portal into which the callout is rendered)
+ * --------------------------- [PORTAL BOUNDARY] ------------------------------
+ * - TooltipPopper (provides positioning for the callout using react-popper)
+ *   - TooltipBubble (renders the callout borders, background and shadow)
+ *     - TooltipContent (renders the callout content; the actual information)
+ *     - TooltipArrow (renders the callout tail and shadow that points from the
+ *                     callout to the anchor content)
+ */
 import * as React from "react";
 
 import {Text} from "@khanacademy/wonder-blocks-core";

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -12,6 +12,7 @@ jest.mock("react-dom");
 import Tooltip from "./components/tooltip.js";
 import TooltipContent from "./components/tooltip-content.js";
 import TooltipArrow from "./components/tooltip-arrow.js";
+import TooltipBubble from "./components/tooltip-bubble.js";
 
 describe("wonder-blocks-tooltip", () => {
     it("example 1", () => {
@@ -206,6 +207,212 @@ describe("wonder-blocks-tooltip", () => {
                 <TooltipArrow placement="left" />
                 <div style={{backgroundColor: "red", width: 4, height: 24}} />
             </div>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 12", () => {
+        const {View} = require("@khanacademy/wonder-blocks-core");
+
+        const popperProps = {
+            style: {
+                position: "absolute",
+                top: 0,
+                left: 0,
+            },
+            placement: "top",
+            ref: () => {},
+            scheduleUpdate: () => {},
+            arrowProps: {
+                style: {
+                    left: 0,
+                    top: 0,
+                },
+                ref: () => {},
+            },
+            outOfBoundaries: false,
+        };
+
+        const example = (
+            <View style={{height: 50, flexDirection: "column"}}>
+                <TooltipBubble popperProps={popperProps}>
+                    <TooltipContent>I'm on the top!</TooltipContent>
+                </TooltipBubble>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 13", () => {
+        const {View} = require("@khanacademy/wonder-blocks-core");
+
+        const popperProps = {
+            style: {
+                position: "absolute",
+                top: 0,
+                left: 0,
+            },
+            placement: "right",
+            ref: () => {},
+            scheduleUpdate: () => {},
+            arrowProps: {
+                style: {
+                    left: 0,
+                    top: 0,
+                },
+                ref: () => {},
+            },
+            outOfBoundaries: false,
+        };
+
+        const example = (
+            <View
+                style={{
+                    height: 50,
+                    flexDirection: "row-reverse",
+                    justifyContent: "flex-end",
+                }}
+            >
+                <TooltipBubble popperProps={popperProps}>
+                    <TooltipContent>I'm on the right!</TooltipContent>
+                </TooltipBubble>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 14", () => {
+        const {View} = require("@khanacademy/wonder-blocks-core");
+
+        const popperProps = {
+            style: {
+                position: "absolute",
+                top: 0,
+                left: 0,
+            },
+            placement: "bottom",
+            ref: () => {},
+            scheduleUpdate: () => {},
+            arrowProps: {
+                style: {
+                    left: 0,
+                    top: 0,
+                },
+                ref: () => {},
+            },
+            outOfBoundaries: false,
+        };
+
+        const example = (
+            <View
+                style={{
+                    height: 50,
+                    display: "flex",
+                    flexDirection: "column-reverse",
+                }}
+            >
+                <TooltipBubble popperProps={popperProps}>
+                    <TooltipContent>I'm on the bottom!</TooltipContent>
+                </TooltipBubble>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 15", () => {
+        const {View} = require("@khanacademy/wonder-blocks-core");
+
+        const popperProps = {
+            style: {
+                position: "absolute",
+                top: 0,
+                left: 0,
+            },
+            placement: "left",
+            ref: () => {},
+            scheduleUpdate: () => {},
+            arrowProps: {
+                style: {
+                    left: 0,
+                    top: 0,
+                },
+                ref: () => {},
+            },
+            outOfBoundaries: false,
+        };
+
+        const example = (
+            <View style={{height: 50, display: "flex", flexDirection: "row"}}>
+                <TooltipBubble popperProps={popperProps}>
+                    <TooltipContent>I'm on the left!</TooltipContent>
+                </TooltipBubble>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 16", () => {
+        const {View} = require("@khanacademy/wonder-blocks-core");
+        const Spacing = require("@khanacademy/wonder-blocks-spacing");
+
+        const popperProps = {
+            placement: "top",
+            style: {
+                position: "absolute",
+                top: 0,
+                left: 0,
+            },
+            ref: () => {},
+            scheduleUpdate: () => {},
+            arrowProps: {
+                style: {
+                    left: 50,
+                    top: 0,
+                },
+                ref: () => {},
+            },
+            outOfBoundaries: false,
+        };
+
+        const example = (
+            <View style={{height: 50, display: "flex", flexDirection: "row"}}>
+                <TooltipBubble popperProps={popperProps}>
+                    <TooltipContent>I'm on the left!</TooltipContent>
+                </TooltipBubble>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 17", () => {
+        const {View} = require("@khanacademy/wonder-blocks-core");
+        const Spacing = require("@khanacademy/wonder-blocks-spacing");
+
+        const popperProps = {
+            placement: "top",
+            style: {
+                position: "absolute",
+                top: 0,
+                left: 0,
+            },
+            ref: () => {},
+            scheduleUpdate: () => {},
+            arrowProps: {
+                style: {
+                    left: 0,
+                    top: 0,
+                },
+                ref: () => {},
+            },
+            outOfBoundaries: true,
+        };
+
+        const example = (
+            <View style={{height: 50}}>
+                <TooltipBubble popperProps={popperProps}>
+                    <TooltipContent>I'm on the left!</TooltipContent>
+                </TooltipBubble>
+            </View>
         );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -233,8 +233,12 @@ describe("wonder-blocks-tooltip", () => {
             outOfBoundaries: false,
         };
 
+        /**
+         * NOTE: We give height because TooltipBubble is positioned absolute and due
+         * to aphrodite styles being "important" we can't override that.
+         */
         const example = (
-            <View style={{height: 50, flexDirection: "column"}}>
+            <View style={{height: 50}}>
                 <TooltipBubble popperProps={popperProps}>
                     <TooltipContent>I'm on the top!</TooltipContent>
                 </TooltipBubble>
@@ -265,14 +269,12 @@ describe("wonder-blocks-tooltip", () => {
             outOfBoundaries: false,
         };
 
+        /**
+         * NOTE: We give height because TooltipBubble is positioned absolute and due
+         * to aphrodite styles being "important" we can't override that.
+         */
         const example = (
-            <View
-                style={{
-                    height: 50,
-                    flexDirection: "row-reverse",
-                    justifyContent: "flex-end",
-                }}
-            >
+            <View style={{height: 50}}>
                 <TooltipBubble popperProps={popperProps}>
                     <TooltipContent>I'm on the right!</TooltipContent>
                 </TooltipBubble>
@@ -303,14 +305,12 @@ describe("wonder-blocks-tooltip", () => {
             outOfBoundaries: false,
         };
 
+        /**
+         * NOTE: We give height because TooltipBubble is positioned absolute and due
+         * to aphrodite styles being "important" we can't override that.
+         */
         const example = (
-            <View
-                style={{
-                    height: 50,
-                    display: "flex",
-                    flexDirection: "column-reverse",
-                }}
-            >
+            <View style={{height: 50}}>
                 <TooltipBubble popperProps={popperProps}>
                     <TooltipContent>I'm on the bottom!</TooltipContent>
                 </TooltipBubble>
@@ -341,8 +341,12 @@ describe("wonder-blocks-tooltip", () => {
             outOfBoundaries: false,
         };
 
+        /**
+         * NOTE: We give height because TooltipBubble is positioned absolute and due
+         * to aphrodite styles being "important" we can't override that.
+         */
         const example = (
-            <View style={{height: 50, display: "flex", flexDirection: "row"}}>
+            <View style={{height: 50, flexDirection: "row"}}>
                 <TooltipBubble popperProps={popperProps}>
                     <TooltipContent>I'm on the left!</TooltipContent>
                 </TooltipBubble>
@@ -374,8 +378,12 @@ describe("wonder-blocks-tooltip", () => {
             outOfBoundaries: false,
         };
 
+        /**
+         * NOTE: We give height because TooltipBubble is positioned absolute and due
+         * to aphrodite styles being "important" we can't override that.
+         */
         const example = (
-            <View style={{height: 50, display: "flex", flexDirection: "row"}}>
+            <View style={{height: 50}}>
                 <TooltipBubble popperProps={popperProps}>
                     <TooltipContent>
                         I'm on the bottom with an arrow 50px in!
@@ -409,6 +417,10 @@ describe("wonder-blocks-tooltip", () => {
             outOfBoundaries: true,
         };
 
+        /**
+         * NOTE: We give height because TooltipBubble is positioned absolute and due
+         * to aphrodite styles being "important" we can't override that.
+         */
         const example = (
             <View style={{height: 50}}>
                 <TooltipBubble popperProps={popperProps}>

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -377,7 +377,9 @@ describe("wonder-blocks-tooltip", () => {
         const example = (
             <View style={{height: 50, display: "flex", flexDirection: "row"}}>
                 <TooltipBubble popperProps={popperProps}>
-                    <TooltipContent>I'm on the left!</TooltipContent>
+                    <TooltipContent>
+                        I'm on the bottom with an arrow 50px in!
+                    </TooltipContent>
                 </TooltipBubble>
             </View>
         );
@@ -410,7 +412,9 @@ describe("wonder-blocks-tooltip", () => {
         const example = (
             <View style={{height: 50}}>
                 <TooltipBubble popperProps={popperProps}>
-                    <TooltipContent>I'm on the left!</TooltipContent>
+                    <TooltipContent>
+                        I'm hidden. So hidden. Shhhhh!
+                    </TooltipContent>
                 </TooltipBubble>
             </View>
         );

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -109,6 +109,7 @@ module.exports = {
                     private: true,
                     components: [
                         "packages/wonder-blocks-tooltip/components/tooltip-arrow.js",
+                        "packages/wonder-blocks-tooltip/components/tooltip-bubble.js",
                     ],
                 },
             ],


### PR DESCRIPTION
This builds on #155 where we introduced the `TooltipArrow` component. The main purpose here is to separate the `TooltipBubble` component into a positioning component (`TooltipPopper`) and a rendering component (`TooltipBubble`).

This also adds some test examples for the bubble. The next task will be to style the bubble content.