### PR TITLE
Remove inner border from button elements for Firefox

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
@@ -19,6 +19,9 @@ exports[`ButtonCore kind:primary color:default size:default light:false disabled
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -82,6 +85,9 @@ exports[`ButtonCore kind:primary color:default size:default light:false focused 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1865f2",
       "border": "none",
@@ -146,6 +152,9 @@ exports[`ButtonCore kind:primary color:default size:default light:false hovered 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1865f2",
       "border": "none",
@@ -210,6 +219,9 @@ exports[`ButtonCore kind:primary color:default size:default light:false pressed 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1b50b3",
       "border": "none",
@@ -275,6 +287,9 @@ exports[`ButtonCore kind:primary color:default size:default light:true disabled 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#b5cefb",
       "border": "none",
@@ -338,6 +353,9 @@ exports[`ButtonCore kind:primary color:default size:default light:true focused 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -402,6 +420,9 @@ exports[`ButtonCore kind:primary color:default size:default light:true hovered 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -466,6 +487,9 @@ exports[`ButtonCore kind:primary color:default size:default light:true pressed 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#b5cefb",
       "border": "none",
@@ -531,6 +555,9 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -594,6 +621,9 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1865f2",
       "border": "none",
@@ -658,6 +688,9 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1865f2",
       "border": "none",
@@ -722,6 +755,9 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1b50b3",
       "border": "none",
@@ -787,6 +823,9 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#b5cefb",
       "border": "none",
@@ -850,6 +889,9 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -914,6 +956,9 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -978,6 +1023,9 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#b5cefb",
       "border": "none",
@@ -1043,6 +1091,9 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false disa
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -1106,6 +1157,9 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false focu
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#d92916",
       "border": "none",
@@ -1170,6 +1224,9 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false hove
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#d92916",
       "border": "none",
@@ -1234,6 +1291,9 @@ exports[`ButtonCore kind:primary color:destructive size:default light:false pres
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#9e271d",
       "border": "none",
@@ -1299,6 +1359,9 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true disab
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#f3bbb4",
       "border": "none",
@@ -1362,6 +1425,9 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true focus
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -1426,6 +1492,9 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true hover
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -1490,6 +1559,9 @@ exports[`ButtonCore kind:primary color:destructive size:default light:true press
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#f3bbb4",
       "border": "none",
@@ -1555,6 +1627,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -1618,6 +1693,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#d92916",
       "border": "none",
@@ -1682,6 +1760,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#d92916",
       "border": "none",
@@ -1746,6 +1827,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#9e271d",
       "border": "none",
@@ -1811,6 +1895,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#f3bbb4",
       "border": "none",
@@ -1874,6 +1961,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -1938,6 +2028,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -2002,6 +2095,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#f3bbb4",
       "border": "none",
@@ -2067,6 +2163,9 @@ exports[`ButtonCore kind:secondary color:default size:default light:false disabl
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2133,6 +2232,9 @@ exports[`ButtonCore kind:secondary color:default size:default light:false focuse
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -2199,6 +2301,9 @@ exports[`ButtonCore kind:secondary color:default size:default light:false hovere
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -2265,6 +2370,9 @@ exports[`ButtonCore kind:secondary color:default size:default light:false presse
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#b5cefb",
       "border": "none",
@@ -2332,6 +2440,9 @@ exports[`ButtonCore kind:secondary color:default size:default light:true disable
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2398,6 +2509,9 @@ exports[`ButtonCore kind:secondary color:default size:default light:true focused
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -2464,6 +2578,9 @@ exports[`ButtonCore kind:secondary color:default size:default light:true hovered
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -2530,6 +2647,9 @@ exports[`ButtonCore kind:secondary color:default size:default light:true pressed
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1b50b3",
       "border": "none",
@@ -2597,6 +2717,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2663,6 +2786,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -2729,6 +2855,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -2795,6 +2924,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#b5cefb",
       "border": "none",
@@ -2862,6 +2994,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2928,6 +3063,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -2994,6 +3132,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -3060,6 +3201,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1b50b3",
       "border": "none",
@@ -3127,6 +3271,9 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false di
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3193,6 +3340,9 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false fo
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -3259,6 +3409,9 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false ho
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -3325,6 +3478,9 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:false pr
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#f3bbb4",
       "border": "none",
@@ -3392,6 +3548,9 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true dis
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3458,6 +3617,9 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true foc
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -3524,6 +3686,9 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true hov
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -3590,6 +3755,9 @@ exports[`ButtonCore kind:secondary color:destructive size:default light:true pre
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#9e271d",
       "border": "none",
@@ -3657,6 +3825,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3723,6 +3894,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -3789,6 +3963,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -3855,6 +4032,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#f3bbb4",
       "border": "none",
@@ -3922,6 +4102,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3988,6 +4171,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -4054,6 +4240,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -4120,6 +4309,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#9e271d",
       "border": "none",
@@ -4187,6 +4379,9 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false disable
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4250,6 +4445,9 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false focused
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#1865f2",
         "borderRadius": 2,
@@ -4322,6 +4520,9 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false hovered
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#1865f2",
         "borderRadius": 2,
@@ -4394,6 +4595,9 @@ exports[`ButtonCore kind:tertiary color:default size:default light:false pressed
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#1b50b3",
         "borderRadius": 2,
@@ -4467,6 +4671,9 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true disabled
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4530,6 +4737,9 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true focused 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#ffffff",
         "borderRadius": 2,
@@ -4602,6 +4812,9 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true hovered 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#ffffff",
         "borderRadius": 2,
@@ -4674,6 +4887,9 @@ exports[`ButtonCore kind:tertiary color:default size:default light:true pressed 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#b5cefb",
         "borderRadius": 2,
@@ -4747,6 +4963,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4810,6 +5029,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#1865f2",
         "borderRadius": 2,
@@ -4882,6 +5104,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#1865f2",
         "borderRadius": 2,
@@ -4954,6 +5179,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#1b50b3",
         "borderRadius": 2,
@@ -5027,6 +5255,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5090,6 +5321,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#ffffff",
         "borderRadius": 2,
@@ -5162,6 +5396,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#ffffff",
         "borderRadius": 2,
@@ -5234,6 +5471,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#b5cefb",
         "borderRadius": 2,
@@ -5307,6 +5547,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false dis
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5370,6 +5613,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false foc
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#d92916",
         "borderRadius": 2,
@@ -5442,6 +5688,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false hov
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#d92916",
         "borderRadius": 2,
@@ -5514,6 +5763,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:false pre
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#9e271d",
         "borderRadius": 2,
@@ -5587,6 +5839,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true disa
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5650,6 +5905,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true focu
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#ffffff",
         "borderRadius": 2,
@@ -5722,6 +5980,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true hove
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#ffffff",
         "borderRadius": 2,
@@ -5794,6 +6055,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:default light:true pres
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#f3bbb4",
         "borderRadius": 2,
@@ -5867,6 +6131,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5930,6 +6197,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#d92916",
         "borderRadius": 2,
@@ -6002,6 +6272,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#d92916",
         "borderRadius": 2,
@@ -6074,6 +6347,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#9e271d",
         "borderRadius": 2,
@@ -6147,6 +6423,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -6210,6 +6489,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#ffffff",
         "borderRadius": 2,
@@ -6282,6 +6564,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#ffffff",
         "borderRadius": 2,
@@ -6354,6 +6639,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       ":after": Object {
         "background": "#f3bbb4",
         "borderRadius": 2,

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -37,6 +37,9 @@ exports[`wonder-blocks-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -98,6 +101,9 @@ exports[`wonder-blocks-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -162,6 +168,9 @@ exports[`wonder-blocks-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -223,6 +232,9 @@ exports[`wonder-blocks-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -288,6 +300,9 @@ exports[`wonder-blocks-button example 2 1`] = `
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "#1865f2",
       "border": "none",
@@ -370,6 +385,9 @@ exports[`wonder-blocks-button example 3 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "rgba(33,36,44,0.32)",
         "border": "none",
@@ -432,6 +450,9 @@ exports[`wonder-blocks-button example 3 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "rgba(33,36,44,0.32)",
         "border": "none",
@@ -516,6 +537,9 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#ffffff",
         "border": "none",
@@ -577,6 +601,9 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -641,6 +668,9 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -703,6 +733,9 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#b5cefb",
         "border": "none",
@@ -765,6 +798,9 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -830,6 +866,9 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -924,6 +963,9 @@ exports[`wonder-blocks-button example 5 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "#1865f2",
               "border": "none",
@@ -992,6 +1034,9 @@ exports[`wonder-blocks-button example 5 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "#1865f2",
               "border": "none",
@@ -1060,6 +1105,9 @@ exports[`wonder-blocks-button example 5 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "#1865f2",
               "border": "none",
@@ -1146,6 +1194,9 @@ exports[`wonder-blocks-button example 5 1`] = `
             onTouchStart={[Function]}
             style={
               Object {
+                "::-moz-focus-inner": Object {
+                  "border": 0,
+                },
                 "alignItems": "center",
                 "background": "#1865f2",
                 "border": "none",
@@ -1234,6 +1285,9 @@ exports[`wonder-blocks-button example 5 1`] = `
             onTouchStart={[Function]}
             style={
               Object {
+                "::-moz-focus-inner": Object {
+                  "border": 0,
+                },
                 "alignItems": "center",
                 "background": "#1865f2",
                 "border": "none",
@@ -1350,6 +1404,9 @@ exports[`wonder-blocks-button example 5 1`] = `
             onTouchStart={[Function]}
             style={
               Object {
+                "::-moz-focus-inner": Object {
+                  "border": 0,
+                },
                 "alignItems": "center",
                 "alignSelf": "flex-end",
                 "background": "#1865f2",
@@ -1485,6 +1542,9 @@ exports[`wonder-blocks-button example 5 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "#1865f2",
                   "border": "none",

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -125,6 +125,9 @@ const sharedStyles = StyleSheet.create({
         outline: "none",
         textDecoration: "none",
         boxSizing: "border-box",
+        "::-moz-focus-inner": {
+            border: 0,
+        },
     },
     disabled: {
         cursor: "auto",

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -126,6 +126,7 @@ const sharedStyles = StyleSheet.create({
         textDecoration: "none",
         boxSizing: "border-box",
         "::-moz-focus-inner": {
+            // Remove inner focus ring from buttons in Firefox
             border: 0,
         },
     },

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -196,6 +196,9 @@ exports[`wonder-blocks-core example 4 1`] = `
       onTouchStart={[Function]}
       style={
         Object {
+          "::-moz-focus-inner": Object {
+            "border": 0,
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -78,6 +78,9 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
         role="menu"
         style={
           Object {
+            "::-moz-focus-inner": Object {
+              "border": 0,
+            },
             "alignItems": "center",
             "background": "none",
             "border": "none",
@@ -203,6 +206,9 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
       role="menu"
       style={
         Object {
+          "::-moz-focus-inner": Object {
+            "border": 0,
+          },
           "alignItems": "center",
           "background": "none",
           "border": "none",

--- a/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
@@ -20,6 +20,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:false disa
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -78,6 +81,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:false focu
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -140,6 +146,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:false hove
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -202,6 +211,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -265,6 +277,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:true disab
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -323,6 +338,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:true focus
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -385,6 +403,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:true hover
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -447,6 +468,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -510,6 +534,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -568,6 +595,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -630,6 +660,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -692,6 +725,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -755,6 +791,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -813,6 +852,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -875,6 +917,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -937,6 +982,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1000,6 +1048,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1058,6 +1109,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1120,6 +1174,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1182,6 +1239,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1245,6 +1305,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true d
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1303,6 +1366,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true f
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1365,6 +1431,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true h
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1427,6 +1496,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1490,6 +1562,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1548,6 +1623,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1610,6 +1688,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1672,6 +1753,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1735,6 +1819,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1793,6 +1880,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1855,6 +1945,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1917,6 +2010,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1980,6 +2076,9 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false di
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2038,6 +2137,9 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false fo
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2100,6 +2202,9 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false ho
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2162,6 +2267,9 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2225,6 +2333,9 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2283,6 +2394,9 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2345,6 +2459,9 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2407,6 +2524,9 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2470,6 +2590,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2528,6 +2651,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2590,6 +2716,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2652,6 +2781,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2715,6 +2847,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2773,6 +2908,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2835,6 +2973,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2897,6 +3038,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2960,6 +3104,9 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false dis
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3018,6 +3165,9 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false foc
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3080,6 +3230,9 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false hov
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3142,6 +3295,9 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3205,6 +3361,9 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3263,6 +3422,9 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3325,6 +3487,9 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3387,6 +3552,9 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3450,6 +3618,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3508,6 +3679,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3570,6 +3744,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3632,6 +3809,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3695,6 +3875,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3753,6 +3936,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3815,6 +4001,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3877,6 +4066,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
   onTouchStart={[Function]}
   style={
     Object {
+      "::-moz-focus-inner": Object {
+        "border": 0,
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",

--- a/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
@@ -38,6 +38,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -94,6 +97,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -150,6 +156,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -207,6 +216,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -287,6 +299,9 @@ exports[`wonder-blocks-icon-button example 2 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -151,6 +151,7 @@ const sharedStyles = StyleSheet.create({
         textDecoration: "none",
         background: "none",
         "::-moz-focus-inner": {
+            // Remove inner focus ring from buttons in Firefox
             border: 0,
         },
     },

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -150,6 +150,9 @@ const sharedStyles = StyleSheet.create({
         outline: "none",
         textDecoration: "none",
         background: "none",
+        "::-moz-focus-inner": {
+            border: 0,
+        },
     },
     disabled: {
         cursor: "default",

--- a/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
@@ -38,6 +38,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -124,6 +127,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -210,6 +216,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -292,6 +301,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -378,6 +390,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        "::-moz-focus-inner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -56,6 +56,9 @@ exports[`wonder-blocks-modal example 1 1`] = `
       onTouchStart={[Function]}
       style={
         Object {
+          "::-moz-focus-inner": Object {
+            "border": 0,
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",
@@ -137,6 +140,9 @@ exports[`wonder-blocks-modal example 1 1`] = `
       onTouchStart={[Function]}
       style={
         Object {
+          "::-moz-focus-inner": Object {
+            "border": 0,
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",
@@ -218,6 +224,9 @@ exports[`wonder-blocks-modal example 1 1`] = `
       onTouchStart={[Function]}
       style={
         Object {
+          "::-moz-focus-inner": Object {
+            "border": 0,
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",
@@ -402,6 +411,9 @@ exports[`wonder-blocks-modal example 2 1`] = `
             onTouchStart={[Function]}
             style={
               Object {
+                "::-moz-focus-inner": Object {
+                  "border": 0,
+                },
                 "alignItems": "center",
                 "background": "none",
                 "border": "none",
@@ -764,6 +776,9 @@ exports[`wonder-blocks-modal example 2 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "#1865f2",
                   "border": "none",
@@ -953,6 +968,9 @@ exports[`wonder-blocks-modal example 3 1`] = `
             onTouchStart={[Function]}
             style={
               Object {
+                "::-moz-focus-inner": Object {
+                  "border": 0,
+                },
                 "alignItems": "center",
                 "background": "none",
                 "border": "none",
@@ -1370,6 +1388,9 @@ exports[`wonder-blocks-modal example 3 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "#1865f2",
                   "border": "none",
@@ -1559,6 +1580,9 @@ exports[`wonder-blocks-modal example 4 1`] = `
             onTouchStart={[Function]}
             style={
               Object {
+                "::-moz-focus-inner": Object {
+                  "border": 0,
+                },
                 "alignItems": "center",
                 "background": "none",
                 "border": "none",
@@ -1976,6 +2000,9 @@ exports[`wonder-blocks-modal example 4 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "#1865f2",
                   "border": "none",
@@ -2310,6 +2337,9 @@ exports[`wonder-blocks-modal example 5 1`] = `
             onTouchStart={[Function]}
             style={
               Object {
+                "::-moz-focus-inner": Object {
+                  "border": 0,
+                },
                 "alignItems": "center",
                 "background": "none",
                 "border": "none",
@@ -2796,6 +2826,9 @@ exports[`wonder-blocks-modal example 5 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "#1865f2",
                   "border": "none",
@@ -3005,6 +3038,9 @@ exports[`wonder-blocks-modal example 6 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "none",
                   "border": "none",
@@ -3449,6 +3485,9 @@ exports[`wonder-blocks-modal example 7 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "none",
                   "border": "none",
@@ -3813,6 +3852,9 @@ exports[`wonder-blocks-modal example 7 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
+                    "::-moz-focus-inner": Object {
+                      "border": 0,
+                    },
                     "alignItems": "center",
                     "background": "#1865f2",
                     "border": "none",
@@ -4022,6 +4064,9 @@ exports[`wonder-blocks-modal example 8 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "none",
                   "border": "none",
@@ -4339,6 +4384,9 @@ exports[`wonder-blocks-modal example 9 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "none",
                   "border": "none",
@@ -4649,6 +4697,9 @@ exports[`wonder-blocks-modal example 10 1`] = `
               onTouchStart={[Function]}
               style={
                 Object {
+                  "::-moz-focus-inner": Object {
+                    "border": 0,
+                  },
                   "alignItems": "center",
                   "background": "none",
                   "border": "none",

--- a/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
@@ -144,6 +144,9 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "#1865f2",
               "border": "none",
@@ -226,6 +229,9 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "none",
               "border": "none",
@@ -381,6 +387,9 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "none",
               "border": "none",
@@ -636,6 +645,9 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "none",
               "border": "none",
@@ -822,6 +834,9 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "#1865f2",
               "border": "none",
@@ -1055,6 +1070,9 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "none",
               "border": "none",
@@ -1140,6 +1158,9 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "#1865f2",
               "border": "none",
@@ -1292,6 +1313,9 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
           onTouchStart={[Function]}
           style={
             Object {
+              "::-moz-focus-inner": Object {
+                "border": 0,
+              },
               "alignItems": "center",
               "background": "none",
               "border": "none",


### PR DESCRIPTION
Firefox adds an additional inner focus ring for buttons. Update `Button` and `IconButton` styles so that the inner focus ring is not shown.

Test plan:
Used keyboard navigation to navigate to `Button` and `IconButton` examples on styleguidist and confirm that the inner focus ring does not show up.