### PR TITLE
don't include test files in coverage reports

### DIFF
--- a/config/jest/test.config.js
+++ b/config/jest/test.config.js
@@ -19,6 +19,7 @@ module.exports = {
     },
     collectCoverageFrom: [
         "packages/**/*.js",
+        "!packages/**/*.vite_test.js",
         "!packages/**/dist/**/*.js",
         "!<rootDir>/node_modules/",
         "!packages/**/node_modules/",

--- a/config/jest/vite.config.js
+++ b/config/jest/vite.config.js
@@ -36,6 +36,7 @@ module.exports = {
         "@khanacademy/jest-environment-vite/dist/setup.js",
     collectCoverageFrom: [
         "packages/**/*.js",
+        "!packages/**/*.test.js",
         "!packages/**/dist/**/*.js",
         "!<rootDir>/node_modules/",
         "!packages/**/node_modules/",


### PR DESCRIPTION
Since the addition of the vite test runner, the normal jest tests weren't excluding `.vite_test.js` files and the normal jest tests weren't excluding `.test.js` files.