### PR TITLE
Breaking(core) - Make mockOnFirstRender required for UniqueIDProvider.

### DIFF
--- a/packages/wonder-blocks-core/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.js
@@ -14,7 +14,8 @@ type Props = {|
      * the content to be rendered.
      *
      * If mockOnFirstRender is false, this is only called after
-     * the initial render has occurred and will always be called with the same
+     * the initial render has occurred -- it will be blank for the
+     * the first render -- and will always be called with the same
      * IIdentifierFactory instance.
      *
      * If mockOnFirstRender is true, this is called once with
@@ -34,7 +35,7 @@ type Props = {|
      * a mock IIdentifierFactory for the initial render, and then a unique ID
      * factory thereafter.
      */
-    mockOnFirstRender?: boolean,
+    mockOnFirstRender: boolean,
 
     /**
      * If this prop is specified, any identifiers provided will contain the

--- a/packages/wonder-blocks-core/components/unique-id-provider.md
+++ b/packages/wonder-blocks-core/components/unique-id-provider.md
@@ -1,6 +1,6 @@
-### mockOnFirstRender absent or false
+### mockOnFirstRender false
 
-When no `mockOnFirstRender` is `false` (the default), the `children` prop is only called after the initial render. Each call provides the same identifier factory, meaning the same identifier gets returned. Try it below.
+When `mockOnFirstRender` is `false`, the `children` prop is only called after the initial render. Each call provides the same identifier factory, meaning the same identifier gets returned. Try it below.
 
 ```jsx
 const {Body, HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
@@ -11,7 +11,7 @@ let providerRef = null;
 
 const renders = [];
 const provider = (
-    <UniqueIDProvider ref={ref => providerRef = ref}>
+    <UniqueIDProvider mockOnFirstRender={false} ref={ref => providerRef = ref}>
         {ids => {
             renders.push(ids.get("my-unique-id"));
             return (
@@ -95,11 +95,11 @@ const children = ({get}) => (
 
 <View>
     <HeadingSmall>First Provider with scope: first</HeadingSmall>
-    <UniqueIDProvider scope="first">
+    <UniqueIDProvider mockOnFirstRender={false} scope="first">
         {children}
     </UniqueIDProvider>
     <HeadingSmall>Second Provider with scope: second</HeadingSmall>
-    <UniqueIDProvider scope="second">
+    <UniqueIDProvider mockOnFirstRender={false} scope="second">
         {children}
     </UniqueIDProvider>
 </View>

--- a/packages/wonder-blocks-core/components/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/components/unique-id-provider.test.js
@@ -20,7 +20,7 @@ describe("UniqueIDProvider", () => {
         test("initial render is nothing on server", () => {
             // Arrange
             const children = jest.fn(() => null);
-            const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
+            const nodes = <UniqueIDProvider mockOnFirstRender={false}>{children}</UniqueIDProvider>;
 
             // Act
             ReactDOMServer.renderToStaticMarkup(nodes);
@@ -32,7 +32,7 @@ describe("UniqueIDProvider", () => {
         test("initial render is skipped on client", () => {
             // Arrange
             const children = jest.fn(() => null);
-            const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
+            const nodes = <UniqueIDProvider mockOnFirstRender={false}>{children}</UniqueIDProvider>;
 
             // Act
             mount(nodes);
@@ -49,7 +49,7 @@ describe("UniqueIDProvider", () => {
         test("all renders get same unique id factory", () => {
             // Arrange
             const children = jest.fn(() => <View />);
-            const nodes = <UniqueIDProvider>{children}</UniqueIDProvider>;
+            const nodes = <UniqueIDProvider mockOnFirstRender={false}>{children}</UniqueIDProvider>;
             const wrapper = mount(nodes);
 
             // Act
@@ -133,7 +133,7 @@ describe("UniqueIDProvider", () => {
             const nodes = (
                 <NoSSR>
                     {() => (
-                        <UniqueIDProvider>
+                        <UniqueIDProvider mockOnFirstRender={false}>
                             {(ids) => foo(ids.get(""))}
                         </UniqueIDProvider>
                     )}

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -274,7 +274,10 @@ describe("wonder-blocks-core", () => {
 
         const renders = [];
         const provider = (
-            <UniqueIDProvider ref={(ref) => (providerRef = ref)}>
+            <UniqueIDProvider
+                mockOnFirstRender={false}
+                ref={(ref) => (providerRef = ref)}
+            >
                 {(ids) => {
                     renders.push(ids.get("my-unique-id"));
                     return (
@@ -372,9 +375,13 @@ describe("wonder-blocks-core", () => {
         const example = (
             <View>
                 <HeadingSmall>First Provider with scope: first</HeadingSmall>
-                <UniqueIDProvider scope="first">{children}</UniqueIDProvider>
+                <UniqueIDProvider mockOnFirstRender={false} scope="first">
+                    {children}
+                </UniqueIDProvider>
                 <HeadingSmall>Second Provider with scope: second</HeadingSmall>
-                <UniqueIDProvider scope="second">{children}</UniqueIDProvider>
+                <UniqueIDProvider mockOnFirstRender={false} scope="second">
+                    {children}
+                </UniqueIDProvider>
             </View>
         );
         const tree = renderer.create(example).toJSON();


### PR DESCRIPTION
The (old) default behavior of UniqueIDProvider is that it would not
actually render its children during server-side rendering -- that is,
for the initial render.  That seems like a very surprising default to
me, and I think it would be for others as well.

I could change the default, but then you get a different non-obvious
behavior, that you get two different unique-id factories for the
initial render and subsequent renders.

So instead, I just make clients be explicit about which alternative
they prefer.  This helps ensure that they understand the consequences
of their choice.

Test Plan:
yarn test