### PR TITLE
Make the distance from corners match latest spec

### DIFF
--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -587,7 +587,7 @@ exports[`wonder-blocks-tooltip example 9 1`] = `
         "pointerEvents": "none",
         "position": "relative",
         "top": -1,
-        "width": 56,
+        "width": 40,
         "zIndex": 0,
       }
     }
@@ -597,8 +597,8 @@ exports[`wonder-blocks-tooltip example 9 1`] = `
       height={12}
       style={
         Object {
-          "marginLeft": 16,
-          "marginRight": 16,
+          "marginLeft": 8,
+          "marginRight": 8,
           "paddingBottom": 8,
         }
       }
@@ -684,7 +684,7 @@ exports[`wonder-blocks-tooltip example 9 1`] = `
           "minWidth": 0,
           "padding": 0,
           "position": "relative",
-          "width": 16,
+          "width": 8,
           "zIndex": 0,
         }
       }
@@ -726,7 +726,7 @@ exports[`wonder-blocks-tooltip example 9 1`] = `
           "minWidth": 0,
           "padding": 0,
           "position": "relative",
-          "width": 16,
+          "width": 8,
           "zIndex": 0,
         }
       }
@@ -807,7 +807,7 @@ exports[`wonder-blocks-tooltip example 10 1`] = `
           "boxSizing": "border-box",
           "display": "flex",
           "flexDirection": "column",
-          "height": 7,
+          "height": 8,
           "margin": 0,
           "minHeight": 0,
           "minWidth": 0,
@@ -849,7 +849,7 @@ exports[`wonder-blocks-tooltip example 10 1`] = `
           "boxSizing": "border-box",
           "display": "flex",
           "flexDirection": "column",
-          "height": 7,
+          "height": 8,
           "margin": 0,
           "minHeight": 0,
           "minWidth": 0,
@@ -892,7 +892,7 @@ exports[`wonder-blocks-tooltip example 10 1`] = `
         "boxSizing": "border-box",
         "display": "flex",
         "flexDirection": "column",
-        "height": 38,
+        "height": 40,
         "left": 1,
         "margin": 0,
         "minHeight": 0,
@@ -910,8 +910,8 @@ exports[`wonder-blocks-tooltip example 10 1`] = `
       height={24}
       style={
         Object {
-          "marginBottom": 7,
-          "marginTop": 7,
+          "marginBottom": 8,
+          "marginTop": 8,
           "paddingLeft": 8,
         }
       }
@@ -1020,7 +1020,7 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
           "minWidth": 0,
           "padding": 0,
           "position": "relative",
-          "width": 16,
+          "width": 8,
           "zIndex": 0,
         }
       }
@@ -1062,7 +1062,7 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
           "minWidth": 0,
           "padding": 0,
           "position": "relative",
-          "width": 16,
+          "width": 8,
           "zIndex": 0,
         }
       }
@@ -1108,7 +1108,7 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
         "pointerEvents": "none",
         "position": "relative",
         "top": 1,
-        "width": 56,
+        "width": 40,
         "zIndex": 0,
       }
     }
@@ -1118,8 +1118,8 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
       height={12}
       style={
         Object {
-          "marginLeft": 16,
-          "marginRight": 16,
+          "marginLeft": 8,
+          "marginRight": 8,
           "paddingTop": 8,
         }
       }
@@ -1175,7 +1175,7 @@ exports[`wonder-blocks-tooltip example 12 1`] = `
         "boxSizing": "border-box",
         "display": "flex",
         "flexDirection": "column",
-        "height": 38,
+        "height": 40,
         "left": -1,
         "margin": 0,
         "minHeight": 0,
@@ -1193,8 +1193,8 @@ exports[`wonder-blocks-tooltip example 12 1`] = `
       height={24}
       style={
         Object {
-          "marginBottom": 7,
-          "marginTop": 7,
+          "marginBottom": 8,
+          "marginTop": 8,
           "paddingRight": 8,
         }
       }
@@ -1275,7 +1275,7 @@ exports[`wonder-blocks-tooltip example 12 1`] = `
           "boxSizing": "border-box",
           "display": "flex",
           "flexDirection": "column",
-          "height": 7,
+          "height": 8,
           "margin": 0,
           "minHeight": 0,
           "minWidth": 0,
@@ -1317,7 +1317,7 @@ exports[`wonder-blocks-tooltip example 12 1`] = `
           "boxSizing": "border-box",
           "display": "flex",
           "flexDirection": "column",
-          "height": 7,
+          "height": 8,
           "margin": 0,
           "minHeight": 0,
           "minWidth": 0,
