### PR TITLE
Replace ClickableBehavior's trigger props with role prop

### DIFF
--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -166,6 +166,7 @@ export default class Button extends React.Component<SharedProps> {
                 disabled={sharedProps.disabled}
                 href={href}
                 onClick={onClick}
+                role="button"
             >
                 {(state, handlers) => {
                     return (

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -1,6 +1,44 @@
 // @flow
 import React from "react";
 
+// NOTE: Potentially add to this as more cases come up.
+type ClickableRole =
+    | "button"
+    | "link"
+    | "checkbox"
+    | "radio"
+    | "listbox"
+    | "option"
+    | "menuitem";
+
+const getAppropriateTriggersForRole = (role: ?ClickableRole) => {
+    switch (role) {
+        // Triggers on ENTER, but not SPACE
+        case "link":
+            return {
+                triggerOnEnter: true,
+                triggerOnSpace: false,
+            };
+        // Triggers on SPACE, but not ENTER
+        case "checkbox":
+        case "radio":
+        case "listbox":
+        case "option":
+            return {
+                triggerOnEnter: false,
+                triggerOnSpace: true,
+            };
+        // Triggers on both ENTER and SPACE
+        case "button":
+        case "menuitem":
+        default:
+            return {
+                triggerOnEnter: true,
+                triggerOnSpace: true,
+            };
+    }
+};
+
 type Props = {|
     /**
      * A function that returns the a React `Element`.
@@ -41,19 +79,12 @@ type Props = {|
     history?: any,
 
     /**
-     * Trigger onClick callback and href navigation, if present, on enter key
-     * press. Default true. Only set to false if the component should definitely
-     * NOT trigger onClick on enter. An example of a component that shouldn't
-     * trigger on enter is a Checkbox or some other form component.
+     * A role that encapsulates how the clickable component should behave, which
+     * affects which keyboard actions trigger the component. For example, a
+     * component with role="button" should be able to be clicked with both the
+     * enter and space keys.
      */
-    triggerOnEnter: boolean,
-
-    /**
-     * Trigger onClick callback on space key press. Only set to false if the
-     * component should definitely NOT trigger onClick on space. An example of a
-     * component that shouldn't trigger on space is Link.
-     */
-    triggerOnSpace: boolean,
+    role?: ClickableRole,
 |};
 
 type State = {|
@@ -203,11 +234,13 @@ const startState = {
 export default class ClickableBehavior extends React.Component<Props, State> {
     waitingForClick: boolean;
     enterClick: boolean;
+    triggers: {
+        triggerOnEnter: boolean,
+        triggerOnSpace: boolean,
+    };
 
     static defaultProps = {
         disabled: false,
-        triggerOnEnter: true,
-        triggerOnSpace: true,
     };
 
     static getDerivedStateFromProps(props: Props, state: State) {
@@ -224,6 +257,9 @@ export default class ClickableBehavior extends React.Component<Props, State> {
         super(props);
 
         this.state = startState;
+        this.waitingForClick = false;
+        this.enterClick = false;
+        this.triggers = getAppropriateTriggersForRole(this.props.role);
     }
 
     handleClick = (e: SyntheticMouseEvent<>) => {
@@ -271,7 +307,7 @@ export default class ClickableBehavior extends React.Component<Props, State> {
 
     handleKeyDown = (e: SyntheticKeyboardEvent<*>) => {
         const keyCode = e.which || e.keyCode;
-        const {triggerOnEnter, triggerOnSpace} = this.props;
+        const {triggerOnEnter, triggerOnSpace} = this.triggers;
         if (
             (triggerOnEnter && keyCode === keyCodes.enter) ||
             (triggerOnSpace && keyCode === keyCodes.space)
@@ -291,7 +327,7 @@ export default class ClickableBehavior extends React.Component<Props, State> {
 
     handleKeyUp = (e: SyntheticKeyboardEvent<*>) => {
         const keyCode = e.which || e.keyCode;
-        const {triggerOnEnter, triggerOnSpace} = this.props;
+        const {triggerOnEnter, triggerOnSpace} = this.triggers;
         if (
             (triggerOnEnter && keyCode === keyCodes.enter) ||
             (triggerOnSpace && keyCode === keyCodes.space)

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -234,10 +234,6 @@ const startState = {
 export default class ClickableBehavior extends React.Component<Props, State> {
     waitingForClick: boolean;
     enterClick: boolean;
-    triggers: {
-        triggerOnEnter: boolean,
-        triggerOnSpace: boolean,
-    };
 
     static defaultProps = {
         disabled: false,
@@ -259,7 +255,6 @@ export default class ClickableBehavior extends React.Component<Props, State> {
         this.state = startState;
         this.waitingForClick = false;
         this.enterClick = false;
-        this.triggers = getAppropriateTriggersForRole(this.props.role);
     }
 
     handleClick = (e: SyntheticMouseEvent<>) => {
@@ -307,7 +302,9 @@ export default class ClickableBehavior extends React.Component<Props, State> {
 
     handleKeyDown = (e: SyntheticKeyboardEvent<*>) => {
         const keyCode = e.which || e.keyCode;
-        const {triggerOnEnter, triggerOnSpace} = this.triggers;
+        const {triggerOnEnter, triggerOnSpace} = getAppropriateTriggersForRole(
+            this.props.role,
+        );
         if (
             (triggerOnEnter && keyCode === keyCodes.enter) ||
             (triggerOnSpace && keyCode === keyCodes.space)
@@ -327,7 +324,9 @@ export default class ClickableBehavior extends React.Component<Props, State> {
 
     handleKeyUp = (e: SyntheticKeyboardEvent<*>) => {
         const keyCode = e.which || e.keyCode;
-        const {triggerOnEnter, triggerOnSpace} = this.triggers;
+        const {triggerOnEnter, triggerOnSpace} = getAppropriateTriggersForRole(
+            this.props.role,
+        );
         if (
             (triggerOnEnter && keyCode === keyCodes.enter) ||
             (triggerOnSpace && keyCode === keyCodes.space)

--- a/packages/wonder-blocks-core/components/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.test.js
@@ -364,8 +364,6 @@ describe("ClickableBehavior", () => {
         const onClick = jest.fn();
         // Use mount instead of a shallow render to trigger event defaults
         const link = mount(
-            // triggerOnSpace is false because links should not navigate or
-            // be activated on a space press
             <ClickableBehavior
                 href="https://khanacademy.org/"
                 onClick={(e) => onClick(e)}

--- a/packages/wonder-blocks-core/components/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.test.js
@@ -170,7 +170,7 @@ describe("ClickableBehavior", () => {
         expect(button.state("pressed")).toEqual(false);
     });
 
-    it("changes pressed state on only enter key down/up if triggerOnSpace=false", () => {
+    it("changes pressed state on only enter key down/up for a link", () => {
         const onClick = jest.fn();
         // Use mount instead of a shallow render to trigger event defaults
         const link = mount(
@@ -178,7 +178,7 @@ describe("ClickableBehavior", () => {
                 disabled={false}
                 onClick={(e) => onClick(e)}
                 href="https://www.khanacademy.org"
-                triggerOnSpace={false}
+                role="link"
             >
                 {(state, handlers) => {
                     return (
@@ -367,9 +367,9 @@ describe("ClickableBehavior", () => {
             // triggerOnSpace is false because links should not navigate or
             // be activated on a space press
             <ClickableBehavior
-                triggerOnSpace={false}
                 href="https://khanacademy.org/"
                 onClick={(e) => onClick(e)}
+                role="link"
             >
                 {(state, handlers) => {
                     // The base element here doesn't matter in this testing
@@ -406,15 +406,12 @@ describe("ClickableBehavior", () => {
         expect(window.location.assign).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onClick correctly for a component with triggerOnEnter false", () => {
+    it("calls onClick correctly for a component that doesn't respond to enter", () => {
         const onClick = jest.fn();
         // Use mount instead of a shallow render to trigger event defaults
         const checkbox = mount(
             // triggerOnEnter may be false for some elements e.g. checkboxes
-            <ClickableBehavior
-                triggerOnEnter={false}
-                onClick={(e) => onClick(e)}
-            >
+            <ClickableBehavior onClick={(e) => onClick(e)} role="checkbox">
                 {(state, handlers) => {
                     // The base element here doesn't matter in this testing
                     // environment, but the simulated events in the test are in
@@ -520,10 +517,7 @@ describe("ClickableBehavior", () => {
         const onClick = jest.fn();
         // Use mount instead of a shallow render to trigger event defaults
         const checkbox = mount(
-            <ClickableBehavior
-                triggerOnEnter={false}
-                onClick={(e) => onClick(e)}
-            >
+            <ClickableBehavior onClick={(e) => onClick(e)} role="checkbox">
                 {(state, handlers) => {
                     // The base element here doesn't matter in this testing
                     // environment, but the simulated events in the test are in

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -106,6 +106,7 @@ export default class ActionItem extends React.Component<ActionProps> {
                 disabled={disabled}
                 onClick={onClick}
                 href={href}
+                role="menuitem"
             >
                 {(state, handlers) => {
                     const {pressed, hovered, focused} = state;
@@ -122,7 +123,6 @@ export default class ActionItem extends React.Component<ActionProps> {
                     const props = {
                         disabled,
                         style: [defaultStyle],
-                        role: "menuitem",
                         ...handlers,
                     };
 

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -93,7 +93,11 @@ export default class OptionItem extends React.Component<OptionProps> {
         const CheckComponent = this.getCheckComponent();
 
         return (
-            <ClickableBehavior disabled={disabled} onClick={this.handleClick}>
+            <ClickableBehavior
+                disabled={disabled}
+                onClick={this.handleClick}
+                role="option"
+            >
                 {(state, handlers) => {
                     const {pressed, hovered, focused} = state;
 

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -96,7 +96,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
             <ClickableBehavior
                 disabled={disabled}
                 onClick={this.handleClick}
-                triggerOnEnter={false}
+                role="listbox"
             >
                 {(state, handlers) => {
                     const stateStyles = _generateStyles(light, {...state});

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -64,7 +64,8 @@ type Props = {|
  * and RadioGroup. This design allows for more explicit prop typing. For
  * example, we can make onChange a required prop on Checkbox but not on Choice
  * (because for Choice, that prop would be auto-populated by CheckboxGroup).
- */ export default class ChoiceInternal extends React.Component<Props> {
+ */
+export default class ChoiceInternal extends React.Component<Props> {
     static defaultProps = {
         checked: false,
         disabled: false,
@@ -93,6 +94,7 @@ type Props = {|
             return CheckboxCore;
         }
     }
+
     getLabel() {
         const {disabled, id, label} = this.props;
         return (
@@ -105,12 +107,14 @@ type Props = {|
             </LabelMedium>
         );
     }
+
     getDescription() {
         const {description} = this.props;
         return (
             <LabelSmall style={styles.description}>{description}</LabelSmall>
         );
     }
+
     render() {
         const {
             label,
@@ -154,12 +158,14 @@ type Props = {|
         );
     }
 }
+
 const styles = StyleSheet.create({
     wrapper: {
         flexDirection: "row",
         alignItems: "flex-start",
         outline: "none",
     },
+
     label: {
         userSelect: "none",
         // NOTE: The checkbox/radio button (height 16px) should be center
@@ -168,9 +174,11 @@ const styles = StyleSheet.create({
         // desired alignment.
         marginTop: -2,
     },
+
     disabledLabel: {
         color: Color.offBlack32,
     },
+
     description: {
         // 16 for icon + 8 for spacing strut
         marginLeft: Spacing.medium + Spacing.xSmall,

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -118,7 +118,6 @@ type Props = {|
             // eslint-disable-next-line no-unused-vars
             onChange,
             style,
-            // eslint-disable-next-line no-unused-vars
             variant,
             ...coreProps
         } = this.props;
@@ -131,7 +130,7 @@ type Props = {|
                 <ClickableBehavior
                     disabled={coreProps.disabled}
                     onClick={this.handleClick}
-                    triggerOnEnter={false}
+                    role={variant}
                 >
                     {(state, handlers) => {
                         return (

--- a/packages/wonder-blocks-form/components/choice.js
+++ b/packages/wonder-blocks-form/components/choice.js
@@ -72,7 +72,8 @@ type Props = {|
  *
  * If you wish to use just a single field, use Checkbox or Radio with the
  * optional label and description props.
- */ export default class Choice extends React.Component<Props> {
+ */
+export default class Choice extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
@@ -84,6 +85,7 @@ type Props = {|
             return Radio;
         }
     }
+
     render() {
         // we don't need this going into the ChoiceComponent
         // eslint-disable-next-line no-unused-vars

--- a/packages/wonder-blocks-form/components/radio.js
+++ b/packages/wonder-blocks-form/components/radio.js
@@ -76,7 +76,8 @@ type ChoiceComponentProps = {|
  *
  * This component should not really be used by itself because radio buttons are
  * often grouped together. See RadioGroup.
- */ export default class Radio extends React.Component<ChoiceComponentProps> {
+ */
+export default class Radio extends React.Component<ChoiceComponentProps> {
     static defaultProps = {
         disabled: false,
         error: false,

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -150,6 +150,7 @@ export default class IconButton extends React.Component<SharedProps> {
                 disabled={sharedProps.disabled}
                 href={href}
                 onClick={onClick}
+                role="button"
             >
                 {(state, handlers) => {
                     return (

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -129,7 +129,7 @@ export default class Link extends React.Component<SharedProps> {
                 disabled={false}
                 onClick={onClick}
                 href={href}
-                triggerOnSpace={false}
+                role="link"
             >
                 {(state, handlers) => {
                     return (


### PR DESCRIPTION
`role` prop is optional, and it defaults to both space and enter being triggers (this was the default behavior before as well).