### PR TITLE
update flow types to be exact object types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
     "extends": [
         "./eslint/eslintrc"
-    ]
+    ],
+    "rules": {
+        "flowtype/require-exact-type": [2, "always"]
+    }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "rm -rf packages/wonder-blocks-*/dist && rm -rf packages/wonder-blocks-*/node_modules",
     "lint": "eslint --config ./eslint/eslintrc packages",
+    "lint:watch": "esw --watch --config ./eslint/eslintrc packages",
     "build:all": "webpack && node utils/package-flow-types.js",
     "watch:all": "webpack -w",
     "flow": "flow",
@@ -47,6 +48,7 @@
     "eslint-plugin-prettier": "2.3.1",
     "eslint-plugin-react": "7.7.0",
     "eslint-plugin-react-native-animation-linter": "0.1.1",
+    "eslint-watch": "^4.0.1",
     "flow-bin": "0.75.0",
     "glob": "^7.1.2",
     "jest": "^23.3.0",

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -13,12 +13,13 @@ import {addStyle} from "@khanacademy/wonder-blocks-core";
 import type {ClickableHandlers} from "@khanacademy/wonder-blocks-core";
 import type {SharedProps} from "./button.js";
 
-type Props = SharedProps &
-    ClickableHandlers & {
-        hovered: boolean,
-        focused: boolean,
-        pressed: boolean,
-    };
+type Props = {|
+    ...SharedProps,
+    ...ClickableHandlers,
+    hovered: boolean,
+    focused: boolean,
+    pressed: boolean,
+|};
 
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");
@@ -84,8 +85,10 @@ export default class ButtonCore extends React.Component<Props> {
 
         if (!disabled && href) {
             if (clientNav) {
+                // $FlowFixMe
                 props.to = href;
             } else {
+                // $FlowFixMe
                 props.href = href;
             }
         }

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 import ButtonCore from "./button-core.js";
 
-export type SharedProps = {
+export type SharedProps = {|
     /**
      * Text to appear on the button.
      */
@@ -94,9 +94,10 @@ export type SharedProps = {
         ...FlexItemStyles,
     }>>,
     */
-};
+|};
 
-type Props = SharedProps & {
+type Props = {|
+    ...SharedProps,
     /**
      * Function to call when button is clicked.
      *
@@ -110,7 +111,7 @@ type Props = SharedProps & {
      * href is not
      */
     onClick?: (e: SyntheticEvent<>) => void,
-};
+|};
 
 /**
  * Reusable button component.

--- a/packages/wonder-blocks-color/docutils/swatch.js
+++ b/packages/wonder-blocks-color/docutils/swatch.js
@@ -10,14 +10,14 @@ import {
 } from "@khanacademy/wonder-blocks-typography";
 import Color from "../index.js";
 
-type Props = {
+type Props = {|
     color: string,
     name: string,
     desc: string,
     use: "text" | "icons" | null,
     width: 256,
     segments: 1 | 2 | 3,
-};
+|};
 
 const constants = {
     segmentHeight: 64,

--- a/packages/wonder-blocks-color/util/utils.js
+++ b/packages/wonder-blocks-color/util/utils.js
@@ -8,12 +8,12 @@ const color6Regexp = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
 const color3Regexp = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i;
 const rgbaRegexp = /^rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\s*\)$/i;
 
-type Color = {
+type Color = {|
     r: number,
     g: number,
     b: number,
     a: number,
-};
+|};
 
 // Parse a color in #abcdef, rgb(...), or rgba(...) form into an object
 // with r,g,b,a keys.

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -51,7 +51,7 @@
  */
 import React from "react";
 
-type Props = {
+type Props = {|
     /**
      * A function that returns the a React `Element`.
      *
@@ -87,9 +87,9 @@ type Props = {
      * Passed in by withRouter HOC.
      */
     history?: any,
-};
+|};
 
-type State = {
+type State = {|
     /**
      * Whether the component is hovered.
      *
@@ -110,9 +110,9 @@ type State = {
      * See component documentation for more details.
      */
     pressed: boolean,
-};
+|};
 
-export type ClickableHandlers = {
+export type ClickableHandlers = {|
     onClick: (e: SyntheticMouseEvent<>) => void,
     onMouseEnter: () => void,
     onMouseLeave: () => void,
@@ -125,7 +125,7 @@ export type ClickableHandlers = {
     onKeyUp: (e: SyntheticKeyboardEvent<*>) => void,
     onBlur: (e: SyntheticFocusEvent<*>) => void,
     tabIndex: number,
-};
+|};
 
 const disabledHandlers = {
     onClick: () => void 0,

--- a/packages/wonder-blocks-core/components/media-layout.js
+++ b/packages/wonder-blocks-core/components/media-layout.js
@@ -7,7 +7,7 @@ import {mediaContextTypes} from "../util/util.js";
 
 import type {MediaSize, MediaSpec} from "../util/types.js";
 
-type Props = {
+type Props = {|
     /**
      * Force the MediaLayout to be a particular size (ignoring the actual
      * dimensions of the viewport).
@@ -29,7 +29,16 @@ type Props = {
 
     /** The contents of the page */
     children: React.Node,
-};
+
+    /**
+     * Style the layout container
+     */
+    style?: any,
+
+    // TODO(kevinb): provide a way to "mixin" allowed roles and aria props
+    role?: "dialog",
+    "aria-labelledby"?: string,
+|};
 
 /**
  * A MediaLayout wraps all parts of a page and tracks the browser viewport, toggling

--- a/packages/wonder-blocks-core/components/no-ssr.js
+++ b/packages/wonder-blocks-core/components/no-ssr.js
@@ -20,7 +20,7 @@ import * as React from "react";
  * We use render functions so that we don't do any work unless we need to.
  * This avoids rendering but not mounting potentially complex component trees.
  */
-type Props = {
+type Props = {|
     /**
      * The content that is client-only.
      */
@@ -35,11 +35,11 @@ type Props = {
      * server, or it defeats the purpose of using the NoSSR component.
      */
     placeholder?: () => ?React.Node,
-};
+|};
 
-type State = {
+type State = {|
     mounted: boolean,
-};
+|};
 
 export default class NoSSR extends React.Component<Props, State> {
     state = {

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -91,7 +91,8 @@ type IdRef = string;
 type IdRefList = IdRef | Array<IdRef>;
 
 // Source: https://www.w3.org/WAI/PF/aria-1.1/states_and_properties
-// TODO(kevinb): figure out how to type ID ref lists
+// TODO(kevinb): convert to disjoint union of exact object types keyed on role
+// eslint-disable-next-line flowtype/require-exact-type
 export type AriaProps = {
     role?: roles,
     "aria-activedescendant"?: IdRef,
@@ -140,6 +141,8 @@ export type Props = AriaProps & {
 
 export type MediaSize = "small" | "medium" | "large";
 
+// TODO(kevinb): dedupe with wonder-blocks-grid
+// eslint-disable-next-line flowtype/require-exact-type
 export type MediaSpec = {
     [sizeName: MediaSize]: {
         /** The query to use to match the viewport against. */

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -17,7 +17,7 @@ import {
 
 const {blue, white, offBlack, offBlack32} = Color;
 
-type ActionProps = {
+type ActionProps = {|
     /**
      * Display text of the menu item.
      */
@@ -68,7 +68,7 @@ type ActionProps = {
      * href is not
      */
     onClick?: () => void,
-};
+|};
 
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -17,7 +17,7 @@ import type {
     SeparatorProps,
 } from "../utils/types.js";
 
-type OpenerProps = {
+type OpenerProps = {|
     /**
      * Display text for the opener.
      */
@@ -30,7 +30,12 @@ type OpenerProps = {
      * Callback for when the opener is pressed.
      */
     onClick: () => void,
-};
+
+    /**
+     * Style to apply to the opener.
+     */
+    style?: any,
+|};
 
 class ActionMenuOpener extends React.Component<OpenerProps> {
     static defaultProps = {
@@ -42,6 +47,7 @@ class ActionMenuOpener extends React.Component<OpenerProps> {
 
         // TODO: incorporate caret once Icon is done
         return (
+            // $FlowFixMe: button doesn't allow 'role' yet
             <Button
                 role="menu"
                 color={"default"}
@@ -59,7 +65,7 @@ class ActionMenuOpener extends React.Component<OpenerProps> {
 
 type ItemProps = ActionItemProps | SelectItemProps | SeparatorProps;
 
-type MenuProps = {
+type MenuProps = {|
     /**
      * The items in this menu.
      */
@@ -98,14 +104,14 @@ type MenuProps = {
      * Optional styling to add.
      */
     style?: any,
-};
+|};
 
-type State = {
+type State = {|
     /**
      * Whether or not menu is open.
      */
     open: boolean,
-};
+|};
 
 export default class ActionMenu extends React.Component<MenuProps, State> {
     static defaultProps = {

--- a/packages/wonder-blocks-dropdown/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core.js
@@ -9,7 +9,7 @@ import Color, {fade} from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {View} from "@khanacademy/wonder-blocks-core";
 
-type DropdownCoreProps = {
+type DropdownCoreProps = {|
     // TODO(sophie): figure out how to type ActionItem | SelectItem | SeperatorItem inline
     /**
      * Items for the menu.
@@ -47,7 +47,7 @@ type DropdownCoreProps = {
      * Optional styling to add to dropdown menu.
      */
     style?: any,
-};
+|};
 
 export default class DropdownCore extends React.Component<DropdownCoreProps> {
     node: ?Node;

--- a/packages/wonder-blocks-dropdown/components/multi-select-menu.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select-menu.js
@@ -12,7 +12,7 @@ import SelectItem from "./select-item.js";
 import SeparatorItem from "./separator-item.js";
 import type {SelectItemProps} from "../utils/types.js";
 
-type Props = {
+type Props = {|
     /**
      * The items in this menu.
      */
@@ -69,14 +69,14 @@ type Props = {
      * Optional styling to add.
      */
     style?: any,
-};
+|};
 
-type State = {
+type State = {|
     /**
      * Whether or not menu is open.
      */
     open: boolean,
-};
+|};
 
 export default class MultiSelectMenu extends React.Component<Props, State> {
     static defaultProps = {

--- a/packages/wonder-blocks-dropdown/components/select-box.js
+++ b/packages/wonder-blocks-dropdown/components/select-box.js
@@ -20,7 +20,7 @@ const {blue, white, offBlack, offBlack16, offBlack32, offBlack50} = Color;
 const caretDown = `M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0
 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z`;
 
-type SelectBoxProps = {
+type SelectBoxProps = {|
     /**
      * Display text in the SelectBox.
      */
@@ -53,7 +53,7 @@ type SelectBoxProps = {
      * Custom style. Mostly used for preferred width of this select box.
      */
     style?: any,
-};
+|};
 
 export default class SelectBox extends React.Component<SelectBoxProps> {
     static defaultProps = {

--- a/packages/wonder-blocks-dropdown/components/select-item.js
+++ b/packages/wonder-blocks-dropdown/components/select-item.js
@@ -21,7 +21,7 @@ l0.9-0.9c0.1-0.1,0.3-0.2,0.4-0.2s0.3,0.1,0.4,0.2l1.9,1.9l4.2-4.2c0.1-0.1,
 
 const {blue, white, offBlack, offBlack32} = Color;
 
-type SelectProps = {
+type SelectProps = {|
     /**
      * Display text of the menu item.
      */
@@ -61,16 +61,16 @@ type SelectProps = {
      * Optional client-supplied callback when this item is called.
      */
     onClick?: (oldSelectionState: boolean) => void,
-};
+|};
 
 const StyledButton = addStyle("button");
 
-type CheckProps = {
+type CheckProps = {|
     selected: boolean,
     pressed: boolean,
     hovered: boolean,
     focused: boolean,
-};
+|};
 
 // TODO: return with Icon once it's been made!
 const Check = (props: CheckProps) => {

--- a/packages/wonder-blocks-dropdown/components/single-select-menu.js
+++ b/packages/wonder-blocks-dropdown/components/single-select-menu.js
@@ -9,7 +9,7 @@ import SelectBox from "./select-box.js";
 import SelectItem from "./select-item.js";
 import type {SelectItemProps} from "../utils/types.js";
 
-type Props = {
+type Props = {|
     /**
      * The items in this menu.
      */
@@ -53,14 +53,14 @@ type Props = {
      * Optional styling to add to dropdown.
      */
     style?: any,
-};
+|};
 
-type State = {
+type State = {|
     /**
      * Whether or not menu is open.
      */
     open: boolean,
-};
+|};
 
 export default class SingleSelectMenu extends React.Component<Props, State> {
     static defaultProps = {

--- a/packages/wonder-blocks-dropdown/utils/types.js
+++ b/packages/wonder-blocks-dropdown/utils/types.js
@@ -1,6 +1,6 @@
 // @flow
 
-export type ActionItemProps = {
+export type ActionItemProps = {|
     type: "action",
     /** Whether this item is disabled. Default false. */
     disabled?: boolean,
@@ -12,9 +12,9 @@ export type ActionItemProps = {
     clientNav?: boolean,
     /** Callback on the action. */
     onClick?: () => void,
-};
+|};
 
-export type SelectItemProps = {
+export type SelectItemProps = {|
     type: "select",
     /** Whether this item is disabled. Default false. */
     disabled?: boolean,
@@ -24,8 +24,8 @@ export type SelectItemProps = {
     value: string,
     /** Optional extra callback. Passes whether this item is selected. */
     onClick?: (selected: boolean) => void,
-};
+|};
 
-export type SeparatorProps = {
+export type SeparatorProps = {|
     type: "separator",
-};
+|};

--- a/packages/wonder-blocks-grid/components/cell.js
+++ b/packages/wonder-blocks-grid/components/cell.js
@@ -7,7 +7,7 @@ import FixedWidthCell from "./fixed-width-cell.js";
 
 import type {MediaSize, MediaSpec} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     /** The number of columns this cell should span on a Small Grid. */
     smallCols?: number,
     /** The number of columns this cell should span on a Medium Grid. */
@@ -40,7 +40,7 @@ type Props = {
      * @ignore
      */
     mediaSpec: MediaSpec,
-};
+|};
 
 /**
  * A Cell is a form of [FixedWidthCell](#fixedwidthcell) whose width is set

--- a/packages/wonder-blocks-grid/components/fixed-width-cell.js
+++ b/packages/wonder-blocks-grid/components/fixed-width-cell.js
@@ -7,7 +7,7 @@ import {flexBasis} from "../util/utils.js";
 
 import type {MediaSize, MediaSpec} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     /** The width of this cell on a Small Grid (in pixels, %, or other). */
     smallWidth?: number | string,
     /** The width of this cell on a Medium Grid (in pixels, %, or other). */
@@ -40,7 +40,7 @@ type Props = {
      * @ignore
      */
     mediaSpec: MediaSpec,
-};
+|};
 
 /**
  * Fixed-width Cell, its width specified using CSS dimensions (such as pixels,

--- a/packages/wonder-blocks-grid/components/flex-cell.js
+++ b/packages/wonder-blocks-grid/components/flex-cell.js
@@ -7,7 +7,7 @@ import {matchesSize} from "../util/utils.js";
 
 import type {MediaSize, MediaSpec} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     /** Should this cell be shown on a Small Grid? */
     small?: boolean,
     /** Should this cell be shown on a Medium Grid? */
@@ -37,7 +37,7 @@ type Props = {
      * @ignore
      */
     mediaSpec: MediaSpec,
-};
+|};
 
 /**
  * A flexible-width grid cell. Expands to fill the available space.

--- a/packages/wonder-blocks-grid/util/types.js
+++ b/packages/wonder-blocks-grid/util/types.js
@@ -2,6 +2,8 @@
 
 export type MediaSize = "small" | "medium" | "large";
 
+// TODO(kevinb): dedupe with wonder-blocks-core
+// eslint-disable-next-line flowtype/require-exact-type
 export type MediaSpec = {
     [sizeName: MediaSize]: {
         /** The query to use to match the viewport against. */

--- a/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
@@ -16,7 +16,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false disa
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -73,7 +72,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false focu
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -134,7 +132,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false hove
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -195,7 +192,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -252,7 +248,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true disab
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -309,7 +304,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true focus
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -370,7 +364,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true hover
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -431,7 +424,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -488,7 +480,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -545,7 +536,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -606,7 +596,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -667,7 +656,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -724,7 +712,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -781,7 +768,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -842,7 +828,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -903,7 +888,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -960,7 +944,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1017,7 +1000,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1078,7 +1060,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1139,7 +1120,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1196,7 +1176,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true d
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1253,7 +1232,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true f
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1314,7 +1292,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true h
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1375,7 +1352,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1432,7 +1408,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -1489,7 +1464,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -1550,7 +1524,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -1611,7 +1584,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -1668,7 +1640,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -1725,7 +1696,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -1786,7 +1756,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -1847,7 +1816,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -1904,7 +1872,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false di
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -1961,7 +1928,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false fo
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2022,7 +1988,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false ho
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2083,7 +2048,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2140,7 +2104,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -2197,7 +2160,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -2258,7 +2220,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -2319,7 +2280,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -2376,7 +2336,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2433,7 +2392,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2494,7 +2452,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2555,7 +2512,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2612,7 +2568,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -2669,7 +2624,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -2730,7 +2684,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -2791,7 +2744,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -2848,7 +2800,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false dis
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2905,7 +2856,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false foc
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -2966,7 +2916,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false hov
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -3027,7 +2976,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -3084,7 +3032,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -3141,7 +3088,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -3202,7 +3148,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -3263,7 +3208,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -3320,7 +3264,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -3377,7 +3320,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -3438,7 +3380,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -3499,7 +3440,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="default"
   style={
     Object {
       "alignItems": "center",
@@ -3556,7 +3496,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -3613,7 +3552,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -3674,7 +3612,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",
@@ -3735,7 +3672,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
-  size="small"
   style={
     Object {
       "alignItems": "center",

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -12,40 +12,42 @@ import type {ClickableHandlers} from "@khanacademy/wonder-blocks-core";
 import Icon from "@khanacademy/wonder-blocks-icon";
 import type {SharedProps} from "./icon-button.js";
 
-type Props = SharedProps &
-    ClickableHandlers & {
-        /**
-         * Whether the IconButton is hovered.
-         *
-         * Same styling as focused. Refer to `ClickableBehavior` for more
-         * information on when this prop should be `true`.
-         */
-        hovered: boolean,
+type Props = {|
+    ...SharedProps,
+    ...ClickableHandlers,
 
-        /**
-         * Whether the IconButton is focused.
-         *
-         * Same styling as hvoered. Refer to `ClickableBehavior` for more
-         * information on when this prop should be `true`.
-         */
-        focused: boolean,
+    /**
+     * Whether the IconButton is hovered.
+     *
+     * Same styling as focused. Refer to `ClickableBehavior` for more
+     * information on when this prop should be `true`.
+     */
+    hovered: boolean,
 
-        /**
-         * Whether the IconButton is pressed.
-         *
-         * Refer to `ClickableBehavior` for more information on when this prop
-         * should be `true`.
-         */
-        pressed: boolean,
+    /**
+     * Whether the IconButton is focused.
+     *
+     * Same styling as hvoered. Refer to `ClickableBehavior` for more
+     * information on when this prop should be `true`.
+     */
+    focused: boolean,
 
-        /**
-         * URL to navigate to.
-         *
-         * Used to determine whether to render an `<a>` or `<button>` tag. Also
-         * passed in as the `<a>` tag's `href` if present.
-         */
-        href?: string,
-    };
+    /**
+     * Whether the IconButton is pressed.
+     *
+     * Refer to `ClickableBehavior` for more information on when this prop
+     * should be `true`.
+     */
+    pressed: boolean,
+
+    /**
+     * URL to navigate to.
+     *
+     * Used to determine whether to render an `<a>` or `<button>` tag. Also
+     * passed in as the `<a>` tag's `href` if present.
+     */
+    href?: string,
+|};
 
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -1,11 +1,11 @@
 // @flow
 import React from "react";
 
-import {ClickableBehavior} from "@khanacademy/wonder-blocks-core";
+import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 import IconButtonCore from "./icon-button-core.js";
 
-export type SharedProps = {
+export type SharedProps = {|
     /**
      * A Wonder Blocks icon asset, an object specifing paths for one or more of
      * the following sizes: small, medium, large, xlarge.
@@ -63,9 +63,11 @@ export type SharedProps = {
         ...FlexItemStyles,
     }>>,
     */
-};
+|};
 
-type Props = SharedProps & {
+type Props = {|
+    ...SharedProps,
+
     /**
      * URL to navigate to.
      *
@@ -81,7 +83,7 @@ type Props = SharedProps & {
      * navigation by doing history.push(this.props.href) using
      * ReactRouter's history object
      */
-    clientSideNav?: boolean,
+    clientNav?: boolean,
 
     /**
      * Function to call when button is clicked.
@@ -96,7 +98,7 @@ type Props = SharedProps & {
      * href is not
      */
     onClick?: (e: SyntheticEvent<>) => void,
-};
+|};
 
 /**
  * An IconButton is a button whose contents are an SVG image.
@@ -128,13 +130,19 @@ export default class IconButton extends React.Component<Props> {
     };
 
     render() {
-        const {onClick, href, clientSideNav, ...sharedProps} = this.props;
+        const {onClick, href, clientNav, ...sharedProps} = this.props;
+
+        const ClickableBehavior = getClickableBehavior(
+            href,
+            clientNav,
+            this.context.router,
+        );
+
         return (
             <ClickableBehavior
                 disabled={sharedProps.disabled}
                 href={href}
                 onClick={onClick}
-                clientSideNav={clientSideNav}
             >
                 {(state, handlers) => {
                     return (

--- a/packages/wonder-blocks-icon-button/custom-snapshot.test.js
+++ b/packages/wonder-blocks-icon-button/custom-snapshot.test.js
@@ -48,15 +48,12 @@ describe("IconButtonCore", () => {
                                         icon={icons.search}
                                         aria-label="search"
                                         kind={kind}
-                                        size={size}
                                         color={color}
                                         light={light}
                                         {...stateProps}
                                         {...defaultHandlers}
                                         tabIndex={stateProps.disabled ? -1 : 0}
-                                    >
-                                        Click me
-                                    </IconButtonCore>,
+                                    />,
                                 )
                                 .toJSON();
                             expect(tree).toMatchSnapshot();

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -6,7 +6,7 @@ import {addStyle} from "@khanacademy/wonder-blocks-core";
 import type {IconAsset, IconSize} from "../util/icon-assets.js";
 import {getPathForIcon, viewportPixelsForSize} from "../util/icon-util.js";
 
-type Props = {
+type Props = {|
     /**
      * Passed transparently to the SVG. If not provided, we assume the SVG is
      * purely decorative and it is invisible to screenreaders.
@@ -31,7 +31,7 @@ type Props = {
      * Aphrodite style objects, or arrays thereof.
      */
     style?: any,
-};
+|};
 
 const StyledSVG = addStyle("svg");
 

--- a/packages/wonder-blocks-layout/components/strut.js
+++ b/packages/wonder-blocks-layout/components/strut.js
@@ -8,9 +8,9 @@ import * as React from "react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     size: number,
-};
+|};
 
 export default class Strut extends React.Component<Props> {
     render() {

--- a/packages/wonder-blocks-link/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__snapshots__/custom-snapshot.test.js.snap
@@ -1,42 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LinkCore kind:primary href:# light:false disabled 1`] = `
-<a
-  className=""
-  disabled={true}
-  href="#"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
-  style={
-    Object {
-      ":visited": Object {
-        "color": "#8755ee",
-      },
-      "color": "#1865f2",
-      "cursor": "pointer",
-      "outline": "none",
-      "textDecoration": "none",
-    }
-  }
-  tabIndex={-1}
->
-  Click me
-</a>
-`;
-
 exports[`LinkCore kind:primary href:# light:false focused 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -69,7 +35,6 @@ exports[`LinkCore kind:primary href:# light:false focused 1`] = `
 exports[`LinkCore kind:primary href:# light:false hovered 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -102,7 +67,6 @@ exports[`LinkCore kind:primary href:# light:false hovered 1`] = `
 exports[`LinkCore kind:primary href:# light:false pressed 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -132,43 +96,9 @@ exports[`LinkCore kind:primary href:# light:false pressed 1`] = `
 </a>
 `;
 
-exports[`LinkCore kind:primary href:# light:true disabled 1`] = `
-<a
-  className=""
-  disabled={true}
-  href="#"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
-  style={
-    Object {
-      ":visited": Object {
-        "color": "#ffffff",
-      },
-      "color": "#ffffff",
-      "cursor": "pointer",
-      "outline": "none",
-      "textDecoration": "none",
-    }
-  }
-  tabIndex={-1}
->
-  Click me
-</a>
-`;
-
 exports[`LinkCore kind:primary href:# light:true focused 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -201,7 +131,6 @@ exports[`LinkCore kind:primary href:# light:true focused 1`] = `
 exports[`LinkCore kind:primary href:# light:true hovered 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -234,7 +163,6 @@ exports[`LinkCore kind:primary href:# light:true hovered 1`] = `
 exports[`LinkCore kind:primary href:# light:true pressed 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -264,43 +192,9 @@ exports[`LinkCore kind:primary href:# light:true pressed 1`] = `
 </a>
 `;
 
-exports[`LinkCore kind:primary href:#non-existent-link light:false disabled 1`] = `
-<a
-  className=""
-  disabled={true}
-  href="#"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
-  style={
-    Object {
-      ":visited": Object {
-        "color": "#8755ee",
-      },
-      "color": "#1865f2",
-      "cursor": "pointer",
-      "outline": "none",
-      "textDecoration": "none",
-    }
-  }
-  tabIndex={-1}
->
-  Click me
-</a>
-`;
-
 exports[`LinkCore kind:primary href:#non-existent-link light:false focused 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -333,7 +227,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false focused 1`] =
 exports[`LinkCore kind:primary href:#non-existent-link light:false hovered 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -366,7 +259,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false hovered 1`] =
 exports[`LinkCore kind:primary href:#non-existent-link light:false pressed 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -396,43 +288,9 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false pressed 1`] =
 </a>
 `;
 
-exports[`LinkCore kind:primary href:#non-existent-link light:true disabled 1`] = `
-<a
-  className=""
-  disabled={true}
-  href="#"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
-  style={
-    Object {
-      ":visited": Object {
-        "color": "#ffffff",
-      },
-      "color": "#ffffff",
-      "cursor": "pointer",
-      "outline": "none",
-      "textDecoration": "none",
-    }
-  }
-  tabIndex={-1}
->
-  Click me
-</a>
-`;
-
 exports[`LinkCore kind:primary href:#non-existent-link light:true focused 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -465,7 +323,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true focused 1`] = 
 exports[`LinkCore kind:primary href:#non-existent-link light:true hovered 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -498,7 +355,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true hovered 1`] = 
 exports[`LinkCore kind:primary href:#non-existent-link light:true pressed 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -528,43 +384,9 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true pressed 1`] = 
 </a>
 `;
 
-exports[`LinkCore kind:secondary href:# light:false disabled 1`] = `
-<a
-  className=""
-  disabled={true}
-  href="#"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
-  style={
-    Object {
-      ":visited": Object {
-        "color": "#8755ee",
-      },
-      "color": "#21242c",
-      "cursor": "pointer",
-      "outline": "none",
-      "textDecoration": "none",
-    }
-  }
-  tabIndex={-1}
->
-  Click me
-</a>
-`;
-
 exports[`LinkCore kind:secondary href:# light:false focused 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -597,7 +419,6 @@ exports[`LinkCore kind:secondary href:# light:false focused 1`] = `
 exports[`LinkCore kind:secondary href:# light:false hovered 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -630,7 +451,6 @@ exports[`LinkCore kind:secondary href:# light:false hovered 1`] = `
 exports[`LinkCore kind:secondary href:# light:false pressed 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -660,43 +480,9 @@ exports[`LinkCore kind:secondary href:# light:false pressed 1`] = `
 </a>
 `;
 
-exports[`LinkCore kind:secondary href:#non-existent-link light:false disabled 1`] = `
-<a
-  className=""
-  disabled={true}
-  href="#"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
-  style={
-    Object {
-      ":visited": Object {
-        "color": "#8755ee",
-      },
-      "color": "#21242c",
-      "cursor": "pointer",
-      "outline": "none",
-      "textDecoration": "none",
-    }
-  }
-  tabIndex={-1}
->
-  Click me
-</a>
-`;
-
 exports[`LinkCore kind:secondary href:#non-existent-link light:false focused 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -729,7 +515,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false focused 1`]
 exports[`LinkCore kind:secondary href:#non-existent-link light:false hovered 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}
@@ -762,7 +547,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false hovered 1`]
 exports[`LinkCore kind:secondary href:#non-existent-link light:false pressed 1`] = `
 <a
   className=""
-  disabled={false}
   href="#"
   onBlur={[Function]}
   onClick={[Function]}

--- a/packages/wonder-blocks-link/components/link-core.js
+++ b/packages/wonder-blocks-link/components/link-core.js
@@ -8,13 +8,15 @@ import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import type {ClickableHandlers} from "@khanacademy/wonder-blocks-core";
 import type {SharedProps} from "./link.js";
 
-type Props = SharedProps &
-    ClickableHandlers & {
-        hovered: boolean,
-        focused: boolean,
-        pressed: boolean,
-        href: string,
-    };
+type Props = {|
+    ...SharedProps,
+    ...ClickableHandlers,
+
+    hovered: boolean,
+    focused: boolean,
+    pressed: boolean,
+    href: string,
+|};
 
 const StyledAnchor = addStyle("a");
 const StyledLink = addStyle(Link);
@@ -52,8 +54,10 @@ export default class LinkCore extends React.Component<Props> {
         };
 
         if (clientNav) {
+            // $FlowFixMe
             props.to = href;
         } else {
+            // $FlowFixMe
             props.href = href;
         }
 

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import LinkCore from "./link-core.js";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 
-export type SharedProps = {
+export type SharedProps = {|
     /**
      * Text to appear on the link.
      */
@@ -62,9 +62,11 @@ export type SharedProps = {
         ...FlexItemStyles,
     }>>,
     */
-};
+|};
 
-type Props = SharedProps & {
+type Props = {|
+    ...SharedProps,
+
     /**
      * Function to call when button is clicked.
      *
@@ -75,7 +77,7 @@ type Props = SharedProps & {
      * stubbed out.
      */
     onClick?: (e: SyntheticEvent<>) => void,
-};
+|};
 
 /**
  * Reusable link component.

--- a/packages/wonder-blocks-link/custom-snapshot.test.js
+++ b/packages/wonder-blocks-link/custom-snapshot.test.js
@@ -22,14 +22,8 @@ describe("LinkCore", () => {
     for (const kind of ["primary", "secondary"]) {
         for (const href of ["#", "#non-existent-link"]) {
             for (const light of kind === "primary" ? [true, false] : [false]) {
-                for (const state of [
-                    "disabled",
-                    "focused",
-                    "hovered",
-                    "pressed",
-                ]) {
+                for (const state of ["focused", "hovered", "pressed"]) {
                     const stateProps = {
-                        disabled: state === "disabled",
                         focused: state === "focused",
                         hovered: state === "hovered",
                         pressed: state === "pressed",
@@ -46,7 +40,7 @@ describe("LinkCore", () => {
                                     light={light}
                                     {...stateProps}
                                     {...defaultHandlers}
-                                    tabIndex={stateProps.disabled ? -1 : 0}
+                                    tabIndex={0}
                                 >
                                     Click me
                                 </LinkCore>,

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -9,10 +9,10 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import FocusTrap from "./focus-trap.js";
 import type {ModalElement} from "../util/types.js";
 
-type Props = {
+type Props = {|
     children: ModalElement,
     onCloseModal: () => void,
-};
+|};
 
 /**
  * A private component used by ModalLauncher. This is the fixed-position

--- a/packages/wonder-blocks-modal/components/modal-close-button.js
+++ b/packages/wonder-blocks-modal/components/modal-close-button.js
@@ -6,7 +6,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
-type Props = {
+type Props = {|
     /**
      * Whether the button icon should be dark (for light backgrounds), or light
      * (for dark backgrounds).
@@ -15,7 +15,7 @@ type Props = {
 
     /** Called when the button is clicked. */
     onClick: () => void,
-};
+|};
 
 /** A close button for modals. */
 export default class ModalCloseButton extends React.Component<Props> {

--- a/packages/wonder-blocks-modal/components/modal-content.js
+++ b/packages/wonder-blocks-modal/components/modal-content.js
@@ -6,7 +6,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 
 import ModalHeader from "./modal-header.js";
 
-type Props = {
+type Props = {|
     /** An optional header to display above the content. */
     header?: React.Element<typeof ModalHeader> | React.Node,
     /** Should the content scroll on overflow, or just expand. */
@@ -15,7 +15,7 @@ type Props = {
     children: React.Node,
     /** Optional styling to apply to the contents. */
     style?: any,
-};
+|};
 
 export default class ModalContent extends React.Component<Props> {
     static defaultProps = {

--- a/packages/wonder-blocks-modal/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/components/modal-dialog.js
@@ -4,10 +4,10 @@ import {StyleSheet} from "aphrodite";
 
 import {MediaLayout, MEDIA_MODAL_SPEC} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     children: React.Node,
     style?: any,
-};
+|};
 
 export default class ModalDialog extends React.Component<Props> {
     render() {

--- a/packages/wonder-blocks-modal/components/modal-footer.js
+++ b/packages/wonder-blocks-modal/components/modal-footer.js
@@ -5,10 +5,10 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     children: React.Node,
     style?: any,
-};
+|};
 
 export default class ModalFooter extends React.Component<Props> {
     render() {

--- a/packages/wonder-blocks-modal/components/modal-header.js
+++ b/packages/wonder-blocks-modal/components/modal-header.js
@@ -5,11 +5,11 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     children: React.Node,
     style?: any,
     color: "light" | "dark",
-};
+|};
 
 export default class ModalHeader extends React.Component<Props> {
     static defaultProps = {

--- a/packages/wonder-blocks-modal/components/modal-launcher-portal.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher-portal.js
@@ -5,9 +5,9 @@ import * as ReactDOM from "react-dom";
 import type {ModalElement} from "../util/types.js";
 import {ModalLauncherPortalAttributeName} from "../util/constants.js";
 
-type Props = {
+type Props = {|
     children: ModalElement,
-};
+|};
 
 /**
  * A private component used by ModalLauncher, that behaves similarly to a React

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -8,7 +8,7 @@ import ModalBackdrop from "./modal-backdrop.js";
 import ScrollDisabler from "./scroll-disabler.js";
 import type {ModalElement} from "../util/types.js";
 
-type Props = {
+type Props = {|
     /**
      * The modal to render.
      *
@@ -41,12 +41,12 @@ type Props = {
      * close events.
      */
     onClose?: () => void,
-};
+|};
 
-type State = {
+type State = {|
     /** Whether the modal should currently be open. */
     opened: boolean,
-};
+|};
 
 /**
  * This component enables you to launch a modal, covering the screen.

--- a/packages/wonder-blocks-modal/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.js
@@ -11,7 +11,7 @@ import ModalTitleBar from "./modal-title-bar.js";
 import ModalHeader from "./modal-header.js";
 import ModalFooter from "./modal-footer.js";
 
-type Props = {
+type Props = {|
     /**
      * The main contents of the ModalPanel. All other parts of the panel
      * are positioned around it.
@@ -48,7 +48,7 @@ type Props = {
      * clicks too.)
      */
     onClickCloseButton: () => void,
-};
+|};
 
 export default class ModalPanel extends React.Component<Props> {
     static defaultProps = {

--- a/packages/wonder-blocks-modal/components/modal-title-bar.js
+++ b/packages/wonder-blocks-modal/components/modal-title-bar.js
@@ -10,7 +10,7 @@ import {
     LabelSmall,
 } from "@khanacademy/wonder-blocks-typography";
 
-type Props = {
+type Props = {|
     /**
      * The title of the modal, appearing in the titlebar.
      *
@@ -26,7 +26,7 @@ type Props = {
 
     color: "light" | "dark",
     style?: any,
-};
+|};
 
 export default class ModalTitleBar extends React.Component<Props> {
     static defaultProps = {

--- a/packages/wonder-blocks-modal/components/one-column-modal.js
+++ b/packages/wonder-blocks-modal/components/one-column-modal.js
@@ -11,7 +11,7 @@ import ModalFooter from "./modal-footer.js";
 
 import type {MediaSize} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     /** The modal's content. */
     content: React.Node,
 
@@ -38,7 +38,7 @@ type Props = {
      * @ignore
      */
     mediaSize: MediaSize,
-};
+|};
 
 class ContentWrapper extends React.Component<Props> {
     static defaultProps = {

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -7,7 +7,7 @@ import ModalPanel from "./modal-panel.js";
 import ModalContent from "./modal-content.js";
 import ModalTitleBar from "./modal-title-bar.js";
 
-type Props = {
+type Props = {|
     /**
      * The content of the modal, appearing between the titlebar and footer.
      */
@@ -58,7 +58,7 @@ type Props = {
      * @ignore
      */
     onClickCloseButton: () => void,
-};
+|};
 
 /**
  * The "standard" modal layout: a titlebar, a content area, and a footer.

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -11,7 +11,7 @@ import ModalPanel from "./modal-panel.js";
 
 import type {MediaSize} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+type Props = {|
     /** The sidebar contents (which becomes the header on mobile screens). */
     sidebar: React.Node,
 
@@ -41,7 +41,7 @@ type Props = {
      * @ignore
      */
     mediaSize: MediaSize,
-};
+|};
 
 class ContentWrapper extends React.Component<Props> {
     static defaultProps = {

--- a/packages/wonder-blocks-progress-spinner/components/circular-spinner.js
+++ b/packages/wonder-blocks-progress-spinner/components/circular-spinner.js
@@ -63,19 +63,21 @@ const _generateSVG = (size, light) => {
     return svg;
 };
 
-type Props = {
+type Props = {|
     /**
      * The size of the spinner. (large = 96px, medium = 48px, small = 24px,
      * xsmall = 16px)
      */
     size: "xsmall" | "small" | "medium" | "large",
+
     /** Should a light version of the spinner be shown?
      * (To be used on a dark background.)
      */
     light: boolean,
+
     /** Any (optional) styling to apply to the spinner container. */
     style?: any,
-};
+|};
 
 /**
  * A circular progress spinner. Used for indicating loading progress. Should

--- a/packages/wonder-blocks-tooltip/components/tooltip-tail.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-tail.js
@@ -8,7 +8,7 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {getRefFn, Placement, Offset} from "../util/types.js";
 
-export type Props = {
+export type Props = {|
     /** The offset of the tail indicating where it should be positioned. */
     offset?: Offset,
 
@@ -17,7 +17,7 @@ export type Props = {
 
     /** A callback to update the ref of the tail element. */
     updateRef?: getRefFn,
-};
+|};
 
 // TODO(somewhatabstract): Replace this really basic unique ID work with
 // something SSR-friendly and more robust.

--- a/packages/wonder-blocks-tooltip/util/types.js
+++ b/packages/wonder-blocks-tooltip/util/types.js
@@ -3,6 +3,9 @@ import * as React from "react";
 
 export type getRefFn = (?(React.Component<*> | Element)) => void;
 
-export type Offset = {top: number, left: number};
+export type Offset = {|
+    top: number,
+    left: number,
+|};
 
 export type Placement = "top" | "right" | "bottom" | "left";

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,13 @@
   version "7.0.0-beta.34"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.34.tgz#05b1e58e4c3f412edb28aa0346c14c5f13c41b46"
 
+"@babel/polyfill@^7.0.0-beta.51":
+  version "7.0.0-beta.52"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0-beta.52.tgz#dcea55e5347e9cea92f5ef945c1a8417ea1d74d4"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.11.1"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -2506,7 +2513,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -2791,7 +2798,7 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -3344,6 +3351,23 @@ eslint-scope@^3.7.1, eslint-scope@~3.7.1:
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint-watch@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-watch/-/eslint-watch-4.0.1.tgz#58fc846029e42dbb5d8c552a3636c26a69ed84ca"
+  dependencies:
+    "@babel/polyfill" "^7.0.0-beta.51"
+    bluebird "^3.5.1"
+    chalk "^2.1.0"
+    chokidar "^2.0.0"
+    debug "^3.0.1"
+    keypress "^0.2.1"
+    lodash "^4.17.4"
+    optionator "^0.8.2"
+    source-map-support "^0.5.3"
+    strip-ansi "^4.0.0"
+    text-table "^0.2.0"
+    unicons "0.0.3"
 
 eslint@^4.19.1:
   version "4.19.1"
@@ -5411,6 +5435,16 @@ jest-matcher-utils@^23.2.0:
     jest-get-type "^22.1.0"
     pretty-format "^23.2.0"
 
+jest-message-util@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.4.3.tgz#cf3d38aafe4befddbfc455e57d65d5239e399eb7"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    stack-utils "^1.0.1"
+
 jest-message-util@^23.3.0:
   version "23.3.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.3.0.tgz#bc07b11cec6971fb5dd9de2dfb60ebc22150c160"
@@ -5420,6 +5454,10 @@ jest-message-util@^23.3.0:
     micromatch "^3.1.10"
     slash "^1.0.0"
     stack-utils "^1.0.1"
+
+jest-mock@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.4.3.tgz#f63ba2f07a1511772cdc7979733397df770aabc7"
 
 jest-mock@^23.2.0:
   version "23.2.0"
@@ -5507,6 +5545,18 @@ jest-snapshot@^23.3.0:
     natural-compare "^1.4.0"
     pretty-format "^23.2.0"
     semver "^5.5.0"
+
+jest-util@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.4.3.tgz#c70fec8eec487c37b10b0809dc064a7ecf6aafac"
+  dependencies:
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    jest-message-util "^22.4.3"
+    mkdirp "^0.5.1"
+    source-map "^0.6.0"
 
 jest-util@^23.3.0:
   version "23.3.0"
@@ -5764,6 +5814,10 @@ jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+keypress@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.2.1.tgz#1e80454250018dbad4c3fe94497d6e67b6269c77"
 
 keyv@3.0.0:
   version "3.0.0"
@@ -8180,7 +8234,7 @@ regenerate@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
@@ -9574,6 +9628,10 @@ unherit@^1.0.4:
   dependencies:
     inherits "^2.0.1"
     xtend "^4.0.1"
+
+unicons@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/unicons/-/unicons-0.0.3.tgz#6e6a7a1a6eaebb01ca3d8b12ad9687279eaba524"
 
 unified@^6.0.0:
   version "6.2.0"


### PR DESCRIPTION
Now that we've upgrade to flow 0.75 we can start using flow's exact object types everywhere.  This PR converts almost all of our types to exact object types.  Doing this revealed a few places where we had extra props that weren't necessary.  It also adds an eslint rule to remind people that we should be using exact object types go forward.  I'm also planning to write up an ADR to adopt this practice in webapp as well.