### PR TITLE
add flow types for react-router-dom

### DIFF
--- a/flow-typed/npm/react-router-dom_v4.x.x.js
+++ b/flow-typed/npm/react-router-dom_v4.x.x.js
@@ -1,0 +1,178 @@
+// flow-typed signature: 1b2e974f9f683ce53055f7c3d60c59c5
+// flow-typed version: e94381d642/react-router-dom_v4.x.x/flow_>=v0.63.x
+
+declare module "react-router-dom" {
+    declare export class BrowserRouter extends React$Component<{|
+        basename?: string,
+        forceRefresh?: boolean,
+        getUserConfirmation?: GetUserConfirmation,
+        keyLength?: number,
+        children?: React$Node,
+    |}> {}
+
+    declare export class HashRouter extends React$Component<{|
+        basename?: string,
+        getUserConfirmation?: GetUserConfirmation,
+        hashType?: "slash" | "noslash" | "hashbang",
+        children?: React$Node,
+    |}> {}
+
+    declare export class Link extends React$Component<{
+        className?: string,
+        to: string | LocationShape,
+        replace?: boolean,
+        children?: React$Node,
+    }> {}
+
+    declare export class NavLink extends React$Component<{
+        to: string | LocationShape,
+        activeClassName?: string,
+        className?: string,
+        activeStyle?: Object,
+        style?: Object,
+        isActive?: (match: Match, location: Location) => boolean,
+        children?: React$Node,
+        exact?: boolean,
+        strict?: boolean,
+    }> {}
+
+    // NOTE: Below are duplicated from react-router. If updating these, please
+    // update the react-router and react-router-native types as well.
+    declare export type Location = {
+        pathname: string,
+        search: string,
+        hash: string,
+        state?: any,
+        key?: string,
+    };
+
+    declare export type LocationShape = {
+        pathname?: string,
+        search?: string,
+        hash?: string,
+        state?: any,
+    };
+
+    declare export type HistoryAction = "PUSH" | "REPLACE" | "POP";
+
+    declare export type RouterHistory = {
+        length: number,
+        location: Location,
+        action: HistoryAction,
+        listen(
+            callback: (location: Location, action: HistoryAction) => void,
+        ): () => void,
+        push(path: string | LocationShape, state?: any): void,
+        replace(path: string | LocationShape, state?: any): void,
+        go(n: number): void,
+        goBack(): void,
+        goForward(): void,
+        canGo?: (n: number) => boolean,
+        block(
+            callback: (location: Location, action: HistoryAction) => boolean,
+        ): void,
+        // createMemoryHistory
+        index?: number,
+        entries?: Array<Location>,
+    };
+
+    declare export type Match = {
+        params: {[key: string]: ?string},
+        isExact: boolean,
+        path: string,
+        url: string,
+    };
+
+    declare export type ContextRouter = {|
+        history: RouterHistory,
+        location: Location,
+        match: Match,
+        staticContext?: StaticRouterContext,
+    |};
+
+    declare type ContextRouterVoid = {
+        history: RouterHistory | void,
+        location: Location | void,
+        match: Match | void,
+        staticContext?: StaticRouterContext | void,
+    };
+
+    declare export type GetUserConfirmation = (
+        message: string,
+        callback: (confirmed: boolean) => void,
+    ) => void;
+
+    declare export type StaticRouterContext = {
+        url?: string,
+    };
+
+    declare export class StaticRouter extends React$Component<{|
+        basename?: string,
+        location?: string | Location,
+        context: StaticRouterContext,
+        children?: React$Node,
+    |}> {}
+
+    declare export class MemoryRouter extends React$Component<{|
+        initialEntries?: Array<LocationShape | string>,
+        initialIndex?: number,
+        getUserConfirmation?: GetUserConfirmation,
+        keyLength?: number,
+        children?: React$Node,
+    |}> {}
+
+    declare export class Router extends React$Component<{|
+        history: RouterHistory,
+        children?: React$Node,
+    |}> {}
+
+    declare export class Prompt extends React$Component<{|
+        message: string | ((location: Location) => string | boolean),
+        when?: boolean,
+    |}> {}
+
+    declare export class Redirect extends React$Component<{|
+        to: string | LocationShape,
+        push?: boolean,
+        from?: string,
+        exact?: boolean,
+        strict?: boolean,
+    |}> {}
+
+    declare export class Route extends React$Component<{|
+        component?: React$ComponentType<*>,
+        render?: (router: ContextRouter) => React$Node,
+        children?: React$ComponentType<ContextRouter> | React$Node,
+        path?: string,
+        exact?: boolean,
+        strict?: boolean,
+        location?: LocationShape,
+        sensitive?: boolean,
+    |}> {}
+
+    declare export class Switch extends React$Component<{|
+        children?: React$Node,
+        location?: Location,
+    |}> {}
+
+    declare export function withRouter<
+        P: {},
+        Component: React$ComponentType<P>,
+    >(
+        WrappedComponent: Component,
+    ): React$ComponentType<
+        $Diff<React$ElementConfig<Component>, ContextRouterVoid>,
+    >;
+
+    declare type MatchPathOptions = {
+        path?: string,
+        exact?: boolean,
+        sensitive?: boolean,
+        strict?: boolean,
+    };
+
+    declare export function matchPath(
+        pathname: string,
+        options?: MatchPathOptions | string,
+    ): null | Match;
+}

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -23,6 +23,7 @@ type Props = {|
 
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");
+// $FlowFixMe: pass props directly to StyledLink instead of to Tag
 const StyledLink = addStyle(Link);
 
 export default class ButtonCore extends React.Component<Props> {

--- a/packages/wonder-blocks-core/util/get-clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/util/get-clickable-behavior.test.js
@@ -54,7 +54,7 @@ describe("getClickableBehavior", () => {
                     // Arrange
                     const url = "/prep/lsat";
                     const clientNav = undefined;
-                    const router = <MemoryRouter history={[]} />;
+                    const router = <MemoryRouter />;
                     const expectation = "withRouter(ClickableBehavior)";
 
                     // Act

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -72,6 +72,7 @@ type ActionProps = {|
 
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");
+// $FlowFixMe: need to ensure we're passing 'to' to Link in a way that flow understands
 const StyledLink = addStyle(Link);
 
 export default class ActionItem extends React.Component<ActionProps> {

--- a/packages/wonder-blocks-link/components/link-core.js
+++ b/packages/wonder-blocks-link/components/link-core.js
@@ -19,6 +19,7 @@ type Props = {|
 |};
 
 const StyledAnchor = addStyle("a");
+// $FlowFixMe: pass props directly to StyledLink instead of to Tag
 const StyledLink = addStyle(Link);
 
 export default class LinkCore extends React.Component<Props> {


### PR DESCRIPTION
This improves flow coverage in clickable-behaviour.js.  We still need to refactor the render method so that flow can better understand which props are going to which components that are being rendered.