### PR TITLE
avoid unnecessary renders by pre-binding all callbacks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     ],
     "rules": {
         "flowtype/require-exact-type": [2, "always"],
-        "react/jsx-handler-names": 2
+        "react/jsx-handler-names": 2,
+        "react/jsx-no-bind": 2
     }
 }

--- a/packages/wonder-blocks-core/components/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.test.js
@@ -14,7 +14,7 @@ describe("ClickableBehavior", () => {
     it("renders a label", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -28,7 +28,7 @@ describe("ClickableBehavior", () => {
     it("changes only hovered state on mouse enter/leave", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -44,7 +44,7 @@ describe("ClickableBehavior", () => {
     it("changes pressed state on mouse down/up", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -60,7 +60,7 @@ describe("ClickableBehavior", () => {
     it("changes pressed state on touch start/end/cancel", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -82,7 +82,7 @@ describe("ClickableBehavior", () => {
     it("enters focused state on key press after click", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -102,7 +102,7 @@ describe("ClickableBehavior", () => {
         window.location.assign = jest.fn();
 
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -122,7 +122,7 @@ describe("ClickableBehavior", () => {
     it("changes pressed state on only space key down/up if <button>", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -144,7 +144,7 @@ describe("ClickableBehavior", () => {
         const button = shallow(
             <ClickableBehavior
                 disabled={false}
-                onClick={(e) => onClick(e)}
+                onClick={onClick}
                 href="https://www.khanacademy.org"
             >
                 {(state, handlers) => {
@@ -170,7 +170,7 @@ describe("ClickableBehavior", () => {
     it("gains focused state on focus event", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -183,7 +183,7 @@ describe("ClickableBehavior", () => {
     it("changes focused state on blur", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -196,7 +196,7 @@ describe("ClickableBehavior", () => {
     it("does not change state if disabled", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={true} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={true} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -270,7 +270,7 @@ describe("ClickableBehavior", () => {
     it("has onClick triggered just once per click by various means", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}
@@ -303,7 +303,7 @@ describe("ClickableBehavior", () => {
     it("resets state when set to disabled", () => {
         const onClick = jest.fn();
         const button = shallow(
-            <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
+            <ClickableBehavior disabled={false} onClick={onClick}>
                 {(state, handlers) => {
                     return <button {...handlers}>Label</button>;
                 }}

--- a/packages/wonder-blocks-core/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.js
@@ -62,7 +62,7 @@ type Props = {|
 export default class UniqueIDProvider extends React.Component<Props> {
     _idFactory: IIdentifierFactory;
 
-    _performRender(firstRender: boolean) {
+    _performRender = (firstRender: boolean) => {
         const {children, mockOnFirstRender, scope} = this.props;
 
         // If this is our first render, we're going to stop right here.
@@ -80,14 +80,18 @@ export default class UniqueIDProvider extends React.Component<Props> {
 
         // It's a regular render, so let's use our identifier factory.
         return children(this._idFactory);
-    }
+    };
+
+    performFirstRender = () => this._performRender(true);
+
+    performSubsequentRenders = () => this._performRender(false);
 
     render() {
         // Here we use the NoSSR component to control when we render and whether
         // we provide a mock or real identifier factory.
         return (
-            <NoSSR placeholder={() => this._performRender(true)}>
-                {() => this._performRender(false)}
+            <NoSSR placeholder={this.performFirstRender}>
+                {this.performSubsequentRenders}
             </NoSSR>
         );
     }

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -135,13 +135,13 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
         };
     }
 
-    handleOpenChanged(open: boolean) {
+    handleOpenChanged = (open: boolean) => {
         this.setState({
             open: open,
         });
-    }
+    };
 
-    handleSelected(selectedValue: string, oldSelectionState: boolean) {
+    handleSelected = (selectedValue: string, oldSelectionState: boolean) => {
         const {onChange, selectedValues} = this.props;
 
         // If either of these are not defined, return.
@@ -160,7 +160,19 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
             // Item was newly selected
             onChange([...selectedValues, selectedValue]);
         }
-    }
+    };
+
+    handleToggleOpener = () => {
+        this.handleOpenChanged(!this.state.open);
+    };
+
+    handleToggleItem = (value: string, state: boolean) => {
+        this.handleSelected(value, state);
+    };
+
+    getOpenerRef = (node: any) => {
+        this.openerElement = ((ReactDOM.findDOMNode(node): any): Element);
+    };
 
     render() {
         const {
@@ -177,12 +189,8 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
         const opener = (
             <ActionMenuOpener
                 disabled={disabled}
-                onClick={() => this.handleOpenChanged(!open)}
-                ref={(node) =>
-                    (this.openerElement = ((ReactDOM.findDOMNode(
-                        node,
-                    ): any): Element))
-                }
+                onClick={this.handleToggleOpener}
+                ref={this.getOpenerRef}
                 style={style}
             >
                 {menuText}
@@ -213,9 +221,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                         label={item.label}
                         /* eslint-disable-next-line react/jsx-handler-names */
                         onClick={item.onClick}
-                        onToggle={(value, state) =>
-                            this.handleSelected(value, state)
-                        }
+                        onToggle={this.handleToggleItem}
                         selected={
                             selectedValues
                                 ? selectedValues.includes(item.value)
@@ -236,7 +242,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                 alignment={alignment}
                 items={menuItems}
                 light={false}
-                onOpenChanged={(open) => this.handleOpenChanged(open)}
+                onOpenChanged={this.handleOpenChanged}
                 open={open}
                 opener={opener}
                 openerElement={this.openerElement}

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -38,7 +38,7 @@ describe("ActionMenu", () => {
                     },
                 ]}
                 menuText={"Action menu!"}
-                onChange={(selectedValues) => onChange()}
+                onChange={onChange}
                 selectedValues={[]}
             />,
         );

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -128,16 +128,18 @@ export default class Dropdown extends React.Component<DropdownProps> {
         }
     };
 
+    handleMouseUp = (event: SyntheticMouseEvent<>) => {
+        // Stop propagation to prevent the mouseup listener
+        // on the document from closing the menu.
+        event.nativeEvent.stopImmediatePropagation();
+    };
+
     renderMenu(outOfBoundaries: ?boolean) {
         const {items, light, dropdownStyle, style} = this.props;
 
         return (
             <View
-                onMouseUp={(event) => {
-                    // Stop propagation to prevent the mouseup listener
-                    // on the document from closing the menu.
-                    event.nativeEvent.stopImmediatePropagation();
-                }}
+                onMouseUp={this.handleMouseUp}
                 style={[
                     styles.dropdown,
                     light && styles.light,
@@ -190,16 +192,16 @@ export default class Dropdown extends React.Component<DropdownProps> {
         }
     }
 
+    getDropdownRef = (node: any) => {
+        this.element = ((ReactDOM.findDOMNode(node): any): Element);
+    };
+
     render() {
         const {alignment, open, opener} = this.props;
 
         return (
             <View
-                ref={(node) =>
-                    (this.element = ((ReactDOM.findDOMNode(
-                        node,
-                    ): any): Element))
-                }
+                ref={this.getDropdownRef}
                 style={[
                     styles.menuWrapper,
                     alignment === "right" && styles.rightAlign,

--- a/packages/wonder-blocks-dropdown/components/multi-select-test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select-test.js
@@ -40,6 +40,7 @@ describe("MultiSelect", () => {
                         value: "3",
                     },
                 ]}
+                /* eslint-disable-next-line react/jsx-no-bind */
                 onChange={(selectedValues) => {
                     saveUpdate(selectedValues);
                     onClick();

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -96,13 +96,13 @@ export default class MultiSelect extends React.Component<Props, State> {
         };
     }
 
-    handleOpenChanged(open: boolean) {
+    handleOpenChanged = (open: boolean) => {
         this.setState({
             open: open,
         });
-    }
+    };
 
-    handleSelected(selectedValue: string, oldSelectionState: boolean) {
+    handleSelected = (selectedValue: string, oldSelectionState: boolean) => {
         const {onChange, selectedValues} = this.props;
 
         if (oldSelectionState) {
@@ -116,18 +116,26 @@ export default class MultiSelect extends React.Component<Props, State> {
             // Item was newly selected
             onChange([...selectedValues, selectedValue]);
         }
-    }
+    };
 
-    handleSelectAll() {
+    handleSelectAll = () => {
         const {items, onChange} = this.props;
         const selected = items.map((item) => item.value);
         onChange(selected);
-    }
+    };
 
-    handleSelectNone() {
+    handleSelectNone = () => {
         const {onChange} = this.props;
         onChange([]);
-    }
+    };
+
+    handleClickOpener = () => {
+        this.handleOpenChanged(!this.state.open);
+    };
+
+    getOpenerRef = (node: any) => {
+        this.openerElement = ((ReactDOM.findDOMNode(node): any): Element);
+    };
 
     getShortcuts() {
         const {items, selectedValues, shortcuts} = this.props;
@@ -139,7 +147,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                     key="select-all"
                     label={`Select all (${items.length})`}
                     indent={true}
-                    onClick={() => this.handleSelectAll()}
+                    onClick={this.handleSelectAll}
                 />
             );
 
@@ -149,7 +157,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                     key="select-none"
                     label="Select none"
                     indent={true}
-                    onClick={() => this.handleSelectNone()}
+                    onClick={this.handleSelectNone}
                 />
             );
 
@@ -195,9 +203,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                     label={item.label}
                     /* eslint-disable-next-line react/jsx-handler-names */
                     onClick={item.onClick}
-                    onToggle={(value, state) =>
-                        this.handleSelected(value, state)
-                    }
+                    onToggle={this.handleSelected}
                     selected={selectedValues.includes(item.value)}
                     value={item.value}
                     variant="checkbox"
@@ -218,12 +224,8 @@ export default class MultiSelect extends React.Component<Props, State> {
             <SelectOpener
                 disabled={disabled}
                 light={light}
-                onClick={() => this.handleOpenChanged(!open)}
-                ref={(node) =>
-                    (this.openerElement = ((ReactDOM.findDOMNode(
-                        node,
-                    ): any): Element))
-                }
+                onClick={this.handleClickOpener}
+                ref={this.getOpenerRef}
                 style={style}
             >
                 {menuText}
@@ -238,7 +240,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 dropdownStyle={{marginTop: 8, marginBottom: 8}}
                 items={menuItems}
                 light={light}
-                onOpenChanged={(open) => this.handleOpenChanged(open)}
+                onOpenChanged={this.handleOpenChanged}
                 open={open}
                 opener={opener}
                 openerElement={this.openerElement}

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -153,29 +153,22 @@ export default class OptionItem extends React.Component<OptionProps> {
         disabled: false,
     };
 
+    handleClick = () => {
+        const {onClick, onToggle, selected, value} = this.props;
+
+        onToggle(value, selected);
+        if (onClick) {
+            onClick(selected);
+        }
+    };
+
     render() {
-        const {
-            disabled,
-            label,
-            onClick,
-            onToggle,
-            selected,
-            value,
-            variant,
-        } = this.props;
+        const {disabled, label, selected, variant} = this.props;
 
         const ClickableBehavior = getClickableBehavior(this.context.router);
 
         return (
-            <ClickableBehavior
-                disabled={disabled}
-                onClick={() => {
-                    onToggle(value, selected);
-                    if (onClick) {
-                        onClick(selected);
-                    }
-                }}
-            >
+            <ClickableBehavior disabled={disabled} onClick={this.handleClick}>
                 {(state, handlers) => {
                     const {pressed, hovered, focused} = state;
 

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -79,13 +79,17 @@ export default class SingleSelect extends React.Component<Props, State> {
         };
     }
 
-    handleOpenChanged(open: boolean) {
+    handleOpenChanged = (open: boolean, source: any) => {
         this.setState({
             open: open,
         });
-    }
+    };
 
-    handleSelected(selectedValue: string) {
+    handleOpenerClick = () => {
+        this.handleOpenChanged(!this.state.open);
+    };
+
+    handleSelected = (selectedValue: string, state: any) => {
         this.setState({
             open: false, // close the menu upon selection
         });
@@ -94,7 +98,11 @@ export default class SingleSelect extends React.Component<Props, State> {
         if (selectedValue !== this.props.selectedValue) {
             this.props.onChange(selectedValue);
         }
-    }
+    };
+
+    getOpenerRef = (node: any) => {
+        this.openerElement = ((ReactDOM.findDOMNode(node): any): Element);
+    };
 
     render() {
         const {
@@ -118,12 +126,8 @@ export default class SingleSelect extends React.Component<Props, State> {
             <SelectOpener
                 disabled={disabled}
                 light={light}
-                onClick={() => this.handleOpenChanged(!open)}
-                ref={(node) =>
-                    (this.openerElement = ((ReactDOM.findDOMNode(
-                        node,
-                    ): any): Element))
-                }
+                onClick={this.handleOpenerClick}
+                ref={this.getOpenerRef}
                 style={style}
             >
                 {menuText}
@@ -136,7 +140,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                     disabled={item.disabled}
                     key={item.value}
                     label={item.label}
-                    onToggle={(value, state) => this.handleSelected(value)}
+                    onToggle={this.handleSelected}
                     selected={selectedValue === item.value}
                     value={item.value}
                     variant="check"
@@ -150,7 +154,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                 dropdownStyle={{marginTop: 8, marginBottom: 8}}
                 items={menuItems}
                 light={light}
-                onOpenChanged={(open, source) => this.handleOpenChanged(open)}
+                onOpenChanged={this.handleOpenChanged}
                 open={open}
                 opener={opener}
                 openerElement={this.openerElement}

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -35,7 +35,7 @@ describe("SingleSelect", () => {
                         value: "3",
                     },
                 ]}
-                onChange={(selectedValue) => onClick()}
+                onChange={onClick}
                 placeholder="Choose"
             />,
         );

--- a/packages/wonder-blocks-form/components/checkbox-core.js
+++ b/packages/wonder-blocks-form/components/checkbox-core.js
@@ -29,6 +29,8 @@ const checkboxCheck: IconAsset = {
         "M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z",
 };
 
+const noop = () => void 0;
+
 /**
  * The internal stateless ☑️ Checkbox
  */
@@ -78,7 +80,7 @@ export default class CheckboxCore extends React.Component<Props> {
                     // Need to specify because this is a controlled React
                     // form component, but we handle the click via
                     // ClickableBehavior already
-                    onChange={() => void 0}
+                    onChange={noop}
                     style={defaultStyle}
                     {...props}
                 />

--- a/packages/wonder-blocks-form/components/checkbox.js
+++ b/packages/wonder-blocks-form/components/checkbox.js
@@ -51,14 +51,20 @@ export default class Checkbox extends React.Component<ChoiceComponentProps> {
         error: false,
     };
 
+    handleClick = () => {
+        const {checked, onChange} = this.props;
+        onChange(!checked);
+    };
+
     render() {
+        /* eslint-disable-next-line no-unused-vars */
         const {onChange, ...coreProps} = this.props;
         const ClickableBehavior = getClickableBehavior();
 
         return (
             <ClickableBehavior
                 disabled={coreProps.disabled}
-                onClick={() => onChange(!coreProps.checked)}
+                onClick={this.handleClick}
             >
                 {(state, handlers) => {
                     return (

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -59,8 +59,7 @@ type Props = {|
  * RadioGroup. ChoiceField is the variant used outside of such a group. The two
  * are different to allow for more explicit flow typing. Choice has many of its
  * props auto-populated, but ChoiceField does not.
- */
-export default class ChoiceInternal extends React.Component<Props> {
+ */ export default class ChoiceInternal extends React.Component<Props> {
     static defaultProps = {
         checked: false,
         disabled: false,
@@ -74,19 +73,36 @@ export default class ChoiceInternal extends React.Component<Props> {
             return CheckboxCore;
         }
     }
+    handleClick = (e: SyntheticEvent<>) => {
+        const {checked, onChange, variant} = this.props;
+
+        // Radio buttons cannot be unchecked and do not change
+        // if clicked on when checked
+        if (variant === "radio" && checked) {
+            return;
+        }
+        onChange(!checked);
+    };
+    handleLabelClick = (e: SyntheticEvent<>) => {
+        e.preventDefault();
+    };
     render() {
         const {
             label,
             description,
+            // we don't need this to go into coreProps
+            // eslint-disable-next-line no-unused-vars
             onChange,
             style,
             // we don't need this to go into coreProps
             // eslint-disable-next-line no-unused-vars
             value,
+            // we don't need this to go into coreProps
+            // eslint-disable-next-line no-unused-vars
             variant,
             ...coreProps
         } = this.props;
-        const {checked, disabled, id} = coreProps;
+        const {disabled, id} = coreProps;
 
         const ChoiceCore = this.getChoiceCoreComponent();
         const ClickableBehavior = getClickableBehavior();
@@ -95,14 +111,7 @@ export default class ChoiceInternal extends React.Component<Props> {
             <View style={style}>
                 <ClickableBehavior
                     disabled={coreProps.disabled}
-                    onClick={(e) => {
-                        // Radio buttons cannot be unchecked and do not change
-                        // if clicked on when checked
-                        if (variant === "radio" && checked) {
-                            return;
-                        }
-                        onChange(!checked);
-                    }}
+                    onClick={this.handleClick}
                 >
                     {(state, handlers) => {
                         return (
@@ -125,7 +134,7 @@ export default class ChoiceInternal extends React.Component<Props> {
                                         // attribute to select the input, but
                                         // we use ClickableBehavior to handle
                                         // this.
-                                        onClick={(e) => e.preventDefault()}
+                                        onClick={this.handleLabelClick}
                                     >
                                         {label}
                                     </label>

--- a/packages/wonder-blocks-form/components/radio-core.js
+++ b/packages/wonder-blocks-form/components/radio-core.js
@@ -21,10 +21,11 @@ const {blue, red, white, offWhite, offBlack16, offBlack32, offBlack50} = Color;
 
 const StyledInput = addStyle("input");
 
+const noop = () => void 0;
+
 /**
  * The internal stateless 🔘 Radio button
- */
-export default class RadioCore extends React.Component<Props> {
+ */ export default class RadioCore extends React.Component<Props> {
     render() {
         const {
             checked,
@@ -70,7 +71,7 @@ export default class RadioCore extends React.Component<Props> {
                     // Need to specify because this is a controlled React
                     // form component, but we handle the click via
                     // ClickableBehavior already
-                    onChange={() => void 0}
+                    onChange={noop}
                     style={defaultStyle}
                     {...props}
                 />

--- a/packages/wonder-blocks-form/components/radio.js
+++ b/packages/wonder-blocks-form/components/radio.js
@@ -44,27 +44,33 @@ type ChoiceComponentProps = {|
  *
  * This component should not really be used by itself because radio buttons are
  * often grouped together. See RadioGroup.
- */
-export default class Radio extends React.Component<ChoiceComponentProps> {
+ */ export default class Radio extends React.Component<ChoiceComponentProps> {
     static defaultProps = {
         disabled: false,
         error: false,
     };
 
+    handleClick = () => {
+        const {checked, onChange} = this.props;
+
+        // Radio buttons cannot be unchecked and therefore only
+        // call onChange if they were not originally checked
+        if (!checked) {
+            onChange(!checked);
+        }
+    };
+
     render() {
-        const {onChange, ...coreProps} = this.props;
+        /* eslint-disable-next-line no-unused-vars */ const {
+            onChange,
+            ...coreProps
+        } = this.props;
         const ClickableBehavior = getClickableBehavior();
 
         return (
             <ClickableBehavior
                 disabled={coreProps.disabled}
-                onClick={() => {
-                    // Radio buttons cannot be unchecked and therefore only
-                    // call onChange if they were not originally checked
-                    if (!coreProps.checked) {
-                        onChange(!coreProps.checked);
-                    }
-                }}
+                onClick={this.handleClick}
             >
                 {(state, handlers) => {
                     return (

--- a/packages/wonder-blocks-icon-button/components/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.test.js
@@ -8,6 +8,8 @@ import {icons} from "@khanacademy/wonder-blocks-icon";
 
 import IconButton from "./icon-button.js";
 
+const noop = () => void 0;
+
 describe("IconButton", () => {
     beforeEach(() => {
         unmountAll();
@@ -18,7 +20,7 @@ describe("IconButton", () => {
             <IconButton
                 icon={icons.search}
                 aria-label="search"
-                onClick={() => done()}
+                onClick={done}
             />,
         );
         wrapper.simulate("click");
@@ -32,7 +34,7 @@ describe("IconButton", () => {
                     aria-label="search"
                     kind="secondary"
                     light={true}
-                    onClick={() => void 0}
+                    onClick={noop}
                 />,
             ),
         ).toThrowError("Light is only supported for primary IconButtons");

--- a/packages/wonder-blocks-modal/components/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.test.js
@@ -5,6 +5,8 @@ import {shallow, mount} from "enzyme";
 import ModalBackdrop from "./modal-backdrop.js";
 import StandardModal from "./standard-modal.js";
 
+const noop = () => {};
+
 const exampleModal = (
     <StandardModal
         content={<div data-modal-content />}
@@ -170,7 +172,7 @@ describe("ModalBackdrop", () => {
 
     test("On mount, we focus the last button in the modal", () => {
         const wrapper = mount(
-            <ModalBackdrop onCloseModal={() => {}}>
+            <ModalBackdrop onCloseModal={noop}>
                 <div>
                     <button />
                     <button />
@@ -191,7 +193,7 @@ describe("ModalBackdrop", () => {
         const wrapper = mount(
             <div>
                 <button data-button-id="A" />
-                <ModalBackdrop onCloseModal={() => {}}>
+                <ModalBackdrop onCloseModal={noop}>
                     <div>
                         <button data-button-id="1" />
                         <button data-button-id="2" />

--- a/packages/wonder-blocks-modal/components/modal-launcher-portal.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher-portal.test.js
@@ -56,6 +56,7 @@ describe("ModalPortal", () => {
 
         const wrapper = mount(
             <ModalLauncherPortal>
+                {/* eslint-disable-next-line react/jsx-no-bind */}
                 <div ref={childrenRef} />
             </ModalLauncherPortal>,
         );

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -47,6 +47,7 @@ describe("ModalLauncher", () => {
         // Mount the modal launcher. This shouldn't trigger any closing yet,
         // because we shouldn't be calling the `modal` function yet.
         const wrapper = shallow(
+            /* eslint-disable-next-line react/jsx-no-bind */
             <ModalLauncher modal={modalFn} onClose={onClose}>
                 {({openModal}) => <button onClick={openModal} />}
             </ModalLauncher>,
@@ -96,6 +97,7 @@ describe("ModalLauncher", () => {
         // ScrollDisabler is present, and trust ScrollDisabler to do its job.
         const wrapper = shallow(
             <ModalLauncher
+                /* eslint-disable-next-line react/jsx-no-bind */
                 modal={({closeModal}) => {
                     savedCloseModal = closeModal;
                     return <div data-modal-child />;

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -7,6 +7,8 @@ import ModalDialog from "./modal-dialog.js";
 import ModalPanel from "./modal-panel.js";
 import ModalContent from "./modal-content.js";
 
+import type {MediaSize} from "@khanacademy/wonder-blocks-core";
+
 type Props = {|
     /**
      * The content of the modal, appearing between the titlebar and footer.
@@ -67,6 +69,10 @@ export default class StandardModal extends React.Component<Props> {
     static defaultProps = {
         onClickCloseButton: () => {},
     };
+
+    getStyle = (mediaSize: MediaSize) =>
+        mediaSize !== "small" && styles.wrapper;
+
     render() {
         const {
             onClickCloseButton,
@@ -79,9 +85,7 @@ export default class StandardModal extends React.Component<Props> {
         } = this.props;
 
         return (
-            <ModalDialog
-                style={(mediaSize) => mediaSize !== "small" && styles.wrapper}
-            >
+            <ModalDialog style={this.getStyle}>
                 <ModalPanel
                     showCloseButton
                     onClickCloseButton={onClickCloseButton}

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -119,13 +119,13 @@ class TwoColumnModal extends React.Component<Props> {
         onClickCloseButton: () => {},
     };
 
+    getStyle = (mediaSize: MediaSize) => {
+        return mediaSize === "small" ? styles.smallDialog : styles.dialog;
+    };
+
     render() {
         return (
-            <ModalDialog
-                style={(mediaSize) =>
-                    mediaSize === "small" ? styles.smallDialog : styles.dialog
-                }
-            >
+            <ModalDialog style={this.getStyle}>
                 <ContentWrapper {...this.props} />
             </ModalDialog>
         );

--- a/packages/wonder-blocks-tooltip/components/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-anchor.test.js
@@ -15,6 +15,8 @@ import {
 
 jest.mock("../util/active-tracker.js");
 
+const noop = () => {};
+
 describe("TooltipAnchor", () => {
     beforeEach(async () => {
         if (typeof document.addEventListener.mockReset === "function") {
@@ -46,7 +48,7 @@ describe("TooltipAnchor", () => {
             >);
         const nodes = (
             <View>
-                <TooltipAnchor anchorRef={() => {}}>
+                <TooltipAnchor anchorRef={noop}>
                     {getFakeTooltipPortalMounter}
                 </TooltipAnchor>
             </View>
@@ -87,7 +89,7 @@ describe("TooltipAnchor", () => {
             >);
         const nodes = (
             <View>
-                <TooltipAnchor anchorRef={() => {}}>
+                <TooltipAnchor anchorRef={noop}>
                     {getFakeTooltipPortalMounter}
                 </TooltipAnchor>
             </View>

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable react/jsx-no-bind */
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
@@ -24,16 +25,11 @@ class TestHarness extends React.Component<*, {ref: ?HTMLElement}> {
     }
 
     render() {
-        const fakeBubble =
-            /* eslint-disable-next-line react/jsx-no-bind */
-            (((
-                <View ref={(ref) => this.props.resultRef(ref)}>
-                    Fake bubble
-                </View>
-            ): any): React.Element<typeof TooltipBubble>);
+        const fakeBubble = (((
+            <View ref={(ref) => this.props.resultRef(ref)}>Fake bubble</View>
+        ): any): React.Element<typeof TooltipBubble>);
         return (
             <View>
-                {/* eslint-disable-next-line react/jsx-no-bind */}
                 <View ref={(ref) => this.updateRef(ref)}>Anchor</View>
                 <TooltipPopper
                     placement={this.props.placement}

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
@@ -24,11 +24,16 @@ class TestHarness extends React.Component<*, {ref: ?HTMLElement}> {
     }
 
     render() {
-        const fakeBubble = (((
-            <View ref={(ref) => this.props.resultRef(ref)}>Fake bubble</View>
-        ): any): React.Element<typeof TooltipBubble>);
+        const fakeBubble =
+            /* eslint-disable-next-line react/jsx-no-bind */
+            (((
+                <View ref={(ref) => this.props.resultRef(ref)}>
+                    Fake bubble
+                </View>
+            ): any): React.Element<typeof TooltipBubble>);
         return (
             <View>
+                {/* eslint-disable-next-line react/jsx-no-bind */}
                 <View ref={(ref) => this.updateRef(ref)}>Anchor</View>
                 <TooltipPopper
                     placement={this.props.placement}

--- a/packages/wonder-blocks-tooltip/components/tooltip.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip.js
@@ -105,11 +105,11 @@ export default class Tooltip extends React.Component<Props, State> {
 
     state = {anchorElement: null};
 
-    _updateAnchorElement(ref: ?Element) {
+    _updateAnchorElement = (ref: ?Element) => {
         if (ref && ref !== this.state.anchorElement) {
             this.setState({anchorElement: ((ref: any): HTMLElement)});
         }
-    }
+    };
 
     _renderAnchorElement(ids?: IIdentifierFactory) {
         // We need to make sure we can anchor on our content.
@@ -179,7 +179,7 @@ export default class Tooltip extends React.Component<Props, State> {
         return (
             <TooltipAnchor
                 forceAnchorFocusivity={forceAnchorFocusivity}
-                anchorRef={(r) => this._updateAnchorElement(r)}
+                anchorRef={this._updateAnchorElement}
             >
                 {(active) => (
                     <TooltipPortalMounter

--- a/packages/wonder-blocks-tooltip/util/is-obscured.test.js
+++ b/packages/wonder-blocks-tooltip/util/is-obscured.test.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable react/jsx-no-bind */
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 


### PR DESCRIPTION
Apparently arrow functions are bad b/c each render generates a new function which means the props aren't equal even if the callback is functionally the same.  This PR pre-binds all backs in non-test code and adds a lint rule to check for this going forward.

https://medium.freecodecamp.org/why-arrow-functions-and-bind-in-reacts-render-are-problematic-f1c08b060e36