### PR TITLE
Change dropdown API, update comments and test structure

### DIFF
--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -132,15 +132,9 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
         };
     }
 
-    toggleMenu() {
-        this.setState((prevState) => ({
-            open: !prevState.open,
-        }));
-    }
-
-    handleClose() {
+    handleOpenChanged(open: boolean) {
         this.setState({
-            open: false,
+            open: open,
         });
     }
 
@@ -180,7 +174,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
         const opener = (
             <ActionMenuOpener
                 disabled={disabled}
-                onClick={() => this.toggleMenu()}
+                onClick={() => this.handleOpenChanged(!open)}
                 style={style}
             >
                 {menuText}
@@ -234,7 +228,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                 alignment={alignment}
                 items={menuItems}
                 light={false}
-                onClose={() => this.handleClose()}
+                onOpenChanged={(open) => this.handleOpenChanged(open)}
                 open={open}
                 opener={opener}
                 style={[styles.menuTopSpace, style]}

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -5,7 +5,7 @@ This menu demonstrates an action menu with
 - a separator
 - a disabled item
 - items that redirect to a link
-- items with an onClick callback (could be used for conversion loggin)
+- items with an onClick callback (could be used for conversion logging)
 
 This menu is also right-aligned.
 

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -1,6 +1,7 @@
 //@flow
 import React from "react";
-import {mount} from "enzyme";
+
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import ActionItem from "./action-item.js";
 import SelectItem from "./select-item.js";
@@ -11,36 +12,45 @@ const keyCodes = {
     space: 32,
 };
 
-describe("MultiSelectMenu", () => {
+describe("ActionMenu", () => {
+    let menu;
     const onClick = jest.fn();
     const onToggle = jest.fn();
     const onChange = jest.fn();
-    const menu = mount(
-        <ActionMenu
-            items={[
-                {
-                    type: "action",
-                    label: "Action",
-                    onClick: () => onClick(),
-                },
-                {
-                    type: "separator",
-                },
-                {
-                    type: "select",
-                    label: "Toggle",
-                    onClick: () => onToggle(),
-                    value: "toggle",
-                },
-            ]}
-            menuText="Action menu!"
-            onChange={(selectedValues) => onChange()}
-            selectedValues={[]}
-        />,
-    );
-    const opener = menu.find("ActionMenuOpener");
+
+    beforeEach(() => {
+        menu = mount(
+            <ActionMenu
+                items={[
+                    {
+                        type: "action",
+                        label: "Action",
+                        onClick: () => onClick(),
+                    },
+                    {
+                        type: "separator",
+                    },
+                    {
+                        type: "select",
+                        label: "Toggle",
+                        onClick: () => onToggle(),
+                        value: "toggle",
+                    },
+                ]}
+                menuText={"Action menu!"}
+                onChange={(selectedValues) => onChange()}
+                selectedValues={[]}
+            />,
+        );
+    });
+
+    afterEach(() => {
+        unmountAll();
+    });
 
     it("closes/opens the menu on mouse click, space, and enter", () => {
+        const opener = menu.find("ActionMenuOpener");
+
         expect(menu.state("open")).toEqual(false);
 
         // Open menu with mouse
@@ -63,18 +73,22 @@ describe("MultiSelectMenu", () => {
     });
 
     it("triggers actions and toggles select items as expected", () => {
-        expect(menu.state("open")).toEqual(true);
+        menu.setState({open: true});
 
+        const noop = jest.fn();
+        const nativeEvent = {
+            nativeEvent: {stopImmediatePropagation: noop},
+        };
         const actionItem = menu.find(ActionItem);
         actionItem.simulate("mousedown");
-        actionItem.simulate("mouseup");
+        actionItem.simulate("mouseup", nativeEvent);
         actionItem.simulate("click");
         expect(onClick).toHaveBeenCalledTimes(1);
 
         const selectItem = menu.find(SelectItem);
         selectItem.simulate("mousedown");
-        selectItem.simulate("mouseup");
-        selectItem.simulate("click");
+        selectItem.simulate("mouseup", nativeEvent);
+        selectItem.simulate("click", nativeEvent);
         expect(onToggle).toHaveBeenCalledTimes(1);
         expect(onChange).toHaveBeenCalledTimes(1);
     });

--- a/packages/wonder-blocks-dropdown/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core.js
@@ -27,12 +27,13 @@ type DropdownCoreProps = {|
     /**
      * The component that opens the menu.
      */
-    opener: React.Node,
+    opener: React.Element<*>,
 
     /**
-     * Callback for when the menu is closed.
+     * Callback for when the menu is opened or closed. Parameter is whether
+     * the dropdown menu should be open.
      */
-    onClose: () => void,
+    onOpenChanged: (open: boolean) => void,
 
     /**
      * Whether this menu should be left-aligned or right-aligned with the
@@ -80,7 +81,7 @@ export default class DropdownCore extends React.Component<DropdownCoreProps> {
             return;
         }
         if (this.props.open) {
-            this.props.onClose();
+            this.props.onOpenChanged(false);
         }
     };
 
@@ -88,7 +89,7 @@ export default class DropdownCore extends React.Component<DropdownCoreProps> {
         if (this.props.open && event.key === "Escape") {
             event.preventDefault();
             event.stopImmediatePropagation();
-            this.props.onClose();
+            this.props.onOpenChanged(false);
         }
     };
 

--- a/packages/wonder-blocks-dropdown/components/multi-select-menu.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select-menu.js
@@ -93,15 +93,9 @@ export default class MultiSelectMenu extends React.Component<Props, State> {
         };
     }
 
-    toggleMenu() {
-        this.setState((prevState) => ({
-            open: !prevState.open,
-        }));
-    }
-
-    handleClose() {
+    handleOpenChanged(open: boolean) {
         this.setState({
-            open: false,
+            open: open,
         });
     }
 
@@ -221,7 +215,7 @@ export default class MultiSelectMenu extends React.Component<Props, State> {
             <SelectBox
                 disabled={disabled}
                 light={light}
-                onClick={() => this.toggleMenu()}
+                onClick={() => this.handleOpenChanged(!open)}
                 style={style}
             >
                 {menuText}
@@ -235,7 +229,7 @@ export default class MultiSelectMenu extends React.Component<Props, State> {
                 alignment={alignment}
                 items={menuItems}
                 light={light}
-                onClose={() => this.handleClose()}
+                onOpenChanged={(open) => this.handleOpenChanged(open)}
                 open={open}
                 opener={opener}
                 style={[styles.menuTopSpace, style]}

--- a/packages/wonder-blocks-dropdown/components/single-select-menu.js
+++ b/packages/wonder-blocks-dropdown/components/single-select-menu.js
@@ -1,5 +1,5 @@
 // @flow
-// A menu that consists of action items
+// A menu that consists of items to be selected, single-choice
 
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
@@ -77,15 +77,9 @@ export default class SingleSelectMenu extends React.Component<Props, State> {
         };
     }
 
-    toggleMenu() {
-        this.setState((prevState) => ({
-            open: !prevState.open,
-        }));
-    }
-
-    handleClose() {
+    handleOpenChanged(open: boolean) {
         this.setState({
-            open: false,
+            open: open,
         });
     }
 
@@ -122,7 +116,7 @@ export default class SingleSelectMenu extends React.Component<Props, State> {
             <SelectBox
                 disabled={disabled}
                 light={light}
-                onClick={() => this.toggleMenu()}
+                onClick={() => this.handleOpenChanged(!open)}
                 style={style}
             >
                 {menuText}
@@ -148,7 +142,7 @@ export default class SingleSelectMenu extends React.Component<Props, State> {
                 alignment={alignment}
                 items={menuItems}
                 light={light}
-                onClose={() => this.handleClose()}
+                onOpenChanged={(open, source) => this.handleOpenChanged(open)}
                 open={open}
                 opener={opener}
                 style={[styles.menuSpacer, style]}

--- a/packages/wonder-blocks-dropdown/components/single-select-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select-menu.test.js
@@ -1,6 +1,6 @@
 //@flow
 import React from "react";
-import {mount} from "enzyme";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import SelectBox from "./select-box";
 import SelectItem from "./select-item";
@@ -12,33 +12,41 @@ const keyCodes = {
 };
 
 describe("SingleSelectMenu", () => {
+    let menu;
     const onClick = jest.fn();
-    const menu = mount(
-        <SingleSelectMenu
-            items={[
-                {
-                    type: "select",
-                    label: "item 1",
-                    value: "1",
-                },
-                {
-                    type: "select",
-                    label: "item 2",
-                    value: "2",
-                },
-                {
-                    type: "select",
-                    label: "item 3",
-                    value: "3",
-                },
-            ]}
-            onChange={(selectedValue) => onClick()}
-            placeholder="Choose"
-        />,
-    );
-    const opener = menu.find(SelectBox);
+
+    beforeEach(() => {
+        menu = mount(
+            <SingleSelectMenu
+                items={[
+                    {
+                        type: "select",
+                        label: "item 1",
+                        value: "1",
+                    },
+                    {
+                        type: "select",
+                        label: "item 2",
+                        value: "2",
+                    },
+                    {
+                        type: "select",
+                        label: "item 3",
+                        value: "3",
+                    },
+                ]}
+                onChange={(selectedValue) => onClick()}
+                placeholder="Choose"
+            />,
+        );
+    });
+
+    afterEach(() => {
+        unmountAll();
+    });
 
     it("closes/opens the menu on mouse click, space, and enter", () => {
+        const opener = menu.find(SelectBox);
         expect(menu.state("open")).toEqual(false);
 
         // Open menu with mouse
@@ -62,6 +70,11 @@ describe("SingleSelectMenu", () => {
 
     it("displays selected item label as expected", () => {
         menu.setState({open: true});
+        const opener = menu.find(SelectBox);
+        const noop = jest.fn();
+        const nativeEvent = {
+            nativeEvent: {stopImmediatePropagation: noop},
+        };
 
         // Grab the second item in the list
         const item = menu.find(SelectItem).at(1);
@@ -69,16 +82,19 @@ describe("SingleSelectMenu", () => {
 
         // Click the item
         item.simulate("mousedown");
-        item.simulate("mouseup");
+        item.simulate("mouseup", nativeEvent);
         item.simulate("click");
+
         // Expect menu's onChange callback to have been called
         expect(onClick).toHaveBeenCalledTimes(1);
+
         // This menu should close afer a single item selection
         expect(menu.state("open")).toEqual(false);
 
         // Selected is still false because the client of SingleSelectMenu is
         // expected to change the props on SingleSelectMenu
         expect(item.prop("selected")).toEqual(false);
+
         // Let's set it manually here via selectedValue on SingleSelectMenu
         menu.setProps({selectedValue: "2"});
 


### PR DESCRIPTION
This pull request has the non-portal related changes from #199:

* changed `onClosed` prop to `onOpenChanged` for `DropdownCore`
* updated enzyme tests to use a better structure
* fixed minor typo in docs