### PR TITLE
Create more natural tab order in modal

### DIFF
--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -358,6 +358,83 @@ exports[`wonder-blocks-modal example 2 1`] = `
           className=""
           style={
             Object {
+              "alignItems": "stretch",
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "boxSizing": "border-box",
+              "display": "flex",
+              "flexDirection": "column",
+              "left": 8,
+              "margin": 0,
+              "minHeight": 0,
+              "minWidth": 0,
+              "padding": 0,
+              "position": "absolute",
+              "top": 8,
+              "zIndex": 1,
+            }
+          }
+        >
+          <button
+            aria-label="Close modal"
+            className=""
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "alignItems": "center",
+                "background": "none",
+                "border": "none",
+                "boxSizing": "border-box",
+                "color": "rgba(33,36,44,0.64)",
+                "cursor": "pointer",
+                "display": "inline-flex",
+                "height": 40,
+                "justifyContent": "center",
+                "margin": 0,
+                "outline": "none",
+                "padding": 0,
+                "position": "relative",
+                "textDecoration": "none",
+                "width": 40,
+              }
+            }
+            tabIndex={0}
+          >
+            <svg
+              className=""
+              height={24}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "verticalAlign": "text-bottom",
+                }
+              }
+              viewBox="0 0 24 24"
+              width={24}
+            >
+              <path
+                d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className=""
+          style={
+            Object {
               "alignItems": "center",
               "borderBottomColor": "rgba(33,36,44,0.16)",
               "borderBottomStyle": "solid",
@@ -510,83 +587,6 @@ exports[`wonder-blocks-modal example 2 1`] = `
               </span>
             </div>
           </div>
-        </div>
-        <div
-          className=""
-          style={
-            Object {
-              "alignItems": "stretch",
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "boxSizing": "border-box",
-              "display": "flex",
-              "flexDirection": "column",
-              "left": 8,
-              "margin": 0,
-              "minHeight": 0,
-              "minWidth": 0,
-              "padding": 0,
-              "position": "absolute",
-              "top": 8,
-              "zIndex": 0,
-            }
-          }
-        >
-          <button
-            aria-label="Close modal"
-            className=""
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchStart={[Function]}
-            style={
-              Object {
-                "alignItems": "center",
-                "background": "none",
-                "border": "none",
-                "boxSizing": "border-box",
-                "color": "rgba(33,36,44,0.64)",
-                "cursor": "pointer",
-                "display": "inline-flex",
-                "height": 40,
-                "justifyContent": "center",
-                "margin": 0,
-                "outline": "none",
-                "padding": 0,
-                "position": "relative",
-                "textDecoration": "none",
-                "width": 40,
-              }
-            }
-            tabIndex={0}
-          >
-            <svg
-              className=""
-              height={24}
-              style={
-                Object {
-                  "display": "inline-block",
-                  "verticalAlign": "text-bottom",
-                }
-              }
-              viewBox="0 0 24 24"
-              width={24}
-            >
-              <path
-                d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
         </div>
         <div
           className=""
@@ -803,6 +803,83 @@ exports[`wonder-blocks-modal example 3 1`] = `
           className=""
           style={
             Object {
+              "alignItems": "stretch",
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "boxSizing": "border-box",
+              "display": "flex",
+              "flexDirection": "column",
+              "left": 8,
+              "margin": 0,
+              "minHeight": 0,
+              "minWidth": 0,
+              "padding": 0,
+              "position": "absolute",
+              "top": 8,
+              "zIndex": 1,
+            }
+          }
+        >
+          <button
+            aria-label="Close modal"
+            className=""
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "alignItems": "center",
+                "background": "none",
+                "border": "none",
+                "boxSizing": "border-box",
+                "color": "rgba(33,36,44,0.64)",
+                "cursor": "pointer",
+                "display": "inline-flex",
+                "height": 40,
+                "justifyContent": "center",
+                "margin": 0,
+                "outline": "none",
+                "padding": 0,
+                "position": "relative",
+                "textDecoration": "none",
+                "width": 40,
+              }
+            }
+            tabIndex={0}
+          >
+            <svg
+              className=""
+              height={24}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "verticalAlign": "text-bottom",
+                }
+              }
+              viewBox="0 0 24 24"
+              width={24}
+            >
+              <path
+                d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className=""
+          style={
+            Object {
               "alignItems": "center",
               "borderBottomColor": "rgba(33,36,44,0.16)",
               "borderBottomStyle": "solid",
@@ -1016,83 +1093,6 @@ exports[`wonder-blocks-modal example 3 1`] = `
               </span>
             </div>
           </div>
