### PR TITLE
Add tests for tooltip.js and tidy up testing

### DIFF
--- a/packages/wonder-blocks-core/components/no-ssr.test.js
+++ b/packages/wonder-blocks-core/components/no-ssr.test.js
@@ -2,11 +2,15 @@
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 
-import {mount} from "enzyme";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import NoSSR from "./no-ssr.js";
 
 describe("NoSSR", () => {
+    beforeEach(() => {
+        unmountAll();
+    });
+
     test("renders a placeholder first, then the actual content", (done) => {
         // Arrange
         const mockPlaceholder = jest.fn(() => null);

--- a/packages/wonder-blocks-core/components/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 
-import {mount} from "enzyme";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import View from "./view.js";
 
@@ -11,6 +11,10 @@ import UniqueIDFactory from "../util/unique-id-factory.js";
 import UniqueIDProvider from "./unique-id-provider.js";
 
 describe("UniqueIDProvider", () => {
+    beforeEach(() => {
+        unmountAll();
+    });
+
     describe("mockOnFirstRender is default (false)", () => {
         test("initial render is nothing on server", () => {
             // Arrange

--- a/packages/wonder-blocks-core/util/enumerate-scroll-ancestors.test.js
+++ b/packages/wonder-blocks-core/util/enumerate-scroll-ancestors.test.js
@@ -1,11 +1,15 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {mount} from "enzyme";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import enumerateScrollAncestors from "./enumerate-scroll-ancestors.js";
 
 describe("enumerateScrollAncestors", () => {
+    beforeEach(() => {
+        unmountAll();
+    });
+
     test("@@iterator() method returns iterator", () => {
         // Arrange
         const enumerator = enumerateScrollAncestors((null: any));

--- a/packages/wonder-blocks-tooltip/components/__snapshots__/tooltip.test.js.snap
+++ b/packages/wonder-blocks-tooltip/components/__snapshots__/tooltip.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tooltip content is TooltipContent with title, overrides title of TooltipContent: Similar to <Body>Some custom content</Body> 1`] = `
+<Body
+  tag="span"
+>
+  Some custom content
+</Body>
+`;
+
+exports[`Tooltip content is TooltipContent with title, sets title of TooltipContent: Similar to <HeadingSmall>Some custom content</HeadingSmall> 1`] = `
+<HeadingSmall
+  tag="h4"
+>
+  Some custom content
+</HeadingSmall>
+`;
+
+exports[`Tooltip content is TooltipContent with title, sets title of TooltipContent: Similar to <HeadingSmall>Title</HeadingSmall> 1`] = `
+<HeadingSmall
+  tag="h4"
+>
+  Title
+</HeadingSmall>
+`;
+
+exports[`Tooltip content is TooltipContent without title, renders content as-is: <Body>Some custom content</Body> 1`] = `
+<Body
+  tag="span"
+>
+  Some custom content
+</Body>
+`;
+
+exports[`Tooltip content is a string, wraps in TooltipContent with title: Similar to <TooltipContent title="Title">Content</TooltipContent> 1`] = `
+<TooltipContent
+  title="Title"
+>
+  Content
+</TooltipContent>
+`;
+
+exports[`Tooltip content is a string, wraps in TooltipContent without title: Similar to <TooltipContent>Content</TooltipContent> 1`] = `
+<TooltipContent>
+  Content
+</TooltipContent>
+`;

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.js
@@ -37,6 +37,8 @@ export type Props = {|
 
     /** The `TooltipContent` element that will be rendered in the bubble. */
     children: React.Element<typeof TooltipContent>,
+    // TODO(somewhatabstract): Update react-docgen to support spread operators
+    // (v3 beta introduces this)
     ...TooltipBubbleProps,
 |};
 

--- a/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-bubble.test.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {mount} from "enzyme";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import TooltipBubble from "./tooltip-bubble.js";
@@ -15,6 +15,10 @@ describe("TooltipBubble", () => {
             top: 0,
             left: 50,
         },
+    });
+
+    beforeEach(() => {
+        unmountAll();
     });
 
     test("updates reference to bubble container", (done) => {

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {mount} from "enzyme";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import TooltipBubble from "./tooltip-bubble.js";
@@ -42,6 +42,10 @@ class TestHarness extends React.Component<*, {ref: ?HTMLElement}> {
 }
 
 describe("TooltipPopper", () => {
+    beforeEach(() => {
+        unmountAll();
+    });
+
     // The TooltipPopper component is just a wrapper around react-popper.
     // PopperJS requires full visual rendering and we don't do that here as
     // we're not in a browser.

--- a/packages/wonder-blocks-tooltip/components/tooltip.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip.js
@@ -85,8 +85,11 @@ type Props = {|
      */
     forceAnchorFocusivity?: boolean,
 
-    /** Where the tooltip should appear in relation to the anchor element. */
-    placement?: Placement,
+    /**
+     * Where the tooltip should appear in relation to the anchor element.
+     * Defaults to "top".
+     */
+    placement: Placement,
 |};
 
 type State = {|
@@ -152,7 +155,7 @@ export default class Tooltip extends React.Component<Props, State> {
         return (
             <TooltipPopper
                 anchorElement={this.state.anchorElement}
-                placement={placement || Tooltip.defaultProps.placement}
+                placement={placement}
             >
                 {(props) => (
                     <TooltipBubble

--- a/packages/wonder-blocks-tooltip/components/tooltip.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip.test.js
@@ -1,4 +1,397 @@
-//@flow
+// @flow
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+
+import Tooltip from "./tooltip.js";
+import TooltipBubble from "./tooltip-bubble.js";
+import TooltipContent from "./tooltip-content.js";
+
+const mockIDENTIFIER = "mock-identifier";
+
+jest.mock("./tooltip-bubble.js");
+jest.mock("@khanacademy/wonder-blocks-core", () => {
+    const Core = jest.requireActual("@khanacademy/wonder-blocks-core");
+    // We want all of Core to be the regular thing except for UniqueIDProvider
+    return {
+        ...Core,
+        UniqueIDProvider: (props) =>
+            props.children({
+                get: () => mockIDENTIFIER,
+            }),
+    };
+});
+
 describe("Tooltip", () => {
-    test("TODO", () => {});
+    beforeEach(() => {
+        unmountAll();
+        jest.clearAllMocks();
+        jest.clearAllTimers();
+        jest.useFakeTimers();
+    });
+
+    describe("content is a string, wraps in TooltipContent", () => {
+        test("with title", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                const nodes = (
+                    <View>
+                        <Tooltip id="tooltip" title="Title" content="Content">
+                            <View ref={resolve}>Anchor</View>
+                        </Tooltip>
+                    </View>
+                );
+                mount(nodes);
+            });
+            const node = (ReactDOM.findDOMNode(ref): any);
+            node && node.dispatchEvent(new FocusEvent("focusin"));
+            jest.runOnlyPendingTimers();
+
+            // Act
+            // Flow doesn't like jest mocks $FlowFixMe
+            const result = TooltipBubble.mock.instances[0].props["children"];
+
+            // Assert
+            expect(result).toMatchSnapshot(
+                `Similar to <TooltipContent title="Title">Content</TooltipContent>`,
+            );
+        });
+
+        test("without title", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                const nodes = (
+                    <View>
+                        <Tooltip id="tooltip" content="Content">
+                            <View ref={resolve}>Anchor</View>
+                        </Tooltip>
+                    </View>
+                );
+                mount(nodes);
+            });
+            const node = (ReactDOM.findDOMNode(ref): any);
+            node && node.dispatchEvent(new FocusEvent("focusin"));
+            jest.runOnlyPendingTimers();
+
+            // Act
+            // Flow doesn't like jest mocks $FlowFixMe
+            const result = TooltipBubble.mock.instances[0].props["children"];
+
+            // Assert
+            expect(result).toMatchSnapshot(
+                `Similar to <TooltipContent>Content</TooltipContent>`,
+            );
+        });
+    });
+
+    describe("content is TooltipContent", () => {
+        test("with title, sets title of TooltipContent", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                const content = (
+                    <TooltipContent>
+                        <HeadingSmall>Some custom content</HeadingSmall>
+                    </TooltipContent>
+                );
+                const title = <HeadingSmall>Title</HeadingSmall>;
+                const nodes = (
+                    <View>
+                        <Tooltip id="tooltip" title={title} content={content}>
+                            <View ref={resolve}>Anchor</View>
+                        </Tooltip>
+                    </View>
+                );
+                mount(nodes);
+            });
+            const node = (ReactDOM.findDOMNode(ref): any);
+            node && node.dispatchEvent(new KeyboardEvent("focusin"));
+            jest.runOnlyPendingTimers();
+
+            // Act
+            // Flow doesn't like jest mocks $FlowFixMe
+            const result = TooltipBubble.mock.instances[0].props["children"];
+
+            // Assert
+            expect(result.props["title"]).toMatchSnapshot(
+                `Similar to <HeadingSmall>Title</HeadingSmall>`,
+            );
+            expect(result.props["children"]).toMatchSnapshot(
+                `Similar to <HeadingSmall>Some custom content</HeadingSmall>`,
+            );
+        });
+
+        test("with title, overrides title of TooltipContent", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                const content = (
+                    <TooltipContent title="Content title">
+                        <Body>Some custom content</Body>
+                    </TooltipContent>
+                );
+                const nodes = (
+                    <View>
+                        <Tooltip id="tooltip" title="Title" content={content}>
+                            <View ref={resolve}>Anchor</View>
+                        </Tooltip>
+                    </View>
+                );
+                mount(nodes);
+            });
+            const node = (ReactDOM.findDOMNode(ref): any);
+            node && node.dispatchEvent(new KeyboardEvent("focusin"));
+            jest.runOnlyPendingTimers();
+
+            // Act
+            // Flow doesn't like jest mocks $FlowFixMe
+            const result = TooltipBubble.mock.instances[0].props["children"];
+
+            // Assert
+            expect(result.props["title"]).toBe("Title");
+            expect(result.props["children"]).toMatchSnapshot(
+                `Similar to <Body>Some custom content</Body>`,
+            );
+        });
+
+        test("without title, renders content as-is", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                const content = (
+                    <TooltipContent title="Content title">
+                        <Body>Some custom content</Body>
+                    </TooltipContent>
+                );
+                const nodes = (
+                    <View>
+                        <Tooltip id="tooltip" content={content}>
+                            <View ref={resolve}>Anchor</View>
+                        </Tooltip>
+                    </View>
+                );
+                mount(nodes);
+            });
+            const node = (ReactDOM.findDOMNode(ref): any);
+            node && node.dispatchEvent(new KeyboardEvent("focusin"));
+            jest.runOnlyPendingTimers();
+
+            // Act
+            // Flow doesn't like jest mocks $FlowFixMe
+            const result = TooltipBubble.mock.instances[0].props["children"];
+
+            // Assert
+            expect(result.props["title"]).toBe("Content title");
+            expect(result.props["children"]).toMatchSnapshot(
+                `<Body>Some custom content</Body>`,
+            );
+        });
+    });
+
+    describe("accessibility", () => {
+        test("no id, sets identifier of TooltipBubble with UniqueIDProvider", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                const nodes = (
+                    <View>
+                        <Tooltip content="Content">
+                            <View ref={resolve}>Anchor</View>
+                        </Tooltip>
+                    </View>
+                );
+                mount(nodes);
+            });
+            const node = (ReactDOM.findDOMNode(ref): any);
+            node && node.dispatchEvent(new KeyboardEvent("focusin"));
+            jest.runOnlyPendingTimers();
+
+            // Act
+            // Flow doesn't like jest mocks $FlowFixMe
+            const result = TooltipBubble.mock.instances[0].props["id"];
+
+            // Assert
+            expect(result).toBe(mockIDENTIFIER);
+        });
+
+        test("custom id, sets identifier of TooltipBubble", async () => {
+            // Arrange
+            const tooltipID = "tooltip-1";
+            const ref = await new Promise((resolve) => {
+                const nodes = (
+                    <View>
+                        <Tooltip id={tooltipID} title="Title" content="Content">
+                            <View ref={resolve}>Anchor</View>
+                        </Tooltip>
+                    </View>
+                );
+                mount(nodes);
+            });
+            const node = (ReactDOM.findDOMNode(ref): any);
+            node && node.dispatchEvent(new KeyboardEvent("focusin"));
+            jest.runOnlyPendingTimers();
+
+            // Act
+            // Flow doesn't like jest mocks $FlowFixMe
+            const result = TooltipBubble.mock.instances[0].props["id"];
+
+            // Assert
+            expect(result).toBe(tooltipID);
+        });
+
+        describe("text-only anchor", () => {
+            test("wraps with element", async () => {
+                // Arrange
+                const ref = await new Promise((resolve) => {
+                    const nodes = (
+                        <View>
+                            <Tooltip ref={resolve} content="Content">
+                                Anchor
+                            </Tooltip>
+                        </View>
+                    );
+                    mount(nodes);
+                });
+
+                // Act
+                const result = (ReactDOM.findDOMNode(ref): any);
+
+                // Assert
+                expect(result).toBeInstanceOf(HTMLSpanElement);
+                expect(result.innerHTML).toBe("Anchor");
+            });
+
+            test("id provided, does not attach aria-describedby", async () => {
+                // Arrange
+                const tooltipID = "tooltip-2";
+                const ref = await new Promise((resolve) => {
+                    const nodes = (
+                        <View>
+                            <Tooltip
+                                ref={resolve}
+                                id={tooltipID}
+                                content="Content"
+                            >
+                                Anchor
+                            </Tooltip>
+                        </View>
+                    );
+                    mount(nodes);
+                });
+                const node = (ReactDOM.findDOMNode(ref): any);
+
+                // Act
+                const result = node.getAttribute("aria-describedby");
+
+                // Assert
+                expect(result).toBeNull();
+            });
+
+            test("no id provided, attaches aria-describedby", async () => {
+                // Arrange
+                const ref = await new Promise((resolve) => {
+                    const nodes = (
+                        <View>
+                            <Tooltip ref={resolve} content="Content">
+                                Anchor
+                            </Tooltip>
+                        </View>
+                    );
+                    mount(nodes);
+                });
+                const node = (ReactDOM.findDOMNode(ref): any);
+
+                // Act
+                const result = node.getAttribute("aria-describedby");
+
+                // Assert
+                expect(result).toBe(mockIDENTIFIER);
+            });
+        });
+
+        describe("element anchor", () => {
+            test("does not wrap", async () => {
+                // Arrange
+                const anchor = (
+                    <View>
+                        <View>Anchor</View>
+                    </View>
+                );
+                const ref = await new Promise((resolve) => {
+                    const nodes = (
+                        <View>
+                            <Tooltip ref={resolve} content="Content">
+                                {anchor}
+                            </Tooltip>
+                        </View>
+                    );
+                    mount(nodes);
+                });
+
+                // Act
+                const result = (ReactDOM.findDOMNode(ref): any);
+
+                // Assert
+                expect(result).toBeInstanceOf(HTMLDivElement);
+                expect(result.innerHTML).not.toBe("Anchor");
+                expect(result.children[0].innerHTML).toBe("Anchor");
+            });
+
+            test("id provided, does not attach aria-describedby", async () => {
+                // Arrange
+                const anchor = (
+                    <View>
+                        <View>Anchor</View>
+                    </View>
+                );
+                const ref = await new Promise((resolve) => {
+                    const nodes = (
+                        <View>
+                            <Tooltip
+                                id="tooltip-3"
+                                ref={resolve}
+                                content="Content"
+                            >
+                                {anchor}
+                            </Tooltip>
+                        </View>
+                    );
+                    mount(nodes);
+                });
+                const node = (ReactDOM.findDOMNode(ref): any);
+
+                // Act
+                const result = node.getAttribute("aria-describedby");
+
+                // Assert
+                expect(result).toBeNull();
+            });
+
+            test("no id provided, attaches aria-describedby", async () => {
+                // Arrange
+                const anchor = (
+                    <View>
+                        <View>Anchor</View>
+                    </View>
+                );
+                const ref = await new Promise((resolve) => {
+                    const nodes = (
+                        <View>
+                            <Tooltip ref={resolve} content="Content">
+                                {anchor}
+                            </Tooltip>
+                        </View>
+                    );
+                    mount(nodes);
+                });
+                const node = (ReactDOM.findDOMNode(ref): any);
+
+                // Act
+                const result = node.getAttribute("aria-describedby");
+
+                // Assert
+                expect(result).toBe(mockIDENTIFIER);
+            });
+        });
+    });
 });

--- a/packages/wonder-blocks-tooltip/util/is-obscured.test.js
+++ b/packages/wonder-blocks-tooltip/util/is-obscured.test.js
@@ -4,7 +4,8 @@ import * as ReactDOM from "react-dom";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import {mount} from "enzyme";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
+
 import isObscured from "./is-obscured.js";
 
 describe("isObscured", () => {
@@ -12,12 +13,12 @@ describe("isObscured", () => {
     beforeEach(() => {
         // Some tests will want to mock this, so let's ensure we can reset it
         ogElementFromPoint = document.elementFromPoint;
+
+        unmountAll();
     });
 
     afterEach(() => {
         if (ogElementFromPoint) {
-            //eslint-disable-next-line no-console
-            console.log("Resetting elementFromPoint");
             const og = ogElementFromPoint;
             ogElementFromPoint = null;
             // Reset the document method to avoid side-effects.
@@ -37,178 +38,158 @@ describe("isObscured", () => {
         expect(underTest).toThrowError();
     });
 
-    test("element is not obscured by anything, returns false", (done) => {
-        const arrange = (actAndAssert) => {
+    test("element is not obscured by anything, returns false", async () => {
+        const ref = await new Promise((resolve) => {
             // Arrange
             const nodes = (
                 <View>
-                    <View ref={actAndAssert}>Unobscured</View>
+                    <View ref={resolve}>Unobscured</View>
                 </View>
             );
             mount(nodes);
-        };
+        });
 
-        const actAndAssert = (ref) => {
-            const element = ((ReactDOM.findDOMNode(ref): any): Element);
+        const element = ((ReactDOM.findDOMNode(ref): any): Element);
 
-            // When not obscurred, elementFromPoint should return the element.
-            // Flow doesn't like us doing this to the document $FlowFixMe
-            document.elementFromPoint = jest.fn().mockReturnValue(element);
+        // When not obscurred, elementFromPoint should return the element.
+        // Flow doesn't like us doing this to the document $FlowFixMe
+        document.elementFromPoint = jest.fn().mockReturnValue(element);
 
-            // Act
-            const result = isObscured(element);
+        // Act
+        const result = isObscured(element);
 
-            // Assert
-            expect(result).toBeFalsy();
-            done();
-        };
-
-        arrange(actAndAssert);
+        // Assert
+        expect(result).toBeFalsy();
     });
 
-    test("element is partially obscured, returns false", (done) => {
+    test("element is partially obscured, returns false", async () => {
         // Arrange
-        let otherRef = null;
-        const arrange = (actAndAssert) => {
+        const {ref, otherRef} = await new Promise((resolve) => {
+            let ref;
+            let otherRef;
+            const tryResolve = (r, or) => {
+                ref = ref || r;
+                otherRef = otherRef || or;
+                if (ref && otherRef) {
+                    resolve({ref, otherRef});
+                }
+            };
+
             const nodes = (
                 <View>
-                    <View ref={(ref) => (otherRef = ref)} />
-                    <View ref={actAndAssert}>Partially obscured</View>
+                    <View ref={(r) => tryResolve(null, r)} />
+                    <View ref={(r) => tryResolve(r, null)}>
+                        Partially obscured
+                    </View>
                 </View>
             );
             mount(nodes);
-        };
+        });
+        const element = ((ReactDOM.findDOMNode(ref): any): Element);
+        const otherElement = ((ReactDOM.findDOMNode(otherRef): any): Element);
+        // When not obscurred, elementFromPoint should return the element.
+        // So let's return the element for one corner but not the other.
+        // Flow doesn't like us doing this to the document $FlowFixMe
+        document.elementFromPoint = jest
+            .fn()
+            .mockImplementationOnce(() => element)
+            .mockImplementationOnce(() => otherElement);
 
-        const actAndAssert = (ref) => {
-            const element = ((ReactDOM.findDOMNode(ref): any): Element);
-            const otherElement = ((ReactDOM.findDOMNode(
-                otherRef,
-            ): any): Element);
-            // When not obscurred, elementFromPoint should return the element.
-            // So let's return the element for one corner but not the other.
-            // Flow doesn't like us doing this to the document $FlowFixMe
-            document.elementFromPoint = jest
-                .fn()
-                .mockImplementationOnce(() => element)
-                .mockImplementationOnce(() => otherElement);
+        // Act
+        const result = isObscured(element);
 
-            // Act
-            const result = isObscured(element);
-
-            // Assert
-            expect(result).toBeFalsy();
-            done();
-        };
-
-        arrange(actAndAssert);
+        // Assert
+        expect(result).toBeFalsy();
     });
 
-    test("element is obscured, returns true", (done) => {
+    test("element is obscured, returns true", async () => {
         // Arrange
-        let otherRef = null;
-        const arrange = (actAndAssert) => {
+        const {ref, otherRef} = await new Promise((resolve) => {
+            let ref;
+            let otherRef;
+            const tryResolve = (r, or) => {
+                ref = ref || r;
+                otherRef = otherRef || or;
+                if (ref && otherRef) {
+                    resolve({ref, otherRef});
+                }
+            };
+
             const nodes = (
                 <View>
-                    <View ref={(ref) => (otherRef = ref)}>
+                    <View ref={(r) => tryResolve(null, r)}>
                         Pretend this covers everything
                     </View>
-                    <View ref={actAndAssert}>Obscured</View>
+                    <View ref={(r) => tryResolve(r, null)}>Obscured</View>
                 </View>
             );
             mount(nodes);
-        };
+        });
+        const element = ((ReactDOM.findDOMNode(ref): any): Element);
+        const otherElement = ((ReactDOM.findDOMNode(otherRef): any): Element);
+        // When not obscurred, elementFromPoint should return the element.
+        // Flow doesn't like us doing this to the document $FlowFixMe
+        document.elementFromPoint = jest.fn().mockReturnValue(otherElement);
 
-        const actAndAssert = (ref) => {
-            const element = ((ReactDOM.findDOMNode(ref): any): Element);
-            const otherElement = ((ReactDOM.findDOMNode(
-                otherRef,
-            ): any): Element);
-            // When not obscurred, elementFromPoint should return the element.
-            // Flow doesn't like us doing this to the document $FlowFixMe
-            document.elementFromPoint = jest.fn().mockReturnValue(otherElement);
+        // Act
+        const result = isObscured(element);
 
-            // Act
-            const result = isObscured(element);
-
-            // Assert
-            expect(result).toBeTruthy();
-            done();
-        };
-
-        arrange(actAndAssert);
+        // Assert
+        expect(result).toBeTruthy();
     });
 
-    test("element is not obscured, but elementFromPoint returns parent or child, returns false", (done) => {
+    test("element is not obscured, but elementFromPoint returns parent or child, returns false", async () => {
         // Arrange
-        let parentRef = null;
-        let elementRef = null;
-        let childRef = null;
-        const arrange = (tryActAndAssert) => {
-            const nodes = (
-                <View>
-                    <View
-                        ref={(ref) => {
-                            parentRef = ref;
-                            tryActAndAssert();
-                        }}
-                    >
-                        <View
-                            ref={(ref) => {
-                                elementRef = ref;
-                                tryActAndAssert();
-                            }}
-                        >
-                            <View
-                                ref={(ref) => {
-                                    childRef = ref;
-                                    tryActAndAssert();
-                                }}
-                            >
-                                Child
+        const {parentRef, elementRef, childRef} = await new Promise(
+            (resolve) => {
+                let parentRef;
+                let elementRef;
+                let childRef;
+                const tryResolve = (pr, er, cr) => {
+                    parentRef = parentRef || pr;
+                    elementRef = elementRef || er;
+                    childRef = childRef || cr;
+                    if (parentRef && elementRef && childRef) {
+                        resolve({parentRef, elementRef, childRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r, null, null)}>
+                            <View ref={(r) => tryResolve(null, r, null)}>
+                                <View ref={(r) => tryResolve(null, null, r)}>
+                                    Child
+                                </View>
                             </View>
                         </View>
                     </View>
-                </View>
-            );
-            mount(nodes);
-        };
+                );
+                mount(nodes);
+            },
+        );
 
-        const actAndAssert = () => {
-            if (!elementRef || !parentRef || !childRef) {
-                // We're not ready to act or assert yet.
-                // We need all three refs to be in.
-                return;
-            }
+        const element = ((ReactDOM.findDOMNode(elementRef): any): Element);
+        expect(element).toBeTruthy();
 
-            const element = ((ReactDOM.findDOMNode(elementRef): any): Element);
-            expect(element).toBeTruthy();
+        const parentElement = ((ReactDOM.findDOMNode(parentRef): any): Element);
+        expect(parentElement).toBeTruthy();
 
-            const parentElement = ((ReactDOM.findDOMNode(
-                parentRef,
-            ): any): Element);
-            expect(parentElement).toBeTruthy();
+        const childElement = ((ReactDOM.findDOMNode(childRef): any): Element);
+        expect(childElement).toBeTruthy();
 
-            const childElement = ((ReactDOM.findDOMNode(
-                childRef,
-            ): any): Element);
-            expect(childElement).toBeTruthy();
+        // When not obscurred, elementFromPoint should return the element.
+        // So let's return the element for one corner but not the other.
+        // Flow doesn't like us doing this to the document $FlowFixMe
+        document.elementFromPoint = jest
+            .fn()
+            .mockImplementationOnce(() => parentElement)
+            .mockImplementationOnce(() => childElement);
 
-            // When not obscurred, elementFromPoint should return the element.
-            // So let's return the element for one corner but not the other.
-            // Flow doesn't like us doing this to the document $FlowFixMe
-            document.elementFromPoint = jest
-                .fn()
-                .mockImplementationOnce(() => parentElement)
-                .mockImplementationOnce(() => childElement);
+        // Act
+        const result = isObscured(element);
 
-            // Act
-            const result = isObscured(element);
-
-            // Assert
-            expect(result).toBeFalsy();
-            done();
-        };
-
-        arrange(actAndAssert);
+        // Assert
+        expect(result).toBeFalsy();
     });
 });

--- a/packages/wonder-blocks-tooltip/util/visibility-modifier.test.js
+++ b/packages/wonder-blocks-tooltip/util/visibility-modifier.test.js
@@ -4,10 +4,15 @@ import * as Core from "@khanacademy/wonder-blocks-core";
 import visibilityModifierDefaultConfig from "./visibility-modifier.js";
 import isObscured from "./is-obscured.js";
 
-jest.mock("@khanacademy/wonder-blocks-core");
 jest.mock("./is-obscured.js");
+jest.mock("@khanacademy/wonder-blocks-core");
 
 describe("Visibility PopperJS Modifier", () => {
+    beforeEach(() => {
+        // Flow doesn't know this is a jest mock $FlowFixMe
+        Core.getElementIntersection.mockClear();
+    });
+
     test("returns an enabled modifier configuration with expected order", () => {
         // Arrange
 
@@ -36,7 +41,7 @@ describe("Visibility PopperJS Modifier", () => {
                     hide: false,
                 };
                 // Flow doesn't know this is a jest mock $FlowFixMe
-                Core.getElementIntersection.mockReturnValue({
+                Core.getElementIntersection.mockReturnValueOnce({
                     horizontal: "before",
                     vertical: "within",
                 });
@@ -60,7 +65,7 @@ describe("Visibility PopperJS Modifier", () => {
                     hide: true,
                 };
                 // Flow doesn't know this is a jest mock $FlowFixMe
-                Core.getElementIntersection.mockReturnValue({
+                Core.getElementIntersection.mockReturnValueOnce({
                     horizontal: "within",
                     vertical: "before",
                 });
@@ -82,7 +87,7 @@ describe("Visibility PopperJS Modifier", () => {
                     hide: false,
                 };
                 // Flow doesn't know this is a jest mock $FlowFixMe
-                Core.getElementIntersection.mockReturnValue({
+                Core.getElementIntersection.mockReturnValueOnce({
                     horizontal: "after",
                     vertical: "after",
                 });
@@ -112,12 +117,12 @@ describe("Visibility PopperJS Modifier", () => {
             // though it would overwise be visible within its scroll parents.
 
             // Flow doesn't know this is a jest mock $FlowFixMe
-            Core.getElementIntersection.mockReturnValue({
+            Core.getElementIntersection.mockReturnValueOnce({
                 horizontal: "within",
                 vertical: "within",
             });
             // Flow doesn't know this is a jest mock $FlowFixMe
-            isObscured.mockReturnValue(true);
+            isObscured.mockReturnValueOnce(true);
 
             // Act
             const result = visibilityModifierDefaultConfig.fn(data);


### PR DESCRIPTION
Here we add some final testing tweaks to the `Tooltip` component and related things, including validation of the a11y work in the previous PR on which this is stacked, #192.

In addition to the `Tooltip` coverage, this set of changes migrates all the tooltip fixtures to use the special version of `mount` that gives us an `unmountAll` method. This is important since tests share a DOM, and without unmounting all mounted things, side-effects can bleed across test boundaries (we should update all our testing to use this model).

Finally, we also rework many tests to use `async`/`await` for a much tidier set of tests.