@@ -1475,7 +1475,7 @@ exports[`wonder-blocks-tooltip example 13 1`] = `
           "pointerEvents": "none",
           "position": "relative",
           "top": -1,
-          "width": 56,
+          "width": 40,
           "zIndex": 0,
         }
       }
@@ -1485,8 +1485,8 @@ exports[`wonder-blocks-tooltip example 13 1`] = `
         height={12}
         style={
           Object {
-            "marginLeft": 16,
-            "marginRight": 16,
+            "marginLeft": 8,
+            "marginRight": 8,
             "paddingBottom": 8,
           }
         }
@@ -1655,7 +1655,7 @@ exports[`wonder-blocks-tooltip example 14 1`] = `
           "boxSizing": "border-box",
           "display": "flex",
           "flexDirection": "column",
-          "height": 38,
+          "height": 40,
           "left": 1,
           "margin": 0,
           "minHeight": 0,
@@ -1673,8 +1673,8 @@ exports[`wonder-blocks-tooltip example 14 1`] = `
         height={24}
         style={
           Object {
-            "marginBottom": 7,
-            "marginTop": 7,
+            "marginBottom": 8,
+            "marginTop": 8,
             "paddingLeft": 8,
           }
         }
@@ -1851,7 +1851,7 @@ exports[`wonder-blocks-tooltip example 15 1`] = `
           "pointerEvents": "none",
           "position": "relative",
           "top": 1,
-          "width": 56,
+          "width": 40,
           "zIndex": 0,
         }
       }
@@ -1861,8 +1861,8 @@ exports[`wonder-blocks-tooltip example 15 1`] = `
         height={12}
         style={
           Object {
-            "marginLeft": 16,
-            "marginRight": 16,
+            "marginLeft": 8,
+            "marginRight": 8,
             "paddingTop": 8,
           }
         }
@@ -2003,7 +2003,7 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
           "boxSizing": "border-box",
           "display": "flex",
           "flexDirection": "column",
-          "height": 38,
+          "height": 40,
           "left": -1,
           "margin": 0,
           "minHeight": 0,
@@ -2021,8 +2021,8 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
         height={24}
         style={
           Object {
-            "marginBottom": 7,
-            "marginTop": 7,
+            "marginBottom": 8,
+            "marginTop": 8,
             "paddingRight": 8,
           }
         }
@@ -2200,7 +2200,7 @@ exports[`wonder-blocks-tooltip example 17 1`] = `
           "pointerEvents": "none",
           "position": "relative",
           "top": 1,
-          "width": 56,
+          "width": 40,
           "zIndex": 0,
         }
       }
@@ -2210,8 +2210,8 @@ exports[`wonder-blocks-tooltip example 17 1`] = `
         height={12}
         style={
           Object {
-            "marginLeft": 16,
-            "marginRight": 16,
+            "marginLeft": 8,
+            "marginRight": 8,
             "paddingTop": 8,
           }
         }
@@ -2363,7 +2363,7 @@ exports[`wonder-blocks-tooltip example 18 1`] = `
           "pointerEvents": "none",
           "position": "relative",
           "top": -1,
-          "width": 56,
+          "width": 40,
           "zIndex": 0,
         }
       }
@@ -2373,8 +2373,8 @@ exports[`wonder-blocks-tooltip example 18 1`] = `
         height={12}
         style={
           Object {
-            "marginLeft": 16,
-            "marginRight": 16,
+            "marginLeft": 8,
+            "marginRight": 8,
             "paddingBottom": 8,
           }
         }

--- a/packages/wonder-blocks-tooltip/components/tooltip-tail.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-tail.js
@@ -234,12 +234,11 @@ export default class TooltipTail extends React.Component<Props> {
         }
     }
 
