### PR TITLE
WB-474: allow dropdowns to work without children

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -589,6 +589,185 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
         "display": "flex",
         "flexDirection": "column",
         "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": "fit-content",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      aria-disabled="true"
+      className=""
+      disabled={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      open={false}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "rgba(33,36,44,0.32)",
+          "cursor": "default",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": 0,
+          "outline": "none",
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+        }
+      }
+      tabIndex={-1}
+      type="button"
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexDirection": "column",
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <span
+          className=""
+          style={
+            Object {
+              "MozOsxFontSmoothing": "grayscale",
+              "WebkitFontSmoothing": "antialiased",
+              "alignItems": "center",
+              "display": "inline-block",
+              "fontFamily": "Lato, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "bold",
+              "lineHeight": "20px",
+              "overflow": "hidden",
+              "pointerEvents": "none",
+              "textAlign": "left",
+              "textOverflow": "ellipsis",
+              "userSelect": "none",
+              "whiteSpace": "nowrap",
+            }
+          }
+        >
+          Empty
+        </span>
+      </div>
+      <div
+        aria-hidden="true"
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "width": 4,
+            "zIndex": 0,
+          }
+        }
+      />
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 5 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
         "maxWidth": 190,
         "minHeight": 0,
         "minWidth": 170,
@@ -691,7 +870,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 5 1`] = `
+exports[`wonder-blocks-dropdown example 6 1`] = `
 <div
   className=""
   style={
@@ -826,7 +1005,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 6 1`] = `
+exports[`wonder-blocks-dropdown example 7 1`] = `
 <div
   className=""
   style={
@@ -960,7 +1139,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 7 1`] = `
+exports[`wonder-blocks-dropdown example 8 1`] = `
 <div
   className=""
   style={
@@ -1095,7 +1274,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 8 1`] = `
+exports[`wonder-blocks-dropdown example 9 1`] = `
 <div
   className=""
   style={
@@ -1255,7 +1434,142 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 9 1`] = `
+exports[`wonder-blocks-dropdown example 10 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": "fit-content",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className=""
+      disabled={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="listbox"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          "alignItems": "center",
+          "backgroundColor": "transparent",
+          "borderColor": "rgba(33,36,44,0.16)",
+          "borderRadius": 4,
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "boxSizing": "border-box",
+          "color": "rgba(33,36,44,0.64)",
+          "cursor": "auto",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "space-between",
+          "margin": 0,
+          "outline": "none",
+          "paddingLeft": 16,
+          "paddingRight": 12,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "whiteSpace": "nowrap",
+        }
+      }
+      tabIndex={-1}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, sans-serif",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+            "marginRight": 8,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        empty
+      </span>
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "minWidth": 16,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="rgba(33,36,44,0.32)"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 11 1`] = `
 <div
   className=""
   style={
@@ -1389,7 +1703,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 10 1`] = `
+exports[`wonder-blocks-dropdown example 12 1`] = `
 <div
   className=""
   style={
@@ -1523,7 +1837,7 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 11 1`] = `
+exports[`wonder-blocks-dropdown example 13 1`] = `
 <div
   className=""
   style={
@@ -1657,7 +1971,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 12 1`] = `
+exports[`wonder-blocks-dropdown example 14 1`] = `
 <div
   className=""
   style={
@@ -1747,5 +2061,140 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
       Open modal!
     </span>
   </button>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 15 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": "fit-content",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className=""
+      disabled={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="listbox"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          "alignItems": "center",
+          "backgroundColor": "transparent",
+          "borderColor": "rgba(33,36,44,0.16)",
+          "borderRadius": 4,
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "boxSizing": "border-box",
+          "color": "rgba(33,36,44,0.64)",
+          "cursor": "auto",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "space-between",
+          "margin": 0,
+          "outline": "none",
+          "paddingLeft": 16,
+          "paddingRight": 12,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "whiteSpace": "nowrap",
+        }
+      }
+      tabIndex={-1}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, sans-serif",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+            "marginRight": 8,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        empty
+      </span>
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "minWidth": 16,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="rgba(33,36,44,0.32)"
+        />
+      </svg>
+    </button>
+  </div>
 </div>
 `;

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -172,9 +172,11 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
         const {alignment, disabled, menuText, style} = this.props;
         const {open} = this.state;
 
+        const items = this.getMenuItems();
+
         const opener = (
             <ActionMenuOpener
-                disabled={disabled}
+                disabled={items.length === 0 || disabled}
                 onOpenChanged={this.handleOpenChanged}
                 open={open}
                 ref={this.handleOpenerRef}
@@ -187,7 +189,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
             <Dropdown
                 alignment={alignment}
                 dropdownStyle={styles.menuTopSpace}
-                items={this.getMenuItems()}
+                items={items}
                 keyboard={this.state.keyboard}
                 light={false}
                 onOpenChanged={this.handleOpenChanged}

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -16,7 +16,7 @@ type MenuProps = {|
     /**
      * The items in this dropdown.
      */
-    children: Array<Item>,
+    children?: Array<Item>,
 
     /**
      * Text for the opener of this menu.

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -130,3 +130,23 @@ class HybridMenu extends React.Component {
     <HybridMenu />
 </View>
 ```
