### PR TITLE
WB-407: prevent spinner's bounding box from change as it rotates

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
@@ -2461,26 +2461,7 @@ exports[`ButtonCore kind:primary size:medium spinner:true 1`] = `
     }
   >
     <svg
-      className=""
       height={24}
-      style={
-        Object {
-          "animationDuration": "1.1s",
-          "animationIterationCount": "infinite",
-          "animationName": Object {
-            "0%": Object {
-              "transform": "rotate(0deg)",
-            },
-            "100%": Object {
-              "transform": "rotate(360deg)",
-            },
-            "50%": Object {
-              "transform": "rotate(180deg)",
-            },
-          },
-          "animationTimingFunction": "linear",
-        }
-      }
       viewBox="0 0 24 24"
       width={24}
       xmlns="http://www.w3.org/2000/svg"
@@ -2491,7 +2472,22 @@ exports[`ButtonCore kind:primary size:medium spinner:true 1`] = `
         fillRule="nonzero"
         style={
           Object {
+            "animationDuration": "1.1s",
+            "animationIterationCount": "infinite",
+            "animationName": Object {
+              "0%": Object {
+                "transform": "rotate(0deg)",
+              },
+              "100%": Object {
+                "transform": "rotate(360deg)",
+              },
+              "50%": Object {
+                "transform": "rotate(180deg)",
+              },
+            },
+            "animationTimingFunction": "linear",
             "fill": "#ffffff",
+            "transformOrigin": "50% 50%",
           }
         }
       />
@@ -2593,26 +2589,7 @@ exports[`ButtonCore kind:primary size:small spinner:true 1`] = `
     }
   >
     <svg
-      className=""
       height={16}
-      style={
-        Object {
-          "animationDuration": "1.1s",
-          "animationIterationCount": "infinite",
-          "animationName": Object {
-            "0%": Object {
-              "transform": "rotate(0deg)",
-            },
-            "100%": Object {
-              "transform": "rotate(360deg)",
-            },
-            "50%": Object {
-              "transform": "rotate(180deg)",
-            },
-          },
-          "animationTimingFunction": "linear",
-        }
-      }
       viewBox="0 0 16 16"
       width={16}
       xmlns="http://www.w3.org/2000/svg"
@@ -2623,7 +2600,22 @@ exports[`ButtonCore kind:primary size:small spinner:true 1`] = `
         fillRule="nonzero"
         style={
           Object {
+            "animationDuration": "1.1s",
+            "animationIterationCount": "infinite",
+            "animationName": Object {
+              "0%": Object {
+                "transform": "rotate(0deg)",
+              },
+              "100%": Object {
+                "transform": "rotate(360deg)",
+              },
+              "50%": Object {
+                "transform": "rotate(180deg)",
+              },
+            },
+            "animationTimingFunction": "linear",
             "fill": "#ffffff",
+            "transformOrigin": "50% 50%",
           }
         }
       />
@@ -5168,26 +5160,7 @@ exports[`ButtonCore kind:secondary size:medium spinner:true 1`] = `
     }
   >
     <svg
-      className=""
       height={24}
-      style={
-        Object {
-          "animationDuration": "1.1s",
-          "animationIterationCount": "infinite",
-          "animationName": Object {
-            "0%": Object {
-              "transform": "rotate(0deg)",
-            },
-            "100%": Object {
-              "transform": "rotate(360deg)",
-            },
-            "50%": Object {
-              "transform": "rotate(180deg)",
-            },
-          },
-          "animationTimingFunction": "linear",
-        }
-      }
       viewBox="0 0 24 24"
       width={24}
       xmlns="http://www.w3.org/2000/svg"
@@ -5198,7 +5171,22 @@ exports[`ButtonCore kind:secondary size:medium spinner:true 1`] = `
         fillRule="nonzero"
         style={
           Object {
+            "animationDuration": "1.1s",
+            "animationIterationCount": "infinite",
+            "animationName": Object {
+              "0%": Object {
+                "transform": "rotate(0deg)",
+              },
+              "100%": Object {
+                "transform": "rotate(360deg)",
+              },
+              "50%": Object {
+                "transform": "rotate(180deg)",
+              },
+            },
+            "animationTimingFunction": "linear",
             "fill": "rgba(33,36,44,0.16)",
+            "transformOrigin": "50% 50%",
           }
         }
       />