-    _getFullTailWidth(placement: Placement) {
-        const minDistanceFromCorners = this._minDistanceFromCorners(placement);
-        return ARROW_WIDTH + 2 * minDistanceFromCorners;
+    _getFullTailWidth() {
+        return ARROW_WIDTH + 2 * MIN_DISTANCE_FROM_CORNERS;
     }
 
-    _getFullTailHeight(placement: Placement) {
+    _getFullTailHeight() {
         return ARROW_HEIGHT + DISTANCE_FROM_ANCHOR;
     }
 
@@ -259,8 +258,8 @@ export default class TooltipTail extends React.Component<Props> {
          * (i.e. placement="top"). When the tail points to the left or right
          * instead, the width/height are inverted.
          */
-        const fullTailWidth = this._getFullTailWidth(placement);
-        const fullTailHeight = this._getFullTailHeight(placement);
+        const fullTailWidth = this._getFullTailWidth();
+        const fullTailHeight = this._getFullTailHeight();
 
         switch (placement) {
             case "top":
@@ -298,33 +297,32 @@ export default class TooltipTail extends React.Component<Props> {
 
     _getArrowStyle() {
         const {placement} = this.props;
-        const minDistanceFromCorners = this._minDistanceFromCorners(placement);
         switch (placement) {
             case "top":
                 return {
-                    marginLeft: minDistanceFromCorners,
-                    marginRight: minDistanceFromCorners,
+                    marginLeft: MIN_DISTANCE_FROM_CORNERS,
+                    marginRight: MIN_DISTANCE_FROM_CORNERS,
                     paddingBottom: DISTANCE_FROM_ANCHOR,
                 };
 
             case "right":
                 return {
-                    marginTop: minDistanceFromCorners,
-                    marginBottom: minDistanceFromCorners,
+                    marginTop: MIN_DISTANCE_FROM_CORNERS,
+                    marginBottom: MIN_DISTANCE_FROM_CORNERS,
                     paddingLeft: DISTANCE_FROM_ANCHOR,
                 };
 
             case "bottom":
                 return {
-                    marginLeft: minDistanceFromCorners,
-                    marginRight: minDistanceFromCorners,
+                    marginLeft: MIN_DISTANCE_FROM_CORNERS,
+                    marginRight: MIN_DISTANCE_FROM_CORNERS,
                     paddingTop: DISTANCE_FROM_ANCHOR,
                 };
 
             case "left":
                 return {
-                    marginTop: minDistanceFromCorners,
-                    marginBottom: minDistanceFromCorners,
+                    marginTop: MIN_DISTANCE_FROM_CORNERS,
+                    marginBottom: MIN_DISTANCE_FROM_CORNERS,
                     paddingRight: DISTANCE_FROM_ANCHOR,
                 };
 
@@ -406,6 +404,8 @@ export default class TooltipTail extends React.Component<Props> {
  * the width/height are inverted.
  */
 const DISTANCE_FROM_ANCHOR = Spacing.xSmall;
+
+const MIN_DISTANCE_FROM_CORNERS = Spacing.xSmall;
 
 const ARROW_WIDTH = Spacing.large;
 const ARROW_HEIGHT = Spacing.small;

--- a/packages/wonder-blocks-tooltip/components/tooltip-tail.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip-tail.md
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
     },
     padding: {
         backgroundColor: "bisque",
-        width: Spacing.medium,
+        width: Spacing.xSmall,
     },
     tail: {
         backgroundColor: "green",
@@ -53,7 +53,7 @@ const styles = StyleSheet.create({
     },
     padding: {
         backgroundColor: "bisque",
-        height: 7,
+        height: Spacing.xSmall,
     },
     tail: {
         backgroundColor: "green",
@@ -87,7 +87,7 @@ const styles = StyleSheet.create({
     },
     padding: {
         backgroundColor: "bisque",
-        width: Spacing.medium,
+        width: Spacing.xSmall,
     },
     tail: {
         backgroundColor: "green",
@@ -123,7 +123,7 @@ const styles = StyleSheet.create({
     },
     padding: {
         backgroundColor: "bisque",
-        height: 7,
+        height: Spacing.xSmall,
     },
     tail: {
         backgroundColor: "green",

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -230,7 +230,7 @@ describe("wonder-blocks-tooltip", () => {
             },
             padding: {
                 backgroundColor: "bisque",
-                width: Spacing.medium,
+                width: Spacing.xSmall,
             },
             tail: {
                 backgroundColor: "green",
@@ -267,7 +267,7 @@ describe("wonder-blocks-tooltip", () => {
             },
             padding: {
                 backgroundColor: "bisque",
-                height: 7,
+                height: Spacing.xSmall,
             },
             tail: {
                 backgroundColor: "green",
@@ -302,7 +302,7 @@ describe("wonder-blocks-tooltip", () => {
             },
             padding: {
                 backgroundColor: "bisque",
-                width: Spacing.medium,
+                width: Spacing.xSmall,
             },
             tail: {
                 backgroundColor: "green",
@@ -339,7 +339,7 @@ describe("wonder-blocks-tooltip", () => {
             },
             padding: {
                 backgroundColor: "bisque",
-                height: 7,
+                height: Spacing.xSmall,
             },
             tail: {
                 backgroundColor: "green",


### PR DESCRIPTION
This updates the `TooltipTail` to match the latest design decisions so that in the rare circumstances that it will butt up against the bubble corners, it has an 8px margin.

See https://zpl.io/2j4zNjQ