### PR TITLE
WB-401: Update styleguidist config to include Lato bold and black variants

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -178,7 +178,7 @@ module.exports = {
                     // Load Lato from Google Fonts.
                     rel: "stylesheet",
                     href:
-                        "https://fonts.googleapis.com/css?family=Lato:400,700,900",
+                        "https://fonts.googleapis.com/css?family=Lato:400,400i,700,900",
                 },
                 {
                     // Load Inconsolata from Google Fonts.

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -177,7 +177,8 @@ module.exports = {
                 {
                     // Load Lato from Google Fonts.
                     rel: "stylesheet",
-                    href: "https://fonts.googleapis.com/css?family=Lato",
+                    href:
+                        "https://fonts.googleapis.com/css?family=Lato:400,700,900",
                 },
                 {
                     // Load Inconsolata from Google Fonts.


### PR DESCRIPTION
We were only downloading Lato at weight 400 (the default).  This PR updates the URL to grab 400, 700, and 900.

BEFORE:
<img width="958" alt="screen shot 2018-11-30 at 10 48 05 am" src="https://user-images.githubusercontent.com/1044413/49299330-7a0c6980-f48d-11e8-8242-8e24cbecca38.png">

AFTER:
<img width="952" alt="screen shot 2018-11-30 at 10 48 10 am" src="https://user-images.githubusercontent.com/1044413/49299333-7c6ec380-f48d-11e8-9676-f35d0fc7d7b0.png">
