### PR TITLE
make Icon fixed size, fix truncation behavior in ActionMenu opener

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run: yarn run gen-snapshot-tests
       - run: yarn run build:cjs
       - run: yarn run build:es6
-      - run: yarn run jest --coverage
+      - run: yarn run jest --coverage --runInBand
       - run: yarn run codecov
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:coverage": "yarn run test:common && yarn run jest --coverage",
     "coverage": "yarn run test:coverage && open coverage/lcov-report/index.html",
     "styleguidist": "styleguidist server",
-    "start": "concurrently --kill-others-on-fail \"yarn run styleguidist\" \"webpack -w\" \"rollup -c rollup.config.js -w\"",
+    "start": "concurrently --kill-others-on-fail \"yarn run styleguidist\" \"webpack --config build-settings/webpack.config.js -w\" \"rollup -c build-settings/rollup.config.js -w\"",
     "start:prod": "yarn run build:styleguidist && yarn run styleguidist --config styleguide.prod.config.js",
     "build:styleguidist": "yarn run gen-styleguide-prod-config && styleguidist build --config styleguide.prod.config.js",
     "git-add-snapshot-tests": "git add packages/*/generated-snapshot.test.js",

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -2194,6 +2194,8 @@ exports[`wonder-blocks-button example 9 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "paddingRight": 8,
               "verticalAlign": "text-bottom",
             }
@@ -2286,6 +2288,8 @@ exports[`wonder-blocks-button example 9 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "paddingRight": 8,
               "verticalAlign": "text-bottom",
             }
@@ -2375,6 +2379,8 @@ exports[`wonder-blocks-button example 9 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "paddingRight": 8,
               "verticalAlign": "text-bottom",
             }
@@ -2485,6 +2491,8 @@ exports[`wonder-blocks-button example 9 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "paddingRight": 8,
               "verticalAlign": "text-bottom",
             }
@@ -2578,6 +2586,8 @@ exports[`wonder-blocks-button example 9 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "paddingRight": 8,
               "verticalAlign": "text-bottom",
             }
@@ -2668,6 +2678,8 @@ exports[`wonder-blocks-button example 9 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "paddingRight": 8,
               "verticalAlign": "text-bottom",
             }

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -78,10 +78,6 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
           "justifyContent": "center",
           "margin": 0,
           "outline": "none",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
           "position": "relative",
           "textDecoration": "none",
           "touchAction": "manipulation",
@@ -133,6 +129,32 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
           Betsy Appleseed
         </span>
       </div>
+      <div
+        aria-hidden="true"
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "width": 4,
+            "zIndex": 0,
+          }
+        }
+      />
       <svg
         className=""
         height={16}
@@ -141,7 +163,6 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
             "display": "inline-block",
             "flexGrow": 0,
             "flexShrink": 0,
-            "paddingLeft": 4,
             "verticalAlign": "text-bottom",
           }
         }
@@ -178,6 +199,27 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
     }
   }
 >
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "flexGrow": 1,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  />
   <div
     className=""
     onKeyDown={[Function]}
@@ -235,10 +277,6 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
           "justifyContent": "center",
           "margin": 0,
           "outline": "none",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
           "position": "relative",
           "textDecoration": "none",
           "touchAction": "manipulation",
@@ -290,6 +328,32 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
           Betsy Appleseed
         </span>
       </div>
+      <div
+        aria-hidden="true"
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "width": 4,
+            "zIndex": 0,
+          }
+        }
+      />
       <svg
         className=""
         height={16}
@@ -298,7 +362,6 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
             "display": "inline-block",
             "flexGrow": 0,
             "flexShrink": 0,
-            "paddingLeft": 4,
             "verticalAlign": "text-bottom",
           }
         }
@@ -392,10 +455,6 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
           "justifyContent": "center",
           "margin": 0,
           "outline": "none",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
           "position": "relative",
           "textDecoration": "none",
           "touchAction": "manipulation",
@@ -447,6 +506,32 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
           Assignments
         </span>
       </div>
+      <div
+        aria-hidden="true"
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "width": 4,
+            "zIndex": 0,
+          }
+        }
+      />
       <svg
         className=""
         height={16}
