### PR TITLE
Fix minor error in Icon docs

### DIFF
--- a/packages/wonder-blocks-icon/docs.md
+++ b/packages/wonder-blocks-icon/docs.md
@@ -52,12 +52,14 @@ const styles = StyleSheet.create({
                 if (icons[iconName][size]) {
                     return <td
                         className={css(styles.iconCell, styles.tableBorder)}
+                        key={size}
                     >
                         <Icon icon={icons[iconName]} size={size} />
                     </td>;
                 }
                 return <td
                     className={css(styles.emptyCell, styles.tableBorder)}
+                    key={size}
                 />;
             })}
         </tr>

--- a/packages/wonder-blocks-icon/generated-snapshot.test.js
+++ b/packages/wonder-blocks-icon/generated-snapshot.test.js
@@ -78,6 +78,7 @@ describe("wonder-blocks-icon", () => {
                                             styles.iconCell,
                                             styles.tableBorder,
                                         )}
+                                        key={size}
                                     >
                                         <Icon
                                             icon={icons[iconName]}
@@ -92,6 +93,7 @@ describe("wonder-blocks-icon", () => {
                                         styles.emptyCell,
                                         styles.tableBorder,
                                     )}
+                                    key={size}
                                 />
                             );
                         })}


### PR DESCRIPTION
Removes the console warning about how iterated-over things need a distinct key