### PR TITLE
Fix missing router context.

### DIFF
--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -5,6 +5,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
+import PropTypes from "prop-types";
 
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
@@ -79,6 +80,8 @@ export default class ActionItem extends React.Component<ActionProps> {
         disabled: false,
         indent: false,
     };
+
+    static contextTypes = {router: PropTypes.any};
 
     handleClick = (e: SyntheticEvent<>) => {
         if (this.props.disabled) {

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -4,6 +4,7 @@
 
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
+import PropTypes from "prop-types";
 
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
@@ -152,6 +153,8 @@ export default class OptionItem extends React.Component<OptionProps> {
     static defaultProps = {
         disabled: false,
     };
+
+    static contextTypes = {router: PropTypes.any};
 
     render() {
         const {

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -3,6 +3,7 @@
 
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
+import PropTypes from "prop-types";
 
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
@@ -67,6 +68,8 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
         light: false,
         isPlaceholder: false,
     };
+
+    static contextTypes = {router: PropTypes.any};
 
     render() {
         const {

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -21,6 +21,7 @@
   "peerDependencies": {
     "aphrodite": "^1.2.5",
     "popper.js": "^1.14.1",
+    "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-popper": "^1.0.0"

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react";
+import PropTypes from "prop-types";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
@@ -128,6 +129,8 @@ export default class IconButton extends React.Component<SharedProps> {
         light: false,
         disabled: false,
     };
+
+    static contextTypes = {router: PropTypes.any};
 
     render() {
         const {onClick, href, clientNav, ...sharedProps} = this.props;

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -20,6 +20,7 @@
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
+    "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-router-dom": "^4.2.2"
   }

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from "react";
+import PropTypes from "prop-types";
 
 import LinkCore from "./link-core.js";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
@@ -103,6 +104,8 @@ export default class Link extends React.Component<SharedProps> {
         kind: "primary",
         light: false,
     };
+
+    static contextTypes = {router: PropTypes.any};
 
     render() {
         const {onClick, href, clientNav, children, ...sharedProps} = this.props;

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -19,6 +19,7 @@
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
+    "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-router-dom": "^4.2.2"
   }


### PR DESCRIPTION
I noticed a couple issues with how we were using the router context.

1) Everywhere, except in the button module, we had forgotten to include the `contextTypes` (meaning that React would never give us access to the context, and thus we'd never get the router).
2) This introduced a dependency on prop-types for link, icon-button, and dropdown so I went to add it as a peerDependency and also realized it was missing for button, so I added it there too.