@@ -455,7 +540,6 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
             "display": "inline-block",
             "flexGrow": 0,
             "flexShrink": 0,
-            "paddingLeft": 4,
             "verticalAlign": "text-bottom",
           }
         }

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -90,52 +90,232 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
       tabIndex={0}
       type="button"
     >
-      <span
+      <div
         className=""
         style={
           Object {
-            "MozOsxFontSmoothing": "grayscale",
-            "WebkitFontSmoothing": "antialiased",
-            "alignItems": "center",
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
             "display": "flex",
-            "fontFamily": "Lato, sans-serif",
-            "fontSize": 16,
-            "fontWeight": "bold",
-            "lineHeight": "20px",
-            "overflow": "hidden",
-            "pointerEvents": "none",
-            "textOverflow": "ellipsis",
-            "userSelect": "none",
-            "whiteSpace": "nowrap",
+            "flexDirection": "column",
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
           }
         }
       >
-        Betsy Appleseed
-        <svg
+        <span
           className=""
-          height={16}
           style={
             Object {
+              "MozOsxFontSmoothing": "grayscale",
+              "WebkitFontSmoothing": "antialiased",
+              "alignItems": "center",
               "display": "inline-block",
-              "paddingLeft": 4,
-              "verticalAlign": "text-bottom",
+              "fontFamily": "Lato, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "bold",
+              "lineHeight": "20px",
+              "overflow": "hidden",
+              "pointerEvents": "none",
+              "textAlign": "left",
+              "textOverflow": "ellipsis",
+              "userSelect": "none",
+              "whiteSpace": "nowrap",
             }
           }
-          viewBox="0 0 16 16"
-          width={16}
         >
-          <path
-            d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
+          Betsy Appleseed
+        </span>
+      </div>
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "paddingLeft": 4,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="currentColor"
+        />
+      </svg>
     </button>
   </div>
 </div>
 `;
 
 exports[`wonder-blocks-dropdown example 2 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 100,
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      open={false}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": 0,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexDirection": "column",
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <span
+          className=""
+          style={
+            Object {
+              "MozOsxFontSmoothing": "grayscale",
+              "WebkitFontSmoothing": "antialiased",
+              "alignItems": "center",
+              "display": "inline-block",
+              "fontFamily": "Lato, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "bold",
+              "lineHeight": "20px",
+              "overflow": "hidden",
+              "pointerEvents": "none",
+              "textAlign": "left",
+              "textOverflow": "ellipsis",
+              "userSelect": "none",
+              "whiteSpace": "nowrap",
+            }
+          }
+        >
+          Betsy Appleseed
+        </span>
+      </div>
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "paddingLeft": 4,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 3 1`] = `
 <div
   className=""
   style={
@@ -224,52 +404,75 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
       tabIndex={0}
       type="button"
     >
-      <span
+      <div
         className=""
         style={
           Object {
-            "MozOsxFontSmoothing": "grayscale",
-            "WebkitFontSmoothing": "antialiased",
-            "alignItems": "center",
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
             "display": "flex",
-            "fontFamily": "Lato, sans-serif",
-            "fontSize": 16,
-            "fontWeight": "bold",
-            "lineHeight": "20px",
-            "overflow": "hidden",
-            "pointerEvents": "none",
-            "textOverflow": "ellipsis",
-            "userSelect": "none",
-            "whiteSpace": "nowrap",
+            "flexDirection": "column",
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
           }
         }
       >
-        Assignments
-        <svg
+        <span
           className=""
-          height={16}
           style={
             Object {
+              "MozOsxFontSmoothing": "grayscale",
+              "WebkitFontSmoothing": "antialiased",
+              "alignItems": "center",
               "display": "inline-block",
-              "paddingLeft": 4,
-              "verticalAlign": "text-bottom",
+              "fontFamily": "Lato, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "bold",
+              "lineHeight": "20px",
+              "overflow": "hidden",
+              "pointerEvents": "none",
+              "textAlign": "left",
+              "textOverflow": "ellipsis",
+              "userSelect": "none",
+              "whiteSpace": "nowrap",
             }
           }
-          viewBox="0 0 16 16"
-          width={16}
         >
-          <path
-            d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
+          Assignments
+        </span>
+      </div>
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "paddingLeft": 4,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="currentColor"
+        />
+      </svg>
     </button>
   </div>
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 3 1`] = `
+exports[`wonder-blocks-dropdown example 4 1`] = `
 <div
   className=""
   style={
@@ -385,6 +588,8 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "minWidth": 16,
             "verticalAlign": "text-bottom",
           }
@@ -402,7 +607,7 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 4 1`] = `
+exports[`wonder-blocks-dropdown example 5 1`] = `
 <div
   className=""
   style={
@@ -517,6 +722,8 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "minWidth": 16,
             "verticalAlign": "text-bottom",
           }
