### PR TITLE
WB-491: update dropdown components to have appropriate aria roles

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -44,6 +44,8 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
     }
   >
     <button
+      aria-expanded="true"
+      aria-haspopup="menu"
       className=""
       data-test-id="teacher-menu"
       disabled={false}
@@ -61,7 +63,6 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
       open={false}
-      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -244,6 +245,8 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
     }
   >
     <button
+      aria-expanded="true"
+      aria-haspopup="menu"
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -260,7 +263,6 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
       open={false}
-      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -422,6 +424,8 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
     }
   >
     <button
+      aria-expanded="true"
+      aria-haspopup="menu"
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -438,7 +442,6 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
       open={false}
-      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -601,6 +604,8 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
   >
     <button
       aria-disabled="true"
+      aria-expanded="true"
+      aria-haspopup="menu"
       className=""
       disabled={true}
       onBlur={[Function]}
@@ -617,7 +622,6 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
       open={false}
-      role="button"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -780,6 +784,8 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       data-test-id="fruit-select"
       disabled={false}
@@ -915,6 +921,8 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -1048,6 +1056,8 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -1181,6 +1191,8 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       disabled={true}
       onBlur={[Function]}
@@ -1340,6 +1352,8 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
       }
     >
       <button
+        aria-expanded="false"
+        aria-haspopup="listbox"
         className=""
         disabled={false}
         onBlur={[Function]}
@@ -1474,6 +1488,8 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       disabled={true}
       onBlur={[Function]}
@@ -1608,6 +1624,8 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       data-test-id="palette"
       disabled={false}
@@ -1742,6 +1760,8 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -1875,6 +1895,8 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -2101,6 +2123,8 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
     }
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       className=""
       disabled={true}
       onBlur={[Function]}

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -796,7 +796,6 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -931,7 +930,6 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1065,7 +1063,6 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1199,7 +1196,6 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1359,7 +1355,6 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
         onTouchCancel={[Function]}
         onTouchEnd={[Function]}
         onTouchStart={[Function]}
