### PR TITLE
add missing peerDependencies

### DIFF
--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -17,5 +17,10 @@
     "@khanacademy/wonder-blocks-color": "^1.0.4",
     "@khanacademy/wonder-blocks-core": "^1.0.4",
     "@khanacademy/wonder-blocks-typography": "^1.0.4"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2",
+    "react-router-dom": "^4.2.2"
   }
 }

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -17,5 +17,9 @@
     "@khanacademy/wonder-blocks-icon": "1.0.1",
     "@khanacademy/wonder-blocks-spacing": "^1.0.0",
     "@khanacademy/wonder-blocks-typography": "^1.0.4"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2"
   }
 }

--- a/packages/wonder-blocks-grid/package.json
+++ b/packages/wonder-blocks-grid/package.json
@@ -18,5 +18,9 @@
     "@khanacademy/wonder-blocks-color": "^1.0.4",
     "@khanacademy/wonder-blocks-core": "^1.0.4",
     "@khanacademy/wonder-blocks-spacing": "^2.0.2"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2"
   }
 }

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -17,5 +17,10 @@
     "@khanacademy/wonder-blocks-color": "^1.0.4",
     "@khanacademy/wonder-blocks-core": "^1.0.4",
     "@khanacademy/wonder-blocks-icon": "^1.0.1"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2",
+    "react-router-dom": "^4.2.2"
   }
 }

--- a/packages/wonder-blocks-icon/package.json
+++ b/packages/wonder-blocks-icon/package.json
@@ -18,5 +18,9 @@
   },
   "devDependencies": {
     "@khanacademy/wonder-blocks-color": "^1.0.4"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2"
   }
 }

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -16,5 +16,10 @@
   "dependencies": {
     "@khanacademy/wonder-blocks-color": "^1.0.4",
     "@khanacademy/wonder-blocks-core": "^1.0.4"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2",
+    "react-router-dom": "^4.2.2"
   }
 }

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -19,5 +19,9 @@
     "@khanacademy/wonder-blocks-icon": "^1.0.1",
     "@khanacademy/wonder-blocks-icon-button": "^1.0.1",
     "@khanacademy/wonder-blocks-typography": "^1.0.4"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2"
   }
 }

--- a/packages/wonder-blocks-progress-spinner/package.json
+++ b/packages/wonder-blocks-progress-spinner/package.json
@@ -17,5 +17,9 @@
     "@khanacademy/wonder-blocks-color": "^1.0.4",
     "@khanacademy/wonder-blocks-core": "^1.0.4",
     "@khanacademy/wonder-blocks-spacing": "^2.0.2"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2"
   }
 }

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -22,5 +22,9 @@
     "@khanacademy/wonder-blocks-spacing": "^2.0.2",
     "@khanacademy/wonder-blocks-typography": "^1.0.4",
     "react-popper": "^1.0.0"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "^15.3.2"
   }
 }


### PR DESCRIPTION
I noticed that some of the packages that were published to npm are bigger than they should be.  This PR adds react, aphrodite, and react-router-dom as peer deps where need which will cause them to be excluded from the bundle b/c our build script marks anything that appears in `dependencies` or `peerDependencies` as external in the webpack settings for that package.