### PR TITLE
Add UniqueIDProvider

### DIFF
--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -852,3 +852,118 @@ exports[`wonder-blocks-core example 8 1`] = `
   </div>
 </div>
 `;
+
+exports[`wonder-blocks-core example 9 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Inconsolata",
+        "fontSize": 17,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    interface IIdentifierFactory {
+  </span>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "row",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "MsFlexBasis": "2em",
+          "MsFlexPreferredSize": "2em",
+          "WebkitFlexBasis": "2em",
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexBasis": "2em",
+          "flexDirection": "column",
+          "flexShrink": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    />
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Inconsolata",
+          "fontSize": 17,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      get(id: string): string;
+    </span>
+  </div>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Inconsolata",
+        "fontSize": 17,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    }
+  </span>
+</div>
+`;

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -523,25 +523,6 @@ exports[`wonder-blocks-core example 6 1`] = `
       Render 
       0
       : 
-      my-unique-id
-    </span>
-    <span
-      className=""
-      style={
-        Object {
-          "MozOsxFontSmoothing": "grayscale",
-          "WebkitFontSmoothing": "antialiased",
-          "display": "block",
-          "fontFamily": "Lato",
-          "fontSize": 16,
-          "fontWeight": 400,
-          "lineHeight": "22px",
-        }
-      }
-    >
-      Render 
-      1
-      : 
       uid--0-my-unique-id
     </span>
   </div>
@@ -584,30 +565,9 @@ exports[`wonder-blocks-core example 7 1`] = `
       }
     }
   >
-    The placeholder rendered as:
+    The initial render ID:
   </h4>
