### PR TITLE
Add NoSSR component

### DIFF
--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -282,3 +282,27 @@ exports[`wonder-blocks-core example 4 1`] = `
   </div>
 </div>
 `;
+
+exports[`wonder-blocks-core example 5 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  This is rendered only by the client for all but the first render.
+</div>
+`;

--- a/packages/wonder-blocks-core/components/no-ssr.js
+++ b/packages/wonder-blocks-core/components/no-ssr.js
@@ -1,0 +1,70 @@
+// @flow
+/**
+ * Defer or change rendering until the component did mount.
+ *
+ * The purpose of this component is to disable or modify serverside rendering
+ * of certain components. Disabling rendering on the server, by itself, would
+ * not be sufficient, since the initial render of the component must match
+ * what is rendered on the server. Therefore, this component also disables
+ * rendering the first time around on the client.
+ *
+ * Example:
+ *
+ *   <NoSSR placeholder={() => <div>This renders on the server.</div>}>
+ *     {() => <div>This will not be rendered on the server.</div>}
+ *   </NoSSR>
+ */
+import * as React from "react";
+
+/**
+ * We use render functions so that we don't do any work unless we need to.
+ * This avoids rendering but not mounting potentially complex component trees.
+ */
+type Props = {
+    /**
+     * The content that is client-only.
+     */
+    children: () => ?React.Node,
+
+    /**
+     * Optionally, instead of rendering nothing the first time around, this
+     * component can render a placeholder. To enable this behavior,
+     * pass a "placeholder" prop.
+     *
+     * NOTE: Make sure the placeholder will render the same for both client and
+     * server, or it defeats the purpose of using the NoSSR component.
+     */
+    placeholder?: () => ?React.Node,
+};
+
+type State = {
+    mounted: boolean,
+};
+
+export default class NoSSR extends React.Component<Props, State> {
+    state = {
+        mounted: false,
+    };
+
+    componentDidMount() {
+        // eslint-disable-next-line react/no-did-mount-set-state
+        this.setState({
+            mounted: true,
+        });
+    }
+
+    render() {
+        const {mounted} = this.state;
+        const {children, placeholder} = this.props;
+
+        if (mounted) {
+            return children();
+        }
+
+        if (placeholder) {
+            return placeholder();
+        }
+
+        return null;
+    }
+}

--- a/packages/wonder-blocks-core/components/no-ssr.md
+++ b/packages/wonder-blocks-core/components/no-ssr.md
@@ -1,0 +1,7 @@
+`NoSSR` is a behavioral component, providing a mechanism to hide the rendering of a component from server-side rendering (SSR).
+
+```jsx
+<NoSSR placeholder={() => <View>This gets rendered on client and server for the first render call</View>}>
+    {() => <View>This is rendered only by the client for all but the first render.</View>}
+</NoSSR>
+```

--- a/packages/wonder-blocks-core/components/no-ssr.test.js
+++ b/packages/wonder-blocks-core/components/no-ssr.test.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from "react";
-// import * as ReactDOM from "react-dom";
 import * as ReactDOMServer from "react-dom/server";
 
 import {mount} from "enzyme";
@@ -28,6 +27,9 @@ describe("NoSSR", () => {
 
         const assert = () => {
             // Assert
+            // This was called from within the NoSSR children render prop.
+            // Therefore, if the placeholder has been called, it must have
+            // been called first.
             expect(mockPlaceholder).toHaveBeenCalledTimes(1);
             done();
         };

--- a/packages/wonder-blocks-core/components/no-ssr.test.js
+++ b/packages/wonder-blocks-core/components/no-ssr.test.js
@@ -1,0 +1,70 @@
+// @flow
+import * as React from "react";
+// import * as ReactDOM from "react-dom";
+import * as ReactDOMServer from "react-dom/server";
+
+import {mount} from "enzyme";
+
+import NoSSR from "./no-ssr.js";
+
+describe("NoSSR", () => {
+    test("renders a placeholder first, then the actual content", (done) => {
+        // Arrange
+        const mockPlaceholder = jest.fn(() => null);
+
+        const arrangeAct = (assert) => {
+            const nodes = (
+                <NoSSR placeholder={mockPlaceholder}>
+                    {() => {
+                        assert();
+                        return null;
+                    }}
+                </NoSSR>
+            );
+
+            // Act
+            mount(nodes);
+        };
+
+        const assert = () => {
+            // Assert
+            expect(mockPlaceholder).toHaveBeenCalledTimes(1);
+            done();
+        };
+
+        arrangeAct(assert);
+    });
+
+    describe("server-side rendering", () => {
+        test("server-side rendering, renders placeholder only", () => {
+            // Arrange
+            const mockChildren = jest.fn(() => null);
+            const mockPlaceholder = jest.fn(() => null);
+
+            const nodes = (
+                <NoSSR placeholder={mockPlaceholder}>{mockChildren}</NoSSR>
+            );
+
+            // Act
+            ReactDOMServer.renderToStaticMarkup(nodes);
+
+            // Assert
+            expect(mockPlaceholder).toHaveBeenCalledTimes(1);
+            expect(mockChildren).toHaveBeenCalledTimes(0);
+        });
+
+        test("no placeholder returns null", () => {
+            // Arrange
+            const mockChildren = jest.fn(() => null);
+
+            const nodes = <NoSSR>{mockChildren}</NoSSR>;
+
+            // Act
+            const result = ReactDOMServer.renderToStaticMarkup(nodes);
+
+            // Assert
+            expect(result).toBe("");
+            expect(mockChildren).toHaveBeenCalledTimes(0);
+        });
+    });
+});

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -11,6 +11,7 @@ import renderer from "react-test-renderer";
 jest.mock("react-dom");
 import ClickableBehavior from "./components/clickable-behavior.js";
 import MediaLayout from "./components/media-layout.js";
+import NoSSR from "./components/no-ssr.js";
 import Text from "./components/text.js";
 import View from "./components/view.js";
 
@@ -122,6 +123,27 @@ describe("wonder-blocks-core", () => {
                     </Row>
                 </MediaLayout>
             </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 5", () => {
+        const example = (
+            <NoSSR
+                placeholder={() => (
+                    <View>
+                        This gets rendered on client and server for the first
+                        render call
+                    </View>
+                )}
+            >
+                {() => (
+                    <View>
+                        This is rendered only by the client for all but the
+                        first render.
+                    </View>
+                )}
+            </NoSSR>
         );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();

--- a/packages/wonder-blocks-core/index.js
+++ b/packages/wonder-blocks-core/index.js
@@ -3,6 +3,7 @@ export {default as ClickableBehavior} from "./components/clickable-behavior.js";
 export {default as MediaLayout} from "./components/media-layout.js";
 export {default as Text} from "./components/text.js";
 export {default as View} from "./components/view.js";
+export {default as NoSSR} from "./components/no-ssr.js";
 export {default as addStyle} from "./util/add-style.js";
 export {
     default as getClickableBehavior,


### PR DESCRIPTION
This adds the `NoSSR` component that @jnetterf created.

I have also added additional tests for the SSR-specific behaviour.

## Why?
Having the ability to avoid rendering things on the server is valuable; especially when we need to have different behaviours between client and server, like when producing identifiers; initial renders much match on server and client, and so unique IDs have to be generated on the client AFTER intial render. This component can help with that. The next work will be to add support for unique identifiers and that will require this SSR/Client behaviour differentiation.