@@ -5303,26 +5291,7 @@ exports[`ButtonCore kind:secondary size:small spinner:true 1`] = `
     }
   >
     <svg
-      className=""
       height={16}
-      style={
-        Object {
-          "animationDuration": "1.1s",
-          "animationIterationCount": "infinite",
-          "animationName": Object {
-            "0%": Object {
-              "transform": "rotate(0deg)",
-            },
-            "100%": Object {
-              "transform": "rotate(360deg)",
-            },
-            "50%": Object {
-              "transform": "rotate(180deg)",
-            },
-          },
-          "animationTimingFunction": "linear",
-        }
-      }
       viewBox="0 0 16 16"
       width={16}
       xmlns="http://www.w3.org/2000/svg"
@@ -5333,7 +5302,22 @@ exports[`ButtonCore kind:secondary size:small spinner:true 1`] = `
         fillRule="nonzero"
         style={
           Object {
+            "animationDuration": "1.1s",
+            "animationIterationCount": "infinite",
+            "animationName": Object {
+              "0%": Object {
+                "transform": "rotate(0deg)",
+              },
+              "100%": Object {
+                "transform": "rotate(360deg)",
+              },
+              "50%": Object {
+                "transform": "rotate(180deg)",
+              },
+            },
+            "animationTimingFunction": "linear",
             "fill": "rgba(33,36,44,0.16)",
+            "transformOrigin": "50% 50%",
           }
         }
       />
@@ -8019,26 +8003,7 @@ exports[`ButtonCore kind:tertiary size:medium spinner:true 1`] = `
     }
   >
     <svg
-      className=""
       height={24}
-      style={
-        Object {
-          "animationDuration": "1.1s",
-          "animationIterationCount": "infinite",
-          "animationName": Object {
-            "0%": Object {
-              "transform": "rotate(0deg)",
-            },
-            "100%": Object {
-              "transform": "rotate(360deg)",
-            },
-            "50%": Object {
-              "transform": "rotate(180deg)",
-            },
-          },
-          "animationTimingFunction": "linear",
-        }
-      }
       viewBox="0 0 24 24"
       width={24}
       xmlns="http://www.w3.org/2000/svg"
@@ -8049,7 +8014,22 @@ exports[`ButtonCore kind:tertiary size:medium spinner:true 1`] = `
         fillRule="nonzero"
         style={
           Object {
+            "animationDuration": "1.1s",
+            "animationIterationCount": "infinite",
+            "animationName": Object {
+              "0%": Object {
+                "transform": "rotate(0deg)",
+              },
+              "100%": Object {
+                "transform": "rotate(360deg)",
+              },
+              "50%": Object {
+                "transform": "rotate(180deg)",
+              },
+            },
+            "animationTimingFunction": "linear",
             "fill": "rgba(33,36,44,0.16)",
+            "transformOrigin": "50% 50%",
           }
         }
       />
@@ -8151,26 +8131,7 @@ exports[`ButtonCore kind:tertiary size:small spinner:true 1`] = `
     }
   >
     <svg
-      className=""
       height={16}
-      style={
-        Object {
-          "animationDuration": "1.1s",
-          "animationIterationCount": "infinite",
-          "animationName": Object {
-            "0%": Object {
-              "transform": "rotate(0deg)",
-            },
-            "100%": Object {
-              "transform": "rotate(360deg)",
-            },
-            "50%": Object {
-              "transform": "rotate(180deg)",
-            },
-          },
-          "animationTimingFunction": "linear",
-        }
-      }
       viewBox="0 0 16 16"
       width={16}
       xmlns="http://www.w3.org/2000/svg"
@@ -8181,7 +8142,22 @@ exports[`ButtonCore kind:tertiary size:small spinner:true 1`] = `
         fillRule="nonzero"
         style={
           Object {
+            "animationDuration": "1.1s",
+            "animationIterationCount": "infinite",
+            "animationName": Object {
+              "0%": Object {
+                "transform": "rotate(0deg)",
+              },
+              "100%": Object {
+                "transform": "rotate(360deg)",
+              },
+              "50%": Object {
+                "transform": "rotate(180deg)",
+              },
+            },
+            "animationTimingFunction": "linear",
             "fill": "rgba(33,36,44,0.16)",
+            "transformOrigin": "50% 50%",
           }
         }
       />

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -1910,26 +1910,7 @@ exports[`wonder-blocks-button example 8 1`] = `
       }
     >
       <svg
-        className=""
         height={24}
-        style={
-          Object {
-            "animationDuration": "1.1s",
-            "animationIterationCount": "infinite",
-            "animationName": Object {
-              "0%": Object {
-                "transform": "rotate(0deg)",
-              },
-              "100%": Object {
-                "transform": "rotate(360deg)",
-              },
-              "50%": Object {
-                "transform": "rotate(180deg)",
-              },
-            },
-            "animationTimingFunction": "linear",
-          }
-        }
         viewBox="0 0 24 24"
         width={24}
         xmlns="http://www.w3.org/2000/svg"
@@ -1940,7 +1921,22 @@ exports[`wonder-blocks-button example 8 1`] = `
           fillRule="nonzero"
           style={
             Object {
+              "animationDuration": "1.1s",
+              "animationIterationCount": "infinite",
+              "animationName": Object {
+                "0%": Object {
+                  "transform": "rotate(0deg)",
+                },
+                "100%": Object {
+                  "transform": "rotate(360deg)",
+                },
+                "50%": Object {
+                  "transform": "rotate(180deg)",
+                },
+              },
+              "animationTimingFunction": "linear",
               "fill": "#ffffff",
+              "transformOrigin": "50% 50%",
             }
           }
         />
