### PR TITLE
Ignore all the dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     },
     "collectCoverageFrom": [
       "packages/**/*.js",
-      "!packages/**/dist/index.js",
+      "!packages/**/dist/**/*.js",
       "!<rootDir>/node_modules/",
       "!packages/**/node_modules/"
     ]


### PR DESCRIPTION
Before this change, the dist/es folders were appearing in the output for `yarn coverage`. We don't want that, so this ensures it doesn't happen.