### PR TITLE
WB-489: prevent navigation when using href and disabled props together

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -1822,11 +1822,11 @@ exports[`wonder-blocks-button example 8 1`] = `
     }
   }
 >
-  <a
+  <button
     aria-disabled="true"
     aria-label="loading"
     className=""
-    href="/foo"
+    disabled={true}
     onBlur={[Function]}
     onClick={[Function]}
     onDragStart={[Function]}
@@ -1843,6 +1843,9 @@ exports[`wonder-blocks-button example 8 1`] = `
     role="button"
     style={
       Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
         "alignItems": "center",
         "background": "rgba(33,36,44,0.32)",
         "border": "none",
@@ -1853,6 +1856,7 @@ exports[`wonder-blocks-button example 8 1`] = `
         "display": "inline-flex",
         "height": 40,
         "justifyContent": "center",
+        "margin": 0,
         "marginRight": 10,
         "outline": "none",
         "paddingBottom": 0,
@@ -1865,6 +1869,7 @@ exports[`wonder-blocks-button example 8 1`] = `
       }
     }
     tabIndex={-1}
+    type="button"
   >
     <span
       className=""
@@ -1946,7 +1951,7 @@ exports[`wonder-blocks-button example 8 1`] = `
         />
       </svg>
     </div>
-  </a>
+  </button>
   <button
     aria-disabled="true"
     aria-label="loading"

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -123,7 +123,7 @@ export default class ButtonCore extends React.Component<Props> {
             </React.Fragment>
         );
 
-        if (href) {
+        if (href && !disabled) {
             return router && !skipClientNav ? (
                 <StyledLink {...commonProps} to={href}>
                     {contents}

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
     </Button>
     <Button
         style={styles.button}
-        onClick={(e) => window.alert("Hello, world!")}
+        href={"/foo"}
         kind="secondary"
         disabled={true}
     >

--- a/packages/wonder-blocks-button/components/button.test.js
+++ b/packages/wonder-blocks-button/components/button.test.js
@@ -84,4 +84,28 @@ describe("Button", () => {
         // Assert
         expect(wrapper.find("#foo").exists()).toBe(false);
     });
+
+    test("disallow navigation when href and disabled are both set", () => {
+        const wrapper = mount(
+            <MemoryRouter>
+                <div>
+                    <Button testId="button" href="/foo" disabled={true}>
+                        Click me!
+                    </Button>
+                    <Switch>
+                        <Route path="/foo">
+                            <div id="foo">Hello, world!</div>
+                        </Route>
+                    </Switch>
+                </div>
+            </MemoryRouter>,
+        );
+
+        // Act
+        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        buttonWrapper.simulate("click", {button: 0});
+
+        // Assert
+        expect(wrapper.find("#foo").exists()).toBe(false);
+    });
 });

--- a/packages/wonder-blocks-button/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/generated-snapshot.test.js
@@ -118,7 +118,7 @@ describe("wonder-blocks-button", () => {
                 </Button>
                 <Button
                     style={styles.button}
-                    onClick={(e) => window.alert("Hello, world!")}
+                    href={"/foo"}
                     kind="secondary"
                     disabled={true}
                 >

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -143,7 +143,7 @@ export default class ActionItem extends React.Component<ActionProps> {
                         </React.Fragment>
                     );
 
-                    if (href) {
+                    if (href && !disabled) {
                         return router && !skipClientNav ? (
                             <StyledLink {...props} to={href}>
                                 {children}

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -34,6 +34,7 @@ const styles = StyleSheet.create({
         <ActionItem label="Teacher dashboard" href="http://khanacademy.org/coach/dashboard" testId="dashboard" />
         <ActionItem label="Settings (onClick)" onClick={() => console.log("user clicked on settings")} testId="settings" />
         <ActionItem label="Help" disabled={true} onClick={() => console.log("this item is disabled...")} testId="help" />
+        <ActionItem label="Feedback" disabled={true} href="/feedback" testId="feedback" />
         <SeparatorItem />
         <ActionItem label="Log out" href="http://khanacademy.org/logout" testId="logout" />
     </ActionMenu>

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -55,6 +55,12 @@ describe("wonder-blocks-dropdown", () => {
                         onClick={() => console.log("this item is disabled...")}
                         testId="help"
                     />
+                    <ActionItem
+                        label="Feedback"
+                        disabled={true}
+                        href="/feedback"
+                        testId="feedback"
+                    />
                     <SeparatorItem />
                     <ActionItem
                         label="Log out"

--- a/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
@@ -257,10 +257,116 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
       }
     }
   >
-    <button
+    <a
       aria-label="search"
       className=""
-      disabled={false}
+      href="/search"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "boxSizing": "border-box",
+          "color": "rgba(33,36,44,0.64)",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": -8,
+          "outline": "none",
+          "padding": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "width": 40,
+        }
+      }
+      tabIndex={0}
+    >
+      <svg
+        className=""
+        height={24}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 24 24"
+        width={24}
+      >
+        <path
+          d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
+          fill="currentColor"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 16,
+        "MsFlexPreferredSize": 16,
+        "WebkitFlexBasis": 16,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 16,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 16,
+        "zIndex": 0,
+      }
+    }
+  />
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      aria-disabled="true"
+      aria-label="search"
+      className=""
+      disabled={true}
       onBlur={[Function]}
       onClick={[Function]}
       onDragStart={[Function]}
@@ -283,8 +389,8 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
           "background": "none",
           "border": "none",
           "boxSizing": "border-box",
-          "color": "rgba(33,36,44,0.64)",
-          "cursor": "pointer",
+          "color": "rgba(33,36,44,0.32)",
+          "cursor": "default",
           "display": "inline-flex",
           "height": 40,
           "justifyContent": "center",
@@ -297,7 +403,7 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
           "width": 40,
         }
       }
-      tabIndex={0}
+      tabIndex={-1}
       type="button"
     >
       <svg

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -106,7 +106,7 @@ export default class IconButtonCore extends React.Component<Props> {
             ...handlers,
         };
 
-        if (href) {
+        if (href && !disabled) {
             return router && !skipClientNav ? (
                 <View style={style}>
                     <StyledLink {...commonProps} to={href}>

--- a/packages/wonder-blocks-icon-button/components/icon-button.md
+++ b/packages/wonder-blocks-icon-button/components/icon-button.md
@@ -22,7 +22,7 @@ const {Strut} = require("@khanacademy/wonder-blocks-layout");
         icon={icons.search}
         aria-label="search"
         kind="tertiary"
-        onClick={(e) => console.log("hello")}
+        href="/search"
     />
     <Strut size={16} />
     <IconButton
@@ -30,6 +30,13 @@ const {Strut} = require("@khanacademy/wonder-blocks-layout");
         icon={icons.search}
         aria-label="search"
         onClick={(e) => console.log("hello")}
+    />
+    <Strut size={16} />
+    <IconButton
+        disabled={true}
+        icon={icons.search}
+        aria-label="search"
+        href="/search"
     />
 </View>
 ```

