### PR TITLE
WB-504: BREAKING(core) - Add testId (and AriaProps) to all public components

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,3 +21,4 @@ comment:
 ignore:
   - "utils/*.js"
   - "packages/**/dist/index.js"
+  - "packages/**/types.js"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:all": "yarn build:cjs && yarn build:es6",
     "watch:cjs": "webpack --config build-settings/webpack.config.js -w",
     "flow": "flow",
-    "flow-coverage": "flow-coverage-report -t text -t html -f ./node_modules/.bin/flow -i 'packages/wonder-blocks-*/**/*.js' -x 'packages/wonder-blocks-*/dist/*.js' -x '**/*.test.js' -x '**/node_modules/**/*.js'",
+    "flow-coverage": "flow-coverage-report -t text -t html -f ./node_modules/.bin/flow -i 'packages/wonder-blocks-*/**/*.js' -x 'packages/wonder-blocks-*/dist/*.js' -x '**/types.js' -x '**/*.test.js' -x '**/node_modules/**/*.js'",
     "gen-snapshot-tests": "node utils/gen-snapshot-tests.js && prettier --write packages/*/generated-snapshot.test.js",
     "gen-styleguide-prod-config": "node utils/gen-styleguide-prod-config.js && prettier --write styleguide.prod.config.js",
     "jest": "jest --config config/jest/test.config.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:all": "yarn build:cjs && yarn build:es6",
     "watch:cjs": "webpack --config build-settings/webpack.config.js -w",
     "flow": "flow",
