### PR TITLE
upgrade Flow to version 0.85

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.79.1
+0.85
 
 [ignore]
 <PROJECT_ROOT>/node_modules/react-element-to-jsx-string

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-react": "7.7.0",
     "eslint-plugin-react-native-animation-linter": "0.1.1",
     "eslint-watch": "^4.0.1",
-    "flow-bin": "0.79.1",
+    "flow-bin": "0.85",
     "flow-coverage-report": "^0.5.0",
     "glob": "^7.1.2",
     "jest": "^23.5.0",

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -26,9 +26,9 @@ type Props = {|
     pressed: boolean,
 |};
 
-const StyledAnchor = addStyle<React.ElementProps<"a">>("a");
-const StyledButton = addStyle<React.ElementProps<"button">>("button");
-const StyledLink = addStyle<React.ElementProps<typeof Link>>(Link);
+const StyledAnchor = addStyle<"a">("a");
+const StyledButton = addStyle<"button">("button");
+const StyledLink = addStyle<typeof Link>(Link);
 
 export default class ButtonCore extends React.Component<Props> {
     static contextTypes = {router: PropTypes.any};

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -26,9 +26,9 @@ type Props = {|
     pressed: boolean,
 |};
 
-const StyledAnchor = addStyle("a");
-const StyledButton = addStyle("button");
-const StyledLink = addStyle(Link);
+const StyledAnchor = addStyle<React.ElementProps<"a">>("a");
+const StyledButton = addStyle<React.ElementProps<"button">>("button");
+const StyledLink = addStyle<React.ElementProps<typeof Link>>(Link);
 
 export default class ButtonCore extends React.Component<Props> {
     static contextTypes = {router: PropTypes.any};

--- a/packages/wonder-blocks-core/components/no-ssr.js
+++ b/packages/wonder-blocks-core/components/no-ssr.js
@@ -26,7 +26,7 @@ type State = {|
     mounted: boolean,
 |};
 
-const HasHadFirstRenderContext = React.createContext(false);
+const HasHadFirstRenderContext = React.createContext<boolean>(false);
 
 /**
  * Defer or change rendering until the component did mount.

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const StyledDiv = addStyle<React.ElementProps<"div">>("div", styles.default);
+const StyledDiv = addStyle<"div">("div", styles.default);
 
 /**
  * View is a building block for constructing other components. `View` roughly

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import addStyle from "../util/add-style.js";
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const StyledDiv = addStyle("div", styles.default);
+const StyledDiv = addStyle<React.ElementProps<"div">>("div", styles.default);
 
 /**
  * View is a building block for constructing other components. `View` roughly

--- a/packages/wonder-blocks-core/util/add-style.js
+++ b/packages/wonder-blocks-core/util/add-style.js
@@ -7,6 +7,7 @@ import {processStyleList} from "./util.js";
 
 import type {StyleType} from "./types.js";
 
+// TODO(kevinb): have an a version which uses exact object types
 export default function addStyle<T: Object>(
     Component: React.ComponentType<T> | string,
     defaultStyle?: StyleType,

--- a/packages/wonder-blocks-core/util/add-style.js
+++ b/packages/wonder-blocks-core/util/add-style.js
@@ -8,11 +8,11 @@ import {processStyleList} from "./util.js";
 import type {StyleType} from "./types.js";
 
 // TODO(kevinb): have an a version which uses exact object types
-export default function addStyle<T: Object>(
-    Component: React.ComponentType<T> | string,
+export default function addStyle<T: React.ComponentType<*> | string>(
+    Component: T,
     defaultStyle?: StyleType,
-): React.ComponentType<T & {style: StyleType}> {
-    function StyleComponent(props: T & {style: StyleType}) {
+): React.ComponentType<React.ElementProps<T> & {style: StyleType}> {
+    function StyleComponent(props: React.ElementProps<T> & {style: StyleType}) {
         const {style, ...otherProps} = props;
         const reset =
             typeof Component === "string" ? overrides[Component] : null;

--- a/packages/wonder-blocks-core/util/add-style.js
+++ b/packages/wonder-blocks-core/util/add-style.js
@@ -12,7 +12,9 @@ export default function addStyle<T: React.ComponentType<*> | string>(
     Component: T,
     defaultStyle?: StyleType,
 ): React.ComponentType<React.ElementProps<T> & {style: StyleType}> {
-    function StyleComponent(props: React.ElementProps<T> & {style: StyleType}) {
+    function StyleComponent(
+        props: React.ElementConfig<T> & {style: StyleType},
+    ) {
         const {style, ...otherProps} = props;
         const reset =
             typeof Component === "string" ? overrides[Component] : null;

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -21,7 +21,7 @@ type Props = {|
     pressed: boolean,
 |};
 
-const StyledButton = addStyle<React.ElementProps<"button">>("button");
+const StyledButton = addStyle<"button">("button");
 
 /**
  * Although this component shares a lot with ButtonCore there are a couple

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -21,7 +21,7 @@ type Props = {|
     pressed: boolean,
 |};
 
-const StyledButton = addStyle("button");
+const StyledButton = addStyle<React.ElementProps<"button">>("button");
 
 /**
  * Although this component shares a lot with ButtonCore there are a couple

--- a/packages/wonder-blocks-form/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/components/checkbox-group.js
@@ -59,8 +59,8 @@ type CheckboxGroupProps = {|
     selectedValues: Array<string>,
 |};
 
-const StyledFieldset = addStyle("fieldset");
-const StyledLegend = addStyle("legend");
+const StyledFieldset = addStyle<React.ElementProps<"fieldset">>("fieldset");
+const StyledLegend = addStyle<React.ElementProps<"legend">>("legend");
 
 /**
  * A checkbox group allows multiple selection. This component auto-populates

--- a/packages/wonder-blocks-form/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/components/checkbox-group.js
@@ -59,8 +59,8 @@ type CheckboxGroupProps = {|
     selectedValues: Array<string>,
 |};
 
-const StyledFieldset = addStyle<React.ElementProps<"fieldset">>("fieldset");
-const StyledLegend = addStyle<React.ElementProps<"legend">>("legend");
+const StyledFieldset = addStyle<"fieldset">("fieldset");
+const StyledLegend = addStyle<"legend">("legend");
 
 /**
  * A checkbox group allows multiple selection. This component auto-populates

--- a/packages/wonder-blocks-form/components/radio-group.js
+++ b/packages/wonder-blocks-form/components/radio-group.js
@@ -58,8 +58,8 @@ type RadioGroupProps = {|
     selectedValue: string,
 |};
 
-const StyledFieldset = addStyle<React.ElementProps<"fieldset">>("fieldset");
-const StyledLegend = addStyle<React.ElementProps<"legend">>("legend");
+const StyledFieldset = addStyle<"fieldset">("fieldset");
+const StyledLegend = addStyle<"legend">("legend");
 
 /**
  * A radio group allows only single selection. Like CheckboxGroup, this

--- a/packages/wonder-blocks-form/components/radio-group.js
+++ b/packages/wonder-blocks-form/components/radio-group.js
@@ -58,8 +58,8 @@ type RadioGroupProps = {|
     selectedValue: string,
 |};
 
-const StyledFieldset = addStyle("fieldset");
-const StyledLegend = addStyle("legend");
+const StyledFieldset = addStyle<React.ElementProps<"fieldset">>("fieldset");
+const StyledLegend = addStyle<React.ElementProps<"legend">>("legend");
 
 /**
  * A radio group allows only single selection. Like CheckboxGroup, this

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -35,7 +35,7 @@ type Props = {|
     style?: StyleType,
 |};
 
-const StyledSVG = addStyle<React.ElementProps<"svg">>("svg");
+const StyledSVG = addStyle<"svg">("svg");
 
 /**
  * An Icon displays a small informational or decorative image as an SVG.

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
@@ -35,7 +35,7 @@ type Props = {|
     style?: StyleType,
 |};
 
-const StyledSVG = addStyle("svg");
+const StyledSVG = addStyle<React.ElementProps<"svg">>("svg");
 
 /**
  * An Icon displays a small informational or decorative image as an SVG.

--- a/packages/wonder-blocks-link/components/link-core.js
+++ b/packages/wonder-blocks-link/components/link-core.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
 import PropTypes from "prop-types";
@@ -19,8 +19,8 @@ type Props = {|
     href: string,
 |};
 
-const StyledAnchor = addStyle("a");
-const StyledLink = addStyle(Link);
+const StyledAnchor = addStyle<React.ElementProps<"a">>("a");
+const StyledLink = addStyle<React.ElementProps<typeof Link>>(Link);
 
 export default class LinkCore extends React.Component<Props> {
     static contextTypes = {router: PropTypes.any};

--- a/packages/wonder-blocks-link/components/link-core.js
+++ b/packages/wonder-blocks-link/components/link-core.js
@@ -19,8 +19,8 @@ type Props = {|
     href: string,
 |};
 
-const StyledAnchor = addStyle<React.ElementProps<"a">>("a");
-const StyledLink = addStyle<React.ElementProps<typeof Link>>(Link);
+const StyledAnchor = addStyle<"a">("a");
+const StyledLink = addStyle<typeof Link>(Link);
 
 export default class LinkCore extends React.Component<Props> {
     static contextTypes = {router: PropTypes.any};

--- a/packages/wonder-blocks-modal/components/modal-context.js
+++ b/packages/wonder-blocks-modal/components/modal-context.js
@@ -9,4 +9,4 @@ const defaultContext: ContextType = {
     closeModal: undefined,
 };
 
-export default React.createContext(defaultContext);
+export default React.createContext<ContextType>(defaultContext);

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -123,7 +123,7 @@ export default class ModalLauncher extends React.Component<Props, State> {
 
         const {body} = document;
         if (!body) {
-            return;
+            return null;
         }
 
         return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,9 +4899,9 @@ flow-annotation-check@1.8.0:
     glob "7.1.1"
     load-pkg "^3.0.1"
 
-flow-bin@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.79.1.tgz#01c9f427baa6556753fa878c192d42e1ecb764b6"
+flow-bin@0.85:
+  version "0.85.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.85.0.tgz#a3ca80748a35a071d5bbb2fcd61d64d977fc53a6"
 
 flow-coverage-report@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
In version 0.85, you now have to specify the type parameter when using functions with parameterized types, see https://medium.com/flow-type/asking-for-required-annotations-64d4f9c1edf8 for details.  As a result, it turns out that our type declaration for the `addStyle` HOC is really awkward.  I'm going to try to simplify as part of this PR.