### PR TITLE
WB-427: prevent page scrolling to bottom when opening modal

### DIFF
--- a/packages/wonder-blocks-modal/components/focus-trap.js
+++ b/packages/wonder-blocks-modal/components/focus-trap.js
@@ -186,12 +186,15 @@ export default class FocusTrap extends React.Component<Props> {
                   * take you to a sentinel node, rather than taking you out of
                   * the document. These sentinels aren't critical to focus
                   * wrapping, though; we're resilient to any kind of focus
-                  * shift, whether it's to the sentinels or somewhere else! */}
-                <div tabIndex="0" />
+                  * shift, whether it's to the sentinels or somewhere else!
+                  * We set the sentinels to be position: fixed to make sure
+                  * they're always in view, this prevents page scrolling when
+                  * tabbing. */}
+                <div tabIndex="0" style={{position: "fixed"}} />
                 <View style={style} ref={this.getModalRoot}>
                     {this.props.children}
                 </View>
-                <div tabIndex="0" />
+                <div tabIndex="0" style={{position: "fixed"}} />
             </React.Fragment>
         );
     }

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -42,7 +42,10 @@ export default class ModalBackdrop extends React.Component<Props> {
         if (!lastButton) {
             return;
         }
-        lastButton.focus();
+        // wait for styles to applied
+        setTimeout(() => {
+            lastButton.focus();
+        }, 0);
     }
 
     /**

--- a/packages/wonder-blocks-modal/components/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.test.js
@@ -5,6 +5,9 @@ import {mount} from "enzyme";
 import ModalBackdrop from "./modal-backdrop.js";
 import StandardModal from "./standard-modal.js";
 
+const sleep = (duration: number = 0) =>
+    new Promise((resolve, reject) => setTimeout(resolve, duration));
+
 const exampleModal = (
     <StandardModal
         content={<div data-modal-content />}
@@ -75,18 +78,20 @@ describe("ModalBackdrop", () => {
         expect(onCloseModal).not.toHaveBeenCalled();
     });
 
-    test("On mount, we focus the last button in the modal", (done) => {
+    test("On mount, we focus the last button in the modal", async () => {
+        // Arrange
         const wrapper = mount(
             <ModalBackdrop onCloseModal={() => {}}>
                 {exampleModalWithButtons}
             </ModalBackdrop>,
         );
 
-        setTimeout(() => {
-            const lastButton = wrapper.find("[data-last-button]").getDOMNode();
-            expect(document.activeElement).toBe(lastButton);
-            done();
-        }, 0);
+        // Act
+        await sleep(); // wait for styles to be applied
+        const lastButton = wrapper.find("[data-last-button]").getDOMNode();
+
+        // Assert
+        expect(document.activeElement).toBe(lastButton);
     });
 
     // TODO(mdr): I haven't figured out how to actually simulate tab keystrokes

--- a/packages/wonder-blocks-modal/components/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.test.js
@@ -75,15 +75,18 @@ describe("ModalBackdrop", () => {
         expect(onCloseModal).not.toHaveBeenCalled();
     });
 
-    test("On mount, we focus the last button in the modal", () => {
+    test("On mount, we focus the last button in the modal", (done) => {
         const wrapper = mount(
             <ModalBackdrop onCloseModal={() => {}}>
                 {exampleModalWithButtons}
             </ModalBackdrop>,
         );
 
-        const lastButton = wrapper.find("[data-last-button]").getDOMNode();
-        expect(document.activeElement).toBe(lastButton);
+        setTimeout(() => {
+            const lastButton = wrapper.find("[data-last-button]").getDOMNode();
+            expect(document.activeElement).toBe(lastButton);
+            done();
+        }, 0);
     });
 
     // TODO(mdr): I haven't figured out how to actually simulate tab keystrokes


### PR DESCRIPTION
This diff solves two issues:
- we were focus the button inside the modal too soon and so it was actually at the bottom of the page since styles hadn't been applied yet
- the sentinel divs in `FocusTrap` were positioned at the bottom of the page

Now we wait a bit for styles to be applied before focusing the button.  We also set the style of the sentinel divs to be `position: fixed` so that they're always in view.