### PR TITLE
Update ClickableBehavior behavior across browsers and components

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
@@ -17,6 +17,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false disabled 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -43,6 +44,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false disabled 
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -84,6 +86,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false focused 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -111,6 +114,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false focused 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -152,6 +156,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false hovered 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -179,6 +184,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false hovered 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -220,6 +226,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false pressed 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -247,6 +254,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false pressed 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -289,6 +297,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true disabled 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -315,6 +324,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true disabled 1
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -356,6 +366,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true focused 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -383,6 +394,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true focused 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -424,6 +436,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true hovered 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -451,6 +464,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true hovered 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -492,6 +506,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true pressed 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -519,6 +534,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true pressed 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -561,6 +577,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -587,6 +604,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -628,6 +646,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -655,6 +674,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -696,6 +716,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -723,6 +744,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -764,6 +786,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -791,6 +814,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -833,6 +857,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -859,6 +884,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -900,6 +926,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -927,6 +954,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -968,6 +996,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -995,6 +1024,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1036,6 +1066,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1063,6 +1094,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1105,6 +1137,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false disab
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1131,6 +1164,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false disab
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -1172,6 +1206,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false focus
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1199,6 +1234,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false focus
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1240,6 +1276,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false hover
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1267,6 +1304,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false hover
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1308,6 +1346,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false press
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1335,6 +1374,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false press
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1377,6 +1417,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true disabl
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1403,6 +1444,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true disabl
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -1444,6 +1486,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true focuse
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1471,6 +1514,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true focuse
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1512,6 +1556,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true hovere
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1539,6 +1584,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true hovere
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1580,6 +1626,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true presse
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1607,6 +1654,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true presse
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1649,6 +1697,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1675,6 +1724,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -1716,6 +1766,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1743,6 +1794,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1784,6 +1836,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1811,6 +1864,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1852,6 +1906,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1879,6 +1934,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -1921,6 +1977,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -1947,6 +2004,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -1988,6 +2046,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2015,6 +2074,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2056,6 +2116,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2083,6 +2144,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2124,6 +2186,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2151,6 +2214,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2193,6 +2257,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false disable
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2222,6 +2287,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false disable
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -2263,6 +2329,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false focused
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2292,6 +2359,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false focused
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2333,6 +2401,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false hovered
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2362,6 +2431,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false hovered
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2403,6 +2473,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false pressed
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2432,6 +2503,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false pressed
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2474,6 +2546,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true disabled
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2503,6 +2576,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true disabled
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -2544,6 +2618,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true focused 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2573,6 +2648,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true focused 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2614,6 +2690,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true hovered 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2643,6 +2720,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true hovered 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2684,6 +2762,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true pressed 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2713,6 +2792,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true pressed 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2755,6 +2835,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2784,6 +2865,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -2825,6 +2907,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2854,6 +2937,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2895,6 +2979,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2924,6 +3009,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -2965,6 +3051,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -2994,6 +3081,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3036,6 +3124,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3065,6 +3154,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -3106,6 +3196,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3135,6 +3226,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3176,6 +3268,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3205,6 +3298,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3246,6 +3340,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3275,6 +3370,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3317,6 +3413,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false dis
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3346,6 +3443,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false dis
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -3387,6 +3485,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false foc
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3416,6 +3515,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false foc
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3457,6 +3557,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false hov
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3486,6 +3587,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false hov
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3527,6 +3629,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false pre
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3556,6 +3659,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false pre
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3598,6 +3702,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true disa
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3627,6 +3732,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true disa
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -3668,6 +3774,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true focu
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3697,6 +3804,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true focu
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3738,6 +3846,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true hove
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3767,6 +3876,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true hove
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3808,6 +3918,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true pres
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3837,6 +3948,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true pres
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -3879,6 +3991,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3908,6 +4021,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -3949,6 +4063,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -3978,6 +4093,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4019,6 +4135,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4048,6 +4165,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4089,6 +4207,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4118,6 +4237,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4160,6 +4280,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4189,6 +4310,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -4230,6 +4352,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4259,6 +4382,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4300,6 +4424,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4329,6 +4454,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4370,6 +4496,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4399,6 +4526,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4441,6 +4569,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false disabled
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4467,6 +4596,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false disabled
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -4508,6 +4638,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false focused 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4543,6 +4674,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false focused 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4584,6 +4716,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false hovered 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4619,6 +4752,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false hovered 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4660,6 +4794,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false pressed 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4695,6 +4830,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false pressed 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4737,6 +4873,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true disabled 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4763,6 +4900,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true disabled 
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -4804,6 +4942,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true focused 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4839,6 +4978,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true focused 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4880,6 +5020,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true hovered 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4915,6 +5056,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true hovered 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -4956,6 +5098,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true pressed 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -4991,6 +5134,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true pressed 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5033,6 +5177,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5059,6 +5204,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -5100,6 +5246,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5135,6 +5282,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5176,6 +5324,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5211,6 +5360,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5252,6 +5402,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5287,6 +5438,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5329,6 +5481,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5355,6 +5508,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -5396,6 +5550,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5431,6 +5586,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5472,6 +5628,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5507,6 +5664,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5548,6 +5706,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5583,6 +5742,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5625,6 +5785,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false disa
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5651,6 +5812,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false disa
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -5692,6 +5854,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false focu
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5727,6 +5890,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false focu
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5768,6 +5932,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false hove
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5803,6 +5968,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false hove
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5844,6 +6010,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false pres
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5879,6 +6046,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false pres
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -5921,6 +6089,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true disab
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -5947,6 +6116,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true disab
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -5988,6 +6158,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true focus
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6023,6 +6194,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true focus
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -6064,6 +6236,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true hover
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6099,6 +6272,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true hover
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -6140,6 +6314,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true press
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6175,6 +6350,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true press
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -6217,6 +6393,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6243,6 +6420,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -6284,6 +6462,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6319,6 +6498,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -6360,6 +6540,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6395,6 +6576,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -6436,6 +6618,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6471,6 +6654,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -6513,6 +6697,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6539,6 +6724,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <span
     className=""
