### PR TITLE
WB-477: Add testId to all components in wonder-blocks-dropdown

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -45,6 +45,7 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
   >
     <button
       className=""
+      data-test-id="teacher-menu"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -601,6 +602,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
   >
     <button
       className=""
+      data-test-id="fruit-select"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -1299,6 +1301,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
   >
     <button
       className=""
+      data-test-id="palette"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -45,6 +45,11 @@ type ActionProps = {|
     skipClientNav?: boolean,
 
     /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+
+    /**
      * Function to call when button is clicked.
      *
      * This callback should be used for things like marking BigBingo
@@ -92,6 +97,7 @@ export default class ActionItem extends React.Component<ActionProps> {
             indent,
             label,
             onClick,
+            testId,
         } = this.props;
         const {router} = this.context;
 
@@ -121,6 +127,7 @@ export default class ActionItem extends React.Component<ActionProps> {
                     ];
 
                     const props = {
+                        "data-test-id": testId,
                         disabled,
                         style: [defaultStyle],
                         ...handlers,

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -51,6 +51,11 @@ type MenuProps = {|
      * Optional styling to add to the opener component wrapper.
      */
     style?: StyleType,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 type State = {|
@@ -169,7 +174,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
     };
 
     render() {
-        const {alignment, disabled, menuText, style} = this.props;
+        const {alignment, disabled, menuText, style, testId} = this.props;
         const {open} = this.state;
 
         const opener = (
@@ -178,6 +183,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                 onOpenChanged={this.handleOpenChanged}
                 open={open}
                 ref={this.handleOpenerRef}
+                testId={testId}
             >
                 {menuText}
             </ActionMenuOpener>

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -28,13 +28,14 @@ const styles = StyleSheet.create({
     <ActionMenu
         alignment="right"
         menuText="Betsy Appleseed"
+        testId="teacher-menu"
     >
-        <ActionItem label="Profile" href="http://khanacademy.org/profile" />
-        <ActionItem label="Teacher dashboard" href="http://khanacademy.org/coach/dashboard" />
-        <ActionItem label="Settings (onClick)" onClick={() => console.log("user clicked on settings")} />
-        <ActionItem label="Help" disabled={true} onClick={() => console.log("this item is disabled...")} />
+        <ActionItem label="Profile" href="http://khanacademy.org/profile" testId="profile" />
+        <ActionItem label="Teacher dashboard" href="http://khanacademy.org/coach/dashboard" testId="dashboard" />
+        <ActionItem label="Settings (onClick)" onClick={() => console.log("user clicked on settings")} testId="settings" />
+        <ActionItem label="Help" disabled={true} onClick={() => console.log("this item is disabled...")} testId="help" />
         <SeparatorItem />
-        <ActionItem label="Log out" href="http://khanacademy.org/logout" />
+        <ActionItem label="Log out" href="http://khanacademy.org/logout" testId="logout" />
     </ActionMenu>
 </View>
 ```

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -73,6 +73,11 @@ type Props = {|
     style?: StyleType,
 
     /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+
+    /**
      * Optional styling to add to the dropdown wrapper.
      */
     dropdownStyle?: StyleType,
@@ -260,6 +265,7 @@ export default class MultiSelect extends React.Component<Props, State> {
             light,
             placeholder,
             style,
+            testId,
             dropdownStyle,
         } = this.props;
         const {open} = this.state;
@@ -274,6 +280,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 onOpenChanged={this.handleOpenChanged}
                 open={open}
                 ref={this.handleOpenerRef}
+                testId={testId}
             >
                 {menuText}
             </SelectOpener>

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -41,14 +41,15 @@ class ExampleNoneSelected extends React.Component {
             selectedValues={this.state.selectedValues}
             selectItemType="colors"
             style={styles.setWidth}
+            testId="palette"
         >
-            <OptionItem label="Red" value="1"
+            <OptionItem label="Red" value="1" testId="red"
                 onClick={() => console.log("Roses are red")}
             />
-            <OptionItem label="Yellow" value="2" disabled />
-            <OptionItem label="Green" value="3" />
-            <OptionItem label="Blue" value="4" />
-            {false && <OptionItem label="Pink" value="5" />}
+            <OptionItem label="Yellow" value="2" disabled testId="yellow"/>
+            <OptionItem label="Green" value="3" testId="green" />
+            <OptionItem label="Blue" value="4" testId="blue" />
+            {false && <OptionItem label="Pink" value="5" testId="pink" />}
         </MultiSelect>;
     }
 }

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -49,6 +49,11 @@ type OptionProps = {|
     selected: boolean,
 
     /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+
+    /**
      * Whether the item should show a check or checkbox to indicate selection
      * state. Auto-populated by menu or select.
      * @ignore
@@ -87,7 +92,7 @@ export default class OptionItem extends React.Component<OptionProps> {
     };
 
     render() {
-        const {disabled, label, selected} = this.props;
+        const {disabled, label, selected, testId} = this.props;
 
         const ClickableBehavior = getClickableBehavior();
         const CheckComponent = this.getCheckComponent();
@@ -111,6 +116,7 @@ export default class OptionItem extends React.Component<OptionProps> {
 
                     return (
                         <View
+                            data-test-id={testId}
                             style={defaultStyle}
                             aria-checked={selected ? "true" : "false"}
                             role="option"

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -50,6 +50,11 @@ type SelectOpenerProps = {|
     light: boolean,
 
     /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+
+    /**
      * Callback for when the SelectOpener is pressed.
      */
     onOpenChanged: (open: boolean, keyboard: boolean) => void,
@@ -78,7 +83,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
     };
 
     render() {
-        const {children, disabled, isPlaceholder, light} = this.props;
+        const {children, disabled, isPlaceholder, light, testId} = this.props;
 
         const ClickableBehavior = getClickableBehavior(this.context.router);
 
@@ -104,6 +109,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
 
                     return (
                         <StyledButton
+                            data-test-id={testId}
                             disabled={disabled}
                             role="listbox"
                             type="button"

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -58,6 +58,11 @@ type Props = {|
     style?: StyleType,
 
     /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+
+    /**
      * Optional styling to add to the dropdown wrapper.
      */
     dropdownStyle?: StyleType,
@@ -168,6 +173,7 @@ export default class SingleSelect extends React.Component<Props, State> {
             placeholder,
             selectedValue,
             style,
+            testId,
         } = this.props;
         const {open} = this.state;
 
@@ -186,6 +192,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                 onOpenChanged={this.handleOpenChanged}
                 open={open}
                 ref={this.handleOpenerRef}
+                testId={testId}
             >
                 {menuText}
             </SelectOpener>

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -42,11 +42,12 @@ class ExampleWithPlaceholder extends React.Component {
             placeholder="Choose a fruit"
             selectedValue={this.state.selectedValue}
             style={styles.setWidth}
+            testId="fruit-select"
         >
-            <OptionItem label="Vine-ripened tomatoes" value="tomato" />
-            <OptionItem label="Watermelon" value="watermelon" />
-            <OptionItem label="Strawberry" value="strawberry" />
-            {false && <OptionItem label="Other" value="other" />}
+            <OptionItem label="Vine-ripened tomatoes" value="tomato" testId="tomato" />
+            <OptionItem label="Watermelon" value="watermelon" testId="watermelon" />
+            <OptionItem label="Strawberry" value="strawberry" testId="strawberry" />
+            {false && <OptionItem label="Other" value="other" testId="other" />}
         </SingleSelect>;
     }
 }

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -29,28 +29,37 @@ describe("wonder-blocks-dropdown", () => {
         });
         const example = (
             <View style={styles.row}>
-                <ActionMenu alignment="right" menuText="Betsy Appleseed">
+                <ActionMenu
+                    alignment="right"
+                    menuText="Betsy Appleseed"
+                    testId="teacher-menu"
+                >
                     <ActionItem
                         label="Profile"
                         href="http://khanacademy.org/profile"
+                        testId="profile"
                     />
                     <ActionItem
                         label="Teacher dashboard"
                         href="http://khanacademy.org/coach/dashboard"
+                        testId="dashboard"
                     />
                     <ActionItem
                         label="Settings (onClick)"
                         onClick={() => console.log("user clicked on settings")}
+                        testId="settings"
                     />
                     <ActionItem
                         label="Help"
                         disabled={true}
                         onClick={() => console.log("this item is disabled...")}
+                        testId="help"
                     />
                     <SeparatorItem />
                     <ActionItem
                         label="Log out"
                         href="http://khanacademy.org/logout"
+                        testId="logout"
                     />
                 </ActionMenu>
             </View>
@@ -227,14 +236,30 @@ describe("wonder-blocks-dropdown", () => {
                         placeholder="Choose a fruit"
                         selectedValue={this.state.selectedValue}
                         style={styles.setWidth}
+                        testId="fruit-select"
                     >
                         <OptionItem
                             label="Vine-ripened tomatoes"
                             value="tomato"
+                            testId="tomato"
                         />
-                        <OptionItem label="Watermelon" value="watermelon" />
-                        <OptionItem label="Strawberry" value="strawberry" />
-                        {false && <OptionItem label="Other" value="other" />}
+                        <OptionItem
+                            label="Watermelon"
+                            value="watermelon"
+                            testId="watermelon"
+                        />
+                        <OptionItem
+                            label="Strawberry"
+                            value="strawberry"
+                            testId="strawberry"
+                        />
+                        {false && (
+                            <OptionItem
+                                label="Other"
+                                value="other"
+                                testId="other"
+                            />
+                        )}
                     </SingleSelect>
                 );
             }
@@ -536,16 +561,25 @@ describe("wonder-blocks-dropdown", () => {
                         selectedValues={this.state.selectedValues}
                         selectItemType="colors"
                         style={styles.setWidth}
+                        testId="palette"
                     >
                         <OptionItem
                             label="Red"
                             value="1"
+                            testId="red"
                             onClick={() => console.log("Roses are red")}
                         />
-                        <OptionItem label="Yellow" value="2" disabled />
-                        <OptionItem label="Green" value="3" />
-                        <OptionItem label="Blue" value="4" />
-                        {false && <OptionItem label="Pink" value="5" />}
+                        <OptionItem
+                            label="Yellow"
+                            value="2"
+                            disabled
+                            testId="yellow"
+                        />
+                        <OptionItem label="Green" value="3" testId="green" />
+                        <OptionItem label="Blue" value="4" testId="blue" />
+                        {false && (
+                            <OptionItem label="Pink" value="5" testId="pink" />
+                        )}
                     </MultiSelect>
                 );
             }


### PR DESCRIPTION
The original request was to add `testId` to `ActionItem` and `ActionMenu` but I decided to add this prop to all components from `wonder-blocks-dropdown`.

Test Plan:
- inspect the first example for ActionMenu and see that data-test-id shows up on the opener and each of the items
- inspect the first example for SingleSelect and see that data-test-id shows up on the opener and each of the items
- inspect the first example for MultiSelect and see that data-test-id shows up on the opener and each of the items
