### PR TITLE
WB-375 Button text shouldn't wrap, WB-376 Control elements shouldn't …

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
@@ -55,7 +55,11 @@ exports[`ButtonCore kind:primary color:default size:medium light:false disabled 
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -119,7 +123,11 @@ exports[`ButtonCore kind:primary color:default size:medium light:false focused 1
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -183,7 +191,11 @@ exports[`ButtonCore kind:primary color:default size:medium light:false hovered 1
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -247,7 +259,11 @@ exports[`ButtonCore kind:primary color:default size:medium light:false pressed 1
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -311,7 +327,11 @@ exports[`ButtonCore kind:primary color:default size:medium light:true disabled 1
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -375,7 +395,11 @@ exports[`ButtonCore kind:primary color:default size:medium light:true focused 1`
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -439,7 +463,11 @@ exports[`ButtonCore kind:primary color:default size:medium light:true hovered 1`
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -503,7 +531,11 @@ exports[`ButtonCore kind:primary color:default size:medium light:true pressed 1`
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -567,7 +599,11 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -631,7 +667,11 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -695,7 +735,11 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -759,7 +803,11 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -823,7 +871,11 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -887,7 +939,11 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -951,7 +1007,11 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1015,7 +1075,11 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1079,7 +1143,11 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false disab
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1143,7 +1211,11 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false focus
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1207,7 +1279,11 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false hover
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1271,7 +1347,11 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false press
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1335,7 +1415,11 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true disabl
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1399,7 +1483,11 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true focuse
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1463,7 +1551,11 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true hovere
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1527,7 +1619,11 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true presse
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1591,7 +1687,11 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1655,7 +1755,11 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1719,7 +1823,11 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1783,7 +1891,11 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1847,7 +1959,11 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1911,7 +2027,11 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -1975,7 +2095,11 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2039,7 +2163,11 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2106,7 +2234,11 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false disable
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2172,7 +2304,11 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false focused
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2238,7 +2374,11 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false hovered
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2304,7 +2444,11 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false pressed
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2371,7 +2515,11 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true disabled
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2437,7 +2585,11 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true focused 
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2503,7 +2655,11 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true hovered 
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2569,7 +2725,11 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true pressed 
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2636,7 +2796,11 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2702,7 +2866,11 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2768,7 +2936,11 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2834,7 +3006,11 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2901,7 +3077,11 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -2967,7 +3147,11 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3033,7 +3217,11 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3099,7 +3287,11 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3166,7 +3358,11 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false dis
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3232,7 +3428,11 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false foc
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3298,7 +3498,11 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false hov
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3364,7 +3568,11 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false pre
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3431,7 +3639,11 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true disa
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3497,7 +3709,11 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true focu
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3563,7 +3779,11 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true hove
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3629,7 +3849,11 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true pres
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3696,7 +3920,11 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3762,7 +3990,11 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3828,7 +4060,11 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3894,7 +4130,11 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -3961,7 +4201,11 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4027,7 +4271,11 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4093,7 +4341,11 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4159,7 +4411,11 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4223,7 +4479,11 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false disabled
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4295,7 +4555,11 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false focused 
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4367,7 +4631,11 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false hovered 
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4439,7 +4707,11 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false pressed 
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4503,7 +4775,11 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true disabled 
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4575,7 +4851,11 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true focused 1
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4647,7 +4927,11 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true hovered 1
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4719,7 +5003,11 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true pressed 1
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4783,7 +5071,11 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4855,7 +5147,11 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4927,7 +5223,11 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -4999,7 +5299,11 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5063,7 +5367,11 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5135,7 +5443,11 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5207,7 +5519,11 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5279,7 +5595,11 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5343,7 +5663,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false disa
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5415,7 +5739,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false focu
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5487,7 +5815,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false hove
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5559,7 +5891,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false pres
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5623,7 +5959,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true disab
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5695,7 +6035,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true focus
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5767,7 +6111,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true hover
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5839,7 +6187,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true press
         "fontSize": 16,
         "fontWeight": "bold",
         "lineHeight": "20px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5903,7 +6255,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -5975,7 +6331,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -6047,7 +6407,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -6119,7 +6483,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -6183,7 +6551,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -6255,7 +6627,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -6327,7 +6703,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >
@@ -6399,7 +6779,11 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
         "fontSize": 14,
         "fontWeight": "bold",
         "lineHeight": "18px",
+        "overflow": "hidden",
         "pointerEvents": "none",
+        "textOverflow": "ellipsis",
+        "userSelect": "none",
+        "whiteSpace": "nowrap",
       }
     }
   >

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -74,7 +74,11 @@ exports[`wonder-blocks-button example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -138,7 +142,11 @@ exports[`wonder-blocks-button example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -199,7 +207,11 @@ exports[`wonder-blocks-button example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -283,7 +295,11 @@ exports[`wonder-blocks-button example 2 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -347,7 +363,11 @@ exports[`wonder-blocks-button example 2 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -408,7 +428,11 @@ exports[`wonder-blocks-button example 2 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -493,7 +517,11 @@ exports[`wonder-blocks-button example 3 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -558,7 +586,11 @@ exports[`wonder-blocks-button example 3 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -620,7 +652,11 @@ exports[`wonder-blocks-button example 3 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -705,7 +741,11 @@ exports[`wonder-blocks-button example 4 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -769,7 +809,11 @@ exports[`wonder-blocks-button example 4 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -830,7 +874,11 @@ exports[`wonder-blocks-button example 4 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -892,7 +940,11 @@ exports[`wonder-blocks-button example 4 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -957,7 +1009,11 @@ exports[`wonder-blocks-button example 4 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1019,7 +1075,11 @@ exports[`wonder-blocks-button example 4 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1103,7 +1163,11 @@ exports[`wonder-blocks-button example 5 1`] = `
           "fontSize": 14,
           "fontWeight": "bold",
           "lineHeight": "18px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1167,7 +1231,11 @@ exports[`wonder-blocks-button example 5 1`] = `
           "fontSize": 14,
           "fontWeight": "bold",
           "lineHeight": "18px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1228,7 +1296,11 @@ exports[`wonder-blocks-button example 5 1`] = `
           "fontSize": 14,
           "fontWeight": "bold",
           "lineHeight": "18px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1308,7 +1380,11 @@ exports[`wonder-blocks-button example 6 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1372,7 +1448,11 @@ exports[`wonder-blocks-button example 6 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1429,7 +1509,11 @@ exports[`wonder-blocks-button example 6 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1509,7 +1593,11 @@ exports[`wonder-blocks-button example 7 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1566,7 +1654,11 @@ exports[`wonder-blocks-button example 7 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1649,7 +1741,11 @@ exports[`wonder-blocks-button example 8 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -1751,7 +1847,11 @@ exports[`wonder-blocks-button example 9 1`] = `
             "fontSize": 16,
             "fontWeight": "bold",
             "lineHeight": "20px",
+            "overflow": "hidden",
             "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -1851,7 +1951,11 @@ exports[`wonder-blocks-button example 9 1`] = `
             "fontSize": 16,
             "fontWeight": "bold",
             "lineHeight": "20px",
+            "overflow": "hidden",
             "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -1940,7 +2044,11 @@ exports[`wonder-blocks-button example 10 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -2002,7 +2110,11 @@ exports[`wonder-blocks-button example 10 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -2105,7 +2217,11 @@ exports[`wonder-blocks-button example 11 1`] = `
             "fontSize": 16,
             "fontWeight": "bold",
             "lineHeight": "20px",
+            "overflow": "hidden",
             "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -2165,7 +2281,11 @@ exports[`wonder-blocks-button example 11 1`] = `
             "fontSize": 16,
             "fontWeight": "bold",
             "lineHeight": "20px",
+            "overflow": "hidden",
             "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -138,6 +138,10 @@ const sharedStyles = StyleSheet.create({
     },
     text: {
         fontWeight: "bold",
+        userSelect: "none",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
         pointerEvents: "none", // fix Safari bug where the browser was eating mouse events
     },
 });

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -363,13 +363,14 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-Layouts often specify a specific width of button.  When implementing such
-designs use `minWidth` instead of `width`.  `minWidth` allows the button
-to resize to fit the content whereas `width` does not.  This is important
+Layouts often specify a specific width of button. When implementing such
+designs use `minWidth` instead of `width`. `minWidth` allows the button
+to resize to fit the content whereas `width` does not. This is important
 for international sites since sometimes strings for UI elements can be much
-longer in other languages.  Both of the buttons below have a "natural" width
-of 144px.  The one on the right is wider but it accommodates the full string
-instead of wrapping or truncating it.
+longer in other languages. Both of the buttons below have a "natural" width
+of 144px. The one on the right is wider but it accommodates the full string
+instead of wrapping it. Try to avoid setting a `maxWidth`, but if one is set,
+the text truncates.
 ```jsx
 const {View} = require("@khanacademy/wonder-blocks-core");
 const {StyleSheet} = require("aphrodite");

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -369,8 +369,8 @@ to resize to fit the content whereas `width` does not. This is important
 for international sites since sometimes strings for UI elements can be much
 longer in other languages. Both of the buttons below have a "natural" width
 of 144px. The one on the right is wider but it accommodates the full string
-instead of wrapping it. Try to avoid setting a `maxWidth`, but if one is set,
-the text truncates.
+instead of wrapping it. Note that if the parent container of the button doesn't
+have enough room to accommodate the width of the button, the text will truncate.
 ```jsx
 const {View} = require("@khanacademy/wonder-blocks-core");
 const {StyleSheet} = require("aphrodite");

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -232,7 +232,11 @@ exports[`wonder-blocks-core example 4 1`] = `
             "fontSize": 16,
             "fontWeight": "bold",
             "lineHeight": "20px",
+            "overflow": "hidden",
             "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -74,12 +74,15 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
           "justifyContent": "center",
           "margin": 0,
           "outline": "none",
+          "overflow": "hidden",
           "paddingBottom": 0,
           "paddingLeft": 8,
           "paddingRight": 8,
           "paddingTop": 0,
           "position": "relative",
           "textDecoration": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
           "whiteSpace": "nowrap",
         }
       }
@@ -96,7 +99,11 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
             "fontSize": 16,
             "fontWeight": "bold",
             "lineHeight": "20px",
+            "overflow": "hidden",
             "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -198,12 +205,15 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
           "justifyContent": "center",
           "margin": 0,
           "outline": "none",
+          "overflow": "hidden",
           "paddingBottom": 0,
           "paddingLeft": 8,
           "paddingRight": 8,
           "paddingTop": 0,
           "position": "relative",
           "textDecoration": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
           "whiteSpace": "nowrap",
         }
       }
@@ -220,7 +230,11 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
             "fontSize": 16,
             "fontWeight": "bold",
             "lineHeight": "20px",
+            "overflow": "hidden",
             "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -348,6 +362,8 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
             "lineHeight": "20px",
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -382,7 +398,9 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
             "minWidth": 16,
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
             "verticalAlign": "text-bottom",
+            "whiteSpace": "nowrap",
           }
         }
         viewBox="0 0 16 16"
@@ -495,6 +513,8 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
             "lineHeight": "20px",
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -528,7 +548,9 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
             "minWidth": 16,
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
             "verticalAlign": "text-bottom",
+            "whiteSpace": "nowrap",
           }
         }
         viewBox="0 0 16 16"
@@ -643,6 +665,8 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
             "lineHeight": "20px",
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -677,7 +701,9 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
             "minWidth": 16,
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
             "verticalAlign": "text-bottom",
+            "whiteSpace": "nowrap",
           }
         }
         viewBox="0 0 16 16"
@@ -813,6 +839,8 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
               "lineHeight": "20px",
               "overflow": "hidden",
               "textOverflow": "ellipsis",
+              "userSelect": "none",
+              "whiteSpace": "nowrap",
             }
           }
         >
@@ -847,7 +875,9 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
               "minWidth": 16,
               "overflow": "hidden",
               "textOverflow": "ellipsis",
+              "userSelect": "none",
               "verticalAlign": "text-bottom",
+              "whiteSpace": "nowrap",
             }
           }
           viewBox="0 0 16 16"
@@ -962,6 +992,8 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
             "lineHeight": "20px",
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -996,7 +1028,9 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
             "minWidth": 16,
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
             "verticalAlign": "text-bottom",
+            "whiteSpace": "nowrap",
           }
         }
         viewBox="0 0 16 16"
@@ -1109,6 +1143,8 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
             "lineHeight": "20px",
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
           }
         }
       >
@@ -1142,7 +1178,9 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
             "minWidth": 16,
             "overflow": "hidden",
             "textOverflow": "ellipsis",
+            "userSelect": "none",
             "verticalAlign": "text-bottom",
+            "whiteSpace": "nowrap",
           }
         }
         viewBox="0 0 16 16"
@@ -1231,7 +1269,11 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -191,6 +191,7 @@ const styles = StyleSheet.create({
 
     label: {
         whiteSpace: "nowrap",
+        userSelect: "none",
     },
 
     indent: {

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -228,6 +228,9 @@ const styles = StyleSheet.create({
         paddingLeft: 8,
         paddingRight: 8,
         whiteSpace: "nowrap",
+        userSelect: "none",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
     },
 
     // This is to adjust the space between the menu and the opener.

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -169,6 +169,7 @@ const styles = StyleSheet.create({
 
     label: {
         whiteSpace: "nowrap",
+        userSelect: "none",
         marginLeft: Spacing.xSmall,
     },
 

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -159,6 +159,8 @@ const styles = StyleSheet.create({
     },
 
     text: {
+        whiteSpace: "nowrap",
+        userSelect: "none",
         overflow: "hidden",
         textOverflow: "ellipsis",
     },

--- a/packages/wonder-blocks-form/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/__snapshots__/generated-snapshot.test.js.snap
@@ -867,6 +867,7 @@ exports[`wonder-blocks-form example 2 1`] = `
             "fontWeight": 400,
             "lineHeight": "20px",
             "marginTop": -2,
+            "userSelect": "none",
           }
         }
       >
@@ -2012,6 +2013,7 @@ exports[`wonder-blocks-form example 5 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -2169,6 +2171,7 @@ exports[`wonder-blocks-form example 5 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -2345,6 +2348,7 @@ exports[`wonder-blocks-form example 5 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -2502,6 +2506,7 @@ exports[`wonder-blocks-form example 5 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -2659,6 +2664,7 @@ exports[`wonder-blocks-form example 5 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -2834,6 +2840,7 @@ exports[`wonder-blocks-form example 5 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -3060,6 +3067,7 @@ exports[`wonder-blocks-form example 6 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -3219,6 +3227,7 @@ exports[`wonder-blocks-form example 6 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -3378,6 +3387,7 @@ exports[`wonder-blocks-form example 6 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -3537,6 +3547,7 @@ exports[`wonder-blocks-form example 6 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -3696,6 +3707,7 @@ exports[`wonder-blocks-form example 6 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -3855,6 +3867,7 @@ exports[`wonder-blocks-form example 6 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -4105,6 +4118,7 @@ exports[`wonder-blocks-form example 7 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -4264,6 +4278,7 @@ exports[`wonder-blocks-form example 7 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -4440,6 +4455,7 @@ exports[`wonder-blocks-form example 7 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -4597,6 +4613,7 @@ exports[`wonder-blocks-form example 7 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >
@@ -4754,6 +4771,7 @@ exports[`wonder-blocks-form example 7 1`] = `
                 "fontWeight": 400,
                 "lineHeight": "20px",
                 "marginTop": -2,
+                "userSelect": "none",
               }
             }
           >

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -57,8 +57,7 @@ type Props = {|
  * and RadioGroup. This design allows for more explicit prop typing. For
  * example, we can make onChange a required prop on Checkbox but not on Choice
  * (because for Choice, that prop would be auto-populated by CheckboxGroup).
- */
-export default class ChoiceInternal extends React.Component<Props> {
+ */ export default class ChoiceInternal extends React.Component<Props> {
     static defaultProps = {
         checked: false,
         disabled: false,
@@ -87,7 +86,6 @@ export default class ChoiceInternal extends React.Component<Props> {
             return CheckboxCore;
         }
     }
-
     getLabel() {
         const {disabled, id, label} = this.props;
         return (
@@ -100,14 +98,12 @@ export default class ChoiceInternal extends React.Component<Props> {
             </LabelMedium>
         );
     }
-
     getDescription() {
         const {description} = this.props;
         return (
             <LabelSmall style={styles.description}>{description}</LabelSmall>
         );
     }
-
     render() {
         const {
             label,
@@ -157,19 +153,17 @@ const styles = StyleSheet.create({
         alignItems: "flex-start",
         outline: "none",
     },
-
     label: {
+        userSelect: "none",
         // NOTE: The checkbox/radio button (height 16px) should be center
         // aligned with the first line of the label. However, LabelMedium has a
         // declared line height of 20px, so we need to adjust the top to get the
         // desired alignment.
         marginTop: -2,
     },
-
     disabledLabel: {
         color: Color.offBlack32,
     },
-
     description: {
         // 16 for icon + 8 for spacing strut
         marginLeft: Spacing.medium + Spacing.xSmall,

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -57,7 +57,8 @@ type Props = {|
  * and RadioGroup. This design allows for more explicit prop typing. For
  * example, we can make onChange a required prop on Checkbox but not on Choice
  * (because for Choice, that prop would be auto-populated by CheckboxGroup).
- */ export default class ChoiceInternal extends React.Component<Props> {
+ */
+export default class ChoiceInternal extends React.Component<Props> {
     static defaultProps = {
         checked: false,
         disabled: false,
@@ -86,6 +87,7 @@ type Props = {|
             return CheckboxCore;
         }
     }
+
     getLabel() {
         const {disabled, id, label} = this.props;
         return (
@@ -98,12 +100,14 @@ type Props = {|
             </LabelMedium>
         );
     }
+
     getDescription() {
         const {description} = this.props;
         return (
             <LabelSmall style={styles.description}>{description}</LabelSmall>
         );
     }
+
     render() {
         const {
             label,
@@ -147,12 +151,14 @@ type Props = {|
         );
     }
 }
+
 const styles = StyleSheet.create({
     wrapper: {
         flexDirection: "row",
         alignItems: "flex-start",
         outline: "none",
     },
+
     label: {
         userSelect: "none",
         // NOTE: The checkbox/radio button (height 16px) should be center
@@ -161,9 +167,11 @@ const styles = StyleSheet.create({
         // desired alignment.
         marginTop: -2,
     },
+
     disabledLabel: {
         color: Color.offBlack32,
     },
+
     description: {
         // 16 for icon + 8 for spacing strut
         marginLeft: Spacing.medium + Spacing.xSmall,

--- a/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
@@ -75,7 +75,11 @@ exports[`wonder-blocks-layout example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -162,7 +166,11 @@ exports[`wonder-blocks-layout example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -249,7 +257,11 @@ exports[`wonder-blocks-layout example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -331,7 +343,11 @@ exports[`wonder-blocks-layout example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -418,7 +434,11 @@ exports[`wonder-blocks-layout example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -73,7 +73,11 @@ exports[`wonder-blocks-modal example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -134,7 +138,11 @@ exports[`wonder-blocks-modal example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -195,7 +203,11 @@ exports[`wonder-blocks-modal example 1 1`] = `
           "fontSize": 16,
           "fontWeight": "bold",
           "lineHeight": "20px",
+          "overflow": "hidden",
           "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "userSelect": "none",
+          "whiteSpace": "nowrap",
         }
       }
     >
@@ -738,7 +750,11 @@ exports[`wonder-blocks-modal example 2 1`] = `
                     "fontSize": 16,
                     "fontWeight": "bold",
                     "lineHeight": "20px",
+                    "overflow": "hidden",
                     "pointerEvents": "none",
+                    "textOverflow": "ellipsis",
+                    "userSelect": "none",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >
@@ -1332,7 +1348,11 @@ exports[`wonder-blocks-modal example 3 1`] = `
                     "fontSize": 16,
                     "fontWeight": "bold",
                     "lineHeight": "20px",
+                    "overflow": "hidden",
                     "pointerEvents": "none",
+                    "textOverflow": "ellipsis",
+                    "userSelect": "none",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >
@@ -1926,7 +1946,11 @@ exports[`wonder-blocks-modal example 4 1`] = `
                     "fontSize": 16,
                     "fontWeight": "bold",
                     "lineHeight": "20px",
+                    "overflow": "hidden",
                     "pointerEvents": "none",
+                    "textOverflow": "ellipsis",
+                    "userSelect": "none",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >
@@ -2722,7 +2746,11 @@ exports[`wonder-blocks-modal example 5 1`] = `
                     "fontSize": 16,
                     "fontWeight": "bold",
                     "lineHeight": "20px",
+                    "overflow": "hidden",
                     "pointerEvents": "none",
+                    "textOverflow": "ellipsis",
+                    "userSelect": "none",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >
@@ -3719,7 +3747,11 @@ exports[`wonder-blocks-modal example 7 1`] = `
                       "fontSize": 16,
                       "fontWeight": "bold",
                       "lineHeight": "20px",
+                      "overflow": "hidden",
                       "pointerEvents": "none",
+                      "textOverflow": "ellipsis",
+                      "userSelect": "none",
+                      "whiteSpace": "nowrap",
                     }
                   }
                 >
@@ -4764,7 +4796,11 @@ exports[`wonder-blocks-modal example 10 1`] = `
                     "fontSize": 16,
                     "fontWeight": "bold",
                     "lineHeight": "20px",
+                    "overflow": "hidden",
                     "pointerEvents": "none",
+                    "textOverflow": "ellipsis",
+                    "userSelect": "none",
+                    "whiteSpace": "nowrap",
                   }
                 }
               >

--- a/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
@@ -181,7 +181,11 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
                 "fontSize": 14,
                 "fontWeight": "bold",
                 "lineHeight": "18px",
+                "overflow": "hidden",
                 "pointerEvents": "none",
+                "textOverflow": "ellipsis",
+                "userSelect": "none",
+                "whiteSpace": "nowrap",
               }
             }
           >
@@ -266,7 +270,11 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
                 "fontSize": 14,
                 "fontWeight": "bold",
                 "lineHeight": "18px",
+                "overflow": "hidden",
                 "pointerEvents": "none",
+                "textOverflow": "ellipsis",
+                "userSelect": "none",
+                "whiteSpace": "nowrap",
               }
             }
           >
@@ -858,7 +866,11 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
                 "fontSize": 16,
                 "fontWeight": "bold",
                 "lineHeight": "20px",
+                "overflow": "hidden",
                 "pointerEvents": "none",
+                "textOverflow": "ellipsis",
+                "userSelect": "none",
+                "whiteSpace": "nowrap",
               }
             }
           >
@@ -1092,7 +1104,11 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
                 "fontSize": 16,
                 "fontWeight": "bold",
                 "lineHeight": "20px",
+                "overflow": "hidden",
                 "pointerEvents": "none",
+                "textOverflow": "ellipsis",
+                "userSelect": "none",
+                "whiteSpace": "nowrap",
               }
             }
           >
@@ -1174,7 +1190,11 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
                 "fontSize": 16,
                 "fontWeight": "bold",
                 "lineHeight": "20px",
+                "overflow": "hidden",
                 "pointerEvents": "none",
+                "textOverflow": "ellipsis",
+                "userSelect": "none",
+                "whiteSpace": "nowrap",
               }
             }
           >


### PR DESCRIPTION
…have selectable text

I went over the dicussion [here](https://ux.stackexchange.com/questions/83184/is-user-select-none-bad-ux) and particularly this paragraph
> The goal in employing user-select: none should always be limited to reducing user frustration from unintended selections resulting from interaction that can easily cause them when attempting to carry out the primary task purpose of a control it is used on.

to determine which existing elements to add `user-select: none` to. Those ended up being Button, ActionMenuOpener, SelectOpener, menu items, and Choice labels.

The potentially debatable one would be the Choice labels, as clicking directly on the checkbox / radio button avoids this issue.

Button no longer wraps, but it also truncates if it's long and there's a `maxWidth` set. The documentation warns against setting this, however.