@@ -534,7 +741,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 5 1`] = `
+exports[`wonder-blocks-dropdown example 6 1`] = `
 <div
   className=""
   style={
@@ -650,6 +857,8 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "minWidth": 16,
             "verticalAlign": "text-bottom",
           }
@@ -667,7 +876,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 6 1`] = `
+exports[`wonder-blocks-dropdown example 7 1`] = `
 <div
   className=""
   style={
@@ -807,6 +1016,8 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "minWidth": 16,
               "verticalAlign": "text-bottom",
             }
@@ -825,7 +1036,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 7 1`] = `
+exports[`wonder-blocks-dropdown example 8 1`] = `
 <div
   className=""
   style={
@@ -940,6 +1151,8 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "minWidth": 16,
             "verticalAlign": "text-bottom",
           }
@@ -957,7 +1170,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 8 1`] = `
+exports[`wonder-blocks-dropdown example 9 1`] = `
 <div
   className=""
   style={
@@ -1072,6 +1285,8 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "minWidth": 16,
             "verticalAlign": "text-bottom",
           }
@@ -1089,7 +1304,7 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 9 1`] = `
+exports[`wonder-blocks-dropdown example 10 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -8,6 +8,7 @@ import Color, {SemanticColor, mix} from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 import type {ClickableHandlers} from "@khanacademy/wonder-blocks-core";
 import type {SharedProps} from "./action-menu-opener.js";
@@ -77,11 +78,11 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
                 >
                     {label}
                 </View>
+                <Strut size={Spacing.xxxSmall} />
                 <Icon
                     size="small"
                     color="currentColor"
                     icon={icons.caretDown}
-                    style={sharedStyles.icon}
                 />
             </StyledButton>
         );
@@ -95,10 +96,6 @@ const sharedStyles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "center",
         height: 40,
-        paddingTop: 0,
-        paddingBottom: 0,
-        paddingLeft: Spacing.medium,
-        paddingRight: Spacing.medium,
         border: "none",
         borderRadius: Spacing.xxxSmall,
         cursor: "pointer",
@@ -132,9 +129,6 @@ const sharedStyles = StyleSheet.create({
     spinner: {
         position: "absolute",
     },
-    icon: {
-        paddingLeft: Spacing.xxxSmall,
-    },
 });
 
 const styles = {};
@@ -154,16 +148,14 @@ const _generateStyles = (color) => {
         default: {
             background: "none",
             color: color,
-            paddingLeft: 0,
-            paddingRight: 0,
         },
         focus: {
             ":after": {
                 content: "''",
                 position: "absolute",
                 height: 2,
-                width: "100%",
                 left: 0,
+                right: 0,
                 bottom: -1,
                 background: "currentColor",
                 borderRadius: 2,

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import Color, {SemanticColor, mix} from "@khanacademy/wonder-blocks-color";
-import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
@@ -52,10 +52,7 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
             disabled && sharedStyles.disabled,
             buttonStyles.default,
             disabled && buttonStyles.disabled,
-            !disabled &&
-                (pressed
-                    ? buttonStyles.active
-                    : (hovered || focused) && buttonStyles.focus),
+            !disabled && pressed && buttonStyles.active,
         ];
 
         const commonProps = {
@@ -68,20 +65,24 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
         };
 
         const label = (
-            <LabelLarge style={sharedStyles.text}>
-                {children}
+            <LabelLarge style={sharedStyles.text}>{children}</LabelLarge>
+        );
+
+        return (
+            <StyledButton type="button" {...commonProps} disabled={disabled}>
+                <View
+                    style={
+                        !disabled && (hovered || focused) && buttonStyles.focus
+                    }
+                >
+                    {label}
+                </View>
                 <Icon
                     size="small"
                     color="currentColor"
                     icon={icons.caretDown}
                     style={sharedStyles.icon}
                 />
-            </LabelLarge>
-        );
-
-        return (
-            <StyledButton type="button" {...commonProps} disabled={disabled}>
-                {label}
             </StyledButton>
         );
     }
@@ -115,7 +116,8 @@ const sharedStyles = StyleSheet.create({
         height: Spacing.xLarge,
     },
     text: {
-        display: "flex",
+        textAlign: "left",
+        display: "inline-block",
         alignItems: "center",
         fontWeight: "bold",
         userSelect: "none",
@@ -160,25 +162,15 @@ const _generateStyles = (color) => {
                 content: "''",
                 position: "absolute",
                 height: 2,
-                width: `calc(100% - 20px)`,
+                width: "100%",
                 left: 0,
-                bottom: "calc(50% - 11px)",
-                background: color,
+                bottom: -1,
+                background: "currentColor",
                 borderRadius: 2,
             },
         },
         active: {
             color: activeColor,
-            ":after": {
-                content: "''",
-                position: "absolute",
-                height: 2,
-                width: `calc(100% - 20px)`,
-                left: 0,
-                bottom: "calc(50% - 11px)",
-                background: activeColor,
-                borderRadius: 2,
-            },
         },
         disabled: {
             color: offBlack32,

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -47,6 +47,7 @@ and the down caret should be the same size as it is for the other examples.
 ```js
 const {View} = require("@khanacademy/wonder-blocks-core");
 const {StyleSheet} = require("aphrodite");
+const {Spring} = require("@khanacademy/wonder-blocks-layout");
 
 const styles = StyleSheet.create({
     row: {
@@ -55,6 +56,7 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
+    <Spring />
     <ActionMenu
         menuText="Betsy Appleseed"
         style={{width: 100}}

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -39,6 +39,36 @@ const styles = StyleSheet.create({
 </View>
 ```
 
+### Truncated opener
+
+The text in the menu opener should be truncated with ellipsis at the end
+and the down caret should be the same size as it is for the other examples.
+
+```js
+const {View} = require("@khanacademy/wonder-blocks-core");
+const {StyleSheet} = require("aphrodite");
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    },
+});
+
+<View style={styles.row}>
+    <ActionMenu
+        menuText="Betsy Appleseed"
+        style={{width: 100}}
+    >
+        <ActionItem label="Profile" href="http://khanacademy.org/profile" />
+        <ActionItem label="Teacher dashboard" href="http://khanacademy.org/coach/dashboard" />
+        <ActionItem label="Settings (onClick)" onClick={() => console.log("user clicked on settings")} />
+        <ActionItem label="Help" disabled={true} onClick={() => console.log("this item is disabled...")} />
+        <SeparatorItem />
+        <ActionItem label="Log out" href="http://khanacademy.org/logout" />
+    </ActionMenu>
+</View>
+```
+
 ### Hybrid menu of action items and option items
 
 The following menu demonstrates a hybrid menu with both action items and items

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -59,6 +59,47 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
     it("example 2", () => {
+        const {View} = require("@khanacademy/wonder-blocks-core");
+        const {StyleSheet} = require("aphrodite");
+
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
+        const example = (
+            <View style={styles.row}>
+                <ActionMenu menuText="Betsy Appleseed" style={{width: 100}}>
+                    <ActionItem
+                        label="Profile"
+                        href="http://khanacademy.org/profile"
+                    />
+                    <ActionItem
+                        label="Teacher dashboard"
+                        href="http://khanacademy.org/coach/dashboard"
+                    />
+                    <ActionItem
+                        label="Settings (onClick)"
+                        onClick={() => console.log("user clicked on settings")}
+                    />
+                    <ActionItem
+                        label="Help"
+                        disabled={true}
+                        onClick={() => console.log("this item is disabled...")}
+                    />
+                    <SeparatorItem />
+                    <ActionItem
+                        label="Log out"
+                        href="http://khanacademy.org/logout"
+                    />
+                </ActionMenu>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 3", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -146,7 +187,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 3", () => {
+    it("example 4", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -205,7 +246,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 4", () => {
+    it("example 5", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -260,7 +301,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 5", () => {
+    it("example 6", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -316,7 +357,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 6", () => {
+    it("example 7", () => {
         const React = require("react");
         const Color = require("@khanacademy/wonder-blocks-color");
         const {View} = require("@khanacademy/wonder-blocks-core");
@@ -391,7 +432,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 7", () => {
+    it("example 8", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -453,7 +494,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 8", () => {
+    it("example 9", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -520,7 +561,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 9", () => {
+    it("example 10", () => {
         const {StyleSheet} = require("aphrodite");
         const React = require("react");
         const {View, Text} = require("@khanacademy/wonder-blocks-core");

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -61,6 +61,7 @@ describe("wonder-blocks-dropdown", () => {
     it("example 2", () => {
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
+        const {Spring} = require("@khanacademy/wonder-blocks-layout");
 
         const styles = StyleSheet.create({
             row: {
@@ -70,6 +71,7 @@ describe("wonder-blocks-dropdown", () => {
 
         const example = (
             <View style={styles.row}>
+                <Spring />
                 <ActionMenu menuText="Betsy Appleseed" style={{width: 100}}>
                     <ActionItem
                         label="Profile"

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -19,7 +19,6 @@
     "@khanacademy/wonder-blocks-color": "^1.0.13",
     "@khanacademy/wonder-blocks-core": "^1.2.6",
     "@khanacademy/wonder-blocks-icon": "^1.0.10",
-    "@khanacademy/wonder-blocks-icon-button": "^3.0.3",
     "@khanacademy/wonder-blocks-layout": "^1.0.10",
     "@khanacademy/wonder-blocks-modal": "^1.2.3",
     "@khanacademy/wonder-blocks-spacing": "^2.0.11",

--- a/packages/wonder-blocks-form/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/__snapshots__/custom-snapshot.test.js.snap
@@ -64,6 +64,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",
@@ -145,6 +147,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",
@@ -227,6 +231,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",
@@ -310,6 +316,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",
@@ -393,6 +401,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",
@@ -476,6 +486,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",
@@ -556,6 +568,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",
@@ -637,6 +651,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",
@@ -719,6 +735,8 @@ Array [
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "pointerEvents": "none",
         "position": "absolute",
         "verticalAlign": "text-bottom",

--- a/packages/wonder-blocks-form/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/__snapshots__/generated-snapshot.test.js.snap
@@ -215,6 +215,8 @@ exports[`wonder-blocks-form example 1 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "pointerEvents": "none",
             "position": "absolute",
             "verticalAlign": "text-bottom",
@@ -451,6 +453,8 @@ exports[`wonder-blocks-form example 1 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "pointerEvents": "none",
             "position": "absolute",
             "verticalAlign": "text-bottom",
@@ -690,6 +694,8 @@ exports[`wonder-blocks-form example 1 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "pointerEvents": "none",
             "position": "absolute",
             "verticalAlign": "text-bottom",
@@ -2809,6 +2815,8 @@ exports[`wonder-blocks-form example 5 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "flexGrow": 0,
+                "flexShrink": 0,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "verticalAlign": "text-bottom",

--- a/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
@@ -70,6 +70,8 @@ exports[`IconButtonCore kind:primary color:default size:default light:false disa
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -158,6 +160,8 @@ exports[`IconButtonCore kind:primary color:default size:default light:false focu
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -246,6 +250,8 @@ exports[`IconButtonCore kind:primary color:default size:default light:false hove
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -334,6 +340,8 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -419,6 +427,8 @@ exports[`IconButtonCore kind:primary color:default size:default light:true disab
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -507,6 +517,8 @@ exports[`IconButtonCore kind:primary color:default size:default light:true focus
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -595,6 +607,8 @@ exports[`IconButtonCore kind:primary color:default size:default light:true hover
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -683,6 +697,8 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -768,6 +784,8 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -856,6 +874,8 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -944,6 +964,8 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1032,6 +1054,8 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1117,6 +1141,8 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1205,6 +1231,8 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1293,6 +1321,8 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1381,6 +1411,8 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1466,6 +1498,8 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1554,6 +1588,8 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1642,6 +1678,8 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1730,6 +1768,8 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1815,6 +1855,8 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true d
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1903,6 +1945,8 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true f
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -1991,6 +2035,8 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true h
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2079,6 +2125,8 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2164,6 +2212,8 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2252,6 +2302,8 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2340,6 +2392,8 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2428,6 +2482,8 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2513,6 +2569,8 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2601,6 +2659,8 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2689,6 +2749,8 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2777,6 +2839,8 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2862,6 +2926,8 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false di
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -2950,6 +3016,8 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false fo
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3038,6 +3106,8 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false ho
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3126,6 +3196,8 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3211,6 +3283,8 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3299,6 +3373,8 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3387,6 +3463,8 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3475,6 +3553,8 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3560,6 +3640,8 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3648,6 +3730,8 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3736,6 +3820,8 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3824,6 +3910,8 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3909,6 +3997,8 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -3997,6 +4087,8 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4085,6 +4177,8 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4173,6 +4267,8 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4258,6 +4354,8 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false dis
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4346,6 +4444,8 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false foc
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4434,6 +4534,8 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false hov
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4522,6 +4624,8 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4607,6 +4711,8 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4695,6 +4801,8 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4783,6 +4891,8 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4871,6 +4981,8 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -4956,6 +5068,8 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -5044,6 +5158,8 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -5132,6 +5248,8 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -5220,6 +5338,8 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -5305,6 +5425,8 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -5393,6 +5515,8 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -5481,6 +5605,8 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }
@@ -5569,6 +5695,8 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
       style={
         Object {
           "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
           "verticalAlign": "text-bottom",
         }
       }

--- a/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
@@ -88,6 +88,8 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "verticalAlign": "text-bottom",
           }
         }
@@ -195,6 +197,8 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "verticalAlign": "text-bottom",
           }
         }
@@ -302,6 +306,8 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "verticalAlign": "text-bottom",
           }
         }
@@ -410,6 +416,8 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "verticalAlign": "text-bottom",
           }
         }
@@ -515,6 +523,8 @@ exports[`wonder-blocks-icon-button example 2 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
             "verticalAlign": "text-bottom",
           }
         }

--- a/packages/wonder-blocks-icon/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon/__snapshots__/generated-snapshot.test.js.snap
@@ -45,6 +45,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -73,6 +75,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -94,6 +98,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -122,6 +128,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -143,6 +151,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -171,6 +181,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -192,6 +204,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -220,6 +234,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -241,6 +257,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -269,6 +287,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -300,6 +320,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -321,6 +343,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -349,6 +373,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -370,6 +396,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -398,6 +426,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -419,6 +449,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -450,6 +482,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -481,6 +515,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -509,6 +545,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -530,6 +568,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -561,6 +601,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -592,6 +634,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -620,6 +664,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -651,6 +697,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -672,6 +720,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -700,6 +750,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -731,6 +783,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -765,6 +819,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -796,6 +852,8 @@ exports[`wonder-blocks-icon example 1 1`] = `
           style={
             Object {
               "display": "inline-block",
+              "flexGrow": 0,
+              "flexShrink": 0,
               "verticalAlign": "text-bottom",
             }
           }
@@ -820,6 +878,8 @@ exports[`wonder-blocks-icon example 2 1`] = `
   style={
     Object {
       "display": "inline-block",
+      "flexGrow": 0,
+      "flexShrink": 0,
       "verticalAlign": "text-bottom",
     }
   }
@@ -859,6 +919,8 @@ exports[`wonder-blocks-icon example 3 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "verticalAlign": "text-bottom",
       }
     }
@@ -876,6 +938,8 @@ exports[`wonder-blocks-icon example 3 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "verticalAlign": "text-bottom",
       }
     }
@@ -893,6 +957,8 @@ exports[`wonder-blocks-icon example 3 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "verticalAlign": "text-bottom",
       }
     }
@@ -910,6 +976,8 @@ exports[`wonder-blocks-icon example 3 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "verticalAlign": "text-bottom",
       }
     }
@@ -951,6 +1019,8 @@ exports[`wonder-blocks-icon example 4 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
         "margin": 2,
         "verticalAlign": "text-bottom",
       }

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -108,5 +108,7 @@ const styles = StyleSheet.create({
     svg: {
         display: "inline-block",
         verticalAlign: "text-bottom",
+        flexShrink: 0,
+        flexGrow: 0,
     },
 });

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -417,46 +417,69 @@ exports[`wonder-blocks-modal example 3 1`] = `
       tabIndex={0}
       type="button"
     >
-      <span
+      <div
         className=""
         style={
           Object {
-            "MozOsxFontSmoothing": "grayscale",
-            "WebkitFontSmoothing": "antialiased",
-            "alignItems": "center",
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
             "display": "flex",
-            "fontFamily": "Lato, sans-serif",
-            "fontSize": 16,
-            "fontWeight": "bold",
-            "lineHeight": "20px",
-            "overflow": "hidden",
-            "pointerEvents": "none",
-            "textOverflow": "ellipsis",
-            "userSelect": "none",
-            "whiteSpace": "nowrap",
+            "flexDirection": "column",
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
           }
         }
       >
-        actions
-        <svg
+        <span
           className=""
-          height={16}
           style={
             Object {
+              "MozOsxFontSmoothing": "grayscale",
+              "WebkitFontSmoothing": "antialiased",
+              "alignItems": "center",
               "display": "inline-block",
-              "paddingLeft": 4,
-              "verticalAlign": "text-bottom",
+              "fontFamily": "Lato, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "bold",
+              "lineHeight": "20px",
+              "overflow": "hidden",
+              "pointerEvents": "none",
+              "textAlign": "left",
+              "textOverflow": "ellipsis",
+              "userSelect": "none",
+              "whiteSpace": "nowrap",
             }
           }
-          viewBox="0 0 16 16"
-          width={16}
         >
-          <path
-            d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
+          actions
+        </span>
+      </div>
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "paddingLeft": 4,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="currentColor"
+        />
+      </svg>
     </button>
   </div>
 </div>
@@ -692,6 +715,8 @@ exports[`wonder-blocks-modal example 4 1`] = `
                     style={
                       Object {
                         "display": "inline-block",
+                        "flexGrow": 0,
+                        "flexShrink": 0,
                         "verticalAlign": "text-bottom",
                       }
                     }
@@ -1251,6 +1276,8 @@ exports[`wonder-blocks-modal example 5 1`] = `
                     style={
                       Object {
                         "display": "inline-block",
+                        "flexGrow": 0,
+                        "flexShrink": 0,
                         "verticalAlign": "text-bottom",
                       }
                     }
@@ -1856,6 +1883,8 @@ exports[`wonder-blocks-modal example 6 1`] = `
                     style={
                       Object {
                         "display": "inline-block",
+                        "flexGrow": 0,
+                        "flexShrink": 0,
                         "verticalAlign": "text-bottom",
                       }
                     }
@@ -2601,6 +2630,8 @@ exports[`wonder-blocks-modal example 7 1`] = `
                     style={
                       Object {
                         "display": "inline-block",
+                        "flexGrow": 0,
+                        "flexShrink": 0,
                         "verticalAlign": "text-bottom",
                       }
                     }
@@ -3247,6 +3278,8 @@ exports[`wonder-blocks-modal example 8 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "flexGrow": 0,
+                      "flexShrink": 0,
                       "verticalAlign": "text-bottom",
                     }
                   }
@@ -3706,6 +3739,8 @@ exports[`wonder-blocks-modal example 9 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "flexGrow": 0,
+                      "flexShrink": 0,
                       "verticalAlign": "text-bottom",
                     }
                   }
@@ -4301,6 +4336,8 @@ exports[`wonder-blocks-modal example 10 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "flexGrow": 0,
+                      "flexShrink": 0,
                       "verticalAlign": "text-bottom",
                     }
                   }
@@ -4646,6 +4683,8 @@ exports[`wonder-blocks-modal example 11 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "flexGrow": 0,
+                      "flexShrink": 0,
                       "verticalAlign": "text-bottom",
                     }
                   }
@@ -5196,6 +5235,8 @@ exports[`wonder-blocks-modal example 12 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "flexGrow": 0,
+                      "flexShrink": 0,
                       "verticalAlign": "text-bottom",
                     }
                   }
@@ -5724,6 +5765,8 @@ exports[`wonder-blocks-modal example 13 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "flexGrow": 0,
+                      "flexShrink": 0,
                       "verticalAlign": "text-bottom",
                     }
                   }
@@ -6055,6 +6098,8 @@ exports[`wonder-blocks-modal example 14 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "flexGrow": 0,
+                      "flexShrink": 0,
                       "verticalAlign": "text-bottom",
                     }
                   }

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -405,10 +405,6 @@ exports[`wonder-blocks-modal example 3 1`] = `
           "justifyContent": "center",
           "margin": 0,
           "outline": "none",
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 0,
           "position": "relative",
           "textDecoration": "none",
           "touchAction": "manipulation",
@@ -460,6 +456,32 @@ exports[`wonder-blocks-modal example 3 1`] = `
           actions
         </span>
       </div>
+      <div
+        aria-hidden="true"
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "width": 4,
+            "zIndex": 0,
+          }
+        }
+      />
       <svg
         className=""
         height={16}
@@ -468,7 +490,6 @@ exports[`wonder-blocks-modal example 3 1`] = `
             "display": "inline-block",
             "flexGrow": 0,
             "flexShrink": 0,
-            "paddingLeft": 4,
             "verticalAlign": "text-bottom",
           }
         }

--- a/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
@@ -415,6 +415,8 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "flexGrow": 0,
+                "flexShrink": 0,
                 "verticalAlign": "text-bottom",
               }
             }