@@ -2040,26 +2036,7 @@ exports[`wonder-blocks-button example 8 1`] = `
       }
     >
       <svg
-        className=""
         height={16}
-        style={
-          Object {
-            "animationDuration": "1.1s",
-            "animationIterationCount": "infinite",
-            "animationName": Object {
-              "0%": Object {
-                "transform": "rotate(0deg)",
-              },
-              "100%": Object {
-                "transform": "rotate(360deg)",
-              },
-              "50%": Object {
-                "transform": "rotate(180deg)",
-              },
-            },
-            "animationTimingFunction": "linear",
-          }
-        }
         viewBox="0 0 16 16"
         width={16}
         xmlns="http://www.w3.org/2000/svg"
@@ -2070,7 +2047,22 @@ exports[`wonder-blocks-button example 8 1`] = `
           fillRule="nonzero"
           style={
             Object {
+              "animationDuration": "1.1s",
+              "animationIterationCount": "infinite",
+              "animationName": Object {
+                "0%": Object {
+                  "transform": "rotate(0deg)",
+                },
+                "100%": Object {
+                  "transform": "rotate(360deg)",
+                },
+                "50%": Object {
+                  "transform": "rotate(180deg)",
+                },
+              },
+              "animationTimingFunction": "linear",
               "fill": "#ffffff",
+              "transformOrigin": "50% 50%",
             }
           }
         />

--- a/packages/wonder-blocks-progress-spinner/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-progress-spinner/__snapshots__/generated-snapshot.test.js.snap
@@ -22,26 +22,7 @@ exports[`wonder-blocks-progress-spinner example 1 1`] = `
   }
 >
   <svg
-    className=""
     height={96}
-    style={
-      Object {
-        "animationDuration": "1.1s",
-        "animationIterationCount": "infinite",
-        "animationName": Object {
-          "0%": Object {
-            "transform": "rotate(0deg)",
-          },
-          "100%": Object {
-            "transform": "rotate(360deg)",
-          },
-          "50%": Object {
-            "transform": "rotate(180deg)",
-          },
-        },
-        "animationTimingFunction": "linear",
-      }
-    }
     viewBox="0 0 96 96"
     width={96}
     xmlns="http://www.w3.org/2000/svg"
@@ -52,7 +33,22 @@ exports[`wonder-blocks-progress-spinner example 1 1`] = `
       fillRule="nonzero"
       style={
         Object {
+          "animationDuration": "1.1s",
+          "animationIterationCount": "infinite",
+          "animationName": Object {
+            "0%": Object {
+              "transform": "rotate(0deg)",
+            },
+            "100%": Object {
+              "transform": "rotate(360deg)",
+            },
+            "50%": Object {
+              "transform": "rotate(180deg)",
+            },
+          },
+          "animationTimingFunction": "linear",
           "fill": "rgba(33,36,44,0.16)",
+          "transformOrigin": "50% 50%",
         }
       }
     />
@@ -144,26 +140,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={96}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 96 96"
           width={96}
           xmlns="http://www.w3.org/2000/svg"
@@ -174,7 +151,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "rgba(33,36,44,0.16)",
+                "transformOrigin": "50% 50%",
               }
             }
           />
@@ -237,26 +229,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={48}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 48 48"
           width={48}
           xmlns="http://www.w3.org/2000/svg"
@@ -267,7 +240,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "rgba(33,36,44,0.16)",
+                "transformOrigin": "50% 50%",
               }
             }
           />
@@ -330,26 +318,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={24}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 24 24"
           width={24}
           xmlns="http://www.w3.org/2000/svg"
@@ -360,7 +329,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "rgba(33,36,44,0.16)",
+                "transformOrigin": "50% 50%",
               }
             }
           />
@@ -423,26 +407,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={16}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 16 16"
           width={16}
           xmlns="http://www.w3.org/2000/svg"
@@ -453,7 +418,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "rgba(33,36,44,0.16)",
+                "transformOrigin": "50% 50%",
               }
             }
           />
