### PR TITLE
Fix dropdown not dismissing on click

### DIFF
--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -124,6 +124,7 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
     keyboardNavOn: boolean;
     // Whether any items have been selected since the menu was opened
     itemsClicked: boolean;
+    popperElement: ?HTMLElement;
 
     static defaultProps = {
         alignment: "left",
@@ -290,13 +291,12 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
         const {open, onOpenChanged} = this.props;
         const target: Node = event.target;
         const thisElement = ReactDOM.findDOMNode(this);
-        const modalHost = this.getModalHost();
         if (
             open &&
             thisElement &&
             !thisElement.contains(target) &&
-            modalHost &&
-            !modalHost.contains(target)
+            this.popperElement &&
+            !this.popperElement.contains(target)
         ) {
             onOpenChanged(false);
         }
@@ -495,24 +495,24 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
         );
     }
 
-    getModalHost() {
-        return (
-            maybeGetPortalMountedModalHostElement(this.props.openerElement) ||
-            document.querySelector("body")
-        );
-    }
-
     renderDropdown() {
-        const {alignment} = this.props;
+        const {alignment, openerElement} = this.props;
         // If we are in a modal, we find where we should be portalling the menu
         // by using the helper function from the modal package on the opener
         // element.
         // If we are not in a modal, we use body as the location to portal to.
-        const modalHost = this.getModalHost();
+        const modalHost =
+            maybeGetPortalMountedModalHostElement(openerElement) ||
+            document.querySelector("body");
 
         if (modalHost) {
             return ReactDOM.createPortal(
                 <Popper
+                    innerRef={(node) => {
+                        if (node) {
+                            this.popperElement = node;
+                        }
+                    }}
                     referenceElement={this.props.openerElement}
                     placement={
                         alignment === "left" ? "bottom-start" : "bottom-end"

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -126,7 +126,11 @@ describe("Dropdown", () => {
         expect(handleOpen.mock.calls[1][0]).toBe(false);
     });
 
-    it("closes on external mouse click", () => {
+    /**
+     * This test produces false positives.
+     * TODO: rewrite as a selenium test once we have a test harness.
+     */
+    it.skip("closes on external mouse click", () => {
         const handleOpen = jest.fn();
         dropdown.setProps({
             onOpenChanged: (open) => handleOpen(open),

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -1,5 +1,6 @@
 //@flow
-import React from "react";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import OptionItem from "./option-item.js";
@@ -126,11 +127,7 @@ describe("Dropdown", () => {
         expect(handleOpen.mock.calls[1][0]).toBe(false);
     });
 
-    /**
-     * This test produces false positives.
-     * TODO: rewrite as a selenium test once we have a test harness.
-     */
-    it.skip("closes on external mouse click", () => {
+    it("closes on external mouse click", () => {
         const handleOpen = jest.fn();
         dropdown.setProps({
             onOpenChanged: (open) => handleOpen(open),
@@ -142,6 +139,81 @@ describe("Dropdown", () => {
 
         expect(handleOpen).toHaveBeenCalledTimes(1);
         expect(handleOpen.mock.calls[0][0]).toBe(false);
+    });
+
+    it("closes on external mouse click on an element inside document.body", () => {
+        const handleOpen = jest.fn();
+        const container = document.createElement("container");
+        if (!document.body) {
+            throw new Error("No document.body");
+        }
+        document.body.appendChild(container);
+
+        ReactDOM.render(
+            <div>
+                <h1 id="foo">Dropdown test</h1>
+                <Dropdown
+                    initialFocusedIndex={0}
+                    // mock the items
+                    items={[
+                        {
+                            component: (
+                                <OptionItem label="item 0" value="0" key="0" />
+                            ),
+                            focusable: true,
+                            populatedProps: {},
+                        },
+                        {
+                            component: (
+                                <OptionItem label="item 1" value="1" key="1" />
+                            ),
+                            focusable: true,
+                            populatedProps: {},
+                        },
+                        {
+                            component: (
+                                <OptionItem label="item 2" value="2" key="2" />
+                            ),
+                            focusable: true,
+                            populatedProps: {},
+                        },
+                    ]}
+                    keyboard={true}
+                    light={false}
+                    open={true}
+                    // mock the opener elements
+                    opener={<button />}
+                    openerElement={null}
+                    onOpenChanged={(open) => handleOpen(open)}
+                />
+            </div>,
+            container,
+        );
+
+        /**
+         * According to https://stackoverflow.com/questions/36803733/jsdom-dispatchevent-addeventlistener-doesnt-seem-to-work
+         * Enzyme uses renderIntoDocument from React.TestUtils which doesn't actually
+         * render the component into document.body so testing behavior that relies
+         * on bubbling won't work.  This test works around this limitation by using
+         * ReactDOM.render() to render our test component into a container that lives
+         * in document.body.
+         */
+        const title = document.querySelector("#foo");
+        if (!title) {
+            throw new Error("Couldn't find title");
+        }
+        const event = new MouseEvent("mouseup", {bubbles: true});
+        title.dispatchEvent(event);
+
+        expect(handleOpen).toHaveBeenCalledTimes(1);
+        expect(handleOpen.mock.calls[0][0]).toBe(false);
+
+        // cleanup
+        ReactDOM.unmountComponentAtNode(container);
+        if (!document.body) {
+            throw new Error("No document.body");
+        }
+        document.body.removeChild(container);
     });
 
     it("doesn't close on external mouse click if already closed", () => {

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -149,6 +149,15 @@ describe("Dropdown", () => {
         }
         document.body.appendChild(container);
 
+        /**
+         * According to https://stackoverflow.com/questions/36803733/jsdom-dispatchevent-addeventlistener-doesnt-seem-to-work
+         * Enzyme uses renderIntoDocument from React.TestUtils which doesn't actually
+         * render the component into document.body so testing behavior that relies
+         * on bubbling won't work.  This test works around this limitation by using
+         * ReactDOM.render() to render our test component into a container that lives
+         * in document.body.
+         */
+
         ReactDOM.render(
             <div>
                 <h1 id="foo">Dropdown test</h1>
@@ -190,14 +199,6 @@ describe("Dropdown", () => {
             container,
         );
 
-        /**
-         * According to https://stackoverflow.com/questions/36803733/jsdom-dispatchevent-addeventlistener-doesnt-seem-to-work
-         * Enzyme uses renderIntoDocument from React.TestUtils which doesn't actually
-         * render the component into document.body so testing behavior that relies
-         * on bubbling won't work.  This test works around this limitation by using
-         * ReactDOM.render() to render our test component into a container that lives
-         * in document.body.
-         */
         const title = document.querySelector("#foo");
         if (!title) {
             throw new Error("Couldn't find title");


### PR DESCRIPTION
fixed a bug in #334. There was a test that should have caught this bug, but it is giving us a false-positive 😭 

Unfortunately the "modalHost" I was using was document.body, so checking
if the event was inside the modalHost always returned true! This uses a
ref on the actual popup element, so it works.

Test plan:
desktop & phone:
- open a SingleSelect
- select an item, it should work
- open it again
- tap/click outside of it, and it should dismiss