### PR TITLE
**Breaking change for Icon and IconButton** -- Add ariaLabel prop to checkbox / radio

### DIFF
--- a/packages/wonder-blocks-form/components/checkbox-core.js
+++ b/packages/wonder-blocks-form/components/checkbox-core.js
@@ -38,6 +38,7 @@ export default class CheckboxCore extends React.Component<Props> {
 
     render() {
         const {
+            ariaLabel,
             checked,
             disabled,
             error,
@@ -71,6 +72,7 @@ export default class CheckboxCore extends React.Component<Props> {
                 <StyledInput
                     type="checkbox"
                     aria-checked={checked}
+                    aria-label={ariaLabel}
                     checked={checked}
                     disabled={disabled}
                     id={id}

--- a/packages/wonder-blocks-form/components/checkbox.js
+++ b/packages/wonder-blocks-form/components/checkbox.js
@@ -28,6 +28,13 @@ type ChoiceComponentProps = {|
     onChange: (newCheckedState: boolean) => void,
 
     /**
+     * Optional label if it is not obvious from the context what the checkbox
+     * does. If the label and id props are defined, this props does not need to
+     * be provided as the label would be matched to this input.
+     */
+    ariaLabel?: string,
+
+    /**
      * Optional label for the field.
      */
     label?: string,

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -26,6 +26,13 @@ type Props = {|
     onChange: (newCheckedState: boolean) => void,
 
     /**
+     * Optional label if it is not obvious from the context what the checkbox
+     * does. If the label and id props are defined, this props does not need to
+     * be provided as the label would be matched to this input.
+     */
+    ariaLabel?: string,
+
+    /**
      * Used for accessibility purposes, where the label id should match the
      * input id.
      */

--- a/packages/wonder-blocks-form/components/radio-core.js
+++ b/packages/wonder-blocks-form/components/radio-core.js
@@ -30,6 +30,7 @@ export default class RadioCore extends React.Component<Props> {
 
     render() {
         const {
+            ariaLabel,
             checked,
             disabled,
             error,
@@ -63,6 +64,7 @@ export default class RadioCore extends React.Component<Props> {
                 <StyledInput
                     type="radio"
                     aria-checked={checked}
+                    aria-label={ariaLabel}
                     checked={checked}
                     disabled={disabled}
                     id={id}
@@ -78,6 +80,7 @@ export default class RadioCore extends React.Component<Props> {
         );
     }
 }
+
 const size = 16; // circle with a different color. Here, we add that center circle.
 
 // If the checkbox is disabled and selected, it has a border but also an inner

--- a/packages/wonder-blocks-form/components/radio.js
+++ b/packages/wonder-blocks-form/components/radio.js
@@ -28,6 +28,13 @@ type ChoiceComponentProps = {|
     onChange: (newCheckedState: boolean) => void,
 
     /**
+     * Optional label if it is not obvious from the context what the radio
+     * does. If the label and id props are defined, this props does not need to
+     * be provided as the label would be matched to this input.
+     */
+    ariaLabel?: string,
+
+    /**
      * Optional label for the field.
      */
     label?: string,

--- a/packages/wonder-blocks-form/util/types.js
+++ b/packages/wonder-blocks-form/util/types.js
@@ -12,6 +12,10 @@ export type ChoiceCoreProps = {|
     disabled: boolean,
     /** Whether this component should show an error state */
     error: boolean,
+    /** Optional label if it is not obvious from the context what the checkbox
+     * does. If the label and id props are defined, this props does not need to
+     * be provided as the label would be matched to this input. */
+    ariaLabel?: string,
     /** Name for the checkbox or radio button group */
     groupName?: string,
     /** Unique identifier attached to the HTML input element. If used, need to

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -61,6 +61,7 @@ export default class IconButtonCore extends React.Component<Props> {
     render() {
         const {
             skipClientNav,
+            ariaLabel,
             color,
             disabled,
             focused,
@@ -99,7 +100,7 @@ export default class IconButtonCore extends React.Component<Props> {
         const commonProps = {
             // TODO(kevinb): figure out a better way of forward ARIA props
             "aria-disabled": disabled ? "true" : undefined,
-            "aria-label": this.props["aria-label"],
+            "aria-label": ariaLabel,
             "data-test-id": testId,
             style: [defaultStyle, style],
             ...handlers,

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -16,7 +16,7 @@ export type SharedProps = {|
     /**
      * Text to display as the title of the svg element.
      */
-    "aria-label": string,
+    ariaLabel: string,
 
     /**
      * The color of the icon button, either blue or red.
@@ -109,7 +109,7 @@ export type SharedProps = {|
  * An IconButton is a button whose contents are an SVG image.
  *
  * To use, supply an onClick function, a wonder-blocks icon asset (see
- * the Icon section) and an aria-label to describe the button functionality.
+ * the Icon section) and an ariaLabel to describe the button functionality.
  * Optionally specify href (URL), clientSideNav, color
  * (Wonder Blocks Blue or Red), kind ("primary", "secondary", or "tertiary"),
  * light (whether the IconButton will be rendered on a dark background),
@@ -120,7 +120,7 @@ export type SharedProps = {|
  *
  * <IconButton
  *     icon={icons.anIcon}
- *     aria-label="An Icon"
+ *     ariaLabel="An Icon"
  *     onClick={(e) => console.log("Hello, world!")}
  * />
  * ```

--- a/packages/wonder-blocks-icon-button/components/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.test.js
@@ -17,7 +17,7 @@ describe("IconButton", () => {
         const wrapper = shallow(
             <IconButton
                 icon={icons.search}
-                aria-label="search"
+                ariaLabel="search"
                 onClick={() => done()}
             />,
         );
@@ -29,7 +29,7 @@ describe("IconButton", () => {
             mount(
                 <IconButton
                     icon={icons.search}
-                    aria-label="search"
+                    ariaLabel="search"
                     kind="secondary"
                     light={true}
                     onClick={() => void 0}
@@ -45,7 +45,7 @@ describe("IconButton", () => {
                 <div>
                     <IconButton
                         icon={icons.search}
-                        aria-label="search"
+                        ariaLabel="search"
                         testId="icon-button"
                         href="/foo"
                     />
@@ -75,7 +75,7 @@ describe("IconButton", () => {
                 <div>
                     <IconButton
                         icon={icons.search}
-                        aria-label="search"
+                        ariaLabel="search"
                         testId="icon-button"
                         href="/unknown"
                     />
@@ -105,7 +105,7 @@ describe("IconButton", () => {
                 <div>
                     <IconButton
                         icon={icons.search}
-                        aria-label="search"
+                        ariaLabel="search"
                         testId="icon-button"
                         href="/foo"
                         skipClientNav

--- a/packages/wonder-blocks-icon-button/custom-snapshot.test.js
+++ b/packages/wonder-blocks-icon-button/custom-snapshot.test.js
@@ -48,7 +48,7 @@ describe("IconButtonCore", () => {
                                 .create(
                                     <IconButtonCore
                                         icon={icons.search}
-                                        aria-label="search"
+                                        ariaLabel="search"
                                         kind={kind}
                                         color={color}
                                         light={light}

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -11,7 +11,7 @@ type Props = {|
      * Passed transparently to the SVG. If not provided, we assume the SVG is
      * purely decorative and it is invisible to screenreaders.
      */
-    "aria-label"?: string,
+    ariaLabel?: string,
     /**
      * The color of the icon. Will default to `currentColor`, which means that
      * it will take on the CSS `color` value from the parent element.
@@ -77,7 +77,7 @@ export default class Icon extends React.PureComponent<Props> {
     };
 
     render() {
-        const {color, icon, size, style} = this.props;
+        const {ariaLabel, color, icon, size, style} = this.props;
         const {assetSize, path} = getPathForIcon(icon, size);
         const pixelSize = viewportPixelsForSize(size);
         const viewboxPixelSize = viewportPixelsForSize(assetSize);
@@ -86,12 +86,7 @@ export default class Icon extends React.PureComponent<Props> {
                 style={[styles.svg, style]}
                 width={pixelSize}
                 height={pixelSize}
-                // There is a weird thing where Flow will only recognize a
-                // string-quoted prop name if it's in single quotes, but our
-                // tooling normalizes it to double-quotes on commit. So the
-                // aria-label prop isn't included in props validation.
-                // eslint-disable-next-line react/prop-types
-                aria-label={this.props["aria-label"]}
+                aria-label={ariaLabel}
                 viewBox={`0 0 ${viewboxPixelSize} ${viewboxPixelSize}`}
             >
                 <path fill={color} d={path} />

--- a/packages/wonder-blocks-modal/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.js
@@ -87,7 +87,7 @@ export default class ModalPanel extends React.Component<Props> {
                 <IconButton
                     icon={icons.dismiss}
                     // TODO(mdr): Translate this string for i18n.
-                    aria-label="Close modal"
+                    ariaLabel="Close modal"
                     onClick={onClickCloseButton}
                     kind={
                         topBackgroundColor === "dark" ? "primary" : "tertiary"


### PR DESCRIPTION
I noticed that some checkboxes in `webapp` try to use `ariaLabel` to provide a label for checkboxes that don't have a clear label e.g.
![image](https://user-images.githubusercontent.com/9587565/44370607-cd831a80-a48f-11e8-90c4-463b7fcb0fd4.png)
However, the current `Checkbox` in `webapp` doesn't actually support an `ariaLabel` prop (which is how I missed this during the implementation spec phase). So all those checkboxes in `webapp` don't really have aria labels attached...oops.