### PR TITLE
Update README to point to correct designs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ More information: https://wonder-blocks.netlify.com/
 
 ## Contributing
 
-Please note – before contributing ensure that any design changes you are wanting to make are reflected in the [Wonder Blocks project in Figma](https://www.figma.com/file/VbVu3h2BpBhH80niq101MHHE/Wonder-Blocks).
+Please note – before contributing ensure that any design changes you are wanting to make are reflected in the [Wonder Blocks project in Figma](https://www.figma.com/file/VbVu3h2BpBhH80niq101MHHE/Wonder-Blocks) or [Zeplin](https://zpl.io/bl1owd1).  We previously used Zeplin, but have since moved to Figma.  Please check Figma first — if a design isn't there please check Zeplin.  Moving forward we will be transitioning away from Zeplin, but in the interim you may need to check both.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ More information: https://wonder-blocks.netlify.com/
 
 ## Contributing
 
-Please note – before contributing ensure that any design changes you are wanting to make are reflected in the [Wonder Blocks project in Zeplin](https://zpl.io/bl1owd1).
+Please note – before contributing ensure that any design changes you are wanting to make are reflected in the [Wonder Blocks project in Figma](https://www.figma.com/file/VbVu3h2BpBhH80niq101MHHE/Wonder-Blocks).


### PR DESCRIPTION
The "Contributing" section of the README pointed at our old and no-longer-used Zeplin comps. We've moved to Figma and this commit updates the README to reflect that.