### PR TITLE
[feature-dropdown] Make dropdown scroll when it doesn't have room

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1144,8 +1144,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
           },
           "alignItems": "center",
           "backgroundColor": "#ffffff",
-          "border": "none",
-          "borderColor": "rgba(33,36,44,0.50)",
+          "borderColor": "rgba(33,36,44,0.16)",
           "borderRadius": 4,
           "borderStyle": "solid",
           "borderWidth": 1,
@@ -1177,6 +1176,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
             "fontSize": 16,
             "fontWeight": 400,
             "lineHeight": "20px",
+            "marginRight": 8,
             "overflow": "hidden",
             "textOverflow": "ellipsis",
             "userSelect": "none",
@@ -1186,25 +1186,6 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
       >
         0 balloons
       </span>
-      <div
-        className=""
-        style={
-          Object {
-            "alignItems": "stretch",
-            "borderStyle": "solid",
-            "borderWidth": 0,
-            "boxSizing": "border-box",
-            "display": "flex",
-            "flexDirection": "column",
-            "margin": 0,
-            "minHeight": 0,
-            "minWidth": 8,
-            "padding": 0,
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      />
       <svg
         className=""
         height={16}
@@ -1212,11 +1193,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
           Object {
             "display": "inline-block",
             "minWidth": 16,
-            "overflow": "hidden",
-            "textOverflow": "ellipsis",
-            "userSelect": "none",
             "verticalAlign": "text-bottom",
-            "whiteSpace": "nowrap",
           }
         }
         viewBox="0 0 16 16"
@@ -1224,7 +1201,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
       >
         <path
           d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-          fill="currentColor"
+          fill="rgba(33,36,44,0.64)"
         />
       </svg>
     </button>

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1084,6 +1084,159 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
   className=""
   style={
     Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": "fit-content",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="listbox"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          "alignItems": "center",
+          "backgroundColor": "#ffffff",
+          "border": "none",
+          "borderColor": "rgba(33,36,44,0.50)",
+          "borderRadius": 4,
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "boxSizing": "border-box",
+          "color": "#21242c",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "space-between",
+          "margin": 0,
+          "outline": "none",
+          "paddingLeft": 16,
+          "paddingRight": 12,
+          "position": "relative",
+          "textDecoration": "none",
+          "whiteSpace": "nowrap",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, sans-serif",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        0 balloons
+      </span>
+      <div
+        className=""
+        style={
+          Object {
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexDirection": "column",
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 8,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      />
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "minWidth": 16,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "verticalAlign": "text-bottom",
+            "whiteSpace": "nowrap",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 10 1`] = `
+<div
+  className=""
+  style={
+    Object {
       "alignItems": "center",
       "borderStyle": "solid",
       "borderWidth": 0,

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -442,11 +442,13 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
         };
     }
 
-    renderItems(outOfBoundaries: ?boolean, placement: string) {
+    renderItems(outOfBoundaries: ?boolean, placement: ?string) {
         const {items, dropdownStyle, light, openerElement} = this.props;
 
         const {top, bottom} = this.getVerticalSpace();
         const maxDropdownHeight =
+        // The placement variable returned by react-popper is the current
+        // position of the dropdown.
             placement && placement.includes("bottom")
                 ? bottom - dropdownPopperPadding
                 : top - dropdownPopperPadding;
@@ -510,9 +512,6 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
             maybeGetPortalMountedModalHostElement(openerElement) ||
             document.querySelector("body");
 
-        const {top, bottom} = this.getVerticalSpace();
-        const moreTopSpace = top > bottom;
-
         if (modalHost) {
             return ReactDOM.createPortal(
                 <Popper
@@ -525,18 +524,16 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
                         preventOverflow: {
                             boundariesElement: "viewport",
                             // For some unidentified reason of react-popper,
-                            // escapeWithReference works better here when the
-                            // dropdown is positioned beneath the opener.
-                            escapeWithReference: !moreTopSpace,
+                            // this causes the popped element to be positioned
+                            // more accurately when this is false. Sometimes
+                            // when the dropdown appears above the opener and
+                            // scrolling is happening, the opener is positioned
+                            // poorly.
+                            escapeWithReference: false,
                         },
                         flip: {
                             padding: dropdownPopperPadding,
-                            // We are disabling flipping when there's more
-                            // bottom space because if there are many items,
-                            // react-popper detects that the popper takes up
-                            // more space than available and starts off the
-                            // popper above the opener.
-                            enabled: moreTopSpace,
+                            enabled: true,
                         },
                     }}
                 >

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -115,6 +115,57 @@ class ExampleWithShortcuts extends React.Component {
 </View>
 ```
 
+### Multi select with lots of options
+
+This example has 24 options. It shows the implemented flip and dropdown scroll
+behavior.
+
+```js
+const React = require("react");
+const {View} = require("@khanacademy/wonder-blocks-core");
+const {StyleSheet} = require("aphrodite");
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    },
+});
+
+class ManyOptions extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            selectedValues: [],
+        };
+    }
+
+    handleChange(update) {
+        console.log("changes happened!");
+        this.setState({
+           selectedValues: update,
+        });
+    }
+
+    render() {
+        const items = Array(24).fill(0);
+        const children = items.map((item, index) => (
+            <OptionItem label="Balloon 🎈" value={index} key={index} />
+        ));
+        return <MultiSelect
+            onChange={(selectedValues) => this.handleChange(selectedValues)}
+            selectedValues={this.state.selectedValues}
+            selectItemType="balloons"
+        >
+            {children}
+        </MultiSelect>;
+    }
+}
+
+<View style={styles.row}>
+    <ManyOptions />
+</View>
+```
+
 ### Multi select in a modal
 
 This multi select is in a modal.

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -149,7 +149,7 @@ class ManyOptions extends React.Component {
     render() {
         const items = Array(24).fill(0);
         const children = items.map((item, index) => (
-            <OptionItem label="Balloon 🎈" value={index} key={index} />
+            <OptionItem label={`🎈Balloon ${index}`} value={index} key={index} />
         ));
         return <MultiSelect
             onChange={(selectedValues) => this.handleChange(selectedValues)}

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -507,6 +507,58 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
     it("example 9", () => {
+        const React = require("react");
+        const {View} = require("@khanacademy/wonder-blocks-core");
+        const {StyleSheet} = require("aphrodite");
+
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
+        class ManyOptions extends React.Component {
+            constructor() {
+                super();
+                this.state = {
+                    selectedValues: [],
+                };
+            }
+
+            handleChange(update) {
+                console.log("changes happened!");
+                this.setState({
+                    selectedValues: update,
+                });
+            }
+
+            render() {
+                const items = Array(24).fill(0);
+                const children = items.map((item, index) => (
+                    <OptionItem label="Balloon 🎈" value={index} key={index} />
+                ));
+                return (
+                    <MultiSelect
+                        onChange={(selectedValues) =>
+                            this.handleChange(selectedValues)
+                        }
+                        selectedValues={this.state.selectedValues}
+                        selectItemType="balloons"
+                    >
+                        {children}
+                    </MultiSelect>
+                );
+            }
+        }
+        const example = (
+            <View style={styles.row}>
+                <ManyOptions />
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 10", () => {
         const {StyleSheet} = require("aphrodite");
         const React = require("react");
         const {View, Text} = require("@khanacademy/wonder-blocks-core");
@@ -542,14 +594,12 @@ describe("wonder-blocks-dropdown", () => {
                 // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(update) {
                 console.log("changes happened!");
                 this.setState({
                     selectedValues: update,
                 });
             }
-
             render() {
                 return (
                     <MultiSelect
@@ -571,7 +621,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const modalContent = (
             <View style={{height: "200vh"}}>
                 <View style={styles.scrolledWrapper}>

--- a/packages/wonder-blocks-dropdown/util/constants.js
+++ b/packages/wonder-blocks-dropdown/util/constants.js
@@ -14,3 +14,7 @@ export const selectDropdownStyle = {
     marginTop: Spacing.xSmall,
     marginBottom: Spacing.xSmall,
 };
+
+// Amount of padding between the edge of the dropdown and the viewport
+// boundaries.
+export const dropdownPopperPadding = 20;


### PR DESCRIPTION
Best way to observe this behavior is to look at the Multi select with many options example at https://deploy-preview-272--wonder-blocks.netlify.com/#multiselect

Basic rules:
* Dropdown prefers to be under the opener
* If there is not enough room under the opener but enough above, the dropdown appears above the opener.
* The dropdown has a scrollbar if there's not enough room on either side of the opener. This is done by calculating how much space there is and setting a `maxHeight` on the dropdown itself.

Update: 2018 August 24
The current issue happens when there isn't enough room on either side to fit the entire dropdown without a scrollbar. What I believe is happening is: say the dropdown is below the opener and you scroll a bit. `react-popper` does a recalculation and detects that there isn't enough room below the opener so it moves the dropdown to above the opener. Scroll a bit more, and the dropdown gets moved below the opener because of course there was never enough room above the opener either. Repeat ad infinitum.

I haven't really looked into the `popper.js` source, but perhaps one way to improve this is to only allow a flip once one side _gains_ more space than the other. Also worth looking into this function you can supply (https://popper.js.org/popper-documentation.html#modifiers..flip.fn) which is called on each recalculation but I was unable to get this to work.

Related: `https://github.com/FezVrasta/popper.js/issues/550`