-  <div
-    className=""
-    style={
-      Object {
-        "alignItems": "stretch",
-        "borderStyle": "solid",
-        "borderWidth": 0,
-        "boxSizing": "border-box",
-        "display": "flex",
-        "flexDirection": "column",
-        "margin": 0,
-        "minHeight": 0,
-        "minWidth": 0,
-        "padding": 0,
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    This is the placeholder. It gets the SSR friendly ID factory so if we ask for an ID, we get: 
-    an-id
-  </div>
+  an-id
   <div
     className=""
     style={
@@ -648,30 +608,9 @@ exports[`wonder-blocks-core example 7 1`] = `
       }
     }
   >
-    But now we render the real deal:
+    Subsequent ID:
   </h4>
-  <div
-    className=""
-    style={
-      Object {
-        "alignItems": "stretch",
-        "borderStyle": "solid",
-        "borderWidth": 0,
-        "boxSizing": "border-box",
-        "display": "flex",
-        "flexDirection": "column",
-        "margin": 0,
-        "minHeight": 0,
-        "minWidth": 0,
-        "padding": 0,
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    This is the real deal. It gets the unique ID factory, so now we ask for an ID and get: 
-    uid--1-an-id
-  </div>
+  uid--1-an-id
 </div>
 `;
 

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -565,9 +565,62 @@ exports[`wonder-blocks-core example 7 1`] = `
       }
     }
   >
-    The initial render ID:
+    The initial render:
   </h4>
-  an-id
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Inconsolata",
+          "fontSize": 17,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      get("an-id"): 
+      an-id
+    </span>
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Inconsolata",
+          "fontSize": 17,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      get("something"): 
+      something
+    </span>
+  </div>
   <div
     className=""
     style={
@@ -608,9 +661,62 @@ exports[`wonder-blocks-core example 7 1`] = `
       }
     }
   >
-    Subsequent ID:
+    Subsequent requests:
   </h4>
-  uid--1-an-id
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Inconsolata",
+          "fontSize": 17,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      get("an-id"): 
+      uid--1-an-id
+    </span>
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Inconsolata",
+          "fontSize": 17,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      get("something"): 
+      uid--1-something
+    </span>
+  </div>
 </div>
 `;
 

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -328,3 +328,482 @@ exports[`wonder-blocks-core example 5 1`] = `
   This is rendered only by the client for all but the first render.
 </div>
 `;
+
+exports[`wonder-blocks-core example 6 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "row",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className=""
+      data-test-id={undefined}
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "background": "#1865f2",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#ffffff",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+        }
+      }
+      tabIndex={0}
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato",
+            "fontSize": 16,
+            "fontWeight": "bold",
+            "lineHeight": "20px",
+            "pointerEvents": "none",
+          }
+        }
+      >
+        Click Me to Rerender
+      </span>
+    </button>
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    />
+  </div>
+  <div
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 16,
+        "MsFlexPreferredSize": 16,
+        "WebkitFlexBasis": 16,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 16,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  />
+  <h4
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 20,
+        "fontWeight": 700,
+        "lineHeight": "24px",
+        "marginBottom": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    The UniqueIDProvider:
+  </h4>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Lato",
+          "fontSize": 16,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      Render 
+      0
+      : 
+      my-unique-id
+    </span>
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Lato",
+          "fontSize": 16,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      Render 
+      1
+      : 
+      uid--0-my-unique-id
+    </span>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-core example 7 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <h4
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 20,
+        "fontWeight": 700,
+        "lineHeight": "24px",
+        "marginBottom": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    The placeholder rendered as:
+  </h4>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    This is the placeholder. It gets the SSR friendly ID factory so if we ask for an ID, we get: 
+    an-id
+  </div>
+  <div
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 16,
+        "MsFlexPreferredSize": 16,
+        "WebkitFlexBasis": 16,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 16,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  />
+  <h4
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 20,
+        "fontWeight": 700,
+        "lineHeight": "24px",
+        "marginBottom": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    But now we render the real deal:
+  </h4>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    This is the real deal. It gets the unique ID factory, so now we ask for an ID and get: 
+    uid--1-an-id
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-core example 8 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <h4
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 20,
+        "fontWeight": 700,
+        "lineHeight": "24px",
+        "marginBottom": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    First Provider with scope: first
+  </h4>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Lato",
+          "fontSize": 16,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      The id returned for "my-identifier": 
+      uid-first-2-my-identifier
+    </span>
+  </div>
+  <h4
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
+        "fontSize": 20,
+        "fontWeight": 700,
+        "lineHeight": "24px",
+        "marginBottom": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    Second Provider with scope: second
+  </h4>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Lato",
+          "fontSize": 16,
+          "fontWeight": 400,
+          "lineHeight": "22px",
+        }
+      }
+    >
+      The id returned for "my-identifier": 
+      uid-second-3-my-identifier
+    </span>
+  </div>
+</div>
+`;

--- a/packages/wonder-blocks-core/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.js
@@ -10,47 +10,56 @@ import type {IIdentifierFactory} from "../util/types.js";
 
 type Props = {|
     // A render prop that takes an instance of IIdentifierFactory and returns
-    // the content to be rendered. See the comments for placeholder prop for
-    // more details.
+    // the content to be rendered.
+    // If mockOnFirstRender is false, this is only called after
+    // the initial render has occurred and will always be called with the same
+    // IIdentifierFactory instance.
+    // If mockOnFirstRender is true, this is called once with
+    // a mock IIdentifierFactory for the initial render, and then a unique ID
+    // factory thereafter.
     children: (IIdentifierFactory) => React.Node,
 
-    // If provided, this render prop is called when rendering for the very first
-    // time. This is useful to support server-side rendering with different
-    // content than will eventually be rendered in the client. The first client
-    // render and the server render will use this prop.
-    //
-    // If not provided, the children render prop will be called on first render.
-    //
-    // Whether this render prop, or children, the first render will receive an
-    // instance of IIdentifierFactory where the id method returns the same
-    // string with which it is called, rather than guaranteeing uniqueness.
-    placeholder?: (IIdentifierFactory) => React.Node,
+    // If mockOnFirstRender is false, children is only called
+    // after the initial render has occurred.
+    // If mockOnFirstRender is true, children is called once with
+    // a mock IIdentifierFactory for the initial render, and then a unique ID
+    // factory thereafter.
+    mockOnFirstRender?: boolean,
 
     // If this prop is specified, any identifiers provided will contain the
     // given scope. This can be useful for making easily readable identifiers.
-    scope?: string,
+    +scope?: string,
 |};
 
 export default class UniqueIDProvider extends React.Component<Props> {
     _idFactory: IIdentifierFactory;
 
-    _performRender() {
-        const {children, placeholder, scope} = this.props;
-        if (this._idFactory) {
-            return children(this._idFactory);
-        }
-        // We haven't rendered yet. This must be our first render.
-        // Let's create our real id factory for use in subsequent renders
-        // and then call our placeholder prop with our SSR-friendly factory.
-        this._idFactory = new UniqueIDFactory(scope);
+    _performRender(firstRender: boolean) {
+        const {children, mockOnFirstRender, scope} = this.props;
 
-        return (placeholder || children)(SsrIDFactory);
+        // If this is our first render, we're going to stop right here.
+        if (firstRender) {
+            // We'll be needing this on the next render, so let's set it up.
+            this._idFactory = new UniqueIDFactory(scope);
+
+            if (mockOnFirstRender) {
+                // We're allowing an initial render, so let's pass our mock
+                // identifier factory to support SSR.
+                return children(SsrIDFactory);
+            }
+            return null;
+        }
+
+        // It's a regular render, so let's use our identifier factory.
+        return children(this._idFactory);
     }
 
     render() {
+        // Here we use the NoSSR component to control when we render and whether
+        // we provide a mock or real identifier factory.
         return (
-            <NoSSR placeholder={() => this._performRender()}>
-                {() => this._performRender()}
+            <NoSSR placeholder={() => this._performRender(true)}>
+                {() => this._performRender(false)}
             </NoSSR>
         );
     }

--- a/packages/wonder-blocks-core/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.js
@@ -9,25 +9,37 @@ import SsrIDFactory from "../util/ssr-id-factory.js";
 import type {IIdentifierFactory} from "../util/types.js";
 
 type Props = {|
-    // A render prop that takes an instance of IIdentifierFactory and returns
-    // the content to be rendered.
-    // If mockOnFirstRender is false, this is only called after
-    // the initial render has occurred and will always be called with the same
-    // IIdentifierFactory instance.
-    // If mockOnFirstRender is true, this is called once with
-    // a mock IIdentifierFactory for the initial render, and then a unique ID
-    // factory thereafter.
+    /**
+     * A render prop that takes an instance of IIdentifierFactory and returns
+     * the content to be rendered.
+     *
+     * If mockOnFirstRender is false, this is only called after
+     * the initial render has occurred and will always be called with the same
+     * IIdentifierFactory instance.
+     *
+     * If mockOnFirstRender is true, this is called once with
+     * a mock IIdentifierFactory for the initial render, and then a unique ID
+     * factory thereafter.
+     *
+     * Full type with `IIdentifierFactory` definition inlined is:
+     *
+     * `{get(id: string): string} => React.Node`
+     */
     children: (IIdentifierFactory) => React.Node,
 
-    // If mockOnFirstRender is false, children is only called
-    // after the initial render has occurred.
-    // If mockOnFirstRender is true, children is called once with
-    // a mock IIdentifierFactory for the initial render, and then a unique ID
-    // factory thereafter.
+    /**
+     * If mockOnFirstRender is false, children is only called
+     * after the initial render has occurred.
+     * If mockOnFirstRender is true, children is called once with
+     * a mock IIdentifierFactory for the initial render, and then a unique ID
+     * factory thereafter.
+     */
     mockOnFirstRender?: boolean,
 
-    // If this prop is specified, any identifiers provided will contain the
-    // given scope. This can be useful for making easily readable identifiers.
+    /**
+     * If this prop is specified, any identifiers provided will contain the
+     * given scope. This can be useful for making easily readable identifiers.
+     */
     +scope?: string,
 |};
 

--- a/packages/wonder-blocks-core/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.js
@@ -1,0 +1,57 @@
+// @flow
+import * as React from "react";
+
+import NoSSR from "./no-ssr.js";
+
+import UniqueIDFactory from "../util/unique-id-factory.js";
+import SsrIDFactory from "../util/ssr-id-factory.js";
+
+import type {IIdentifierFactory} from "../util/types.js";
+
+type Props = {|
+    // A render prop that takes an instance of IIdentifierFactory and returns
+    // the content to be rendered. See the comments for placeholder prop for
+    // more details.
+    children: (IIdentifierFactory) => React.Node,
+
+    // If provided, this render prop is called when rendering for the very first
+    // time. This is useful to support server-side rendering with different
+    // content than will eventually be rendered in the client. The first client
+    // render and the server render will use this prop.
+    //
+    // If not provided, the children render prop will be called on first render.
+    //
+    // Whether this render prop, or children, the first render will receive an
+    // instance of IIdentifierFactory where the id method returns the same
+    // string with which it is called, rather than guaranteeing uniqueness.
+    placeholder?: (IIdentifierFactory) => React.Node,
+
+    // If this prop is specified, any identifiers provided will contain the
+    // given scope. This can be useful for making easily readable identifiers.
+    scope?: string,
+|};
+
+export default class UniqueIDProvider extends React.Component<Props> {
+    _idFactory: IIdentifierFactory;
+
+    _performRender() {
+        const {children, placeholder, scope} = this.props;
+        if (this._idFactory) {
+            return children(this._idFactory);
+        }
+        // We haven't rendered yet. This must be our first render.
+        // Let's create our real id factory for use in subsequent renders
+        // and then call our placeholder prop with our SSR-friendly factory.
+        this._idFactory = new UniqueIDFactory(scope);
+
+        return (placeholder || children)(SsrIDFactory);
+    }
+
+    render() {
+        return (
+            <NoSSR placeholder={() => this._performRender()}>
+                {() => this._performRender()}
+            </NoSSR>
+        );
+    }
+}

--- a/packages/wonder-blocks-core/components/unique-id-provider.md
+++ b/packages/wonder-blocks-core/components/unique-id-provider.md
@@ -1,6 +1,8 @@
-The `UniqueIDProvider` component is how Wonder Blocks components obtain unique identifiers. This component ensures that server-side rendering and initial client rendering match while allowing the provision of unique identifiers for the client. It does this by not guaranteeing unique identifiers for the initial render, but instead allowing for a placeholder to be rendered in place of the real content, or for non-unique values to be provided as identifiers.
+The `UniqueIDProvider` component is how Wonder Blocks components obtain unique identifiers. This component ensures that server-side rendering and initial client rendering match while allowing the provision of unique identifiers for the client.
 
 In all but the first render, the children are rendered with the same `IIdentifierFactory` instance, ensuring that the same calls will return the same identifiers.
+
+The `get` method of the identifier factory ensures that the same identifier is returned for like requests, but also that all identifiers provided are unique. Therefore, `get("test")` will always equal `get("test")`, and `get("test2")` will always equal `get("test2")`, but `get("test")` will never equal `get("test2")`.
 
 ### mockOnFirstRender absent or false
 
@@ -17,7 +19,7 @@ const renders = [];
 const provider = (
     <UniqueIDProvider ref={ref => providerRef = ref}>
         {ids => {
-            renders.push(ids.id("my-unique-id"));
+            renders.push(ids.get("my-unique-id"));
             return (
                 <View>
                     {renders.map((id,i) => (
@@ -45,24 +47,33 @@ const onClick = () => {
 
 ### mockOnFirstRender is true
 
-When specifying `mockOnFirstRender` to be `true`, the first render will use a mock identifier factory that doesn't guarantee identifier uniqueness.
+When specifying `mockOnFirstRender` to be `true`, the first render will use a mock identifier factory that doesn't guarantee identifier uniqueness. Mock mode can help things appear on the screen during the initial render, but is not the default, because it is not always safe (e.g., we need actual IDs for some SVG constructs).
 
 ```jsx
