### PR TITLE
ignore more files to avoid unnecessary upgrades while publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,9 @@
     "publish": {
       "ignore": [
         "*.test.js",
-        "*.md"
+        "*.vite_test.js",
+        "*.md",
+        "*.js.snap"
       ]
     }
   },


### PR DESCRIPTION
In order to avoid bumping all modules all the time, I've added some more files to ignore to our lerna.json file.

Test Plan:
- run `node_modules/.bin/lerna updated`
- see the following output

```
lerna info version 2.11.0
lerna info versioning independent
lerna info ignore [ '*.test.js', '*.vite_test.js', '*.md', '*.js.snap' ]
lerna info Checking for updated packages...
lerna info Comparing with @khanacademy/wonder-blocks-button@2.2.5.
lerna info Checking for prereleased packages...
lerna info result 
- @khanacademy/wonder-blocks-dropdown
```

In this case `wonder-blocks-dropdown` has actually seen some code changes since the last publish.