### PR TITLE
Show the spinner if href is also set

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -1776,11 +1776,11 @@ exports[`wonder-blocks-button example 8 1`] = `
     }
   }
 >
-  <button
+  <a
     aria-disabled="true"
     aria-label="loading"
     className=""
-    disabled={true}
+    href="/foo"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -1796,9 +1796,6 @@ exports[`wonder-blocks-button example 8 1`] = `
     role="button"
     style={
       Object {
-        "::MozFocusInner": Object {
-          "border": 0,
-        },
         "alignItems": "center",
         "background": "rgba(33,36,44,0.32)",
         "border": "none",
@@ -1809,7 +1806,6 @@ exports[`wonder-blocks-button example 8 1`] = `
         "display": "inline-flex",
         "height": 40,
         "justifyContent": "center",
-        "margin": 0,
         "marginRight": 10,
         "outline": "none",
         "paddingBottom": 0,
@@ -1821,7 +1817,6 @@ exports[`wonder-blocks-button example 8 1`] = `
       }
     }
     tabIndex={-1}
-    type="button"
   >
     <span
       className=""
@@ -1903,7 +1898,7 @@ exports[`wonder-blocks-button example 8 1`] = `
         />
       </svg>
     </div>
-  </button>
+  </a>
   <button
     aria-disabled="true"
     aria-label="loading"

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -110,14 +110,27 @@ export default class ButtonCore extends React.Component<Props> {
             </Label>
         );
 
+        const contents = (
+            <React.Fragment>
+                {label}
+                {spinner && (
+                    <CircularSpinner
+                        style={sharedStyles.spinner}
+                        size={{medium: "small", small: "xsmall"}[size]}
+                        light={kind === "primary"}
+                    />
+                )}
+            </React.Fragment>
+        );
+
         if (href) {
             return router && !skipClientNav ? (
                 <StyledLink {...commonProps} to={href}>
-                    {label}
+                    {contents}
                 </StyledLink>
             ) : (
                 <StyledAnchor {...commonProps} href={href}>
-                    {label}
+                    {contents}
                 </StyledAnchor>
             );
         } else {
@@ -127,14 +140,7 @@ export default class ButtonCore extends React.Component<Props> {
                     {...commonProps}
                     disabled={disabled}
                 >
-                    {label}
-                    {spinner && (
-                        <CircularSpinner
-                            style={sharedStyles.spinner}
-                            size={{medium: "small", small: "xsmall"}[size]}
-                            light={kind === "primary"}
-                        />
-                    )}
+                    {contents}
                 </StyledButton>
             );
         }

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -327,7 +327,7 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
-    <Button spinner={true} aria-label="loading" style={styles.button}>
+    <Button spinner={true} aria-label="loading" style={styles.button} href="/foo">
         Click me!
     </Button>
     <Button spinner={true} aria-label="loading" size="small" style={styles.button}>

--- a/packages/wonder-blocks-button/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/generated-snapshot.test.js
@@ -346,6 +346,7 @@ describe("wonder-blocks-button", () => {
                     spinner={true}
                     aria-label="loading"
                     style={styles.button}
+                    href="/foo"
                 >
                     Click me!
                 </Button>
@@ -403,19 +404,6 @@ describe("wonder-blocks-button", () => {
                             size="small"
                         >
                             {kind} small
-                        </Button>
-                    ))}
-                </View>
-                <View style={styles.row}>
-                    {kinds.map((kind, idx) => (
-                        <Button
-                            kind={kind}
-                            icon={icons.contentExercise}
-                            style={styles.button}
-                            key={idx}
-                            href="/"
-                        >
-                            {kind} with href
                         </Button>
                     ))}
                 </View>


### PR DESCRIPTION
I forgot to fix this when I merged the original work on the button spinner.  Now the spinner shows up if `href` is set (before it wasn't).