-        </div>
-        <div
-          className=""
-          style={
-            Object {
-              "alignItems": "stretch",
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "boxSizing": "border-box",
-              "display": "flex",
-              "flexDirection": "column",
-              "left": 8,
-              "margin": 0,
-              "minHeight": 0,
-              "minWidth": 0,
-              "padding": 0,
-              "position": "absolute",
-              "top": 8,
-              "zIndex": 0,
-            }
-          }
-        >
-          <button
-            aria-label="Close modal"
-            className=""
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchStart={[Function]}
-            style={
-              Object {
-                "alignItems": "center",
-                "background": "none",
-                "border": "none",
-                "boxSizing": "border-box",
-                "color": "rgba(33,36,44,0.64)",
-                "cursor": "pointer",
-                "display": "inline-flex",
-                "height": 40,
-                "justifyContent": "center",
-                "margin": 0,
-                "outline": "none",
-                "padding": 0,
-                "position": "relative",
-                "textDecoration": "none",
-                "width": 40,
-              }
-            }
-            tabIndex={0}
-          >
-            <svg
-              className=""
-              height={24}
-              style={
-                Object {
-                  "display": "inline-block",
-                  "verticalAlign": "text-bottom",
-                }
-              }
-              viewBox="0 0 24 24"
-              width={24}
-            >
-              <path
-                d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
         </div>
         <div
           className=""
@@ -1309,6 +1309,83 @@ exports[`wonder-blocks-modal example 4 1`] = `
           className=""
           style={
             Object {
+              "alignItems": "stretch",
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "boxSizing": "border-box",
+              "display": "flex",
+              "flexDirection": "column",
+              "left": 8,
+              "margin": 0,
+              "minHeight": 0,
+              "minWidth": 0,
+              "padding": 0,
+              "position": "absolute",
+              "top": 8,
+              "zIndex": 1,
+            }
+          }
+        >
+          <button
+            aria-label="Close modal"
+            className=""
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "alignItems": "center",
+                "background": "none",
+                "border": "none",
+                "boxSizing": "border-box",
+                "color": "rgba(33,36,44,0.64)",
+                "cursor": "pointer",
+                "display": "inline-flex",
+                "height": 40,
+                "justifyContent": "center",
+                "margin": 0,
+                "outline": "none",
+                "padding": 0,
+                "position": "relative",
+                "textDecoration": "none",
+                "width": 40,
+              }
+            }
+            tabIndex={0}
+          >
+            <svg
+              className=""
+              height={24}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "verticalAlign": "text-bottom",
+                }
+              }
+              viewBox="0 0 24 24"
+              width={24}
+            >
+              <path
+                d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className=""
+          style={
+            Object {
               "alignItems": "center",
               "borderBottomColor": "rgba(33,36,44,0.16)",
               "borderBottomStyle": "solid",
@@ -1522,83 +1599,6 @@ exports[`wonder-blocks-modal example 4 1`] = `
               </span>
             </div>
           </div>
-        </div>
-        <div
-          className=""
-          style={
-            Object {
-              "alignItems": "stretch",
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "boxSizing": "border-box",
-              "display": "flex",
-              "flexDirection": "column",
-              "left": 8,
-              "margin": 0,
-              "minHeight": 0,
-              "minWidth": 0,
-              "padding": 0,
-              "position": "absolute",
-              "top": 8,
-              "zIndex": 0,
-            }
-          }
-        >
-          <button
-            aria-label="Close modal"
-            className=""
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchStart={[Function]}
-            style={
-              Object {
-                "alignItems": "center",
-                "background": "none",
-                "border": "none",
-                "boxSizing": "border-box",
-                "color": "rgba(33,36,44,0.64)",
-                "cursor": "pointer",
-                "display": "inline-flex",
-                "height": 40,
-                "justifyContent": "center",
-                "margin": 0,
-                "outline": "none",
-                "padding": 0,
-                "position": "relative",
-                "textDecoration": "none",
-                "width": 40,
-              }
-            }
-            tabIndex={0}
-          >
-            <svg
-              className=""
-              height={24}
-              style={
-                Object {
-                  "display": "inline-block",
-                  "verticalAlign": "text-bottom",
-                }
-              }
-              viewBox="0 0 24 24"
-              width={24}
-            >
-              <path
-                d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
         </div>
         <div
           className=""
