### PR TITLE
Remove warning messages about scrollTo not being implemented

### DIFF
--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -7,8 +7,8 @@ import Dropdown from "./dropdown.js";
 import {keyCodes} from "../util/constants.js";
 
 describe("Dropdown", () => {
-    global.scrollTo = jest.fn();
-    global.getComputedStyle = jest.fn();
+    window.scrollTo = jest.fn();
+    window.getComputedStyle = jest.fn();
 
     let dropdown;
 

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -6,6 +6,8 @@ import {mount, unmountAll} from "../../../utils/testing/mount.js";
 import ModalLauncher from "./modal-launcher.js";
 
 describe("ModalLauncher", () => {
+    window.scrollTo = jest.fn();
+
     beforeEach(() => {
         unmountAll();
     });


### PR DESCRIPTION
Also changed the mock functions in`dropdown.test` to use `window` instead of `global`.

Run `yarn run jest`. Yay no more warnings about `scrollTo`.