### PR TITLE
WB-180: Give toolbar titles and modals an optional unique id prop

### DIFF
--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -539,7 +539,7 @@ exports[`wonder-blocks-modal example 2 1`] = `
             >
               <h4
                 className=""
-                id="wb-toolbar-title"
+                id="wb-modal-title"
                 style={
                   Object {
                     "MozOsxFontSmoothing": "grayscale",
@@ -1079,7 +1079,7 @@ exports[`wonder-blocks-modal example 3 1`] = `
             >
               <span
                 className=""
-                id="wb-toolbar-title"
+                id="wb-modal-title"
                 style={
                   Object {
                     "MozOsxFontSmoothing": "grayscale",
@@ -1665,7 +1665,7 @@ exports[`wonder-blocks-modal example 4 1`] = `
             >
               <span
                 className=""
-                id="wb-toolbar-title"
+                id="wb-modal-title"
                 style={
                   Object {
                     "MozOsxFontSmoothing": "grayscale",
@@ -2390,7 +2390,7 @@ exports[`wonder-blocks-modal example 5 1`] = `
             >
               <span
                 className=""
-                id="wb-toolbar-title"
+                id="wb-modal-title"
                 style={
                   Object {
                     "MozOsxFontSmoothing": "grayscale",

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -45,6 +45,12 @@ type Props = {|
     preview?: React.Node,
 
     /**
+     * An optional id to provide a selector for the title element. Uses
+     * "wb-modal-title" as a default if titleId is not specified.
+     */
+    titleId?: string,
+
+    /**
      * Called when the close button is clicked.
      *
      * If you're using `ModalLauncher`, you probably shouldn't use this prop!
@@ -76,6 +82,7 @@ export default class StandardModal extends React.Component<Props> {
             footer,
             content,
             preview,
+            titleId,
         } = this.props;
 
         return (
@@ -90,6 +97,7 @@ export default class StandardModal extends React.Component<Props> {
                             title={title}
                             subtitle={subtitle}
                             color={header ? "dark" : "light"}
+                            titleId={titleId || "wb-modal-title"}
                         />
                     }
                     header={header}

--- a/packages/wonder-blocks-toolbar/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/components/toolbar.js
@@ -49,6 +49,12 @@ type Props = {|
      * The main title rendered in larger bold text.
      */
     title?: string,
+
+    /**
+     * An optional id to provide a selector for the title element. Uses
+     * "wb-toolbar-title" as a default if titleId is not specified.
+     */
+    titleId?: string,
 |};
 
 export default class Toolbar extends React.Component<Props> {
@@ -80,6 +86,7 @@ export default class Toolbar extends React.Component<Props> {
             size,
             subtitle,
             title,
+            titleId,
         } = this.props;
 
         const TitleComponent = subtitle ? LabelLarge : HeadingSmall;
@@ -107,7 +114,7 @@ export default class Toolbar extends React.Component<Props> {
                                 sharedStyles.center,
                             ]}
                         >
-                            <TitleComponent id="wb-toolbar-title">
+                            <TitleComponent id={titleId || "wb-toolbar-title"}>
                                 {title}
                             </TitleComponent>
                             {subtitle && (

--- a/packages/wonder-blocks-toolbar/components/toolbar.test.js
+++ b/packages/wonder-blocks-toolbar/components/toolbar.test.js
@@ -1,0 +1,19 @@
+// @flow
+import * as React from "react";
+import {shallow} from "enzyme";
+
+import Toolbar from "./toolbar.js";
+
+describe("Toolbar", () => {
+    test("Title id can be specified", () => {
+        const wrapper = shallow(<Toolbar title="Title" />);
+        expect(wrapper.find("#wb-toolbar-title").exists()).toBe(true);
+
+        const titleId = "test-title-id-element";
+        const wrapperWithId = shallow(
+            <Toolbar title="Title" titleId={titleId} />,
+        );
+        expect(wrapperWithId.find("#wb-toolbar-title").exists()).toBe(false);
+        expect(wrapperWithId.find(`#${titleId}`).exists()).toBe(true);
+    });
+});


### PR DESCRIPTION
Rather than enforce a static id value for Toolbar and StandardModal, provide an optional prop that can be used to pass a new string. This means that if we have multiple modals on one page, they can be referenced individually.