@@ -6580,6 +6766,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6615,6 +6802,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -6656,6 +6844,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6691,6 +6880,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""
@@ -6732,6 +6922,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchStart={[Function]}
+  role="button"
   style={
     Object {
       "::MozFocusInner": Object {
@@ -6767,6 +6958,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
     }
   }
   tabIndex={0}
+  type="button"
 >
   <span
     className=""

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -35,6 +35,7 @@ exports[`wonder-blocks-button example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -62,6 +63,7 @@ exports[`wonder-blocks-button example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -100,6 +102,7 @@ exports[`wonder-blocks-button example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -130,6 +133,7 @@ exports[`wonder-blocks-button example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -168,6 +172,7 @@ exports[`wonder-blocks-button example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -195,6 +200,7 @@ exports[`wonder-blocks-button example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -256,6 +262,7 @@ exports[`wonder-blocks-button example 2 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -283,6 +290,7 @@ exports[`wonder-blocks-button example 2 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -321,6 +329,7 @@ exports[`wonder-blocks-button example 2 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -351,6 +360,7 @@ exports[`wonder-blocks-button example 2 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -389,6 +399,7 @@ exports[`wonder-blocks-button example 2 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -416,6 +427,7 @@ exports[`wonder-blocks-button example 2 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -478,6 +490,7 @@ exports[`wonder-blocks-button example 3 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -505,6 +518,7 @@ exports[`wonder-blocks-button example 3 1`] = `
       }
     }
     tabIndex={-1}
+    type="button"
   >
     <span
       className=""
@@ -544,6 +558,7 @@ exports[`wonder-blocks-button example 3 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -574,6 +589,7 @@ exports[`wonder-blocks-button example 3 1`] = `
       }
     }
     tabIndex={-1}
+    type="button"
   >
     <span
       className=""
@@ -613,6 +629,7 @@ exports[`wonder-blocks-button example 3 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -640,6 +657,7 @@ exports[`wonder-blocks-button example 3 1`] = `
       }
     }
     tabIndex={-1}
+    type="button"
   >
     <span
       className=""
@@ -702,6 +720,7 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -729,6 +748,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -767,6 +787,7 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -797,6 +818,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -835,6 +857,7 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -862,6 +885,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -901,6 +925,7 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -928,6 +953,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       }
     }
     tabIndex={-1}
+    type="button"
   >
     <span
       className=""
@@ -967,6 +993,7 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -997,6 +1024,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       }
     }
     tabIndex={-1}
+    type="button"
   >
     <span
       className=""
@@ -1036,6 +1064,7 @@ exports[`wonder-blocks-button example 4 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -1063,6 +1092,7 @@ exports[`wonder-blocks-button example 4 1`] = `
       }
     }
     tabIndex={-1}
+    type="button"
   >
     <span
       className=""
