### PR TITLE
Breaking(core) - Rename NoSSR to WithSSRPlaceholder

### DIFF
--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -6,209 +6,6 @@ exports[`wonder-blocks-core example 1 1`] = `
   style={
     Object {
       "alignItems": "stretch",
-      "borderStyle": "solid",
-      "borderWidth": 0,
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flexDirection": "column",
-      "margin": 0,
-      "minHeight": 0,
-      "minWidth": 0,
-      "padding": 0,
-      "position": "relative",
-      "zIndex": 0,
-    }
-  }
->
-  This is rendered only by the client for all but the very first render of the component tree.
-</div>
-`;
-
-exports[`wonder-blocks-core example 2 1`] = `
-<div
-  className=""
-  style={
-    Object {
-      "alignItems": "stretch",
-      "borderStyle": "solid",
-      "borderWidth": 0,
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flexDirection": "column",
-      "margin": 0,
-      "minHeight": 0,
-      "minWidth": 0,
-      "padding": 0,
-      "position": "relative",
-      "zIndex": 0,
-    }
-  }
->
-  <span
-    className=""
-    style={
-      Object {
-        "MozOsxFontSmoothing": "grayscale",
-        "WebkitFontSmoothing": "antialiased",
-        "display": "block",
-        "fontFamily": "Lato, sans-serif",
-        "fontSize": 16,
-        "fontWeight": 400,
-        "lineHeight": "22px",
-      }
-    }
-  >
-    The list below should have three render entries; root placeholder, root children render, and child children render. If there are two child renders that means that the second forced render is still occurring for nested NoSSR components, which would be a bug.
-  </span>
-  <ul
-    id="nossr-example-2-results"
-  />
-  <span
-    className=""
-    style={
-      Object {
-        "MozOsxFontSmoothing": "grayscale",
-        "WebkitFontSmoothing": "antialiased",
-        "display": "block",
-        "fontFamily": "Lato, sans-serif",
-        "fontSize": 16,
-        "fontWeight": 400,
-        "lineHeight": "22px",
-      }
-    }
-  >
-    And below this is the actual NoSSR nesting, which should just show the child render.
-  </span>
-  <div
-    className=""
-    style={
-      Object {
-        "alignItems": "stretch",
-        "borderStyle": "solid",
-        "borderWidth": 0,
-        "boxSizing": "border-box",
-        "display": "flex",
-        "flexDirection": "column",
-        "margin": 0,
-        "minHeight": 0,
-        "minWidth": 0,
-        "padding": 0,
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    Child: render
-  </div>
-</div>
-`;
-
-exports[`wonder-blocks-core example 3 1`] = `
-<div
-  className=""
-  style={
-    Object {
-      "alignItems": "stretch",
-      "borderStyle": "solid",
-      "borderWidth": 0,
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flexDirection": "column",
-      "margin": 0,
-      "minHeight": 0,
-      "minWidth": 0,
-      "padding": 0,
-      "position": "relative",
-      "zIndex": 0,
-    }
-  }
->
-  <span
-    className=""
-    style={
-      Object {
-        "MozOsxFontSmoothing": "grayscale",
-        "WebkitFontSmoothing": "antialiased",
-        "display": "block",
-        "fontFamily": "Lato, sans-serif",
-        "fontSize": 16,
-        "fontWeight": 400,
-        "lineHeight": "22px",
-      }
-    }
-  >
-    The list below should have six render entries; 2 x root placeholder, 2 x root children render, and 2 x child children render.
-  </span>
-  <ul
-    id="nossr-example-3-results"
-  />
-  <span
-    className=""
-    style={
-      Object {
-        "MozOsxFontSmoothing": "grayscale",
-        "WebkitFontSmoothing": "antialiased",
-        "display": "block",
-        "fontFamily": "Lato, sans-serif",
-        "fontSize": 16,
-        "fontWeight": 400,
-        "lineHeight": "22px",
-      }
-    }
-  >
-    And below this are the NoSSR component trees, which should just show their child renders.
-  </span>
-  <div
-    className=""
-    style={
-      Object {
-        "alignItems": "stretch",
-        "borderStyle": "solid",
-        "borderWidth": 0,
-        "boxSizing": "border-box",
-        "display": "flex",
-        "flexDirection": "column",
-        "margin": 0,
-        "minHeight": 0,
-        "minWidth": 0,
-        "padding": 0,
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    Child 1: render
-  </div>
-  <div
-    className=""
-    style={
-      Object {
-        "alignItems": "stretch",
-        "borderStyle": "solid",
-        "borderWidth": 0,
-        "boxSizing": "border-box",
-        "display": "flex",
-        "flexDirection": "column",
-        "margin": 0,
-        "minHeight": 0,
-        "minWidth": 0,
-        "padding": 0,
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    Child 2: render
-  </div>
-</div>
-`;
-
-exports[`wonder-blocks-core example 4 1`] = `
-<div
-  className=""
-  style={
-    Object {
-      "alignItems": "stretch",
       "backgroundColor": "plum",
       "borderStyle": "solid",
       "borderWidth": 0,
@@ -262,7 +59,7 @@ exports[`wonder-blocks-core example 4 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 5 1`] = `
+exports[`wonder-blocks-core example 2 1`] = `
 <div
   className=""
   style={
@@ -319,7 +116,7 @@ exports[`wonder-blocks-core example 5 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 6 1`] = `
+exports[`wonder-blocks-core example 3 1`] = `
 <div
   className=""
   style={
@@ -536,7 +333,7 @@ exports[`wonder-blocks-core example 6 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 7 1`] = `
+exports[`wonder-blocks-core example 4 1`] = `
 <div
   className=""
   style={
@@ -729,7 +526,7 @@ exports[`wonder-blocks-core example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 8 1`] = `
+exports[`wonder-blocks-core example 5 1`] = `
 <div
   className=""
   style={
@@ -862,7 +659,7 @@ exports[`wonder-blocks-core example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 9 1`] = `
+exports[`wonder-blocks-core example 6 1`] = `
 <div
   className=""
   style={
@@ -979,7 +776,7 @@ exports[`wonder-blocks-core example 9 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 10 1`] = `
+exports[`wonder-blocks-core example 7 1`] = `
 <div
   className=""
   style={
@@ -1038,7 +835,7 @@ exports[`wonder-blocks-core example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 11 1`] = `
+exports[`wonder-blocks-core example 8 1`] = `
 <div
   className=""
   style={
@@ -1092,5 +889,232 @@ exports[`wonder-blocks-core example 11 1`] = `
   >
     This text is hidden from screen readers.
   </span>
