### PR TITLE
Don't render empty elements inside toolbar components

### DIFF
--- a/packages/wonder-blocks-toolbar/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/components/toolbar.js
@@ -60,9 +60,9 @@ export default class Toolbar extends React.Component<Props> {
     };
 
     renderContent(content: React.Node) {
-        const contentArray = Array.isArray(content) ? content : [content];
-
-        return contentArray.map((content, i) => (
+        let contentArray = Array.isArray(content) ? content : [content];
+	// Remove empty/null/undefined elements, then map to Views
+	return contentArray.filter(c => c).map((content, i) => (
             <View
                 style={[sharedStyles.content, sharedStyles.verticalAlign]}
                 key={i.toString()}

--- a/packages/wonder-blocks-toolbar/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/components/toolbar.js
@@ -60,9 +60,9 @@ export default class Toolbar extends React.Component<Props> {
     };
 
     renderContent(content: React.Node) {
-        let contentArray = Array.isArray(content) ? content : [content];
-	    // Remove empty/null/undefined elements, then map to Views
-	    return contentArray.filter(c => c).map((content, i) => (
+        const contentArray = Array.isArray(content) ? content : [content];
+        // Remove empty/null/undefined elements, then map to Views
+        return contentArray.filter(c => c).map((content, i) => (
             <View
                 style={[sharedStyles.content, sharedStyles.verticalAlign]}
                 key={i.toString()}

--- a/packages/wonder-blocks-toolbar/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/components/toolbar.js
@@ -61,8 +61,8 @@ export default class Toolbar extends React.Component<Props> {
 
     renderContent(content: React.Node) {
         let contentArray = Array.isArray(content) ? content : [content];
-	// Remove empty/null/undefined elements, then map to Views
-	return contentArray.filter(c => c).map((content, i) => (
+	    // Remove empty/null/undefined elements, then map to Views
+	    return contentArray.filter(c => c).map((content, i) => (
             <View
                 style={[sharedStyles.content, sharedStyles.verticalAlign]}
                 key={i.toString()}


### PR DESCRIPTION
I have a usecase for CS scratchpads where the toolbar editor variably shows different elements, ie. many of them are null at any given time. With the WB toolbar, it currently shows an empty View for each of those null elements, which is undesirable. This change filters out empty elements using Array.filter() before mapping them.

For testing, I manually edited the generated file in webapp/third_party/node_modules and verified it works for my use case. I did not see other obvious ways to test it, since the jest tests are auto-generated. I'm assuming those tests are run by a CI.
