### PR TITLE
don't package deps

### DIFF
--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -16,10 +16,12 @@
     "@khanacademy/wonder-blocks-core": "^1.0.4",
     "@khanacademy/wonder-blocks-icon": "1.0.1",
     "@khanacademy/wonder-blocks-spacing": "^2.0.2",
-    "@khanacademy/wonder-blocks-typography": "^1.0.4"
+    "@khanacademy/wonder-blocks-typography": "^1.0.4",
+    "react-popper": "^1.0.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "^16.4.1"
+    "react": "^16.4.1",
+    "react-router-dom": "^4.2.2"
   }
 }


### PR DESCRIPTION
I've added some deps, but it looks like we're still including popper related deps in the dist bundles for the dropdown and tooltip components.  Further investigation is required.