### PR TITLE
Fix build to find codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 install:
   - yarn install
   - yarn run build:all
-  - yarn global add codecov
+  - yarn global add codecov && PATH=$PATH:$(yarn global bin)
 script:
   - yarn test
   - yarn run build:coverage && codecov


### PR DESCRIPTION
The command `yarn run build:coverage && codecov` started failing with message `codecov: command not found` in the travis builds. Build [#1663](https://travis-ci.org/Khan/wonder-blocks/builds/403894931) passed but build [#1666](https://travis-ci.org/Khan/wonder-blocks/builds/404475845) failed. We didn't change our config files between those builds, so perhaps something changed with travis or `yarn`.

This [issue](https://github.com/yarnpkg/yarn/issues/648) indicates that `global add` didn't put the binary in the expected location, so we append `yarn global bin` to `PATH`.