### PR TITLE
Build files before linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gen-styleguide-prod-config": "node utils/gen-styleguide-prod-config.js && prettier --write styleguide.prod.config.js",
     "jest": "jest --config config/jest/test.config.js",
     "test:vite": "jest --config config/jest/vite.config.js",
-    "test:common": "yarn run lint && yarn run gen-snapshot-tests && yarn run build:all && yarn run flow",
+    "test:common": "yarn run build:all && yarn run lint && yarn run gen-snapshot-tests && yarn run flow",
     "test": "yarn run test:common && yarn run jest",
     "test:coverage": "yarn run test:common && yarn run jest --coverage",
     "coverage": "yarn run test:coverage && open coverage/lcov-report/index.html",


### PR DESCRIPTION
We need to build all the packages before linting because we have a lint
check that verifies that all imports can be resolved.  The main entry
point for all of our packages is dist/index.js which is a built file.
Thus, in order to pass this check we must build the files before running
lint.  Reording the commands in the "test" script in package.json fixes
this.

Test Plan:
- yarn clean
- yarn install
- yarn test