### PR TITLE
output ES5 code so that we can run the phantomjs tests in webapp

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,3 +5,4 @@ last 1 Edge version
 last 1 Firefox version
 last 1 iOS version
 last 1 Safari version
+IE 10

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,4 +6,20 @@ module.exports = {
         "@babel/plugin-proposal-export-default-from",
         "babel-plugin-dynamic-import-node",
     ],
+    env: {
+        test: {
+            presets: [
+                "@babel/preset-flow",
+                "@babel/preset-react",
+                [
+                    "@babel/preset-env",
+                    {
+                        targets: {
+                            node: true,
+                        },
+                    },
+                ],
+            ],
+        },
+    },
 };

--- a/packages/wonder-blocks-form/components/checkbox-group.test.js
+++ b/packages/wonder-blocks-form/components/checkbox-group.test.js
@@ -66,13 +66,13 @@ describe("CheckboxGroup", () => {
     it("calls onChange for each new selection", () => {
         // a is clicked
         const a = group.find(Choice).at(0);
-        const aTarget = a.find("clickable_behavior_ClickableBehavior");
+        const aTarget = a.find("ClickableBehavior");
         aTarget.simulate("click");
         expect(onChange).toHaveBeenCalledTimes(1);
 
         // now b is clicked, onChange should also be called
         const b = group.find(Choice).at(1);
-        const bTarget = b.find("clickable_behavior_ClickableBehavior");
+        const bTarget = b.find("ClickableBehavior");
         bTarget.simulate("click");
         expect(onChange).toHaveBeenCalledTimes(2);
     });

--- a/packages/wonder-blocks-form/components/radio-group.test.js
+++ b/packages/wonder-blocks-form/components/radio-group.test.js
@@ -66,13 +66,13 @@ describe("RadioGroup", () => {
     it("doesn't change when an already selected item is reselected", () => {
         // a is already selected, onChange shouldn't be called
         const a = group.find(Choice).at(0);
-        const aTarget = a.find("clickable_behavior_ClickableBehavior");
+        const aTarget = a.find("ClickableBehavior");
         aTarget.simulate("click");
         expect(onChange).toHaveBeenCalledTimes(0);
 
         // now b is clicked, onChange should be called
         const b = group.find(Choice).at(1);
-        const bTarget = b.find("clickable_behavior_ClickableBehavior");
+        const bTarget = b.find("ClickableBehavior");
         bTarget.simulate("click");
         expect(onChange).toHaveBeenCalledTimes(1);
     });

--- a/packages/wonder-blocks-tooltip/components/__snapshots__/tooltip.test.js.snap
+++ b/packages/wonder-blocks-tooltip/components/__snapshots__/tooltip.test.js.snap
@@ -1,35 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip content is TooltipContent with title, overrides title of TooltipContent: Similar to <Body>Some custom content</Body> 1`] = `
-<body_Body
+<Body
   tag="span"
 >
   Some custom content
-</body_Body>
+</Body>
 `;
 
 exports[`Tooltip content is TooltipContent with title, sets title of TooltipContent: Similar to <HeadingSmall>Some custom content</HeadingSmall> 1`] = `
-<heading_small_HeadingSmall
+<HeadingSmall
   tag="h4"
 >
   Some custom content
-</heading_small_HeadingSmall>
+</HeadingSmall>
 `;
 
 exports[`Tooltip content is TooltipContent with title, sets title of TooltipContent: Similar to <HeadingSmall>Title</HeadingSmall> 1`] = `
-<heading_small_HeadingSmall
+<HeadingSmall
   tag="h4"
 >
   Title
-</heading_small_HeadingSmall>
+</HeadingSmall>
 `;
 
 exports[`Tooltip content is TooltipContent without title, renders content as-is: <Body>Some custom content</Body> 1`] = `
-<body_Body
+<Body
   tag="span"
 >
   Some custom content
-</body_Body>
+</Body>
 `;
 
 exports[`Tooltip content is a string, wraps in TooltipContent with title: Similar to <TooltipContent title="Title">Content</TooltipContent> 1`] = `


### PR DESCRIPTION
This will also avoid having to update UglifyJS which also can't handle ES6 code.  Upgrading both the phantomjs test runner and UglifyJS as part of the current build system aren't good uses of time given that we'll soon be replacing our current build system and test runner.