### PR TITLE
update some of tooltip tests to use async/await

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-launcher-portal.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher-portal.test.js
@@ -6,41 +6,40 @@ import ModalLauncherPortal from "./modal-launcher-portal.js";
 import {ModalLauncherPortalAttributeName} from "../util/constants.js";
 
 describe("ModalPortal", () => {
-    test("Mounts its children in document.body", (done) => {
-        // Once the child mounts, check that it was mounted directly-ish into
-        // `document.body`, and finish the test.
-        const childrenRef = (element) => {
-            if (element) {
-                // Find the nearest parent, disregarding nodes created by
-                // ModalLauncherPortal and by `ReactDOM.render`.
-                let parent = element.parentElement;
-                while (
-                    parent &&
-                    (parent.hasAttribute(ModalLauncherPortalAttributeName) ||
-                        parent.hasAttribute("data-reactroot"))
-                ) {
-                    parent = parent.parentNode;
-                }
-
-                // This nearest parent _should_ be document.body. It definitely
-                // should not be the `data-this-should-not-contain-the-children`
-                // element! That element shouldn't be in the ancestor chain at
-                // all.
-                expect(parent).toBe(document.body);
-                done();
-            }
-        };
-
-        mount(
+    test("Mounts its children in document.body", async () => {
+        const element = await new Promise((resolve, reject) => {
             // We include an extra wrapper element here, just to extra confirm
             // that this _isn't_ part of the tree where the children get
             // mounted.
-            <div data-this-should-not-contain-the-children>
-                <ModalLauncherPortal>
-                    <div ref={childrenRef} />
-                </ModalLauncherPortal>
-            </div>,
-        );
+            mount(
+                <div data-this-should-not-contain-the-children>
+                    <ModalLauncherPortal>
+                        <div ref={resolve} />
+                    </ModalLauncherPortal>
+                </div>,
+            );
+        });
+
+        // Once the child mounts, check that it was mounted directly-ish into
+        // `document.body`, and finish the test.
+        if (element) {
+            // Find the nearest parent, disregarding nodes created by
+            // ModalLauncherPortal and by `ReactDOM.render`.
+            let parent = element.parentElement;
+            while (
+                parent &&
+                (parent.hasAttribute(ModalLauncherPortalAttributeName) ||
+                    parent.hasAttribute("data-reactroot"))
+            ) {
+                parent = parent.parentNode;
+            }
+
+            // This nearest parent _should_ be document.body. It definitely
+            // should not be the `data-this-should-not-contain-the-children`
+            // element! That element shouldn't be in the ancestor chain at
+            // all.
+            expect(parent).toBe(document.body);
+        }
     });
 
     test("Children unmount when the portal unmounts", (done) => {

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
@@ -7,6 +7,9 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import TooltipBubble from "./tooltip-bubble.js";
 import TooltipContent from "./tooltip-content.js";
 
+const sleep = (duration = 0) =>
+    new Promise((resolve, reject) => setTimeout(resolve, duration));
+
 describe("TooltipBubble", () => {
     // A little helper method to make the actual test more readable.
     const makePopperProps = () => ({
@@ -21,9 +24,9 @@ describe("TooltipBubble", () => {
         unmountAll();
     });
 
-    test("updates reference to bubble container", (done) => {
+    test("updates reference to bubble container", async () => {
         // Arrange
-        const arrangeAct = (assert) => {
+        const bubbleNode = await new Promise((resolve) => {
             // Get some props and set the ref to our assert, that way we assert
             // when the bubble component is mounted.
             const props = makePopperProps();
@@ -39,7 +42,7 @@ describe("TooltipBubble", () => {
                         id="bubble"
                         placement={props.placement}
                         tailOffset={props.tailOffset}
-                        updateBubbleRef={assert}
+                        updateBubbleRef={resolve}
                     >
                         {fakeContent}
                     </TooltipBubble>
@@ -48,35 +51,29 @@ describe("TooltipBubble", () => {
 
             // Act
             mount(nodes);
-        };
+        });
 
-        const andAssert = (bubbleNode) => {
-            /**
-             * All we're doing is making sure we got called and verifying that
-             * we got called with an element we expect.
-             */
-            // Assert
-            // Did we get a node?
-            expect(bubbleNode).toBeDefined();
+        /**
+         * All we're doing is making sure we got called and verifying that
+         * we got called with an element we expect.
+         */
+        // Assert
+        // Did we get a node?
+        expect(bubbleNode).toBeDefined();
 
-            // Is the node a mounted element?
-            const realElement = ReactDOM.findDOMNode(bubbleNode);
-            expect(realElement instanceof Element).toBeTruthy();
+        // Is the node a mounted element?
+        const realElement = ReactDOM.findDOMNode(bubbleNode);
+        expect(realElement instanceof Element).toBeTruthy();
 
-            // Keep flow happy...
-            if (realElement instanceof Element) {
-                // Did we apply our data attribute?
-                expect(realElement.getAttribute("data-placement")).toBe("top");
+        // Keep flow happy...
+        if (realElement instanceof Element) {
+            // Did we apply our data attribute?
+            expect(realElement.getAttribute("data-placement")).toBe("top");
 
-                // Did we render our content?
-                setTimeout(() => {
-                    const contentElement = document.getElementById("content");
-                    expect(contentElement).toBeDefined();
-                    done();
-                }, 0);
-            }
-        };
-
-        arrangeAct(andAssert);
+            // Did we render our content?
+            await sleep();
+            const contentElement = document.getElementById("content");
+            expect(contentElement).toBeDefined();
+        }
     });
 });

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
@@ -51,28 +51,23 @@ describe("TooltipPopper", () => {
     // we're not in a browser.
     // So, let's do a test that we at least render the content how we expect
     // and use other things to test the overall placement things.
-    test("ensure component renders", (done) => {
+    test("ensure component renders", async () => {
         // Arrange
-        const arrange = (actAssert) => {
+        const ref = await new Promise((resolve, reject) => {
             const nodes = (
                 <View>
-                    <TestHarness placement="bottom" resultRef={actAssert} />
+                    <TestHarness placement="bottom" resultRef={resolve} />
                 </View>
             );
             mount(nodes);
-        };
+        });
 
-        const actAndAssert = (resultRef) => {
-            if (!resultRef) {
-                return;
-            }
+        if (!ref) {
+            return;
+        }
 
-            // Act
-            // Assert
-            expect(resultRef).toBeDefined();
-            done();
-        };
-
-        arrange(actAndAssert);
+        // Act
+        // Assert
+        expect(ref).toBeDefined();
     });
 });


### PR DESCRIPTION
Unfortunately I wasn't able to convert all async tests to use async/await.  In particular I couldn't get the tests in tooltip-portal-mounter.test.js to work b/c for some reason `node` wasn't actually mounted.  I do believe that using async/await results in more readable tests so it would be good to figure out why things weren't working in that particular situation.