### PR TITLE
Add keyboard accessibility to dropdown menus

### DIFF
--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -318,8 +318,6 @@ export default class ClickableBehavior extends React.Component<Props, State> {
     };
 
     handleBlur = (e: SyntheticFocusEvent<*>) => {
-        this.keyboardClick = false;
-        this.waitingForClick = false;
         this.setState({focused: false, pressed: false});
     };
 

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -318,6 +318,8 @@ export default class ClickableBehavior extends React.Component<Props, State> {
     };
 
     handleBlur = (e: SyntheticFocusEvent<*>) => {
+        this.keyboardClick = false;
+        this.waitingForClick = false;
         this.setState({focused: false, pressed: false});
     };
 

--- a/packages/wonder-blocks-core/components/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.test.js
@@ -12,11 +12,10 @@ const keyCodes = {
 };
 
 describe("ClickableBehavior", () => {
-    // Note: window.location.assign needs a mock function in the testing
-    // environment.
-    window.location.assign = jest.fn();
-
     beforeEach(() => {
+        // Note: window.location.assign needs a mock function in the testing
+        // environment.
+        window.location.assign = jest.fn();
         unmountAll();
     });
 

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -23,6 +23,8 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
 >
   <div
     className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
     style={
       Object {
         "alignItems": "stretch",
@@ -155,6 +157,8 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
 >
   <div
     className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
     style={
       Object {
         "alignItems": "stretch",
@@ -287,6 +291,8 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
 >
   <div
     className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
     style={
       Object {
         "alignItems": "stretch",
@@ -441,6 +447,8 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
 >
   <div
     className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
     style={
       Object {
         "alignItems": "stretch",
@@ -592,6 +600,8 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
 >
   <div
     className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
     style={
       Object {
         "alignItems": "stretch",
@@ -771,6 +781,8 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
   >
     <div
       className=""
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
       style={
         Object {
           "alignItems": "stretch",
@@ -922,6 +934,8 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
 >
   <div
     className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
     style={
       Object {
         "alignItems": "stretch",
@@ -1075,6 +1089,8 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
 >
   <div
     className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
     style={
       Object {
         "alignItems": "stretch",

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -40,7 +40,6 @@ class ActionMenuOpener extends React.Component<OpenerProps> {
 
     handleClick = (e: SyntheticEvent<>) => {
         const {open} = this.props;
-        // TODO: also detect enter click events
         this.props.onOpenChanged(!open, e.type === "keyup");
     };
 
@@ -185,8 +184,11 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
         const containsOptionItems = Array.isArray(selectedValues);
 
         return React.Children.map(children, (item) => {
-            if (item.type === ActionItem) {
-                const {disabled} = item.props;
+            const {
+                type,
+                props: {disabled, value},
+            } = item;
+            if (type === ActionItem) {
                 return {
                     component: item,
                     focusable: !disabled,
@@ -194,8 +196,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                         indent: containsOptionItems,
                     },
                 };
-            } else if (item.type === OptionItem) {
-                const {disabled, value} = item.props;
+            } else if (type === OptionItem) {
                 return {
                     component: item,
                     focusable: !disabled,

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -10,7 +10,9 @@ import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import Dropdown from "./dropdown.js";
 import ActionItem from "./action-item.js";
 import OptionItem from "./option-item.js";
-import SeparatorItem from "./separator-item.js";
+
+import type {Item} from "../util/types.js";
+import type {DropdownItem} from "../util/types.js";
 
 type OpenerProps = {|
     /**
@@ -24,7 +26,11 @@ type OpenerProps = {|
     /**
      * Callback for when the opener is pressed.
      */
-    onClick: () => void,
+    onOpenChanged: (open: boolean, keyboard: boolean) => void,
+    /**
+     * Whether the dropdown is open.
+     */
+    open: boolean,
 |};
 
 class ActionMenuOpener extends React.Component<OpenerProps> {
@@ -32,8 +38,14 @@ class ActionMenuOpener extends React.Component<OpenerProps> {
         disabled: false,
     };
 
+    handleClick = (e: SyntheticEvent<>) => {
+        const {open} = this.props;
+        // TODO: also detect enter click events
+        this.props.onOpenChanged(!open, e.type === "keyup");
+    };
+
     render() {
-        const {children, disabled, onClick} = this.props;
+        const {children, disabled} = this.props;
 
         return (
             // $FlowFixMe: button doesn't allow 'role' prop or Icon as children
@@ -43,7 +55,7 @@ class ActionMenuOpener extends React.Component<OpenerProps> {
                 disabled={disabled}
                 kind="tertiary"
                 light={false}
-                onClick={onClick}
+                onClick={this.handleClick}
                 style={styles.opener}
             >
                 {children}
@@ -61,11 +73,7 @@ type MenuProps = {|
     /**
      * The items in this dropdown.
      */
-    children: Array<
-        React.Element<
-            typeof ActionItem | typeof OptionItem | typeof SeparatorItem,
-        >,
-    >,
+    children: Array<React.Element<Item>>,
 
     /**
      * Text for the opener of this menu.
@@ -107,13 +115,17 @@ type State = {|
      * Whether or not the dropdown is open.
      */
     open: boolean,
+    /**
+     * Whether or not last open state change was triggered by a keyboard click.
+     */
+    keyboard?: boolean,
 |};
 
 /**
  * A menu that consists of various types of items.
  */
 export default class ActionMenu extends React.Component<MenuProps, State> {
-    openerElement: ?Element;
+    openerElement: ?HTMLElement;
 
     static defaultProps = {
         alignment: "left",
@@ -128,13 +140,25 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
         };
     }
 
-    handleOpenChanged(open: boolean) {
+    handleOpenChanged = (open: boolean, keyboard?: boolean) => {
         this.setState({
-            open: open,
+            open,
+            keyboard,
         });
-    }
+    };
 
-    handleSelected(selectedValue: string) {
+    handleItemSelected = () => {
+        // Bring focus back to the opener element.
+        if (this.openerElement) {
+            this.openerElement.focus();
+        }
+
+        this.setState({
+            open: false, // close the menu upon selection
+        });
+    };
+
+    handleOptionSelected = (selectedValue: string) => {
         const {onChange, selectedValues} = this.props;
 
         // If either of these are not defined, return.
@@ -153,49 +177,60 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
             // Item was newly selected
             onChange([...selectedValues, selectedValue]);
         }
-    }
+        this.handleItemSelected();
+    };
 
-    getMenuItems(): Array<
-        React.Element<
-            typeof ActionItem | typeof OptionItem | typeof SeparatorItem,
-        >,
-    > {
+    getMenuItems(): Array<DropdownItem> {
         const {children, selectedValues} = this.props;
         const containsOptionItems = Array.isArray(selectedValues);
 
-        return React.Children.map(children, (item, index) => {
+        return React.Children.map(children, (item) => {
             if (item.type === ActionItem) {
-                return React.cloneElement(item, {
-                    indent: containsOptionItems,
-                });
+                const {disabled} = item.props;
+                return {
+                    component: item,
+                    focusable: !disabled,
+                    populatedProps: {
+                        indent: containsOptionItems,
+                    },
+                };
             } else if (item.type === OptionItem) {
-                return React.cloneElement(item, {
-                    onToggle: (value) => this.handleSelected(value),
-                    selected: selectedValues
-                        ? selectedValues.includes(item.props.value)
-                        : false,
-                    variant: "check",
-                });
+                const {disabled, value} = item.props;
+                return {
+                    component: item,
+                    focusable: !disabled,
+                    populatedProps: {
+                        onToggle: this.handleOptionSelected,
+                        selected: selectedValues
+                            ? selectedValues.includes(value)
+                            : false,
+                        variant: "check",
+                    },
+                };
             } else {
-                return item;
+                return {
+                    component: item,
+                    focusable: false,
+                    populatedProps: {},
+                };
             }
         });
     }
 
+    handleOpenerRef = (node: any) => {
+        this.openerElement = ((ReactDOM.findDOMNode(node): any): HTMLElement);
+    };
+
     render() {
         const {alignment, disabled, menuText, style} = this.props;
-
         const {open} = this.state;
 
         const opener = (
             <ActionMenuOpener
                 disabled={disabled}
-                onClick={() => this.handleOpenChanged(!open)}
-                ref={(node) =>
-                    (this.openerElement = ((ReactDOM.findDOMNode(
-                        node,
-                    ): any): Element))
-                }
+                onOpenChanged={this.handleOpenChanged}
+                open={open}
+                ref={this.handleOpenerRef}
             >
                 {menuText}
             </ActionMenuOpener>
@@ -205,15 +240,15 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
             <Dropdown
                 alignment={alignment}
                 dropdownStyle={styles.menuTopSpace}
+                items={this.getMenuItems()}
+                keyboard={this.state.keyboard}
                 light={false}
-                onOpenChanged={(open) => this.handleOpenChanged(open)}
+                onOpenChanged={this.handleOpenChanged}
                 open={open}
                 opener={opener}
                 openerElement={this.openerElement}
                 style={style}
-            >
-                {this.getMenuItems()}
-            </Dropdown>
+            />
         );
     }
 }

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -62,6 +62,7 @@ class HybridMenu extends React.Component {
         this.state = {
             selectedValues: ["homework"],
         };
+        // Styleguidist doesn't support arrow functions in class field properties
         this.handleChange = this.handleChange.bind(this);
     }
 

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -62,6 +62,7 @@ class HybridMenu extends React.Component {
         this.state = {
             selectedValues: ["homework"],
         };
+        this.handleChange = this.handleChange.bind(this);
     }
 
     handleChange(update) {
@@ -73,7 +74,7 @@ class HybridMenu extends React.Component {
     render() {
         return <ActionMenu
             menuText="Assignments"
-            onChange={(selectedValues) => this.handleChange(selectedValues)}
+            onChange={this.handleChange}
             selectedValues={this.state.selectedValues}
         >
             <ActionItem label="Create..." onClick={() => console.log("create action")} />

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -7,13 +7,10 @@ import ActionItem from "./action-item.js";
 import OptionItem from "./option-item.js";
 import SeparatorItem from "./separator-item.js";
 import ActionMenu from "./action-menu.js";
-
-const keyCodes = {
-    enter: 13,
-    space: 32,
-};
+import {keyCodes} from "../util/constants.js";
 
 describe("ActionMenu", () => {
+    global.scrollTo = jest.fn();
     let menu;
     const onClick = jest.fn();
     const onToggle = jest.fn();
@@ -23,16 +20,12 @@ describe("ActionMenu", () => {
         menu = mount(
             <ActionMenu
                 menuText={"Action menu!"}
-                onChange={(selectedValues) => onChange()}
+                onChange={onChange}
                 selectedValues={[]}
             >
-                <ActionItem label="Action" onClick={() => onClick()} />
+                <ActionItem label="Action" onClick={onClick} />
                 <SeparatorItem />
-                <OptionItem
-                    label="Toggle"
-                    value="toggle"
-                    onClick={() => onToggle()}
-                />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
             </ActionMenu>,
         );
     });
@@ -75,6 +68,9 @@ describe("ActionMenu", () => {
         actionItem.simulate("mouseup", nativeEvent);
         actionItem.simulate("click");
         expect(onClick).toHaveBeenCalledTimes(1);
+
+        // Have to reopen menu because menu closes after an item is selected
+        menu.setState({open: true});
 
         const optionItem = menu.find(OptionItem);
         optionItem.simulate("mousedown");

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -10,13 +10,13 @@ import ActionMenu from "./action-menu.js";
 import {keyCodes} from "../util/constants.js";
 
 describe("ActionMenu", () => {
-    global.scrollTo = jest.fn();
     let menu;
     const onClick = jest.fn();
     const onToggle = jest.fn();
     const onChange = jest.fn();
 
     beforeEach(() => {
+        window.scrollTo = jest.fn();
         menu = mount(
             <ActionMenu
                 menuText={"Action menu!"}
@@ -31,6 +31,7 @@ describe("ActionMenu", () => {
     });
 
     afterEach(() => {
+        window.scrollTo.mockClear();
         unmountAll();
     });
 

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -12,15 +12,34 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {View} from "@khanacademy/wonder-blocks-core";
 
 import visibilityModifierDefaultConfig from "../util/visibility-modifier.js";
-import typeof ActionItem from "./action-item.js";
-import typeof OptionItem from "./option-item.js";
-import typeof SeparatorItem from "./separator-item.js";
+import SeparatorItem from "./separator-item.js";
+import {keyCodes} from "../util/constants.js";
+import type {DropdownItem} from "../util/types.js";
 
 type DropdownProps = {|
     /**
      * Items for the menu.
      */
-    children: Array<React.Element<ActionItem | OptionItem | SeparatorItem>>,
+    items: Array<DropdownItem>,
+
+    /**
+     * An index that represents the index of the focused element when the menu
+     * is opened.
+     */
+    initialFocusedIndex: number,
+
+    /**
+     * Whether the user used the keyboard to open this menu. This activates
+     * keyboard navigation behavior and focus from the very start.
+     */
+    keyboard: ?boolean,
+
+    /**
+     * Callback for when the menu is opened or closed. Parameter is whether
+     * the dropdown menu should be open and whether a keyboard event triggered
+     * the change.
+     */
+    onOpenChanged: (open: boolean, keyboard?: boolean) => void,
 
     /**
      * Whether the menu is open or not.
@@ -35,13 +54,7 @@ type DropdownProps = {|
     /**
      * Ref to the opener element.
      */
-    openerElement: ?Element,
-
-    /**
-     * Callback for when the menu is opened or closed. Parameter is whether
-     * the dropdown menu should be open.
-     */
-    onOpenChanged: (open: boolean) => void,
+    openerElement: ?HTMLElement,
 
     /**
      * Whether this menu should be left-aligned or right-aligned with the
@@ -56,14 +69,37 @@ type DropdownProps = {|
     light: boolean,
 
     /**
-     * Styling specific to the dropdown component that isn't part of the opener.
+     * Styling specific to the dropdown component that isn't part of the opener,
+     * passed by the specific implementation of the dropdown menu,
      */
     dropdownStyle?: any,
 
     /**
-     * User-supplied optional styling.
+     * Optional styling for the entire dropdown component.
      */
     style?: any,
+|};
+
+type State = {|
+    /**
+     * Refs to use for keyboard focus, contains only those for focusable items.
+     * Also keeps track of the original index of the item.
+     */
+    itemRefs: Array<{ref: {current: any}, originalIndex: number}>,
+
+    /**
+     * Because getDerivedStateFromProps doesn't store previous props (in the
+     * spirit of performance), we store the previous items just to be able to
+     * compare them to see if we need to update itemRefs. Inspired by
+     * https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization
+     */
+    prevItems: Array<DropdownItem>,
+
+    /**
+     * Whether the set of items that are focusable are the same, used for
+     * resetting focusedIndex and focusedOriginalIndex when an update happens.
+     */
+    sameItemsFocusable: boolean,
 |};
 
 /**
@@ -71,29 +107,146 @@ type DropdownProps = {|
  * part of the dropdown menu. Renders the dropdown as a portal to avoid clipping
  * in overflow: auto containers.
  */
-export default class Dropdown extends React.Component<DropdownProps> {
-    element: ?Element;
+export default class Dropdown extends React.Component<DropdownProps, State> {
+    // Keeps track of the index of the focused item, out of a list of focusable items
+    focusedIndex: number;
+    // Keeps track of the index of the focused item in the context of all the
+    // items contained by this menu, whether focusable or not, used for figuring
+    // out focus correctly when the items have changed in terms of whether
+    // they're focusable or not
+    focusedOriginalIndex: number;
+    // Whether keyboard nav has been activated
+    keyboardNavOn: boolean;
 
     static defaultProps = {
         alignment: "left",
+        initialFocusedIndex: 0,
+        light: false,
     };
+
+    // Figure out if the same items are focusable. If an item has been added or
+    // removed, this method will return false.
+    static sameItemsFocusable(
+        prevItems: Array<DropdownItem>,
+        currentItems: Array<DropdownItem>,
+    ) {
+        if (prevItems.length !== currentItems.length) {
+            return false;
+        }
+        for (let i = 0; i < prevItems.length; i++) {
+            if (prevItems[i].focusable !== currentItems[i].focusable) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // This is here to avoid calling React.createRef on each rerender. Instead,
+    // we create the itemRefs only if it's the first time or if the set of items
+    // that are focusable has changed.
+    static getDerivedStateFromProps(props: DropdownProps, state: State) {
+        if (
+            (state.itemRefs.length === 0 && props.open) ||
+            !Dropdown.sameItemsFocusable(state.prevItems, props.items)
+        ) {
+            const itemRefs = [];
+            for (let i = 0; i < props.items.length; i++) {
+                if (props.items[i].focusable) {
+                    const ref = React.createRef();
+                    itemRefs.push({ref, originalIndex: i});
+                }
+            }
+            return {
+                itemRefs,
+                prevItems: props.items,
+                sameItemsFocusable: false,
+            };
+        } else {
+            return {
+                prevItems: props.items,
+                sameItemsFocusable: true,
+            };
+        }
+    }
 
     constructor(props: DropdownProps) {
         super(props);
+
+        this.focusedIndex = this.props.initialFocusedIndex;
+        this.keyboardNavOn = false;
+        this.state = {
+            prevItems: this.props.items,
+            itemRefs: [],
+            sameItemsFocusable: false,
+        };
     }
 
     componentDidMount() {
         this.updateEventListeners();
+        this.initialFocusItem();
     }
 
     componentDidUpdate(prevProps: DropdownProps) {
-        if (prevProps.open !== this.props.open) {
+        const {open} = this.props;
+
+        if (prevProps.open !== open) {
             this.updateEventListeners();
+            this.initialFocusItem();
+        }
+        // If the menu changed, but from open to open, figure out if we need
+        // to recalculate the focus somehow.
+        else if (open) {
+            const {itemRefs, sameItemsFocusable} = this.state;
+            // Check if the same items are focused by comparing the items at
+            // each index and seeing if the {focusable} property is the same.
+            // Very rarely do the set of focusable items change if the menu
+            // hasn't been re-opened. This is for cases like a {Select all}
+            // option that becomes disabled iff all the options are selected.
+            if (sameItemsFocusable) {
+                return;
+            } else {
+                // If the set of items that was focusabled changed, it's very
+                // likely that the previously focused item no longer has the
+                // same index relative to the list of focusable items. Instead,
+                // use the focusedOriginalIndex to find the new index of the
+                // last item that was focused before this change
+                const newFocusableIndex = itemRefs.findIndex(
+                    (ref) => ref.originalIndex === this.focusedOriginalIndex,
+                );
+                if (newFocusableIndex === -1) {
+                    // Can't find the originally focused item, return focus to
+                    // the first item that IS focusable
+                    this.focusedIndex = 0;
+                } else {
+                    this.focusedIndex = newFocusableIndex;
+                }
+                this.focusCurrentItem();
+            }
         }
     }
 
     componentWillUnmount() {
         this.removeEventListeners();
+    }
+
+    // Figure out focus states for the dropdown after it has changed from open
+    // to closed or vice versa
+    initialFocusItem() {
+        const {keyboard, initialFocusedIndex, open} = this.props;
+
+        if (open) {
+            // Reset focused index
+            this.focusedIndex = initialFocusedIndex;
+            // We explicitly set focus to the first item only if we sense
+            // that the user opened the menu via the keyboard
+            if (keyboard) {
+                this.keyboardNavOn = true;
+                this.focusCurrentItem();
+            }
+        } else if (!open) {
+            // If the dropdown has been closed, reset the keyboardNavOn boolean
+            this.keyboardNavOn = false;
+        }
     }
 
     updateEventListeners() {
@@ -107,13 +260,11 @@ export default class Dropdown extends React.Component<DropdownProps> {
     addEventListeners() {
         document.addEventListener("mouseup", this.handleInteract);
         document.addEventListener("touchend", this.handleInteract);
-        document.addEventListener("keyup", this.handleKeyup);
     }
 
     removeEventListeners() {
         document.removeEventListener("mouseup", this.handleInteract);
         document.removeEventListener("touchend", this.handleInteract);
-        document.removeEventListener("keyup", this.handleKeyup);
     }
 
     handleInteract = (event: {target: any}) => {
@@ -125,17 +276,137 @@ export default class Dropdown extends React.Component<DropdownProps> {
         }
     };
 
-    handleKeyup = (event: KeyboardEvent) => {
-        const {open, onOpenChanged} = this.props;
-        if (open && event.key === "Escape") {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            onOpenChanged(false);
+    focusCurrentItem = () => {
+        // Because the dropdown menu is portalled, focusing this element
+        // will scroll the window all the way to the top of the screen.
+        const x = window.scrollX;
+        const y = window.scrollY;
+        const node = ((ReactDOM.findDOMNode(
+            this.state.itemRefs[this.focusedIndex].ref.current,
+        ): any): HTMLElement);
+        if (node) {
+            node.focus();
+            // Keep track of the original index of the newly focused item.
+            // To be used if the set of focusable items in the menu changes
+            this.focusedOriginalIndex = this.state.itemRefs[
+                this.focusedIndex
+            ].originalIndex;
+        }
+        window.scrollTo(x, y);
+    };
+
+    focusPreviousItem = () => {
+        if (this.focusedIndex === 0) {
+            this.focusedIndex = this.state.itemRefs.length - 1;
+        } else {
+            this.focusedIndex -= 1;
+        }
+        this.focusCurrentItem();
+    };
+
+    focusNextItem = () => {
+        if (this.focusedIndex === this.state.itemRefs.length - 1) {
+            this.focusedIndex = 0;
+        } else {
+            this.focusedIndex += 1;
+        }
+        this.focusCurrentItem();
+    };
+
+    restoreTabOrder = () => {
+        // NOTE: Because the dropdown is portalled out of its natural
+        // position in the DOM, we need to manually return focus to the
+        // opener element before we let the natural propagation of tab
+        // shift the focus to the next element in the tab order.
+        if (this.props.openerElement) {
+            this.props.openerElement.focus();
         }
     };
 
-    renderMenu(outOfBoundaries: ?boolean) {
-        const {children, dropdownStyle, light, openerElement} = this.props;
+    handleKeyDown = (event: SyntheticKeyboardEvent<>) => {
+        const {initialFocusedIndex, onOpenChanged, open} = this.props;
+        const keyCode = event.which || event.keyCode;
+
+        // If menu isn't open and user presses down, open the menu
+        if (!open) {
+            if (keyCode === keyCodes.down) {
+                event.preventDefault();
+                onOpenChanged(true, true);
+                return;
+            }
+            return;
+        }
+
+        // This is the first use of keyboard navigation and no items have been
+        // clicked yet, so we should focus the original intended first index
+        if (
+            !this.keyboardNavOn &&
+            this.focusedIndex === initialFocusedIndex &&
+            (keyCode === keyCodes.up || keyCode === keyCodes.down)
+        ) {
+            event.preventDefault();
+            this.keyboardNavOn = true;
+            this.focusCurrentItem();
+            return;
+        }
+
+        // Handle all other key behavior
+        switch (keyCode) {
+            case keyCodes.tab:
+                this.restoreTabOrder();
+                onOpenChanged(false, true);
+                return;
+            case keyCodes.space:
+                // Prevent space from scrolling down the page
+                event.preventDefault();
+                return;
+            case keyCodes.up:
+                event.preventDefault();
+                this.focusPreviousItem();
+                return;
+            case keyCodes.down:
+                event.preventDefault();
+                this.focusNextItem();
+                return;
+        }
+    };
+
+    // Some keys should be handled during the keyup event instead.
+    handleKeyUp = (event: SyntheticKeyboardEvent<>) => {
+        const {onOpenChanged} = this.props;
+        const keyCode = event.which || event.keyCode;
+
+        switch (keyCode) {
+            case keyCodes.space:
+                // Prevent space from scrolling down the page
+                event.preventDefault();
+                return;
+            case keyCodes.escape:
+                // Close only the dropdown, not other elements that are
+                // listening for an escape press
+                event.stopPropagation();
+                this.restoreTabOrder();
+                onOpenChanged(false, true);
+                return;
+        }
+    };
+
+    handleClickFocus = (index: number) => {
+        // Turn keyboard nav on so pressing up or down would focus the
+        // appropriate item in handleKeyDown
+        this.keyboardNavOn = true;
+        this.focusedIndex = index;
+        this.focusedOriginalIndex = this.state.itemRefs[
+            this.focusedIndex
+        ].originalIndex;
+    };
+
+    handleDropdownMouseUp = (event: SyntheticMouseEvent<>) => {
+        event.nativeEvent.stopImmediatePropagation();
+    };
+
+    renderItems(outOfBoundaries: ?boolean) {
+        const {items, dropdownStyle, light, openerElement} = this.props;
 
         // The dropdown width is at least the width of the opener.
         const openerStyle = window.getComputedStyle(openerElement);
@@ -143,13 +414,13 @@ export default class Dropdown extends React.Component<DropdownProps> {
             ? openerStyle.getPropertyValue("width")
             : 0;
 
+        let focusCounter = 0;
+
         return (
             <View
-                onMouseUp={(event) => {
-                    // Stop propagation to prevent the mouseup listener
-                    // on the document from closing the menu.
-                    event.nativeEvent.stopImmediatePropagation();
-                }}
+                // Stop propagation to prevent the mouseup listener on the
+                // document from closing the menu.
+                onMouseUp={this.handleDropdownMouseUp}
                 style={[
                     styles.dropdown,
                     light && styles.light,
@@ -158,7 +429,30 @@ export default class Dropdown extends React.Component<DropdownProps> {
                     dropdownStyle,
                 ]}
             >
-                {children}
+                {items.map((item, index) => {
+                    if (item.component.type === SeparatorItem) {
+                        return item.component;
+                    } else {
+                        if (item.focusable) {
+                            focusCounter += 1;
+                        }
+                        const focusIndex = focusCounter - 1;
+                        return React.cloneElement(item.component, {
+                            ...item.populatedProps,
+                            key: index,
+                            ref:
+                                item.focusable &&
+                                this.state.itemRefs[focusIndex].ref,
+                            onClick: () => {
+                                this.handleClickFocus(focusIndex);
+                                if (item.component.props.onClick) {
+                                    //$FlowFixMe
+                                    item.component.props.onClick();
+                                }
+                            },
+                        });
+                    }
+                })}
             </View>
         );
     }
@@ -195,7 +489,7 @@ export default class Dropdown extends React.Component<DropdownProps> {
                                 style={style}
                                 data-placement={placement}
                             >
-                                {this.renderMenu(outOfBoundaries)}
+                                {this.renderItems(outOfBoundaries)}
                             </div>
                         );
                     }}
@@ -207,9 +501,12 @@ export default class Dropdown extends React.Component<DropdownProps> {
 
     render() {
         const {open, opener, style} = this.props;
-
         return (
-            <View style={[styles.menuWrapper, style]}>
+            <View
+                onKeyDown={this.handleKeyDown}
+                onKeyUp={this.handleKeyUp}
+                style={[styles.menuWrapper, style]}
+            >
                 {opener}
                 {open && this.renderDropdown()}
             </View>

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -276,7 +276,7 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
         }
     };
 
-    focusCurrentItem = () => {
+    focusCurrentItem() {
         // Because the dropdown menu is portalled, focusing this element
         // will scroll the window all the way to the top of the screen.
         const x = window.scrollX;
@@ -293,27 +293,27 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
             ].originalIndex;
         }
         window.scrollTo(x, y);
-    };
+    }
 
-    focusPreviousItem = () => {
+    focusPreviousItem() {
         if (this.focusedIndex === 0) {
             this.focusedIndex = this.state.itemRefs.length - 1;
         } else {
             this.focusedIndex -= 1;
         }
         this.focusCurrentItem();
-    };
+    }
 
-    focusNextItem = () => {
+    focusNextItem() {
         if (this.focusedIndex === this.state.itemRefs.length - 1) {
             this.focusedIndex = 0;
         } else {
             this.focusedIndex += 1;
         }
         this.focusCurrentItem();
-    };
+    }
 
-    restoreTabOrder = () => {
+    restoreTabOrder() {
         // NOTE: Because the dropdown is portalled out of its natural
         // position in the DOM, we need to manually return focus to the
         // opener element before we let the natural propagation of tab
@@ -321,7 +321,7 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
         if (this.props.openerElement) {
             this.props.openerElement.focus();
         }
-    };
+    }
 
     handleKeyDown = (event: SyntheticKeyboardEvent<>) => {
         const {initialFocusedIndex, onOpenChanged, open} = this.props;
@@ -391,7 +391,7 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
         }
     };
 
-    handleClickFocus = (index: number) => {
+    handleClickFocus(index: number) {
         // Turn keyboard nav on so pressing up or down would focus the
         // appropriate item in handleKeyDown
         this.keyboardNavOn = true;
@@ -399,7 +399,7 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
         this.focusedOriginalIndex = this.state.itemRefs[
             this.focusedIndex
         ].originalIndex;
-    };
+    }
 
     handleDropdownMouseUp = (event: SyntheticMouseEvent<>) => {
         event.nativeEvent.stopImmediatePropagation();

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -66,28 +66,24 @@ describe("Dropdown", () => {
             open: true,
         });
 
-        const option0 = dropdown.find("OptionItem").at(0);
-        const option1 = dropdown.find("OptionItem").at(1);
-        const option2 = dropdown.find("OptionItem").at(2);
-
         expect(dropdown.instance().focusedIndex).toBe(0);
 
         // navigate down three times
-        option0.simulate("keydown", {keyCode: keyCodes.down});
-        option0.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(1);
 
-        option1.simulate("keydown", {keyCode: keyCodes.down});
-        option1.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(2);
 
-        option2.simulate("keydown", {keyCode: keyCodes.down});
-        option2.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(0);
 
         // navigate up back to last item
-        option0.simulate("keydown", {keyCode: keyCodes.up});
-        option0.simulate("keyup", {keyCode: keyCodes.up});
+        dropdown.simulate("keydown", {keyCode: keyCodes.up});
+        dropdown.simulate("keyup", {keyCode: keyCodes.up});
         expect(dropdown.instance().focusedIndex).toBe(2);
     });
 
@@ -98,14 +94,13 @@ describe("Dropdown", () => {
             open: true,
         });
 
-        const option0 = dropdown.find("OptionItem").at(0);
-
         // "close" some menus
-        option0.simulate("keydown", {keyCode: keyCodes.tab});
-        option0.simulate("keyup", {keyCode: keyCodes.tab});
-        option0.simulate("keydown", {keyCode: keyCodes.escape});
-        option0.simulate("keyup", {keyCode: keyCodes.escape});
+        dropdown.simulate("keydown", {keyCode: keyCodes.tab});
+        dropdown.simulate("keyup", {keyCode: keyCodes.tab});
+        dropdown.simulate("keydown", {keyCode: keyCodes.escape});
+        dropdown.simulate("keyup", {keyCode: keyCodes.escape});
         expect(handleOpen).toHaveBeenCalledTimes(2);
+        // Test that we pass "false" to handleOpenChanged both times
         expect(handleOpen.mock.calls[0][0]).toBe(false);
         expect(handleOpen.mock.calls[1][0]).toBe(false);
     });
@@ -159,13 +154,11 @@ describe("Dropdown", () => {
             open: true,
         });
 
-        const option2 = dropdown.find("OptionItem").at(2);
-
         expect(dropdown.instance().focusedIndex).toBe(2);
 
         // navigate down
-        option2.simulate("keydown", {keyCode: keyCodes.down});
-        option2.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(0);
     });
 
@@ -194,8 +187,8 @@ describe("Dropdown", () => {
         option1.simulate("click");
 
         // When starting to use keyboard behavior, should move to next item
-        option1.simulate("keydown", {keyCode: keyCodes.down});
-        option1.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(2);
     });
 
@@ -213,8 +206,8 @@ describe("Dropdown", () => {
         option1.simulate("click");
 
         // When starting to use keyboard behavior, should move to next item
-        option1.simulate("keydown", {keyCode: keyCodes.down});
-        option1.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(2);
     });
 
@@ -242,20 +235,17 @@ describe("Dropdown", () => {
             open: true,
         });
 
-        const option0 = dropdown.find("OptionItem").at(0);
-        const option2 = dropdown.find("OptionItem").at(2);
-
         expect(dropdown.instance().focusedIndex).toBe(0);
 
         // Should select option2
-        option0.simulate("keydown", {keyCode: keyCodes.down});
-        option0.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(1);
         expect(dropdown.instance().focusedOriginalIndex).toBe(2);
 
         // Should select option0
-        option2.simulate("keydown", {keyCode: keyCodes.down});
-        option2.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(0);
         expect(dropdown.instance().focusedOriginalIndex).toBe(0);
     });
@@ -267,13 +257,11 @@ describe("Dropdown", () => {
             open: true,
         });
 
-        const option0 = dropdown.find("OptionItem").at(0);
-
         expect(dropdown.instance().focusedIndex).toBe(0);
 
         // Should select option1
-        option0.simulate("keydown", {keyCode: keyCodes.down});
-        option0.simulate("keyup", {keyCode: keyCodes.down});
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
         expect(dropdown.instance().focusedIndex).toBe(1);
 
         dropdown.setProps({
@@ -306,6 +294,10 @@ describe("Dropdown", () => {
             open: true,
         });
 
+        expect(dropdown.instance().focusedIndex).toBe(0);
+
+        const option0 = dropdown.find("OptionItem").at(0);
+        option0.simulate("click");
         expect(dropdown.instance().focusedIndex).toBe(0);
 
         dropdown.setProps({

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -1,0 +1,379 @@
+//@flow
+import React from "react";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
+
+import OptionItem from "./option-item.js";
+import Dropdown from "./dropdown.js";
+import {keyCodes} from "../util/constants.js";
+
+describe("Dropdown", () => {
+    global.scrollTo = jest.fn();
+    global.getComputedStyle = jest.fn();
+
+    let dropdown;
+
+    beforeEach(() => {
+        const dummyOpener = mount(<button />);
+        const openChanged = jest.fn();
+        dropdown = mount(
+            <Dropdown
+                initialFocusedIndex={0}
+                // mock the items
+                items={[
+                    {
+                        component: (
+                            <OptionItem label="item 0" value="0" key="0" />
+                        ),
+                        focusable: true,
+                        populatedProps: {},
+                    },
+                    {
+                        component: (
+                            <OptionItem label="item 1" value="1" key="1" />
+                        ),
+                        focusable: true,
+                        populatedProps: {},
+                    },
+                    {
+                        component: (
+                            <OptionItem label="item 2" value="2" key="2" />
+                        ),
+                        focusable: true,
+                        populatedProps: {},
+                    },
+                ]}
+                keyboard={true}
+                light={false}
+                open={false}
+                // mock the opener elements
+                opener={dummyOpener}
+                openerElement={null}
+                onOpenChanged={openChanged}
+            />,
+        );
+    });
+
+    afterEach(() => {
+        unmountAll();
+    });
+
+    it("handles basic keyboard navigation as expected", () => {
+        const handleOpen = jest.fn();
+        dropdown.setProps({
+            initialFocusedIndex: 0,
+            keyboard: true,
+            onOpenChanged: (open) => handleOpen(open),
+            open: true,
+        });
+
+        const option0 = dropdown.find("OptionItem").at(0);
+        const option1 = dropdown.find("OptionItem").at(1);
+        const option2 = dropdown.find("OptionItem").at(2);
+
+        expect(dropdown.instance().focusedIndex).toBe(0);
+
+        // navigate down three times
+        option0.simulate("keydown", {keyCode: keyCodes.down});
+        option0.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(1);
+
+        option1.simulate("keydown", {keyCode: keyCodes.down});
+        option1.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(2);
+
+        option2.simulate("keydown", {keyCode: keyCodes.down});
+        option2.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(0);
+
+        // navigate up back to last item
+        option0.simulate("keydown", {keyCode: keyCodes.up});
+        option0.simulate("keyup", {keyCode: keyCodes.up});
+        expect(dropdown.instance().focusedIndex).toBe(2);
+    });
+
+    it("closes on tab and escape as expected", () => {
+        const handleOpen = jest.fn();
+        dropdown.setProps({
+            onOpenChanged: (open) => handleOpen(open),
+            open: true,
+        });
+
+        const option0 = dropdown.find("OptionItem").at(0);
+
+        // "close" some menus
+        option0.simulate("keydown", {keyCode: keyCodes.tab});
+        option0.simulate("keyup", {keyCode: keyCodes.tab});
+        option0.simulate("keydown", {keyCode: keyCodes.escape});
+        option0.simulate("keyup", {keyCode: keyCodes.escape});
+        expect(handleOpen).toHaveBeenCalledTimes(2);
+        expect(handleOpen.mock.calls[0][0]).toBe(false);
+        expect(handleOpen.mock.calls[1][0]).toBe(false);
+    });
+
+    it("closes on external mouse click", () => {
+        const handleOpen = jest.fn();
+        dropdown.setProps({
+            onOpenChanged: (open) => handleOpen(open),
+            open: true,
+        });
+
+        const event = new MouseEvent("mouseup");
+        document.dispatchEvent(event);
+
+        expect(handleOpen).toHaveBeenCalledTimes(1);
+        expect(handleOpen.mock.calls[0][0]).toBe(false);
+    });
+
+    it("doesn't close on external mouse click if already closed", () => {
+        const handleOpen = jest.fn();
+        dropdown.setProps({
+            onOpenChanged: (open) => handleOpen(open),
+            open: false,
+        });
+
+        const event = new MouseEvent("mouseup");
+        document.dispatchEvent(event);
+
+        expect(handleOpen).toHaveBeenCalledTimes(0);
+    });
+
+    it("opens on down key as expected", () => {
+        const handleOpen = jest.fn();
+        dropdown.setProps({
+            onOpenChanged: (open) => handleOpen(open),
+        });
+
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
+
+        expect(handleOpen).toHaveBeenCalledTimes(1);
+        expect(handleOpen.mock.calls[0][0]).toBe(true);
+    });
+
+    it("selects correct item when starting off at a different index", () => {
+        const handleOpen = jest.fn();
+        dropdown.setProps({
+            initialFocusedIndex: 2,
+            keyboard: true,
+            onOpenChanged: (open) => handleOpen(open),
+            open: true,
+        });
+
+        const option2 = dropdown.find("OptionItem").at(2);
+
+        expect(dropdown.instance().focusedIndex).toBe(2);
+
+        // navigate down
+        option2.simulate("keydown", {keyCode: keyCodes.down});
+        option2.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(0);
+    });
+
+    it("focuses correct item when opened with click, then switching to keyboard", () => {
+        dropdown.setProps({
+            initialFocusedIndex: 1,
+            keyboard: false,
+            open: true,
+        });
+
+        dropdown.simulate("keydown", {keyCode: keyCodes.down});
+        dropdown.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(1);
+    });
+
+    it("focuses correct item after clicking on option, then switching to keyboard", () => {
+        dropdown.setProps({
+            initialFocusedIndex: 0,
+            keyboard: false,
+            open: true,
+        });
+
+        const option1 = dropdown.find("OptionItem").at(1);
+
+        // Click on item at index 1
+        option1.simulate("click");
+
+        // When starting to use keyboard behavior, should move to next item
+        option1.simulate("keydown", {keyCode: keyCodes.down});
+        option1.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(2);
+    });
+
+    it("focuses correct item with clicking/pressing with initial focused of not 0", () => {
+        // Same as the previous test, expect initialFocusedIndex is 2 now
+        dropdown.setProps({
+            initialFocusedIndex: 2,
+            keyboard: false,
+            open: true,
+        });
+
+        const option1 = dropdown.find("OptionItem").at(1);
+
+        // Click on item at index 1
+        option1.simulate("click");
+
+        // When starting to use keyboard behavior, should move to next item
+        option1.simulate("keydown", {keyCode: keyCodes.down});
+        option1.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(2);
+    });
+
+    it("focuses correct item with a disabled item", () => {
+        dropdown.setProps({
+            initialFocusedIndex: 0,
+            items: [
+                {
+                    component: <OptionItem label="item 0" value="0" key="0" />,
+                    focusable: true,
+                    populatedProps: {},
+                },
+                {
+                    component: <OptionItem label="item 1" value="1" key="1" />,
+                    focusable: false,
+                    populatedProps: {},
+                },
+                {
+                    component: <OptionItem label="item 2" value="2" key="2" />,
+                    focusable: true,
+                    populatedProps: {},
+                },
+            ],
+            keyboard: true,
+            open: true,
+        });
+
+        const option0 = dropdown.find("OptionItem").at(0);
+        const option2 = dropdown.find("OptionItem").at(2);
+
+        expect(dropdown.instance().focusedIndex).toBe(0);
+
+        // Should select option2
+        option0.simulate("keydown", {keyCode: keyCodes.down});
+        option0.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(1);
+        expect(dropdown.instance().focusedOriginalIndex).toBe(2);
+
+        // Should select option0
+        option2.simulate("keydown", {keyCode: keyCodes.down});
+        option2.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(0);
+        expect(dropdown.instance().focusedOriginalIndex).toBe(0);
+    });
+
+    it("focuses correct item after different items become focusable", () => {
+        dropdown.setProps({
+            initialFocusedIndex: 0,
+            keyboard: true,
+            open: true,
+        });
+
+        const option0 = dropdown.find("OptionItem").at(0);
+
+        expect(dropdown.instance().focusedIndex).toBe(0);
+
+        // Should select option1
+        option0.simulate("keydown", {keyCode: keyCodes.down});
+        option0.simulate("keyup", {keyCode: keyCodes.down});
+        expect(dropdown.instance().focusedIndex).toBe(1);
+
+        dropdown.setProps({
+            items: [
+                {
+                    component: <OptionItem label="item 0" value="0" key="0" />,
+                    focusable: false,
+                    populatedProps: {},
+                },
+                {
+                    component: <OptionItem label="item 1" value="1" key="1" />,
+                    focusable: true,
+                    populatedProps: {},
+                },
+                {
+                    component: <OptionItem label="item 2" value="2" key="2" />,
+                    focusable: true,
+                    populatedProps: {},
+                },
+            ],
+        });
+
+        // Should figure out that option1, which is now at index 0, is selected
+        expect(dropdown.instance().focusedIndex).toBe(0);
+    });
+
+    it("focuses first item after currently focused item is no longer focusable", () => {
+        dropdown.setProps({
+            initialFocusedIndex: 0,
+            open: true,
+        });
+
+        expect(dropdown.instance().focusedIndex).toBe(0);
+
+        dropdown.setProps({
+            items: [
+                {
+                    component: <OptionItem label="item 0" value="0" key="0" />,
+                    focusable: false,
+                    populatedProps: {},
+                },
+                {
+                    component: <OptionItem label="item 1" value="1" key="1" />,
+                    focusable: true,
+                    populatedProps: {},
+                },
+                {
+                    component: <OptionItem label="item 2" value="2" key="2" />,
+                    focusable: true,
+                    populatedProps: {},
+                },
+            ],
+        });
+
+        // Should figure out that option1 is now selected
+        expect(dropdown.instance().focusedIndex).toBe(0);
+        expect(dropdown.instance().focusedOriginalIndex).toBe(1);
+    });
+
+    it("calls correct onclick for an option item", () => {
+        const onClick0 = jest.fn();
+        const onClick1 = jest.fn();
+        dropdown.setProps({
+            items: [
+                {
+                    component: (
+                        <OptionItem
+                            label="item 0"
+                            value="0"
+                            key="0"
+                            onClick={onClick0}
+                        />
+                    ),
+                    focusable: true,
+                    populatedProps: {},
+                },
+                {
+                    component: (
+                        <OptionItem
+                            label="item 1"
+                            value="1"
+                            key="1"
+                            onClick={onClick1}
+                        />
+                    ),
+                    focusable: true,
+                    populatedProps: {},
+                },
+                {
+                    component: <OptionItem label="item 2" value="2" key="2" />,
+                    focusable: true,
+                    populatedProps: {},
+                },
+            ],
+            open: true,
+        });
+
+        const option1 = dropdown.find("OptionItem").at(1);
+
+        option1.simulate("click");
+        expect(onClick1).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -9,6 +9,7 @@ import SelectOpener from "./select-opener.js";
 import SeparatorItem from "./separator-item.js";
 
 import typeof OptionItem from "./option-item.js";
+import type {DropdownItem} from "../util/types.js";
 
 type Props = {|
     /**
@@ -74,6 +75,10 @@ type State = {|
      * Whether or not the dropdown is open.
      */
     open: boolean,
+    /**
+     * Whether or not last open state change was triggered by a keyboard click.
+     */
+    keyboard?: boolean,
 |};
 
 /**
@@ -85,7 +90,7 @@ type State = {|
  * happens every time there is a change in the selection of the items.
  */
 export default class MultiSelect extends React.Component<Props, State> {
-    openerElement: ?Element;
+    openerElement: ?HTMLElement;
 
     static defaultProps = {
         alignment: "left",
@@ -96,18 +101,20 @@ export default class MultiSelect extends React.Component<Props, State> {
 
     constructor(props: Props) {
         super(props);
+
         this.state = {
             open: false,
         };
     }
 
-    handleOpenChanged(open: boolean) {
+    handleOpenChanged = (open: boolean, keyboard?: boolean) => {
         this.setState({
-            open: open,
+            open,
+            keyboard,
         });
-    }
+    };
 
-    handleToggle(selectedValue: string) {
+    handleToggle = (selectedValue: string) => {
         const {onChange, selectedValues} = this.props;
 
         if (selectedValues.includes(selectedValue)) {
@@ -121,21 +128,21 @@ export default class MultiSelect extends React.Component<Props, State> {
             // Item was newly selected
             onChange([...selectedValues, selectedValue]);
         }
-    }
+    };
 
-    handleSelectAll() {
+    handleSelectAll = () => {
         const {children, onChange} = this.props;
         const selected = React.Children.map(
             children,
             (option) => option.props.value,
         );
         onChange(selected);
-    }
+    };
 
-    handleSelectNone() {
+    handleSelectNone = () => {
         const {onChange} = this.props;
         onChange([]);
-    }
+    };
 
     // TODO(sophie): need to configure for i18n for the word "All" and
     // potentially the concept of plurals
@@ -168,50 +175,75 @@ export default class MultiSelect extends React.Component<Props, State> {
         }
     }
 
-    getShortcuts(): Array<
-        React.Element<typeof ActionItem | typeof SeparatorItem>,
-    > {
+    getShortcuts(): Array<DropdownItem> {
         const {children, selectedValues, shortcuts} = this.props;
-        const numOptions = React.Children.count(children);
-        // TODO(sophie): translate for i18n
+
         if (shortcuts) {
-            return [
-                <ActionItem
-                    disabled={numOptions === selectedValues.length}
-                    key="select-all"
-                    label={`Select all (${numOptions})`}
-                    indent={true}
-                    onClick={() => this.handleSelectAll()}
-                />,
-                <ActionItem
-                    disabled={selectedValues.length === 0}
-                    key="select-none"
-                    label="Select none"
-                    indent={true}
-                    onClick={() => this.handleSelectNone()}
-                />,
-                <SeparatorItem key="shortcuts-separator" />,
-            ];
+            const numOptions = React.Children.count(children);
+
+            // TODO(sophie): translate for i18n
+            const selectAllDisabled = numOptions === selectedValues.length;
+            const selectAll = {
+                component: (
+                    <ActionItem
+                        disabled={selectAllDisabled}
+                        label={`Select all (${numOptions})`}
+                        indent={true}
+                        onClick={this.handleSelectAll}
+                    />
+                ),
+                focusable: !selectAllDisabled,
+                populatedProps: {},
+            };
+
+            const selectNoneDisabled = selectedValues.length === 0;
+            const selectNone = {
+                component: (
+                    <ActionItem
+                        disabled={selectNoneDisabled}
+                        label="Select none"
+                        indent={true}
+                        onClick={this.handleSelectNone}
+                    />
+                ),
+                focusable: !selectNoneDisabled,
+                populatedProps: {},
+            };
+
+            const separator = {
+                component: <SeparatorItem key="shortcuts-separator" />,
+                focusable: false,
+                populatedProps: {},
+            };
+
+            return [selectAll, selectNone, separator];
         } else {
             return [];
         }
     }
 
-    getMenuItems(): Array<React.Element<OptionItem>> {
+    getMenuItems(): Array<DropdownItem> {
         const {children, selectedValues} = this.props;
         return React.Children.map(children, (option) => {
-            const {value} = option.props;
-            return React.cloneElement(option, {
-                onToggle: (value) => this.handleToggle(value),
-                selected: selectedValues.includes(value),
-                variant: "checkbox",
-            });
+            const {disabled, value} = option.props;
+            return {
+                component: option,
+                focusable: !disabled,
+                populatedProps: {
+                    onToggle: this.handleToggle,
+                    selected: selectedValues.includes(value),
+                    variant: "checkbox",
+                },
+            };
         });
     }
 
+    handleOpenerRef = (node: any) => {
+        this.openerElement = ((ReactDOM.findDOMNode(node): any): HTMLElement);
+    };
+
     render() {
         const {alignment, disabled, light, placeholder, style} = this.props;
-
         const {open} = this.state;
 
         const menuText = this.getMenuText();
@@ -221,12 +253,9 @@ export default class MultiSelect extends React.Component<Props, State> {
                 disabled={disabled}
                 isPlaceholder={menuText === placeholder}
                 light={light}
-                onClick={() => this.handleOpenChanged(!open)}
-                ref={(node) =>
-                    (this.openerElement = ((ReactDOM.findDOMNode(
-                        node,
-                    ): any): Element))
-                }
+                onOpenChanged={this.handleOpenChanged}
+                open={open}
+                ref={this.handleOpenerRef}
             >
                 {menuText}
             </SelectOpener>
@@ -238,15 +267,15 @@ export default class MultiSelect extends React.Component<Props, State> {
             <Dropdown
                 alignment={alignment}
                 dropdownStyle={{marginTop: 8, marginBottom: 8}}
+                items={items}
+                keyboard={this.state.keyboard}
                 light={light}
-                onOpenChanged={(open) => this.handleOpenChanged(open)}
+                onOpenChanged={this.handleOpenChanged}
                 open={open}
                 opener={opener}
                 openerElement={this.openerElement}
                 style={style}
-            >
-                {items}
-            </Dropdown>
+            />
         );
     }
 }

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -181,12 +181,12 @@ export default class MultiSelect extends React.Component<Props, State> {
         if (shortcuts) {
             const numOptions = React.Children.count(children);
 
-            // TODO(sophie): translate for i18n
             const selectAllDisabled = numOptions === selectedValues.length;
             const selectAll = {
                 component: (
                     <ActionItem
                         disabled={selectAllDisabled}
+                        // TODO(sophie): translate for i18n
                         label={`Select all (${numOptions})`}
                         indent={true}
                         onClick={this.handleSelectAll}
@@ -201,6 +201,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 component: (
                     <ActionItem
                         disabled={selectNoneDisabled}
+                        // TODO(sophie): translate for i18n
                         label="Select none"
                         indent={true}
                         onClick={this.handleSelectNone}

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -23,9 +23,10 @@ class ExampleNoneSelected extends React.Component {
         this.state = {
             selectedValues: [],
         };
+        this.handleChange = this.handleChange.bind(this);
     }
 
-    handleChanges(update) {
+    handleChange(update) {
         console.log("changes happened!");
         this.setState({
            selectedValues: update,
@@ -34,13 +35,15 @@ class ExampleNoneSelected extends React.Component {
 
     render() {
         return <MultiSelect
-            onChange={(selectedValues) => this.handleChanges(selectedValues)}
+            onChange={this.handleChange}
             placeholder="Color palette"
             selectedValues={this.state.selectedValues}
             selectItemType="colors"
             style={styles.setWidth}
         >
-            <OptionItem label="Red" value="1" />
+            <OptionItem label="Red" value="1"
+                onClick={() => console.log("Roses are red")}
+            />
             <OptionItem label="Yellow" value="2" disabled />
             <OptionItem label="Green" value="3" />
             <OptionItem label="Blue" value="4" />
@@ -75,6 +78,7 @@ class ExampleWithShortcuts extends React.Component {
         this.state = {
             selectedValues: ["wonderblocks 4ever"],
         };
+        this.handleChange = this.handleChange.bind(this);
     }
 
     handleChange(update) {
@@ -87,7 +91,7 @@ class ExampleWithShortcuts extends React.Component {
     render() {
         return <MultiSelect
             shortcuts={true}
-            onChange={(selectedValues) => this.handleChange(selectedValues)}
+            onChange={this.handleChange}
             selectedValues={this.state.selectedValues}
             selectItemType="interns"
         >
@@ -143,9 +147,10 @@ class SimpleMultiSelect extends React.Component {
         this.state = {
             selectedValues: [],
         };
+        this.handleChange = this.handleChange.bind(this);
     }
 
-    handleChanges(update) {
+    handleChange(update) {
         console.log("changes happened!");
         this.setState({
            selectedValues: update,
@@ -154,7 +159,7 @@ class SimpleMultiSelect extends React.Component {
 
     render() {
         return <MultiSelect
-            onChange={(selectedValues) => this.handleChanges(selectedValues)}
+            onChange={this.handleChange}
             selectedValues={this.state.selectedValues}
             selectItemType="Great Houses"
             style={styles.setWidth}

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -23,6 +23,7 @@ class ExampleNoneSelected extends React.Component {
         this.state = {
             selectedValues: [],
         };
+        // Styleguidist doesn't support arrow functions in class field properties
         this.handleChange = this.handleChange.bind(this);
     }
 
@@ -78,6 +79,7 @@ class ExampleWithShortcuts extends React.Component {
         this.state = {
             selectedValues: ["wonderblocks 4ever"],
         };
+        // Styleguidist doesn't support arrow functions in class field properties
         this.handleChange = this.handleChange.bind(this);
     }
 
@@ -147,6 +149,7 @@ class SimpleMultiSelect extends React.Component {
         this.state = {
             selectedValues: [],
         };
+        // Styleguidist doesn't support arrow functions in class field properties
         this.handleChange = this.handleChange.bind(this);
     }
 

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -6,26 +6,23 @@ import SelectOpener from "./select-opener.js";
 import ActionItem from "./action-item.js";
 import OptionItem from "./option-item.js";
 import MultiSelect from "./multi-select.js";
-
-const keyCodes = {
-    enter: 13,
-    space: 32,
-};
+import {keyCodes} from "../util/constants.js";
 
 describe("MultiSelect", () => {
+    global.scrollTo = jest.fn();
     let select;
     const allChanges = [];
     const saveUpdate = (update) => {
         allChanges.push(update);
     };
-    const onClick = jest.fn();
+    const onChange = jest.fn();
 
     beforeEach(() => {
         select = mount(
             <MultiSelect
                 onChange={(selectedValues) => {
                     saveUpdate(selectedValues);
-                    onClick();
+                    onChange();
                 }}
                 placeholder="Choose"
                 selectItemType="students"
@@ -82,7 +79,7 @@ describe("MultiSelect", () => {
         item.simulate("click");
 
         // Expect select's onChange callback to have been called
-        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledTimes(1);
         expect(allChanges.length).toEqual(1);
         const currentlySelected = allChanges.pop();
 

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -9,7 +9,6 @@ import MultiSelect from "./multi-select.js";
 import {keyCodes} from "../util/constants.js";
 
 describe("MultiSelect", () => {
-    global.scrollTo = jest.fn();
     let select;
     const allChanges = [];
     const saveUpdate = (update) => {
@@ -18,6 +17,7 @@ describe("MultiSelect", () => {
     const onChange = jest.fn();
 
     beforeEach(() => {
+        window.scrollTo = jest.fn();
         select = mount(
             <MultiSelect
                 onChange={(selectedValues) => {
@@ -37,6 +37,7 @@ describe("MultiSelect", () => {
     });
 
     afterEach(() => {
+        window.scrollTo.mockClear();
         unmountAll();
     });
 

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -78,29 +78,22 @@ export default class OptionItem extends React.Component<OptionProps> {
         }
     }
 
+    handleClick = () => {
+        const {onClick, onToggle, value} = this.props;
+        onToggle(value);
+        if (onClick) {
+            onClick();
+        }
+    };
+
     render() {
-        const {
-            disabled,
-            label,
-            onClick,
-            onToggle,
-            selected,
-            value,
-        } = this.props;
+        const {disabled, label, selected} = this.props;
 
         const ClickableBehavior = getClickableBehavior();
         const CheckComponent = this.getCheckComponent();
 
         return (
-            <ClickableBehavior
-                disabled={disabled}
-                onClick={() => {
-                    onToggle(value);
-                    if (onClick) {
-                        onClick();
-                    }
-                }}
-            >
+            <ClickableBehavior disabled={disabled} onClick={this.handleClick}>
                 {(state, handlers) => {
                     const {pressed, hovered, focused} = state;
 
@@ -139,12 +132,14 @@ const {blue, white, offBlack, offBlack32} = Color;
 
 const styles = StyleSheet.create({
     itemContainer: {
+        display: "flex",
+        flexDirection: "row",
         backgroundColor: white,
         color: offBlack,
-        flexDirection: "row",
         alignItems: "center",
         height: 40,
         minHeight: 40,
+        border: 0,
         outline: 0,
         paddingLeft: Spacing.xSmall,
         paddingRight: Spacing.medium,

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -132,7 +132,6 @@ const {blue, white, offBlack, offBlack32} = Color;
 
 const styles = StyleSheet.create({
     itemContainer: {
-        display: "flex",
         flexDirection: "row",
         backgroundColor: white,
         color: offBlack,

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -1,5 +1,4 @@
 // @flow
-// A select opener
 
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
@@ -37,28 +36,33 @@ type SelectOpenerProps = {|
      * Whether the SelectOpener is disabled. If disabled, disallows interaction.
      * Default false.
      */
-    disabled?: boolean,
+    disabled: boolean,
 
     /**
      * Whether the displayed text is a placeholder, determined by the creator
      * of this component. A placeholder has more faded text colors and styles.
      */
-    isPlaceholder?: boolean,
+    isPlaceholder: boolean,
 
     /**
      * Whether to display the "light" version of this component instead, for
      * use when the item is used on a dark background.
      */
-    light?: boolean,
+    light: boolean,
 
     /**
      * Callback for when the SelectOpener is pressed.
      */
-    onClick: () => void,
+    onOpenChanged: (open: boolean, keyboard: boolean) => void,
+
+    /**
+     * Whether the dropdown is open.
+     */
+    open: boolean,
 |};
 
 /**
- * An opener that opens selects.
+ * An opener that opens select boxes.
  */
 export default class SelectOpener extends React.Component<SelectOpenerProps> {
     static defaultProps = {
@@ -69,8 +73,14 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
 
     static contextTypes = {router: PropTypes.any};
 
+    handleClick = (e: SyntheticEvent<>) => {
+        const {open} = this.props;
+        // TODO: also detect enter click events
+        this.props.onOpenChanged(!open, e.type === "keyup");
+    };
+
     render() {
-        const {children, disabled, isPlaceholder, light, onClick} = this.props;
+        const {children, disabled, isPlaceholder, light} = this.props;
 
         const ClickableBehavior = getClickableBehavior(this.context.router);
 
@@ -86,7 +96,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
         return (
             <ClickableBehavior
                 disabled={disabled}
-                onClick={onClick}
+                onClick={this.handleClick}
                 triggerOnEnter={false}
             >
                 {(state, handlers) => {

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -75,7 +75,6 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
 
     handleClick = (e: SyntheticEvent<>) => {
         const {open} = this.props;
-        // TODO: also detect enter click events
         this.props.onOpenChanged(!open, e.type === "keyup");
     };
 

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -7,6 +7,7 @@ import Dropdown from "./dropdown.js";
 import SelectOpener from "./select-opener.js";
 
 import typeof OptionItem from "./option-item.js";
+import type {DropdownItem} from "../util/types.js";
 
 type Props = {|
     /**
@@ -59,14 +60,22 @@ type State = {|
      * Whether or not the dropdown is open.
      */
     open: boolean,
+    /**
+     * Whether or not last open state change was triggered by a keyboard click.
+     */
+    keyboard?: boolean,
 |};
 
 /**
  * The single select allows the selection of one item. Clients are responsible
  * for keeping track of the selected item in the select.
+ *
+ * The single select dropdown closes after the selection of an item. If the
+ * same item is selected, there is no callback.
  */
 export default class SingleSelect extends React.Component<Props, State> {
-    openerElement: ?Element;
+    openerElement: ?HTMLElement;
+    selectedIndex: number;
 
     static defaultProps = {
         alignment: "left",
@@ -77,39 +86,67 @@ export default class SingleSelect extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
+        this.selectedIndex = 0;
+
         this.state = {
             open: false,
         };
     }
 
-    handleOpenChanged(open: boolean) {
+    handleOpenChanged = (open: boolean, keyboard?: boolean) => {
         this.setState({
-            open: open,
+            open,
+            keyboard,
         });
-    }
+    };
 
-    handleToggle(selectedValue: string) {
-        this.setState({
-            open: false, // close the menu upon selection
-        });
-
-        // Call callback if selection changes.
+    handleToggle = (selectedValue: string) => {
+        // Call callback if selection changed.
         if (selectedValue !== this.props.selectedValue) {
             this.props.onChange(selectedValue);
         }
-    }
 
-    getMenuItems(): Array<React.Element<OptionItem>> {
+        // Bring focus back to the opener element.
+        if (open && this.openerElement) {
+            this.openerElement.focus();
+        }
+
+        this.setState({
+            open: false, // close the menu upon selection
+        });
+    };
+
+    getMenuItems(): Array<DropdownItem> {
         const {children, selectedValue} = this.props;
+        // Figure out which index should receive focus when this select opens
+        // Needs to exclude counting items that are disabled
+        let indexCounter = 0;
+        this.selectedIndex = 0;
+
         return React.Children.map(children, (option) => {
-            const {value} = option.props;
-            return React.cloneElement(option, {
-                onToggle: (value, state) => this.handleToggle(value),
-                selected: selectedValue === value,
-                variant: "check",
-            });
+            const {disabled, value} = option.props;
+            const selected = selectedValue === value;
+            if (selected) {
+                this.selectedIndex = indexCounter;
+            }
+            if (!disabled) {
+                indexCounter += 1;
+            }
+            return {
+                component: option,
+                focusable: !disabled,
+                populatedProps: {
+                    onToggle: this.handleToggle,
+                    selected: selected,
+                    variant: "check",
+                },
+            };
         });
     }
+
+    handleOpenerRef = (node: any) => {
+        this.openerElement = ((ReactDOM.findDOMNode(node): any): HTMLElement);
+    };
 
     render() {
         const {
@@ -121,7 +158,6 @@ export default class SingleSelect extends React.Component<Props, State> {
             selectedValue,
             style,
         } = this.props;
-
         const {open} = this.state;
 
         const selectedItem = React.Children.toArray(children).find(
@@ -136,32 +172,30 @@ export default class SingleSelect extends React.Component<Props, State> {
                 disabled={disabled}
                 isPlaceholder={!selectedItem}
                 light={light}
-                onClick={() => this.handleOpenChanged(!open)}
-                ref={(node) =>
-                    (this.openerElement = ((ReactDOM.findDOMNode(
-                        node,
-                    ): any): Element))
-                }
+                onOpenChanged={this.handleOpenChanged}
+                open={open}
+                ref={this.handleOpenerRef}
             >
                 {menuText}
             </SelectOpener>
         );
 
-        const items = [...this.getMenuItems()];
+        const items = this.getMenuItems();
 
         return (
             <Dropdown
                 alignment={alignment}
                 dropdownStyle={{marginTop: 8, marginBottom: 8}}
+                initialFocusedIndex={this.selectedIndex}
+                items={items}
+                keyboard={this.state.keyboard}
                 light={light}
-                onOpenChanged={(open, source) => this.handleOpenChanged(open)}
+                onOpenChanged={this.handleOpenChanged}
                 open={open}
                 opener={opener}
                 openerElement={this.openerElement}
                 style={style}
-            >
-                {items}
-            </Dropdown>
+            />
         );
     }
 }

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -1,4 +1,4 @@
-### Single select with placeholder
+### Single select with placeholder and set widths
 
 This single select has a starting placeholder and a set minWidth and maxWidth.
 Notice how the dropdown is always at least as wide as the opener. Also, when
@@ -25,7 +25,8 @@ class ExampleWithPlaceholder extends React.Component {
         super();
         this.state = {
             selectedValue: null,
-        }
+        };
+        this.handleChange = this.handleChange.bind(this);
     }
 
     handleChange(selected) {
@@ -37,7 +38,7 @@ class ExampleWithPlaceholder extends React.Component {
 
     render() {
         return <SingleSelect
-            onChange={(selected) => this.handleChange(selected)}
+            onChange={this.handleChange}
             placeholder="Choose a fruit"
             selectedValue={this.state.selectedValue}
             style={styles.setWidth}
@@ -75,7 +76,8 @@ class ExampleWithStartingSelection extends React.Component {
         super();
         this.state = {
             selectedValue: "banana",
-        }
+        };
+        this.handleChange = this.handleChange.bind(this);
     }
 
     handleChange(selected) {
@@ -87,7 +89,7 @@ class ExampleWithStartingSelection extends React.Component {
 
     render() {
         return <SingleSelect
-            onChange={(selected) => this.handleChange(selected)}
+            onChange={this.handleChange}
             placeholder="Choose a juice"
             selectedValue={this.state.selectedValue}
         >
@@ -122,7 +124,8 @@ class DisabledExample extends React.Component {
         super();
         this.state = {
             selectedValue: "banana",
-        }
+        };
+        this.handleChange = this.handleChange.bind(this);
     }
 
     handleChange(selected) {
@@ -135,7 +138,7 @@ class DisabledExample extends React.Component {
     render() {
         return <SingleSelect
             disabled={true}
-            onChange={(selected) => this.handleChange(selected)}
+            onChange={this.handleChange}
             placeholder="Choose a juice"
             selectedValue={this.state.selectedValue}
         >
@@ -181,7 +184,8 @@ class LightRightAlignedExample extends React.Component {
         super();
         this.state = {
             selectedValue: null,
-        }
+        };
+        this.handleChange = this.handleChange.bind(this);
     }
 
     handleChange(selected) {
@@ -195,7 +199,7 @@ class LightRightAlignedExample extends React.Component {
         return <SingleSelect
             alignment="right"
             light={true}
-            onChange={(selected) => this.handleChange(selected)}
+            onChange={this.handleChange}
             placeholder="Boba order"
             selectedValue={this.state.selectedValue}
         >

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -77,6 +77,7 @@ class ExampleWithStartingSelection extends React.Component {
         this.state = {
             selectedValue: "banana",
         };
+        // Styleguidist doesn't support arrow functions in class field properties
         this.handleChange = this.handleChange.bind(this);
     }
 
@@ -125,6 +126,7 @@ class DisabledExample extends React.Component {
         this.state = {
             selectedValue: "banana",
         };
+        // Styleguidist doesn't support arrow functions in class field properties
         this.handleChange = this.handleChange.bind(this);
     }
 
@@ -185,6 +187,7 @@ class LightRightAlignedExample extends React.Component {
         this.state = {
             selectedValue: null,
         };
+        // Styleguidist doesn't support arrow functions in class field properties
         this.handleChange = this.handleChange.bind(this);
     }
 

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -5,22 +5,16 @@ import {mount, unmountAll} from "../../../utils/testing/mount.js";
 import SelectOpener from "./select-opener.js";
 import OptionItem from "./option-item.js";
 import SingleSelect from "./single-select.js";
-
-const keyCodes = {
-    enter: 13,
-    space: 32,
-};
+import {keyCodes} from "../util/constants.js";
 
 describe("SingleSelect", () => {
+    global.scrollTo = jest.fn();
     let select;
-    const onClick = jest.fn();
+    const onChange = jest.fn();
 
     beforeEach(() => {
         select = mount(
-            <SingleSelect
-                onChange={(selectedValue) => onClick()}
-                placeholder="Choose"
-            >
+            <SingleSelect onChange={onChange} placeholder="Choose">
                 <OptionItem label="item 1" value="1" />
                 <OptionItem label="item 2" value="2" />
                 <OptionItem label="item 3" value="3" />
@@ -70,7 +64,7 @@ describe("SingleSelect", () => {
         item.simulate("click");
 
         // Expect select's onChange callback to have been called
-        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledTimes(1);
 
         // This select should close afer a single item selection
         expect(select.state("open")).toEqual(false);

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -8,11 +8,11 @@ import SingleSelect from "./single-select.js";
 import {keyCodes} from "../util/constants.js";
 
 describe("SingleSelect", () => {
-    global.scrollTo = jest.fn();
     let select;
     const onChange = jest.fn();
 
     beforeEach(() => {
+        window.scrollTo = jest.fn();
         select = mount(
             <SingleSelect onChange={onChange} placeholder="Choose">
                 <OptionItem label="item 1" value="1" />
@@ -23,6 +23,7 @@ describe("SingleSelect", () => {
     });
 
     afterEach(() => {
+        window.scrollTo.mockClear();
         unmountAll();
     });
 

--- a/packages/wonder-blocks-dropdown/docs.md
+++ b/packages/wonder-blocks-dropdown/docs.md
@@ -1,1 +1,12 @@
-NOTE: Do not use yet for longer dropdowns (like more than six items or so).
+Dropdowns consist of an opener and the part that contains the items. The latter
+component is portalled to a place in the DOM that prevents is from being clipped
+by an overflow: auto container. This would be either as a child of `body` or the
+modal launcher portal if the dropdown is used in a portal.
+
+Clicking the opener should open and close the dropdown. It is also possible to
+close the dropdown by clicking elsewhere on the page.
+
+For keyboard use, use space to open the menu and up/down arrow keys for item
+navigation. Space may be used for selection on option items. The tab or escape
+key may be used to close the menu (tab would also shift focus to the next
+element on the page).

--- a/packages/wonder-blocks-dropdown/docs.md
+++ b/packages/wonder-blocks-dropdown/docs.md
@@ -1,12 +1,12 @@
 Dropdowns consist of an opener and the part that contains the items. The latter
 component is portalled to a place in the DOM that prevents is from being clipped
 by an overflow: auto container. This would be either as a child of `body` or the
-modal launcher portal if the dropdown is used in a portal.
+modal launcher portal if the dropdown is used in a modal.
 
 Clicking the opener should open and close the dropdown. It is also possible to
 close the dropdown by clicking elsewhere on the page.
 
-For keyboard use, use space to open the menu and up/down arrow keys for item
-navigation. Space may be used for selection on option items. The tab or escape
-key may be used to close the menu (tab would also shift focus to the next
+For keyboard use, use space/down key to open the menu and up/down arrow keys for
+item navigation. Space may be used for selection on option items. The tab or
+escape key may be used to close the menu (tab would also shift focus to the next
 element on the page).

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -75,6 +75,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValues: ["homework"],
                 };
+                // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
 
@@ -208,6 +209,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValue: "banana",
                 };
+                // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
 
@@ -262,6 +264,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValue: "banana",
                 };
+                // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
 
@@ -327,6 +330,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValue: null,
                 };
+                // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
 
@@ -394,6 +398,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValues: [],
                 };
+                // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
 
@@ -451,6 +456,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValues: ["wonderblocks 4ever"],
                 };
+                // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
 
@@ -533,6 +539,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValues: [],
                 };
+                // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
 

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -75,6 +75,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValues: ["homework"],
                 };
+                this.handleChange = this.handleChange.bind(this);
             }
 
             handleChange(update) {
@@ -87,9 +88,7 @@ describe("wonder-blocks-dropdown", () => {
                 return (
                     <ActionMenu
                         menuText="Assignments"
-                        onChange={(selectedValues) =>
-                            this.handleChange(selectedValues)
-                        }
+                        onChange={this.handleChange}
                         selectedValues={this.state.selectedValues}
                     >
                         <ActionItem
@@ -155,6 +154,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValue: null,
                 };
+                this.handleChange = this.handleChange.bind(this);
             }
 
             handleChange(selected) {
@@ -167,7 +167,7 @@ describe("wonder-blocks-dropdown", () => {
             render() {
                 return (
                     <SingleSelect
-                        onChange={(selected) => this.handleChange(selected)}
+                        onChange={this.handleChange}
                         placeholder="Choose a fruit"
                         selectedValue={this.state.selectedValue}
                         style={styles.setWidth}
@@ -208,6 +208,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValue: "banana",
                 };
+                this.handleChange = this.handleChange.bind(this);
             }
 
             handleChange(selected) {
@@ -220,7 +221,7 @@ describe("wonder-blocks-dropdown", () => {
             render() {
                 return (
                     <SingleSelect
-                        onChange={(selected) => this.handleChange(selected)}
+                        onChange={this.handleChange}
                         placeholder="Choose a juice"
                         selectedValue={this.state.selectedValue}
                     >
@@ -261,6 +262,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValue: "banana",
                 };
+                this.handleChange = this.handleChange.bind(this);
             }
 
             handleChange(selected) {
@@ -274,7 +276,7 @@ describe("wonder-blocks-dropdown", () => {
                 return (
                     <SingleSelect
                         disabled={true}
-                        onChange={(selected) => this.handleChange(selected)}
+                        onChange={this.handleChange}
                         placeholder="Choose a juice"
                         selectedValue={this.state.selectedValue}
                     >
@@ -325,6 +327,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValue: null,
                 };
+                this.handleChange = this.handleChange.bind(this);
             }
 
             handleChange(selected) {
@@ -339,7 +342,7 @@ describe("wonder-blocks-dropdown", () => {
                     <SingleSelect
                         alignment="right"
                         light={true}
-                        onChange={(selected) => this.handleChange(selected)}
+                        onChange={this.handleChange}
                         placeholder="Boba order"
                         selectedValue={this.state.selectedValue}
                     >
@@ -391,9 +394,10 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValues: [],
                 };
+                this.handleChange = this.handleChange.bind(this);
             }
 
-            handleChanges(update) {
+            handleChange(update) {
                 console.log("changes happened!");
                 this.setState({
                     selectedValues: update,
@@ -403,15 +407,17 @@ describe("wonder-blocks-dropdown", () => {
             render() {
                 return (
                     <MultiSelect
-                        onChange={(selectedValues) =>
-                            this.handleChanges(selectedValues)
-                        }
+                        onChange={this.handleChange}
                         placeholder="Color palette"
                         selectedValues={this.state.selectedValues}
                         selectItemType="colors"
                         style={styles.setWidth}
                     >
-                        <OptionItem label="Red" value="1" />
+                        <OptionItem
+                            label="Red"
+                            value="1"
+                            onClick={() => console.log("Roses are red")}
+                        />
                         <OptionItem label="Yellow" value="2" disabled />
                         <OptionItem label="Green" value="3" />
                         <OptionItem label="Blue" value="4" />
@@ -445,6 +451,7 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValues: ["wonderblocks 4ever"],
                 };
+                this.handleChange = this.handleChange.bind(this);
             }
 
             handleChange(update) {
@@ -458,9 +465,7 @@ describe("wonder-blocks-dropdown", () => {
                 return (
                     <MultiSelect
                         shortcuts={true}
-                        onChange={(selectedValues) =>
-                            this.handleChange(selectedValues)
-                        }
+                        onChange={this.handleChange}
                         selectedValues={this.state.selectedValues}
                         selectItemType="interns"
                     >
@@ -528,9 +533,10 @@ describe("wonder-blocks-dropdown", () => {
                 this.state = {
                     selectedValues: [],
                 };
+                this.handleChange = this.handleChange.bind(this);
             }
 
-            handleChanges(update) {
+            handleChange(update) {
                 console.log("changes happened!");
                 this.setState({
                     selectedValues: update,
@@ -540,9 +546,7 @@ describe("wonder-blocks-dropdown", () => {
             render() {
                 return (
                     <MultiSelect
-                        onChange={(selectedValues) =>
-                            this.handleChanges(selectedValues)
-                        }
+                        onChange={this.handleChange}
                         selectedValues={this.state.selectedValues}
                         selectItemType="Great Houses"
                         style={styles.setWidth}

--- a/packages/wonder-blocks-dropdown/util/constants.js
+++ b/packages/wonder-blocks-dropdown/util/constants.js
@@ -1,5 +1,7 @@
+//@flow
 export const keyCodes = {
     tab: 9,
+    enter: 13,
     escape: 27,
     space: 32,
     up: 38,

--- a/packages/wonder-blocks-dropdown/util/constants.js
+++ b/packages/wonder-blocks-dropdown/util/constants.js
@@ -1,0 +1,7 @@
+export const keyCodes = {
+    tab: 9,
+    escape: 27,
+    space: 32,
+    up: 38,
+    down: 40,
+};

--- a/packages/wonder-blocks-dropdown/util/types.js
+++ b/packages/wonder-blocks-dropdown/util/types.js
@@ -1,31 +1,15 @@
 // @flow
 
-export type ActionItemProps = {|
-    type: "action",
-    /** Whether this item is disabled. Default false. */
-    disabled?: boolean,
-    /** Display text of the item. */
-    label: string,
-    /** URL to navigate to. */
-    href?: string,
-    /** Whether to avoid using client-side navigation. */
-    skipClientNav?: boolean,
-    /** Callback on the action. */
-    onClick?: () => void,
-|};
+import * as React from "react";
+import typeof ActionItem from "../components/action-item.js";
+import typeof OptionItem from "../components/option-item.js";
+import typeof SeparatorItem from "../components/separator-item.js";
 
-export type OptionItemProps = {|
-    type: "select",
-    /** Whether this item is disabled. Default false. */
-    disabled?: boolean,
-    /** Display text of the item. */
-    label: string,
-    /** Value of this item. Treat as a key. */
-    value: string,
-    /** Optional extra callback. Passes whether this item is selected. */
-    onClick?: (selected: boolean) => void,
-|};
+//TODO: rename into something more descriptive
+export type Item = ActionItem | OptionItem | SeparatorItem;
 
-export type SeparatorProps = {|
-    type: "separator",
+export type DropdownItem = {|
+    component: React.Element<ActionItem | OptionItem | SeparatorItem>,
+    focusable: boolean,
+    populatedProps: any,
 |};


### PR DESCRIPTION
This change creates refs for each item in the Dropdown component, which handles focus navigation logic based on a keyboard event listener. Instead of the menu/select components cloning the user-supplied items, this now happens at the Dropdown component level so that the Dropdown component can also create the refs and manage indices without having to reclone each item.

Also now pre-binding callbacks.

Expected behavior:
* Opening the menu with mouse click doesn't automatically fous an item, but opening the menu with the keyboard does
* Action menus and MultiSelect start off with the first item focused, but SingleSelect starts off with the selected item focused
* Pressing space on an item no longer scrolls the page, and it selects the item as expected
* Both tab and escape keys should close the menu. Because the menu is portalled, tabbing would naturally go to the next element in the DOM, which is probably the very first item on the page. I had to account for this by explicitly shifting focus back to the opener.
* Focused item should still be consistent even when an item becomes disabled (and thus is no longer focusable). This took a bit of extra variable tracking/code.

Changes to other components:
* Resetting the internal variables in ClickableBehavior in `handleBlur`. Originally, pressing space on an item would not always trigger the `handleClick` handler, which caused `keyboardClick` to never be reset. So pressing space and then clicking with the mouse would not trigger a click the second time as expected.
There are still other bugs in ClickableBehavior that I want to look at and address, but that's a separate task.

Future TODO:
* Write more extensive tests for item callbacks and ActionMenu, SingleSelect, MultiSelect-level navigation.