### PR TITLE
setup circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  one:
+    docker:
+      - image: circleci/node:8-browsers
+    steps:
+      - checkout
+      - run: echo "A first hello"
+      - run: sleep 25
+  two:
+    docker:
+      - image: circleci/node:8-browsers
+    steps:
+      - checkout
+      - run: echo "A more familiar hi"
+      - run: sleep 15
+workflows:
+  version: 2
+  one_and_two:
+    jobs:
+      - one
+      - two


### PR DESCRIPTION
I've found circleci builds are faster.  Also, we can parallelize different parts of the build, e.g. run eslint, flow, etc. as one sub-job and the build itself along with all tests as a separate sub-job.