### PR TITLE
add eslint rule for event handlers names

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
         "./eslint/eslintrc"
     ],
     "rules": {
-        "flowtype/require-exact-type": [2, "always"]
+        "flowtype/require-exact-type": [2, "always"],
+        "react/jsx-handler-names": 2
     }
 }

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -193,6 +193,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                         key={index}
                         disabled={item.disabled}
                         label={item.label}
+                        /* eslint-disable-next-line react/jsx-handler-names */
                         onClick={item.onClick}
                         onToggle={(value, state) =>
                             this.handleSelected(value, state)
@@ -215,6 +216,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                         label={item.label}
                         href={item.href}
                         clientNav={item.clientNav}
+                        /* eslint-disable-next-line react/jsx-handler-names */
                         onClick={item.onClick}
                     />
                 );

--- a/packages/wonder-blocks-dropdown/components/multi-select-menu.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select-menu.js
@@ -172,6 +172,7 @@ export default class MultiSelectMenu extends React.Component<Props, State> {
                     disabled={item.disabled}
                     key={item.value}
                     label={item.label}
+                    /* eslint-disable-next-line react/jsx-handler-names */
                     onClick={item.onClick}
                     onToggle={(value, state) =>
                         this.handleSelected(value, state)

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -50,7 +50,7 @@ export default class ModalBackdrop extends React.Component<Props> {
      * _directly_ from the positioner, not bubbled up from its children), close
      * the modal.
      */
-    _handleClick = (e: SyntheticEvent<>) => {
+    handleClick = (e: SyntheticEvent<>) => {
         // Was the lowest-level click target (`e.target`) the positioner element
         // (`e.currentTarget`)?
         if (e.target === e.currentTarget) {
@@ -70,7 +70,7 @@ export default class ModalBackdrop extends React.Component<Props> {
         });
 
         return (
-            <View style={styles.modalPositioner} onClick={this._handleClick}>
+            <View style={styles.modalPositioner} onClick={this.handleClick}>
                 {/* When you press Tab on the last focusable node of the
                   * document, some browsers will move your tab focus outside of
                   * the document. But we want to capture that as a focus event,

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -71,7 +71,7 @@ export default class ModalLauncher extends React.Component<Props, State> {
         this.setState({opened: true});
     };
 
-    _closeModal = () => {
+    handleCloseModal = () => {
         this.setState({opened: false}, () => {
             this.props.onClose && this.props.onClose();
         });
@@ -80,7 +80,7 @@ export default class ModalLauncher extends React.Component<Props, State> {
     _renderModal() {
         if (typeof this.props.modal === "function") {
             return this.props.modal({
-                closeModal: this._closeModal,
+                closeModal: this.handleCloseModal,
             });
         } else {
             return this.props.modal;
@@ -98,13 +98,15 @@ export default class ModalLauncher extends React.Component<Props, State> {
                 {renderedChildren}
                 {this.state.opened && (
                     <ModalLauncherPortal>
-                        <ModalBackdrop onCloseModal={this._closeModal}>
+                        <ModalBackdrop onCloseModal={this.handleCloseModal}>
                             {this._renderModal()}
                         </ModalBackdrop>
                     </ModalLauncherPortal>
                 )}
                 {this.state.opened && (
-                    <ModalLauncherKeypressListener onClose={this._closeModal} />
+                    <ModalLauncherKeypressListener
+                        onClose={this.handleCloseModal}
+                    />
                 )}
                 {this.state.opened && <ScrollDisabler />}
             </View>


### PR DESCRIPTION
Uses [react/jsx-handler-names](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md) to check that our event handlers conform to our react style guide guidelines for [event handlers](https://github.com/Khan/style-guides/blob/master/style/react.md#name-handlers-handleeventname).