+</div>
+`;
+
+exports[`wonder-blocks-core example 9 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  This is rendered only by the client, for all renders after the rehydration render.
+</div>
+`;
+
+exports[`wonder-blocks-core example 10 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  This is rendered only by the client, while nothing was rendered on the server.
+</div>
+`;
+
+exports[`wonder-blocks-core example 11 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    The list below should have three render entries; root placeholder, root children render, and child children render. If there are two child renders that means that the second forced render is still occurring for nested WithSSRPlaceholder components, which would be a bug.
+  </span>
+  <ul
+    id="nossr-example-2-results"
+  />
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    And below this is the actual WithSSRPlaceholder nesting, which should just show the child render.
+  </span>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    Child: render
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-core example 12 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    The list below should have six render entries; 2 x root placeholder, 2 x root children render, and 2 x child children render.
+  </span>
+  <ul
+    id="nossr-example-3-results"
+  />
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    And below this are the WithSSRPlaceholder component trees, which should just show their child renders.
+  </span>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    Child 1: render
+  </div>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    Child 2: render
+  </div>
 </div>
 `;

--- a/packages/wonder-blocks-core/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import NoSSR from "./no-ssr.js";
+import WithSSRPlaceholder from "./with-ssr-placeholder.js";
 
 import UniqueIDFactory from "../util/unique-id-factory.js";
 import SsrIDFactory from "../util/ssr-id-factory.js";
@@ -67,7 +67,7 @@ export default class UniqueIDProvider extends React.Component<Props> {
 
         // If this is our first render, we're going to stop right here.
         // Note: `firstRender` will be `false` on the first render if this
-        // component is a descendant of a `NoSSR`.
+        // component is a descendant of a `WithSSRPlaceholder`.
         if (firstRender) {
             if (mockOnFirstRender) {
                 // We're allowing an initial render, so let's pass our mock
@@ -87,12 +87,13 @@ export default class UniqueIDProvider extends React.Component<Props> {
     }
 
     render() {
-        // Here we use the NoSSR component to control when we render and whether
-        // we provide a mock or real identifier factory.
+        // Here we use the WithSSRPlaceholder component to control
+        // when we render and whether we provide a mock or real
+        // identifier factory.
         return (
-            <NoSSR placeholder={() => this._performRender(true)}>
+            <WithSSRPlaceholder placeholder={() => this._performRender(true)}>
                 {() => this._performRender(false)}
-            </NoSSR>
+            </WithSSRPlaceholder>
         );
     }
 }

--- a/packages/wonder-blocks-core/components/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.test.js
@@ -9,7 +9,7 @@ import View from "./view.js";
 import SsrIDFactory from "../util/ssr-id-factory.js";
 import UniqueIDFactory from "../util/unique-id-factory.js";
 import UniqueIDProvider from "./unique-id-provider.js";
-import NoSSR from "./no-ssr.js";
+import WithSSRPlaceholder from "./with-ssr-placeholder.js";
 
 describe("UniqueIDProvider", () => {
     beforeEach(() => {
@@ -126,18 +126,18 @@ describe("UniqueIDProvider", () => {
         });
     });
 
-    describe("inside a NoSSR", () => {
+    describe("inside a WithSSRPlaceholder", () => {
         test("it should pass an id to its children", () => {
             // Arrange
             const foo = jest.fn(() => null);
             const nodes = (
-                <NoSSR>
+                <WithSSRPlaceholder placeholder={null}>
                     {() => (
                         <UniqueIDProvider>
                             {(ids) => foo(ids.get(""))}
                         </UniqueIDProvider>
                     )}
-                </NoSSR>
+                </WithSSRPlaceholder>
             );
 
             // Act

--- a/packages/wonder-blocks-core/components/with-ssr-placeholder.js
+++ b/packages/wonder-blocks-core/components/with-ssr-placeholder.js
@@ -22,7 +22,7 @@ type Props = {|
      * the server-side renderer and the rehydration -- or it defeats
      * the purpose of using the WithSSRPlaceholder component.
      */
-    placeholder: null | (() => React.Node),
+    placeholder: ?(() => ?React.Node),
 |};
 
 type State = {|

--- a/packages/wonder-blocks-core/components/with-ssr-placeholder.md
+++ b/packages/wonder-blocks-core/components/with-ssr-placeholder.md
@@ -1,12 +1,20 @@
-`NoSSR` is a behavioral component, providing a mechanism to hide the rendering of a component from server-side rendering (SSR).
+`WithSSRPlaceholder` is a behavioral component, providing a mechanism to hide the rendering of a component from server-side rendering (SSR).
 
 ```jsx
