### PR TITLE
fix element intersection func to work with overflow-y: scroll hack

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:coverage": "yarn run test:common && yarn run jest --coverage",
     "coverage": "yarn run test:coverage && open coverage/lcov-report/index.html",
     "styleguidist": "styleguidist server",
-    "start": "concurrently --kill-others-on-fail \"yarn run styleguidist\" \"webpack -w\"",
+    "start": "concurrently --kill-others-on-fail \"yarn run styleguidist\" \"webpack -w\" \"rollup -c rollup.config.js -w\"",
     "start:prod": "yarn run build:styleguidist && yarn run styleguidist --config styleguide.prod.config.js",
     "build:styleguidist": "yarn run gen-styleguide-prod-config && styleguidist build --config styleguide.prod.config.js",
     "git-add-snapshot-tests": "git add packages/*/generated-snapshot.test.js",

--- a/packages/wonder-blocks-core/util/get-element-intersection.js
+++ b/packages/wonder-blocks-core/util/get-element-intersection.js
@@ -39,9 +39,18 @@ function FullIntersection() {
     };
 }
 
+type Rect = {|
+    top: number,
+    bottom: number,
+    left: number,
+    right: number,
+    width: number,
+    height: number,
+|};
+
 function getAxisIntersection(
     intersectingRect: ClientRect | DOMRect,
-    boundsRect: ClientRect | DOMRect,
+    boundsRect: Rect,
     axis: "vertical" | "horizontal",
 ): AxisIntersection {
     const start = (rect) => (axis === "horizontal" ? rect.left : rect.top);
@@ -74,7 +83,17 @@ function getElementIntersectionAgainstParent(
         ((boundsElement: any).currentStyle: ?CSSStyleDeclaration) ||
         window.getComputedStyle(boundsElement);
 
-    const boundsRect = boundsElement.getBoundingClientRect();
+    const boundsRect = {...boundsElement.getBoundingClientRect()};
+
+    // In webapp we set height: 100% on html, body and overflow-y: scroll on body.
+    // This results in the height reported by getBoundingClientRect being the height
+    // of the viewport instead of the height of the page.  We use the scrollHeight
+    // of the body to corect the bounds.
+    // TODO(kevinb): screenshot test this
+    if (boundsElement === document.body) {
+        boundsRect.height = (boundsElement: any).scrollHeight;
+        boundsRect.bottom = boundsRect.top + boundsRect.height;
+    }
 
     // We assume we're within this specific bounds element if it's overflow is
     // visible.


### PR DESCRIPTION
The fix wasn't too bad, set the bounding rect's height to be the scrollHeight and add update its bottom to be consistent.  Unfortunately, this is hard to write a unit test for.  I'd rather spend time working on setting up image regression tests for this as those will be useful for other things that are hard (or impossible) to test as well.

I tested this by setting the `height: 100%` on `body, html` and `overflow-y: scroll` on `body`.  Then I navigated to http://localhost:6060/#tooltip-1 and hovered over items and saw their tooltips.

<img width="1500" alt="screen shot 2018-08-27 at 5 53 10 pm" src="https://user-images.githubusercontent.com/1044413/44688387-1ef85000-aa22-11e8-8f2b-15500a820506.png">
