### PR TITLE
lint our promises

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,9 +2,18 @@
     "extends": [
         "./eslint/eslintrc"
     ],
+    "plugins": [
+        "promise"
+    ],
     "rules": {
-        "flowtype/require-exact-type": [2, "always"],
-        "flowtype/no-types-missing-file-annotation": 2,
-        "react/jsx-handler-names": 2
+        "flowtype/require-exact-type": ["error", "always"],
+        "flowtype/no-types-missing-file-annotation": "error",
+        "promise/always-return": "error",
+        "promise/no-return-wrap": "error",
+        "promise/param-names": "error",
+        "promise/catch-or-return": "error",
+        "promise/no-new-statics": "error",
+        "promise/no-return-in-finally": "error",
+        "react/jsx-handler-names": "error"
     }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-flowtype": "^2.25.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "2.3.1",
+    "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-react": "7.7.0",
     "eslint-plugin-react-native-animation-linter": "0.1.1",
     "eslint-watch": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,6 +3408,10 @@ eslint-plugin-prettier@2.3.1:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
+eslint-plugin-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.0.tgz#bc15a4aa04fa6116113b6c47488c421821b758fc"
+
 eslint-plugin-react-native-animation-linter@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-animation-linter/-/eslint-plugin-react-native-animation-linter-0.1.1.tgz#500e2dcb4d99a8e16b891c9eadc72980d61ac363"


### PR DESCRIPTION
I just reviewed a PR in another project that fixed a misuse of promises that could've been caught with lint so figured we may as well lint our promises just in case.  Thankfully no lint, phew!  Descriptions of the rules can be found at https://github.com/xjamundx/eslint-plugin-promise#rules.  Warning: the docs are missing for some of the rules.  I also change our use of numbers in .eslintrc to strings.  The number `2` dead, long live `"error"`.