--- a/packages/wonder-blocks-icon-button/components/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.test.js
@@ -127,4 +127,34 @@ describe("IconButton", () => {
         // Assert
         expect(wrapper.find("#foo").exists()).toBe(false);
     });
+
+    test("disallow navigation when href and disabled are both set", () => {
+        const wrapper = mount(
+            <MemoryRouter>
+                <div>
+                    <IconButton
+                        icon={icons.search}
+                        aria-label="search"
+                        testId="icon-button"
+                        href="/foo"
+                        disabled={true}
+                    />
+                    <Switch>
+                        <Route path="/foo">
+                            <div id="foo">Hello, world!</div>
+                        </Route>
+                    </Switch>
+                </div>
+            </MemoryRouter>,
+        );
+
+        // Act
+        const buttonWrapper = wrapper
+            .find(`[data-test-id="icon-button"]`)
+            .first();
+        buttonWrapper.simulate("click", {button: 0});
+
+        // Assert
+        expect(wrapper.find("#foo").exists()).toBe(false);
+    });
 });

--- a/packages/wonder-blocks-icon-button/generated-snapshot.test.js
+++ b/packages/wonder-blocks-icon-button/generated-snapshot.test.js
@@ -35,7 +35,7 @@ describe("wonder-blocks-icon-button", () => {
                     icon={icons.search}
                     aria-label="search"
                     kind="tertiary"
-                    onClick={(e) => console.log("hello")}
+                    href="/search"
                 />
                 <Strut size={16} />
                 <IconButton
@@ -43,6 +43,13 @@ describe("wonder-blocks-icon-button", () => {
                     icon={icons.search}
                     aria-label="search"
                     onClick={(e) => console.log("hello")}
+                />
+                <Strut size={16} />
+                <IconButton
+                    disabled={true}
+                    icon={icons.search}
+                    aria-label="search"
+                    href="/search"
                 />
             </View>
         );


### PR DESCRIPTION
The issue is that when using href we end up rendering either an `<a>` or a ` <Link>`.  With `<a>` you can disabled it not giving an `href`, but with `<Link>` its `to` prop is a required.  This PR instead renders a `<button>` whenever the Button, IconButton or ActionItem is disabled and sets `disabled={true}`.  This results in the component being un-clickable when disabled regardless of whether it uses `href` or not.