### PR TITLE
Tooltip behavior: one at a time and delays

### DIFF
--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -192,6 +192,165 @@ exports[`wonder-blocks-tooltip example 5 1`] = `
         "WebkitFontSmoothing": "antialiased",
         "display": "block",
         "fontFamily": "Lato",
+        "fontSize": 14,
+        "fontWeight": 400,
+        "lineHeight": "18px",
+      }
+    }
+  >
+    Here, we can see that the first tooltip shown has an initial delay before it appears, as does the last tooltip shown, yet when moving between tooltipped items, the transition from one to another is instantaneous.
+  </span>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "row",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "center",
+          "border": "solid 1px steelblue",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 32,
+          "justifyContent": "center",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "width": 32,
+          "zIndex": 0,
+        }
+      }
+    >
+      A
+    </div>
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "center",
+          "border": "solid 1px steelblue",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 32,
+          "justifyContent": "center",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "width": 32,
+          "zIndex": 0,
+        }
+      }
+    >
+      B
+    </div>
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "center",
+          "border": "solid 1px steelblue",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 32,
+          "justifyContent": "center",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "width": 32,
+          "zIndex": 0,
+        }
+      }
+    >
+      C
+    </div>
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "center",
+          "border": "solid 1px steelblue",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "height": 32,
+          "justifyContent": "center",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "width": 32,
+          "zIndex": 0,
+        }
+      }
+    >
+      D
+    </div>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-tooltip example 6 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato",
         "fontSize": 16,
         "fontWeight": 400,
         "lineHeight": "20px",
@@ -203,7 +362,7 @@ exports[`wonder-blocks-tooltip example 5 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 6 1`] = `
+exports[`wonder-blocks-tooltip example 7 1`] = `
 <div
   className=""
   style={
@@ -284,7 +443,7 @@ exports[`wonder-blocks-tooltip example 6 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 7 1`] = `
+exports[`wonder-blocks-tooltip example 8 1`] = `
 <div
   className=""
   style={
@@ -379,7 +538,7 @@ exports[`wonder-blocks-tooltip example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 8 1`] = `
+exports[`wonder-blocks-tooltip example 9 1`] = `
 <div
   className=""
   style={
@@ -586,7 +745,7 @@ exports[`wonder-blocks-tooltip example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 9 1`] = `
+exports[`wonder-blocks-tooltip example 10 1`] = `
 <div
   className=""
   style={
@@ -793,7 +952,7 @@ exports[`wonder-blocks-tooltip example 9 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 10 1`] = `
+exports[`wonder-blocks-tooltip example 11 1`] = `
 <div
   className=""
   style={
@@ -972,7 +1131,7 @@ exports[`wonder-blocks-tooltip example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 11 1`] = `
+exports[`wonder-blocks-tooltip example 12 1`] = `
 <div
   className=""
   style={
@@ -1179,7 +1338,7 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 12 1`] = `
+exports[`wonder-blocks-tooltip example 13 1`] = `
 <div
   className=""
   style={
@@ -1366,7 +1525,7 @@ exports[`wonder-blocks-tooltip example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 13 1`] = `
+exports[`wonder-blocks-tooltip example 14 1`] = `
 <div
   className=""
   style={
@@ -1553,7 +1712,7 @@ exports[`wonder-blocks-tooltip example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 14 1`] = `
+exports[`wonder-blocks-tooltip example 15 1`] = `
 <div
   className=""
   style={
@@ -1712,7 +1871,7 @@ exports[`wonder-blocks-tooltip example 14 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 15 1`] = `
+exports[`wonder-blocks-tooltip example 16 1`] = `
 <div
   className=""
   style={
@@ -1899,7 +2058,7 @@ exports[`wonder-blocks-tooltip example 15 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 16 1`] = `
+exports[`wonder-blocks-tooltip example 17 1`] = `
 <div
   className=""
   style={
@@ -2059,7 +2218,7 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-tooltip example 17 1`] = `
+exports[`wonder-blocks-tooltip example 18 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-tooltip/components/tooltip-anchor.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-anchor.js
@@ -90,7 +90,7 @@ export default class TooltipAnchor extends React.Component<Props, State>
              * TODO(somewhatabstract): Work out how to allow pointer to go over
              * the tooltip content to keep it active. This likely requires
              * pointer events but that would break the obscurement checks we do.
-             * So, careful consideration required. See
+             * So, careful consideration required. See WB-302.
              */
             anchorNode.addEventListener("focusin", this._handleFocusIn);
             anchorNode.addEventListener("focusout", this._handleFocusOut);
@@ -112,7 +112,9 @@ export default class TooltipAnchor extends React.Component<Props, State>
     }
 
     componentWillUnmount() {
-        this._unsubscribeFromTracker && this._unsubscribeFromTracker();
+        if (this._unsubscribeFromTracker) {
+            this._unsubscribeFromTracker();
+        }
         this._clearPendingAction();
 
         const anchorNode = this._anchorNode;

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.js
@@ -17,8 +17,8 @@ import type {TooltipBubbleProps} from "./tooltip-bubble.js";
 type Props = {|
     /**
      * This uses the children-as-a-function approach, mirroring react-popper's
-     * implementation, except we enforce the return type to be our TooltipBubble
-     * component.
+     * implementation, except we enforce the return type to be our
+     * `TooltipBubble` component.
      */
     children: (TooltipBubbleProps) => React.Element<typeof TooltipBubble>,
 

--- a/packages/wonder-blocks-tooltip/components/tooltip.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip.md
@@ -109,3 +109,42 @@ const modal = (
     {({openModal}) => <button onClick={openModal}>Click here!</button>}
 </ModalLauncher>
 ```
+
+### Tooltips side-by-side
+
+```js
+const {StyleSheet} = require("aphrodite");
+const React = require("react");
+
+const {View} = require("@khanacademy/wonder-blocks-core");
+const {LabelSmall} = require("@khanacademy/wonder-blocks-typography");
+
+const styles = StyleSheet.create({
+    "block": {
+        border: "solid 1px steelblue",
+        width: 32,
+        height: 32,
+        alignItems: "center",
+        justifyContent: "center",
+    }
+});
+
+<View>
+    <LabelSmall>Here, we can see that the first tooltip shown has an initial delay before it appears, as does the last tooltip shown, yet when moving between tooltipped items, the transition from one to another is instantaneous.</LabelSmall>
+
+    <View style={{flexDirection: "row"}}>
+        <Tooltip content={"Tooltip A"} placement="bottom">
+            <View style={styles.block}>A</View>
+        </Tooltip>
+        <Tooltip content={"Tooltip B"} placement="bottom">
+            <View style={styles.block}>B</View>
+        </Tooltip>
+        <Tooltip content={"Tooltip C"} placement="bottom">
+            <View style={styles.block}>C</View>
+        </Tooltip>
+        <Tooltip content={"Tooltip D"} placement="bottom">
+            <View style={styles.block}>D</View>
+        </Tooltip>
+    </View>
+</View>
+```

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -136,11 +136,56 @@ describe("wonder-blocks-tooltip", () => {
         expect(tree).toMatchSnapshot();
     });
     it("example 5", () => {
-        const example = <TooltipContent>Just the content</TooltipContent>;
+        const {StyleSheet} = require("aphrodite");
+        const React = require("react");
+
+        const {View} = require("@khanacademy/wonder-blocks-core");
+        const {LabelSmall} = require("@khanacademy/wonder-blocks-typography");
+
+        const styles = StyleSheet.create({
+            block: {
+                border: "solid 1px steelblue",
+                width: 32,
+                height: 32,
+                alignItems: "center",
+                justifyContent: "center",
+            },
+        });
+
+        const example = (
+            <View>
+                <LabelSmall>
+                    Here, we can see that the first tooltip shown has an initial
+                    delay before it appears, as does the last tooltip shown, yet
+                    when moving between tooltipped items, the transition from
+                    one to another is instantaneous.
+                </LabelSmall>
+
+                <View style={{flexDirection: "row"}}>
+                    <Tooltip content={"Tooltip A"} placement="bottom">
+                        <View style={styles.block}>A</View>
+                    </Tooltip>
+                    <Tooltip content={"Tooltip B"} placement="bottom">
+                        <View style={styles.block}>B</View>
+                    </Tooltip>
+                    <Tooltip content={"Tooltip C"} placement="bottom">
+                        <View style={styles.block}>C</View>
+                    </Tooltip>
+                    <Tooltip content={"Tooltip D"} placement="bottom">
+                        <View style={styles.block}>D</View>
+                    </Tooltip>
+                </View>
+            </View>
+        );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
     it("example 6", () => {
+        const example = <TooltipContent>Just the content</TooltipContent>;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 7", () => {
         const example = (
             <TooltipContent title="Title text!">
                 Some content in my content
@@ -149,7 +194,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 7", () => {
+    it("example 8", () => {
         const {
             Body,
             LabelSmall,
@@ -164,7 +209,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 8", () => {
+    it("example 9", () => {
         const {StyleSheet} = require("aphrodite");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {Spring} = require("@khanacademy/wonder-blocks-layout");
@@ -199,7 +244,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 9", () => {
+    it("example 10", () => {
         const {StyleSheet} = require("aphrodite");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {Spring} = require("@khanacademy/wonder-blocks-layout");
@@ -236,7 +281,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 10", () => {
+    it("example 11", () => {
         const {StyleSheet} = require("aphrodite");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {Spring} = require("@khanacademy/wonder-blocks-layout");
@@ -271,7 +316,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 11", () => {
+    it("example 12", () => {
         const {StyleSheet} = require("aphrodite");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {Spring} = require("@khanacademy/wonder-blocks-layout");
@@ -308,7 +353,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 12", () => {
+    it("example 13", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
 
         const example = (
@@ -321,7 +366,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 13", () => {
+    it("example 14", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
 
         const example = (
@@ -334,7 +379,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 14", () => {
+    it("example 15", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
 
         const example = (
@@ -350,7 +395,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 15", () => {
+    it("example 16", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
 
         const example = (
@@ -363,7 +408,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 16", () => {
+    it("example 17", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
         const Spacing = require("@khanacademy/wonder-blocks-spacing");
 
@@ -383,7 +428,7 @@ describe("wonder-blocks-tooltip", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 17", () => {
+    it("example 18", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
         const Spacing = require("@khanacademy/wonder-blocks-spacing");
 

--- a/packages/wonder-blocks-tooltip/util/__snapshots__/active-tracker.test.js.snap
+++ b/packages/wonder-blocks-tooltip/util/__snapshots__/active-tracker.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActiveTracker #subscribe if already subscribed, throws 1`] = `"Already subscribed."`;

--- a/packages/wonder-blocks-tooltip/util/active-tracker.js
+++ b/packages/wonder-blocks-tooltip/util/active-tracker.js
@@ -1,0 +1,60 @@
+// @flow
+export interface IActiveTrackerSubscriber {
+    activeStateStolen: () => void;
+}
+
+export default class ActiveTracker {
+    _subscribers: Array<IActiveTrackerSubscriber> = [];
+    _active: boolean;
+
+    _getIndex(who: IActiveTrackerSubscriber) {
+        return this._subscribers.findIndex((v) => v === who);
+    }
+
+    /**
+     * Called when a tooltip anchor becomes active so that it can tell all other
+     * anchors that they are no longer the active tooltip. Returns true if
+     * the there was a steal of active state from another anchor; otherwise, if
+     * no other anchor had been active, returns false.
+     */
+    steal(who: IActiveTrackerSubscriber) {
+        const wasActive = !!this._active;
+        this._active = true;
+        for (const anchor of this._subscribers) {
+            if (anchor === who) {
+                // We don't need to notify the thief.
+                continue;
+            }
+            anchor.activeStateStolen();
+        }
+        return wasActive;
+    }
+
+    /**
+     * Called if a tooltip doesn't want to be active anymore.
+     * Should not be called when being told the active spot was stolen by
+     * another anchor, only when the anchor is unhovered and unfocused and they
+     * were active.
+     */
+    giveup() {
+        this._active = false;
+    }
+
+    /**
+     * Subscribes a tooltip anchor to the tracker so that it can be notified of
+     * steals. Returns a method that can be used to unsubscribe the anchor from
+     * notifications.
+     */
+    subscribe(who: IActiveTrackerSubscriber): () => void {
+        if (this._getIndex(who) >= 0) {
+            throw new Error("Already subscribed.");
+        }
+        this._subscribers.push(who);
+
+        const unsubscribe = () => {
+            const index = this._getIndex(who);
+            this._subscribers.splice(index, 1);
+        };
+        return unsubscribe;
+    }
+}

--- a/packages/wonder-blocks-tooltip/util/active-tracker.test.js
+++ b/packages/wonder-blocks-tooltip/util/active-tracker.test.js
@@ -1,0 +1,145 @@
+// @flow
+import {
+    default as ActiveTracker,
+    IActiveTrackerSubscriber,
+} from "./active-tracker.js";
+
+class MockSubscriber implements IActiveTrackerSubscriber {
+    activeStateStolen = jest.fn();
+}
+
+describe("ActiveTracker", () => {
+    describe("#subscribe", () => {
+        test("subscribes to notifications", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const subscriber = new MockSubscriber();
+            const thief = new MockSubscriber();
+
+            // Act
+            tracker.subscribe(subscriber);
+            tracker.steal(thief);
+
+            // Assert
+            expect(subscriber.activeStateStolen).toHaveBeenCalledTimes(1);
+        });
+
+        test("if already subscribed, throws", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const subscriber = new MockSubscriber();
+            tracker.subscribe(subscriber);
+
+            // Act
+            const underTest = () => tracker.subscribe(subscriber);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingSnapshot();
+        });
+
+        test("returns a function", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const subscriber = new MockSubscriber();
+
+            // Act
+            const result = tracker.subscribe(subscriber);
+
+            // Assert
+            expect(result).toBeInstanceOf(Function);
+        });
+
+        test("returned function unsubscribes from notifications", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const subscriber1 = new MockSubscriber();
+            const testCase = new MockSubscriber();
+            const subscriber3 = new MockSubscriber();
+            const subscriber4 = new MockSubscriber();
+            tracker.subscribe(subscriber1);
+            const unsubscribe = tracker.subscribe(testCase);
+            tracker.subscribe(subscriber3);
+
+            // Act
+            unsubscribe();
+            tracker.steal(subscriber4);
+
+            // Assert
+            expect(testCase.activeStateStolen).not.toHaveBeenCalled();
+            expect(subscriber1.activeStateStolen).toHaveBeenCalledTimes(1);
+            expect(subscriber3.activeStateStolen).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("#steal", () => {
+        test("notifies subscribers of theft attempt", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const thief = new MockSubscriber();
+            const subscriber = new MockSubscriber();
+            tracker.subscribe(subscriber);
+
+            // Act
+            tracker.steal(thief);
+
+            // Assert
+            expect(subscriber.activeStateStolen).toHaveBeenCalledTimes(1);
+        });
+
+        test("does not notifier thief of their own theft attempt", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const thief = new MockSubscriber();
+            tracker.subscribe(thief);
+
+            // Act
+            tracker.steal(thief);
+
+            // Assert
+            expect(thief.activeStateStolen).not.toHaveBeenCalledTimes(1);
+        });
+
+        test("returns falsy if active state was not stolen", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const thief = new MockSubscriber();
+
+            // Act
+            const result = tracker.steal(thief);
+
+            // Assert
+            expect(result).toBeFalsy();
+        });
+
+        test("returns truthy if active state was stolen", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const thief = new MockSubscriber();
+            const owner = new MockSubscriber();
+            tracker.steal(owner);
+
+            // Act
+            const result = tracker.steal(thief);
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+    });
+
+    describe("#giveup", () => {
+        test("marks the active state as false", () => {
+            // Arrange
+            const tracker = new ActiveTracker();
+            const owner = new MockSubscriber();
+            tracker.steal(owner);
+
+            // Act
+            expect(tracker.steal(owner)).toBeTruthy();
+            tracker.giveup();
+            const result = tracker.steal(owner);
+
+            // Assert
+            expect(result).toBeFalsy();
+        });
+    });
+});

--- a/packages/wonder-blocks-tooltip/util/constants.js
+++ b/packages/wonder-blocks-tooltip/util/constants.js
@@ -2,6 +2,6 @@
 /**
  * The attribute used to identify a tooltip portal.
  */
-const TooltipPortalAttributeName = "data-tooltip-portal";
-
-export {TooltipPortalAttributeName};
+export const TooltipPortalAttributeName = "data-tooltip-portal";
+export const TooltipAppearanceDelay = 100;
+export const TooltipDisappearanceDelay = 75;


### PR DESCRIPTION
This PR updates the `TooltipAnchor` to enforce tooltip behavior:
1. Only one tooltip visible at a time
2. Delay first tooltip appearance by 100ms
3. Delay last tooltip disappearance by 75ms
4. Switch tooltips instantly if going from one to another
