### PR TITLE
Make sure we take overflow visible into account when calculating intersections

### DIFF
--- a/packages/wonder-blocks-core/util/get-element-intersection.js
+++ b/packages/wonder-blocks-core/util/get-element-intersection.js
@@ -66,19 +66,29 @@ function getElementIntersectionAgainstParent(
     intersectingRect: ClientRect | DOMRect,
     boundsElement: Element,
 ): Intersection {
+    // We need to check that it matters if we're out of bounds. If the parent
+    // element isn't clipping or otherwise hiding things outside its bounds,
+    // then checking against bounds isn't going to be much use.
+    // So, let's get the style for the element and use the overflow values.
+    const style =
+        ((boundsElement: any).currentStyle: ?CSSStyleDeclaration) ||
+        window.getComputedStyle(boundsElement);
+
     const boundsRect = boundsElement.getBoundingClientRect();
 
-    const horizontal = getAxisIntersection(
-        intersectingRect,
-        boundsRect,
-        "horizontal",
-    );
+    // We assume we're within this specific bounds element if it's overflow is
+    // visible.
+    const horizontal =
+        style.overflowX === "visible"
+            ? "within"
+            : getAxisIntersection(intersectingRect, boundsRect, "horizontal");
 
-    const vertical = getAxisIntersection(
-        intersectingRect,
-        boundsRect,
-        "vertical",
-    );
+    // We assume we're within this specific bounds element if it's overflow is
+    // visible.
+    const vertical =
+        style.overflowY === "visible"
+            ? "within"
+            : getAxisIntersection(intersectingRect, boundsRect, "vertical");
 
     return {horizontal, vertical};
 }

--- a/packages/wonder-blocks-core/util/get-element-intersection.test.js
+++ b/packages/wonder-blocks-core/util/get-element-intersection.test.js
@@ -79,7 +79,13 @@ describe("getElementIntersection", () => {
             // First, let's fake out some scroll parent.
             // Flow doesn't like jest mocks $FlowFixMe
             enumerateScrollAncestors.mockImplementation(() => [
-                {getBoundingClientRect: jest.fn(() => rect(0, 100, 100, 0))},
+                {
+                    getBoundingClientRect: jest.fn(() => rect(0, 100, 100, 0)),
+                    currentStyle: {
+                        overflowX: "auto",
+                        overflowY: "auto",
+                    },
+                },
             ]);
             const ref = await new Promise((resolve) => {
                 const nodes = (
@@ -113,6 +119,10 @@ describe("getElementIntersection", () => {
                         getBoundingClientRect: jest.fn(() =>
                             rect(0, 100, 100, 0),
                         ),
+                        currentStyle: {
+                            overflowX: "auto",
+                            overflowY: "auto",
+                        },
                     },
                 ]);
                 const ref = await new Promise((resolve) => {
@@ -148,6 +158,10 @@ describe("getElementIntersection", () => {
                         getBoundingClientRect: jest.fn(() =>
                             rect(0, 100, 100, 0),
                         ),
+                        currentStyle: {
+                            overflowX: "auto",
+                            overflowY: "auto",
+                        },
                     },
                 ]);
                 const ref = await new Promise((resolve) => {
@@ -185,6 +199,10 @@ describe("getElementIntersection", () => {
                         getBoundingClientRect: jest.fn(() =>
                             rect(0, 100, 100, 0),
                         ),
+                        currentStyle: {
+                            overflowX: "auto",
+                            overflowY: "auto",
+                        },
                     },
                 ]);
                 const ref = await new Promise((resolve) => {
@@ -220,6 +238,10 @@ describe("getElementIntersection", () => {
                         getBoundingClientRect: jest.fn(() =>
                             rect(0, 100, 100, 0),
                         ),
+                        currentStyle: {
+                            overflowX: "auto",
+                            overflowY: "auto",
+                        },
                     },
                 ]);
                 const ref = await new Promise((resolve) => {
@@ -252,7 +274,13 @@ describe("getElementIntersection", () => {
             // First, let's fake out some scroll parent.
             // Flow doesn't like jest mocks $FlowFixMe
             enumerateScrollAncestors.mockImplementation(() => [
-                {getBoundingClientRect: jest.fn(() => rect(0, 100, 100, 0))},
+                {
+                    getBoundingClientRect: jest.fn(() => rect(0, 100, 100, 0)),
+                    currentStyle: {
+                        overflowX: "auto",
+                        overflowY: "auto",
+                    },
+                },
             ]);
             const ref = await new Promise((resolve) => {
                 const nodes = (
@@ -278,13 +306,62 @@ describe("getElementIntersection", () => {
             });
         });
 
+        test("element is before or after, but parent overflow is visible, returns within", async () => {
+            // Arrange
+            // First, let's fake out some scroll parent.
+            // Flow doesn't like jest mocks $FlowFixMe
+            enumerateScrollAncestors.mockImplementation(() => [
+                {
+                    getBoundingClientRect: jest.fn(() => rect(0, 100, 100, 0)),
+                    currentStyle: {
+                        overflowX: "visible",
+                        overflowY: "visible",
+                    },
+                },
+            ]);
+            const ref = await new Promise((resolve) => {
+                const nodes = (
+                    <div>
+                        <div ref={resolve}>Test</div>
+                    </div>
+                );
+
+                mount(nodes);
+            });
+            const element = (ReactDOM.findDOMNode(ref): any);
+            element.getBoundingClientRect = jest.fn(() =>
+                rect(-50, 150, -25, 125),
+            );
+
+            // Act
+            const result = getElementIntersection(element);
+
+            // Assert
+            expect(result).toMatchObject({
+                horizontal: "within",
+                vertical: "within",
+            });
+        });
+
         test("multiple scroll ancestors, stops enumeration on first before/after", async () => {
             // Arrange
             // First, let's fake out some scroll parent.
             // Flow doesn't like jest mocks $FlowFixMe
             enumerateScrollAncestors.mockImplementation(() => [
-                {getBoundingClientRect: jest.fn(() => rect(0, 100, 100, 0))},
-                {getBoundingClientRect: jest.fn(() => rect(50, 200, 250, 0))},
+                {
+                    getBoundingClientRect: jest.fn(() => rect(0, 100, 100, 0)),
+                    currentStyle: {
+                        overflowX: "auto",
+                        overflowY: "auto",
+                    },
+                },
+                {
+                    getBoundingClientRect: jest.fn(() => rect(50, 200, 250, 0)),
+                    currentStyle: {
+                        overflowX: "auto",
+                        overflowY: "auto",
+                    },
+                },
                 null,
             ]);
             const ref = await new Promise((resolve) => {
@@ -312,6 +389,10 @@ describe("getElementIntersection", () => {
             // Arrange
             const fakeParentElement = ({
                 getBoundingClientRect: jest.fn(() => rect(0, 100, 100, 0)),
+                currentStyle: {
+                    overflowX: "auto",
+                    overflowY: "auto",
+                },
             }: any);
             const ref = await new Promise((resolve) => {
                 const nodes = (


### PR DESCRIPTION
This addresses an issue we found when integrating the `Tooltip` component with webapp. The bounds checking used to detect visibility did not take into account that regardless of parent element bounds, the anchor may still be visible if the parent has `overflow` set to `visible` for the relevant axis.

This fixes that. We also update all the tests to make sure they have overflow styles to look at and we add a new test case for this new behaviour.