-const {Body, HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
+const {Body, BodyMonospace, HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
 const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
 
 let firstId = null;
+let secondId = null;
 
 const children = (idf) => {
-    const id = idf.id("an-id");
-    firstId = firstId || id;
+    const id1 = idf.get("an-id");
+    const id2 = idf.get("something");
+    firstId = firstId || id1;
+    secondId = secondId || id2
     return (
         <View>
-            <HeadingSmall>The initial render ID:</HeadingSmall>
-            {firstId}
+            <HeadingSmall>The initial render:</HeadingSmall>
+            <View>
+                <BodyMonospace>get("an-id"): {firstId}</BodyMonospace>
+                <BodyMonospace>get("something"): {secondId}</BodyMonospace>
+            </View>
             <Strut size={16} />
-            <HeadingSmall>Subsequent ID:</HeadingSmall>
-            {id}
+            <HeadingSmall>Subsequent requests:</HeadingSmall>
+            <View>
+                <BodyMonospace>get("an-id"): {id1}</BodyMonospace>
+                <BodyMonospace>get("something"): {id2}</BodyMonospace>
+            </View>
         </View>
     );
 };
@@ -80,10 +91,10 @@ const children = (idf) => {
 const {Body, HeadingSmall, BodyMonospace} = require("@khanacademy/wonder-blocks-typography");
 const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
 
-const children = ({id}) => (
+const children = ({get}) => (
     <View>
         <Body>
-            The id returned for "my-identifier": {id("my-identifier")}
+            The id returned for "my-identifier": {get("my-identifier")}
         </Body>
     </View>
 );

--- a/packages/wonder-blocks-core/components/unique-id-provider.md
+++ b/packages/wonder-blocks-core/components/unique-id-provider.md
@@ -110,3 +110,21 @@ const children = ({get}) => (
     </UniqueIDProvider>
 </View>
 ```
+
+### IIdentifierFactory
+
+```jsx
+const {BodyMonospace} = require("@khanacademy/wonder-blocks-typography");
+const {Strut} = require("@khanacademy/wonder-blocks-layout");
+
+// TODO(somewhatabstract): Update this to be nice once we can get BodyMonospace
+// to allow us to properly preserve whitespace or have an alternative. Or remove
+// this entirely when our styleguide renders our interface definitions.
+<View>
+    <BodyMonospace>interface IIdentifierFactory &#123;</BodyMonospace>
+    <View style={{flexDirection: "row"}}>
+        <Strut size={"2em"} /><BodyMonospace>get(id: string): string;</BodyMonospace>
+    </View>
+    <BodyMonospace>&#125;</BodyMonospace>
+</View>
+```

--- a/packages/wonder-blocks-core/components/unique-id-provider.md
+++ b/packages/wonder-blocks-core/components/unique-id-provider.md
@@ -2,9 +2,9 @@ The `UniqueIDProvider` component is how Wonder Blocks components obtain unique i
 
 In all but the first render, the children are rendered with the same `IIdentifierFactory` instance, ensuring that the same calls will return the same identifiers.
 
-### No placeholder
+### mockOnFirstRender absent or false
 
-When no placeholder is provided, the `children` prop is used for rendering. However, the first call uses a server-side friendly identifier factory. Note that after the initial render, each re-render will give the same identifier.
+When no `mockOnFirstRender` is `false` (the default), the `children` prop is only called after the initial render. Each call provides the same identifier factory, meaning the same identifier gets returned. Try it below.
 
 ```jsx
 const {Body, HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
@@ -43,33 +43,31 @@ const onClick = () => {
 </View>
 ```
 
-### Placeholder
+### mockOnFirstRender is true
 
-When specifying a `placeholder` prop, the first render will use that to render the content, then use the `children` prop thereafter.
+When specifying `mockOnFirstRender` to be `true`, the first render will use a mock identifier factory that doesn't guarantee identifier uniqueness.
 
 ```jsx
 const {Body, HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
 const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
 
-let placeholderContent = null;
-const placeholder = ({id}) => {
-    placeholderContent = (
-        <View>This is the placeholder. It gets the SSR friendly ID factory so if we ask for an ID, we get: {id("an-id")}</View>
+let firstId = null;
+
+const children = (idf) => {
+    const id = idf.id("an-id");
+    firstId = firstId || id;
+    return (
+        <View>
+            <HeadingSmall>The initial render ID:</HeadingSmall>
+            {firstId}
+            <Strut size={16} />
+            <HeadingSmall>Subsequent ID:</HeadingSmall>
+            {id}
+        </View>
     );
-    return placeholderContent;
 };
 
-const children = ({id}) => (
-    <View>
-        <HeadingSmall>The placeholder rendered as:</HeadingSmall>
-        {placeholderContent}
-        <Strut size={16} />
-        <HeadingSmall>But now we render the real deal:</HeadingSmall>
-        <View>This is the real deal. It gets the unique ID factory, so now we ask for an ID and get: {id("an-id")}</View>
-    </View>
-);
-
-<UniqueIDProvider placeholder={placeholder}>
+<UniqueIDProvider mockOnFirstRender={true}>
     {children}
 </UniqueIDProvider>
 ```

--- a/packages/wonder-blocks-core/components/unique-id-provider.md
+++ b/packages/wonder-blocks-core/components/unique-id-provider.md
@@ -1,0 +1,103 @@
+The `UniqueIDProvider` component is how Wonder Blocks components obtain unique identifiers. This component ensures that server-side rendering and initial client rendering match while allowing the provision of unique identifiers for the client. It does this by not guaranteeing unique identifiers for the initial render, but instead allowing for a placeholder to be rendered in place of the real content, or for non-unique values to be provided as identifiers.
+
+In all but the first render, the children are rendered with the same `IIdentifierFactory` instance, ensuring that the same calls will return the same identifiers.
+
+### No placeholder
+
+When no placeholder is provided, the `children` prop is used for rendering. However, the first call uses a server-side friendly identifier factory. Note that after the initial render, each re-render will give the same identifier.
+
+```jsx
+const {Body, HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
+const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
+const Button = require("@khanacademy/wonder-blocks-button").default;
+
+let providerRef = null;
+
+const renders = [];
+const provider = (
+    <UniqueIDProvider ref={ref => providerRef = ref}>
+        {ids => {
+            renders.push(ids.id("my-unique-id"));
+            return (
+                <View>
+                    {renders.map((id,i) => (
+                        <Body key={i}>Render {i}: {id}</Body>
+                    ))}
+                </View>
+            );
+        }}
+    </UniqueIDProvider>
+);
+
+const onClick = () => {
+    if (providerRef) {
+        providerRef.forceUpdate();
+    }
+};
+
+<View>
+    <View style={{flexDirection: "row"}}><Button onClick={onClick}>Click Me to Rerender</Button><Spring /></View>
+    <Strut size={16} />
+    <HeadingSmall>The UniqueIDProvider:</HeadingSmall>
+    {provider}
+</View>
+```
+
+### Placeholder
+
+When specifying a `placeholder` prop, the first render will use that to render the content, then use the `children` prop thereafter.
+
+```jsx
+const {Body, HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
+const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
+
+let placeholderContent = null;
+const placeholder = ({id}) => {
+    placeholderContent = (
+        <View>This is the placeholder. It gets the SSR friendly ID factory so if we ask for an ID, we get: {id("an-id")}</View>
+    );
+    return placeholderContent;
+};
+
+const children = ({id}) => (
+    <View>
+        <HeadingSmall>The placeholder rendered as:</HeadingSmall>
+        {placeholderContent}
+        <Strut size={16} />
+        <HeadingSmall>But now we render the real deal:</HeadingSmall>
+        <View>This is the real deal. It gets the unique ID factory, so now we ask for an ID and get: {id("an-id")}</View>
+    </View>
+);
+
+<UniqueIDProvider placeholder={placeholder}>
+    {children}
+</UniqueIDProvider>
+```
+
+### Scoped
+
+`UniqueIDProvider` ensures every identifier factory is unique using a unique number for each one. However, this isn't very readable when wanting to differentiate the types of things using unique identifiers. If we want to, we can provide a `scope` prop that adds some text to each identifier provided. This can be useful for providing some quick at-a-glance component identification to identifiers when there are multiple providers.
+
+```jsx
+const {Body, HeadingSmall, BodyMonospace} = require("@khanacademy/wonder-blocks-typography");
+const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
+
+const children = ({id}) => (
+    <View>
+        <Body>
+            The id returned for "my-identifier": {id("my-identifier")}
+        </Body>
+    </View>
+);
+
+<View>
+    <HeadingSmall>First Provider with scope: first</HeadingSmall>
+    <UniqueIDProvider scope="first">
+        {children}
+    </UniqueIDProvider>
+    <HeadingSmall>Second Provider with scope: second</HeadingSmall>
+    <UniqueIDProvider scope="second">
+        {children}
+    </UniqueIDProvider>
+</View>
+```

--- a/packages/wonder-blocks-core/components/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.test.js
@@ -24,7 +24,7 @@ describe("UniqueIDProvider", () => {
             expect(children).not.toHaveBeenCalled();
         });
 
-        test("initial render is nothing on client", () => {
+        test("initial render is skipped on client", () => {
             // Arrange
             const children = jest.fn(() => null);
             const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
@@ -33,8 +33,12 @@ describe("UniqueIDProvider", () => {
             mount(nodes);
 
             // Assert
+            // Called once; for real render.
+            // Compare with case where mock factory is provided and note that
+            // children gets called twice, once for initial render, and once
+            // for real render with unique ID factory.
             expect(children).toHaveBeenCalledTimes(1);
-            expect(children).not.toHaveBeenCalledWith(SsrIDFactory);
+            expect(children.mock.calls[0][0]).toBeInstanceOf(UniqueIDFactory);
         });
 
         test("all renders get same unique id factory", () => {

--- a/packages/wonder-blocks-core/components/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.test.js
@@ -1,0 +1,166 @@
+// @flow
+import * as React from "react";
+import * as ReactDOMServer from "react-dom/server";
+
+import {shallow, mount} from "enzyme";
+
+import View from "./view.js";
+
+import SsrIDFactory from "../util/ssr-id-factory.js";
+import UniqueIDFactory from "../util/unique-id-factory.js";
+import UniqueIDProvider from "./unique-id-provider.js";
+
+describe("UniqueIDProvider", () => {
+    describe("no placeholder", () => {
+        test("initial render identifiers match on client & server", () => {
+            // Arrange
+            const id = "view-id";
+            const nodes = (
+                <UniqueIDProvider>
+                    {(ids) => <View id={ids.id(id)}>My view</View>}
+                </UniqueIDProvider>
+            );
+
+            // Act
+            const serverRender = ReactDOMServer.renderToString(nodes);
+            const clientRender = shallow(nodes).html();
+
+            // Assert
+            const expectation = `id="${id}"`;
+            expect(serverRender).toContain(expectation);
+            expect(clientRender).toContain(expectation);
+        });
+
+        test("initial render should use SSR id factory", () => {
+            // Arrange
+            const children = jest.fn(() => <View />);
+            const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
+
+            // Act
+            mount(nodes);
+
+            // Assert
+            expect(children).toHaveBeenCalledTimes(2);
+            expect(children.mock.calls[0][0]).toBe(SsrIDFactory);
+            expect(children.mock.calls[1][0]).toBeInstanceOf(UniqueIDFactory);
+        });
+
+        test("subsequent renders get same unique id factory", () => {
+            // Arrange
+            const children = jest.fn(() => <View />);
+            const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
+            const wrapper = mount(nodes);
+
+            // Act
+            wrapper.instance().forceUpdate();
+
+            // Assert
+            // Check our forced render worked and we rendered three times.
+            expect(children).toHaveBeenCalledTimes(3);
+            // Check the second render gets a UniqueIDFactory instance.
+            expect(children.mock.calls[1][0]).toBeInstanceOf(UniqueIDFactory);
+            // Check the third render gets the same UniqueIDFactory instance.
+            expect(children.mock.calls[2][0]).toBe(children.mock.calls[1][0]);
+        });
+    });
+
+    describe("with placeholder", () => {
+        test("initial render, children is not called", () => {
+            // Arrange
+            const id = "view-id";
+            const placeholder = (ids) => <View id={ids.id(id)}>My view</View>;
+            const children = jest.fn();
+            const nodes = (
+                <UniqueIDProvider placeholder={placeholder}>
+                    {children}
+                </UniqueIDProvider>
+            );
+
+            // Act
+            shallow(nodes).html();
+
+            // Assert
+            expect(children).not.toHaveBeenCalled();
+        });
+
+        test("initial render identifiers match on client & server", () => {
+            // Arrange
+            const id = "view-id";
+            const placeholder = (ids) => <View id={ids.id(id)}>My view</View>;
+            const children = jest.fn();
+            const nodes = (
+                <UniqueIDProvider placeholder={placeholder}>
+                    {children}
+                </UniqueIDProvider>
+            );
+
+            // Act
+            const serverRender = ReactDOMServer.renderToString(nodes);
+            const clientRender = shallow(nodes).html();
+
+            // Assert
+            const expectation = `id="${id}"`;
+            expect(serverRender).toContain(expectation);
+            expect(clientRender).toContain(expectation);
+        });
+
+        test("placeholder called with SSR id factory", () => {
+            // Arrange
+            const placeholder = jest.fn(() => <View />);
+            const children = jest.fn(() => <View />);
+            const nodes = (
+                <UniqueIDProvider placeholder={placeholder}>
+                    {children}
+                </UniqueIDProvider>
+            );
+
+            // Act
+            mount(nodes);
+
+            // Assert
+            expect(placeholder).toHaveBeenCalledTimes(1);
+            expect(placeholder).toHaveBeenCalledWith(SsrIDFactory);
+        });
+
+        test("children called with unique id factory", () => {
+            // Arrange
+            const placeholder = jest.fn(() => <View />);
+            const children = jest.fn(() => <View />);
+            const nodes = (
+                <UniqueIDProvider placeholder={placeholder}>
+                    {children}
+                </UniqueIDProvider>
+            );
+
+            // Act
+            mount(nodes);
+
+            // Assert
+            expect(children).toHaveBeenCalledTimes(1);
+            expect(children).toHaveBeenCalledWith(expect.any(UniqueIDFactory));
+        });
+
+        test("all children calls get same unique id factory", () => {
+            // Arrange
+            const placeholder = jest.fn(() => <View />);
+            const children = jest.fn(() => <View />);
+            const nodes = (
+                <UniqueIDProvider placeholder={placeholder}>
+                    {children}
+                </UniqueIDProvider>
+            );
+            const wrapper = mount(nodes);
+
+            // Act
+            wrapper.instance().forceUpdate();
+
+            // Assert
+            // Check our forced render worked and we rendered three times.
+            expect(children).toHaveBeenCalledTimes(2);
+            // Check the second render gets a UniqueIDFactory instance.
+            expect(children.mock.calls[0][0]).toBeInstanceOf(UniqueIDFactory);
+            // Check the third render gets the same UniqueIDFactory instance.
+            expect(children.mock.calls[1][0]).toBe(children.mock.calls[1][0]);
+        });
+    });
+});

--- a/packages/wonder-blocks-core/components/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 
-import {shallow, mount} from "enzyme";
+import {mount} from "enzyme";
 
 import View from "./view.js";
 
@@ -11,44 +11,97 @@ import UniqueIDFactory from "../util/unique-id-factory.js";
 import UniqueIDProvider from "./unique-id-provider.js";
 
 describe("UniqueIDProvider", () => {
-    describe("no placeholder", () => {
-        test("initial render identifiers match on client & server", () => {
+    describe("mockOnFirstRender is default (false)", () => {
+        test("initial render is nothing on server", () => {
             // Arrange
-            const id = "view-id";
-            const nodes = (
-                <UniqueIDProvider>
-                    {(ids) => <View id={ids.id(id)}>My view</View>}
-                </UniqueIDProvider>
-            );
+            const children = jest.fn(() => null);
+            const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
 
             // Act
-            const serverRender = ReactDOMServer.renderToString(nodes);
-            const clientRender = shallow(nodes).html();
+            ReactDOMServer.renderToStaticMarkup(nodes);
 
             // Assert
-            const expectation = `id="${id}"`;
-            expect(serverRender).toContain(expectation);
-            expect(clientRender).toContain(expectation);
+            expect(children).not.toHaveBeenCalled();
         });
 
-        test("initial render should use SSR id factory", () => {
+        test("initial render is nothing on client", () => {
             // Arrange
-            const children = jest.fn(() => <View />);
+            const children = jest.fn(() => null);
             const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
 
             // Act
             mount(nodes);
 
             // Assert
-            expect(children).toHaveBeenCalledTimes(2);
-            expect(children.mock.calls[0][0]).toBe(SsrIDFactory);
-            expect(children.mock.calls[1][0]).toBeInstanceOf(UniqueIDFactory);
+            expect(children).toHaveBeenCalledTimes(1);
+            expect(children).not.toHaveBeenCalledWith(SsrIDFactory);
         });
 
-        test("subsequent renders get same unique id factory", () => {
+        test("all renders get same unique id factory", () => {
             // Arrange
             const children = jest.fn(() => <View />);
             const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
+            const wrapper = mount(nodes);
+
+            // Act
+            wrapper.instance().forceUpdate();
+
+            // Assert
+            // Check our forced render worked and we rendered three times.
+            expect(children).toHaveBeenCalledTimes(2);
+            // Check the first render gets a UniqueIDFactory instance.
+            expect(children.mock.calls[0][0]).toBeInstanceOf(UniqueIDFactory);
+            // Check the second render gets the same UniqueIDFactory instance.
+            expect(children.mock.calls[1][0]).toBe(children.mock.calls[1][0]);
+        });
+    });
+
+    describe("mockOnFirstRender is true", () => {
+        test("initial server render, children called with SsrIDFactory", () => {
+            // Arrange
+            const children = jest.fn(() => null);
+            const nodes = (
+                <UniqueIDProvider mockOnFirstRender={true}>
+                    {children}
+                </UniqueIDProvider>
+            );
+
+            // Act
+            ReactDOMServer.renderToStaticMarkup(nodes);
+
+            // Assert
+            // Called twice; once for initial mock render only.
+            expect(children).toHaveBeenCalledTimes(1);
+            expect(children).toHaveBeenCalledWith(SsrIDFactory);
+        });
+
+        test("initial client render, children called with SsrIDFactory", () => {
+            // Arrange
+            const children = jest.fn(() => null);
+            const nodes = (
+                <UniqueIDProvider mockOnFirstRender={true}>
+                    {children}
+                </UniqueIDProvider>
+            );
+
+            // Act
+            mount(nodes);
+
+            // Assert
+            // Called twice; once for initial mock render, and again for real
+            // render.
+            expect(children).toHaveBeenCalledTimes(2);
+            expect(children).toHaveBeenCalledWith(SsrIDFactory);
+        });
+
+        test("children calls after first get same unique id factory", () => {
+            // Arrange
+            const children = jest.fn(() => null);
+            const nodes = (
+                <UniqueIDProvider mockOnFirstRender={true}>
+                    {children}
+                </UniqueIDProvider>
+            );
             const wrapper = mount(nodes);
 
             // Act
@@ -61,106 +114,6 @@ describe("UniqueIDProvider", () => {
             expect(children.mock.calls[1][0]).toBeInstanceOf(UniqueIDFactory);
             // Check the third render gets the same UniqueIDFactory instance.
             expect(children.mock.calls[2][0]).toBe(children.mock.calls[1][0]);
-        });
-    });
-
-    describe("with placeholder", () => {
-        test("initial render, children is not called", () => {
-            // Arrange
-            const id = "view-id";
-            const placeholder = (ids) => <View id={ids.id(id)}>My view</View>;
-            const children = jest.fn();
-            const nodes = (
-                <UniqueIDProvider placeholder={placeholder}>
-                    {children}
-                </UniqueIDProvider>
-            );
-
-            // Act
-            shallow(nodes).html();
-
-            // Assert
-            expect(children).not.toHaveBeenCalled();
-        });
-
-        test("initial render identifiers match on client & server", () => {
-            // Arrange
-            const id = "view-id";
-            const placeholder = (ids) => <View id={ids.id(id)}>My view</View>;
-            const children = jest.fn();
-            const nodes = (
-                <UniqueIDProvider placeholder={placeholder}>
-                    {children}
-                </UniqueIDProvider>
-            );
-
-            // Act
-            const serverRender = ReactDOMServer.renderToString(nodes);
-            const clientRender = shallow(nodes).html();
-
-            // Assert
-            const expectation = `id="${id}"`;
-            expect(serverRender).toContain(expectation);
-            expect(clientRender).toContain(expectation);
-        });
-
-        test("placeholder called with SSR id factory", () => {
-            // Arrange
-            const placeholder = jest.fn(() => <View />);
-            const children = jest.fn(() => <View />);
-            const nodes = (
-                <UniqueIDProvider placeholder={placeholder}>
-                    {children}
-                </UniqueIDProvider>
-            );
-
-            // Act
-            mount(nodes);
-
-            // Assert
-            expect(placeholder).toHaveBeenCalledTimes(1);
-            expect(placeholder).toHaveBeenCalledWith(SsrIDFactory);
-        });
-
-        test("children called with unique id factory", () => {
-            // Arrange
-            const placeholder = jest.fn(() => <View />);
-            const children = jest.fn(() => <View />);
-            const nodes = (
-                <UniqueIDProvider placeholder={placeholder}>
-                    {children}
-                </UniqueIDProvider>
-            );
-
-            // Act
-            mount(nodes);
-
-            // Assert
-            expect(children).toHaveBeenCalledTimes(1);
-            expect(children).toHaveBeenCalledWith(expect.any(UniqueIDFactory));
-        });
-
-        test("all children calls get same unique id factory", () => {
-            // Arrange
-            const placeholder = jest.fn(() => <View />);
-            const children = jest.fn(() => <View />);
-            const nodes = (
-                <UniqueIDProvider placeholder={placeholder}>
-                    {children}
-                </UniqueIDProvider>
-            );
-            const wrapper = mount(nodes);
-
-            // Act
-            wrapper.instance().forceUpdate();
-
-            // Assert
-            // Check our forced render worked and we rendered three times.
-            expect(children).toHaveBeenCalledTimes(2);
-            // Check the second render gets a UniqueIDFactory instance.
-            expect(children.mock.calls[0][0]).toBeInstanceOf(UniqueIDFactory);
-            // Check the third render gets the same UniqueIDFactory instance.
-            expect(children.mock.calls[1][0]).toBe(children.mock.calls[1][0]);
         });
     });
 });

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -211,32 +211,24 @@ describe("wonder-blocks-core", () => {
         } = require("@khanacademy/wonder-blocks-typography");
         const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
 
-        let placeholderContent = null;
-        const placeholder = ({id}) => {
-            placeholderContent = (
+        let firstId = null;
+
+        const children = (idf) => {
+            const id = idf.id("an-id");
+            firstId = firstId || id;
+            return (
                 <View>
-                    This is the placeholder. It gets the SSR friendly ID factory
-                    so if we ask for an ID, we get: {id("an-id")}
+                    <HeadingSmall>The initial render ID:</HeadingSmall>
+                    {firstId}
+                    <Strut size={16} />
+                    <HeadingSmall>Subsequent ID:</HeadingSmall>
+                    {id}
                 </View>
             );
-            return placeholderContent;
         };
 
-        const children = ({id}) => (
-            <View>
-                <HeadingSmall>The placeholder rendered as:</HeadingSmall>
-                {placeholderContent}
-                <Strut size={16} />
-                <HeadingSmall>But now we render the real deal:</HeadingSmall>
-                <View>
-                    This is the real deal. It gets the unique ID factory, so now
-                    we ask for an ID and get: {id("an-id")}
-                </View>
-            </View>
-        );
-
         const example = (
-            <UniqueIDProvider placeholder={placeholder}>
+            <UniqueIDProvider mockOnFirstRender={true}>
                 {children}
             </UniqueIDProvider>
         );

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -170,7 +170,7 @@ describe("wonder-blocks-core", () => {
         const provider = (
             <UniqueIDProvider ref={(ref) => (providerRef = ref)}>
                 {(ids) => {
-                    renders.push(ids.id("my-unique-id"));
+                    renders.push(ids.get("my-unique-id"));
                     return (
                         <View>
                             {renders.map((id, i) => (
@@ -207,22 +207,34 @@ describe("wonder-blocks-core", () => {
     it("example 7", () => {
         const {
             Body,
+            BodyMonospace,
             HeadingSmall,
         } = require("@khanacademy/wonder-blocks-typography");
         const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
 
         let firstId = null;
+        let secondId = null;
 
         const children = (idf) => {
-            const id = idf.id("an-id");
-            firstId = firstId || id;
+            const id1 = idf.get("an-id");
+            const id2 = idf.get("something");
+            firstId = firstId || id1;
+            secondId = secondId || id2;
             return (
                 <View>
-                    <HeadingSmall>The initial render ID:</HeadingSmall>
-                    {firstId}
+                    <HeadingSmall>The initial render:</HeadingSmall>
+                    <View>
+                        <BodyMonospace>get("an-id"): {firstId}</BodyMonospace>
+                        <BodyMonospace>
+                            get("something"): {secondId}
+                        </BodyMonospace>
+                    </View>
                     <Strut size={16} />
-                    <HeadingSmall>Subsequent ID:</HeadingSmall>
-                    {id}
+                    <HeadingSmall>Subsequent requests:</HeadingSmall>
+                    <View>
+                        <BodyMonospace>get("an-id"): {id1}</BodyMonospace>
+                        <BodyMonospace>get("something"): {id2}</BodyMonospace>
+                    </View>
                 </View>
             );
         };
@@ -243,10 +255,10 @@ describe("wonder-blocks-core", () => {
         } = require("@khanacademy/wonder-blocks-typography");
         const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
 
-        const children = ({id}) => (
+        const children = ({get}) => (
             <View>
                 <Body>
-                    The id returned for "my-identifier": {id("my-identifier")}
+                    The id returned for "my-identifier": {get("my-identifier")}
                 </Body>
             </View>
         );

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -12,6 +12,7 @@ import ClickableBehavior from "./components/clickable-behavior.js";
 import MediaLayout from "./components/media-layout.js";
 import NoSSR from "./components/no-ssr.js";
 import Text from "./components/text.js";
+import UniqueIDProvider from "./components/unique-id-provider.js";
 import View from "./components/view.js";
 
 describe("wonder-blocks-core", () => {
@@ -151,6 +152,120 @@ describe("wonder-blocks-core", () => {
                     </View>
                 )}
             </NoSSR>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 6", () => {
+        const {
+            Body,
+            HeadingSmall,
+        } = require("@khanacademy/wonder-blocks-typography");
+        const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
+        const Button = require("@khanacademy/wonder-blocks-button").default;
+
+        let providerRef = null;
+
+        const renders = [];
+        const provider = (
+            <UniqueIDProvider ref={(ref) => (providerRef = ref)}>
+                {(ids) => {
+                    renders.push(ids.id("my-unique-id"));
+                    return (
+                        <View>
+                            {renders.map((id, i) => (
+                                <Body key={i}>
+                                    Render {i}: {id}
+                                </Body>
+                            ))}
+                        </View>
+                    );
+                }}
+            </UniqueIDProvider>
+        );
+
+        const onClick = () => {
+            if (providerRef) {
+                providerRef.forceUpdate();
+            }
+        };
+
+        const example = (
+            <View>
+                <View style={{flexDirection: "row"}}>
+                    <Button onClick={onClick}>Click Me to Rerender</Button>
+                    <Spring />
+                </View>
+                <Strut size={16} />
+                <HeadingSmall>The UniqueIDProvider:</HeadingSmall>
+                {provider}
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 7", () => {
+        const {
+            Body,
+            HeadingSmall,
+        } = require("@khanacademy/wonder-blocks-typography");
+        const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
+
+        let placeholderContent = null;
+        const placeholder = ({id}) => {
+            placeholderContent = (
+                <View>
+                    This is the placeholder. It gets the SSR friendly ID factory
+                    so if we ask for an ID, we get: {id("an-id")}
+                </View>
+            );
+            return placeholderContent;
+        };
+
+        const children = ({id}) => (
+            <View>
+                <HeadingSmall>The placeholder rendered as:</HeadingSmall>
+                {placeholderContent}
+                <Strut size={16} />
+                <HeadingSmall>But now we render the real deal:</HeadingSmall>
+                <View>
+                    This is the real deal. It gets the unique ID factory, so now
+                    we ask for an ID and get: {id("an-id")}
+                </View>
+            </View>
+        );
+
+        const example = (
+            <UniqueIDProvider placeholder={placeholder}>
+                {children}
+            </UniqueIDProvider>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 8", () => {
+        const {
+            Body,
+            HeadingSmall,
+            BodyMonospace,
+        } = require("@khanacademy/wonder-blocks-typography");
+        const {Spring, Strut} = require("@khanacademy/wonder-blocks-layout");
+
+        const children = ({id}) => (
+            <View>
+                <Body>
+                    The id returned for "my-identifier": {id("my-identifier")}
+                </Body>
+            </View>
+        );
+
+        const example = (
+            <View>
+                <HeadingSmall>First Provider with scope: first</HeadingSmall>
+                <UniqueIDProvider scope="first">{children}</UniqueIDProvider>
+                <HeadingSmall>Second Provider with scope: second</HeadingSmall>
+                <UniqueIDProvider scope="second">{children}</UniqueIDProvider>
+            </View>
         );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -274,4 +274,28 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+    it("example 9", () => {
+        const {
+            BodyMonospace,
+        } = require("@khanacademy/wonder-blocks-typography");
+        const {Strut} = require("@khanacademy/wonder-blocks-layout");
+
+        // TODO(somewhatabstract): Update this to be nice once we can get BodyMonospace
+        // to allow us to properly preserve whitespace or have an alternative. Or remove
+        // this entirely when our styleguide renders our interface definitions.
+        const example = (
+            <View>
+                <BodyMonospace>
+                    interface IIdentifierFactory &#123;
+                </BodyMonospace>
+                <View style={{flexDirection: "row"}}>
+                    <Strut size={"2em"} />
+                    <BodyMonospace>get(id: string): string;</BodyMonospace>
+                </View>
+                <BodyMonospace>&#125;</BodyMonospace>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/packages/wonder-blocks-core/index.js
+++ b/packages/wonder-blocks-core/index.js
@@ -4,6 +4,7 @@ export {default as MediaLayout} from "./components/media-layout.js";
 export {default as Text} from "./components/text.js";
 export {default as View} from "./components/view.js";
 export {default as NoSSR} from "./components/no-ssr.js";
+export {default as UniqueIDProvider} from "./components/unique-id-provider.js";
 export {default as addStyle} from "./util/add-style.js";
 export {
     default as getClickableBehavior,
@@ -15,12 +16,19 @@ export * from "./util/specs.js";
 export {MediaLayoutWrapper} from "./util/util.js";
 
 import type {ClickableHandlers} from "./components/clickable-behavior.js";
-import type {AriaProps, TextTag, MediaSize, MediaSpec} from "./util/types.js";
+import type {
+    AriaProps,
+    IIdentifierFactory,
+    TextTag,
+    MediaSize,
+    MediaSpec,
+} from "./util/types.js";
 import type {Intersection} from "./util/get-element-intersection.js";
 export type {
     AriaProps,
     ClickableHandlers,
     Intersection,
+    IIdentifierFactory,
     TextTag,
     MediaSize,
     MediaSpec,

--- a/packages/wonder-blocks-core/index.test.js
+++ b/packages/wonder-blocks-core/index.test.js
@@ -8,20 +8,23 @@ describe("@khanacademy/wonder-blocks-core", () => {
         const result = await importedModule;
 
         // Assert
-        expect(Object.keys(result).sort()).toEqual([
-            "ClickableBehavior",
-            "MediaLayout",
-            "Text",
-            "View",
-            "NoSSR",
-            "addStyle",
-            "getClickableBehavior",
-            "getElementIntersection",
-            "VALID_MEDIA_SIZES",
-            "MEDIA_DEFAULT_SPEC",
-            "MEDIA_INTERNAL_SPEC",
-            "MEDIA_MODAL_SPEC",
-            "MediaLayoutWrapper",
-        ].sort());
+        expect(Object.keys(result).sort()).toEqual(
+            [
+                "ClickableBehavior",
+                "MediaLayout",
+                "Text",
+                "View",
+                "NoSSR",
+                "addStyle",
+                "getClickableBehavior",
+                "getElementIntersection",
+                "VALID_MEDIA_SIZES",
+                "MEDIA_DEFAULT_SPEC",
+                "MEDIA_INTERNAL_SPEC",
+                "MEDIA_MODAL_SPEC",
+                "MediaLayoutWrapper",
+                "UniqueIDProvider",
+            ].sort(),
+        );
     });
 });

--- a/packages/wonder-blocks-core/util/__snapshots__/unique-id-factory.test.js.snap
+++ b/packages/wonder-blocks-core/util/__snapshots__/unique-id-factory.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UniqueIDFactory #constructor special characters in scope, throws 1`] = `"Invalid factory name: invalid$%^&*("`;
+
+exports[`UniqueIDFactory #constructor whitespace in scope, throws 1`] = `"Invalid factory name: not valid scope"`;
+
+exports[`UniqueIDFactory #constructor whitespace only scope, throws 1`] = `"Invalid factory name:      "`;
+
+exports[`UniqueIDFactory #id should throw on invalid key 1`] = `"Invalid identifier key: IN*89098 08a7 jhufs"`;

--- a/packages/wonder-blocks-core/util/__snapshots__/unique-id-factory.test.js.snap
+++ b/packages/wonder-blocks-core/util/__snapshots__/unique-id-factory.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniqueIDFactory #constructor special characters in scope, throws 1`] = `"Invalid factory name: invalid$%^&*("`;
+exports[`UniqueIDFactory #constructor special characters in scope, throws 1`] = `"Invalid factory scope: invalid$%^&*("`;
 
-exports[`UniqueIDFactory #constructor whitespace in scope, throws 1`] = `"Invalid factory name: not valid scope"`;
+exports[`UniqueIDFactory #constructor whitespace in scope, throws 1`] = `"Invalid factory scope: not valid scope"`;
 
-exports[`UniqueIDFactory #constructor whitespace only scope, throws 1`] = `"Invalid factory name:      "`;
+exports[`UniqueIDFactory #constructor whitespace only scope, throws 1`] = `"Invalid factory scope:      "`;
 
-exports[`UniqueIDFactory #id should throw on invalid key 1`] = `"Invalid identifier key: IN*89098 08a7 jhufs"`;
+exports[`UniqueIDFactory #get should throw on invalid key 1`] = `"Invalid identifier key: IN*89098 08a7 jhufs"`;

--- a/packages/wonder-blocks-core/util/ssr-id-factory.js
+++ b/packages/wonder-blocks-core/util/ssr-id-factory.js
@@ -1,0 +1,22 @@
+// @flow
+import {IIdentifierFactory} from "../util/types.js";
+
+/**
+ * This is NOT for direct use. Instead, see the UniqueIDProvider component.
+ *
+ * Implements a version of IIdentifierFactory that can be used for providing
+ * identifiers on initial render of components that are eligible for server-side
+ * rendering.
+ *
+ * The identifiers are not guaranteed to be unique, but they will match between
+ * server and the first client render.
+ */
+class SsrIDFactory implements IIdentifierFactory {
+    static Default = new SsrIDFactory();
+
+    id(id: string) {
+        return id;
+    }
+}
+
+export default SsrIDFactory.Default;

--- a/packages/wonder-blocks-core/util/ssr-id-factory.js
+++ b/packages/wonder-blocks-core/util/ssr-id-factory.js
@@ -14,7 +14,7 @@ import {IIdentifierFactory} from "../util/types.js";
 class SsrIDFactory implements IIdentifierFactory {
     static Default = new SsrIDFactory();
 
-    id(id: string) {
+    get(id: string) {
         return id;
     }
 }

--- a/packages/wonder-blocks-core/util/ssr-id-factory.test.js
+++ b/packages/wonder-blocks-core/util/ssr-id-factory.test.js
@@ -6,7 +6,7 @@ describe("SsrIDFactory", () => {
         const {default: SsrIDFactory} = await import("./ssr-id-factory.js");
 
         // Act
-        const result = SsrIDFactory.id(id);
+        const result = SsrIDFactory.get(id);
 
         // Assert
         expect(result).toBe(id);

--- a/packages/wonder-blocks-core/util/ssr-id-factory.test.js
+++ b/packages/wonder-blocks-core/util/ssr-id-factory.test.js
@@ -1,0 +1,14 @@
+// @flow
+describe("SsrIDFactory", () => {
+    test("returns the same id, regardless of client or server render", async () => {
+        // Arrange
+        const id = "this-is-the-id";
+        const {default: SsrIDFactory} = await import("./ssr-id-factory.js");
+
+        // Act
+        const result = SsrIDFactory.id(id);
+
+        // Assert
+        expect(result).toBe(id);
+    });
+});

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -155,6 +155,9 @@ export type MediaSpec = {
     },
 };
 
+/**
+ * Interface implemented by types that can provide identifiers.
+ */
 export interface IIdentifierFactory {
     get(id: string): string;
 }

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -154,3 +154,7 @@ export type MediaSpec = {
         hasMaxWidth?: boolean,
     },
 };
+
+export interface IIdentifierFactory {
+    id(id: string): string;
+}

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -156,5 +156,5 @@ export type MediaSpec = {
 };
 
 export interface IIdentifierFactory {
-    id(id: string): string;
+    get(id: string): string;
 }

--- a/packages/wonder-blocks-core/util/unique-id-factory.js
+++ b/packages/wonder-blocks-core/util/unique-id-factory.js
@@ -1,0 +1,58 @@
+// @flow
+import {IIdentifierFactory} from "../util/types.js";
+
+/**
+ * This is NOT for direct use. Instead, see the UniqueIDProvider component.
+ *
+ * Implements IIdentifierFactory to provide unique identifiers.
+ */
+export default class UniqueIDFactory implements IIdentifierFactory {
+    _uniqueFactoryName: string;
+
+    static _factoryUniquenessCounter = 0;
+
+    /**
+     * Creates a UniqueIDFactory instance.
+     *
+     * @param {string} factoryName An optional case-insensitive name for the
+     * factory. This will be used as part of the identifier. Useful for
+     * providing context to the identifiers, which can be useful in
+     * differentiating elements when debugging the DOM. This must contain only
+     * hyphen and alphanumeric characters.
+     */
+    constructor(scope?: string) {
+        scope = typeof scope === "string" ? scope : "";
+        const normalizedScope = scope.toLowerCase();
+        if (!this._hasValidIdChars(normalizedScope)) {
+            throw new Error(`Invalid factory name: ${scope}`);
+        }
+        this._uniqueFactoryName = `uid-${normalizedScope}-${UniqueIDFactory._factoryUniquenessCounter++}`;
+    }
+
+    _hasValidIdChars(value: ?string) {
+        if (typeof value === "string") {
+            const invalidCharsReplaced = value.replace(/[^\d\w-]/g, "-");
+            if (value === invalidCharsReplaced) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Provides a unique identifier with the given key.
+     *
+     * @param {string} key The case-insensitive key of the identifier.
+     *
+     * @returns {string} A unique identifier that will remain the same for this
+     * key in this factory. This must contain only hyphen and alphanumeric
+     * characters.
+     */
+    id = (key: string) => {
+        const normalizedKey = key.toLowerCase();
+        if (!this._hasValidIdChars(key)) {
+            throw new Error(`Invalid identifier key: ${key}`);
+        }
+        return `${this._uniqueFactoryName}-${normalizedKey}`;
+    };
+}

--- a/packages/wonder-blocks-core/util/unique-id-factory.js
+++ b/packages/wonder-blocks-core/util/unique-id-factory.js
@@ -14,7 +14,7 @@ export default class UniqueIDFactory implements IIdentifierFactory {
     /**
      * Creates a UniqueIDFactory instance.
      *
-     * @param {string} factoryName An optional case-insensitive name for the
+     * @param {string} scope An optional case-insensitive scope for the
      * factory. This will be used as part of the identifier. Useful for
      * providing context to the identifiers, which can be useful in
      * differentiating elements when debugging the DOM. This must contain only
@@ -24,19 +24,24 @@ export default class UniqueIDFactory implements IIdentifierFactory {
         scope = typeof scope === "string" ? scope : "";
         const normalizedScope = scope.toLowerCase();
         if (!this._hasValidIdChars(normalizedScope)) {
-            throw new Error(`Invalid factory name: ${scope}`);
+            throw new Error(`Invalid factory scope: ${scope}`);
         }
         this._uniqueFactoryName = `uid-${normalizedScope}-${UniqueIDFactory._factoryUniquenessCounter++}`;
     }
 
+    /**
+     * This method verifies that a string contains valid characters for an
+     * identifier. It does not assert that a string IS a valid identifier (for
+     * example, that it doesn't start with numbers). We don't need to do that
+     * here because all identifiers are prefixed to avoid needing that check.
+     */
     _hasValidIdChars(value: ?string) {
-        if (typeof value === "string") {
-            const invalidCharsReplaced = value.replace(/[^\d\w-]/g, "-");
-            if (value === invalidCharsReplaced) {
-                return true;
-            }
+        if (typeof value !== "string") {
+            return false;
         }
-        return false;
+
+        const invalidCharsReplaced = value.replace(/[^\d\w-]/g, "-");
+        return value === invalidCharsReplaced;
     }
 
     /**
@@ -48,7 +53,7 @@ export default class UniqueIDFactory implements IIdentifierFactory {
      * key in this factory. This must contain only hyphen and alphanumeric
      * characters.
      */
-    id = (key: string) => {
+    get = (key: string) => {
         const normalizedKey = key.toLowerCase();
         if (!this._hasValidIdChars(key)) {
             throw new Error(`Invalid identifier key: ${key}`);

--- a/packages/wonder-blocks-core/util/unique-id-factory.test.js
+++ b/packages/wonder-blocks-core/util/unique-id-factory.test.js
@@ -58,13 +58,13 @@ describe("UniqueIDFactory", () => {
         });
     });
 
-    describe("#id", () => {
+    describe("#get", () => {
         test("should return an identifier", () => {
             // Arrange
             const factory = new UniqueIDFactory();
 
             // Act
-            const actual = factory.id("mynamedid");
+            const actual = factory.get("mynamedid");
 
             // Assert
             expect(typeof actual).toBe("string");
@@ -77,7 +77,7 @@ describe("UniqueIDFactory", () => {
             const expected = /^uid-factory-for-testing.*/g;
 
             // Act
-            const actual = factory.id("anotherid");
+            const actual = factory.get("anotherid");
 
             // Assert
             expect(actual).toMatch(expected);
@@ -88,7 +88,7 @@ describe("UniqueIDFactory", () => {
             const factory = new UniqueIDFactory();
 
             // Act
-            const underTest = () => factory.id("IN*89098 08a7 jhufs");
+            const underTest = () => factory.get("IN*89098 08a7 jhufs");
 
             // Assert
             expect(underTest).toThrowErrorMatchingSnapshot();
@@ -100,7 +100,7 @@ describe("UniqueIDFactory", () => {
             const expected = /.*this-id-please/g;
 
             // Act
-            const actual = factory.id("ThiS-ID-PLEASE");
+            const actual = factory.get("ThiS-ID-PLEASE");
 
             // Assert
             expect(actual).toMatch(expected);
@@ -113,7 +113,7 @@ describe("UniqueIDFactory", () => {
             const expected = /.*factory-name.*/g;
 
             // Act
-            const actual = factory.id("anotherid");
+            const actual = factory.get("anotherid");
 
             // Assert
             expect(actual).toMatch(expected);
@@ -122,10 +122,10 @@ describe("UniqueIDFactory", () => {
         test("should return unique identifiers", () => {
             // Arrange
             const factory = new UniqueIDFactory();
-            const id1 = factory.id("first");
+            const id1 = factory.get("first");
 
             // Act
-            const id2 = factory.id("second");
+            const id2 = factory.get("second");
 
             // Assert
             expect(id2).not.toEqual(id1);
@@ -138,12 +138,12 @@ describe("UniqueIDFactory", () => {
             // Generate some ids either side of our test case.
             // Just to validate that we're not benefiting from some
             // "only id requested" side-effect.
-            factory.id("before");
-            const expected = factory.id("name");
-            factory.id("after");
+            factory.get("before");
+            const expected = factory.get("name");
+            factory.get("after");
 
             // Act
-            const actual = factory.id("name");
+            const actual = factory.get("name");
 
             // Assert
             expect(actual).toBe(expected);
@@ -155,8 +155,8 @@ describe("UniqueIDFactory", () => {
             const factory2 = new UniqueIDFactory();
 
             // Act
-            const id1 = factory1.id("testname");
-            const id2 = factory2.id("testname");
+            const id1 = factory1.get("testname");
+            const id2 = factory2.get("testname");
 
             // Assert
             expect(id2).not.toEqual(id1);

--- a/packages/wonder-blocks-core/util/unique-id-factory.test.js
+++ b/packages/wonder-blocks-core/util/unique-id-factory.test.js
@@ -1,0 +1,165 @@
+// @flow
+import UniqueIDFactory from "./unique-id-factory.js";
+
+describe("UniqueIDFactory", () => {
+    describe("#constructor", () => {
+        test("no scope, should not throw", () => {
+            // Arrange
+
+            // Act
+            const underTest = () => new UniqueIDFactory();
+
+            // Assert
+            expect(underTest).not.toThrow();
+        });
+
+        test("valid scope, should not throw", () => {
+            // Arrange
+            const scope = "this-is-a-scope";
+
+            // Act
+            const underTest = () => new UniqueIDFactory(scope);
+
+            // Assert
+            expect(underTest).not.toThrow();
+        });
+
+        test("whitespace in scope, throws", () => {
+            // Arrange
+            const scope = "not valid scope";
+
+            // Act
+            const underTest = () => new UniqueIDFactory(scope);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingSnapshot();
+        });
+
+        test("whitespace only scope, throws", () => {
+            // Arrange
+            const scope = "     ";
+
+            // Act
+            const underTest = () => new UniqueIDFactory(scope);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingSnapshot();
+        });
+
+        test("special characters in scope, throws", () => {
+            // Arrange
+            const scope = "invalid$%^&*(";
+
+            // Act
+            const underTest = () => new UniqueIDFactory(scope);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingSnapshot();
+        });
+    });
+
+    describe("#id", () => {
+        test("should return an identifier", () => {
+            // Arrange
+            const factory = new UniqueIDFactory();
+
+            // Act
+            const actual = factory.id("mynamedid");
+
+            // Assert
+            expect(typeof actual).toBe("string");
+        });
+
+        test("should return an identifier with the factory name", () => {
+            // Arrange
+            const name = "factory-for-testing";
+            const factory = new UniqueIDFactory(name);
+            const expected = /^uid-factory-for-testing.*/g;
+
+            // Act
+            const actual = factory.id("anotherid");
+
+            // Assert
+            expect(actual).toMatch(expected);
+        });
+
+        test("should throw on invalid key", () => {
+            // Arrange
+            const factory = new UniqueIDFactory();
+
+            // Act
+            const underTest = () => factory.id("IN*89098 08a7 jhufs");
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingSnapshot();
+        });
+
+        test("should normalize key to lowercase", () => {
+            // Arrange
+            const factory = new UniqueIDFactory();
+            const expected = /.*this-id-please/g;
+
+            // Act
+            const actual = factory.id("ThiS-ID-PLEASE");
+
+            // Assert
+            expect(actual).toMatch(expected);
+        });
+
+        test("should normalize factory name to lowercase", () => {
+            // Arrange
+            const name = "FACTory-NamE";
+            const factory = new UniqueIDFactory(name);
+            const expected = /.*factory-name.*/g;
+
+            // Act
+            const actual = factory.id("anotherid");
+
+            // Assert
+            expect(actual).toMatch(expected);
+        });
+
+        test("should return unique identifiers", () => {
+            // Arrange
+            const factory = new UniqueIDFactory();
+            const id1 = factory.id("first");
+
+            // Act
+            const id2 = factory.id("second");
+
+            // Assert
+            expect(id2).not.toEqual(id1);
+        });
+
+        test("should return the same identifier for the same key", () => {
+            // Arrange
+            const factory = new UniqueIDFactory();
+
+            // Generate some ids either side of our test case.
+            // Just to validate that we're not benefiting from some
+            // "only id requested" side-effect.
+            factory.id("before");
+            const expected = factory.id("name");
+            factory.id("after");
+
+            // Act
+            const actual = factory.id("name");
+
+            // Assert
+            expect(actual).toBe(expected);
+        });
+
+        test("should return unique identifiers across factories", () => {
+            // Arrange
+            const factory1 = new UniqueIDFactory();
+            const factory2 = new UniqueIDFactory();
+
+            // Act
+            const id1 = factory1.id("testname");
+            const id2 = factory2.id("testname");
+
+            // Assert
+            expect(id2).not.toEqual(id1);
+        });
+    });
+});


### PR DESCRIPTION
This PR adds the `UniqueIDProvider` component for the provision of unique identifiers in a server-side render-friendly manner (for those with access, this is detailed in [ADR #60](https://docs.google.com/document/d/1BYQtb6GLZpruWEoYYQ74_7H8qZ41UbFuVsQBVGFew3o/edit#)).

The component uses the `NoSSR` component to control behavior based on whether something is being rendered for the first time or not, allowing us to ensure that initial rendering on both client and server will match.

This also adds documentation and test coverage for the component and the utilities that it uses.

NOTE: This is part of the `Tooltip` work as we need unique identifiers for the a11y solution.