-        role="listbox"
         style={
           Object {
             "::MozFocusInner": Object {
@@ -1494,7 +1489,6 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1630,7 +1624,6 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1764,7 +1757,6 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -1898,7 +1890,6 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -2125,7 +2116,6 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      role="listbox"
       style={
         Object {
           "::MozFocusInner": Object {

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -70,6 +70,11 @@ type ActionProps = {|
      * @ignore
      */
     indent: boolean,
+
+    /**
+     * Aria role to use, defaults to "menuitem".
+     */
+    role: "menuitem" | "option",
 |};
 
 const StyledAnchor = addStyle("a");
@@ -85,6 +90,7 @@ export default class ActionItem extends React.Component<ActionProps> {
     static defaultProps = {
         disabled: false,
         indent: false,
+        role: "menuitem",
     };
 
     static contextTypes = {router: PropTypes.any};
@@ -97,6 +103,7 @@ export default class ActionItem extends React.Component<ActionProps> {
             indent,
             label,
             onClick,
+            role,
             testId,
         } = this.props;
         const {router} = this.context;
@@ -112,7 +119,7 @@ export default class ActionItem extends React.Component<ActionProps> {
                 disabled={disabled}
                 onClick={onClick}
                 href={href}
-                role="menuitem"
+                role={role}
             >
                 {(state, handlers) => {
                     const {pressed, hovered, focused} = state;
@@ -129,6 +136,7 @@ export default class ActionItem extends React.Component<ActionProps> {
                     const props = {
                         "data-test-id": testId,
                         disabled,
+                        role,
                         style: [defaultStyle],
                         ...handlers,
                     };

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -56,21 +56,22 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
             !disabled && pressed && buttonStyles.active,
         ];
 
-        const commonProps = {
-            "aria-disabled": disabled ? "true" : undefined,
-            "aria-label": ariaLabel,
-            "data-test-id": testId,
-            role: "button",
-            style: [defaultStyle],
-            ...handlers,
-        };
-
         const label = (
             <LabelLarge style={sharedStyles.text}>{children}</LabelLarge>
         );
 
         return (
-            <StyledButton type="button" {...commonProps} disabled={disabled}>
+            <StyledButton
+                aria-disabled={disabled ? "true" : undefined}
+                aria-expanded={open ? "true" : "false"}
+                aria-haspopup="menu"
+                aria-label={ariaLabel}
+                data-test-id={testId}
+                disabled={disabled}
+                style={defaultStyle}
+                type="button"
+                {...handlers}
+            >
                 <View
                     style={
                         !disabled && (hovered || focused) && buttonStyles.focus

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -203,6 +203,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
                 opener={opener}
                 openerElement={this.openerElement}
                 style={style}
+                role="menu"
             />
         );
     }

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -83,6 +83,11 @@ type DropdownProps = {|
      * Optional styling for the entire dropdown component.
      */
     style?: StyleType,
+
+    /**
+     * The aria "role" applied to the dropdown container.
+     */
+    role: "listbox" | "menu",
 |};
 
 type State = {|
@@ -450,12 +455,23 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
             : 0;
 
         let focusCounter = 0;
+        let itemRole;
+
+        switch (this.props.role) {
+            case "listbox":
+                itemRole = "option";
+                break;
+            case "menu":
+                itemRole = "menuitem";
+                break;
+        }
 
         return (
             <View
                 // Stop propagation to prevent the mouseup listener on the
                 // document from closing the menu.
                 onMouseUp={this.handleDropdownMouseUp}
+                role={this.props.role}
                 style={[
                     styles.dropdown,
                     light && styles.light,
@@ -478,6 +494,7 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
                             ref:
                                 item.focusable &&
                                 this.state.itemRefs[focusIndex].ref,
+                            role: itemRole,
                             onClick: () => {
                                 this.handleClickFocus(focusIndex);
                                 if (item.component.props.onClick) {

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -445,6 +445,15 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
         }
     };
 
+    getItemRole() {
+        switch (this.props.role) {
+            case "listbox":
+                return "option";
+            case "menu":
+                return "menuitem";
+        }
+    }
+
     renderItems(outOfBoundaries: ?boolean) {
         const {items, dropdownStyle, light, openerElement} = this.props;
 
@@ -454,17 +463,9 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
             ? openerStyle.getPropertyValue("width")
             : 0;
 
-        let focusCounter = 0;
-        let itemRole;
+        const itemRole = this.getItemRole();
 
-        switch (this.props.role) {
-            case "listbox":
-                itemRole = "option";
-                break;
-            case "menu":
-                itemRole = "menuitem";
-                break;
-        }
+        let focusCounter = 0;
 
         return (
             <View

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -446,11 +446,17 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
     };
 
     getItemRole() {
-        switch (this.props.role) {
+        const {role} = this.props;
+
+        switch (role) {
             case "listbox":
                 return "option";
             case "menu":
                 return "menuitem";
+            default:
+                throw new Error(
+                    `Expected "listbox" or "menu" for role, but receieved "${role}" instead.`,
+                );
         }
     }
 

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -43,6 +43,7 @@ describe("Dropdown", () => {
                         populatedProps: {},
                     },
                 ]}
+                role="listbox"
                 keyboard={true}
                 light={false}
                 open={false}
@@ -187,6 +188,7 @@ describe("Dropdown", () => {
                             populatedProps: {},
                         },
                     ]}
+                    role="listbox"
                     keyboard={true}
                     light={false}
                     open={true}

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -291,6 +291,7 @@ export default class MultiSelect extends React.Component<Props, State> {
 
         return (
             <Dropdown
+                role="listbox"
                 alignment={alignment}
                 dropdownStyle={[selectDropdownStyle, dropdownStyle]}
                 items={items}

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -56,10 +56,10 @@ describe("MultiSelect", () => {
         opener.simulate("keyup", {keyCode: keyCodes.space});
         expect(select.state("open")).toEqual(false);
 
-        // Shouldn't open with enter
+        // Should open with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(select.state("open")).toEqual(false);
+        expect(select.state("open")).toEqual(true);
     });
 
     it("selects items as expected", () => {

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -49,6 +49,11 @@ type OptionProps = {|
     selected: boolean,
 
     /**
+     * Aria role to use, defaults to "option".
+     */
+    role: "menuitem" | "option",
+
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string,
@@ -70,6 +75,7 @@ export default class OptionItem extends React.Component<OptionProps> {
     static defaultProps = {
         disabled: false,
         onToggle: () => void 0,
+        role: "option",
         selected: false,
     };
 
@@ -92,7 +98,7 @@ export default class OptionItem extends React.Component<OptionProps> {
     };
 
     render() {
-        const {disabled, label, selected, testId} = this.props;
+        const {disabled, label, role, selected, testId} = this.props;
 
         const ClickableBehavior = getClickableBehavior();
         const CheckComponent = this.getCheckComponent();
@@ -101,7 +107,7 @@ export default class OptionItem extends React.Component<OptionProps> {
             <ClickableBehavior
                 disabled={disabled}
                 onClick={this.handleClick}
-                role="option"
+                role={role}
             >
                 {(state, handlers) => {
                     const {pressed, hovered, focused} = state;
@@ -119,7 +125,7 @@ export default class OptionItem extends React.Component<OptionProps> {
                             data-test-id={testId}
                             style={defaultStyle}
                             aria-checked={selected ? "true" : "false"}
-                            role="option"
+                            role={role}
                             {...handlers}
                         >
                             <CheckComponent

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -124,7 +124,7 @@ export default class OptionItem extends React.Component<OptionProps> {
                         <View
                             data-test-id={testId}
                             style={defaultStyle}
-                            aria-checked={selected ? "true" : "false"}
+                            aria-selected={selected ? "true" : "false"}
                             role={role}
                             {...handlers}
                         >

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -83,7 +83,14 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
     };
 
     render() {
-        const {children, disabled, isPlaceholder, light, testId} = this.props;
+        const {
+            children,
+            disabled,
+            isPlaceholder,
+            light,
+            open,
+            testId,
+        } = this.props;
 
         const ClickableBehavior = getClickableBehavior(this.context.router);
 
@@ -103,21 +110,24 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                             ? offBlack32
                             : offBlack64;
 
+                    const style = [
+                        styles.shared,
+                        stateStyles.default,
+                        disabled && stateStyles.disabled,
+                        !disabled &&
+                            (pressed
+                                ? stateStyles.active
+                                : (hovered || focused) && stateStyles.focus),
+                    ];
+
                     return (
                         <StyledButton
+                            aria-expanded={open ? "true" : "false"}
+                            aria-haspopup="listbox"
                             data-test-id={testId}
                             disabled={disabled}
+                            style={style}
                             type="button"
-                            style={[
-                                styles.shared,
-                                stateStyles.default,
-                                disabled && stateStyles.disabled,
-                                !disabled &&
-                                    (pressed
-                                        ? stateStyles.active
-                                        : (hovered || focused) &&
-                                          stateStyles.focus),
-                            ]}
                             {...handlers}
                         >
                             <LabelMedium style={styles.text}>

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -88,11 +88,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
         const ClickableBehavior = getClickableBehavior(this.context.router);
 
         return (
-            <ClickableBehavior
-                disabled={disabled}
-                onClick={this.handleClick}
-                role="listbox"
-            >
+            <ClickableBehavior disabled={disabled} onClick={this.handleClick}>
                 {(state, handlers) => {
                     const stateStyles = _generateStyles(light, isPlaceholder);
                     const {hovered, focused, pressed} = state;
@@ -111,7 +107,6 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                         <StyledButton
                             data-test-id={testId}
                             disabled={disabled}
-                            role="listbox"
                             type="button"
                             style={[
                                 styles.shared,

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -202,6 +202,7 @@ export default class SingleSelect extends React.Component<Props, State> {
 
         return (
             <Dropdown
+                role="listbox"
                 alignment={alignment}
                 dropdownStyle={[selectDropdownStyle, dropdownStyle]}
                 initialFocusedIndex={this.selectedIndex}

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -42,10 +42,10 @@ describe("SingleSelect", () => {
         opener.simulate("keyup", {keyCode: keyCodes.space});
         expect(select.state("open")).toEqual(false);
 
-        // Shouldn't open with enter
+        // Should open with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(select.state("open")).toEqual(false);
+        expect(select.state("open")).toEqual(true);
     });
 
     it("displays selected item label as expected", () => {

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -371,6 +371,8 @@ exports[`wonder-blocks-modal example 3 1`] = `
     }
   >
     <button
+      aria-expanded="true"
+      aria-haspopup="menu"
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -387,7 +389,6 @@ exports[`wonder-blocks-modal example 3 1`] = `
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
       open={false}
-      role="button"
       style={
         Object {
           "::MozFocusInner": Object {


### PR DESCRIPTION
I'm not sure if I'm using the right roles for the right things.  The openers no-longer have any role.  They use a `<button>` under the hood whose role is `button` by default which I think is okay.  `Dropdown` is a pretty general component so in order to make people think about what role they want I've made `role` mandatory.

