### PR TITLE
Fix all console errors emitted during tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
   },
   "author": "",
   "license": "MIT",
-  "//": [
-    "enzyme-adapter-react-16: TODO(sophie): We should revert back to the latest release of this when the issue at https://github.com/airbnb/enzyme/issues/1509 is fixed"
-  ],
   "devDependencies": {
     "babel-core": "6.26.3",
     "babel-eslint": "^9.0.0-beta.3",
@@ -50,7 +47,7 @@
     "codecov": "^3.0.4",
     "concurrently": "^3.6.0",
     "enzyme": "^3.3.0",
-    "enzyme-adapter-react-16": "npm:enzyme-react-adapter-future",
+    "enzyme-adapter-react-16": "^1.5.0",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "2.6.0",
     "eslint-plugin-flowtype": "^2.25.0",
@@ -87,8 +84,8 @@
     "inquirer": "^6.0.0",
     "popper.js": "^1.14.1",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1",
+    "react": "^16.4.3",
+    "react-dom": "^16.4.3",
     "react-popper": "^1.0.0",
     "react-router-dom": "^4.2.2"
   },

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -13,7 +13,7 @@ describe("Dropdown", () => {
     let dropdown;
 
     beforeEach(() => {
-        const dummyOpener = mount(<button />);
+        const dummyOpener = <button />;
         const openChanged = jest.fn();
         dropdown = mount(
             <Dropdown

--- a/packages/wonder-blocks-icon-button/components/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.test.js
@@ -1,10 +1,11 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import {shallow} from "enzyme";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
+import expectRenderError from "../../../utils/testing/expect-render-error.js";
 import IconButton from "./icon-button.js";
 
 describe("IconButton", () => {
@@ -24,17 +25,16 @@ describe("IconButton", () => {
     });
 
     test("throw an error for if light and not primary", () => {
-        expect(() =>
-            mount(
-                <IconButton
-                    icon={icons.search}
-                    aria-label="search"
-                    kind="secondary"
-                    light={true}
-                    onClick={() => void 0}
-                />,
-            ),
-        ).toThrowError("Light is only supported for primary IconButtons");
+        expectRenderError(
+            <IconButton
+                icon={icons.search}
+                aria-label="search"
+                kind="secondary"
+                light={true}
+                onClick={() => void 0}
+            />,
+            "Light is only supported for primary IconButtons",
+        );
     });
 
     test("client-side navigation", () => {

--- a/packages/wonder-blocks-modal/components/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.test.js
@@ -13,6 +13,20 @@ const exampleModal = (
     />
 );
 
+const exampleModalWithButtons = (
+    <StandardModal
+        content={
+            <div>
+                <button data-button-id="1" />
+                <button data-button-id="2" />
+                <button data-button-id="3" data-last-button />
+            </div>
+        }
+        title="Title"
+        footer={<div data-modal-footer />}
+    />
+);
+
 // This is a basic wrapper component, to confirm that wrapper components work
 // too! It passes along extra props, as required to get the default behavior for
 // `onClickCloseButton`.
@@ -172,11 +186,7 @@ describe("ModalBackdrop", () => {
     test("On mount, we focus the last button in the modal", () => {
         const wrapper = mount(
             <ModalBackdrop onCloseModal={() => {}}>
-                <div>
-                    <button />
-                    <button />
-                    <button data-last-button />
-                </div>
+                {exampleModalWithButtons}
             </ModalBackdrop>,
         );
 
@@ -193,11 +203,7 @@ describe("ModalBackdrop", () => {
             <div>
                 <button data-button-id="A" />
                 <ModalBackdrop onCloseModal={() => {}}>
-                    <div>
-                        <button data-button-id="1" />
-                        <button data-button-id="2" />
-                        <button data-button-id="3" />
-                    </div>
+                    {exampleModalWithButtons}
                 </ModalBackdrop>
                 <button data-button-id="Z" />
             </div>,

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -4,6 +4,9 @@ import {shallow} from "enzyme";
 
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 import ModalLauncher from "./modal-launcher.js";
+import OneColumnModal from "./one-column-modal.js";
+
+const exampleModal = <OneColumnModal content={<div data-modal-child />} />;
 
 describe("ModalLauncher", () => {
     window.scrollTo = jest.fn();
@@ -14,7 +17,7 @@ describe("ModalLauncher", () => {
 
     test("Children can launch the modal", () => {
         const wrapper = mount(
-            <ModalLauncher modal={<div />}>
+            <ModalLauncher modal={exampleModal}>
                 {({openModal}) => <button onClick={openModal} />}
             </ModalLauncher>,
         );
@@ -42,7 +45,7 @@ describe("ModalLauncher", () => {
         const modalFn = ({closeModal}: {closeModal: () => void}) => {
             expect(opened).toBe(true);
             setImmediate(closeModal);
-            return <div />;
+            return exampleModal;
         };
 
         // Once the modal closes, we'll check that it _really_ closed, and
@@ -78,7 +81,7 @@ describe("ModalLauncher", () => {
         // We mount into a real DOM, in order to simulate and capture real key
         // presses anywhere in the document.
         const wrapper = mount(
-            <ModalLauncher modal={<div data-modal-child />}>
+            <ModalLauncher modal={exampleModal}>
                 {({openModal}) => <button onClick={openModal} />}
             </ModalLauncher>,
         );
@@ -112,7 +115,7 @@ describe("ModalLauncher", () => {
             <ModalLauncher
                 modal={({closeModal}) => {
                     savedCloseModal = closeModal;
-                    return <div data-modal-child />;
+                    return exampleModal;
                 }}
             >
                 {({openModal}) => <button onClick={openModal} />}

--- a/test-setup.js
+++ b/test-setup.js
@@ -2,6 +2,10 @@ const {StyleSheetTestUtils} = require("aphrodite");
 const Enzyme = require("enzyme");
 const EnzymeAdapter = require("enzyme-adapter-react-16");
 
+jest.spyOn(console, "error").mockImplementation((msg) => {
+    throw new Error(`Unexpected call to console.error: ${msg}`);
+});
+
 StyleSheetTestUtils.suppressStyleInjection();
 
 // Setup enzyme's react adapter

--- a/utils/testing/expect-render-error.js
+++ b/utils/testing/expect-render-error.js
@@ -1,0 +1,45 @@
+// @flow
+import * as React from "react";
+import ReactDOM from "react-dom";
+
+// Code from:
+// https://gist.github.com/gaearon/adf9d5500e11a4e7b2c6f7ebf994fe56
+// See: https://github.com/facebook/react/issues/11098
+
+export default (element: React.Node, expectedError: string) => {
+    // Noop error boundary for testing.
+    class TestBoundary extends React.Component<
+        {children: React.Node},
+        {didError: boolean},
+    > {
+        constructor(props) {
+            super(props);
+            this.state = {didError: false};
+        }
+        componentDidCatch(err) {
+            this.setState({didError: true});
+        }
+        render() {
+            return this.state.didError ? null : this.props.children;
+        }
+    }
+
+    // Record all errors.
+    const topLevelErrors = [];
+    function handleTopLevelError(event) {
+        topLevelErrors.push(event.error);
+        // Prevent logging
+        event.preventDefault();
+    }
+
+    const div = document.createElement("div");
+    window.addEventListener("error", handleTopLevelError);
+    try {
+        ReactDOM.render(<TestBoundary>{element}</TestBoundary>, div);
+    } finally {
+        window.removeEventListener("error", handleTopLevelError);
+    }
+
+    expect(topLevelErrors.length).toBe(1);
+    expect(topLevelErrors[0].message).toContain(expectedError);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,25 +3270,25 @@ envinfo@^5.7.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-5.10.0.tgz#503a9774ae15b93ea68bdfae2ccd6306624ea6df"
 
-"enzyme-adapter-react-16@npm:enzyme-react-adapter-future":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/enzyme-react-adapter-future/-/enzyme-react-adapter-future-1.1.3.tgz#f0c102f098086a0ad0270bbdaf9da5113297dc05"
+enzyme-adapter-react-16@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.5.0.tgz#50af8d76a45fe0915de932bd95d34cdca75c0be3"
   dependencies:
-    enzyme-adapter-utils "^1.3.0"
-    lodash "^4.17.4"
+    enzyme-adapter-utils "^1.8.0"
+    function.prototype.name "^1.1.0"
     object.assign "^4.1.0"
     object.values "^1.0.4"
-    prop-types "^15.6.0"
-    react-reconciler "^0.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.4.2"
     react-test-renderer "^16.0.0-0"
 
-enzyme-adapter-utils@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz#d6c85756826c257a8544d362cc7a67e97ea698c7"
+enzyme-adapter-utils@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.0.tgz#ee9f07250663a985f1f2caaf297720787da559f1"
   dependencies:
-    lodash "^4.17.4"
-    object.assign "^4.0.4"
-    prop-types "^15.6.0"
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    prop-types "^15.6.2"
 
 enzyme-matchers@^6.0.2:
   version "6.0.2"
@@ -4163,7 +4163,7 @@ function.name-polyfill@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/function.name-polyfill/-/function.name-polyfill-1.0.6.tgz#c54e37cae0a77dfcb49d47982815b0826b5c60d9"
 
-function.prototype.name@^1.0.3:
+function.prototype.name@^1.0.3, function.prototype.name@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
   dependencies:
@@ -7132,7 +7132,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.4, object.assign@^4.1.0:
+object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   dependencies:
@@ -8208,14 +8208,14 @@ react-dom@15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-dom@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+react-dom@^16.4.3:
+  version "16.5.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.1.tgz#29d0c5a01ed3b6b4c14309aa91af6ec4eb4f292c"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.4.0"
 
 react-error-overlay@^4.0.0:
   version "4.0.0"
@@ -8241,6 +8241,10 @@ react-is@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
 
+react-is@^16.4.2:
+  version "16.5.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.1.tgz#c6e8734fd548a22e1cef4fd0833afbeb433b85ee"
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -8255,15 +8259,6 @@ react-popper@^1.0.0:
     prop-types "^15.6.1"
     typed-styles "^0.0.5"
     warning "^3.0.0"
-
-react-reconciler@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
 
 react-router-dom@^4.2.2:
   version "4.2.2"
@@ -8369,14 +8364,14 @@ react@15.5.4:
     object-assign "^4.1.0"
     prop-types "^15.5.7"
 
-react@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+react@^16.4.3:
+  version "16.5.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.5.1.tgz#8cb8e9f8cdcb4bde41c9a138bfbf907e66132372"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.4.0"
 
 read-chunk@^2.1.0:
   version "2.1.0"
@@ -9008,6 +9003,12 @@ sax@^1.2.4, sax@~1.2.1:
 sax@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.6.1.tgz#563b19c7c1de892e09bfc4f2fc30e3c27f0952b9"
+
+schedule@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.4.0.tgz#fa20cfd0bfbf91c47d02272fd7096780d3170bbb"
+  dependencies:
+    object-assign "^4.1.1"
 
 schema-utils@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
I was bothered by the console errors that were coming up during testing, I was worried that they might be obscuring real errors so I went and fixed them all.

- IconButton: This was fixed by creating an ErrorBoundary around the component that intentionally swallows the error. This was discussed in https://github.com/facebook/react/issues/11098 and required an upgrade to React 16.4.3 - which, in turn, required an upgrade of the Enzyme React Adapter. I pulled in the utility for testing these in the future into `utils/testing/expect-render-error.js`.
- Dropdown: We needed to not pre-mount the button before passing it in. The tests worked fine even without doing that!
- ModalBackdrop & ModalLauncher: Both needed to reference real Modals, not mock divs.

I also modified test-setup.js to throw an error if a `console.error` is ever logged in our tests -- these should be failing as they might indicate a problem with our code! We may want to consider doing this with `console.log`, as well (but we don't currently have any of those). 