@@ -521,6 +523,8 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "flexGrow": 0,
+                "flexShrink": 0,
                 "verticalAlign": "text-bottom",
               }
             }
@@ -784,6 +788,8 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "flexGrow": 0,
+                "flexShrink": 0,
                 "verticalAlign": "text-bottom",
               }
             }
@@ -1047,6 +1053,8 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "flexGrow": 0,
+                "flexShrink": 0,
                 "verticalAlign": "text-bottom",
               }
             }
@@ -1303,6 +1311,8 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "flexGrow": 0,
+                "flexShrink": 0,
                 "verticalAlign": "text-bottom",
               }
             }
@@ -1955,6 +1965,8 @@ exports[`wonder-blocks-toolbar example 7 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "flexGrow": 0,
+                "flexShrink": 0,
                 "verticalAlign": "text-bottom",
               }
             }


### PR DESCRIPTION
This PR fixes a couple of issues with the ActionMenu opener:
- text wasn't being truncated
- icon was be squished

Icon is now fixed size.  It can't shrink or grow.

Before:
<img width="371" alt="screen shot 2018-10-19 at 9 30 50 am" src="https://user-images.githubusercontent.com/1044413/47277559-8698ca80-d58f-11e8-8717-b8ec32689d06.png">

After:
<img width="174" alt="screen shot 2018-10-22 at 12 15 45 am" src="https://user-images.githubusercontent.com/1044413/47277568-a5975c80-d58f-11e8-80c1-7e65033c8c35.png">

Unfortunately we don't have an easy way to test changes in webapp.  We will once the webpack work is done, but I have high confidence that this will fix the issue.  In the before screenshot notice how the down caret is smaller than it should be.  I was able to reproduce this in one of the ActionMenu examples before fixing it with by setting `flexShrink: 0` on the Icon component.  I'll try copy/pasting the built component into webapp to verify things are working as expected.