### PR TITLE
Fix dry-run-publish command to use --skip-git/--skip-npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "git-add-snapshot-tests": "git add packages/*/generated-snapshot.test.js",
     "pretty-quick": "pretty-quick --staged",
     "publish": "node utils/pre-publish-check.js && git diff --stat --exit-code HEAD && yarn build:cjs && yarn build:es6 && lerna publish",
-    "dry-run-publish": "yarn run publish --no-npm --no-git"
+    "dry-run-publish": "yarn run publish --skip-npm --skip-git"
   },
   "author": "",
   "license": "MIT",
@@ -36,10 +36,6 @@
     "enzyme-adapter-react-16: TODO(sophie): We should revert back to the latest release of this when the issue at https://github.com/airbnb/enzyme/issues/1509 is fixed"
   ],
   "devDependencies": {
-    "//": [
-      "TODO(sophie): We should revert back to the latest release of this",
-      "when the issue at https://github.com/airbnb/enzyme/issues/1509 is fixed"
-    ],
     "babel-core": "6.26.3",
     "babel-eslint": "^9.0.0-beta.3",
     "babel-jest": "^22.4.1",


### PR DESCRIPTION
Either I just got it wrong or the API changed, I'm not sure! Either way these are the right options.