### PR TITLE
Add a simple example of using BodyMonospace

### DIFF
--- a/packages/wonder-blocks-typography/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-typography/__snapshots__/generated-snapshot.test.js.snap
@@ -380,3 +380,25 @@ exports[`wonder-blocks-typography example 3 1`] = `
   Title
 </h1>
 `;
+
+exports[`wonder-blocks-typography example 4 1`] = `
+<span
+  className=""
+  style={
+    Object {
+      "MozOsxFontSmoothing": "grayscale",
+      "WebkitFontSmoothing": "antialiased",
+      "display": "block",
+      "fontFamily": "Inconsolata, monospace",
+      "fontSize": 17,
+      "fontWeight": 400,
+      "lineHeight": "22px",
+      "whiteSpace": "pre",
+    }
+  }
+>
+  const things = {
+            areTested: "This is my new Code element with my code.",
+        };
+</span>
+`;

--- a/packages/wonder-blocks-typography/components/body-monospace.md
+++ b/packages/wonder-blocks-typography/components/body-monospace.md
@@ -1,0 +1,15 @@
+One example of using the `BodyMonospace` typography component is to create a `Code` component for rendering pre-formatted code blocks.
+
+```jsx
+const Code = ({children}) => (
+    <BodyMonospace style={{whiteSpace: "pre"}}>{children}</BodyMonospace>
+);
+
+const code = (
+`const things = {
+    areTested\: "This is my new Code element with my code.",
+};`
+);
+
+<Code>{code}</Code>
+```

--- a/packages/wonder-blocks-typography/generated-snapshot.test.js
+++ b/packages/wonder-blocks-typography/generated-snapshot.test.js
@@ -86,4 +86,19 @@ describe("wonder-blocks-typography", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+    it("example 4", () => {
+        const Code = ({children}) => (
+            <BodyMonospace style={{whiteSpace: "pre"}}>
+                {children}
+            </BodyMonospace>
+        );
+
+        const code = `const things = {
+            areTested\: "This is my new Code element with my code.",
+        };`;
+
+        const example = <Code>{code}</Code>;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
I had created a `Code` component for use in my React Sandbox work and thought it made a nice simple example. So I've added it to the docs.