### PR TITLE
fix issue with UniqueIdProvider inside NoSSR

### DIFF
--- a/packages/wonder-blocks-core/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.js
@@ -66,16 +66,20 @@ export default class UniqueIDProvider extends React.Component<Props> {
         const {children, mockOnFirstRender, scope} = this.props;
 
         // If this is our first render, we're going to stop right here.
+        // Note: `firstRender` will be `false` on the first render if this
+        // component is a descendant of a `NoSSR`.
         if (firstRender) {
-            // We'll be needing this on the next render, so let's set it up.
-            this._idFactory = new UniqueIDFactory(scope);
-
             if (mockOnFirstRender) {
                 // We're allowing an initial render, so let's pass our mock
                 // identifier factory to support SSR.
                 return children(SsrIDFactory);
             }
             return null;
+        }
+
+        // Create an identifier factory if we don't already have one
+        if (!this._idFactory) {
+            this._idFactory = new UniqueIDFactory(scope);
         }
 
         // It's a regular render, so let's use our identifier factory.

--- a/packages/wonder-blocks-core/components/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.test.js
@@ -9,6 +9,7 @@ import View from "./view.js";
 import SsrIDFactory from "../util/ssr-id-factory.js";
 import UniqueIDFactory from "../util/unique-id-factory.js";
 import UniqueIDProvider from "./unique-id-provider.js";
+import NoSSR from "./no-ssr.js";
 
 describe("UniqueIDProvider", () => {
     beforeEach(() => {
@@ -122,6 +123,30 @@ describe("UniqueIDProvider", () => {
             expect(children.mock.calls[1][0]).toBeInstanceOf(UniqueIDFactory);
             // Check the third render gets the same UniqueIDFactory instance.
             expect(children.mock.calls[2][0]).toBe(children.mock.calls[1][0]);
+        });
+    });
+
+    describe("inside a NoSSR", () => {
+        test("it should pass an id to its children", () => {
+            // Arrange
+            const foo = jest.fn(() => null);
+            const nodes = (
+                <NoSSR>
+                    {() => (
+                        <UniqueIDProvider>
+                            {(ids) => foo(ids.get(""))}
+                        </UniqueIDProvider>
+                    )}
+                </NoSSR>
+            );
+            const wrapper = mount(nodes);
+
+            // Act
+            wrapper.instance().forceUpdate();
+
+            // Assert
+            expect(foo).toHaveBeenCalled();
+            expect(foo.mock.calls[0][0]).toBeTruthy();
         });
     });
 });

--- a/packages/wonder-blocks-core/components/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.test.js
@@ -139,10 +139,9 @@ describe("UniqueIDProvider", () => {
                     )}
                 </NoSSR>
             );
-            const wrapper = mount(nodes);
 
             // Act
-            wrapper.instance().forceUpdate();
+            mount(nodes);
 
             // Assert
             expect(foo).toHaveBeenCalled();


### PR DESCRIPTION
I ran into a situation where having a `NoSSR` wrapping a `UniqueIdProvider` resulted in `this._performRender(true)` not getting called which meant that `this._idFactory` never gets initialized.  This PR fixes that by always check if `this._idFactory` is initialized before calling it and initializing it if it hasn't already been done.