### PR TITLE
Fix modal tests after update to react 16

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.test.js
@@ -80,6 +80,7 @@ describe("ModalBackdrop", () => {
             <ModalBackdrop onCloseModal={onCloseModal}>
                 {exampleModal}
             </ModalBackdrop>,
+            {disableLifecycleMethods: true},
         );
 
         // Assert that the modal inside the backdrop was created from the
@@ -142,6 +143,7 @@ describe("ModalBackdrop", () => {
                         onClickCloseButton: customOnClickCloseButton,
                     })}
                 </ModalBackdrop>,
+                {disableLifecycleMethods: true},
             );
 
             // Assert that the modal inside the backdrop was created from the


### PR DESCRIPTION
I think the tests were failing because they were doing a shallow render, causing `ReactDOM.findDOMNode(this)` in `ModalBackdrop.componentDidMount` to fail. If we do a full mount instead, the tests pass. Alternatively, we can disable the lifecycle methods, which don't appear to be relevant what these particular tests are testing for.