-    "flow-coverage": "flow-coverage-report -t text -t html -f ./node_modules/.bin/flow -i 'packages/wonder-blocks-*/**/*.js' -x 'packages/wonder-blocks-*/dist/*.js' -x '**/types.js' -x '**/*.test.js' -x '**/node_modules/**/*.js'",
+    "flow-coverage": "flow-coverage-report -t text -t html -f ./node_modules/.bin/flow -i 'packages/wonder-blocks-*/**/*.js' -x 'packages/wonder-blocks-*/dist/*.js' -x '**/*.test.js' -x '**/node_modules/**/*.js'",
     "gen-snapshot-tests": "node utils/gen-snapshot-tests.js && prettier --write packages/*/generated-snapshot.test.js",
     "gen-styleguide-prod-config": "node utils/gen-styleguide-prod-config.js && prettier --write styleguide.prod.config.js",
     "jest": "jest --config config/jest/test.config.js",

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -138,6 +138,63 @@ exports[`wonder-blocks-core example 3 1`] = `
 >
   <div
     className=""
+    data-test-id="foo"
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    Foo
+  </div>
+  <span
+    className=""
+    data-test-id="bar"
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+      }
+    }
+  >
+    Bar
+  </span>
+</div>
+`;
+
+exports[`wonder-blocks-core example 4 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
     style={
       Object {
         "alignItems": "stretch",
@@ -333,7 +390,7 @@ exports[`wonder-blocks-core example 3 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 4 1`] = `
+exports[`wonder-blocks-core example 5 1`] = `
 <div
   className=""
   style={
@@ -526,7 +583,7 @@ exports[`wonder-blocks-core example 4 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 5 1`] = `
+exports[`wonder-blocks-core example 6 1`] = `
 <div
   className=""
   style={
@@ -659,7 +716,7 @@ exports[`wonder-blocks-core example 5 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 6 1`] = `
+exports[`wonder-blocks-core example 7 1`] = `
 <div
   className=""
   style={
@@ -776,7 +833,7 @@ exports[`wonder-blocks-core example 6 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 7 1`] = `
+exports[`wonder-blocks-core example 8 1`] = `
 <div
   className=""
   style={
@@ -835,7 +892,7 @@ exports[`wonder-blocks-core example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 8 1`] = `
+exports[`wonder-blocks-core example 9 1`] = `
 <div
   className=""
   style={
@@ -892,7 +949,7 @@ exports[`wonder-blocks-core example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 9 1`] = `
+exports[`wonder-blocks-core example 10 1`] = `
 <div
   className=""
   style={
@@ -916,7 +973,7 @@ exports[`wonder-blocks-core example 9 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 10 1`] = `
+exports[`wonder-blocks-core example 11 1`] = `
 <div
   className=""
   style={
@@ -940,7 +997,7 @@ exports[`wonder-blocks-core example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 11 1`] = `
+exports[`wonder-blocks-core example 12 1`] = `
 <div
   className=""
   style={
@@ -1019,7 +1076,7 @@ exports[`wonder-blocks-core example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 12 1`] = `
+exports[`wonder-blocks-core example 13 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-core/components/text.js
+++ b/packages/wonder-blocks-core/components/text.js
@@ -5,14 +5,13 @@ import {StyleSheet} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {processStyleList} from "../util/util.js";
 
-import type {AriaProps, TextTag} from "../util/types.js";
+import type {TextTag, CommonProps} from "../util/types.js";
 
-type Props = AriaProps & {
+type Props = {|
+    ...CommonProps,
     style?: StyleType,
     tag: TextTag,
-    children?: any,
-    [otherProp: string]: any,
-};
+|};
 
 const isHeaderRegex = /^h[1-6]$/;
 

--- a/packages/wonder-blocks-core/components/text.js
+++ b/packages/wonder-blocks-core/components/text.js
@@ -49,7 +49,7 @@ export default class Text extends React.Component<Props> {
     };
 
     render() {
-        const {children, style, tag: Tag, ...otherProps} = this.props;
+        const {children, style, tag: Tag, testId, ...otherProps} = this.props;
 
         const isHeader = isHeaderRegex.test(Tag);
         const styleAttributes = processStyleList([
@@ -63,6 +63,7 @@ export default class Text extends React.Component<Props> {
                 {...otherProps}
                 style={styleAttributes.style}
                 className={styleAttributes.className}
+                data-test-id={testId}
             >
                 {children}
             </Tag>

--- a/packages/wonder-blocks-core/components/text.js
+++ b/packages/wonder-blocks-core/components/text.js
@@ -5,10 +5,10 @@ import {StyleSheet} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {processStyleList} from "../util/util.js";
 
-import type {TextTag, CommonProps} from "../util/types.js";
+import type {TextTag, TextViewSharedProps} from "../util/types.js";
 
 type Props = {|
-    ...CommonProps,
+    ...TextViewSharedProps,
     style?: StyleType,
     tag: TextTag,
 |};

--- a/packages/wonder-blocks-core/components/text.md
+++ b/packages/wonder-blocks-core/components/text.md
@@ -38,3 +38,12 @@ Other props can be passed through `View` or `Text`, as if they were normal tags.
     </Text>
 </View>
 ```
+
+Both `View` and `Text` support a `testId` prop.
+
+```js
+<View>
+    <View testId="foo">Foo</View>
+    <Text testId="bar">Bar</Text>
+</View>
+```

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 
 import addStyle from "../util/add-style.js";
 
-import type {CommonProps} from "../util/types.js";
+import type {TextViewSharedProps} from "../util/types.js";
 
 const styles = StyleSheet.create({
     // https://github.com/facebook/css-layout#default-values
@@ -40,7 +40,7 @@ const StyledDiv = addStyle<"div">("div", styles.default);
  * - An `aphrodite` StyleSheet style
  * - An array combining the above
  */
-export default class View extends React.Component<CommonProps> {
+export default class View extends React.Component<TextViewSharedProps> {
     render() {
         const {testId, ...restProps} = this.props;
         return <StyledDiv data-test-id={testId} {...restProps} />;

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 
 import addStyle from "../util/add-style.js";
 
-import type {Props} from "../util/types.js";
+import type {CommonProps} from "../util/types.js";
 
 const styles = StyleSheet.create({
     // https://github.com/facebook/css-layout#default-values
@@ -40,8 +40,9 @@ const StyledDiv = addStyle<"div">("div", styles.default);
  * - An `aphrodite` StyleSheet style
  * - An array combining the above
  */
-export default class View extends React.Component<Props> {
+export default class View extends React.Component<CommonProps> {
     render() {
-        return <StyledDiv {...this.props} />;
+        const {testId, ...restProps} = this.props;
+        return <StyledDiv data-test-id={testId} {...restProps} />;
     }
 }

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -60,6 +60,16 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
     it("example 3", () => {
+        const example = (
+            <View>
+                <View testId="foo">Foo</View>
+                <Text testId="bar">Bar</Text>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 4", () => {
         const {
             Body,
             HeadingSmall,
@@ -110,7 +120,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 4", () => {
+    it("example 5", () => {
         const {
             Body,
             BodyMonospace,
@@ -153,7 +163,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 5", () => {
+    it("example 6", () => {
         const {
             Body,
             HeadingSmall,
@@ -184,7 +194,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 6", () => {
+    it("example 7", () => {
         const {
             BodyMonospace,
         } = require("@khanacademy/wonder-blocks-typography");
@@ -208,7 +218,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 7", () => {
+    it("example 8", () => {
         const {StyleSheet} = require("aphrodite");
 
         const styles = StyleSheet.create({
@@ -238,7 +248,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 8", () => {
+    it("example 9", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -251,7 +261,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 9", () => {
+    it("example 10", () => {
         const example = (
             <WithSSRPlaceholder
                 placeholder={() => (
@@ -272,7 +282,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 10", () => {
+    it("example 11", () => {
         const example = (
             <WithSSRPlaceholder placeholder={null}>
                 {() => (
@@ -286,7 +296,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 11", () => {
+    it("example 12", () => {
         const {
             Body,
             BodyMonospace,
@@ -365,7 +375,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 12", () => {
+    it("example 13", () => {
         const {
             Body,
             BodyMonospace,

--- a/packages/wonder-blocks-core/index.js
+++ b/packages/wonder-blocks-core/index.js
@@ -2,6 +2,7 @@
 import type {ClickableHandlers} from "./components/clickable-behavior.js";
 import type {
     AriaProps,
+    CommonProps,
     IIdentifierFactory,
     TextTag,
     MediaSize,
@@ -30,6 +31,7 @@ export {MediaLayoutWrapper} from "./util/util.js";
 
 export type {
     AriaProps,
+    CommonProps,
     ClickableHandlers,
     Intersection,
     IIdentifierFactory,

--- a/packages/wonder-blocks-core/index.js
+++ b/packages/wonder-blocks-core/index.js
@@ -2,7 +2,6 @@
 import type {ClickableHandlers} from "./components/clickable-behavior.js";
 import type {
     AriaProps,
-    CommonProps,
     IIdentifierFactory,
     TextTag,
     MediaSize,
@@ -31,7 +30,6 @@ export {MediaLayoutWrapper} from "./util/util.js";
 
 export type {
     AriaProps,
-    CommonProps,
     ClickableHandlers,
     Intersection,
     IIdentifierFactory,

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -94,7 +94,7 @@ type IdRefList = IdRef | Array<IdRef>;
 // Source: https://www.w3.org/WAI/PF/aria-1.1/states_and_properties
 // TODO(kevinb): convert to disjoint union of exact object types keyed on role
 // eslint-disable-next-line flowtype/require-exact-type
-export type AriaProps = {
+export type AriaProps = {|
     role?: roles,
     "aria-activedescendant"?: IdRef,
     "aria-atomic"?: "false" | "true",
@@ -132,13 +132,92 @@ export type AriaProps = {
     "aria-valuemin"?: number,
     "aria-valuenow"?: number,
     "aria-valuetext"?: string,
-};
+|};
 
-export type Props = AriaProps & {
-    style?: StyleType,
+type MouseEvents = {|
+    onMouseDown?: (e: SyntheticMouseEvent<*>) => void,
+    onMouseUp?: (e: SyntheticMouseEvent<*>) => void,
+    onMouseMove?: (e: SyntheticMouseEvent<*>) => void,
+    onClick?: (e: SyntheticMouseEvent<*>) => void,
+    onDoubleClick?: (e: SyntheticMouseEvent<*>) => void,
+    onMouseEnter?: (e: SyntheticMouseEvent<*>) => void,
+    onMouseLeave?: (e: SyntheticMouseEvent<*>) => void,
+    onMouseOut?: (e: SyntheticMouseEvent<*>) => void,
+    onMouseOver?: (e: SyntheticMouseEvent<*>) => void,
+    onDrag?: (e: SyntheticMouseEvent<*>) => void,
+    onDragEnd?: (e: SyntheticMouseEvent<*>) => void,
+    onDragEnter?: (e: SyntheticMouseEvent<*>) => void,
+    onDragExit?: (e: SyntheticMouseEvent<*>) => void,
+    onDragLeave?: (e: SyntheticMouseEvent<*>) => void,
+    onDragOver?: (e: SyntheticMouseEvent<*>) => void,
+    onDragStart?: (e: SyntheticMouseEvent<*>) => void,
+    onDrop?: (e: SyntheticMouseEvent<*>) => void,
+|};
+
+type KeyboardEvents = {|
+    onKeyDown?: (e: SyntheticKeyboardEvent<*>) => void,
+    onKeyPress?: (e: SyntheticKeyboardEvent<*>) => void,
+    onKeyUp?: (e: SyntheticKeyboardEvent<*>) => void,
+|};
+
+type InputEvents = {|
+    onChange?: (e: SyntheticInputEvent<*>) => void,
+    onInput?: (e: SyntheticInputEvent<*>) => void,
+    onInvalid?: (e: SyntheticInputEvent<*>) => void,
+    onSubmit?: (e: SyntheticInputEvent<*>) => void,
+|};
+
+type TouchEvents = {|
+    onTouchCancel?: (e: SyntheticTouchEvent<*>) => void,
+    onTouchEnd?: (e: SyntheticTouchEvent<*>) => void,
+    onTouchMove?: (e: SyntheticTouchEvent<*>) => void,
+    onTouchStart?: (e: SyntheticTouchEvent<*>) => void,
+|};
+
+type FocusEvents = {|
+    onFocus?: (e: SyntheticFocusEvent<*>) => void,
+    onBlur?: (e: SyntheticFocusEvent<*>) => void,
+|};
+
+type EventHandlers = {|
+    ...MouseEvents,
+    ...KeyboardEvents,
+    ...InputEvents,
+    ...TouchEvents,
+    ...FocusEvents,
+    // TODO: add remaining supported events https://reactjs.org/docs/events.html#supported-events
+|};
+
+export type CommonProps = {|
+    /**
+     * Text to appear on the button.
+     */
     children?: React.Node,
-    [otherProp: string]: any,
-};
+
+    /**
+     * Optional custom styles.
+     */
+    style?: StyleType,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+
+    tabIndex?: number,
+
+    id?: string,
+
+    // TODO(kevinb) remove the need for this
+    "data-modal-launcher-portal"?: boolean,
+
+    // Used by tooltip bubble
+    "data-placement"?: string,
+
+    ...AriaProps,
+
+    ...EventHandlers,
+|};
 
 export type MediaSize = "small" | "medium" | "large";
 

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -188,7 +188,8 @@ type EventHandlers = {|
     // TODO: add remaining supported events https://reactjs.org/docs/events.html#supported-events
 |};
 
-export type CommonProps = {|
+// Props shared between Text and View components.
+export type TextViewSharedProps = {|
     /**
      * Text to appear on the button.
      */

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener.js
@@ -2,9 +2,12 @@
 import * as React from "react";
 
 import {ClickableBehavior} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import ActionMenuOpenerCore from "./action-menu-opener-core.js";
 
 export type SharedProps = {|
+    ...AriaProps,
+
     /**
      * Display text for the opener.
      */
@@ -24,11 +27,6 @@ export type SharedProps = {|
      * Whether the dropdown is open.
      */
     open: boolean,
-
-    /**
-     * Optional aria-label for screen readers.
-     */
-    "aria-label"?: string,
 |};
 
 type Props = {|

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -122,7 +122,7 @@ export default class OptionItem extends React.Component<OptionProps> {
 
                     return (
                         <View
-                            data-test-id={testId}
+                            testId={testId}
                             style={defaultStyle}
                             aria-selected={selected ? "true" : "false"}
                             role={role}

--- a/packages/wonder-blocks-form/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/components/checkbox-group.js
@@ -57,6 +57,11 @@ type CheckboxGroupProps = {|
      * An array of the values of the selected values in this checkbox group.
      */
     selectedValues: Array<string>,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 const StyledFieldset = addStyle<"fieldset">("fieldset");
@@ -93,10 +98,11 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps> {
             groupName,
             selectedValues,
             style,
+            testId,
         } = this.props;
 
         return (
-            <StyledFieldset style={styles.fieldset}>
+            <StyledFieldset data-test-id={testId} style={styles.fieldset}>
                 {/* We have a View here because fieldset cannot be used with flexbox*/}
                 <View style={style}>
                     {label && (

--- a/packages/wonder-blocks-form/components/checkbox.js
+++ b/packages/wonder-blocks-form/components/checkbox.js
@@ -2,11 +2,13 @@
 
 import * as React from "react";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import ChoiceInternal from "./choice-internal.js";
 
 // Keep synced with ChoiceComponentProps in ../util/types.js
 type ChoiceComponentProps = {|
+    ...AriaProps,
+
     /**
      * Whether this component is checked
      */
@@ -27,13 +29,6 @@ type ChoiceComponentProps = {|
      * new checked state of the component.
      */
     onChange: (newCheckedState: boolean) => void,
-
-    /**
-     * Optional label if it is not obvious from the context what the checkbox
-     * does. If the label and id props are defined, this props does not need to
-     * be provided as the label would be matched to this input.
-     */
-    "aria-label"?: string,
 
     /**
      * Optional label for the field.

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -8,11 +8,13 @@ import {View, getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import CheckboxCore from "./checkbox-core.js";
 import RadioCore from "./radio-core.js";
 
 type Props = {|
+    ...AriaProps,
+
     /** Whether this choice is checked. */
     checked: boolean,
 
@@ -24,13 +26,6 @@ type Props = {|
 
     /** Returns the new checked state of the component. */
     onChange: (newCheckedState: boolean) => void,
-
-    /**
-     * Optional label if it is not obvious from the context what the checkbox
-     * does. If the label and id props are defined, this props does not need to
-     * be provided as the label would be matched to this input.
-     */
-    "aria-label"?: string,
 
     /**
      * Used for accessibility purposes, where the label id should match the
@@ -64,8 +59,7 @@ type Props = {|
  * and RadioGroup. This design allows for more explicit prop typing. For
  * example, we can make onChange a required prop on Checkbox but not on Choice
  * (because for Choice, that prop would be auto-populated by CheckboxGroup).
- */
-export default class ChoiceInternal extends React.Component<Props> {
+ */ export default class ChoiceInternal extends React.Component<Props> {
     static defaultProps = {
         checked: false,
         disabled: false,
@@ -94,7 +88,6 @@ export default class ChoiceInternal extends React.Component<Props> {
             return CheckboxCore;
         }
     }
-
     getLabel() {
         const {disabled, id, label} = this.props;
         return (
@@ -107,14 +100,12 @@ export default class ChoiceInternal extends React.Component<Props> {
             </LabelMedium>
         );
     }
-
     getDescription() {
         const {description} = this.props;
         return (
             <LabelSmall style={styles.description}>{description}</LabelSmall>
         );
     }
-
     render() {
         const {
             label,
@@ -158,14 +149,12 @@ export default class ChoiceInternal extends React.Component<Props> {
         );
     }
 }
-
 const styles = StyleSheet.create({
     wrapper: {
         flexDirection: "row",
         alignItems: "flex-start",
         outline: "none",
     },
-
     label: {
         userSelect: "none",
         // NOTE: The checkbox/radio button (height 16px) should be center
@@ -174,11 +163,9 @@ const styles = StyleSheet.create({
         // desired alignment.
         marginTop: -2,
     },
-
     disabledLabel: {
         color: Color.offBlack32,
     },
-
     description: {
         // 16 for icon + 8 for spacing strut
         marginLeft: Spacing.medium + Spacing.xSmall,

--- a/packages/wonder-blocks-form/components/radio-group.js
+++ b/packages/wonder-blocks-form/components/radio-group.js
@@ -56,6 +56,11 @@ type RadioGroupProps = {|
      * Value of the selected radio item.
      */
     selectedValue: string,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 const StyledFieldset = addStyle<"fieldset">("fieldset");
@@ -83,10 +88,11 @@ export default class RadioGroup extends React.Component<RadioGroupProps> {
             groupName,
             selectedValue,
             style,
+            testId,
         } = this.props;
 
         return (
-            <StyledFieldset style={styles.fieldset}>
+            <StyledFieldset data-test-id={testId} style={styles.fieldset}>
                 {/* We have a View here because fieldset cannot be used with flexbox*/}
                 <View style={style}>
                     {label && (

--- a/packages/wonder-blocks-form/components/radio.js
+++ b/packages/wonder-blocks-form/components/radio.js
@@ -2,11 +2,13 @@
 
 import * as React from "react";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import ChoiceInternal from "./choice-internal.js";
 
 // Keep synced with ChoiceComponentProps in ../util/types.js
 type ChoiceComponentProps = {|
+    ...AriaProps,
+
     /**
      * Whether this component is checked
      */
@@ -27,13 +29,6 @@ type ChoiceComponentProps = {|
      * new checked state of the component.
      */
     onChange: (newCheckedState: boolean) => void,
-
-    /**
-     * Optional label if it is not obvious from the context what the radio
-     * does. If the label and id props are defined, this props does not need to
-     * be provided as the label would be matched to this input.
-     */
-    "aria-label"?: string,
 
     /**
      * Optional label for the field.
@@ -76,8 +71,7 @@ type ChoiceComponentProps = {|
  *
  * This component should not really be used by itself because radio buttons are
  * often grouped together. See RadioGroup.
- */
-export default class Radio extends React.Component<ChoiceComponentProps> {
+ */ export default class Radio extends React.Component<ChoiceComponentProps> {
     static defaultProps = {
         disabled: false,
         error: false,

--- a/packages/wonder-blocks-form/util/types.js
+++ b/packages/wonder-blocks-form/util/types.js
@@ -3,22 +3,19 @@
 // from imported types. We've duplicated the shared props for each component
 // they apply to, so that the prop definitions will show up on the generated
 // guide.
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
 import typeof Choice from "../components/choice.js";
 
 // Shared props for radio-core and checkbox-core
 export type ChoiceCoreProps = {|
+    ...AriaProps,
     /** Whether this component is checked */
     checked: boolean,
     /** Whether this component is disabled */
     disabled: boolean,
     /** Whether this component should show an error state */
     error: boolean,
-    /** Optional label if it is not obvious from the context what the checkbox
-     * does. If the label and id props are defined, this props does not need to
-     * be provided as the label would be matched to this input. */
-    "aria-label"?: string,
     /** Name for the checkbox or radio button group */
     groupName?: string,
     /** Unique identifier attached to the HTML input element. If used, need to

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -4,20 +4,17 @@ import PropTypes from "prop-types";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import IconButtonCore from "./icon-button-core.js";
 
 export type SharedProps = {|
+    ...AriaProps,
+
     /**
      * A Wonder Blocks icon asset, an object specifing paths for one or more of
      * the following sizes: small, medium, large, xlarge.
      */
     icon: IconAsset,
-
-    /**
-     * Text to display as the title of the svg element.
-     */
-    "aria-label": string,
 
     /**
      * The color of the icon button, either blue or red.

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -3,17 +3,13 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import {getPathForIcon, viewportPixelsForSize} from "../util/icon-util.js";
 
 import type {IconAsset, IconSize} from "../util/icon-assets.js";
 
 type Props = {|
-    /**
-     * Passed transparently to the SVG. If not provided, we assume the SVG is
-     * purely decorative and it is invisible to screenreaders.
-     */
-    "aria-label"?: string,
+    ...AriaProps,
     /**
      * The color of the icon. Will default to `currentColor`, which means that
      * it will take on the CSS `color` value from the parent element.
@@ -33,6 +29,10 @@ type Props = {|
      * Aphrodite style objects, or arrays thereof.
      */
     style?: StyleType,
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 const StyledSVG = addStyle<"svg">("svg");

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -3,10 +3,12 @@ import * as React from "react";
 import PropTypes from "prop-types";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import LinkCore from "./link-core.js";
 
 export type SharedProps = {|
+    ...AriaProps,
+
     /**
      * Text to appear on the link.
      */

--- a/packages/wonder-blocks-modal/components/one-column-modal.js
+++ b/packages/wonder-blocks-modal/components/one-column-modal.js
@@ -4,13 +4,15 @@ import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View, MediaLayoutWrapper} from "@khanacademy/wonder-blocks-core";
-import type {MediaSize} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, MediaSize} from "@khanacademy/wonder-blocks-core";
 
 import ModalDialog from "./modal-dialog.js";
 import ModalPanel from "./modal-panel.js";
 import ModalFooter from "./modal-footer.js";
 
 type BaseProps = {|
+    ...AriaProps,
+
     /** The modal's content. */
     content: React.Node,
 
@@ -25,6 +27,11 @@ type BaseProps = {|
      * to the `ModalLauncher`.  Doing so will result in a console.warn().
      */
     onClose?: () => void,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 type WrappedProps = {|

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import Toolbar from "@khanacademy/wonder-blocks-toolbar";
+import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import ModalDialog from "./modal-dialog.js";
 import ModalPanel from "./modal-panel.js";
@@ -9,6 +10,8 @@ import ModalContent from "./modal-content.js";
 import CloseButton from "./close-button.js";
 
 type Props = {|
+    ...AriaProps,
+
     /**
      * The content of the modal, appearing between the titlebar and footer.
      */
@@ -53,6 +56,11 @@ type Props = {|
      * to the `ModalLauncher`.  Doing so will result in a console.warn().
      */
     onClose?: () => void,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 /**

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View, MediaLayoutWrapper} from "@khanacademy/wonder-blocks-core";
-import type {MediaSize} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, MediaSize} from "@khanacademy/wonder-blocks-core";
 
 import ModalDialog from "./modal-dialog.js";
 import ModalFooter from "./modal-footer.js";
@@ -12,6 +12,8 @@ import ModalPanel from "./modal-panel.js";
 import ModalContent from "./modal-content.js";
 
 type BaseProps = {|
+    ...AriaProps,
+
     /** Whether to allow the sidebar contents to be fullbleed. */
     fullBleedSidebar: boolean,
 
@@ -32,6 +34,11 @@ type BaseProps = {|
      * to the `ModalLauncher`.  Doing so will result in a console.warn().
      */
     onClose?: () => void,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 type WrappedProps = {|

--- a/packages/wonder-blocks-progress-spinner/components/circular-spinner.js
+++ b/packages/wonder-blocks-progress-spinner/components/circular-spinner.js
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
 const heights = {
     xsmall: 16,
@@ -32,6 +32,8 @@ const colors = {
 const StyledPath = addStyle("path");
 
 type Props = {|
+    ...AriaProps,
+
     /**
      * The size of the spinner. (large = 96px, medium = 48px, small = 24px,
      * xsmall = 16px)
@@ -45,6 +47,11 @@ type Props = {|
 
     /** Any (optional) styling to apply to the spinner container. */
     style?: StyleType,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 /**

--- a/packages/wonder-blocks-toolbar/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/components/toolbar.js
@@ -12,8 +12,11 @@ import {
     LabelLarge,
     LabelSmall,
 } from "@khanacademy/wonder-blocks-typography";
+import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 
 type Props = {|
+    ...AriaProps,
+
     /**
      * Whether we should use the default light color scheme or switch to a
      * darker blue scheme.
@@ -48,6 +51,11 @@ type Props = {|
      * The main title rendered in larger bold text.
      */
     title?: string,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 export default class Toolbar extends React.Component<Props> {

--- a/packages/wonder-blocks-tooltip/components/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-anchor.test.js
@@ -138,7 +138,7 @@ describe("TooltipAnchor", () => {
                         anchorRef={resolve}
                         onActiveChanged={() => {}}
                     >
-                        <View tabIndex="-1">This is the anchor</View>
+                        <View tabIndex={-1}>This is the anchor</View>
                     </TooltipAnchor>
                 );
                 mount(nodes);
@@ -211,7 +211,7 @@ describe("TooltipAnchor", () => {
                         anchorRef={resolve}
                         onActiveChanged={() => {}}
                     >
-                        <View tabIndex="-1">This is the anchor</View>
+                        <View tabIndex={-1}>This is the anchor</View>
                     </TooltipAnchor>
                 );
                 const wrapper = mount(<TestFixture force={true} />);

--- a/packages/wonder-blocks-tooltip/components/tooltip.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip.js
@@ -27,6 +27,7 @@ import {
 } from "@khanacademy/wonder-blocks-core";
 import {maybeGetPortalMountedModalHostElement} from "@khanacademy/wonder-blocks-modal";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
+import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import TooltipAnchor from "./tooltip-anchor.js";
 import TooltipBubble from "./tooltip-bubble.js";
@@ -35,6 +36,8 @@ import TooltipPopper from "./tooltip-popper.js";
 import type {Placement} from "../util/types.js";
 
 type Props = {|
+    ...AriaProps,
+
     /**
      * The content for anchoring the tooltip.
      * This component will be used to position the tooltip.
@@ -92,6 +95,11 @@ type Props = {|
      * Defaults to "top".
      */
     placement: Placement,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 type State = {|

--- a/packages/wonder-blocks-typography/util/types.js
+++ b/packages/wonder-blocks-typography/util/types.js
@@ -1,15 +1,6 @@
 // @flow
-import type {Node} from "react";
-import type {
-    AriaProps,
-    TextTag,
-    StyleType,
-} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
 
-// TODO(kevinb): fix style type after upgrading flow
-export type Props = AriaProps & {
-    style?: StyleType,
-    children?: Node,
-    id?: string,
-    tag: TextTag,
-};
+import {Text} from "@khanacademy/wonder-blocks-core";
+
+export type Props = React.ElementConfig<typeof Text>;


### PR DESCRIPTION
This PR does a little more work than is necessary, but I ran into some issues with the inexact types we were using for `View` and `Text` so I ended up making them exact including `AriaProps`.  Also, now that `AriaProps` is exact it was super easy to add it to all of our other components which had `aria-label?: string` as a prop.

This would be a breaking change if we were using flow typing.  I'm going to try to turn on flow typing for some packages (not typography).  There's another breaking change I'd like to make to switch to adopt ref forwarding on all of our components so that people can easily access the underlying DOM element.  I'd like to group multiple breaking changes together to avoid having more versions than is necessary of components in webapp.