@@ -1951,6 +1951,83 @@ exports[`wonder-blocks-modal example 5 1`] = `
           className=""
           style={
             Object {
+              "alignItems": "stretch",
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "boxSizing": "border-box",
+              "display": "flex",
+              "flexDirection": "column",
+              "left": 8,
+              "margin": 0,
+              "minHeight": 0,
+              "minWidth": 0,
+              "padding": 0,
+              "position": "absolute",
+              "top": 8,
+              "zIndex": 1,
+            }
+          }
+        >
+          <button
+            aria-label="Close modal"
+            className=""
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "alignItems": "center",
+                "background": "none",
+                "border": "none",
+                "boxSizing": "border-box",
+                "color": "#ffffff",
+                "cursor": "pointer",
+                "display": "inline-flex",
+                "height": 40,
+                "justifyContent": "center",
+                "margin": 0,
+                "outline": "none",
+                "padding": 0,
+                "position": "relative",
+                "textDecoration": "none",
+                "width": 40,
+              }
+            }
+            tabIndex={0}
+          >
+            <svg
+              className=""
+              height={24}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "verticalAlign": "text-bottom",
+                }
+              }
+              viewBox="0 0 24 24"
+              width={24}
+            >
+              <path
+                d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className=""
+          style={
+            Object {
               "alignItems": "center",
               "background": "#0a2a66",
               "borderBottomColor": "rgba(255,255,255,0.64)",
@@ -2235,83 +2312,6 @@ exports[`wonder-blocks-modal example 5 1`] = `
           className=""
           style={
             Object {
-              "alignItems": "stretch",
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "boxSizing": "border-box",
-              "display": "flex",
-              "flexDirection": "column",
-              "left": 8,
-              "margin": 0,
-              "minHeight": 0,
-              "minWidth": 0,
-              "padding": 0,
-              "position": "absolute",
-              "top": 8,
-              "zIndex": 0,
-            }
-          }
-        >
-          <button
-            aria-label="Close modal"
-            className=""
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchStart={[Function]}
-            style={
-              Object {
-                "alignItems": "center",
-                "background": "none",
-                "border": "none",
-                "boxSizing": "border-box",
-                "color": "#ffffff",
-                "cursor": "pointer",
-                "display": "inline-flex",
-                "height": 40,
-                "justifyContent": "center",
-                "margin": 0,
-                "outline": "none",
-                "padding": 0,
-                "position": "relative",
-                "textDecoration": "none",
-                "width": 40,
-              }
-            }
-            tabIndex={0}
-          >
-            <svg
-              className=""
-              height={24}
-              style={
-                Object {
-                  "display": "inline-block",
-                  "verticalAlign": "text-bottom",
-                }
-              }
-              viewBox="0 0 24 24"
-              width={24}
-            >
-              <path
-                d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-        </div>
-        <div
-          className=""
-          style={
-            Object {
               "alignItems": "center",
               "borderStyle": "solid",
               "borderTopColor": "rgba(33,36,44,0.16)",
@@ -2547,6 +2547,83 @@ exports[`wonder-blocks-modal example 6 1`] = `
                 "borderStyle": "solid",
                 "borderWidth": 0,
                 "boxSizing": "border-box",
+                "display": "flex",
+                "flexDirection": "column",
+                "left": 8,
+                "margin": 0,
+                "minHeight": 0,
+                "minWidth": 0,
+                "padding": 0,
+                "position": "absolute",
+                "top": 8,
+                "zIndex": 1,
+              }
+            }
+          >
+            <button
+              aria-label="Close modal"
+              className=""
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "background": "none",
+                  "border": "none",
+                  "boxSizing": "border-box",
+                  "color": "#ffffff",
+                  "cursor": "pointer",
+                  "display": "inline-flex",
+                  "height": 40,
+                  "justifyContent": "center",
+                  "margin": 0,
+                  "outline": "none",
+                  "padding": 0,
+                  "position": "relative",
+                  "textDecoration": "none",
+                  "width": 40,
+                }
+              }
+              tabIndex={0}
+            >
+              <svg
+                className=""
+                height={24}
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "verticalAlign": "text-bottom",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            className=""
+            style={
+              Object {
+                "alignItems": "stretch",
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "boxSizing": "border-box",
                 "display": "block",
                 "flex": 1,
                 "flexDirection": "column",
@@ -2641,83 +2718,6 @@ exports[`wonder-blocks-modal example 6 1`] = `
                 </span>
               </div>
             </div>
-          </div>
-          <div
-            className=""
-            style={
-              Object {
-                "alignItems": "stretch",
-                "borderStyle": "solid",
-                "borderWidth": 0,
-                "boxSizing": "border-box",
-                "display": "flex",
-                "flexDirection": "column",
-                "left": 8,
-                "margin": 0,
-                "minHeight": 0,
-                "minWidth": 0,
-                "padding": 0,
-                "position": "absolute",
-                "top": 8,
-                "zIndex": 0,
-              }
-            }
-          >
-            <button
-              aria-label="Close modal"
-              className=""
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchStart={[Function]}
-              style={
-                Object {
-                  "alignItems": "center",
-                  "background": "none",
-                  "border": "none",
-                  "boxSizing": "border-box",
-                  "color": "#ffffff",
-                  "cursor": "pointer",
-                  "display": "inline-flex",
-                  "height": 40,
-                  "justifyContent": "center",
-                  "margin": 0,
-                  "outline": "none",
-                  "padding": 0,
-                  "position": "relative",
-                  "textDecoration": "none",
-                  "width": 40,
-                }
-              }
-              tabIndex={0}
-            >
-              <svg
-                className=""
-                height={24}
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "verticalAlign": "text-bottom",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width={24}
-              >
-                <path
-                  d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
           </div>
         </div>
         <div
@@ -2979,6 +2979,83 @@ exports[`wonder-blocks-modal example 7 1`] = `
                 "borderStyle": "solid",
                 "borderWidth": 0,
                 "boxSizing": "border-box",
+                "display": "flex",
+                "flexDirection": "column",
+                "left": 8,
+                "margin": 0,
+                "minHeight": 0,
+                "minWidth": 0,
+                "padding": 0,
+                "position": "absolute",
+                "top": 8,
+                "zIndex": 1,
+              }
+            }
+          >
+            <button
+              aria-label="Close modal"
+              className=""
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "background": "none",
+                  "border": "none",
+                  "boxSizing": "border-box",
+                  "color": "#ffffff",
+                  "cursor": "pointer",
+                  "display": "inline-flex",
+                  "height": 40,
+                  "justifyContent": "center",
+                  "margin": 0,
+                  "outline": "none",
+                  "padding": 0,
+                  "position": "relative",
+                  "textDecoration": "none",
+                  "width": 40,
+                }
+              }
+              tabIndex={0}
+            >
+              <svg
+                className=""
+                height={24}
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "verticalAlign": "text-bottom",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            className=""
+            style={
+              Object {
+                "alignItems": "stretch",
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "boxSizing": "border-box",
                 "display": "block",
                 "flex": 1,
                 "flexDirection": "column",
@@ -3073,83 +3150,6 @@ exports[`wonder-blocks-modal example 7 1`] = `
                 </span>
               </div>
             </div>
-          </div>
-          <div
-            className=""
-            style={
-              Object {
-                "alignItems": "stretch",
-                "borderStyle": "solid",
-                "borderWidth": 0,
-                "boxSizing": "border-box",
-                "display": "flex",
-                "flexDirection": "column",
-                "left": 8,
-                "margin": 0,
-                "minHeight": 0,
-                "minWidth": 0,
-                "padding": 0,
-                "position": "absolute",
-                "top": 8,
-                "zIndex": 0,
-              }
-            }
-          >
-            <button
-              aria-label="Close modal"
-              className=""
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchStart={[Function]}
-              style={
-                Object {
-                  "alignItems": "center",
-                  "background": "none",
-                  "border": "none",
-                  "boxSizing": "border-box",
-                  "color": "#ffffff",
-                  "cursor": "pointer",
-                  "display": "inline-flex",
-                  "height": 40,
-                  "justifyContent": "center",
-                  "margin": 0,
-                  "outline": "none",
-                  "padding": 0,
-                  "position": "relative",
-                  "textDecoration": "none",
-                  "width": 40,
-                }
-              }
-              tabIndex={0}
-            >
-              <svg
-                className=""
-                height={24}
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "verticalAlign": "text-bottom",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width={24}
-              >
-                <path
-                  d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
           </div>
         </div>
         <div
@@ -3534,52 +3534,6 @@ exports[`wonder-blocks-modal example 8 1`] = `
                 "borderStyle": "solid",
                 "borderWidth": 0,
                 "boxSizing": "border-box",
-                "display": "block",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 0,
-                "minHeight": 0,
-                "minWidth": 0,
-                "overflow": "auto",
-                "padding": 0,
-                "position": "relative",
-                "zIndex": 0,
-              }
-            }
-          >
-            <div
-              className=""
-              style={
-                Object {
-                  "alignItems": "stretch",
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "boxSizing": "border-box",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "column",
-                  "margin": 0,
-                  "minHeight": 0,
-                  "minWidth": 0,
-                  "padding": 64,
-                  "position": "relative",
-                  "zIndex": 0,
-                }
-              }
-            >
-              <span>
-                foo
-              </span>
-            </div>
-          </div>
-          <div
-            className=""
-            style={
-              Object {
-                "alignItems": "stretch",
-                "borderStyle": "solid",
-                "borderWidth": 0,
-                "boxSizing": "border-box",
                 "display": "flex",
                 "flexDirection": "column",
                 "left": 8,
@@ -3589,7 +3543,7 @@ exports[`wonder-blocks-modal example 8 1`] = `
                 "padding": 0,
                 "position": "absolute",
                 "top": 8,
-                "zIndex": 0,
+                "zIndex": 1,
               }
             }
           >
