### PR TITLE
WIP: ProviderGroup component wrt ADR-77

### DIFF
--- a/packages/wonder-blocks-core/components/provider-group.js
+++ b/packages/wonder-blocks-core/components/provider-group.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from "react";
+
+type Provider<P> = {|
+    type: React.ComponentType<P>,
+    props?: P,
+|};
+
+type Props = {|
+    providers: Array<Provider<any>>,
+    children: (Array<any>) => React.Node,
+|};
+
+export default class ProviderGroup extends React.Component<Props> {
+    render() {
+        const {providers, children} = this.props;
+        const provided = [];
+        let i = 0;
+        const buildProviders = (...args) => {
+            if (i > 0) {
+                provided.push(...args);
+            }
+            if (i < providers.length) {
+                const providerEl = React.createElement(providers[i].type, {
+                    ...providers[i].props,
+                    children: buildProviders,
+                });
+                i++;
+                return providerEl;
+            } else {
+                return children(provided);
+            }
+        };
+
+        return buildProviders();
+    }
+}

--- a/packages/wonder-blocks-core/components/provider-group.test.js
+++ b/packages/wonder-blocks-core/components/provider-group.test.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from "react";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
+
+import UniqueIDProvider from "./unique-id-provider.js";
+import ProviderGroup from "./provider-group.js";
+
+describe("ProviderGroup", () => {
+    afterEach(() => {
+        unmountAll();
+    });
+
+    test("provides values to children from specified providers", () => {
+        // Arrange
+        const gatherer = jest.fn((...args) => {
+            // eslint-disable-next-line no-console
+            console.log(args[0]);
+            return "Gathered";
+        });
+        const providers = [
+            {type: UniqueIDProvider, props: {}},
+            {type: UniqueIDProvider, props: {scope: "test"}},
+        ];
+        const underTest = (
+            <ProviderGroup providers={providers}>
+                {(...args) => gatherer(args)}
+            </ProviderGroup>
+        );
+
+        // Act
+        mount(underTest);
+
+        // Assert
+        expect(gatherer).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -11,6 +11,7 @@ jest.mock("react-dom");
 import ClickableBehavior from "./components/clickable-behavior.js";
 import MediaLayout from "./components/media-layout.js";
 import NoSSR from "./components/no-ssr.js";
+import ProviderGroup from "./components/provider-group.js";
 import Text from "./components/text.js";
 import UniqueIDProvider from "./components/unique-id-provider.js";
 import View from "./components/view.js";


### PR DESCRIPTION
Thought I'd have a go at a component that can amalgamate other "provider"-style children-as-a-function (CaaF) components so that instead of deeply nested renders we can have a more flat style.

I'm not sure the types are right or not, so putting up this WIP for some feedback before this gets written up as an ADR for inclusion in Wonder Blocks (currently added to Core, but perhaps this shouldn't be Core?).

## Usage
Instead of:

```
return (
    <Provider1 myProp="value">
        {x => (
            <Provider2 myProp="value">
                {y => (
                    <ThingThatWantsXAndY prop1={x} prop2={y} />
                )}
            </Provider2>
        )}
    </Provider1>
);
```

We can do:

```
const providers = [
    {type: Provider1, props: {myProp: "value"}},
    {type: Provider2, props: {myProp: "value"}},
];

return (
    <ProviderGroup providers={providers}>
        {([x, y]) => <ThingThatWantsXAndY prop1={x} prop2={y} />}
    </ProviderGroup>
);
```

The downside here is that `x` and `y` are no longer strongly typed by flow, but instead provided as `any`. I couldn't work out how we could do that differently with flow, but I think this loss is acceptable for the cleaner nesting, since callers should know what types their providers are returning and can just reapply those types as needed.

Introducing a component like this allows us to leverage the provider-style approach for more things (like the pending ADR-77 work for implementing managed `timeout` and `interval` replacements) without driving consuming code to have deeply nested "provider" trees.