### PR TITLE
Make client-side navigation the default.

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -25,10 +25,10 @@ class App extends React.Component<{}> {
                         </Route>
                     </Switch>
                     <View style={styles.buttonContainer}>
-                        <Button style={styles.button} href="/foo" clientNav>
+                        <Button style={styles.button} href="/foo">
                             Foo
                         </Button>
-                        <Button style={styles.button} href="/bar" clientNav>
+                        <Button style={styles.button} href="/bar">
                             Bar
                         </Button>
                         <Button
@@ -39,11 +39,8 @@ class App extends React.Component<{}> {
                         </Button>
                     </View>
                     <Body style={styles.body}>
-                        Click{" "}
-                        <Link href="/" clientNav>
-                            Home
-                        </Link>{" "}
-                        to return to the homepage.
+                        Click <Link href="/">Home</Link> to return to the
+                        homepage.
                     </Body>
                 </View>
             </BrowserRouter>

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -2,6 +2,7 @@
 import React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
+import PropTypes from "prop-types";
 
 import {LabelLarge, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Color, {
@@ -26,6 +27,8 @@ const StyledButton = addStyle("button");
 const StyledLink = addStyle(Link);
 
 export default class ButtonCore extends React.Component<Props> {
+    static contextTypes = {router: PropTypes.any};
+
     handleClick = (e: SyntheticEvent<>) => {
         if (this.props.disabled) {
             e.preventDefault();
@@ -35,7 +38,7 @@ export default class ButtonCore extends React.Component<Props> {
     render() {
         const {
             children,
-            clientNav,
+            directNav,
             color,
             disabled,
             focused,
@@ -49,6 +52,7 @@ export default class ButtonCore extends React.Component<Props> {
             testId,
             ...handlers
         } = this.props;
+        const {router} = this.context;
 
         const buttonColor =
             color === "destructive"
@@ -81,7 +85,7 @@ export default class ButtonCore extends React.Component<Props> {
         const label = <Label style={sharedStyles.text}>{children}</Label>;
 
         if (href) {
-            return clientNav ? (
+            return router && !directNav ? (
                 <StyledLink
                     {...commonProps}
                     onClick={this.handleClick}

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -70,17 +70,18 @@ export type SharedProps = {|
     href?: string,
 
     /**
-     * Whether to use client-side navigation.
+     * Whether to avoid using client-side navigation.
      *
      * If the URL passed to href is local to the client-side, e.g.
-     * /math/algebra/eval-exprs, then it uses react-router-dom's Link
-     * component which handles the client-side navigation.
+     * /math/algebra/eval-exprs, then it tries to use react-router-dom's Link
+     * component which handles the client-side navigation. You can set
+     * `directNav` to true avoid using client-side nav entirely.
      *
      * NOTE: All URLs containing a protocol are considered external, e.g.
      * https://khanacademy.org/math/algebra/eval-exprs will trigger a full
      * page reload.
      */
-    clientNav?: boolean,
+    directNav?: boolean,
 
     /**
      * The content of the modal, appearing between the titlebar and footer.
@@ -145,11 +146,11 @@ export default class Button extends React.Component<SharedProps> {
     static contextTypes = {router: PropTypes.any};
 
     render() {
-        const {onClick, href, children, clientNav, ...sharedProps} = this.props;
+        const {onClick, href, children, directNav, ...sharedProps} = this.props;
 
         const ClickableBehavior = getClickableBehavior(
             href,
-            clientNav,
+            directNav,
             this.context.router,
         );
 
@@ -165,7 +166,7 @@ export default class Button extends React.Component<SharedProps> {
                             {...sharedProps}
                             {...state}
                             {...handlers}
-                            clientNav={clientNav}
+                            directNav={directNav}
                             href={href}
                         >
                             {children}

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -274,7 +274,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-Buttons can do client-side navigation if `clientNav` is `true`.
+Buttons do client-side navigation by default, if React Router exists:
 ```jsx
 const {StyleSheet} = require("aphrodite");
 const {View} = require("@khanacademy/wonder-blocks-core");
@@ -293,7 +293,7 @@ const styles = StyleSheet.create({
 // NOTE: In actual code you would use BrowserRouter instead
 <MemoryRouter>
     <View style={styles.row}>
-        <Button testId="button" href="/foo" clientNav={true} style={styles.button}>
+        <Button testId="button" href="/foo" style={styles.button}>
             Click me!
         </Button>
         <Switch>

--- a/packages/wonder-blocks-button/components/button.test.js
+++ b/packages/wonder-blocks-button/components/button.test.js
@@ -15,7 +15,7 @@ describe("Button", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button testId="button" href="/foo" clientNav={true}>
+                    <Button testId="button" href="/foo">
                         Click me!
                     </Button>
                     <Switch>
@@ -35,12 +35,37 @@ describe("Button", () => {
         expect(wrapper.find("#foo").exists()).toBe(true);
     });
 
-    test("client-side navigation without 'clientNav' prop fails", () => {
+    test("client-side navigation with unknown URL fails", () => {
         // Arrange
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button testId="button" href="/foo">
+                    <Button testId="button" href="/unknown">
+                        Click me!
+                    </Button>
+                    <Switch>
+                        <Route path="/foo">
+                            <div id="foo">Hello, world!</div>
+                        </Route>
+                    </Switch>
+                </div>
+            </MemoryRouter>,
+        );
+
+        // Act
+        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        buttonWrapper.simulate("click", {button: 0});
+
+        // Assert
+        expect(wrapper.find("#foo").exists()).toBe(false);
+    });
+
+    test("client-side navigation with `directNav` set to `true` fails", () => {
+        // Arrange
+        const wrapper = mount(
+            <MemoryRouter>
+                <div>
+                    <Button testId="button" href="/foo" directNav>
                         Click me!
                     </Button>
                     <Switch>

--- a/packages/wonder-blocks-button/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/generated-snapshot.test.js
@@ -309,12 +309,7 @@ describe("wonder-blocks-button", () => {
         const example = (
             <MemoryRouter>
                 <View style={styles.row}>
-                    <Button
-                        testId="button"
-                        href="/foo"
-                        clientNav={true}
-                        style={styles.button}
-                    >
+                    <Button testId="button" href="/foo" style={styles.button}>
                         Click me!
                     </Button>
                     <Switch>

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -158,15 +158,12 @@ const startState = {
  * (https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9).
  *
  * WARNING: Do not use this component directly, use getClickableBehavior
- * instead. getClickableBehavior takes three arguments (href, clientNav, and
+ * instead. getClickableBehavior takes three arguments (href, directtNav, and
  * router) and returns either the default ClickableBehavior or a react-router
  * aware version.
  *
- * The react-router aware version is return if the following conditions are met:
- *
- * - `href` is an external URL
- * - `clientNav` is `true`
- * - `router` is a react-router-dom router.
+ * The react-router aware version is returned if `router` is a react-router-dom
+ * router, `directNav` is not `true`, and `href` is an internal URL.
  *
  * The `router` can be accessed via this.context.router from a component
  * rendered as a descendant of a BrowserRouter.

--- a/packages/wonder-blocks-core/util/get-clickable-behavior.js
+++ b/packages/wonder-blocks-core/util/get-clickable-behavior.js
@@ -2,11 +2,8 @@
 /**
  * Returns either the default ClickableBehavior or a react-router aware version.
  *
- * The react-router aware version is return if the following conditions are met:
- *
- * - `href` is an external URL
- * - `clientNav` is `true`
- * - `router` is a react-router-dom router.
+ * The react-router aware version is returned if `router` is a react-router-dom
+ * router, `directNav` is not `true`, and `href` is an internal URL.
  *
  * The `router` can be accessed via this.context.router from a component rendered
  * as a descendant of a BrowserRouter.
@@ -23,26 +20,22 @@ function isExternalUrl(url: string) {
 const ClickableBehaviorWithRouter = withRouter(ClickableBehavior);
 
 export default function getClickableBehavior(
+    /**
+     * The URL to navigate to.
+     */
     href?: string,
-    clientNav?: boolean,
+    /**
+     * Should we skip using the react router and go to the page directly.
+     */
+    directNav?: boolean,
     /**
      * router object added to the React context object by react-router-dom.
      */
     router?: any,
 ) {
-    if (!href) {
-        return ClickableBehavior;
-    } else if (isExternalUrl(href)) {
-        return ClickableBehavior;
-    } else if (clientNav != null) {
-        if (clientNav) {
-            return ClickableBehaviorWithRouter;
-        } else {
-            return ClickableBehavior;
-        }
-    } else if (router) {
+    if (router && directNav !== true && href && !isExternalUrl(href)) {
         return ClickableBehaviorWithRouter;
-    } else {
-        return ClickableBehavior;
     }
+
+    return ClickableBehavior;
 }

--- a/packages/wonder-blocks-core/util/get-clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/util/get-clickable-behavior.test.js
@@ -8,12 +8,12 @@ describe("getClickableBehavior", () => {
     test("Without href, returns ClickableBehavior", () => {
         // Arrange
         const url = undefined;
-        const clientNav = undefined;
+        const directNav = undefined;
         const router = undefined;
         const expectation = ClickableBehavior;
 
         // Act
-        const result = getClickableBehavior(url, clientNav, router);
+        const result = getClickableBehavior(url, directNav, router);
 
         // Assert
         expect(result).toBe(expectation);
@@ -23,28 +23,28 @@ describe("getClickableBehavior", () => {
         test("External URL, returns ClickableBehavior", () => {
             // Arrange
             const url = "http://google.com";
-            const clientNav = undefined;
+            const directNav = undefined;
             const router = <MemoryRouter />;
             const expectation = ClickableBehavior;
 
             // Act
-            const result = getClickableBehavior(url, clientNav, router);
+            const result = getClickableBehavior(url, directNav, router);
 
             // Assert
             expect(result).toBe(expectation);
         });
 
         describe("Internal URL", () => {
-            describe("Client navigation is undefined", () => {
+            describe("Direct navigation is undefined", () => {
                 test("No router, returns ClickableBehavior", () => {
                     // Arrange
                     const url = "/prep/lsat";
-                    const clientNav = undefined;
+                    const directNav = undefined;
                     const router = undefined;
                     const expectation = ClickableBehavior;
 
                     // Act
-                    const result = getClickableBehavior(url, clientNav, router);
+                    const result = getClickableBehavior(url, directNav, router);
 
                     // Assert
                     expect(result).toBe(expectation);
@@ -53,44 +53,44 @@ describe("getClickableBehavior", () => {
                 test("Router, returns ClickableBehaviorWithRouter", () => {
                     // Arrange
                     const url = "/prep/lsat";
-                    const clientNav = undefined;
+                    const directNav = undefined;
                     const router = <MemoryRouter />;
                     const expectation = "withRouter(ClickableBehavior)";
 
                     // Act
-                    const result = getClickableBehavior(url, clientNav, router);
+                    const result = getClickableBehavior(url, directNav, router);
 
                     // Assert
                     expect(result.displayName).toBe(expectation);
                 });
             });
 
-            test("Client navigation is false, returns ClickableBehavior", () => {
+            test("Direct navigation is false, returns ClickableBehaviorWithRouter", () => {
                 // Arrange
                 const url = "/prep/lsat";
-                const clientNav = false;
+                const directNav = false;
+                const router = <MemoryRouter />;
+                const expectation = "withRouter(ClickableBehavior)";
+
+                // Act
+                const result = getClickableBehavior(url, directNav, router);
+
+                // Assert
+                expect(result.displayName).toBe(expectation);
+            });
+
+            test("Direct navigation is true, returns ClickableBehavior", () => {
+                // Arrange
+                const url = "/prep/lsat";
+                const directNav = true;
                 const router = <MemoryRouter />;
                 const expectation = ClickableBehavior;
 
                 // Act
-                const result = getClickableBehavior(url, clientNav, router);
+                const result = getClickableBehavior(url, directNav, router);
 
                 // Assert
                 expect(result).toBe(expectation);
-            });
-
-            test("Client navigation is true, returns ClickableBehaviorWithRouter", () => {
-                // Arrange
-                const url = "/prep/lsat";
-                const clientNav = true;
-                const router = undefined;
-                const expectation = "withRouter(ClickableBehavior)";
-
-                // Act
-                const result = getClickableBehavior(url, clientNav, router);
-
-                // Assert
-                expect(result.displayName).toBe(expectation);
             });
         });
     });

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -44,17 +44,18 @@ type ActionProps = {|
     href?: string,
 
     /**
-     * Whether to use client-side navigation.
+     * Whether to avoid using client-side navigation.
      *
      * If the URL passed to href is local to the client-side, e.g.
-     * /math/algebra/eval-exprs, then it uses react-router-dom's Link
-     * component which handles the client-side navigation.
+     * /math/algebra/eval-exprs, then it tries to use react-router-dom's Link
+     * component which handles the client-side navigation. You can set
+     * `directNav` to true avoid using client-side nav entirely.
      *
      * NOTE: All URLs containing a protocol are considered external, e.g.
      * https://khanacademy.org/math/algebra/eval-exprs will trigger a full
      * page reload.
      */
-    clientNav?: boolean,
+    directNav?: boolean,
 
     /**
      * Function to call when button is clicked.
@@ -90,13 +91,10 @@ export default class ActionItem extends React.Component<ActionProps> {
     };
 
     render() {
-        const {clientNav, disabled, href, indent, label, onClick} = this.props;
+        const {directNav, disabled, href, indent, label, onClick} = this.props;
+        const {router} = this.context;
 
-        const ClickableBehavior = getClickableBehavior(
-            href,
-            clientNav,
-            this.context.router,
-        );
+        const ClickableBehavior = getClickableBehavior(href, directNav, router);
 
         return (
             <ClickableBehavior
@@ -132,10 +130,8 @@ export default class ActionItem extends React.Component<ActionProps> {
                         </React.Fragment>
                     );
 
-                    const {href, clientNav} = this.props;
-
                     if (href) {
-                        return clientNav ? (
+                        return router && !directNav ? (
                             <StyledLink
                                 {...props}
                                 onClick={this.handleClick}

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -200,7 +200,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                         indent={containsOptionItems}
                         label={item.label}
                         href={item.href}
-                        clientNav={item.clientNav}
+                        directNav={item.directNav}
                         /* eslint-disable-next-line react/jsx-handler-names */
                         onClick={item.onClick}
                     />

--- a/packages/wonder-blocks-dropdown/util/types.js
+++ b/packages/wonder-blocks-dropdown/util/types.js
@@ -8,8 +8,8 @@ export type ActionItemProps = {|
     label: string,
     /** URL to navigate to. */
     href?: string,
-    /** Whether to use client-side navigation. */
-    clientNav?: boolean,
+    /** Whether to avoid using client-side navigation. */
+    directNav?: boolean,
     /** Callback on the action. */
     onClick?: () => void,
 |};

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -2,6 +2,7 @@
 import React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
+import PropTypes from "prop-types";
 
 import Color, {
     SemanticColor,
@@ -55,6 +56,8 @@ const StyledButton = addStyle("button");
 const StyledLink = addStyle(Link);
 
 export default class IconButtonCore extends React.Component<Props> {
+    static contextTypes = {router: PropTypes.any};
+
     handleClick = (e: SyntheticEvent<>) => {
         if (this.props.disabled) {
             e.preventDefault();
@@ -63,7 +66,7 @@ export default class IconButtonCore extends React.Component<Props> {
 
     render() {
         const {
-            clientNav,
+            directNav,
             color,
             disabled,
             focused,
@@ -77,6 +80,7 @@ export default class IconButtonCore extends React.Component<Props> {
             testId,
             ...handlers
         } = this.props;
+        const {router} = this.context;
 
         const buttonColor =
             color === "destructive"
@@ -108,7 +112,7 @@ export default class IconButtonCore extends React.Component<Props> {
         };
 
         if (href) {
-            return clientNav ? (
+            return router && !directNav ? (
                 <StyledLink
                     {...commonProps}
                     onClick={this.handleClick}

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -78,14 +78,18 @@ export type SharedProps = {|
     href?: string,
 
     /**
-     * Whether to use client-side navigation.
+     * Whether to avoid using client-side navigation.
      *
      * If the URL passed to href is local to the client-side, e.g.
-     * /math/algebra/eval-exprs, then use ReactRouter to do a client side
-     * navigation by doing history.push(this.props.href) using
-     * ReactRouter's history object
+     * /math/algebra/eval-exprs, then it tries to use react-router-dom's Link
+     * component which handles the client-side navigation. You can set
+     * `directNav` to true avoid using client-side nav entirely.
+     *
+     * NOTE: All URLs containing a protocol are considered external, e.g.
+     * https://khanacademy.org/math/algebra/eval-exprs will trigger a full
+     * page reload.
      */
-    clientNav?: boolean,
+    directNav?: boolean,
 
     /**
      * Function to call when button is clicked.
@@ -133,11 +137,11 @@ export default class IconButton extends React.Component<SharedProps> {
     static contextTypes = {router: PropTypes.any};
 
     render() {
-        const {onClick, href, clientNav, ...sharedProps} = this.props;
+        const {onClick, href, directNav, ...sharedProps} = this.props;
 
         const ClickableBehavior = getClickableBehavior(
             href,
-            clientNav,
+            directNav,
             this.context.router,
         );
 
@@ -153,7 +157,7 @@ export default class IconButton extends React.Component<SharedProps> {
                             {...sharedProps}
                             {...state}
                             {...handlers}
-                            clientNav={clientNav}
+                            directNav={directNav}
                             href={href}
                         />
                     );

--- a/packages/wonder-blocks-icon-button/components/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.test.js
@@ -48,7 +48,6 @@ describe("IconButton", () => {
                         aria-label="search"
                         testId="icon-button"
                         href="/foo"
-                        clientNav={true}
                     />
                     <Switch>
                         <Route path="/foo">
@@ -69,7 +68,37 @@ describe("IconButton", () => {
         expect(wrapper.find("#foo").exists()).toBe(true);
     });
 
-    test("client-side navigation without 'clientNav' prop fails", () => {
+    test("client-side navigation with unknown URL fails", () => {
+        // Arrange
+        const wrapper = mount(
+            <MemoryRouter>
+                <div>
+                    <IconButton
+                        icon={icons.search}
+                        aria-label="search"
+                        testId="icon-button"
+                        href="/unknown"
+                    />
+                    <Switch>
+                        <Route path="/foo">
+                            <div id="foo">Hello, world!</div>
+                        </Route>
+                    </Switch>
+                </div>
+            </MemoryRouter>,
+        );
+
+        // Act
+        const buttonWrapper = wrapper
+            .find(`[data-test-id="icon-button"]`)
+            .first();
+        buttonWrapper.simulate("click", {button: 0});
+
+        // Assert
+        expect(wrapper.find("#foo").exists()).toBe(false);
+    });
+
+    test("client-side navigation with `directNav` set to `true` fails", () => {
         // Arrange
         const wrapper = mount(
             <MemoryRouter>
@@ -79,6 +108,7 @@ describe("IconButton", () => {
                         aria-label="search"
                         testId="icon-button"
                         href="/foo"
+                        directNav
                     />
                     <Switch>
                         <Route path="/foo">

--- a/packages/wonder-blocks-link/components/link-core.js
+++ b/packages/wonder-blocks-link/components/link-core.js
@@ -2,6 +2,7 @@
 import React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
+import PropTypes from "prop-types";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
@@ -22,11 +23,13 @@ const StyledAnchor = addStyle("a");
 const StyledLink = addStyle(Link);
 
 export default class LinkCore extends React.Component<Props> {
+    static contextTypes = {router: PropTypes.any};
+
     render() {
         const {
             caret, // eslint-disable-line no-unused-vars
             children,
-            clientNav,
+            directNav,
             focused,
             hovered,
             href,
@@ -37,6 +40,7 @@ export default class LinkCore extends React.Component<Props> {
             testId,
             ...handlers
         } = this.props;
+        const {router} = this.context;
 
         const linkStyles = _generateStyles(kind, light);
 
@@ -54,7 +58,7 @@ export default class LinkCore extends React.Component<Props> {
             ...handlers,
         };
 
-        return clientNav ? (
+        return router && !directNav ? (
             <StyledLink {...commonProps} to={href}>
                 {children}
             </StyledLink>

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -38,17 +38,18 @@ export type SharedProps = {|
     testId?: string,
 
     /**
-     * Whether to use client-side navigation.
+     * Whether to avoid using client-side navigation.
      *
      * If the URL passed to href is local to the client-side, e.g.
-     * /math/algebra/eval-exprs, then it uses react-router-dom's Link
-     * component which handles the client-side navigation.
+     * /math/algebra/eval-exprs, then it tries to use react-router-dom's Link
+     * component which handles the client-side navigation. You can set
+     * `directNav` to true avoid using client-side nav entirely.
      *
      * NOTE: All URLs containing a protocol are considered external, e.g.
      * https://khanacademy.org/math/algebra/eval-exprs will trigger a full
      * page reload.
      */
-    clientNav?: boolean,
+    directNav?: boolean,
 
     /**
      * Custom styles.
@@ -108,11 +109,11 @@ export default class Link extends React.Component<SharedProps> {
     static contextTypes = {router: PropTypes.any};
 
     render() {
-        const {onClick, href, clientNav, children, ...sharedProps} = this.props;
+        const {onClick, href, directNav, children, ...sharedProps} = this.props;
 
         const ClickableBehavior = getClickableBehavior(
             href,
-            clientNav,
+            directNav,
             this.context.router,
         );
 
@@ -124,7 +125,7 @@ export default class Link extends React.Component<SharedProps> {
                             {...sharedProps}
                             {...state}
                             {...handlers}
-                            clientNav={clientNav}
+                            directNav={directNav}
                             href={href}
                         >
                             {children}

--- a/packages/wonder-blocks-link/components/link.test.js
+++ b/packages/wonder-blocks-link/components/link.test.js
@@ -15,7 +15,7 @@ describe("Link", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Link testId="link" href="/foo" clientNav={true}>
+                    <Link testId="link" href="/foo">
                         Click me!
                     </Link>
                     <Switch>
@@ -35,12 +35,37 @@ describe("Link", () => {
         expect(wrapper.find("#foo").exists()).toBe(true);
     });
 
-    test("client-side navigation without 'clientNav' prop fails", () => {
+    test("client-side navigation with unknown URL fails", () => {
         // Arrange
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Link testId="link" href="/foo">
+                    <Link testId="link" href="/unknown">
+                        Click me!
+                    </Link>
+                    <Switch>
+                        <Route path="/foo">
+                            <div id="foo">Hello, world!</div>
+                        </Route>
+                    </Switch>
+                </div>
+            </MemoryRouter>,
+        );
+
+        // Act
+        const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+        buttonWrapper.simulate("click", {button: 0});
+
+        // Assert
+        expect(wrapper.find("#foo").exists()).toBe(false);
+    });
+
+    test("client-side navigation with `directNav` set to `true` fails", () => {
+        // Arrange
+        const wrapper = mount(
+            <MemoryRouter>
+                <div>
+                    <Link testId="link" href="/foo" directNav>
                         Click me!
                     </Link>
                     <Switch>


### PR DESCRIPTION
If a React Router is available then we would be defaulting to using client-side navigation and force the dev to opt out of it explicitly (rather than the other way around). This simplifies that logic for using these components a bit. Simply: If a React Router exists (and the href is a non-external URL) then it'll try to use React Router. If you don't want to use React Router then you opt out of it by providing a `directNav={true}`. This replaces the use of `clientNav` (which was the opposite, opting in).

There is similar logic in ActionItem, Link, Button, and IconButton so there is a lot of duplicate code in this diff, but it's all pretty similar.