### PR TITLE
WB-320: update IconButton to handle clientNav, fix FlowFixMes

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`ButtonCore kind:primary color:default size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -38,7 +38,6 @@ exports[`ButtonCore kind:primary color:default size:default light:false disabled
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -66,7 +65,6 @@ exports[`ButtonCore kind:primary color:default size:default light:false disabled
 exports[`ButtonCore kind:primary color:default size:default light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -102,7 +100,6 @@ exports[`ButtonCore kind:primary color:default size:default light:false focused 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -130,7 +127,6 @@ exports[`ButtonCore kind:primary color:default size:default light:false focused 
 exports[`ButtonCore kind:primary color:default size:default light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -166,7 +162,6 @@ exports[`ButtonCore kind:primary color:default size:default light:false hovered 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -194,7 +189,6 @@ exports[`ButtonCore kind:primary color:default size:default light:false hovered 
 exports[`ButtonCore kind:primary color:default size:default light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -229,7 +223,6 @@ exports[`ButtonCore kind:primary color:default size:default light:false pressed 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -256,8 +249,8 @@ exports[`ButtonCore kind:primary color:default size:default light:false pressed 
 
 exports[`ButtonCore kind:primary color:default size:default light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -292,7 +285,6 @@ exports[`ButtonCore kind:primary color:default size:default light:true disabled 
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -320,7 +312,6 @@ exports[`ButtonCore kind:primary color:default size:default light:true disabled 
 exports[`ButtonCore kind:primary color:default size:default light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -356,7 +347,6 @@ exports[`ButtonCore kind:primary color:default size:default light:true focused 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -384,7 +374,6 @@ exports[`ButtonCore kind:primary color:default size:default light:true focused 1
 exports[`ButtonCore kind:primary color:default size:default light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -420,7 +409,6 @@ exports[`ButtonCore kind:primary color:default size:default light:true hovered 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -448,7 +436,6 @@ exports[`ButtonCore kind:primary color:default size:default light:true hovered 1
 exports[`ButtonCore kind:primary color:default size:default light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -483,7 +470,6 @@ exports[`ButtonCore kind:primary color:default size:default light:true pressed 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -510,8 +496,8 @@ exports[`ButtonCore kind:primary color:default size:default light:true pressed 1
 
 exports[`ButtonCore kind:primary color:default size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -546,7 +532,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -574,7 +559,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
 exports[`ButtonCore kind:primary color:default size:small light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -610,7 +594,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -638,7 +621,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
 exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -674,7 +656,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -702,7 +683,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
 exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -737,7 +717,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -764,8 +743,8 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
 
 exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -800,7 +779,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -828,7 +806,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
 exports[`ButtonCore kind:primary color:default size:small light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -864,7 +841,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -892,7 +868,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
 exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -928,7 +903,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -956,7 +930,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
 exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -991,7 +964,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1018,8 +990,8 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
 
 exports[`ButtonCore kind:primary color:destructive size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1054,7 +1026,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false disa
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -1082,7 +1053,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false disa
 exports[`ButtonCore kind:primary color:destructive size:default light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1118,7 +1088,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false focu
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1146,7 +1115,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false focu
 exports[`ButtonCore kind:primary color:destructive size:default light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1182,7 +1150,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false hove
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1210,7 +1177,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false hove
 exports[`ButtonCore kind:primary color:destructive size:default light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1245,7 +1211,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false pres
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1272,8 +1237,8 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false pres
 
 exports[`ButtonCore kind:primary color:destructive size:default light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1308,7 +1273,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true disab
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -1336,7 +1300,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true disab
 exports[`ButtonCore kind:primary color:destructive size:default light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1372,7 +1335,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true focus
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1400,7 +1362,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true focus
 exports[`ButtonCore kind:primary color:destructive size:default light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1436,7 +1397,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true hover
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1464,7 +1424,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true hover
 exports[`ButtonCore kind:primary color:destructive size:default light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1499,7 +1458,6 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true press
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1526,8 +1484,8 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true press
 
 exports[`ButtonCore kind:primary color:destructive size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1562,7 +1520,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -1590,7 +1547,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
 exports[`ButtonCore kind:primary color:destructive size:small light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1626,7 +1582,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1654,7 +1609,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
 exports[`ButtonCore kind:primary color:destructive size:small light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1690,7 +1644,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1718,7 +1671,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
 exports[`ButtonCore kind:primary color:destructive size:small light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1753,7 +1705,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1780,8 +1731,8 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
 
 exports[`ButtonCore kind:primary color:destructive size:small light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1816,7 +1767,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -1844,7 +1794,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
 exports[`ButtonCore kind:primary color:destructive size:small light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1880,7 +1829,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1908,7 +1856,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
 exports[`ButtonCore kind:primary color:destructive size:small light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1944,7 +1891,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -1972,7 +1918,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
 exports[`ButtonCore kind:primary color:destructive size:small light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2007,7 +1952,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2034,8 +1978,8 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
 
 exports[`ButtonCore kind:secondary color:default size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2073,7 +2017,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:false disabl
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -2101,7 +2044,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:false disabl
 exports[`ButtonCore kind:secondary color:default size:default light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2139,7 +2081,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:false focuse
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2167,7 +2108,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:false focuse
 exports[`ButtonCore kind:secondary color:default size:default light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2205,7 +2145,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:false hovere
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2233,7 +2172,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:false hovere
 exports[`ButtonCore kind:secondary color:default size:default light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2271,7 +2209,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:false presse
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2298,8 +2235,8 @@ exports[`ButtonCore kind:secondary color:default size:default light:false presse
 
 exports[`ButtonCore kind:secondary color:default size:default light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2337,7 +2274,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:true disable
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -2365,7 +2301,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:true disable
 exports[`ButtonCore kind:secondary color:default size:default light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2403,7 +2338,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:true focused
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2431,7 +2365,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:true focused
 exports[`ButtonCore kind:secondary color:default size:default light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2469,7 +2402,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:true hovered
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2497,7 +2429,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:true hovered
 exports[`ButtonCore kind:secondary color:default size:default light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2535,7 +2466,6 @@ exports[`ButtonCore kind:secondary color:default size:default light:true pressed
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2562,8 +2492,8 @@ exports[`ButtonCore kind:secondary color:default size:default light:true pressed
 
 exports[`ButtonCore kind:secondary color:default size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2601,7 +2531,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -2629,7 +2558,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
 exports[`ButtonCore kind:secondary color:default size:small light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2667,7 +2595,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2695,7 +2622,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
 exports[`ButtonCore kind:secondary color:default size:small light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2733,7 +2659,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2761,7 +2686,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
 exports[`ButtonCore kind:secondary color:default size:small light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2799,7 +2723,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2826,8 +2749,8 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
 
 exports[`ButtonCore kind:secondary color:default size:small light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2865,7 +2788,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -2893,7 +2815,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
 exports[`ButtonCore kind:secondary color:default size:small light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2931,7 +2852,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -2959,7 +2879,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
 exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2997,7 +2916,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3025,7 +2943,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
 exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3063,7 +2980,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3090,8 +3006,8 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
 
 exports[`ButtonCore kind:secondary color:destructive size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3129,7 +3045,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false di
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -3157,7 +3072,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false di
 exports[`ButtonCore kind:secondary color:destructive size:default light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3195,7 +3109,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false fo
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3223,7 +3136,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false fo
 exports[`ButtonCore kind:secondary color:destructive size:default light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3261,7 +3173,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false ho
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3289,7 +3200,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false ho
 exports[`ButtonCore kind:secondary color:destructive size:default light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3327,7 +3237,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false pr
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3354,8 +3263,8 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false pr
 
 exports[`ButtonCore kind:secondary color:destructive size:default light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3393,7 +3302,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true dis
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -3421,7 +3329,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true dis
 exports[`ButtonCore kind:secondary color:destructive size:default light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3459,7 +3366,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true foc
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3487,7 +3393,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true foc
 exports[`ButtonCore kind:secondary color:destructive size:default light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3525,7 +3430,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true hov
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3553,7 +3457,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true hov
 exports[`ButtonCore kind:secondary color:destructive size:default light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3591,7 +3494,6 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true pre
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3618,8 +3520,8 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true pre
 
 exports[`ButtonCore kind:secondary color:destructive size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3657,7 +3559,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -3685,7 +3586,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
 exports[`ButtonCore kind:secondary color:destructive size:small light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3723,7 +3623,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3751,7 +3650,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
 exports[`ButtonCore kind:secondary color:destructive size:small light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3789,7 +3687,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3817,7 +3714,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
 exports[`ButtonCore kind:secondary color:destructive size:small light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3855,7 +3751,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -3882,8 +3777,8 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
 
 exports[`ButtonCore kind:secondary color:destructive size:small light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3921,7 +3816,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -3949,7 +3843,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
 exports[`ButtonCore kind:secondary color:destructive size:small light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3987,7 +3880,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4015,7 +3907,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
 exports[`ButtonCore kind:secondary color:destructive size:small light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4053,7 +3944,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4081,7 +3971,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
 exports[`ButtonCore kind:secondary color:destructive size:small light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4119,7 +4008,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4146,8 +4034,8 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
 
 exports[`ButtonCore kind:tertiary color:default size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4182,7 +4070,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false disable
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -4210,7 +4097,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false disable
 exports[`ButtonCore kind:tertiary color:default size:default light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4254,7 +4140,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false focused
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4282,7 +4167,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false focused
 exports[`ButtonCore kind:tertiary color:default size:default light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4326,7 +4210,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false hovered
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4354,7 +4237,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false hovered
 exports[`ButtonCore kind:tertiary color:default size:default light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4389,7 +4271,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false pressed
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4416,8 +4297,8 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false pressed
 
 exports[`ButtonCore kind:tertiary color:default size:default light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4452,7 +4333,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true disabled
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -4480,7 +4360,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true disabled
 exports[`ButtonCore kind:tertiary color:default size:default light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4524,7 +4403,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true focused 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4552,7 +4430,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true focused 
 exports[`ButtonCore kind:tertiary color:default size:default light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4596,7 +4473,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true hovered 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4624,7 +4500,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true hovered 
 exports[`ButtonCore kind:tertiary color:default size:default light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4659,7 +4534,6 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true pressed 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4686,8 +4560,8 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true pressed 
 
 exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4722,7 +4596,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -4750,7 +4623,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
 exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4794,7 +4666,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4822,7 +4693,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
 exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4866,7 +4736,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4894,7 +4763,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
 exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4929,7 +4797,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -4956,8 +4823,8 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
 
 exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4992,7 +4859,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -5020,7 +4886,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
 exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5064,7 +4929,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5092,7 +4956,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
 exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5136,7 +4999,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5164,7 +5026,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
 exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5199,7 +5060,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5226,8 +5086,8 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
 
 exports[`ButtonCore kind:tertiary color:destructive size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5262,7 +5122,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false dis
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -5290,7 +5149,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false dis
 exports[`ButtonCore kind:tertiary color:destructive size:default light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5334,7 +5192,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false foc
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5362,7 +5219,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false foc
 exports[`ButtonCore kind:tertiary color:destructive size:default light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5406,7 +5262,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false hov
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5434,7 +5289,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false hov
 exports[`ButtonCore kind:tertiary color:destructive size:default light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5469,7 +5323,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false pre
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5496,8 +5349,8 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false pre
 
 exports[`ButtonCore kind:tertiary color:destructive size:default light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5532,7 +5385,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true disa
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -5560,7 +5412,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true disa
 exports[`ButtonCore kind:tertiary color:destructive size:default light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5604,7 +5455,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true focu
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5632,7 +5482,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true focu
 exports[`ButtonCore kind:tertiary color:destructive size:default light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5676,7 +5525,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true hove
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5704,7 +5552,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true hove
 exports[`ButtonCore kind:tertiary color:destructive size:default light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5739,7 +5586,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true pres
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5766,8 +5612,8 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true pres
 
 exports[`ButtonCore kind:tertiary color:destructive size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5802,7 +5648,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -5830,7 +5675,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
 exports[`ButtonCore kind:tertiary color:destructive size:small light:false focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5874,7 +5718,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5902,7 +5745,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
 exports[`ButtonCore kind:tertiary color:destructive size:small light:false hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5946,7 +5788,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -5974,7 +5815,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
 exports[`ButtonCore kind:tertiary color:destructive size:small light:false pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -6009,7 +5849,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -6036,8 +5875,8 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
 
 exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   className=""
-  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -6072,7 +5911,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
       "textDecoration": "none",
     }
   }
-  tabIndex={-1}
 >
   <span
     className=""
@@ -6100,7 +5938,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
 exports[`ButtonCore kind:tertiary color:destructive size:small light:true focused 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -6144,7 +5981,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -6172,7 +6008,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
 exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovered 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -6216,7 +6051,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -6244,7 +6078,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
 exports[`ButtonCore kind:tertiary color:destructive size:small light:true pressed 1`] = `
 <button
   className=""
-  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -6279,7 +6112,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""

--- a/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
@@ -4,6 +4,7 @@ exports[`ButtonCore kind:primary color:default size:default light:false disabled
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -65,6 +66,7 @@ exports[`ButtonCore kind:primary color:default size:default light:false disabled
 exports[`ButtonCore kind:primary color:default size:default light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -127,6 +129,7 @@ exports[`ButtonCore kind:primary color:default size:default light:false focused 
 exports[`ButtonCore kind:primary color:default size:default light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -189,6 +192,7 @@ exports[`ButtonCore kind:primary color:default size:default light:false hovered 
 exports[`ButtonCore kind:primary color:default size:default light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -251,6 +255,7 @@ exports[`ButtonCore kind:primary color:default size:default light:true disabled 
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -312,6 +317,7 @@ exports[`ButtonCore kind:primary color:default size:default light:true disabled 
 exports[`ButtonCore kind:primary color:default size:default light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -374,6 +380,7 @@ exports[`ButtonCore kind:primary color:default size:default light:true focused 1
 exports[`ButtonCore kind:primary color:default size:default light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -436,6 +443,7 @@ exports[`ButtonCore kind:primary color:default size:default light:true hovered 1
 exports[`ButtonCore kind:primary color:default size:default light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -498,6 +506,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -559,6 +568,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
 exports[`ButtonCore kind:primary color:default size:small light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -621,6 +631,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
 exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -683,6 +694,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
 exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -745,6 +757,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -806,6 +819,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
 exports[`ButtonCore kind:primary color:default size:small light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -868,6 +882,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
 exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -930,6 +945,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
 exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -992,6 +1008,7 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false disa
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1053,6 +1070,7 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false disa
 exports[`ButtonCore kind:primary color:destructive size:default light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1115,6 +1133,7 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false focu
 exports[`ButtonCore kind:primary color:destructive size:default light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1177,6 +1196,7 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false hove
 exports[`ButtonCore kind:primary color:destructive size:default light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1239,6 +1259,7 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true disab
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1300,6 +1321,7 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true disab
 exports[`ButtonCore kind:primary color:destructive size:default light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1362,6 +1384,7 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true focus
 exports[`ButtonCore kind:primary color:destructive size:default light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1424,6 +1447,7 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true hover
 exports[`ButtonCore kind:primary color:destructive size:default light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1486,6 +1510,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1547,6 +1572,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
 exports[`ButtonCore kind:primary color:destructive size:small light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1609,6 +1635,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
 exports[`ButtonCore kind:primary color:destructive size:small light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1671,6 +1698,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
 exports[`ButtonCore kind:primary color:destructive size:small light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1733,6 +1761,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1794,6 +1823,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
 exports[`ButtonCore kind:primary color:destructive size:small light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1856,6 +1886,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
 exports[`ButtonCore kind:primary color:destructive size:small light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1918,6 +1949,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
 exports[`ButtonCore kind:primary color:destructive size:small light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -1980,6 +2012,7 @@ exports[`ButtonCore kind:secondary color:default size:default light:false disabl
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2044,6 +2077,7 @@ exports[`ButtonCore kind:secondary color:default size:default light:false disabl
 exports[`ButtonCore kind:secondary color:default size:default light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2108,6 +2142,7 @@ exports[`ButtonCore kind:secondary color:default size:default light:false focuse
 exports[`ButtonCore kind:secondary color:default size:default light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2172,6 +2207,7 @@ exports[`ButtonCore kind:secondary color:default size:default light:false hovere
 exports[`ButtonCore kind:secondary color:default size:default light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2237,6 +2273,7 @@ exports[`ButtonCore kind:secondary color:default size:default light:true disable
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2301,6 +2338,7 @@ exports[`ButtonCore kind:secondary color:default size:default light:true disable
 exports[`ButtonCore kind:secondary color:default size:default light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2365,6 +2403,7 @@ exports[`ButtonCore kind:secondary color:default size:default light:true focused
 exports[`ButtonCore kind:secondary color:default size:default light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2429,6 +2468,7 @@ exports[`ButtonCore kind:secondary color:default size:default light:true hovered
 exports[`ButtonCore kind:secondary color:default size:default light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2494,6 +2534,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2558,6 +2599,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
 exports[`ButtonCore kind:secondary color:default size:small light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2622,6 +2664,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
 exports[`ButtonCore kind:secondary color:default size:small light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2686,6 +2729,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
 exports[`ButtonCore kind:secondary color:default size:small light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2751,6 +2795,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2815,6 +2860,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
 exports[`ButtonCore kind:secondary color:default size:small light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2879,6 +2925,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
 exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -2943,6 +2990,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
 exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3008,6 +3056,7 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false di
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3072,6 +3121,7 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false di
 exports[`ButtonCore kind:secondary color:destructive size:default light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3136,6 +3186,7 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false fo
 exports[`ButtonCore kind:secondary color:destructive size:default light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3200,6 +3251,7 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false ho
 exports[`ButtonCore kind:secondary color:destructive size:default light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3265,6 +3317,7 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true dis
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3329,6 +3382,7 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true dis
 exports[`ButtonCore kind:secondary color:destructive size:default light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3393,6 +3447,7 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true foc
 exports[`ButtonCore kind:secondary color:destructive size:default light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3457,6 +3512,7 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true hov
 exports[`ButtonCore kind:secondary color:destructive size:default light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3522,6 +3578,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3586,6 +3643,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
 exports[`ButtonCore kind:secondary color:destructive size:small light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3650,6 +3708,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
 exports[`ButtonCore kind:secondary color:destructive size:small light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3714,6 +3773,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
 exports[`ButtonCore kind:secondary color:destructive size:small light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3779,6 +3839,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3843,6 +3904,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
 exports[`ButtonCore kind:secondary color:destructive size:small light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3907,6 +3969,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
 exports[`ButtonCore kind:secondary color:destructive size:small light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -3971,6 +4034,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
 exports[`ButtonCore kind:secondary color:destructive size:small light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4036,6 +4100,7 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false disable
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4097,6 +4162,7 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false disable
 exports[`ButtonCore kind:tertiary color:default size:default light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4167,6 +4233,7 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false focused
 exports[`ButtonCore kind:tertiary color:default size:default light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4237,6 +4304,7 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false hovered
 exports[`ButtonCore kind:tertiary color:default size:default light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4299,6 +4367,7 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true disabled
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4360,6 +4429,7 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true disabled
 exports[`ButtonCore kind:tertiary color:default size:default light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4430,6 +4500,7 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true focused 
 exports[`ButtonCore kind:tertiary color:default size:default light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4500,6 +4571,7 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true hovered 
 exports[`ButtonCore kind:tertiary color:default size:default light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4562,6 +4634,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4623,6 +4696,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
 exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4693,6 +4767,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
 exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4763,6 +4838,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
 exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4825,6 +4901,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4886,6 +4963,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
 exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -4956,6 +5034,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
 exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5026,6 +5105,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
 exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5088,6 +5168,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false dis
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5149,6 +5230,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false dis
 exports[`ButtonCore kind:tertiary color:destructive size:default light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5219,6 +5301,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false foc
 exports[`ButtonCore kind:tertiary color:destructive size:default light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5289,6 +5372,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false hov
 exports[`ButtonCore kind:tertiary color:destructive size:default light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5351,6 +5435,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true disa
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5412,6 +5497,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true disa
 exports[`ButtonCore kind:tertiary color:destructive size:default light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5482,6 +5568,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true focu
 exports[`ButtonCore kind:tertiary color:destructive size:default light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5552,6 +5639,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true hove
 exports[`ButtonCore kind:tertiary color:destructive size:default light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5614,6 +5702,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5675,6 +5764,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
 exports[`ButtonCore kind:tertiary color:destructive size:small light:false focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5745,6 +5835,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
 exports[`ButtonCore kind:tertiary color:destructive size:small light:false hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5815,6 +5906,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
 exports[`ButtonCore kind:tertiary color:destructive size:small light:false pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5877,6 +5969,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
 <button
   aria-disabled="true"
   className=""
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -5938,6 +6031,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
 exports[`ButtonCore kind:tertiary color:destructive size:small light:true focused 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -6008,6 +6102,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
 exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovered 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -6078,6 +6173,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
 exports[`ButtonCore kind:tertiary color:destructive size:small light:true pressed 1`] = `
 <button
   className=""
+  disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -417,6 +417,7 @@ exports[`wonder-blocks-button example 3 1`] = `
   <a
     className=""
     disabled={true}
+    href="https://khanacademy.org"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -22,6 +22,7 @@ exports[`wonder-blocks-button example 1 1`] = `
 >
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -81,6 +82,7 @@ exports[`wonder-blocks-button example 1 1`] = `
   </button>
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -143,6 +145,7 @@ exports[`wonder-blocks-button example 1 1`] = `
   </button>
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -202,6 +205,7 @@ exports[`wonder-blocks-button example 1 1`] = `
   </button>
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -346,6 +350,7 @@ exports[`wonder-blocks-button example 3 1`] = `
   <button
     aria-disabled="true"
     className=""
+    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -381,6 +386,7 @@ exports[`wonder-blocks-button example 3 1`] = `
         "textDecoration": "none",
       }
     }
+    tabIndex={-1}
   >
     <span
       className=""
@@ -441,6 +447,7 @@ exports[`wonder-blocks-button example 3 1`] = `
         "textDecoration": "none",
       }
     }
+    tabIndex={-1}
   >
     <span
       className=""
@@ -498,6 +505,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       <td>
         <button
           className=""
+          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -564,6 +572,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       <td>
         <button
           className=""
+          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -630,6 +639,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       <td>
         <button
           className=""
+          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -714,6 +724,7 @@ exports[`wonder-blocks-button example 4 1`] = `
         >
           <button
             className=""
+            disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -800,6 +811,7 @@ exports[`wonder-blocks-button example 4 1`] = `
         >
           <button
             className=""
+            disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -914,6 +926,7 @@ exports[`wonder-blocks-button example 4 1`] = `
         >
           <button
             className=""
+            disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1047,6 +1060,7 @@ exports[`wonder-blocks-button example 4 1`] = `
           >
             <button
               className=""
+              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -22,7 +22,6 @@ exports[`wonder-blocks-button example 1 1`] = `
 >
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -58,7 +57,6 @@ exports[`wonder-blocks-button example 1 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex={0}
   >
     <span
       className=""
@@ -83,7 +81,6 @@ exports[`wonder-blocks-button example 1 1`] = `
   </button>
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -122,7 +119,6 @@ exports[`wonder-blocks-button example 1 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex={0}
   >
     <span
       className=""
@@ -147,7 +143,6 @@ exports[`wonder-blocks-button example 1 1`] = `
   </button>
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -183,7 +178,6 @@ exports[`wonder-blocks-button example 1 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex={0}
   >
     <span
       className=""
@@ -208,7 +202,6 @@ exports[`wonder-blocks-button example 1 1`] = `
   </button>
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -244,7 +237,6 @@ exports[`wonder-blocks-button example 1 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex={0}
   >
     <span
       className=""
@@ -272,7 +264,6 @@ exports[`wonder-blocks-button example 1 1`] = `
 
 exports[`wonder-blocks-button example 2 1`] = `
 <a
-  aria-disabled="false"
   className=""
   href="#button-1"
   onBlur={[Function]}
@@ -353,8 +344,8 @@ exports[`wonder-blocks-button example 3 1`] = `
   }
 >
   <button
+    aria-disabled="true"
     className=""
-    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -390,7 +381,6 @@ exports[`wonder-blocks-button example 3 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex={-1}
   >
     <span
       className=""
@@ -451,7 +441,6 @@ exports[`wonder-blocks-button example 3 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex="-1"
   >
     <span
       className=""
@@ -509,7 +498,6 @@ exports[`wonder-blocks-button example 4 1`] = `
       <td>
         <button
           className=""
-          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -545,7 +533,6 @@ exports[`wonder-blocks-button example 4 1`] = `
               "width": 200,
             }
           }
-          tabIndex={0}
         >
           <span
             className=""
@@ -577,7 +564,6 @@ exports[`wonder-blocks-button example 4 1`] = `
       <td>
         <button
           className=""
-          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -613,7 +599,6 @@ exports[`wonder-blocks-button example 4 1`] = `
               "width": "75%",
             }
           }
-          tabIndex={0}
         >
           <span
             className=""
@@ -645,7 +630,6 @@ exports[`wonder-blocks-button example 4 1`] = `
       <td>
         <button
           className=""
-          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -680,7 +664,6 @@ exports[`wonder-blocks-button example 4 1`] = `
               "textDecoration": "none",
             }
           }
-          tabIndex={0}
         >
           <span
             className=""
@@ -731,7 +714,6 @@ exports[`wonder-blocks-button example 4 1`] = `
         >
           <button
             className=""
-            disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -767,7 +749,6 @@ exports[`wonder-blocks-button example 4 1`] = `
                 "textDecoration": "none",
               }
             }
-            tabIndex={0}
           >
             <span
               className=""
@@ -819,7 +800,6 @@ exports[`wonder-blocks-button example 4 1`] = `
         >
           <button
             className=""
-            disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -857,7 +837,6 @@ exports[`wonder-blocks-button example 4 1`] = `
                 "width": "300px",
               }
             }
-            tabIndex={0}
           >
             <span
               className=""
@@ -935,7 +914,6 @@ exports[`wonder-blocks-button example 4 1`] = `
         >
           <button
             className=""
-            disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -972,7 +950,6 @@ exports[`wonder-blocks-button example 4 1`] = `
                 "textDecoration": "none",
               }
             }
-            tabIndex={0}
           >
             <span
               className=""
@@ -1070,7 +1047,6 @@ exports[`wonder-blocks-button example 4 1`] = `
           >
             <button
               className=""
-              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1106,7 +1082,6 @@ exports[`wonder-blocks-button example 4 1`] = `
                   "textDecoration": "none",
                 }
               }
-              tabIndex={0}
             >
               <span
                 className=""

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -272,8 +272,8 @@ exports[`wonder-blocks-button example 1 1`] = `
 
 exports[`wonder-blocks-button example 2 1`] = `
 <a
+  aria-disabled="false"
   className=""
-  disabled={false}
   href="#button-1"
   onBlur={[Function]}
   onClick={[Function]}
@@ -308,7 +308,6 @@ exports[`wonder-blocks-button example 2 1`] = `
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   <span
     className=""
@@ -415,8 +414,8 @@ exports[`wonder-blocks-button example 3 1`] = `
     </span>
   </button>
   <a
+    aria-disabled="true"
     className=""
-    disabled={true}
     href="https://khanacademy.org"
     onBlur={[Function]}
     onClick={[Function]}
@@ -452,7 +451,7 @@ exports[`wonder-blocks-button example 3 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex={-1}
+    tabIndex="-1"
   >
     <span
       className=""

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -23,37 +23,24 @@ type Props = {|
 
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");
-// $FlowFixMe: pass props directly to StyledLink instead of to Tag
 const StyledLink = addStyle(Link);
 
 export default class ButtonCore extends React.Component<Props> {
-    getTag() {
-        const {href, clientNav} = this.props;
-        if (href) {
-            if (clientNav) {
-                return StyledLink;
-            } else {
-                return StyledAnchor;
-            }
-        } else {
-            return StyledButton;
-        }
-    }
-
-    getProps() {
+    render() {
         const {
+            children,
+            clientNav,
             color,
+            disabled,
+            focused,
+            hovered,
+            href,
             kind,
             light,
-            size,
-            testId,
-            style,
-            disabled,
-            hovered,
-            focused,
             pressed,
-            href,
-            clientNav,
+            size,
+            style,
+            testId,
             ...handlers
         } = this.props;
 
@@ -76,37 +63,30 @@ export default class ButtonCore extends React.Component<Props> {
             size === "small" && sharedStyles.small,
         ];
 
-        const props = {
-            style: [defaultStyle, style],
-            disabled,
+        const commonProps = {
             "data-test-id": testId,
+            disabled,
+            style: [defaultStyle, style],
             ...handlers,
         };
 
-        if (!disabled && href) {
-            if (clientNav) {
-                // $FlowFixMe
-                props.to = href;
-            } else {
-                // $FlowFixMe
-                props.href = href;
-            }
-        }
-
-        return props;
-    }
-
-    render() {
-        const {children, size} = this.props;
-
-        const Tag = this.getTag();
-        const props = this.getProps();
         const Label = size === "small" ? LabelSmall : LabelLarge;
-        return (
-            <Tag {...props}>
-                <Label style={sharedStyles.text}>{children}</Label>
-            </Tag>
-        );
+
+        const label = <Label style={sharedStyles.text}>{children}</Label>;
+
+        if (href) {
+            return clientNav ? (
+                <StyledLink {...commonProps} to={href}>
+                    {label}
+                </StyledLink>
+            ) : (
+                <StyledAnchor {...commonProps} href={href}>
+                    {label}
+                </StyledAnchor>
+            );
+        } else {
+            return <StyledButton {...commonProps}>{label}</StyledButton>;
+        }
     }
 }
 

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -65,7 +65,6 @@ export default class ButtonCore extends React.Component<Props> {
 
         const commonProps = {
             "data-test-id": testId,
-            disabled,
             style: [defaultStyle, style],
             ...handlers,
         };
@@ -75,17 +74,26 @@ export default class ButtonCore extends React.Component<Props> {
         const label = <Label style={sharedStyles.text}>{children}</Label>;
 
         if (href) {
+            const linkProps = {
+                "aria-disabled": disabled ? "true" : "false",
+                tabIndex: disabled ? "-1" : undefined,
+            };
+
             return clientNav ? (
-                <StyledLink {...commonProps} to={href}>
+                <StyledLink {...commonProps} {...linkProps} to={href}>
                     {label}
                 </StyledLink>
             ) : (
-                <StyledAnchor {...commonProps} href={href}>
+                <StyledAnchor {...commonProps} {...linkProps} href={href}>
                     {label}
                 </StyledAnchor>
             );
         } else {
-            return <StyledButton {...commonProps}>{label}</StyledButton>;
+            return (
+                <StyledButton {...commonProps} disabled={disabled}>
+                    {label}
+                </StyledButton>
+            );
         }
     }
 }

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -65,6 +65,7 @@ export default class ButtonCore extends React.Component<Props> {
 
         const commonProps = {
             "data-test-id": testId,
+            "aria-disabled": disabled ? "true" : undefined,
             style: [defaultStyle, style],
             ...handlers,
         };
@@ -74,26 +75,17 @@ export default class ButtonCore extends React.Component<Props> {
         const label = <Label style={sharedStyles.text}>{children}</Label>;
 
         if (href) {
-            const linkProps = {
-                "aria-disabled": disabled ? "true" : "false",
-                tabIndex: disabled ? "-1" : undefined,
-            };
-
             return clientNav ? (
-                <StyledLink {...commonProps} {...linkProps} to={href}>
+                <StyledLink {...commonProps} to={href}>
                     {label}
                 </StyledLink>
             ) : (
-                <StyledAnchor {...commonProps} {...linkProps} href={href}>
+                <StyledAnchor {...commonProps} href={href}>
                     {label}
                 </StyledAnchor>
             );
         } else {
-            return (
-                <StyledButton {...commonProps} disabled={disabled}>
-                    {label}
-                </StyledButton>
-            );
+            return <StyledButton {...commonProps}>{label}</StyledButton>;
         }
     }
 }

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -64,8 +64,8 @@ export default class ButtonCore extends React.Component<Props> {
         ];
 
         const commonProps = {
-            "data-test-id": testId,
             "aria-disabled": disabled ? "true" : undefined,
+            "data-test-id": testId,
             style: [defaultStyle, style],
             ...handlers,
         };
@@ -85,7 +85,11 @@ export default class ButtonCore extends React.Component<Props> {
                 </StyledAnchor>
             );
         } else {
-            return <StyledButton {...commonProps}>{label}</StyledButton>;
+            return (
+                <StyledButton {...commonProps} disabled={disabled}>
+                    {label}
+                </StyledButton>
+            );
         }
     }
 }

--- a/packages/wonder-blocks-button/custom-snapshot.test.js
+++ b/packages/wonder-blocks-button/custom-snapshot.test.js
@@ -48,7 +48,6 @@ describe("ButtonCore", () => {
                                         light={light}
                                         {...stateProps}
                                         {...defaultHandlers}
-                                        tabIndex={stateProps.disabled ? -1 : 0}
                                     >
                                         Click me
                                     </ButtonCore>,

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -181,7 +181,6 @@ exports[`wonder-blocks-core example 4 1`] = `
   >
     <button
       className=""
-      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -216,7 +215,6 @@ exports[`wonder-blocks-core example 4 1`] = `
           "textDecoration": "none",
         }
       }
-      tabIndex={0}
     >
       <span
         className=""

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -181,6 +181,7 @@ exports[`wonder-blocks-core example 4 1`] = `
   >
     <button
       className=""
+      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -75,11 +75,10 @@ export type ClickableHandlers = {|
     onKeyUp: (e: SyntheticKeyboardEvent<*>) => void,
     onFocus: (e: SyntheticFocusEvent<*>) => void,
     onBlur: (e: SyntheticFocusEvent<*>) => void,
-    tabIndex: number,
 |};
 
 const disabledHandlers = {
-    onClick: () => void 0,
+    onClick: (e) => e.preventDefault(),
     onMouseEnter: () => void 0,
     onMouseLeave: () => void 0,
     onMouseDown: () => void 0,
@@ -91,7 +90,6 @@ const disabledHandlers = {
     onKeyUp: () => void 0,
     onFocus: () => void 0,
     onBlur: () => void 0,
-    tabIndex: -1,
 };
 
 const keyCodes = {
@@ -300,7 +298,6 @@ export default class ClickableBehavior extends React.Component<Props, State> {
                   onKeyUp: this.handleKeyUp,
                   onFocus: this.handleFocus,
                   onBlur: this.handleBlur,
-                  tabIndex: 0,
               };
         const {children} = this.props;
         return children && children(this.state, handlers);

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -75,6 +75,7 @@ export type ClickableHandlers = {|
     onKeyUp: (e: SyntheticKeyboardEvent<*>) => void,
     onFocus: (e: SyntheticFocusEvent<*>) => void,
     onBlur: (e: SyntheticFocusEvent<*>) => void,
+    tabIndex?: number,
 |};
 
 const disabledHandlers = {
@@ -90,6 +91,7 @@ const disabledHandlers = {
     onKeyUp: () => void 0,
     onFocus: () => void 0,
     onBlur: () => void 0,
+    tabIndex: -1,
 };
 
 const keyCodes = {

--- a/packages/wonder-blocks-core/components/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.test.js
@@ -204,7 +204,7 @@ describe("ClickableBehavior", () => {
         );
 
         expect(onClick).not.toHaveBeenCalled();
-        button.simulate("click");
+        button.simulate("click", {preventDefault: jest.fn()});
         expect(onClick).not.toHaveBeenCalled();
 
         expect(button.state("hovered")).toEqual(false);

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -62,6 +62,7 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
     >
       <button
         className=""
+        disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -185,6 +186,7 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
   >
     <button
       className=""
+      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -639,6 +641,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
           "whiteSpace": "nowrap",
         }
       }
+      tabIndex={-1}
     >
       <span
         className=""
@@ -1248,6 +1251,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
           "whiteSpace": "nowrap",
         }
       }
+      tabIndex={-1}
     >
       <span
         className=""

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -62,7 +62,6 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
     >
       <button
         className=""
-        disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -99,7 +98,6 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
             "whiteSpace": "nowrap",
           }
         }
-        tabIndex={0}
       >
         <span
           className=""
@@ -187,7 +185,6 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
   >
     <button
       className=""
-      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -224,7 +221,6 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
           "whiteSpace": "nowrap",
         }
       }
-      tabIndex={0}
     >
       <span
         className=""
@@ -351,7 +347,6 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
           "width": 170,
         }
       }
-      tabIndex={0}
     >
       <span
         className=""
@@ -498,7 +493,6 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
           "whiteSpace": "nowrap",
         }
       }
-      tabIndex={0}
     >
       <span
         className=""
@@ -645,7 +639,6 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
           "whiteSpace": "nowrap",
         }
       }
-      tabIndex={-1}
     >
       <span
         className=""
@@ -814,7 +807,6 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
             "whiteSpace": "nowrap",
           }
         }
-        tabIndex={0}
       >
         <span
           className=""
@@ -964,7 +956,6 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
           "width": 170,
         }
       }
-      tabIndex={0}
     >
       <span
         className=""
@@ -1111,7 +1102,6 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
           "whiteSpace": "nowrap",
         }
       }
-      tabIndex={0}
     >
       <span
         className=""
@@ -1258,7 +1248,6 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
           "whiteSpace": "nowrap",
         }
       }
-      tabIndex={-1}
     >
       <span
         className=""
@@ -1427,7 +1416,6 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
             "whiteSpace": "nowrap",
           }
         }
-        tabIndex={0}
       >
         <span
           className=""

--- a/packages/wonder-blocks-form/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/__snapshots__/generated-snapshot.test.js.snap
@@ -349,6 +349,7 @@ exports[`wonder-blocks-form example 1 1`] = `
           "width": 16,
         }
       }
+      tabIndex={-1}
       type="checkbox"
     />
   </div>
@@ -409,6 +410,7 @@ exports[`wonder-blocks-form example 1 1`] = `
           "width": 16,
         }
       }
+      tabIndex={-1}
       type="checkbox"
     />
     <svg
@@ -901,6 +903,7 @@ exports[`wonder-blocks-form example 3 1`] = `
           "width": 16,
         }
       }
+      tabIndex={-1}
       type="radio"
     />
   </div>
@@ -962,6 +965,7 @@ exports[`wonder-blocks-form example 3 1`] = `
           "width": 16,
         }
       }
+      tabIndex={-1}
       type="radio"
     />
     <div

--- a/packages/wonder-blocks-form/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/__snapshots__/generated-snapshot.test.js.snap
@@ -76,7 +76,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="checkbox"
     />
   </div>
@@ -135,7 +134,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="checkbox"
     />
     <svg
@@ -214,7 +212,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="checkbox"
     />
   </div>
@@ -273,7 +270,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="checkbox"
     />
     <svg
@@ -353,7 +349,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           "width": 16,
         }
       }
-      tabIndex={-1}
       type="checkbox"
     />
   </div>
@@ -414,7 +409,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           "width": 16,
         }
       }
-      tabIndex={-1}
       type="checkbox"
     />
     <svg
@@ -583,7 +577,6 @@ exports[`wonder-blocks-form example 2 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="checkbox"
     />
   </div>
@@ -667,7 +660,6 @@ exports[`wonder-blocks-form example 3 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="radio"
     />
   </div>
@@ -728,7 +720,6 @@ exports[`wonder-blocks-form example 3 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="radio"
     />
   </div>
@@ -789,7 +780,6 @@ exports[`wonder-blocks-form example 3 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="radio"
     />
   </div>
@@ -850,7 +840,6 @@ exports[`wonder-blocks-form example 3 1`] = `
           "width": 16,
         }
       }
-      tabIndex={0}
       type="radio"
     />
   </div>
@@ -912,7 +901,6 @@ exports[`wonder-blocks-form example 3 1`] = `
           "width": 16,
         }
       }
-      tabIndex={-1}
       type="radio"
     />
   </div>
@@ -974,7 +962,6 @@ exports[`wonder-blocks-form example 3 1`] = `
           "width": 16,
         }
       }
-      tabIndex={-1}
       type="radio"
     />
     <div

--- a/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`IconButtonCore kind:primary color:default size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -36,7 +37,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false disa
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -98,7 +98,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false focu
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -160,7 +159,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false hove
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -218,7 +216,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -242,6 +239,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
 
 exports[`IconButtonCore kind:primary color:default size:default light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -276,7 +274,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true disab
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -338,7 +335,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true focus
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -400,7 +396,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true hover
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -458,7 +453,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -482,6 +476,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
 
 exports[`IconButtonCore kind:primary color:default size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -516,7 +511,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -578,7 +572,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -640,7 +633,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -698,7 +690,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -722,6 +713,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
 
 exports[`IconButtonCore kind:primary color:default size:small light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -756,7 +748,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -818,7 +809,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -880,7 +870,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -938,7 +927,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -962,6 +950,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
 
 exports[`IconButtonCore kind:primary color:destructive size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -996,7 +985,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -1058,7 +1046,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1120,7 +1107,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1178,7 +1164,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1202,6 +1187,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
 
 exports[`IconButtonCore kind:primary color:destructive size:default light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -1236,7 +1222,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true d
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -1298,7 +1283,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true f
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1360,7 +1344,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true h
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1418,7 +1401,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1442,6 +1424,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
 
 exports[`IconButtonCore kind:primary color:destructive size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -1476,7 +1459,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -1538,7 +1520,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1600,7 +1581,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1658,7 +1638,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1682,6 +1661,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
 
 exports[`IconButtonCore kind:primary color:destructive size:small light:true disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -1716,7 +1696,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -1778,7 +1757,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1840,7 +1818,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1898,7 +1875,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -1922,6 +1898,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
 
 exports[`IconButtonCore kind:secondary color:default size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -1956,7 +1933,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false di
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -2018,7 +1994,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false fo
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2080,7 +2055,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false ho
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2138,7 +2112,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2162,6 +2135,7 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
 
 exports[`IconButtonCore kind:secondary color:default size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -2196,7 +2170,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -2258,7 +2231,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2320,7 +2292,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2378,7 +2349,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2402,6 +2372,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
 
 exports[`IconButtonCore kind:secondary color:destructive size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -2436,7 +2407,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -2498,7 +2468,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2560,7 +2529,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2618,7 +2586,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2642,6 +2609,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
 
 exports[`IconButtonCore kind:secondary color:destructive size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -2676,7 +2644,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -2738,7 +2705,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2800,7 +2766,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2858,7 +2823,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -2882,6 +2846,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
 
 exports[`IconButtonCore kind:tertiary color:default size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -2916,7 +2881,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false dis
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -2978,7 +2942,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false foc
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3040,7 +3003,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false hov
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3098,7 +3060,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3122,6 +3083,7 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
 
 exports[`IconButtonCore kind:tertiary color:default size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -3156,7 +3118,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -3218,7 +3179,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3280,7 +3240,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3338,7 +3297,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3362,6 +3320,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
 
 exports[`IconButtonCore kind:tertiary color:destructive size:default light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -3396,7 +3355,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -3458,7 +3416,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3520,7 +3477,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3578,7 +3534,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3602,6 +3557,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
 
 exports[`IconButtonCore kind:tertiary color:destructive size:small light:false disabled 1`] = `
 <button
+  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -3636,7 +3592,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
       "width": 40,
     }
   }
-  tabIndex={-1}
 >
   <svg
     className=""
@@ -3698,7 +3653,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3760,7 +3714,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""
@@ -3818,7 +3771,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
       "width": 40,
     }
   }
-  tabIndex={0}
 >
   <svg
     className=""

--- a/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
@@ -56,7 +56,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         "width": 40,
       }
     }
-    tabIndex={0}
   >
     <svg
       className=""
@@ -112,7 +111,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         "width": 40,
       }
     }
-    tabIndex={0}
   >
     <svg
       className=""
@@ -168,7 +166,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         "width": 40,
       }
     }
-    tabIndex={0}
   >
     <svg
       className=""

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -96,23 +96,31 @@ export default class IconButtonCore extends React.Component<Props> {
             // TODO(kevinb): figure out a better way of forward ARIA props
             "aria-label": this.props["aria-label"],
             "data-test-id": testId,
-            disabled: disabled,
             style: [defaultStyle, style],
             ...handlers,
         };
 
         if (href) {
+            const linkProps = {
+                "aria-disabled": disabled ? "true" : "false",
+                tabIndex: disabled ? "-1" : undefined,
+            };
+
             return clientNav ? (
-                <StyledLink {...commonProps} to={href}>
+                <StyledLink {...commonProps} {...linkProps} to={href}>
                     {child}
                 </StyledLink>
             ) : (
-                <StyledAnchor {...commonProps} href={href}>
+                <StyledAnchor {...commonProps} {...linkProps} href={href}>
                     {child}
                 </StyledAnchor>
             );
         } else {
-            return <StyledButton {...commonProps}>{child}</StyledButton>;
+            return (
+                <StyledButton {...commonProps} disabled={disabled}>
+                    {child}
+                </StyledButton>
+            );
         }
     }
 }

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -95,23 +95,19 @@ export default class IconButtonCore extends React.Component<Props> {
         const commonProps = {
             // TODO(kevinb): figure out a better way of forward ARIA props
             "aria-label": this.props["aria-label"],
+            "aria-disabled": disabled ? "true" : undefined,
             "data-test-id": testId,
             style: [defaultStyle, style],
             ...handlers,
         };
 
         if (href) {
-            const linkProps = {
-                "aria-disabled": disabled ? "true" : "false",
-                tabIndex: disabled ? "-1" : undefined,
-            };
-
             return clientNav ? (
-                <StyledLink {...commonProps} {...linkProps} to={href}>
+                <StyledLink {...commonProps} to={href}>
                     {child}
                 </StyledLink>
             ) : (
-                <StyledAnchor {...commonProps} {...linkProps} href={href}>
+                <StyledAnchor {...commonProps} href={href}>
                     {child}
                 </StyledAnchor>
             );

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -94,8 +94,8 @@ export default class IconButtonCore extends React.Component<Props> {
 
         const commonProps = {
             // TODO(kevinb): figure out a better way of forward ARIA props
-            "aria-label": this.props["aria-label"],
             "aria-disabled": disabled ? "true" : undefined,
+            "aria-label": this.props["aria-label"],
             "data-test-id": testId,
             style: [defaultStyle, style],
             ...handlers,

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
 import {StyleSheet} from "aphrodite";
+import {Link} from "react-router-dom";
 
 import Color, {
     SemanticColor,
@@ -51,21 +52,23 @@ type Props = {|
 
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");
+const StyledLink = addStyle(Link);
 
 export default class IconButtonCore extends React.Component<Props> {
     render() {
         const {
-            icon,
+            clientNav,
             color,
+            disabled,
+            focused,
+            hovered,
+            href,
+            icon,
             kind,
             light,
-            disabled,
-            testId,
-            style,
-            hovered,
-            focused,
             pressed,
-            href,
+            style,
+            testId,
             ...handlers
         } = this.props;
 
@@ -87,20 +90,30 @@ export default class IconButtonCore extends React.Component<Props> {
                     : (hovered || focused) && buttonStyles.focus),
         ];
 
-        const Tag = href ? StyledAnchor : StyledButton;
+        const child = <Icon size="medium" color="currentColor" icon={icon} />;
 
-        return (
-            <Tag
-                data-test-id={testId}
-                href={href}
-                disabled={disabled}
-                aria-label={this.props["aria-label"]}
-                style={[defaultStyle, style]}
-                {...handlers}
-            >
-                <Icon size="medium" color="currentColor" icon={icon} />
-            </Tag>
-        );
+        const commonProps = {
+            // TODO(kevinb): figure out a better way of forward ARIA props
+            "aria-label": this.props["aria-label"],
+            "data-test-id": testId,
+            disabled: disabled,
+            style: [defaultStyle, style],
+            ...handlers,
+        };
+
+        if (href) {
+            return clientNav ? (
+                <StyledLink {...commonProps} to={href}>
+                    {child}
+                </StyledLink>
+            ) : (
+                <StyledAnchor {...commonProps} href={href}>
+                    {child}
+                </StyledAnchor>
+            );
+        } else {
+            return <StyledButton {...commonProps}>{child}</StyledButton>;
+        }
     }
 }
 

--- a/packages/wonder-blocks-icon-button/custom-snapshot.test.js
+++ b/packages/wonder-blocks-icon-button/custom-snapshot.test.js
@@ -53,7 +53,6 @@ describe("IconButtonCore", () => {
                                         light={light}
                                         {...stateProps}
                                         {...defaultHandlers}
-                                        tabIndex={stateProps.disabled ? -1 : 0}
                                     />,
                                 )
                                 .toJSON();

--- a/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
@@ -23,7 +23,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
 >
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -59,7 +58,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
         "width": 100,
       }
     }
-    tabIndex={0}
   >
     <span
       className=""
@@ -109,7 +107,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
   />
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -145,7 +142,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
         "width": 100,
       }
     }
-    tabIndex={0}
   >
     <span
       className=""
@@ -195,7 +191,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
   />
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -231,7 +226,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
         "width": 100,
       }
     }
-    tabIndex={0}
   >
     <span
       className=""
@@ -277,7 +271,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
   />
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -313,7 +306,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
         "width": 100,
       }
     }
-    tabIndex={0}
   >
     <span
       className=""
@@ -363,7 +355,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
   />
   <button
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -399,7 +390,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
         "width": 100,
       }
     }
-    tabIndex={0}
   >
     <span
       className=""

--- a/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
@@ -23,6 +23,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
 >
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -107,6 +108,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
   />
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -191,6 +193,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
   />
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -271,6 +274,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
   />
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -355,6 +359,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
   />
   <button
     className=""
+    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}

--- a/packages/wonder-blocks-link/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__snapshots__/custom-snapshot.test.js.snap
@@ -27,7 +27,6 @@ exports[`LinkCore kind:primary href:# light:false focused 1`] = `
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -60,7 +59,6 @@ exports[`LinkCore kind:primary href:# light:false hovered 1`] = `
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -93,7 +91,6 @@ exports[`LinkCore kind:primary href:# light:false pressed 1`] = `
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -126,7 +123,6 @@ exports[`LinkCore kind:primary href:# light:true focused 1`] = `
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -159,7 +155,6 @@ exports[`LinkCore kind:primary href:# light:true hovered 1`] = `
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -192,7 +187,6 @@ exports[`LinkCore kind:primary href:# light:true pressed 1`] = `
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -225,7 +219,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false focused 1`] =
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -258,7 +251,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false hovered 1`] =
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -291,7 +283,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false pressed 1`] =
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -324,7 +315,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true focused 1`] = 
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -357,7 +347,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true hovered 1`] = 
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -390,7 +379,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true pressed 1`] = 
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -423,7 +411,6 @@ exports[`LinkCore kind:secondary href:# light:false focused 1`] = `
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -456,7 +443,6 @@ exports[`LinkCore kind:secondary href:# light:false hovered 1`] = `
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -489,7 +475,6 @@ exports[`LinkCore kind:secondary href:# light:false pressed 1`] = `
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -522,7 +507,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false focused 1`]
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -555,7 +539,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false hovered 1`]
       "textDecoration": "underline currentcolor solid",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>
@@ -588,7 +571,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false pressed 1`]
       "textDecoration": "none",
     }
   }
-  tabIndex={0}
 >
   Click me
 </a>

--- a/packages/wonder-blocks-link/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__snapshots__/generated-snapshot.test.js.snap
@@ -29,7 +29,6 @@ exports[`wonder-blocks-link example 1 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex={0}
   >
     Link
   </a>
@@ -60,7 +59,6 @@ exports[`wonder-blocks-link example 1 1`] = `
         "textDecoration": "none",
       }
     }
-    tabIndex={0}
   >
     Visited Link
   </a>

--- a/packages/wonder-blocks-link/components/link-core.js
+++ b/packages/wonder-blocks-link/components/link-core.js
@@ -19,22 +19,22 @@ type Props = {|
 |};
 
 const StyledAnchor = addStyle("a");
-// $FlowFixMe: pass props directly to StyledLink instead of to Tag
 const StyledLink = addStyle(Link);
 
 export default class LinkCore extends React.Component<Props> {
-    getProps() {
+    render() {
         const {
             caret, // eslint-disable-line no-unused-vars
+            children,
+            clientNav,
+            focused,
+            hovered,
+            href,
             kind,
             light,
-            testId,
-            style,
-            hovered,
-            focused,
             pressed,
-            href,
-            clientNav,
+            style,
+            testId,
             ...handlers
         } = this.props;
 
@@ -48,29 +48,21 @@ export default class LinkCore extends React.Component<Props> {
                 : (hovered || focused) && linkStyles.focus,
         ];
 
-        const props = {
-            style: [defaultStyles, style],
+        const commonProps = {
             "data-test-id": testId,
+            style: [defaultStyles, style],
             ...handlers,
         };
 
-        if (clientNav) {
-            // $FlowFixMe
-            props.to = href;
-        } else {
-            // $FlowFixMe
-            props.href = href;
-        }
-
-        return props;
-    }
-
-    render() {
-        const {children, clientNav} = this.props;
-
-        const Tag = clientNav ? StyledLink : StyledAnchor;
-
-        return <Tag {...this.getProps()}>{children}</Tag>;
+        return clientNav ? (
+            <StyledLink {...commonProps} to={href}>
+                {children}
+            </StyledLink>
+        ) : (
+            <StyledAnchor {...commonProps} href={href}>
+                {children}
+            </StyledAnchor>
+        );
     }
 }
 

--- a/packages/wonder-blocks-link/custom-snapshot.test.js
+++ b/packages/wonder-blocks-link/custom-snapshot.test.js
@@ -41,7 +41,6 @@ describe("LinkCore", () => {
                                     light={light}
                                     {...stateProps}
                                     {...defaultHandlers}
-                                    tabIndex={0}
                                 >
                                     Click me
                                 </LinkCore>,

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -41,7 +41,6 @@ exports[`wonder-blocks-modal example 1 1`] = `
   >
     <button
       className=""
-      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -76,7 +75,6 @@ exports[`wonder-blocks-modal example 1 1`] = `
           "textDecoration": "none",
         }
       }
-      tabIndex={0}
     >
       <span
         className=""
@@ -122,7 +120,6 @@ exports[`wonder-blocks-modal example 1 1`] = `
   >
     <button
       className=""
-      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -157,7 +154,6 @@ exports[`wonder-blocks-modal example 1 1`] = `
           "textDecoration": "none",
         }
       }
-      tabIndex={0}
     >
       <span
         className=""
@@ -203,7 +199,6 @@ exports[`wonder-blocks-modal example 1 1`] = `
   >
     <button
       className=""
-      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -238,7 +233,6 @@ exports[`wonder-blocks-modal example 1 1`] = `
           "textDecoration": "none",
         }
       }
-      tabIndex={0}
     >
       <span
         className=""
@@ -419,7 +413,6 @@ exports[`wonder-blocks-modal example 2 1`] = `
                 "width": 40,
               }
             }
-            tabIndex={0}
           >
             <svg
               className=""
@@ -747,7 +740,6 @@ exports[`wonder-blocks-modal example 2 1`] = `
           >
             <button
               className=""
-              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -782,7 +774,6 @@ exports[`wonder-blocks-modal example 2 1`] = `
                   "textDecoration": "none",
                 }
               }
-              tabIndex={0}
               type="button"
             >
               <span
@@ -968,7 +959,6 @@ exports[`wonder-blocks-modal example 3 1`] = `
                 "width": 40,
               }
             }
-            tabIndex={0}
           >
             <svg
               className=""
@@ -1351,7 +1341,6 @@ exports[`wonder-blocks-modal example 3 1`] = `
           >
             <button
               className=""
-              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1386,7 +1375,6 @@ exports[`wonder-blocks-modal example 3 1`] = `
                   "textDecoration": "none",
                 }
               }
-              tabIndex={0}
               type="button"
             >
               <span
@@ -1572,7 +1560,6 @@ exports[`wonder-blocks-modal example 4 1`] = `
                 "width": 40,
               }
             }
-            tabIndex={0}
           >
             <svg
               className=""
@@ -1955,7 +1942,6 @@ exports[`wonder-blocks-modal example 4 1`] = `
           >
             <button
               className=""
-              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1990,7 +1976,6 @@ exports[`wonder-blocks-modal example 4 1`] = `
                   "textDecoration": "none",
                 }
               }
-              tabIndex={0}
               type="button"
             >
               <span
@@ -2321,7 +2306,6 @@ exports[`wonder-blocks-modal example 5 1`] = `
                 "width": 40,
               }
             }
-            tabIndex={0}
           >
             <svg
               className=""
@@ -2773,7 +2757,6 @@ exports[`wonder-blocks-modal example 5 1`] = `
           >
             <button
               className=""
-              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -2808,7 +2791,6 @@ exports[`wonder-blocks-modal example 5 1`] = `
                   "textDecoration": "none",
                 }
               }
-              tabIndex={0}
               type="button"
             >
               <span
@@ -3014,7 +2996,6 @@ exports[`wonder-blocks-modal example 6 1`] = `
                   "width": 40,
                 }
               }
-              tabIndex={0}
             >
               <svg
                 className=""
@@ -3458,7 +3439,6 @@ exports[`wonder-blocks-modal example 7 1`] = `
                   "width": 40,
                 }
               }
-              tabIndex={0}
             >
               <svg
                 className=""
@@ -3790,7 +3770,6 @@ exports[`wonder-blocks-modal example 7 1`] = `
             >
               <button
                 className=""
-                disabled={false}
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -3825,7 +3804,6 @@ exports[`wonder-blocks-modal example 7 1`] = `
                     "textDecoration": "none",
                   }
                 }
-                tabIndex={0}
               >
                 <span
                   className=""
@@ -4031,7 +4009,6 @@ exports[`wonder-blocks-modal example 8 1`] = `
                   "width": 40,
                 }
               }
-              tabIndex={0}
             >
               <svg
                 className=""
@@ -4348,7 +4325,6 @@ exports[`wonder-blocks-modal example 9 1`] = `
                   "width": 40,
                 }
               }
-              tabIndex={0}
             >
               <svg
                 className=""
@@ -4658,7 +4634,6 @@ exports[`wonder-blocks-modal example 10 1`] = `
                   "width": 40,
                 }
               }
-              tabIndex={0}
             >
               <svg
                 className=""

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -41,6 +41,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
   >
     <button
       className=""
+      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -120,6 +121,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
   >
     <button
       className=""
+      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -199,6 +201,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
   >
     <button
       className=""
+      disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -740,6 +743,7 @@ exports[`wonder-blocks-modal example 2 1`] = `
           >
             <button
               className=""
+              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1341,6 +1345,7 @@ exports[`wonder-blocks-modal example 3 1`] = `
           >
             <button
               className=""
+              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -1942,6 +1947,7 @@ exports[`wonder-blocks-modal example 4 1`] = `
           >
             <button
               className=""
+              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -2757,6 +2763,7 @@ exports[`wonder-blocks-modal example 5 1`] = `
           >
             <button
               className=""
+              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -3770,6 +3777,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
             >
               <button
                 className=""
+                disabled={false}
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}

--- a/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
@@ -127,7 +127,6 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
       >
         <button
           className=""
-          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -162,7 +161,6 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
               "textDecoration": "none",
             }
           }
-          tabIndex={0}
         >
           <span
             className=""
@@ -208,7 +206,6 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
       >
         <button
           className=""
-          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -246,7 +243,6 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
               "textDecoration": "none",
             }
           }
-          tabIndex={0}
         >
           <span
             className=""
@@ -392,7 +388,6 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
               "width": 28,
             }
           }
-          tabIndex={0}
         >
           <svg
             className=""
@@ -644,7 +639,6 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
               "width": 28,
             }
           }
-          tabIndex={0}
         >
           <svg
             className=""
@@ -797,7 +791,6 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
       >
         <button
           className=""
-          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -832,7 +825,6 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
               "textDecoration": "none",
             }
           }
-          tabIndex={0}
         >
           <span
             className=""
@@ -1028,7 +1020,6 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
       >
         <button
           className=""
-          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1066,7 +1057,6 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
               "textDecoration": "none",
             }
           }
-          tabIndex={0}
         >
           <span
             className=""
@@ -1112,7 +1102,6 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
       >
         <button
           className=""
-          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1147,7 +1136,6 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
               "textDecoration": "none",
             }
           }
-          tabIndex={0}
         >
           <span
             className=""
@@ -1293,7 +1281,6 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
               "width": 28,
             }
           }
-          tabIndex={0}
         >
           <svg
             className=""
@@ -1488,7 +1475,6 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
               "textDecoration": "none",
             }
           }
-          tabIndex={0}
         >
           Go to exercise 
           <svg

--- a/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
@@ -127,6 +127,7 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
       >
         <button
           className=""
+          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -206,6 +207,7 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
       >
         <button
           className=""
+          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -791,6 +793,7 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
       >
         <button
           className=""
+          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1020,6 +1023,7 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
       >
         <button
           className=""
+          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1102,6 +1106,7 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
       >
         <button
           className=""
+          disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}


### PR DESCRIPTION
`IconButton` had a `clientNav` prop, but its behaviour was never implemented.  This PR implements that prop bringing `IconButton` in line with `Button`.  I would like to add some automated test for `clientNav`, but I'll try to do this in a separate PR.  This PR also removes some `$FlowFixMe`s.