+
+### Empty and disabled
+
+`ActionMenu` can be disabled.  In this situation it may make sense to not
+provide any children to the component.
+
+```js
+const {StyleSheet} = require("aphrodite");
+const {View} = require("@khanacademy/wonder-blocks-core");
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    },
+});
+
+<View style={styles.row}>
+    <ActionMenu menuText="Empty" disabled={true} />
+</View>
+```

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -131,10 +131,7 @@ class HybridMenu extends React.Component {
 </View>
 ```
 
-### Empty and disabled
-
-`ActionMenu` can be disabled.  In this situation it may make sense to not
-provide any children to the component.
+### Empty menus are disabled automatically
 
 ```js
 const {StyleSheet} = require("aphrodite");
@@ -147,6 +144,6 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
-    <ActionMenu menuText="Empty" disabled={true} />
+    <ActionMenu menuText="Empty" />
 </View>
 ```

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -18,7 +18,7 @@ type Props = {|
     /**
      * The items in this select.
      */
-    children: Array<React.Element<OptionItem>>,
+    children?: Array<React.Element<OptionItem>>,
 
     /**
      * Callback for when the selection changes. Parameter is an updated array of
@@ -105,6 +105,7 @@ export default class MultiSelect extends React.Component<Props, State> {
         disabled: false,
         light: false,
         shortcuts: false,
+        selectedValues: [],
     };
 
     constructor(props: Props) {

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -267,9 +267,11 @@ export default class MultiSelect extends React.Component<Props, State> {
 
         const menuText = this.getMenuText();
 
+        const items = [...this.getShortcuts(), ...this.getMenuItems()];
+
         const opener = (
             <SelectOpener
-                disabled={disabled}
+                disabled={items.length === 0 || disabled}
                 isPlaceholder={menuText === placeholder}
                 light={light}
                 onOpenChanged={this.handleOpenChanged}
@@ -279,8 +281,6 @@ export default class MultiSelect extends React.Component<Props, State> {
                 {menuText}
             </SelectOpener>
         );
-
-        const items = [...this.getShortcuts(), ...this.getMenuItems()];
 
         return (
             <Dropdown

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -270,3 +270,23 @@ const modal = (
     </ModalLauncher>
 </View>
 ```
+
+### Empty and disabled
+
+`MultiSelect` can be disabled.  In this situation it may make sense to not
+provide any children to the component.
+
+```js
+const {StyleSheet} = require("aphrodite");
+const {View} = require("@khanacademy/wonder-blocks-core");
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    },
+});
+
+<View style={styles.row}>
+    <MultiSelect menuText="Empty" disabled={true} placeholder="empty" />
+</View>
+```

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -271,10 +271,7 @@ const modal = (
 </View>
 ```
 
-### Empty and disabled
-
-`MultiSelect` can be disabled.  In this situation it may make sense to not
-provide any children to the component.
+### Empty menus are disabled automatically
 
 ```js
 const {StyleSheet} = require("aphrodite");
@@ -287,6 +284,6 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
-    <MultiSelect menuText="Empty" disabled={true} placeholder="empty" />
+    <MultiSelect menuText="Empty" placeholder="empty" />
 </View>
 ```

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -16,7 +16,7 @@ type Props = {|
     /**
      * The items in this select.
      */
-    children: Array<React.Element<OptionItem>>,
+    children?: Array<React.Element<OptionItem>>,
 
     /**
      * Callback for when the selection. Parameter is the value of the newly

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -178,9 +178,11 @@ export default class SingleSelect extends React.Component<Props, State> {
         // item in the menu, use the placeholder.
         const menuText = selectedItem ? selectedItem.props.label : placeholder;
 
+        const items = this.getMenuItems();
+
         const opener = (
             <SelectOpener
-                disabled={disabled}
+                disabled={items.length === 0 || disabled}
                 isPlaceholder={!selectedItem}
                 light={light}
                 onOpenChanged={this.handleOpenChanged}
@@ -190,8 +192,6 @@ export default class SingleSelect extends React.Component<Props, State> {
                 {menuText}
             </SelectOpener>
         );
-
-        const items = this.getMenuItems();
 
         return (
             <Dropdown

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -284,10 +284,7 @@ class LightRightAlignedExample extends React.Component {
 
 ```
 
-### Empty and disabled
-
-`SingleSelect` can be disabled.  In this situation it may make sense to not
-provide any children to the component.
+### Empty menus are disabled automatically
 
 ```js
 const {View} = require("@khanacademy/wonder-blocks-core");
@@ -300,6 +297,6 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
-    <SingleSelect menuText="Empty" disabled={true} placeholder="empty" />
+    <SingleSelect menuText="Empty" placeholder="empty" />
 </View>
 ```

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -283,3 +283,23 @@ class LightRightAlignedExample extends React.Component {
 </View>
 
 ```
+
+### Empty and disabled
+
+`SingleSelect` can be disabled.  In this situation it may make sense to not
+provide any children to the component.
+
+```js
+const {View} = require("@khanacademy/wonder-blocks-core");
+const {StyleSheet} = require("aphrodite");
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    },
+});
+
+<View style={styles.row}>
+    <SingleSelect menuText="Empty" disabled={true} placeholder="empty" />
+</View>
+```

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -190,6 +190,24 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
     it("example 4", () => {
+        const {StyleSheet} = require("aphrodite");
+        const {View} = require("@khanacademy/wonder-blocks-core");
+
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
+        const example = (
+            <View style={styles.row}>
+                <ActionMenu menuText="Empty" disabled={true} />
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 5", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -248,7 +266,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 5", () => {
+    it("example 6", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -311,7 +329,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 6", () => {
+    it("example 7", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -366,7 +384,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 7", () => {
+    it("example 8", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -422,7 +440,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 8", () => {
+    it("example 9", () => {
         const React = require("react");
         const Color = require("@khanacademy/wonder-blocks-color");
         const {View} = require("@khanacademy/wonder-blocks-core");
@@ -497,7 +515,29 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 9", () => {
+    it("example 10", () => {
+        const {View} = require("@khanacademy/wonder-blocks-core");
+        const {StyleSheet} = require("aphrodite");
+
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
+        const example = (
+            <View style={styles.row}>
+                <SingleSelect
+                    menuText="Empty"
+                    disabled={true}
+                    placeholder="empty"
+                />
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 11", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -559,7 +599,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 10", () => {
+    it("example 12", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -624,7 +664,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 11", () => {
+    it("example 13", () => {
         const React = require("react");
         const {View} = require("@khanacademy/wonder-blocks-core");
         const {StyleSheet} = require("aphrodite");
@@ -691,7 +731,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 12", () => {
+    it("example 14", () => {
         const {StyleSheet} = require("aphrodite");
         const React = require("react");
         const {View, Text} = require("@khanacademy/wonder-blocks-core");
@@ -782,6 +822,28 @@ describe("wonder-blocks-dropdown", () => {
                         <Button onClick={openModal}>Open modal!</Button>
                     )}
                 </ModalLauncher>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 15", () => {
+        const {StyleSheet} = require("aphrodite");
+        const {View} = require("@khanacademy/wonder-blocks-core");
+
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
+        const example = (
+            <View style={styles.row}>
+                <MultiSelect
+                    menuText="Empty"
+                    disabled={true}
+                    placeholder="empty"
+                />
             </View>
         );
         const tree = renderer.create(example).toJSON();

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -201,7 +201,7 @@ describe("wonder-blocks-dropdown", () => {
 
         const example = (
             <View style={styles.row}>
-                <ActionMenu menuText="Empty" disabled={true} />
+                <ActionMenu menuText="Empty" />
             </View>
         );
         const tree = renderer.create(example).toJSON();
@@ -527,11 +527,7 @@ describe("wonder-blocks-dropdown", () => {
 
         const example = (
             <View style={styles.row}>
-                <SingleSelect
-                    menuText="Empty"
-                    disabled={true}
-                    placeholder="empty"
-                />
+                <SingleSelect menuText="Empty" placeholder="empty" />
             </View>
         );
         const tree = renderer.create(example).toJSON();
@@ -839,11 +835,7 @@ describe("wonder-blocks-dropdown", () => {
 
         const example = (
             <View style={styles.row}>
-                <MultiSelect
-                    menuText="Empty"
-                    disabled={true}
-                    placeholder="empty"
-                />
+                <MultiSelect menuText="Empty" placeholder="empty" />
             </View>
         );
         const tree = renderer.create(example).toJSON();


### PR DESCRIPTION
It seems that ActionMenu and SingleSelect already worked without any children.  This PR adds examples to show that they work and update MultiSelect to ensure that it works.  I've also updated the flow types for all of the dropdowns to allow code to type check when not passing children.

TODO: move the examples closer to the exiting disabled examples.