@@ -3648,6 +3602,52 @@ exports[`wonder-blocks-modal example 8 1`] = `
                 />
               </svg>
             </button>
+          </div>
+          <div
+            className=""
+            style={
+              Object {
+                "alignItems": "stretch",
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 0,
+                "minHeight": 0,
+                "minWidth": 0,
+                "overflow": "auto",
+                "padding": 0,
+                "position": "relative",
+                "zIndex": 0,
+              }
+            }
+          >
+            <div
+              className=""
+              style={
+                Object {
+                  "alignItems": "stretch",
+                  "borderStyle": "solid",
+                  "borderWidth": 0,
+                  "boxSizing": "border-box",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "column",
+                  "margin": 0,
+                  "minHeight": 0,
+                  "minWidth": 0,
+                  "padding": 64,
+                  "position": "relative",
+                  "zIndex": 0,
+                }
+              }
+            >
+              <span>
+                foo
+              </span>
+            </div>
           </div>
         </div>
         <div
@@ -3851,6 +3851,83 @@ exports[`wonder-blocks-modal example 9 1`] = `
                 "borderStyle": "solid",
                 "borderWidth": 0,
                 "boxSizing": "border-box",
+                "display": "flex",
+                "flexDirection": "column",
+                "left": 8,
+                "margin": 0,
+                "minHeight": 0,
+                "minWidth": 0,
+                "padding": 0,
+                "position": "absolute",
+                "top": 8,
+                "zIndex": 1,
+              }
+            }
+          >
+            <button
+              aria-label="Close modal"
+              className=""
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "background": "none",
+                  "border": "none",
+                  "boxSizing": "border-box",
+                  "color": "rgba(33,36,44,0.64)",
+                  "cursor": "pointer",
+                  "display": "inline-flex",
+                  "height": 40,
+                  "justifyContent": "center",
+                  "margin": 0,
+                  "outline": "none",
+                  "padding": 0,
+                  "position": "relative",
+                  "textDecoration": "none",
+                  "width": 40,
+                }
+              }
+              tabIndex={0}
+            >
+              <svg
+                className=""
+                height={24}
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "verticalAlign": "text-bottom",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            className=""
+            style={
+              Object {
+                "alignItems": "stretch",
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "boxSizing": "border-box",
                 "display": "block",
                 "flex": 1,
                 "flexDirection": "column",
@@ -3945,83 +4022,6 @@ exports[`wonder-blocks-modal example 9 1`] = `
                 </span>
               </div>
             </div>
-          </div>
-          <div
-            className=""
-            style={
-              Object {
-                "alignItems": "stretch",
-                "borderStyle": "solid",
-                "borderWidth": 0,
-                "boxSizing": "border-box",
-                "display": "flex",
-                "flexDirection": "column",
-                "left": 8,
-                "margin": 0,
-                "minHeight": 0,
-                "minWidth": 0,
-                "padding": 0,
-                "position": "absolute",
-                "top": 8,
-                "zIndex": 0,
-              }
-            }
-          >
-            <button
-              aria-label="Close modal"
-              className=""
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchStart={[Function]}
-              style={
-                Object {
-                  "alignItems": "center",
-                  "background": "none",
-                  "border": "none",
-                  "boxSizing": "border-box",
-                  "color": "rgba(33,36,44,0.64)",
-                  "cursor": "pointer",
-                  "display": "inline-flex",
-                  "height": 40,
-                  "justifyContent": "center",
-                  "margin": 0,
-                  "outline": "none",
-                  "padding": 0,
-                  "position": "relative",
-                  "textDecoration": "none",
-                  "width": 40,
-                }
-              }
-              tabIndex={0}
-            >
-              <svg
-                className=""
-                height={24}
-                style={
-                  Object {
-                    "display": "inline-block",
-                    "verticalAlign": "text-bottom",
-                  }
-                }
-                viewBox="0 0 24 24"
-                width={24}
-              >
-                <path
-                  d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
           </div>
         </div>
       </div>
@@ -4155,53 +4155,6 @@ exports[`wonder-blocks-modal example 10 1`] = `
                 "borderStyle": "solid",
                 "borderWidth": 0,
                 "boxSizing": "border-box",
-                "display": "block",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 0,
-                "minHeight": 0,
-                "minWidth": 0,
-                "overflow": "auto",
-                "padding": 0,
-                "position": "relative",
-                "zIndex": 0,
-              }
-            }
-          >
-            <div
-              className=""
-              style={
-                Object {
-                  "alignItems": "stretch",
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "boxSizing": "border-box",
-                  "display": "flex",
-                  "flex": 1,
-                  "flexDirection": "column",
-                  "margin": 0,
-                  "minHeight": 0,
-                  "minWidth": 0,
-                  "padding": 64,
-                  "paddingBottom": 32,
-                  "position": "relative",
-                  "zIndex": 0,
-                }
-              }
-            >
-              <span>
-                Foo
-              </span>
-            </div>
-          </div>
-          <div
-            className=""
-            style={
-              Object {
-                "alignItems": "stretch",
-                "borderStyle": "solid",
-                "borderWidth": 0,
-                "boxSizing": "border-box",
                 "display": "flex",
                 "flexDirection": "column",
                 "left": 8,
@@ -4211,7 +4164,7 @@ exports[`wonder-blocks-modal example 10 1`] = `
                 "padding": 0,
                 "position": "absolute",
                 "top": 8,
-                "zIndex": 0,
+                "zIndex": 1,
               }
             }
           >
@@ -4270,6 +4223,53 @@ exports[`wonder-blocks-modal example 10 1`] = `
                 />
               </svg>
             </button>
+          </div>
+          <div
+            className=""
+            style={
+              Object {
+                "alignItems": "stretch",
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 0,
+                "minHeight": 0,
+                "minWidth": 0,
+                "overflow": "auto",
+                "padding": 0,
+                "position": "relative",
+                "zIndex": 0,
+              }
+            }
+          >
+            <div
+              className=""
+              style={
+                Object {
+                  "alignItems": "stretch",
+                  "borderStyle": "solid",
+                  "borderWidth": 0,
+                  "boxSizing": "border-box",
+                  "display": "flex",
+                  "flex": 1,
+                  "flexDirection": "column",
+                  "margin": 0,
+                  "minHeight": 0,
+                  "minWidth": 0,
+                  "padding": 64,
+                  "paddingBottom": 32,
+                  "position": "relative",
+                  "zIndex": 0,
+                }
+              }
+            >
+              <span>
+                Foo
+              </span>
+            </div>
           </div>
           <div
             className=""

--- a/packages/wonder-blocks-modal/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.js
@@ -145,9 +145,9 @@ export default class ModalPanel extends React.Component<Props> {
             <View
                 style={[styles.wrapper, color === "dark" && styles.dark, style]}
             >
+                {this.maybeRenderCloseButton()}
                 {titleBar}
                 {mainContent}
-                {this.maybeRenderCloseButton()}
                 {!footer ||
                 (typeof footer === "object" && footer.type === ModalFooter) ? (
                     footer
@@ -175,6 +175,9 @@ const styles = StyleSheet.create({
         position: "absolute",
         left: 8,
         top: 8,
+        // This is to allow the button to be tab-ordered before the modal
+        // content but still be above the header and content.
+        zIndex: 1,
     },
 
     smallCloseButton: {


### PR DESCRIPTION
The close button is `position: absolute`, so changing this doesn't change where the button renders. This creates a more natural order for tab navigation in the modal. Previously, the tab ordering went footer -> content -> close. Now it goes footer -> close -> content.

Go to https://deploy-preview-232--wonder-blocks.netlify.com/#modal and open the one-column modal, which has tab-active elements in the modal content.