### PR TITLE
Implement a11y solution

### DIFF
--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -424,6 +424,7 @@ exports[`wonder-blocks-core example 6 1`] = `
       </span>
     </button>
     <div
+      aria-hidden="true"
       className=""
       style={
         Object {
@@ -445,6 +446,7 @@ exports[`wonder-blocks-core example 6 1`] = `
     />
   </div>
   <div
+    aria-hidden="true"
     className=""
     style={
       Object {
@@ -621,6 +623,7 @@ exports[`wonder-blocks-core example 7 1`] = `
     </span>
   </div>
   <div
+    aria-hidden="true"
     className=""
     style={
       Object {
@@ -908,6 +911,7 @@ exports[`wonder-blocks-core example 9 1`] = `
     }
   >
     <div
+      aria-hidden="true"
       className=""
       style={
         Object {

--- a/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
@@ -36,6 +36,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     A
   </button>
   <div
+    aria-hidden="true"
     className=""
     style={
       Object {
@@ -74,6 +75,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     B
   </button>
   <div
+    aria-hidden="true"
     className=""
     style={
       Object {
@@ -112,6 +114,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     C
   </button>
   <div
+    aria-hidden="true"
     className=""
     style={
       Object {
@@ -146,6 +149,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     Cancel
   </button>
   <div
+    aria-hidden="true"
     className=""
     style={
       Object {

--- a/packages/wonder-blocks-layout/components/spring.js
+++ b/packages/wonder-blocks-layout/components/spring.js
@@ -11,7 +11,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 
 export default class Spring extends React.Component<{}> {
     render() {
-        return <View style={styles.grow} />;
+        return <View aria-hidden="true" style={styles.grow} />;
     }
 }
 

--- a/packages/wonder-blocks-layout/components/strut.js
+++ b/packages/wonder-blocks-layout/components/strut.js
@@ -14,7 +14,7 @@ type Props = {
 
 export default class Strut extends React.Component<Props> {
     render() {
-        return <View style={flexBasis(this.props.size)} />;
+        return <View aria-hidden="true" style={flexBasis(this.props.size)} />;
     }
 }
 

--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -1375,7 +1375,6 @@ exports[`wonder-blocks-tooltip example 13 1`] = `
   <div
     className=""
     data-placement="top"
-    id={undefined}
     role="tooltip"
     style={
       Object {
@@ -1564,7 +1563,6 @@ exports[`wonder-blocks-tooltip example 14 1`] = `
   <div
     className=""
     data-placement="right"
-    id={undefined}
     role="tooltip"
     style={
       Object {
@@ -1753,7 +1751,6 @@ exports[`wonder-blocks-tooltip example 15 1`] = `
   <div
     className=""
     data-placement="bottom"
-    id={undefined}
     role="tooltip"
     style={
       Object {
@@ -1914,7 +1911,6 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
   <div
     className=""
     data-placement="left"
-    id={undefined}
     role="tooltip"
     style={
       Object {
@@ -2103,7 +2099,6 @@ exports[`wonder-blocks-tooltip example 17 1`] = `
   <div
     className=""
     data-placement="bottom"
-    id={undefined}
     role="tooltip"
     style={
       Object {
@@ -2265,7 +2260,6 @@ exports[`wonder-blocks-tooltip example 18 1`] = `
   <div
     className=""
     data-placement="top"
-    id={undefined}
     role="tooltip"
     style={
       Object {

--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`wonder-blocks-tooltip example 1 1`] = `
 <span
+  aria-describedby="uid-tooltip-0-aria-content"
   className=""
   style={
     Object {
@@ -35,7 +36,9 @@ exports[`wonder-blocks-tooltip example 2 1`] = `
   }
 >
   Some text
-  <input />
+  <input
+    aria-describedby="my-a11y-tooltip"
+  />
 </div>
 `;
 
@@ -116,6 +119,7 @@ exports[`wonder-blocks-tooltip example 3 1`] = `
       >
         This is a big long piece of text with a
         <span
+          aria-describedby="uid-tooltip-1-aria-content"
           className=""
           style={
             Object {
@@ -220,6 +224,7 @@ exports[`wonder-blocks-tooltip example 5 1`] = `
     }
   >
     <div
+      aria-describedby="uid-tooltip-2-aria-content"
       className=""
       style={
         Object {
@@ -245,6 +250,7 @@ exports[`wonder-blocks-tooltip example 5 1`] = `
       A
     </div>
     <div
+      aria-describedby="uid-tooltip-3-aria-content"
       className=""
       style={
         Object {
@@ -270,6 +276,7 @@ exports[`wonder-blocks-tooltip example 5 1`] = `
       B
     </div>
     <div
+      aria-describedby="uid-tooltip-4-aria-content"
       className=""
       style={
         Object {
@@ -295,6 +302,7 @@ exports[`wonder-blocks-tooltip example 5 1`] = `
       C
     </div>
     <div
+      aria-describedby="uid-tooltip-5-aria-content"
       className=""
       style={
         Object {
@@ -401,6 +409,7 @@ exports[`wonder-blocks-tooltip example 7 1`] = `
     Title text!
   </h4>
   <div
+    aria-hidden="true"
     className=""
     style={
       Object {
@@ -480,6 +489,7 @@ exports[`wonder-blocks-tooltip example 8 1`] = `
     Body text title!
   </span>
   <div
+    aria-hidden="true"
     className=""
     style={
       Object {
@@ -722,6 +732,7 @@ exports[`wonder-blocks-tooltip example 9 1`] = `
       }
     />
     <div
+      aria-hidden="true"
       className=""
       style={
         Object {
@@ -849,6 +860,7 @@ exports[`wonder-blocks-tooltip example 10 1`] = `
       }
     />
     <div
+      aria-hidden="true"
       className=""
       style={
         Object {
@@ -1056,6 +1068,7 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
       }
     />
     <div
+      aria-hidden="true"
       className=""
       style={
         Object {
@@ -1315,6 +1328,7 @@ exports[`wonder-blocks-tooltip example 12 1`] = `
       }
     />
     <div
+      aria-hidden="true"
       className=""
       style={
         Object {
@@ -1361,6 +1375,8 @@ exports[`wonder-blocks-tooltip example 13 1`] = `
   <div
     className=""
     data-placement="top"
+    id={undefined}
+    role="tooltip"
     style={
       Object {
         "alignItems": "stretch",
@@ -1548,6 +1564,8 @@ exports[`wonder-blocks-tooltip example 14 1`] = `
   <div
     className=""
     data-placement="right"
+    id={undefined}
+    role="tooltip"
     style={
       Object {
         "alignItems": "stretch",
@@ -1735,6 +1753,8 @@ exports[`wonder-blocks-tooltip example 15 1`] = `
   <div
     className=""
     data-placement="bottom"
+    id={undefined}
+    role="tooltip"
     style={
       Object {
         "alignItems": "stretch",
@@ -1894,6 +1914,8 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
   <div
     className=""
     data-placement="left"
+    id={undefined}
+    role="tooltip"
     style={
       Object {
         "alignItems": "stretch",
@@ -2081,6 +2103,8 @@ exports[`wonder-blocks-tooltip example 17 1`] = `
   <div
     className=""
     data-placement="bottom"
+    id={undefined}
+    role="tooltip"
     style={
       Object {
         "alignItems": "stretch",
@@ -2241,6 +2265,8 @@ exports[`wonder-blocks-tooltip example 18 1`] = `
   <div
     className=""
     data-placement="top"
+    id={undefined}
+    role="tooltip"
     style={
       Object {
         "alignItems": "stretch",

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
@@ -32,7 +32,10 @@ export type TooltipBubbleProps = {|
 |};
 
 export type Props = {|
-    /** The `TooltipContent` element that will be rendered in the bubble.*/
+    /** The unique identifier for this component. */
+    id: string,
+
+    /** The `TooltipContent` element that will be rendered in the bubble. */
     children: React.Element<typeof TooltipContent>,
     ...TooltipBubbleProps,
 |};
@@ -40,6 +43,7 @@ export type Props = {|
 export default class TooltipBubble extends React.Component<Props> {
     render() {
         const {
+            id,
             children,
             updateBubbleRef,
             placement,
@@ -51,6 +55,8 @@ export default class TooltipBubble extends React.Component<Props> {
 
         return (
             <View
+                id={id}
+                role="tooltip"
                 data-placement={placement}
                 ref={updateBubbleRef}
                 style={[

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
@@ -32,6 +32,7 @@ describe("TooltipBubble", () => {
             const nodes = (
                 <View>
                     <TooltipBubble
+                        id="bubble"
                         placement={props.placement}
                         tailOffset={props.tailOffset}
                         updateBubbleRef={assert}

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
@@ -52,7 +52,7 @@ describe("TooltipPopper", () => {
         const arrange = (actAssert) => {
             const nodes = (
                 <View>
-                    <TestHarness placement={"bottom"} resultRef={actAssert} />
+                    <TestHarness placement="bottom" resultRef={actAssert} />
                 </View>
             );
             mount(nodes);

--- a/packages/wonder-blocks-tooltip/components/tooltip-tail.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-tail.js
@@ -164,8 +164,8 @@ export default class TooltipTail extends React.Component<Props> {
                 // draw based on its parent size. i.e. 2 times bigger.
                 // This is so that the diffuse gaussian blur has space to
                 // bleed into.
-                width={"200%"}
-                height={"200%"}
+                width="200%"
+                height="200%"
                 // The x and y values tell the filter where, relative to its
                 // parent, it should begin showing its canvas. Without these
                 // the filter would clip at 0,0, which would look really

--- a/packages/wonder-blocks-tooltip/components/tooltip-tail.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-tail.test.js
@@ -47,7 +47,7 @@ describe("TooltipTail", () => {
             const fakePlacement = (("notaplacement": any): Placement);
             // We need an instance so let's make one with a valid placement so
             // that we can render it.
-            const nodes = <TooltipTail placement={"top"} />;
+            const nodes = <TooltipTail placement="top" />;
             const wrapper = shallow(nodes);
             const tailInstance = wrapper.instance();
             // Sneakily change props so as not to re-render.
@@ -73,7 +73,7 @@ describe("TooltipTail", () => {
             const fakePlacement = (("notaplacement": any): Placement);
             // We need an instance so let's make one with a valid placement so
             // that we can render it.
-            const nodes = <TooltipTail placement={"top"} />;
+            const nodes = <TooltipTail placement="top" />;
             const wrapper = shallow(nodes);
             const tailInstance = wrapper.instance();
             // Sneakily change props so as not to re-render.
@@ -100,7 +100,7 @@ describe("TooltipTail", () => {
             const fakePlacement = (("notaplacement": any): Placement);
             // We need an instance so let's make one with a valid placement so
             // that we can render it.
-            const nodes = <TooltipTail placement={"top"} />;
+            const nodes = <TooltipTail placement="top" />;
             const wrapper = shallow(nodes);
             const tailInstance = wrapper.instance();
 

--- a/packages/wonder-blocks-tooltip/components/tooltip.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip.md
@@ -3,7 +3,7 @@
 ```js
 const React = require("react");
 
-<Tooltip content={"This is a text tooltip on the right"} placement="right">
+<Tooltip content="This is a text tooltip on the right" placement="right">
     Some text
 </Tooltip>
 ```
@@ -19,8 +19,8 @@ const {View} = require("@khanacademy/wonder-blocks-core");
 <Tooltip
     id="my-a11y-tooltip"
     forceAnchorFocusivity={false}
-    title={"This tooltip has a title"}
-    content={"I'm at the top!"}
+    title="This tooltip has a title"
+    content="I'm at the top!"
 >
     <View>
         Some text
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
         <View style={styles.hostbox}>
             <Body>
                 This is a big long piece of text with a
-                <Tooltip content={"This tooltip will disappear when scrolled out of bounds"} placement={"bottom"}>
+                <Tooltip content="This tooltip will disappear when scrolled out of bounds" placement="bottom">
                     [tooltip]
                 </Tooltip>
                 <span> </span>in the middle.
@@ -92,7 +92,7 @@ const styles = StyleSheet.create({
 const scrollyContent = (
      <View style={styles.scrollbox}>
         <View style={styles.hostbox}>
-            <Tooltip content={"I'm on the left!"} placement="left">
+            <Tooltip content="I'm on the left!" placement="left">
                 tooltip
             </Tooltip>
         </View>
@@ -140,16 +140,16 @@ const styles = StyleSheet.create({
     <LabelSmall>Here, we can see that the first tooltip shown has an initial delay before it appears, as does the last tooltip shown, yet when moving between tooltipped items, the transition from one to another is instantaneous.</LabelSmall>
 
     <View style={{flexDirection: "row"}}>
-        <Tooltip content={"Tooltip A"} placement="bottom">
+        <Tooltip content="Tooltip A" placement="bottom">
             <View style={styles.block}>A</View>
         </Tooltip>
-        <Tooltip content={"Tooltip B"} placement="bottom">
+        <Tooltip content="Tooltip B" placement="bottom">
             <View style={styles.block}>B</View>
         </Tooltip>
-        <Tooltip content={"Tooltip C"} placement="bottom">
+        <Tooltip content="Tooltip C" placement="bottom">
             <View style={styles.block}>C</View>
         </Tooltip>
-        <Tooltip content={"Tooltip D"} placement="bottom">
+        <Tooltip content="Tooltip D" placement="bottom">
             <View style={styles.block}>D</View>
         </Tooltip>
     </View>

--- a/packages/wonder-blocks-tooltip/components/tooltip.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip.md
@@ -3,28 +3,34 @@
 ```js
 const React = require("react");
 
-<Tooltip content={"I'm on the right!"} placement="right">
+<Tooltip content={"This is a text tooltip on the right"} placement="right">
     Some text
 </Tooltip>
 ```
 
-### Complex anchor & text tooltip & placement default (top)
+### Complex anchor & title tooltip & placement default (top)
 
-In this example, we're no longer forcing the anchor root to be focusable, since the text input can take focus.
+In this example, we're no longer forcing the anchor root to be focusable, since the text input can take focus. However, that needs a custom accessibility implementation too (for that, we should use `UniqueIDProvider`, but we'll cheat here and just give our own identifier).
 
 ```js
 const React = require("react");
 const {View} = require("@khanacademy/wonder-blocks-core");
 
-<Tooltip forceAnchorFocusivity={false} content={"I'm at the top!"}>
+<Tooltip
+    id="my-a11y-tooltip"
+    forceAnchorFocusivity={false}
+    title={"This tooltip has a title"}
+    content={"I'm at the top!"}
+>
     <View>
         Some text
-        <input />
+        <input aria-describedby="my-a11y-tooltip" />
     </View>
 </Tooltip>
 ```
 
 ### Substring anchor in scrollable parent & placement bottom
+In this example, we have the anchor in a scrollable parent. Notice how, when the anchor is focused but scrolled out of bounds, the tooltip disappears.
 
 ```js
 const {StyleSheet} = require("aphrodite");
@@ -49,7 +55,7 @@ const styles = StyleSheet.create({
         <View style={styles.hostbox}>
             <Body>
                 This is a big long piece of text with a
-                <Tooltip content={"I'm on the bottom!"} placement={"bottom"}>
+                <Tooltip content={"This tooltip will disappear when scrolled out of bounds"} placement={"bottom"}>
                     [tooltip]
                 </Tooltip>
                 <span> </span>in the middle.
@@ -60,6 +66,7 @@ const styles = StyleSheet.create({
 ```
 
 ### Tooltip in a modal & placement left
+This checks that the tooltip works how we want inside a modal. Click the button to take a look.
 
 ```js
 const {StyleSheet} = require("aphrodite");

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -18,7 +18,10 @@ describe("wonder-blocks-tooltip", () => {
         const React = require("react");
 
         const example = (
-            <Tooltip content={"I'm on the right!"} placement="right">
+            <Tooltip
+                content={"This is a text tooltip on the right"}
+                placement="right"
+            >
                 Some text
             </Tooltip>
         );
@@ -30,10 +33,15 @@ describe("wonder-blocks-tooltip", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
 
         const example = (
-            <Tooltip forceAnchorFocusivity={false} content={"I'm at the top!"}>
+            <Tooltip
+                id="my-a11y-tooltip"
+                forceAnchorFocusivity={false}
+                title={"This tooltip has a title"}
+                content={"I'm at the top!"}
+            >
                 <View>
                     Some text
-                    <input />
+                    <input aria-describedby="my-a11y-tooltip" />
                 </View>
             </Tooltip>
         );
@@ -65,7 +73,9 @@ describe("wonder-blocks-tooltip", () => {
                         <Body>
                             This is a big long piece of text with a
                             <Tooltip
-                                content={"I'm on the bottom!"}
+                                content={
+                                    "This tooltip will disappear when scrolled out of bounds"
+                                }
                                 placement={"bottom"}
                             >
                                 [tooltip]

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -19,7 +19,7 @@ describe("wonder-blocks-tooltip", () => {
 
         const example = (
             <Tooltip
-                content={"This is a text tooltip on the right"}
+                content="This is a text tooltip on the right"
                 placement="right"
             >
                 Some text
@@ -36,8 +36,8 @@ describe("wonder-blocks-tooltip", () => {
             <Tooltip
                 id="my-a11y-tooltip"
                 forceAnchorFocusivity={false}
-                title={"This tooltip has a title"}
-                content={"I'm at the top!"}
+                title="This tooltip has a title"
+                content="I'm at the top!"
             >
                 <View>
                     Some text
@@ -73,10 +73,8 @@ describe("wonder-blocks-tooltip", () => {
                         <Body>
                             This is a big long piece of text with a
                             <Tooltip
-                                content={
-                                    "This tooltip will disappear when scrolled out of bounds"
-                                }
-                                placement={"bottom"}
+                                content="This tooltip will disappear when scrolled out of bounds"
+                                placement="bottom"
                             >
                                 [tooltip]
                             </Tooltip>
@@ -116,7 +114,7 @@ describe("wonder-blocks-tooltip", () => {
         const scrollyContent = (
             <View style={styles.scrollbox}>
                 <View style={styles.hostbox}>
-                    <Tooltip content={"I'm on the left!"} placement="left">
+                    <Tooltip content="I'm on the left!" placement="left">
                         tooltip
                     </Tooltip>
                 </View>
@@ -172,16 +170,16 @@ describe("wonder-blocks-tooltip", () => {
                 </LabelSmall>
 
                 <View style={{flexDirection: "row"}}>
-                    <Tooltip content={"Tooltip A"} placement="bottom">
+                    <Tooltip content="Tooltip A" placement="bottom">
                         <View style={styles.block}>A</View>
                     </Tooltip>
-                    <Tooltip content={"Tooltip B"} placement="bottom">
+                    <Tooltip content="Tooltip B" placement="bottom">
                         <View style={styles.block}>B</View>
                     </Tooltip>
-                    <Tooltip content={"Tooltip C"} placement="bottom">
+                    <Tooltip content="Tooltip C" placement="bottom">
                         <View style={styles.block}>C</View>
                     </Tooltip>
-                    <Tooltip content={"Tooltip D"} placement="bottom">
+                    <Tooltip content="Tooltip D" placement="bottom">
                         <View style={styles.block}>D</View>
                     </Tooltip>
                 </View>


### PR DESCRIPTION
This PR adds our main accessibility feature to the tooltip. It is stacked on #190 so that the next PR can add testing for everything in the `Tooltip` component and make use of the testing utilities introduced in #188.

Here we add an identifier to the `TooltipBubble` and then force the anchor point to have `aria-describedby` that points to that identifier. This means when the anchor gets focused, assistive tech will give the tooltip content as additional information.

This also adds `aria-hidden` to `Spring` and `Strut`, as well as provide an escape hatch on the `Tooltip` for situations where a more complex or different accessibility solution is required.

NOTE: Additional test coverage to be added in separate PR.