@@ -538,26 +518,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={96}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 96 96"
           width={96}
           xmlns="http://www.w3.org/2000/svg"
@@ -568,7 +529,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "#ffffff",
+                "transformOrigin": "50% 50%",
               }
             }
           />
@@ -631,26 +607,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={48}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 48 48"
           width={48}
           xmlns="http://www.w3.org/2000/svg"
@@ -661,7 +618,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "#ffffff",
+                "transformOrigin": "50% 50%",
               }
             }
           />
@@ -724,26 +696,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={24}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 24 24"
           width={24}
           xmlns="http://www.w3.org/2000/svg"
@@ -754,7 +707,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "#ffffff",
+                "transformOrigin": "50% 50%",
               }
             }
           />
@@ -817,26 +785,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={16}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 16 16"
           width={16}
           xmlns="http://www.w3.org/2000/svg"
@@ -847,7 +796,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "#ffffff",
+                "transformOrigin": "50% 50%",
               }
             }
           />
@@ -916,26 +880,7 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
         }
       >
         <svg
-          className=""
           height={16}
-          style={
-            Object {
-              "animationDuration": "1.1s",
-              "animationIterationCount": "infinite",
-              "animationName": Object {
-                "0%": Object {
-                  "transform": "rotate(0deg)",
-                },
-                "100%": Object {
-                  "transform": "rotate(360deg)",
-                },
-                "50%": Object {
-                  "transform": "rotate(180deg)",
-                },
-              },
-              "animationTimingFunction": "linear",
-            }
-          }
           viewBox="0 0 16 16"
           width={16}
           xmlns="http://www.w3.org/2000/svg"
@@ -946,7 +891,22 @@ exports[`wonder-blocks-progress-spinner example 2 1`] = `
             fillRule="nonzero"
             style={
               Object {
+                "animationDuration": "1.1s",
+                "animationIterationCount": "infinite",
+                "animationName": Object {
+                  "0%": Object {
+                    "transform": "rotate(0deg)",
+                  },
+                  "100%": Object {
+                    "transform": "rotate(360deg)",
+                  },
+                  "50%": Object {
+                    "transform": "rotate(180deg)",
+                  },
+                },
+                "animationTimingFunction": "linear",
                 "fill": "rgba(33,36,44,0.16)",
+                "transformOrigin": "50% 50%",
               }
             }
           />

--- a/packages/wonder-blocks-progress-spinner/components/circular-spinner.js
+++ b/packages/wonder-blocks-progress-spinner/components/circular-spinner.js
@@ -29,40 +29,7 @@ const colors = {
     dark: Color.offBlack16,
 };
 
-const StyledSVG = addStyle("svg");
 const StyledPath = addStyle("path");
-
-const svgs = {
-    light: {},
-    dark: {},
-};
-
-const _generateSVG = (size, light) => {
-    const svgCache = svgs[light];
-
-    if (svgCache[size]) {
-        return svgCache[size];
-    }
-
-    const height = heights[size];
-    const path = paths[size];
-    const color = colors[light];
-
-    const svg = (
-        <StyledSVG
-            xmlns="http://www.w3.org/2000/svg"
-            width={height}
-            height={height}
-            viewBox={`0 0 ${height} ${height}`}
-            style={styles.loadingSpinner}
-        >
-            <StyledPath style={{fill: color}} fillRule="nonzero" d={path} />
-        </StyledSVG>
-    );
-
-    svgCache[size] = svg;
-    return svg;
-};
 
 type Props = {|
     /**
@@ -92,7 +59,25 @@ export default class CircularSpinner extends React.Component<Props> {
 
     render() {
         const {size, light, style} = this.props;
-        const svg = _generateSVG(size, light ? "light" : "dark");
+
+        const height = heights[size];
+        const path = paths[size];
+        const color = light ? colors.light : colors.dark;
+
+        const svg = (
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width={height}
+                height={height}
+                viewBox={`0 0 ${height} ${height}`}
+            >
+                <StyledPath
+                    style={[styles.loadingSpinner, {fill: color}]}
+                    fillRule="nonzero"
+                    d={path}
+                />
+            </svg>
+        );
 
         return <View style={[styles.spinnerContainer, style]}>{svg}</View>;
     }
@@ -115,6 +100,7 @@ const styles = StyleSheet.create({
         justifyContent: "center",
     },
     loadingSpinner: {
+        transformOrigin: "50% 50%",
         animationName: rotateKeyFrames,
         animationDuration: "1.1s",
         animationIterationCount: "infinite",


### PR DESCRIPTION
This diff rotates the path inside the svg.  I removed the caching but I can put it back if necessary.