-<NoSSR placeholder={() => <View>This gets rendered on client and server for the first render call in the component tree</View>}>
-    {() => <View>This is rendered only by the client for all but the very first render of the component tree.</View>}
-</NoSSR>
+<WithSSRPlaceholder placeholder={() => <View>This gets rendered on server, and also on the client for the very first render (the "rehydration" render)</View>}>
+    {() => <View>This is rendered only by the client, for all renders after the rehydration render.</View>}
+</WithSSRPlaceholder>
 ```
 
-Here, we nest two `NoSSR` components and use an array to track rendering, so that we can see how only the top level `NoSSR` component skips the initial render.
+This example shows how you can use a `null` placeholder to just display nothing during server-side render.
+
+```jsx
+<WithSSRPlaceholder placeholder={null}>
+    {() => <View>This is rendered only by the client, while nothing was rendered on the server.</View>}
+</WithSSRPlaceholder>
+```
+
+Here, we nest two `WithSSRPlaceholder` components and use an array to track rendering, so that we can see how only the top level `WithSSRPlaceholder` component skips the initial render.
 
 ```jsx
 const {Body, BodyMonospace} = require("@khanacademy/wonder-blocks-typography");
@@ -44,32 +52,32 @@ const trackAndRender = text => {
         The list below should have three render entries; root placeholder,
         root children render, and child children render. If there are two child
         renders that means that the second forced render is still occurring for
-        nested NoSSR components, which would be a bug.
+        nested WithSSRPlaceholder components, which would be a bug.
     </Body>
     <ul id={resultsId}>
     </ul>
     <Body>
-        And below this is the actual NoSSR nesting, which should just show the
+        And below this is the actual WithSSRPlaceholder nesting, which should just show the
         child render.
     </Body>
-    <NoSSR placeholder={() => <View>{trackAndRender("Root: placeholder")}</View>}>
+    <WithSSRPlaceholder placeholder={() => <View>{trackAndRender("Root: placeholder")}</View>}>
         {() => {
             addTrackedRender("Root: render");
             return (
-                <NoSSR placeholder={() => (
+                <WithSSRPlaceholder placeholder={() => (
                     <View>
                         {trackAndRender("Child: placeholder (should never see me)")}
                     </View>
                 )}>
                     {() => <View>{trackAndRender("Child: render")}</View>}
-                </NoSSR>
+                </WithSSRPlaceholder>
             );
         }}
-    </NoSSR>
+    </WithSSRPlaceholder>
 </View>
 ```
 
-In this example, we have side-by-side `NoSSR` components. This demonstrates how component non-nested `NoSSR` components independently track the first render.
+In this example, we have side-by-side `WithSSRPlaceholder` components. This demonstrates how component non-nested `WithSSRPlaceholder` components independently track the first render.
 
 ```jsx
 const {Body, BodyMonospace} = require("@khanacademy/wonder-blocks-typography");
@@ -110,36 +118,36 @@ const trackAndRender = text => {
     <ul id={resultsId}>
     </ul>
     <Body>
-        And below this are the NoSSR component trees, which should just show
+        And below this are the WithSSRPlaceholder component trees, which should just show
         their child renders.
     </Body>
-    <NoSSR placeholder={() => <View>{trackAndRender("Root 1: placeholder")}</View>}>
+    <WithSSRPlaceholder placeholder={() => <View>{trackAndRender("Root 1: placeholder")}</View>}>
         {() => {
             addTrackedRender("Root 1: render");
             return (
-                <NoSSR placeholder={() => (
+                <WithSSRPlaceholder placeholder={() => (
                     <View>
                         {trackAndRender("Child 1: placeholder (should never see me)")}
                     </View>
                 )}>
                     {() => <View>{trackAndRender("Child 1: render")}</View>}
-                </NoSSR>
+                </WithSSRPlaceholder>
             );
         }}
-    </NoSSR>
-    <NoSSR placeholder={() => <View>{trackAndRender("Root 2: placeholder")}</View>}>
+    </WithSSRPlaceholder>
+    <WithSSRPlaceholder placeholder={() => <View>{trackAndRender("Root 2: placeholder")}</View>}>
         {() => {
             addTrackedRender("Root 2: render");
             return (
-                <NoSSR placeholder={() => (
+                <WithSSRPlaceholder placeholder={() => (
                     <View>
                         {trackAndRender("Child 2: placeholder (should never see me)")}
                     </View>
                 )}>
                     {() => <View>{trackAndRender("Child 2: render")}</View>}
-                </NoSSR>
+                </WithSSRPlaceholder>
             );
         }}
-    </NoSSR>
+    </WithSSRPlaceholder>
 </View>
 ```

--- a/packages/wonder-blocks-core/components/with-ssr-placeholder.test.js
+++ b/packages/wonder-blocks-core/components/with-ssr-placeholder.test.js
@@ -4,9 +4,9 @@ import * as ReactDOMServer from "react-dom/server.js";
 
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
-import NoSSR from "./no-ssr.js";
+import WithSSRPlaceholder from "./with-ssr-placeholder.js";
 
-describe("NoSSR", () => {
+describe("WithSSRPlaceholder", () => {
     beforeEach(() => {
         unmountAll();
     });
@@ -16,12 +16,12 @@ describe("NoSSR", () => {
         const mockPlaceholder = jest.fn(() => null);
         await new Promise((resolve) => {
             const nodes = (
-                <NoSSR placeholder={mockPlaceholder}>
+                <WithSSRPlaceholder placeholder={mockPlaceholder}>
                     {() => {
                         resolve();
                         return null;
                     }}
-                </NoSSR>
+                </WithSSRPlaceholder>
             );
 
             // Act
@@ -35,22 +35,24 @@ describe("NoSSR", () => {
         expect(mockPlaceholder).toHaveBeenCalledTimes(1);
     });
 
-    test("calls children render right away if a parent NoSSR component handled first render", async () => {
+    test("calls children render right away if a parent WithSSRPlaceholder component handled first render", async () => {
         // Arrange
         const mockPlaceholder = jest.fn(() => null);
         const mockPlaceholderNotCalled = jest.fn(() => null);
         await new Promise((resolve) => {
             const nodes = (
-                <NoSSR placeholder={mockPlaceholder}>
+                <WithSSRPlaceholder placeholder={mockPlaceholder}>
                     {() => (
-                        <NoSSR placeholder={mockPlaceholderNotCalled}>
+                        <WithSSRPlaceholder
+                            placeholder={mockPlaceholderNotCalled}
+                        >
                             {() => {
                                 resolve();
                                 return null;
                             }}
-                        </NoSSR>
+                        </WithSSRPlaceholder>
                     )}
-                </NoSSR>
+                </WithSSRPlaceholder>
             );
 
             // Act
@@ -58,7 +60,7 @@ describe("NoSSR", () => {
         });
 
         // Assert
-        // Our promise doesn't resolve until the children of our nested NoSSR
+        // Our promise doesn't resolve until the children of our nested WithSSRPlaceholder
         // are rendered, therefore we don't get here until that and so if the
         // parent placeholder has been called, it must have been called first.
         // In addition, if our code is working right, the placeholder of the
@@ -74,7 +76,9 @@ describe("NoSSR", () => {
             const mockPlaceholder = jest.fn(() => null);
 
             const nodes = (
-                <NoSSR placeholder={mockPlaceholder}>{mockChildren}</NoSSR>
+                <WithSSRPlaceholder placeholder={mockPlaceholder}>
+                    {mockChildren}
+                </WithSSRPlaceholder>
             );
 
             // Act
@@ -85,11 +89,15 @@ describe("NoSSR", () => {
             expect(mockChildren).toHaveBeenCalledTimes(0);
         });
 
-        test("no placeholder returns null", () => {
+        test("null placeholder returns null", () => {
             // Arrange
             const mockChildren = jest.fn(() => null);
 
-            const nodes = <NoSSR>{mockChildren}</NoSSR>;
+            const nodes = (
+                <WithSSRPlaceholder placeholder={null}>
+                    {mockChildren}
+                </WithSSRPlaceholder>
+            );
 
             // Act
             const result = ReactDOMServer.renderToStaticMarkup(nodes);

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -10,216 +10,13 @@ import renderer from "react-test-renderer";
 jest.mock("react-dom");
 import ClickableBehavior from "./components/clickable-behavior.js";
 import MediaLayout from "./components/media-layout.js";
-import NoSSR from "./components/no-ssr.js";
 import Text from "./components/text.js";
 import UniqueIDProvider from "./components/unique-id-provider.js";
 import View from "./components/view.js";
+import WithSSRPlaceholder from "./components/with-ssr-placeholder.js";
 
 describe("wonder-blocks-core", () => {
     it("example 1", () => {
-        const example = (
-            <NoSSR
-                placeholder={() => (
-                    <View>
-                        This gets rendered on client and server for the first
-                        render call in the component tree
-                    </View>
-                )}
-            >
-                {() => (
-                    <View>
-                        This is rendered only by the client for all but the very
-                        first render of the component tree.
-                    </View>
-                )}
-            </NoSSR>
-        );
-        const tree = renderer.create(example).toJSON();
-        expect(tree).toMatchSnapshot();
-    });
-    it("example 2", () => {
-        const {
-            Body,
-            BodyMonospace,
-        } = require("@khanacademy/wonder-blocks-typography");
-
-        const trackingArray = [];
-        const resultsId = "nossr-example-2-results";
-        const newLi = (text) => {
-            const li = document.createElement("li");
-            li.appendChild(document.createTextNode(text));
-            return li;
-        };
-
-        const addTrackedRender = (text) => {
-            const el = document.getElementById(resultsId);
-            if (el) {
-                for (let i = 0; i < trackingArray.length; i++) {
-                    el.append(newLi(trackingArray[i]));
-                }
-                trackingArray.length = 0;
-                el.append(newLi(text));
-            } else {
-                // We may not have rendered the results element yet, so if we haven't
-                // use an array to keep track of the things until we have.
-                trackingArray.push(text);
-            }
-        };
-
-        const trackAndRender = (text) => {
-            addTrackedRender(text);
-            return text;
-        };
-
-        const example = (
-            <View>
-                <Body>
-                    The list below should have three render entries; root
-                    placeholder, root children render, and child children
-                    render. If there are two child renders that means that the
-                    second forced render is still occurring for nested NoSSR
-                    components, which would be a bug.
-                </Body>
-                <ul id={resultsId} />
-                <Body>
-                    And below this is the actual NoSSR nesting, which should
-                    just show the child render.
-                </Body>
-                <NoSSR
-                    placeholder={() => (
-                        <View>{trackAndRender("Root: placeholder")}</View>
-                    )}
-                >
-                    {() => {
-                        addTrackedRender("Root: render");
-                        return (
-                            <NoSSR
-                                placeholder={() => (
-                                    <View>
-                                        {trackAndRender(
-                                            "Child: placeholder (should never see me)",
-                                        )}
-                                    </View>
-                                )}
-                            >
-                                {() => (
-                                    <View>
-                                        {trackAndRender("Child: render")}
-                                    </View>
-                                )}
-                            </NoSSR>
-                        );
-                    }}
-                </NoSSR>
-            </View>
-        );
-        const tree = renderer.create(example).toJSON();
-        expect(tree).toMatchSnapshot();
-    });
-    it("example 3", () => {
-        const {
-            Body,
-            BodyMonospace,
-        } = require("@khanacademy/wonder-blocks-typography");
-
-        const trackingArray = [];
-        const resultsId = "nossr-example-3-results";
-        const newLi = (text) => {
-            const li = document.createElement("li");
-            li.appendChild(document.createTextNode(text));
-            return li;
-        };
-
-        const addTrackedRender = (text) => {
-            const el = document.getElementById(resultsId);
-            if (el) {
-                for (let i = 0; i < trackingArray.length; i++) {
-                    el.append(newLi(trackingArray[i]));
-                }
-                trackingArray.length = 0;
-                el.append(newLi(text));
-            } else {
-                // We may not have rendered the results element yet, so if we haven't
-                // use an array to keep track of the things until we have.
-                trackingArray.push(text);
-            }
-        };
-
-        const trackAndRender = (text) => {
-            addTrackedRender(text);
-            return text;
-        };
-
-        const example = (
-            <View>
-                <Body>
-                    The list below should have six render entries; 2 x root
-                    placeholder, 2 x root children render, and 2 x child
-                    children render.
-                </Body>
-                <ul id={resultsId} />
-                <Body>
-                    And below this are the NoSSR component trees, which should
-                    just show their child renders.
-                </Body>
-                <NoSSR
-                    placeholder={() => (
-                        <View>{trackAndRender("Root 1: placeholder")}</View>
-                    )}
-                >
-                    {() => {
-                        addTrackedRender("Root 1: render");
-                        return (
-                            <NoSSR
-                                placeholder={() => (
-                                    <View>
-                                        {trackAndRender(
-                                            "Child 1: placeholder (should never see me)",
-                                        )}
-                                    </View>
-                                )}
-                            >
-                                {() => (
-                                    <View>
-                                        {trackAndRender("Child 1: render")}
-                                    </View>
-                                )}
-                            </NoSSR>
-                        );
-                    }}
-                </NoSSR>
-                <NoSSR
-                    placeholder={() => (
-                        <View>{trackAndRender("Root 2: placeholder")}</View>
-                    )}
-                >
-                    {() => {
-                        addTrackedRender("Root 2: render");
-                        return (
-                            <NoSSR
-                                placeholder={() => (
-                                    <View>
-                                        {trackAndRender(
-                                            "Child 2: placeholder (should never see me)",
-                                        )}
-                                    </View>
-                                )}
-                            >
-                                {() => (
-                                    <View>
-                                        {trackAndRender("Child 2: render")}
-                                    </View>
-                                )}
-                            </NoSSR>
-                        );
-                    }}
-                </NoSSR>
-            </View>
-        );
-        const tree = renderer.create(example).toJSON();
-        expect(tree).toMatchSnapshot();
-    });
-    it("example 4", () => {
         const {StyleSheet} = require("aphrodite");
 
         const styles = StyleSheet.create({
@@ -249,7 +46,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 5", () => {
+    it("example 2", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -262,7 +59,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 6", () => {
+    it("example 3", () => {
         const {
             Body,
             HeadingSmall,
@@ -310,7 +107,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 7", () => {
+    it("example 4", () => {
         const {
             Body,
             BodyMonospace,
@@ -353,7 +150,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 8", () => {
+    it("example 5", () => {
         const {
             Body,
             HeadingSmall,
@@ -380,7 +177,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 9", () => {
+    it("example 6", () => {
         const {
             BodyMonospace,
         } = require("@khanacademy/wonder-blocks-typography");
@@ -404,7 +201,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 10", () => {
+    it("example 7", () => {
         const {StyleSheet} = require("aphrodite");
 
         const styles = StyleSheet.create({
@@ -434,7 +231,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 11", () => {
+    it("example 8", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -442,6 +239,223 @@ describe("wonder-blocks-core", () => {
                 <Text aria-hidden="true">
                     This text is hidden from screen readers.
                 </Text>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 9", () => {
+        const example = (
+            <WithSSRPlaceholder
+                placeholder={() => (
+                    <View>
+                        This gets rendered on server, and also on the client for
+                        the very first render (the "rehydration" render)
+                    </View>
+                )}
+            >
+                {() => (
+                    <View>
+                        This is rendered only by the client, for all renders
+                        after the rehydration render.
+                    </View>
+                )}
+            </WithSSRPlaceholder>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 10", () => {
+        const example = (
+            <WithSSRPlaceholder placeholder={null}>
+                {() => (
+                    <View>
+                        This is rendered only by the client, while nothing was
+                        rendered on the server.
+                    </View>
+                )}
+            </WithSSRPlaceholder>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 11", () => {
+        const {
+            Body,
+            BodyMonospace,
+        } = require("@khanacademy/wonder-blocks-typography");
+
+        const trackingArray = [];
+        const resultsId = "nossr-example-2-results";
+        const newLi = (text) => {
+            const li = document.createElement("li");
+            li.appendChild(document.createTextNode(text));
+            return li;
+        };
+
+        const addTrackedRender = (text) => {
+            const el = document.getElementById(resultsId);
+            if (el) {
+                for (let i = 0; i < trackingArray.length; i++) {
+                    el.append(newLi(trackingArray[i]));
+                }
+                trackingArray.length = 0;
+                el.append(newLi(text));
+            } else {
+                // We may not have rendered the results element yet, so if we haven't
+                // use an array to keep track of the things until we have.
+                trackingArray.push(text);
+            }
+        };
+
+        const trackAndRender = (text) => {
+            addTrackedRender(text);
+            return text;
+        };
+
+        const example = (
+            <View>
+                <Body>
+                    The list below should have three render entries; root
+                    placeholder, root children render, and child children
+                    render. If there are two child renders that means that the
+                    second forced render is still occurring for nested
+                    WithSSRPlaceholder components, which would be a bug.
+                </Body>
+                <ul id={resultsId} />
+                <Body>
+                    And below this is the actual WithSSRPlaceholder nesting,
+                    which should just show the child render.
+                </Body>
+                <WithSSRPlaceholder
+                    placeholder={() => (
+                        <View>{trackAndRender("Root: placeholder")}</View>
+                    )}
+                >
+                    {() => {
+                        addTrackedRender("Root: render");
+                        return (
+                            <WithSSRPlaceholder
+                                placeholder={() => (
+                                    <View>
+                                        {trackAndRender(
+                                            "Child: placeholder (should never see me)",
+                                        )}
+                                    </View>
+                                )}
+                            >
+                                {() => (
+                                    <View>
+                                        {trackAndRender("Child: render")}
+                                    </View>
+                                )}
+                            </WithSSRPlaceholder>
+                        );
+                    }}
+                </WithSSRPlaceholder>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 12", () => {
+        const {
+            Body,
+            BodyMonospace,
+        } = require("@khanacademy/wonder-blocks-typography");
+
+        const trackingArray = [];
+        const resultsId = "nossr-example-3-results";
+        const newLi = (text) => {
+            const li = document.createElement("li");
+            li.appendChild(document.createTextNode(text));
+            return li;
+        };
+
+        const addTrackedRender = (text) => {
+            const el = document.getElementById(resultsId);
+            if (el) {
+                for (let i = 0; i < trackingArray.length; i++) {
+                    el.append(newLi(trackingArray[i]));
+                }
+                trackingArray.length = 0;
+                el.append(newLi(text));
+            } else {
+                // We may not have rendered the results element yet, so if we haven't
+                // use an array to keep track of the things until we have.
+                trackingArray.push(text);
+            }
+        };
+
+        const trackAndRender = (text) => {
+            addTrackedRender(text);
+            return text;
+        };
+
+        const example = (
+            <View>
+                <Body>
+                    The list below should have six render entries; 2 x root
+                    placeholder, 2 x root children render, and 2 x child
+                    children render.
+                </Body>
+                <ul id={resultsId} />
+                <Body>
+                    And below this are the WithSSRPlaceholder component trees,
+                    which should just show their child renders.
+                </Body>
+                <WithSSRPlaceholder
+                    placeholder={() => (
+                        <View>{trackAndRender("Root 1: placeholder")}</View>
+                    )}
+                >
+                    {() => {
+                        addTrackedRender("Root 1: render");
+                        return (
+                            <WithSSRPlaceholder
+                                placeholder={() => (
+                                    <View>
+                                        {trackAndRender(
+                                            "Child 1: placeholder (should never see me)",
+                                        )}
+                                    </View>
+                                )}
+                            >
+                                {() => (
+                                    <View>
+                                        {trackAndRender("Child 1: render")}
+                                    </View>
+                                )}
+                            </WithSSRPlaceholder>
+                        );
+                    }}
+                </WithSSRPlaceholder>
+                <WithSSRPlaceholder
+                    placeholder={() => (
+                        <View>{trackAndRender("Root 2: placeholder")}</View>
+                    )}
+                >
+                    {() => {
+                        addTrackedRender("Root 2: render");
+                        return (
+                            <WithSSRPlaceholder
+                                placeholder={() => (
+                                    <View>
+                                        {trackAndRender(
+                                            "Child 2: placeholder (should never see me)",
+                                        )}
+                                    </View>
+                                )}
+                            >
+                                {() => (
+                                    <View>
+                                        {trackAndRender("Child 2: render")}
+                                    </View>
+                                )}
+                            </WithSSRPlaceholder>
+                        );
+                    }}
+                </WithSSRPlaceholder>
             </View>
         );
         const tree = renderer.create(example).toJSON();

--- a/packages/wonder-blocks-core/index.js
+++ b/packages/wonder-blocks-core/index.js
@@ -14,7 +14,9 @@ export {default as ClickableBehavior} from "./components/clickable-behavior.js";
 export {default as MediaLayout} from "./components/media-layout.js";
 export {default as Text} from "./components/text.js";
 export {default as View} from "./components/view.js";
-export {default as NoSSR} from "./components/no-ssr.js";
+export {
+    default as WithSSRPlaceholder,
+} from "./components/with-ssr-placeholder.js";
 export {default as UniqueIDProvider} from "./components/unique-id-provider.js";
 export {default as addStyle} from "./util/add-style.js";
 export {

--- a/packages/wonder-blocks-core/index.test.js
+++ b/packages/wonder-blocks-core/index.test.js
@@ -14,7 +14,7 @@ describe("@khanacademy/wonder-blocks-core", () => {
                 "MediaLayout",
                 "Text",
                 "View",
-                "NoSSR",
+                "WithSSRPlaceholder",
                 "addStyle",
                 "getClickableBehavior",
                 "getElementIntersection",


### PR DESCRIPTION
`NoSSR` is a misleading name, because with the `placeholder` param
it's not actually "no" ssr, it's "different" ssr.  (The name is doubly
misleading, since to me "No ssr" means that you can't render this
component during ssr -- it will raise an exception or some such --
when really what it means is that, by default, its children are
ignored when rendered via ssr.)

The new name, I think, makes the intent clearer.  I also made the
placeholder arg required, since I don't think it's right to privilege
"don't show anything" as the default behavior, since it's probably
not the right thing to do most of the time.  (If anything, I'd have
the default be "show a spinner".)

Test Plan:
yarn test