### PR TITLE
WB-338: exclude all external deps from built files

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,10 @@
   "dependencies": {
     "aphrodite": "^1.2.5",
     "prop-types": "^15.6.2",
+    "popper.js": "^1.14.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
+    "react-popper": "^1.0.0",
     "react-router-dom": "^4.2.2"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf packages/wonder-blocks-*/dist && rm -rf packages/wonder-blocks-*/node_modules",
     "lint": "eslint --config ./eslint/eslintrc packages",
     "lint:watch": "esw --watch --config ./eslint/eslintrc packages",
-    "build:all": "webpack && node utils/package-flow-types.js",
+    "build:all": "webpack --display-modules && node utils/package-flow-types.js",
     "watch:all": "webpack -w",
     "flow": "flow",
     "flow-coverage": "flow-coverage-report -t text -t html -f ./node_modules/.bin/flow -i 'packages/wonder-blocks-*/**/*.js' -x 'packages/wonder-blocks-*/dist/*.js' -x '**/*.test.js' -x '**/node_modules/**/*.js'",

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -20,6 +20,7 @@
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
+    "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-router-dom": "^4.2.2"
   }

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -16,7 +16,9 @@
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
+    "prop-types": "^15.6.2",
     "react": "^16.4.1",
+    "react-dom": "^16.4.1",
     "react-router-dom": "^4.2.2"
   },
   "author": "",

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -20,6 +20,9 @@
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "^16.4.1"
+    "popper.js": "^1.14.1",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "react-popper": "^1.0.0"
   }
 }

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -23,7 +23,8 @@
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "^16.4.1"
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1"
   },
   "devDependencies": {
     "@khanacademy/wonder-blocks-button": "^1.0.1"

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -20,11 +20,13 @@
     "@khanacademy/wonder-blocks-layout": "^1.0.1",
     "@khanacademy/wonder-blocks-modal": "^1.0.1",
     "@khanacademy/wonder-blocks-spacing": "^2.0.2",
-    "@khanacademy/wonder-blocks-typography": "^1.0.4",
-    "react-popper": "^1.0.0"
+    "@khanacademy/wonder-blocks-typography": "^1.0.4"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "^16.4.1"
+    "popper.js": "^1.14.1",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "react-popper": "^1.0.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,24 +11,25 @@ const packages = fs
     .map((dir) => path.join(__dirname, "packages", dir));
 
 const genWebpackConfig = function(subPkgRoot) {
-    const subPkgJson = require(path.join(subPkgRoot, "./package.json"));
-    const subPkgDeps = subPkgJson.dependencies
-        ? Object.keys(subPkgJson.dependencies)
+    const pkgJson = require(path.join(subPkgRoot, "./package.json"));
+    const pkgDeps = pkgJson.dependencies
+        ? Object.keys(pkgJson.dependencies)
         : [];
-
-    const rootPkgJson = require(path.join(subPkgRoot, "../../package.json"));
-    const rootPkgDeps = rootPkgJson.dependencies
-        ? Object.keys(rootPkgJson.dependencies)
+    const pkgPeerDeps = pkgJson.peerDependencies
+        ? Object.keys(pkgJson.peerDependencies)
         : [];
 
     return {
         entry: path.join(subPkgRoot, "index.js"),
         output: {
             libraryTarget: "commonjs2",
-            filename: "dist/index.js",
-            path: path.join(subPkgRoot),
+            filename: path.relative(
+                __dirname,
+                path.join(subPkgRoot, "dist/index.js"),
+            ),
+            path: path.join(__dirname),
         },
-        externals: [...rootPkgDeps, ...subPkgDeps],
+        externals: [...pkgPeerDeps, pkgDeps],
         module: {
             rules: [
                 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7477,8 +7477,8 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
 popper.js@^1.14.1:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
 
 portfinder@^1.0.9:
   version "1.0.13"


### PR DESCRIPTION
This is still kind of error prone b/c I had to check things manually.  I would like to create a script to verify that all require/import state for an external dep appear in the modules "dependencies" or "peerDependencies".  That'll be a separate PR b/c I want to get some of these components published.  For now we can verify what's being bundled by looking at the output of webpack which we're now passing `--display-modules` to which will show all modules.  Ones that aren't bundled are marked as `external` and only occupy 42 bytes in the bundle.