### PR TITLE
Rename dropdown to more closely match existing and base elements

### DIFF
--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -73,7 +73,7 @@ type ItemProps = ActionItemProps | OptionItemProps | SeparatorProps;
 
 type MenuProps = {|
     /**
-     * The items in this menu.
+     * The items in this dropdown.
      */
     items: Array<ItemProps>,
 
@@ -101,8 +101,8 @@ type MenuProps = {|
     alignment: "left" | "right",
 
     /**
-     * Whether this menu is disabled. A disabled menu may not be opened and
-     * does not support interaction. Defaults to false.
+     * Whether this component is disabled. A disabled dropdown may not be opened
+     * and does not support interaction. Defaults to false.
      */
     disabled: boolean,
 
@@ -114,7 +114,7 @@ type MenuProps = {|
 
 type State = {|
     /**
-     * Whether or not menu is open.
+     * Whether or not the dropdown is open.
      */
     open: boolean,
 |};

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -9,13 +9,13 @@ import Button from "@khanacademy/wonder-blocks-button";
 import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 
 import ActionItem from "./action-item.js";
-import DropdownCore from "./dropdown-core.js";
-import SelectItem from "./select-item.js";
+import Dropdown from "./dropdown.js";
+import OptionItem from "./option-item.js";
 import SeparatorItem from "./separator-item.js";
 
 import type {
     ActionItemProps,
-    SelectItemProps,
+    OptionItemProps,
     SeparatorProps,
 } from "../util/types.js";
 
@@ -69,7 +69,7 @@ class ActionMenuOpener extends React.Component<OpenerProps> {
     }
 }
 
-type ItemProps = ActionItemProps | SelectItemProps | SeparatorProps;
+type ItemProps = ActionItemProps | OptionItemProps | SeparatorProps;
 
 type MenuProps = {|
     /**
@@ -189,7 +189,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
             </ActionMenuOpener>
         );
 
-        const containsSelectItems = Array.isArray(selectedValues);
+        const containsOptionItems = Array.isArray(selectedValues);
 
         const menuItems = items.map((item, index) => {
             if (item.type === "action") {
@@ -197,7 +197,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                     <ActionItem
                         key={index}
                         disabled={item.disabled}
-                        indent={containsSelectItems}
+                        indent={containsOptionItems}
                         label={item.label}
                         href={item.href}
                         clientNav={item.clientNav}
@@ -207,7 +207,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                 );
             } else if (item.type === "select") {
                 return (
-                    <SelectItem
+                    <OptionItem
                         key={index}
                         disabled={item.disabled}
                         label={item.label}
@@ -232,7 +232,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
         });
 
         return (
-            <DropdownCore
+            <Dropdown
                 alignment={alignment}
                 items={menuItems}
                 light={false}

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -4,7 +4,7 @@ import React from "react";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import ActionItem from "./action-item.js";
-import SelectItem from "./select-item.js";
+import OptionItem from "./option-item.js";
 import ActionMenu from "./action-menu.js";
 
 const keyCodes = {
@@ -85,10 +85,10 @@ describe("ActionMenu", () => {
         actionItem.simulate("click");
         expect(onClick).toHaveBeenCalledTimes(1);
 
-        const selectItem = menu.find(SelectItem);
-        selectItem.simulate("mousedown");
-        selectItem.simulate("mouseup", nativeEvent);
-        selectItem.simulate("click", nativeEvent);
+        const optionItem = menu.find(OptionItem);
+        optionItem.simulate("mousedown");
+        optionItem.simulate("mouseup", nativeEvent);
+        optionItem.simulate("click", nativeEvent);
         expect(onToggle).toHaveBeenCalledTimes(1);
         expect(onChange).toHaveBeenCalledTimes(1);
     });

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -13,14 +13,14 @@ import {View} from "@khanacademy/wonder-blocks-core";
 
 import visibilityModifierDefaultConfig from "../util/visibility-modifier.js";
 import typeof ActionItem from "./action-item.js";
-import typeof SelectItem from "./select-item.js";
+import typeof OptionItem from "./option-item.js";
 import typeof SeparatorItem from "./separator-item.js";
 
-type DropdownCoreProps = {|
+type DropdownProps = {|
     /**
      * Items for the menu.
      */
-    items: Array<React.Element<ActionItem | SelectItem | SeparatorItem>>,
+    items: Array<React.Element<ActionItem | OptionItem | SeparatorItem>>,
 
     /**
      * Whether the menu is open or not.
@@ -63,14 +63,14 @@ type DropdownCoreProps = {|
     dropdownStyle?: any,
 |};
 
-export default class DropdownCore extends React.Component<DropdownCoreProps> {
+export default class Dropdown extends React.Component<DropdownProps> {
     element: ?Element;
 
     static defaultProps = {
         alignment: "left",
     };
 
-    constructor(props: DropdownCoreProps) {
+    constructor(props: DropdownProps) {
         super(props);
     }
 
@@ -78,7 +78,7 @@ export default class DropdownCore extends React.Component<DropdownCoreProps> {
         this.updateEventListeners();
     }
 
-    componentDidUpdate(prevProps: DropdownCoreProps) {
+    componentDidUpdate(prevProps: DropdownProps) {
         if (prevProps.open !== this.props.open) {
             this.updateEventListeners();
         }

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -56,11 +56,14 @@ type DropdownProps = {|
     light: boolean,
 
     /**
-     * Optional styling to add to dropdown menu.
+     * Styling specific to the dropdown component that isn't part of the opener.
+     */
+    dropdownStyle?: any,
+
+    /**
+     * Optional styling to add to the entire menu.
      */
     style?: any,
-
-    dropdownStyle?: any,
 |};
 
 export default class Dropdown extends React.Component<DropdownProps> {
@@ -126,7 +129,7 @@ export default class Dropdown extends React.Component<DropdownProps> {
     };
 
     renderMenu(outOfBoundaries: ?boolean) {
-        const {items, light, dropdownStyle} = this.props;
+        const {items, light, dropdownStyle, style} = this.props;
 
         return (
             <View
@@ -140,6 +143,7 @@ export default class Dropdown extends React.Component<DropdownProps> {
                     light && styles.light,
                     outOfBoundaries && styles.hidden,
                     dropdownStyle,
+                    style,
                 ]}
             >
                 {items}

--- a/packages/wonder-blocks-dropdown/components/multi-select-test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select-test.js
@@ -2,17 +2,17 @@
 import React from "react";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
-import SelectBox from "./select-box";
-import ActionItem from "./action-item";
-import SelectItem from "./select-item";
-import MultiSelectMenu from "./multi-select-menu.js";
+import SelectOpener from "./select-opener.js";
+import ActionItem from "./action-item.js";
+import OptionItem from "./option-item.js";
+import MultiSelect from "./multi-select.js";
 
 const keyCodes = {
     enter: 13,
     space: 32,
 };
 
-describe("MultiSelectMenu", () => {
+describe("MultiSelect", () => {
     let menu;
     const allChanges = [];
     const saveUpdate = (update) => {
@@ -22,7 +22,7 @@ describe("MultiSelectMenu", () => {
 
     beforeEach(() => {
         menu = mount(
-            <MultiSelectMenu
+            <MultiSelect
                 items={[
                     {
                         type: "select",
@@ -57,7 +57,7 @@ describe("MultiSelectMenu", () => {
     });
 
     it("closes/opens the menu on mouse click, space, and enter", () => {
-        const opener = menu.find(SelectBox);
+        const opener = menu.find(SelectOpener);
         expect(menu.state("open")).toEqual(false);
 
         // Open menu with mouse
@@ -89,7 +89,7 @@ describe("MultiSelectMenu", () => {
         expect(menu.prop("selectedValues")).toEqual(["2"]);
 
         // Grab the second item in the list
-        const item = menu.find(SelectItem).at(0);
+        const item = menu.find(OptionItem).at(0);
         expect(item.text()).toEqual("item 1");
         // Click the item 2, deselecting it
         item.simulate("mousedown");
@@ -132,7 +132,7 @@ describe("MultiSelectMenu", () => {
     });
 
     it("displays correct text for opener", () => {
-        const opener = menu.find(SelectBox);
+        const opener = menu.find(SelectOpener);
 
         // No items are selected, display placeholder because there is one
         menu.setProps({selectedValues: []});

--- a/packages/wonder-blocks-dropdown/components/multi-select-test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select-test.js
@@ -13,7 +13,7 @@ const keyCodes = {
 };
 
 describe("MultiSelect", () => {
-    let menu;
+    let select;
     const allChanges = [];
     const saveUpdate = (update) => {
         allChanges.push(update);
@@ -21,7 +21,7 @@ describe("MultiSelect", () => {
     const onClick = jest.fn();
 
     beforeEach(() => {
-        menu = mount(
+        select = mount(
             <MultiSelect
                 items={[
                     {
@@ -56,47 +56,47 @@ describe("MultiSelect", () => {
         unmountAll();
     });
 
-    it("closes/opens the menu on mouse click, space, and enter", () => {
-        const opener = menu.find(SelectOpener);
-        expect(menu.state("open")).toEqual(false);
+    it("closes/opens the select on mouse click, space, and enter", () => {
+        const opener = select.find(SelectOpener);
+        expect(select.state("open")).toEqual(false);
 
-        // Open menu with mouse
+        // Open select with mouse
         opener.simulate("mousedown");
         opener.simulate("mouseup");
         opener.simulate("click");
-        expect(menu.state("open")).toEqual(true);
+        expect(select.state("open")).toEqual(true);
 
-        // Close menu with space
+        // Close select with space
         opener.simulate("keydown", {keyCode: keyCodes.space});
         opener.simulate("keyup", {keyCode: keyCodes.space});
         opener.simulate("click", {preventDefault: jest.fn()});
-        expect(menu.state("open")).toEqual(false);
+        expect(select.state("open")).toEqual(false);
 
-        // Open menu again with enter
+        // Open select again with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
         opener.simulate("click", {preventDefault: jest.fn()});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(menu.state("open")).toEqual(true);
+        expect(select.state("open")).toEqual(true);
     });
 
     it("selects items as expected", () => {
-        menu.setState({open: true});
+        select.setState({open: true});
         const noop = jest.fn();
         const nativeEvent = {
             nativeEvent: {stopImmediatePropagation: noop},
         };
 
-        expect(menu.prop("selectedValues")).toEqual(["2"]);
+        expect(select.prop("selectedValues")).toEqual(["2"]);
 
         // Grab the second item in the list
-        const item = menu.find(OptionItem).at(0);
+        const item = select.find(OptionItem).at(0);
         expect(item.text()).toEqual("item 1");
         // Click the item 2, deselecting it
         item.simulate("mousedown");
         item.simulate("mouseup", nativeEvent);
         item.simulate("click");
 
-        // Expect menu's onChange callback to have been called
+        // Expect select's onChange callback to have been called
         expect(onClick).toHaveBeenCalledTimes(1);
         expect(allChanges.length).toEqual(1);
         const currentlySelected = allChanges.pop();
@@ -108,46 +108,46 @@ describe("MultiSelect", () => {
         expect(currentlySelected.includes("3")).toEqual(false);
 
         // Now manually set the selectedValues like clients would
-        menu.setProps({selectedValues: ["1", "2"]});
+        select.setProps({selectedValues: ["1", "2"]});
 
-        // This menu should still be open afer a selection
-        expect(menu.state("open")).toEqual(true);
+        // This select should still be open afer a selection
+        expect(select.state("open")).toEqual(true);
 
         // Select all of the items
-        const selectAll = menu.find(ActionItem).at(0);
+        const selectAll = select.find(ActionItem).at(0);
         selectAll.simulate("mousedown");
         selectAll.simulate("mouseup", nativeEvent);
         selectAll.simulate("click");
         expect(allChanges.pop().length).toEqual(3);
 
         // Select none of the items
-        const selectNone = menu.find(ActionItem).at(1);
+        const selectNone = select.find(ActionItem).at(1);
         selectNone.simulate("mousedown");
         selectNone.simulate("mouseup", nativeEvent);
         selectNone.simulate("click");
         expect(allChanges.pop().length).toEqual(0);
 
         // Menu should still be open
-        expect(menu.state("open")).toEqual(true);
+        expect(select.state("open")).toEqual(true);
     });
 
     it("displays correct text for opener", () => {
-        const opener = menu.find(SelectOpener);
+        const opener = select.find(SelectOpener);
 
         // No items are selected, display placeholder because there is one
-        menu.setProps({selectedValues: []});
+        select.setProps({selectedValues: []});
         expect(opener.text()).toEqual("Choose");
 
         // One item is selected, display that item's label
-        menu.setProps({selectedValues: ["1"]});
+        select.setProps({selectedValues: ["1"]});
         expect(opener.text()).toEqual("item 1");
 
         // More than one item is selected, display n itemTypes
-        menu.setProps({selectedValues: ["1", "2"]});
+        select.setProps({selectedValues: ["1", "2"]});
         expect(opener.text()).toEqual("2 students");
 
         // All items are selected
-        menu.setProps({selectedValues: ["1", "2", "3"]});
+        select.setProps({selectedValues: ["1", "2", "3"]});
         expect(opener.text()).toEqual("All students");
     });
 });

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -1,6 +1,6 @@
 // @flow
-// A menu that consists of multiple selection items. This menu allows multiple
-// items to be selected.
+// A dropdown that consists of multiple selection items. This select allows
+// multiple options to be selected.
 
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -15,23 +15,23 @@ import type {OptionItemProps} from "../util/types.js";
 
 type Props = {|
     /**
-     * The items in this menu.
+     * The items in this select.
      */
     items: Array<OptionItemProps>,
 
     /**
-     * Callback for when the selection of the menu changes. Parameter is an
-     * updated array of the values that are now selected.
+     * Callback for when the selection changes. Parameter is an updated array of
+     * the values that are now selected.
      */
     onChange: (selectedValues: Array<string>) => void,
 
     /**
-     * List of the item values that are currently selected.
+     * The values of the items that are currently selected.
      */
     selectedValues: Array<string>,
 
     /**
-     * Type of the menu items.
+     * Type of the option.
      * For example, if selectItemType is "student" and there are two students
      * selected, the SelectOpener would display "2 students"
      */
@@ -49,20 +49,20 @@ type Props = {|
     shortcuts?: boolean,
 
     /**
-     * Whether this menu should be left-aligned or right-aligned with the
+     * Whether this dropdown should be left-aligned or right-aligned with the
      * opener component. Defaults to left-aligned.
      */
     alignment: "left" | "right",
 
     /**
-     * Whether this menu is disabled. A disabled menu may not be opened and
-     * does not support interaction. Defaults to false.
+     * Whether this component is disabled. A disabled dropdown may not be opened
+     * and does not support interaction. Defaults to false.
      */
     disabled: boolean,
 
     /**
      * Whether to display the "light" version of this component instead, for
-     * use when the item is used on a dark background.
+     * use when the component is used on a dark background.
      */
     light: boolean,
 
@@ -74,7 +74,7 @@ type Props = {|
 
 type State = {|
     /**
-     * Whether or not menu is open.
+     * Whether or not the dropdown is open.
      */
     open: boolean,
 |};

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -6,17 +6,18 @@ import * as React from "react";
 import ReactDOM from "react-dom";
 
 import ActionItem from "./action-item.js";
-import DropdownCore from "./dropdown-core.js";
-import SelectBox from "./select-box.js";
-import SelectItem from "./select-item.js";
+import Dropdown from "./dropdown.js";
+import OptionItem from "./option-item.js";
+import SelectOpener from "./select-opener.js";
 import SeparatorItem from "./separator-item.js";
-import type {SelectItemProps} from "../util/types.js";
+
+import type {OptionItemProps} from "../util/types.js";
 
 type Props = {|
     /**
      * The items in this menu.
      */
-    items: Array<SelectItemProps>,
+    items: Array<OptionItemProps>,
 
     /**
      * Callback for when the selection of the menu changes. Parameter is an
@@ -32,7 +33,7 @@ type Props = {|
     /**
      * Type of the menu items.
      * For example, if selectItemType is "student" and there are two students
-     * selected, the SelectBox would display "2 students"
+     * selected, the SelectOpener would display "2 students"
      */
     selectItemType: string,
 
@@ -78,7 +79,7 @@ type State = {|
     open: boolean,
 |};
 
-export default class MultiSelectMenu extends React.Component<Props, State> {
+export default class MultiSelect extends React.Component<Props, State> {
     openerElement: ?Element;
 
     static defaultProps = {
@@ -188,7 +189,7 @@ export default class MultiSelectMenu extends React.Component<Props, State> {
         const {items, selectedValues} = this.props;
         const menuItems = items.map((item, index) => {
             return (
-                <SelectItem
+                <OptionItem
                     disabled={item.disabled}
                     key={item.value}
                     label={item.label}
@@ -214,7 +215,7 @@ export default class MultiSelectMenu extends React.Component<Props, State> {
         const menuText = this.getMenuText();
 
         const opener = (
-            <SelectBox
+            <SelectOpener
                 disabled={disabled}
                 light={light}
                 onClick={() => this.handleOpenChanged(!open)}
@@ -226,13 +227,13 @@ export default class MultiSelectMenu extends React.Component<Props, State> {
                 style={style}
             >
                 {menuText}
-            </SelectBox>
+            </SelectOpener>
         );
 
         const menuItems = [...this.getShortcuts(), ...this.getMenuItems()];
 
         return (
-            <DropdownCore
+            <Dropdown
                 alignment={alignment}
                 dropdownStyle={{marginTop: 8, marginBottom: 8}}
                 items={menuItems}

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -36,7 +36,7 @@ class ExampleNoneSelected extends React.Component {
     }
 
     render() {
-        return <MultiSelectMenu
+        return <MultiSelect
             items={[
                 {label: "Red", value: "1"},
                 {label: "Yellow", value: "2", disabled: true},
@@ -92,7 +92,7 @@ class ExampleWithShortcuts extends React.Component {
     }
 
     render() {
-        return <MultiSelectMenu
+        return <MultiSelect
             items={[
                 {label: "Anesu", value: "very mobile"},
                 {label: "Ioana", value: "lives in roma"},
@@ -161,7 +161,7 @@ class SimpleMultiSelect extends React.Component {
     }
 
     render() {
-        return <MultiSelectMenu
+        return <MultiSelect
             items={[
                 {label: "Stark", value: "1"},
                 {label: "Arryn", value: "2"},

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -27,7 +27,7 @@ const {
     offWhite,
 } = Color;
 
-type SelectProps = {|
+type OptionProps = {|
     /**
      * Display text of the menu item.
      */
@@ -147,7 +147,7 @@ const Checkbox = (props: CheckProps) => {
     );
 };
 
-export default class SelectItem extends React.Component<SelectProps> {
+export default class OptionItem extends React.Component<OptionProps> {
     static defaultProps = {
         disabled: false,
     };

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -1,5 +1,5 @@
 // @flow
-// For menu items that can be selected, selection denoted either with a
+// For option items that can be selected, selection denoted either with a
 // check ✔️ or a checkbox ☑️
 
 import * as React from "react";
@@ -29,7 +29,7 @@ const {
 
 type OptionProps = {|
     /**
-     * Display text of the menu item.
+     * Display text of the option item.
      */
     label: string,
 
@@ -39,9 +39,9 @@ type OptionProps = {|
     selected: boolean,
 
     /**
-     * Value of the item, used as a key of sorts for the parent menu to manage
-     * its menu items, because label/display text may be identical in some
-     * menus. This is the value passed back when the item is pressed.
+     * Value of the item, used as a key of sorts for the parent to manage its
+     * items, because label/display text may be identical for some selects. This
+     * is the value passed back when the item is selected.
      */
     value: string,
 
@@ -59,7 +59,8 @@ type OptionProps = {|
     onToggle: (value: string, oldSelectionState: boolean) => void,
 
     /**
-     * Whether this menu item is disabled. A disabled item may not be selected.
+     * Whether this option item is disabled. A disabled item may not be
+     * selected.
      */
     disabled: boolean,
 

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -18,15 +18,15 @@ const StyledButton = addStyle("button");
 
 const {blue, white, offBlack, offBlack16, offBlack32, offBlack50} = Color;
 
-type SelectBoxProps = {|
+type SelectOpenerProps = {|
     /**
-     * Display text in the SelectBox.
+     * Display text in the SelectOpener.
      */
     children: string,
 
     /**
-     * Whether the SelectBox opener is disabled. If disabled, disallows
-     * interaction. Default false.
+     * Whether the SelectOpener is disabled. If disabled, disallows interaction.
+     * Default false.
      */
     disabled?: boolean,
 
@@ -43,7 +43,7 @@ type SelectBoxProps = {|
     light?: boolean,
 
     /**
-     * Callback for when the SelectBox is pressed.
+     * Callback for when the SelectOpener is pressed.
      */
     onClick: () => void,
 
@@ -53,7 +53,7 @@ type SelectBoxProps = {|
     style?: any,
 |};
 
-export default class SelectBox extends React.Component<SelectBoxProps> {
+export default class SelectOpener extends React.Component<SelectOpenerProps> {
     static defaultProps = {
         disabled: false,
         light: false,

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -1,5 +1,5 @@
 // @flow
-// A menu opener
+// A select opener
 
 import * as React from "react";
 import {StyleSheet} from "aphrodite";

--- a/packages/wonder-blocks-dropdown/components/separator-item.js
+++ b/packages/wonder-blocks-dropdown/components/separator-item.js
@@ -1,5 +1,5 @@
 // @flow
-// Separator item in a menu, used to denote a semantic break in the menu.
+// Separator item in a dropdown, used to denote a semantic break.
 // Actualized as a horizontal line with surrounding whitespace. -----
 
 import * as React from "react";

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -4,16 +4,16 @@
 import * as React from "react";
 import ReactDOM from "react-dom";
 
-import DropdownCore from "./dropdown-core.js";
-import SelectBox from "./select-box.js";
-import SelectItem from "./select-item.js";
-import type {SelectItemProps} from "../util/types.js";
+import Dropdown from "./dropdown.js";
+import SelectOpener from "./select-opener.js";
+import OptionItem from "./option-item.js";
+import type {OptionItemProps} from "../util/types.js";
 
 type Props = {|
     /**
      * The items in this menu.
      */
-    items: Array<SelectItemProps>,
+    items: Array<OptionItemProps>,
 
     /**
      * Callback for when the selection of the menu changes. Parameter is the
@@ -62,7 +62,7 @@ type State = {|
     open: boolean,
 |};
 
-export default class SingleSelectMenu extends React.Component<Props, State> {
+export default class SingleSelect extends React.Component<Props, State> {
     openerElement: ?Element;
 
     static defaultProps = {
@@ -115,7 +115,7 @@ export default class SingleSelectMenu extends React.Component<Props, State> {
         const menuText = selectedItem ? selectedItem.label : placeholder;
 
         const opener = (
-            <SelectBox
+            <SelectOpener
                 disabled={disabled}
                 light={light}
                 onClick={() => this.handleOpenChanged(!open)}
@@ -127,12 +127,12 @@ export default class SingleSelectMenu extends React.Component<Props, State> {
                 style={style}
             >
                 {menuText}
-            </SelectBox>
+            </SelectOpener>
         );
 
         const menuItems = items.map((item, index) => {
             return (
-                <SelectItem
+                <OptionItem
                     disabled={item.disabled}
                     key={item.value}
                     label={item.label}
@@ -145,7 +145,7 @@ export default class SingleSelectMenu extends React.Component<Props, State> {
         });
 
         return (
-            <DropdownCore
+            <Dropdown
                 alignment={alignment}
                 dropdownStyle={{marginTop: 8, marginBottom: 8}}
                 items={menuItems}

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -11,13 +11,13 @@ import type {OptionItemProps} from "../util/types.js";
 
 type Props = {|
     /**
-     * The items in this menu.
+     * The items in this select.
      */
     items: Array<OptionItemProps>,
 
     /**
-     * Callback for when the selection of the menu changes. Parameter is the
-     * newly selected item.
+     * Callback for when the selection. Parameter is the value of the newly
+     * selected item.
      */
     onChange: (selectedValue: string) => void,
 
@@ -27,37 +27,37 @@ type Props = {|
     placeholder: string,
 
     /**
-     * Value of the currently selected item for this menu.
+     * Value of the currently selected item.
      */
     selectedValue?: string,
 
     /**
-     * Whether this menu should be left-aligned or right-aligned with the
+     * Whether this dropdown should be left-aligned or right-aligned with the
      * opener component. Defaults to left-aligned.
      */
     alignment: "left" | "right",
 
     /**
-     * Whether to display the "light" version of this component instead, for
-     * use when the item is used on a dark background.
-     */
-    light: boolean,
-
-    /**
-     * Whether this menu is disabled. A disabled menu may not be opened and
-     * does not support interaction. Defaults to false.
+     * Whether this component is disabled. A disabled dropdown may not be opened
+     * and does not support interaction. Defaults to false.
      */
     disabled: boolean,
 
     /**
-     * Optional styling to add to dropdown.
+     * Whether to display the "light" version of this component instead, for
+     * use when the component is used on a dark background.
+     */
+    light: boolean,
+
+    /**
+     * Optional styling to add.
      */
     style?: any,
 |};
 
 type State = {|
     /**
-     * Whether or not menu is open.
+     * Whether or not the dropdown is open.
      */
     open: boolean,
 |};

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -33,7 +33,7 @@ class ExampleWithPlaceholder extends React.Component {
     }
 
     render() {
-        return <SingleSelectMenu
+        return <SingleSelect
             items={[
                 {label: "Vine-ripened tomatoes", value: "tomato"},
                 {label: "Watermelon", value: "watermelon"},
@@ -88,7 +88,7 @@ class ExampleWithStartingSelection extends React.Component {
     }
 
     render() {
-        return <SingleSelectMenu
+        return <SingleSelect
             items={[
                 {label: "Banana juice", value: "banana"},
                 {label: "Guava juice", value: "guava", disabled: true},
@@ -136,7 +136,7 @@ class DisabledExample extends React.Component {
     }
 
     render() {
-        return <SingleSelectMenu
+        return <SingleSelect
             disabled={true}
             items={[
                 {label: "Banana juice", value: "banana"},
@@ -157,7 +157,7 @@ class DisabledExample extends React.Component {
 
 ### Select on dark background, right-aligned
 
-This select is on a dark background and is also right-aligned.
+This single select is on a dark background and is also right-aligned.
 
 ```js
 const React = require("react");
@@ -194,7 +194,7 @@ class LightRightAlignedExample extends React.Component {
     }
 
     render() {
-        return <SingleSelectMenu
+        return <SingleSelect
             items={[
                 {label: "Regular milk tea with boba", value: "regular"},
                 {label: "Wintermelon milk tea with boba", value: "wintermelon"},

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -12,11 +12,11 @@ const keyCodes = {
 };
 
 describe("SingleSelect", () => {
-    let menu;
+    let select;
     const onClick = jest.fn();
 
     beforeEach(() => {
-        menu = mount(
+        select = mount(
             <SingleSelect
                 items={[
                     {
@@ -45,57 +45,57 @@ describe("SingleSelect", () => {
         unmountAll();
     });
 
-    it("closes/opens the menu on mouse click, space, and enter", () => {
-        const opener = menu.find(SelectOpener);
-        expect(menu.state("open")).toEqual(false);
+    it("closes/opens the select on mouse click, space, and enter", () => {
+        const opener = select.find(SelectOpener);
+        expect(select.state("open")).toEqual(false);
 
-        // Open menu with mouse
+        // Open select with mouse
         opener.simulate("mousedown");
         opener.simulate("mouseup");
         opener.simulate("click");
-        expect(menu.state("open")).toEqual(true);
+        expect(select.state("open")).toEqual(true);
 
-        // Close menu with space
+        // Close select with space
         opener.simulate("keydown", {keyCode: keyCodes.space});
         opener.simulate("keyup", {keyCode: keyCodes.space});
         opener.simulate("click", {preventDefault: jest.fn()});
-        expect(menu.state("open")).toEqual(false);
+        expect(select.state("open")).toEqual(false);
 
-        // Open menu again with enter
+        // Open select again with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
         opener.simulate("click", {preventDefault: jest.fn()});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(menu.state("open")).toEqual(true);
+        expect(select.state("open")).toEqual(true);
     });
 
     it("displays selected item label as expected", () => {
-        menu.setState({open: true});
-        const opener = menu.find(SelectOpener);
+        select.setState({open: true});
+        const opener = select.find(SelectOpener);
         const noop = jest.fn();
         const nativeEvent = {
             nativeEvent: {stopImmediatePropagation: noop},
         };
 
         // Grab the second item in the list
-        const item = menu.find(OptionItem).at(1);
+        const item = select.find(OptionItem).at(1);
         expect(item.text()).toEqual("item 2");
         // Click the item
         item.simulate("mousedown");
         item.simulate("mouseup", nativeEvent);
         item.simulate("click");
 
-        // Expect menu's onChange callback to have been called
+        // Expect select's onChange callback to have been called
         expect(onClick).toHaveBeenCalledTimes(1);
 
-        // This menu should close afer a single item selection
-        expect(menu.state("open")).toEqual(false);
+        // This select should close afer a single item selection
+        expect(select.state("open")).toEqual(false);
 
         // Selected is still false because the client of SingleSelect is
         // expected to change the props on SingleSelect
         expect(item.prop("selected")).toEqual(false);
 
         // Let's set it manually here via selectedValue on SingleSelect
-        menu.setProps({selectedValue: "2"});
+        select.setProps({selectedValue: "2"});
 
         // Now the SelectOpener should display the label of the selected item
         // instead of the placeholder

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -2,22 +2,22 @@
 import React from "react";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
-import SelectBox from "./select-box";
-import SelectItem from "./select-item";
-import SingleSelectMenu from "./single-select-menu.js";
+import SelectOpener from "./select-opener.js";
+import OptionItem from "./option-item.js";
+import SingleSelect from "./single-select.js";
 
 const keyCodes = {
     enter: 13,
     space: 32,
 };
 
-describe("SingleSelectMenu", () => {
+describe("SingleSelect", () => {
     let menu;
     const onClick = jest.fn();
 
     beforeEach(() => {
         menu = mount(
-            <SingleSelectMenu
+            <SingleSelect
                 items={[
                     {
                         type: "select",
@@ -46,7 +46,7 @@ describe("SingleSelectMenu", () => {
     });
 
     it("closes/opens the menu on mouse click, space, and enter", () => {
-        const opener = menu.find(SelectBox);
+        const opener = menu.find(SelectOpener);
         expect(menu.state("open")).toEqual(false);
 
         // Open menu with mouse
@@ -70,16 +70,15 @@ describe("SingleSelectMenu", () => {
 
     it("displays selected item label as expected", () => {
         menu.setState({open: true});
-        const opener = menu.find(SelectBox);
+        const opener = menu.find(SelectOpener);
         const noop = jest.fn();
         const nativeEvent = {
             nativeEvent: {stopImmediatePropagation: noop},
         };
 
         // Grab the second item in the list
-        const item = menu.find(SelectItem).at(1);
+        const item = menu.find(OptionItem).at(1);
         expect(item.text()).toEqual("item 2");
-
         // Click the item
         item.simulate("mousedown");
         item.simulate("mouseup", nativeEvent);
@@ -91,14 +90,14 @@ describe("SingleSelectMenu", () => {
         // This menu should close afer a single item selection
         expect(menu.state("open")).toEqual(false);
 
-        // Selected is still false because the client of SingleSelectMenu is
-        // expected to change the props on SingleSelectMenu
+        // Selected is still false because the client of SingleSelect is
+        // expected to change the props on SingleSelect
         expect(item.prop("selected")).toEqual(false);
 
-        // Let's set it manually here via selectedValue on SingleSelectMenu
+        // Let's set it manually here via selectedValue on SingleSelect
         menu.setProps({selectedValue: "2"});
 
-        // Now the SelectBox should display the label of the selected item
+        // Now the SelectOpener should display the label of the selected item
         // instead of the placeholder
         expect(opener.text()).toEqual("item 2");
     });

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -9,8 +9,8 @@ import renderer from "react-test-renderer";
 // Mock react-dom as jest doesn't like findDOMNode.
 jest.mock("react-dom");
 import ActionMenu from "./components/action-menu.js";
-import SingleSelectMenu from "./components/single-select-menu.js";
-import MultiSelectMenu from "./components/multi-select-menu.js";
+import SingleSelectMenu from "./components/single-select.js";
+import MultiSelectMenu from "./components/multi-select.js";
 
 describe("wonder-blocks-dropdown", () => {
     it("example 1", () => {

--- a/packages/wonder-blocks-dropdown/index.js
+++ b/packages/wonder-blocks-dropdown/index.js
@@ -1,6 +1,6 @@
-// // @flow
-// import ActionMenu from "./components/action-menu.js";
-// import SingleSelectMenu from "./components/single-select-menu.js";
-// import MultiSelectMenu from "./components/multi-select-menu.js";
-//
-// export {ActionMenu, SingleSelectMenu, MultiSelectMenu};
+// @flow
+import ActionMenu from "./components/action-menu.js";
+import SingleSelect from "./components/single-select.js";
+import MultiSelect from "./components/multi-select.js";
+
+export {ActionMenu, SingleSelect, MultiSelect};

--- a/packages/wonder-blocks-dropdown/index.test.js
+++ b/packages/wonder-blocks-dropdown/index.test.js
@@ -1,0 +1,16 @@
+// @flow
+
+describe("@khanacademy/wonder-blocks-dropdown", () => {
+    test("package exports default", async () => {
+        // Arrange
+        const importedModule = import("./index.js");
+
+        // Act
+        const result = await importedModule;
+
+        // Assert
+        expect(Object.keys(result).sort()).toEqual(
+            ["ActionMenu", "MultiSelect", "SingleSelect"].sort(),
+        );
+    });
+});

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.3",
   "design": "v1",
-  "description": "Dropdown menu variants for Wonder Blocks.",
+  "description": "Dropdown variants for Wonder Blocks.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/wonder-blocks-dropdown/util/types.js
+++ b/packages/wonder-blocks-dropdown/util/types.js
@@ -14,7 +14,7 @@ export type ActionItemProps = {|
     onClick?: () => void,
 |};
 
-export type SelectItemProps = {|
+export type OptionItemProps = {|
     type: "select",
     /** Whether this item is disabled. Default false. */
     disabled?: boolean,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -29,8 +29,8 @@ module.exports = {
             name: "Dropdown",
             components: [
                 "packages/wonder-blocks-dropdown/components/action-menu.js",
-                "packages/wonder-blocks-dropdown/components/single-select-menu.js",
-                "packages/wonder-blocks-dropdown/components/multi-select-menu.js",
+                "packages/wonder-blocks-dropdown/components/single-select.js",
+                "packages/wonder-blocks-dropdown/components/multi-select.js",
             ],
         },
         {


### PR DESCRIPTION
I originally named the components closely to what they were called in the design. I realized that those names don't match the existing components or the basic HTML elements that the components correspond to, so I'm trying to improve that.

Test plan:
The snapshot of this package doesn't change with this diff. Searched through the codebase for all instances of the names I changed.