@@ -1124,6 +1154,7 @@ exports[`wonder-blocks-button example 5 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -1151,6 +1182,7 @@ exports[`wonder-blocks-button example 5 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -1189,6 +1221,7 @@ exports[`wonder-blocks-button example 5 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -1219,6 +1252,7 @@ exports[`wonder-blocks-button example 5 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -1257,6 +1291,7 @@ exports[`wonder-blocks-button example 5 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -1284,6 +1319,7 @@ exports[`wonder-blocks-button example 5 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -1345,6 +1381,7 @@ exports[`wonder-blocks-button example 6 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "alignItems": "center",
@@ -1406,6 +1443,7 @@ exports[`wonder-blocks-button example 6 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -1436,6 +1474,7 @@ exports[`wonder-blocks-button example 6 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -1474,6 +1513,7 @@ exports[`wonder-blocks-button example 6 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "alignItems": "center",
@@ -1558,6 +1598,7 @@ exports[`wonder-blocks-button example 7 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "alignItems": "center",
@@ -1619,6 +1660,7 @@ exports[`wonder-blocks-button example 7 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "alignItems": "center",
@@ -1703,6 +1745,7 @@ exports[`wonder-blocks-button example 8 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -1729,6 +1772,7 @@ exports[`wonder-blocks-button example 8 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -1809,6 +1853,7 @@ exports[`wonder-blocks-button example 9 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1835,6 +1880,7 @@ exports[`wonder-blocks-button example 9 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -1913,6 +1959,7 @@ exports[`wonder-blocks-button example 9 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1939,6 +1986,7 @@ exports[`wonder-blocks-button example 9 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -2001,6 +2049,7 @@ exports[`wonder-blocks-button example 10 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -2032,6 +2081,7 @@ exports[`wonder-blocks-button example 10 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -2070,6 +2120,7 @@ exports[`wonder-blocks-button example 10 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -2098,6 +2149,7 @@ exports[`wonder-blocks-button example 10 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -2178,6 +2230,7 @@ exports[`wonder-blocks-button example 11 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -2205,6 +2258,7 @@ exports[`wonder-blocks-button example 11 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -2243,6 +2297,7 @@ exports[`wonder-blocks-button example 11 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -2269,6 +2324,7 @@ exports[`wonder-blocks-button example 11 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -29,12 +29,6 @@ const StyledLink = addStyle(Link);
 export default class ButtonCore extends React.Component<Props> {
     static contextTypes = {router: PropTypes.any};
 
-    handleClick = (e: SyntheticEvent<>) => {
-        if (this.props.disabled) {
-            e.preventDefault();
-        }
-    };
-
     render() {
         const {
             children,
@@ -76,6 +70,7 @@ export default class ButtonCore extends React.Component<Props> {
         const commonProps = {
             "aria-disabled": disabled ? "true" : undefined,
             "data-test-id": testId,
+            role: "button",
             style: [defaultStyle, style],
             ...handlers,
         };
@@ -86,25 +81,21 @@ export default class ButtonCore extends React.Component<Props> {
 
         if (href) {
             return router && !skipClientNav ? (
-                <StyledLink
-                    {...commonProps}
-                    onClick={this.handleClick}
-                    to={href}
-                >
+                <StyledLink {...commonProps} to={href}>
                     {label}
                 </StyledLink>
             ) : (
-                <StyledAnchor
-                    {...commonProps}
-                    onClick={this.handleClick}
-                    href={href}
-                >
+                <StyledAnchor {...commonProps} href={href}>
                     {label}
                 </StyledAnchor>
             );
         } else {
             return (
-                <StyledButton {...commonProps} disabled={disabled}>
+                <StyledButton
+                    type="button"
+                    {...commonProps}
+                    disabled={disabled}
+                >
                     {label}
                 </StyledButton>
             );

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -163,8 +163,8 @@ export default class Button extends React.Component<SharedProps> {
         return (
             <ClickableBehavior
                 disabled={sharedProps.disabled}
-                onClick={onClick}
                 href={href}
+                onClick={onClick}
             >
                 {(state, handlers) => {
                     return (

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -194,6 +194,7 @@ exports[`wonder-blocks-core example 4 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -220,6 +221,7 @@ exports[`wonder-blocks-core example 4 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -22,9 +22,9 @@ type Props = {|
      * A URL.
      *
      * If specified, we will assume the rendered component should react like an
-     * `<a>` tag and respond to enter/return key press. Otherwise, we will
-     * assume the rendered component should react like a `<button>` tag and
-     * respond to spacebar key press.
+     * `<a>` tag and respond to enter/return key press but not space key press.
+     * If not specified, the component will react to both enter and space key
+     * presses.
      */
     href?: string,
 
@@ -35,8 +35,26 @@ type Props = {|
 
     /**
      * Passed in by withRouter HOC.
+     * @ignore
      */
     history?: any,
+
+    /**
+     * Trigger onClick callback and href navigation, if present, on enter key
+     * press. Default true. Only set to false if the component should definitely
+     * NOT trigger onClick on enter. An example of a component that shouldn't
+     * trigger on enter is Checkbox.
+     * @ignore
+     */
+    triggerOnEnter: boolean,
+
+    /**
+     * Trigger onClick callback on space key press. Only set to false if the
+     * component should definitely NOT trigger onClick on space. An example of a
+     * component that shouldn't trigger on space is Link.
+     * @ignore
+     */
+    triggerOnSpace: boolean,
 |};
 
 type State = {|
@@ -126,6 +144,17 @@ const startState = {
  * 2. Keydown (spacebar/enter) -> active state
  * 3. Keyup (spacebar/enter) -> focus state
  *
+ * Warning: The event handlers returned (onClick, onMouseEnter, onMouseLeave,
+ * onMouseDown, onMouseUp, onTouchStart, onTouchEnd, onTouchCancel, onKeyDown,
+ * onKeyUp, onFocus, onBlur, tabIndex) should be passed on to the component
+ * that has the ClickableBehavior. You cannot override these handlers without
+ * potentially breaking the functionality of ClickableBehavior.
+ *
+ * There are internal props triggerOnEnter and triggerOnSpace that can be set
+ * to false if one of those keys shouldn't count as a click on this component.
+ * Be careful about setting those to false -- make certain that the component
+ * shouldn't process that key.
+ *
  * `ClickableBehavior` accepts a function as `children` which is passed state
  * and an object containing event handlers. The `children` function should
  * return a clickable React Element of some sort.
@@ -171,10 +200,12 @@ const startState = {
  */
 export default class ClickableBehavior extends React.Component<Props, State> {
     waitingForClick: boolean;
-    keyboardClick: boolean;
+    enterClick: boolean;
 
     static defaultProps = {
         disabled: false,
+        triggerOnEnter: true,
+        triggerOnSpace: true,
     };
 
     static getDerivedStateFromProps(props: Props, state: State) {
@@ -194,9 +225,8 @@ export default class ClickableBehavior extends React.Component<Props, State> {
     }
 
     handleClick = (e: SyntheticMouseEvent<>) => {
-        if (this.keyboardClick) {
-            this.keyboardClick = false;
-            e.preventDefault();
+        if (this.enterClick) {
+            return;
         } else if (this.props.onClick) {
             this.waitingForClick = false;
             this.props.onClick(e);
@@ -239,28 +269,45 @@ export default class ClickableBehavior extends React.Component<Props, State> {
 
     handleKeyDown = (e: SyntheticKeyboardEvent<*>) => {
         const keyCode = e.which || e.keyCode;
+        const {triggerOnEnter, triggerOnSpace} = this.props;
         if (
-            this.props.href
-                ? keyCode === keyCodes.enter
-                : keyCode === keyCodes.space
+            (triggerOnEnter && keyCode === keyCodes.enter) ||
+            (triggerOnSpace && keyCode === keyCodes.space)
         ) {
-            this.keyboardClick = true;
+            // This prevents space from scrolling down. It also prevents the
+            // space and enter keys from triggering click events. We manually
+            // call the supplied onClick and handle potential navigation in
+            // handleKeyUp instead.
+            e.preventDefault();
             this.setState({pressed: true});
+        } else if (!triggerOnEnter && keyCode === keyCodes.enter) {
+            // If the component isn't supposed to trigger on enter, we have to
+            // keep track of the enter keydown to negate the onClick callback
+            this.enterClick = true;
         }
     };
 
     handleKeyUp = (e: SyntheticKeyboardEvent<*>) => {
         const keyCode = e.which || e.keyCode;
+        const {triggerOnEnter, triggerOnSpace} = this.props;
         if (
-            this.props.href
-                ? keyCode === keyCodes.enter
-                : keyCode === keyCodes.space
+            (triggerOnEnter && keyCode === keyCodes.enter) ||
+            (triggerOnSpace && keyCode === keyCodes.space)
         ) {
+            // NOTE: In Firefox, the keyup event needs to be preventDefault-ed
+            // for space.
+            // https://stackoverflow.com/questions/24383722/unable-to-prevent-spacebar-default-action-in-firefox
+            if (keyCode === keyCodes.space) {
+                e.preventDefault();
+            }
+
             this.setState({pressed: false, focused: true});
             if (this.props.onClick) {
                 this.props.onClick(e);
             }
             this.maybeNavigate();
+        } else if (!triggerOnEnter && keyCode === keyCodes.enter) {
+            this.enterClick = false;
         }
     };
 

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -21,10 +21,11 @@ type Props = {|
     /**
      * A URL.
      *
-     * If specified, we will assume the rendered component should react like an
-     * `<a>` tag and respond to enter/return key press but not space key press.
-     * If not specified, the component will react to both enter and space key
-     * presses.
+     * If specified, clicking on the component will navigate to the location
+     * provided.
+     * For keyboard navigation, the default is that both an enter and space
+     * press would also navigate to this location. See the triggerOnEnter and
+     * triggerOnSpace props for more details.
      */
     href?: string,
 
@@ -43,8 +44,7 @@ type Props = {|
      * Trigger onClick callback and href navigation, if present, on enter key
      * press. Default true. Only set to false if the component should definitely
      * NOT trigger onClick on enter. An example of a component that shouldn't
-     * trigger on enter is Checkbox.
-     * @ignore
+     * trigger on enter is a Checkbox or some other form component.
      */
     triggerOnEnter: boolean,
 
@@ -52,7 +52,6 @@ type Props = {|
      * Trigger onClick callback on space key press. Only set to false if the
      * component should definitely NOT trigger onClick on space. An example of a
      * component that shouldn't trigger on space is Link.
-     * @ignore
      */
     triggerOnSpace: boolean,
 |};
@@ -154,6 +153,9 @@ const startState = {
  * to false if one of those keys shouldn't count as a click on this component.
  * Be careful about setting those to false -- make certain that the component
  * shouldn't process that key.
+ *
+ * See [this document](https://docs.google.com/document/d/1DG5Rg2f0cawIL5R8UqnPQpd7pbdObk8OyjO5ryYQmBM/edit#)
+ * for a more thorough explanation of expected behaviors and potential cavaets.
  *
  * `ClickableBehavior` accepts a function as `children` which is passed state
  * and an object containing event handlers. The `children` function should

--- a/packages/wonder-blocks-core/components/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.test.js
@@ -280,6 +280,9 @@ describe("ClickableBehavior", () => {
         button.simulate("blur");
         expect(button.state("pressed")).toEqual(false);
 
+        button.simulate("focus");
+        expect(button.state("focused")).toEqual(false);
+
         const anchor = shallow(
             <ClickableBehavior
                 disabled={true}
@@ -417,13 +420,7 @@ describe("ClickableBehavior", () => {
                     // The base element here doesn't matter in this testing
                     // environment, but the simulated events in the test are in
                     // line with what browsers do for this element.
-                    return (
-                        <input
-                            type="checkbox"
-                            href="https://khanacademy.org/"
-                            {...handlers}
-                        />
-                    );
+                    return <input type="checkbox" {...handlers} />;
                 }}
             </ClickableBehavior>,
         );
@@ -518,5 +515,30 @@ describe("ClickableBehavior", () => {
         clickableDiv.simulate("click");
         expectedNumberTimesCalled += 1;
         expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+    });
+
+    it("doesn't trigger enter key when browser doesn't stop the click", () => {
+        const onClick = jest.fn();
+        // Use mount instead of a shallow render to trigger event defaults
+        const checkbox = mount(
+            <ClickableBehavior
+                triggerOnEnter={false}
+                onClick={(e) => onClick(e)}
+            >
+                {(state, handlers) => {
+                    // The base element here doesn't matter in this testing
+                    // environment, but the simulated events in the test are in
+                    // line with what browsers do for this element.
+                    return <input type="checkbox" {...handlers} />;
+                }}
+            </ClickableBehavior>,
+        );
+
+        // Enter press should not do anything
+        checkbox.simulate("keydown", {keyCode: keyCodes.enter});
+        // This element still wants to have a click on enter press
+        checkbox.simulate("click");
+        checkbox.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(onClick).toHaveBeenCalledTimes(0);
     });
 });

--- a/packages/wonder-blocks-core/components/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
 import {shallow} from "enzyme";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import ClickableBehavior from "./clickable-behavior.js";
 
@@ -11,6 +12,18 @@ const keyCodes = {
 };
 
 describe("ClickableBehavior", () => {
+    // Note: window.location.assign needs a mock function in the testing
+    // environment.
+    window.location.assign = jest.fn();
+
+    beforeEach(() => {
+        unmountAll();
+    });
+
+    afterEach(() => {
+        window.location.assign.mockClear();
+    });
+
     it("renders a label", () => {
         const onClick = jest.fn();
         const button = shallow(
@@ -89,17 +102,20 @@ describe("ClickableBehavior", () => {
             </ClickableBehavior>,
         );
         expect(button.state("focused")).toEqual(false);
-        button.simulate("keydown", {keyCode: keyCodes.space});
-        button.simulate("keyup", {keyCode: keyCodes.space});
-        button.simulate("click", {preventDefault: jest.fn()});
+        button.simulate("keydown", {
+            keyCode: keyCodes.space,
+            preventDefault: jest.fn(),
+        });
+        button.simulate("keyup", {
+            keyCode: keyCodes.space,
+            preventDefault: jest.fn(),
+        });
+        button.simulate("click");
         expect(button.state("focused")).toEqual(true);
     });
 
     it("exits focused state on click after key press", () => {
         const onClick = jest.fn();
-        // Note: window.location.assign is not called, but jest logs an error
-        // if it's not stubbed out.
-        window.location.assign = jest.fn();
 
         const button = shallow(
             <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
@@ -109,17 +125,23 @@ describe("ClickableBehavior", () => {
             </ClickableBehavior>,
         );
         expect(button.state("focused")).toEqual(false);
-        button.simulate("keydown", {keyCode: keyCodes.space});
-        button.simulate("keyup", {keyCode: keyCodes.space});
-        button.simulate("click", {preventDefault: jest.fn()});
+        button.simulate("keydown", {
+            keyCode: keyCodes.space,
+            preventDefault: jest.fn(),
+        });
+        button.simulate("keyup", {
+            keyCode: keyCodes.space,
+            preventDefault: jest.fn(),
+        });
+        button.simulate("click");
         expect(button.state("focused")).toEqual(true);
         button.simulate("mousedown");
-        button.simulate("click");
         button.simulate("mouseup");
+        button.simulate("click");
         expect(button.state("focused")).toEqual(false);
     });
 
-    it("changes pressed state on only space key down/up if <button>", () => {
+    it("changes pressed state on space/enter key down/up if <button>", () => {
         const onClick = jest.fn();
         const button = shallow(
             <ClickableBehavior disabled={false} onClick={(e) => onClick(e)}>
@@ -129,23 +151,35 @@ describe("ClickableBehavior", () => {
             </ClickableBehavior>,
         );
         expect(button.state("pressed")).toEqual(false);
-        button.simulate("keydown", {keyCode: keyCodes.space});
+        button.simulate("keydown", {
+            keyCode: keyCodes.space,
+            preventDefault: jest.fn(),
+        });
         expect(button.state("pressed")).toEqual(true);
-        button.simulate("keyup", {keyCode: keyCodes.space});
+        button.simulate("keyup", {
+            keyCode: keyCodes.space,
+            preventDefault: jest.fn(),
+        });
         expect(button.state("pressed")).toEqual(false);
 
-        expect(button.state("pressed")).toEqual(false);
-        button.simulate("keydown", {keyCode: keyCodes.enter});
+        button.simulate("keydown", {
+            keyCode: keyCodes.enter,
+            preventDefault: jest.fn(),
+        });
+        expect(button.state("pressed")).toEqual(true);
+        button.simulate("keyup", {keyCode: keyCodes.enter});
         expect(button.state("pressed")).toEqual(false);
     });
 
-    it("changes pressed state on only enter key down/up if <a>", () => {
+    it("changes pressed state on only enter key down/up if triggerOnSpace=false", () => {
         const onClick = jest.fn();
-        const button = shallow(
+        // Use mount instead of a shallow render to trigger event defaults
+        const link = mount(
             <ClickableBehavior
                 disabled={false}
                 onClick={(e) => onClick(e)}
                 href="https://www.khanacademy.org"
+                triggerOnSpace={false}
             >
                 {(state, handlers) => {
                     return (
@@ -156,15 +190,16 @@ describe("ClickableBehavior", () => {
                 }}
             </ClickableBehavior>,
         );
-        expect(button.state("pressed")).toEqual(false);
-        button.simulate("keydown", {keyCode: keyCodes.enter});
-        expect(button.state("pressed")).toEqual(true);
-        button.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(button.state("pressed")).toEqual(false);
+        expect(link.state("pressed")).toEqual(false);
+        link.simulate("keydown", {keyCode: keyCodes.enter});
+        expect(link.state("pressed")).toEqual(true);
+        link.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(link.state("pressed")).toEqual(false);
 
-        expect(button.state("pressed")).toEqual(false);
-        button.simulate("keydown", {keyCode: keyCodes.space});
-        expect(button.state("pressed")).toEqual(false);
+        link.simulate("keydown", {keyCode: keyCodes.space});
+        expect(link.state("pressed")).toEqual(false);
+        link.simulate("keyup", {keyCode: keyCodes.space});
+        expect(link.state("pressed")).toEqual(false);
     });
 
     it("gains focused state on focus event", () => {
@@ -283,20 +318,26 @@ describe("ClickableBehavior", () => {
         button.simulate("click", {preventDefault: jest.fn()});
         expect(onClick).toHaveBeenCalledTimes(1);
 
-        // Order of DOM events is different for space vs. enter
-        button.simulate("keydown", {keyCode: keyCodes.space});
-        button.simulate("keyup", {keyCode: keyCodes.space});
-        button.simulate("click", {preventDefault: jest.fn()});
+        button.simulate("keydown", {
+            keyCode: keyCodes.space,
+            preventDefault: jest.fn(),
+        });
+        button.simulate("keyup", {
+            keyCode: keyCodes.space,
+            preventDefault: jest.fn(),
+        });
         expect(onClick).toHaveBeenCalledTimes(2);
 
-        button.simulate("keydown", {keyCode: keyCodes.enter});
-        button.simulate("click", {preventDefault: jest.fn()});
+        button.simulate("keydown", {
+            keyCode: keyCodes.enter,
+            preventDefault: jest.fn(),
+        });
         button.simulate("keyup", {keyCode: keyCodes.enter});
         expect(onClick).toHaveBeenCalledTimes(3);
 
         button.simulate("touchstart", {keyCode: keyCodes.space});
         button.simulate("touchend", {keyCode: keyCodes.space});
-        button.simulate("click", {preventDefault: jest.fn()});
+        button.simulate("click");
         expect(onClick).toHaveBeenCalledTimes(4);
     });
 
@@ -315,5 +356,167 @@ describe("ClickableBehavior", () => {
         expect(button.state("hovered")).toEqual(false);
         expect(button.state("pressed")).toEqual(false);
         expect(button.state("focused")).toEqual(false);
+    });
+
+    it("both navigates and calls onClick for an anchor link", () => {
+        const onClick = jest.fn();
+        // Use mount instead of a shallow render to trigger event defaults
+        const link = mount(
+            // triggerOnSpace is false because links should not navigate or
+            // be activated on a space press
+            <ClickableBehavior
+                triggerOnSpace={false}
+                href="https://khanacademy.org/"
+                onClick={(e) => onClick(e)}
+            >
+                {(state, handlers) => {
+                    // The base element here doesn't matter in this testing
+                    // environment, but the simulated events in the test are in
+                    // line with what browsers do for this element.
+                    return (
+                        <a href="https://khanacademy.org/" {...handlers}>
+                            Label
+                        </a>
+                    );
+                }}
+            </ClickableBehavior>,
+        );
+
+        // Space press should not trigger the onClick
+        link.simulate("keydown", {keyCode: keyCodes.space});
+        link.simulate("keyup", {keyCode: keyCodes.space});
+        expect(onClick).toHaveBeenCalledTimes(0);
+
+        // Navigation didn't happen with space
+        expect(window.location.assign).toHaveBeenCalledTimes(0);
+
+        // Enter press should trigger the onClick after keyup
+        link.simulate("keydown", {keyCode: keyCodes.enter});
+        expect(onClick).toHaveBeenCalledTimes(0);
+
+        // Navigation doesn't happen until after enter is released
+        expect(window.location.assign).toHaveBeenCalledTimes(0);
+
+        link.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(onClick).toHaveBeenCalledTimes(1);
+
+        // Navigation happened after enter click
+        expect(window.location.assign).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClick correctly for a component with triggerOnEnter false", () => {
+        const onClick = jest.fn();
+        // Use mount instead of a shallow render to trigger event defaults
+        const checkbox = mount(
+            // triggerOnEnter may be false for some elements e.g. checkboxes
+            <ClickableBehavior
+                triggerOnEnter={false}
+                onClick={(e) => onClick(e)}
+            >
+                {(state, handlers) => {
+                    // The base element here doesn't matter in this testing
+                    // environment, but the simulated events in the test are in
+                    // line with what browsers do for this element.
+                    return (
+                        <input
+                            type="checkbox"
+                            href="https://khanacademy.org/"
+                            {...handlers}
+                        />
+                    );
+                }}
+            </ClickableBehavior>,
+        );
+
+        // Enter press should not do anything
+        checkbox.simulate("keydown", {keyCode: keyCodes.enter});
+        expect(onClick).toHaveBeenCalledTimes(0);
+        checkbox.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(onClick).toHaveBeenCalledTimes(0);
+
+        // Space press should trigger the onClick
+        checkbox.simulate("keydown", {keyCode: keyCodes.space});
+        checkbox.simulate("keyup", {keyCode: keyCodes.space});
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClick for a button component on both enter/space", () => {
+        const onClick = jest.fn();
+        // Use mount instead of a shallow render to trigger event defaults
+        const button = mount(
+            <ClickableBehavior onClick={(e) => onClick(e)}>
+                {(state, handlers) => {
+                    // The base element here doesn't matter in this testing
+                    // environment, but the simulated events in the test are in
+                    // line with what browsers do for this element.
+                    return <button {...handlers}>Label</button>;
+                }}
+            </ClickableBehavior>,
+        );
+
+        // Enter press
+        button.simulate("keydown", {keyCode: keyCodes.enter});
+        expect(onClick).toHaveBeenCalledTimes(0);
+        button.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(onClick).toHaveBeenCalledTimes(1);
+
+        // Space press
+        button.simulate("keydown", {keyCode: keyCodes.space});
+        expect(onClick).toHaveBeenCalledTimes(1);
+        button.simulate("keyup", {keyCode: keyCodes.space});
+        expect(onClick).toHaveBeenCalledTimes(2);
+    });
+
+    // This tests the case where we attach the handlers to an element that is
+    // not canonically clickable (like a div). The browser doesn't naturally
+    // trigger keyboard click events for such an element.
+    it("calls onClick listener on space/enter with a non-usually clickable element", () => {
+        const onClick = jest.fn();
+        // Use mount instead of a shallow render to trigger event defaults
+        const div = mount(
+            <ClickableBehavior onClick={(e) => onClick(e)}>
+                {(state, handlers) => {
+                    // The base element here doesn't matter in this testing
+                    // environment, but the simulated events in the test are in
+                    // line with what browsers do for this element.
+                    return <div {...handlers}>Label</div>;
+                }}
+            </ClickableBehavior>,
+        );
+
+        let expectedNumberTimesCalled = 0;
+        const clickableDiv = div.find("div");
+
+        // Enter press on a div
+        clickableDiv.simulate("keydown", {keyCode: keyCodes.enter});
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+        clickableDiv.simulate("keyup", {keyCode: keyCodes.enter});
+        expectedNumberTimesCalled += 1;
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+
+        // Simulate a mouse click.
+        clickableDiv.simulate("mousedown");
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+        clickableDiv.simulate("mouseup");
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+        clickableDiv.simulate("click");
+        expectedNumberTimesCalled += 1;
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+
+        // Space press on a div
+        clickableDiv.simulate("keydown", {keyCode: keyCodes.space});
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+        clickableDiv.simulate("keyup", {keyCode: keyCodes.space});
+        expectedNumberTimesCalled += 1;
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+
+        // Simulate another mouse click.
+        clickableDiv.simulate("mousedown");
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+        clickableDiv.simulate("mouseup");
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
+        clickableDiv.simulate("click");
+        expectedNumberTimesCalled += 1;
+        expect(onClick).toHaveBeenCalledTimes(expectedNumberTimesCalled);
     });
 });

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -321,7 +321,7 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="button"
+      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -474,7 +474,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="button"
+      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -625,7 +625,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="button"
+      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -804,7 +804,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
         onTouchCancel={[Function]}
         onTouchEnd={[Function]}
         onTouchStart={[Function]}
-        role="button"
+        role="listbox"
         style={
           Object {
             "::MozFocusInner": Object {
@@ -955,7 +955,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="button"
+      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1108,7 +1108,7 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="button"
+      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -87,6 +87,7 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -218,6 +219,7 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -319,7 +321,7 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="menu"
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -347,6 +349,7 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -471,7 +474,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="menu"
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -499,6 +502,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -621,7 +625,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="menu"
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -650,6 +654,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
         }
       }
       tabIndex={-1}
+      type="button"
     >
       <span
         className=""
@@ -799,7 +804,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
         onTouchCancel={[Function]}
         onTouchEnd={[Function]}
         onTouchStart={[Function]}
-        role="menu"
+        role="button"
         style={
           Object {
             "::MozFocusInner": Object {
@@ -824,6 +829,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
           }
         }
         tabIndex={0}
+        type="button"
       >
         <span
           className=""
@@ -949,7 +955,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="menu"
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -977,6 +983,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -1101,7 +1108,7 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="menu"
+      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1129,6 +1136,7 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
         }
       }
       tabIndex={0}
+      type="button"
     >
       <span
         className=""
@@ -1231,6 +1239,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -1257,6 +1266,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -84,12 +84,6 @@ export default class ActionItem extends React.Component<ActionProps> {
 
     static contextTypes = {router: PropTypes.any};
 
-    handleClick = (e: SyntheticEvent<>) => {
-        if (this.props.disabled) {
-            e.preventDefault();
-        }
-    };
-
     render() {
         const {
             skipClientNav,
@@ -144,25 +138,21 @@ export default class ActionItem extends React.Component<ActionProps> {
 
                     if (href) {
                         return router && !skipClientNav ? (
-                            <StyledLink
-                                {...props}
-                                onClick={this.handleClick}
-                                to={href}
-                            >
+                            <StyledLink {...props} to={href}>
                                 {children}
                             </StyledLink>
                         ) : (
-                            <StyledAnchor
-                                {...props}
-                                onClick={this.handleClick}
-                                href={href}
-                            >
+                            <StyledAnchor {...props} href={href}>
                                 {children}
                             </StyledAnchor>
                         );
                     } else {
                         return (
-                            <StyledButton {...props} disabled={disabled}>
+                            <StyledButton
+                                type="button"
+                                {...props}
+                                disabled={disabled}
+                            >
                                 {children}
                             </StyledButton>
                         );

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -55,12 +55,10 @@ describe("ActionMenu", () => {
         // Close menu with space
         opener.simulate("keydown", {keyCode: keyCodes.space});
         opener.simulate("keyup", {keyCode: keyCodes.space});
-        opener.simulate("click", {preventDefault: jest.fn()});
         expect(menu.state("open")).toEqual(false);
 
         // Open menu again with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
-        opener.simulate("click", {preventDefault: jest.fn()});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
         expect(menu.state("open")).toEqual(true);
     });

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -56,14 +56,12 @@ describe("MultiSelect", () => {
         // Close select with space
         opener.simulate("keydown", {keyCode: keyCodes.space});
         opener.simulate("keyup", {keyCode: keyCodes.space});
-        opener.simulate("click", {preventDefault: jest.fn()});
         expect(select.state("open")).toEqual(false);
 
-        // Open select again with enter
+        // Shouldn't open with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
-        opener.simulate("click", {preventDefault: jest.fn()});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(select.state("open")).toEqual(true);
+        expect(select.state("open")).toEqual(false);
     });
 
     it("selects items as expected", () => {

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -116,7 +116,7 @@ export default class OptionItem extends React.Component<OptionProps> {
                         <View
                             style={defaultStyle}
                             aria-checked={selected ? "true" : "false"}
-                            role="menuitemcheckbox"
+                            role="option"
                             {...handlers}
                         >
                             <CheckComponent

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -95,7 +95,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                     return (
                         <StyledButton
                             disabled={disabled}
-                            role="button"
+                            role="listbox"
                             type="button"
                             style={[
                                 styles.shared,

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -84,14 +84,19 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
         ];
 
         return (
-            <ClickableBehavior disabled={disabled} onClick={onClick}>
+            <ClickableBehavior
+                disabled={disabled}
+                onClick={onClick}
+                triggerOnEnter={false}
+            >
                 {(state, handlers) => {
                     const stateStyles = _generateStyles(light, {...state});
                     const {hovered, focused, pressed} = state;
                     return (
                         <StyledButton
                             disabled={disabled}
-                            role="menu"
+                            role="button"
+                            type="button"
                             style={[
                                 styles.shared,
                                 stateStyles.default,

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -45,14 +45,12 @@ describe("SingleSelect", () => {
         // Close select with space
         opener.simulate("keydown", {keyCode: keyCodes.space});
         opener.simulate("keyup", {keyCode: keyCodes.space});
-        opener.simulate("click", {preventDefault: jest.fn()});
         expect(select.state("open")).toEqual(false);
 
-        // Open select again with enter
+        // Shouldn't open with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
-        opener.simulate("click", {preventDefault: jest.fn()});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(select.state("open")).toEqual(true);
+        expect(select.state("open")).toEqual(false);
     });
 
     it("displays selected item label as expected", () => {

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -128,6 +128,7 @@ export default class ChoiceInternal extends React.Component<Props> {
                 <ClickableBehavior
                     disabled={coreProps.disabled}
                     onClick={this.handleClick}
+                    triggerOnEnter={false}
                 >
                     {(state, handlers) => {
                         return (

--- a/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
@@ -41,6 +41,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false disa
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -106,6 +107,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false focu
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -171,6 +173,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false hove
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -236,6 +239,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -298,6 +302,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:true disab
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -363,6 +368,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:true focus
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -428,6 +434,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:true hover
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -493,6 +500,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -555,6 +563,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -620,6 +629,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -685,6 +695,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -750,6 +761,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -812,6 +824,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -877,6 +890,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -942,6 +956,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1007,6 +1022,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1069,6 +1085,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -1134,6 +1151,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1199,6 +1217,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1264,6 +1283,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1326,6 +1346,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true d
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -1391,6 +1412,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true f
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1456,6 +1478,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true h
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1521,6 +1544,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1583,6 +1607,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -1648,6 +1673,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1713,6 +1739,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1778,6 +1805,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1840,6 +1868,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -1905,6 +1934,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -1970,6 +2000,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2035,6 +2066,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2097,6 +2129,7 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false di
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -2162,6 +2195,7 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false fo
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2227,6 +2261,7 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false ho
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2292,6 +2327,7 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2354,6 +2390,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -2419,6 +2456,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2484,6 +2522,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2549,6 +2588,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2611,6 +2651,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -2676,6 +2717,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2741,6 +2783,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2806,6 +2849,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2868,6 +2912,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -2933,6 +2978,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -2998,6 +3044,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3063,6 +3110,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3125,6 +3173,7 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false dis
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -3190,6 +3239,7 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false foc
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3255,6 +3305,7 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false hov
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3320,6 +3371,7 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3382,6 +3434,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -3447,6 +3500,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3512,6 +3566,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3577,6 +3632,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3639,6 +3695,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -3704,6 +3761,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3769,6 +3827,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3834,6 +3893,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -3896,6 +3956,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
     }
   }
   tabIndex={-1}
+  type="button"
 >
   <svg
     className=""
@@ -3961,6 +4022,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -4026,6 +4088,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""
@@ -4091,6 +4154,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
     }
   }
   tabIndex={0}
+  type="button"
 >
   <svg
     className=""

--- a/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
@@ -60,6 +60,7 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <svg
       className=""
@@ -119,6 +120,7 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <svg
       className=""
@@ -178,6 +180,7 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <svg
       className=""
@@ -238,6 +241,7 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
       }
     }
     tabIndex={-1}
+    type="button"
   >
     <svg
       className=""
@@ -320,6 +324,7 @@ exports[`wonder-blocks-icon-button example 2 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <svg
       className=""

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -58,12 +58,6 @@ const StyledLink = addStyle(Link);
 export default class IconButtonCore extends React.Component<Props> {
     static contextTypes = {router: PropTypes.any};
 
-    handleClick = (e: SyntheticEvent<>) => {
-        if (this.props.disabled) {
-            e.preventDefault();
-        }
-    };
-
     render() {
         const {
             skipClientNav,
@@ -113,25 +107,21 @@ export default class IconButtonCore extends React.Component<Props> {
 
         if (href) {
             return router && !skipClientNav ? (
-                <StyledLink
-                    {...commonProps}
-                    onClick={this.handleClick}
-                    to={href}
-                >
+                <StyledLink {...commonProps} to={href}>
                     {child}
                 </StyledLink>
             ) : (
-                <StyledAnchor
-                    {...commonProps}
-                    onClick={this.handleClick}
-                    href={href}
-                >
+                <StyledAnchor {...commonProps} href={href}>
                     {child}
                 </StyledAnchor>
             );
         } else {
             return (
-                <StyledButton {...commonProps} disabled={disabled}>
+                <StyledButton
+                    type="button"
+                    {...commonProps}
+                    disabled={disabled}
+                >
                     {child}
                 </StyledButton>
             );

--- a/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
@@ -36,6 +36,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -63,6 +64,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -127,6 +129,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -154,6 +157,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -218,6 +222,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -245,6 +250,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -304,6 +310,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -331,6 +338,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -395,6 +403,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -422,6 +431,7 @@ exports[`wonder-blocks-layout example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -124,7 +124,12 @@ export default class Link extends React.Component<SharedProps> {
         );
 
         return (
-            <ClickableBehavior disabled={false} onClick={onClick} href={href}>
+            <ClickableBehavior
+                disabled={false}
+                onClick={onClick}
+                href={href}
+                triggerOnSpace={false}
+            >
                 {(state, handlers) => {
                     return (
                         <LinkCore

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -35,6 +35,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -61,6 +62,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -100,6 +102,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -126,6 +129,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -165,6 +169,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="button"
     style={
       Object {
         "::MozFocusInner": Object {
@@ -191,6 +196,7 @@ exports[`wonder-blocks-modal example 1 1`] = `
       }
     }
     tabIndex={0}
+    type="button"
   >
     <span
       className=""
@@ -375,6 +381,7 @@ exports[`wonder-blocks-modal example 2 1`] = `
               }
             }
             tabIndex={0}
+            type="button"
           >
             <svg
               className=""
@@ -711,6 +718,7 @@ exports[`wonder-blocks-modal example 2 1`] = `
               onTouchCancel={[Function]}
               onTouchEnd={[Function]}
               onTouchStart={[Function]}
+              role="button"
               style={
                 Object {
                   "::MozFocusInner": Object {
@@ -927,6 +935,7 @@ exports[`wonder-blocks-modal example 3 1`] = `
               }
             }
             tabIndex={0}
+            type="button"
           >
             <svg
               className=""
@@ -1309,6 +1318,7 @@ exports[`wonder-blocks-modal example 3 1`] = `
               onTouchCancel={[Function]}
               onTouchEnd={[Function]}
               onTouchStart={[Function]}
+              role="button"
               style={
                 Object {
                   "::MozFocusInner": Object {
@@ -1525,6 +1535,7 @@ exports[`wonder-blocks-modal example 4 1`] = `
               }
             }
             tabIndex={0}
+            type="button"
           >
             <svg
               className=""
@@ -1907,6 +1918,7 @@ exports[`wonder-blocks-modal example 4 1`] = `
               onTouchCancel={[Function]}
               onTouchEnd={[Function]}
               onTouchStart={[Function]}
+              role="button"
               style={
                 Object {
                   "::MozFocusInner": Object {
@@ -2259,6 +2271,7 @@ exports[`wonder-blocks-modal example 5 1`] = `
               }
             }
             tabIndex={0}
+            type="button"
           >
             <svg
               className=""
@@ -2707,6 +2720,7 @@ exports[`wonder-blocks-modal example 5 1`] = `
               onTouchCancel={[Function]}
               onTouchEnd={[Function]}
               onTouchStart={[Function]}
+              role="button"
               style={
                 Object {
                   "::MozFocusInner": Object {
@@ -2944,6 +2958,7 @@ exports[`wonder-blocks-modal example 6 1`] = `
                 }
               }
               tabIndex={0}
+              type="button"
             >
               <svg
                 className=""
@@ -3380,6 +3395,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
                 }
               }
               tabIndex={0}
+              type="button"
             >
               <svg
                 className=""
@@ -3709,6 +3725,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
                 onTouchCancel={[Function]}
                 onTouchEnd={[Function]}
                 onTouchStart={[Function]}
+                role="button"
                 style={
                   Object {
                     "::MozFocusInner": Object {
@@ -3735,6 +3752,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
                   }
                 }
                 tabIndex={0}
+                type="button"
               >
                 <span
                   className=""
@@ -3946,6 +3964,7 @@ exports[`wonder-blocks-modal example 8 1`] = `
                 }
               }
               tabIndex={0}
+              type="button"
             >
               <svg
                 className=""
@@ -4267,6 +4286,7 @@ exports[`wonder-blocks-modal example 9 1`] = `
                 }
               }
               tabIndex={0}
+              type="button"
             >
               <svg
                 className=""
@@ -4575,6 +4595,7 @@ exports[`wonder-blocks-modal example 10 1`] = `
                 }
               }
               tabIndex={0}
+              type="button"
             >
               <svg
                 className=""
@@ -4758,6 +4779,7 @@ exports[`wonder-blocks-modal example 10 1`] = `
               onTouchCancel={[Function]}
               onTouchEnd={[Function]}
               onTouchStart={[Function]}
+              role="button"
               style={
                 Object {
                   "::MozFocusInner": Object {
@@ -4784,6 +4806,7 @@ exports[`wonder-blocks-modal example 10 1`] = `
                 }
               }
               tabIndex={0}
+              type="button"
             >
               <span
                 className=""

--- a/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
@@ -142,6 +142,7 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
           onTouchCancel={[Function]}
           onTouchEnd={[Function]}
           onTouchStart={[Function]}
+          role="button"
           style={
             Object {
               "::MozFocusInner": Object {
@@ -169,6 +170,7 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
             }
           }
           tabIndex={0}
+          type="button"
         >
           <span
             className=""
@@ -228,6 +230,7 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
           onTouchCancel={[Function]}
           onTouchEnd={[Function]}
           onTouchStart={[Function]}
+          role="button"
           style={
             Object {
               "::MozFocusInner": Object {
@@ -258,6 +261,7 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
             }
           }
           tabIndex={0}
+          type="button"
         >
           <span
             className=""
@@ -411,6 +415,7 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
             }
           }
           tabIndex={0}
+          type="button"
         >
           <svg
             className=""
@@ -666,6 +671,7 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
             }
           }
           tabIndex={0}
+          type="button"
         >
           <svg
             className=""
@@ -828,6 +834,7 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
           onTouchCancel={[Function]}
           onTouchEnd={[Function]}
           onTouchStart={[Function]}
+          role="button"
           style={
             Object {
               "::MozFocusInner": Object {
@@ -854,6 +861,7 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
             }
           }
           tabIndex={0}
+          type="button"
         >
           <span
             className=""
@@ -1062,6 +1070,7 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
           onTouchCancel={[Function]}
           onTouchEnd={[Function]}
           onTouchStart={[Function]}
+          role="button"
           style={
             Object {
               "::MozFocusInner": Object {
@@ -1092,6 +1101,7 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
             }
           }
           tabIndex={0}
+          type="button"
         >
           <span
             className=""
@@ -1151,6 +1161,7 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
           onTouchCancel={[Function]}
           onTouchEnd={[Function]}
           onTouchStart={[Function]}
+          role="button"
           style={
             Object {
               "::MozFocusInner": Object {
@@ -1178,6 +1189,7 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
             }
           }
           tabIndex={0}
+          type="button"
         >
           <span
             className=""
@@ -1331,6 +1343,7 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
             }
           }
           tabIndex={0}
+          type="button"
         >
           <svg
             className=""


### PR DESCRIPTION
After some invesigation and discussion, I wrote up [this document](https://docs.google.com/document/d/1DG5Rg2f0cawIL5R8UqnPQpd7pbdObk8OyjO5ryYQmBM/edit?usp=sharing) to describe the expected behavior of ClickableBehavior.

The main change here is to allow components that use ClickableBehavior to indicate whether they should be triggered on enter, or space, or both. This change also fixes a bug where a mouse click that directly followed a space click sometimes wasn't registered and attempts to normalize the ClickableBehavior across major browsers.

I added unit tests for the new cases, but since browsers have slightly different behavior in where event defaults happen, they're not perfect or fully comprehensive.

Test plan prereq:
* On Safari, may have to enable Preferences -> Advanced -> Check "Press Tab to highlight each item..."
* On Firefox (macOS), may have to go into System Preferences -> Keyboard -> Shortcuts -> Change Full Keyboard Access to "All controls"

Edge was the least well tested due to lagginess in BrowserStack.

Basic manual test plan (on Chrome, Firefox, Safari, Edge):
### Button
- triggers once on space (not until keyup), on enter (not until keyup), on mouse click, on touch
- also test Button with both `href` and `onClick` to make sure both happen (fixing https://khanacademy.atlassian.net/browse/WB-369)
### Link
- triggers once on enter (not until keyup), on mouse click, on touch
- space _doesn't_ trigger click but does scroll
### Checkbox
- triggers once on space, on mouse click, on touch
- doesn't trigger on enter