### PR TITLE
Upgrade Flow and Handle Flow Edge Cases

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.85
+0.93.0
 
 [ignore]
 <PROJECT_ROOT>/node_modules/react-element-to-jsx-string

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-react": "7.7.0",
     "eslint-plugin-react-native-animation-linter": "0.1.1",
     "eslint-watch": "^4.0.1",
-    "flow-bin": "0.85",
+    "flow-bin": "0.93.0",
     "flow-coverage-report": "^0.5.0",
     "glob": "^7.1.2",
     "jest": "^23.5.0",

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -125,7 +125,7 @@ export type SharedProps = {|
      * Note: onClick is optional if href is present, but must be defined if
      * href is not
      */
-    onClick?: (e: SyntheticEvent<>) => void,
+    onClick?: (e: SyntheticEvent<>) => mixed,
 |};
 
 /**

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -72,7 +72,7 @@ type Props = {|
     /**
      * A function to be executed `onclick`.
      */
-    onClick?: (e: SyntheticEvent<>) => void,
+    onClick?: (e: SyntheticEvent<>) => mixed,
 
     /**
      * Passed in by withRouter HOC.
@@ -113,19 +113,19 @@ type State = {|
 |};
 
 export type ClickableHandlers = {|
-    onClick: (e: SyntheticMouseEvent<>) => void,
-    onMouseEnter: (e: SyntheticMouseEvent<>) => void,
-    onMouseLeave: () => void,
-    onMouseDown: () => void,
-    onMouseUp: (e: SyntheticMouseEvent<>) => void,
-    onDragStart: (e: SyntheticMouseEvent<>) => void,
-    onTouchStart: () => void,
-    onTouchEnd: () => void,
-    onTouchCancel: () => void,
-    onKeyDown: (e: SyntheticKeyboardEvent<*>) => void,
-    onKeyUp: (e: SyntheticKeyboardEvent<*>) => void,
-    onFocus: (e: SyntheticFocusEvent<*>) => void,
-    onBlur: (e: SyntheticFocusEvent<*>) => void,
+    onClick: (e: SyntheticMouseEvent<>) => mixed,
+    onMouseEnter: (e: SyntheticMouseEvent<>) => mixed,
+    onMouseLeave: () => mixed,
+    onMouseDown: () => mixed,
+    onMouseUp: (e: SyntheticMouseEvent<>) => mixed,
+    onDragStart: (e: SyntheticMouseEvent<>) => mixed,
+    onTouchStart: () => mixed,
+    onTouchEnd: () => mixed,
+    onTouchCancel: () => mixed,
+    onKeyDown: (e: SyntheticKeyboardEvent<*>) => mixed,
+    onKeyUp: (e: SyntheticKeyboardEvent<*>) => mixed,
+    onFocus: (e: SyntheticFocusEvent<*>) => mixed,
+    onBlur: (e: SyntheticFocusEvent<*>) => mixed,
     tabIndex: number,
 |};
 

--- a/packages/wonder-blocks-core/components/text.js
+++ b/packages/wonder-blocks-core/components/text.js
@@ -2,11 +2,13 @@
 import React from "react";
 import {StyleSheet} from "aphrodite";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {processStyleList} from "../util/util.js";
 
 import type {TextViewSharedProps} from "../util/types.js";
 
+// NOTE(jeresig): We want to leave the props for these open so that we can
+// handle uncommon props for elements (e.g. htmlFor for labels).
+// eslint-disable-next-line flowtype/require-exact-type
 type Props = {
     ...TextViewSharedProps,
     tag: string,

--- a/packages/wonder-blocks-core/components/text.js
+++ b/packages/wonder-blocks-core/components/text.js
@@ -5,13 +5,12 @@ import {StyleSheet} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {processStyleList} from "../util/util.js";
 
-import type {TextTag, TextViewSharedProps} from "../util/types.js";
+import type {TextViewSharedProps} from "../util/types.js";
 
-type Props = {|
+type Props = {
     ...TextViewSharedProps,
-    style?: StyleType,
-    tag: TextTag,
-|};
+    tag: string,
+};
 
 const isHeaderRegex = /^h[1-6]$/;
 

--- a/packages/wonder-blocks-core/index.js
+++ b/packages/wonder-blocks-core/index.js
@@ -3,7 +3,6 @@ import type {ClickableHandlers} from "./components/clickable-behavior.js";
 import type {
     AriaProps,
     IIdentifierFactory,
-    TextTag,
     MediaSize,
     MediaSpec,
     StyleType,
@@ -33,7 +32,6 @@ export type {
     ClickableHandlers,
     Intersection,
     IIdentifierFactory,
-    TextTag,
     MediaSize,
     MediaSpec,
     StyleType,

--- a/packages/wonder-blocks-core/util/add-style.js
+++ b/packages/wonder-blocks-core/util/add-style.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from "react";
-import propTypes from "prop-types";
 import {StyleSheet} from "aphrodite";
 
 import {processStyleList} from "./util.js";
@@ -8,14 +7,16 @@ import {processStyleList} from "./util.js";
 import type {StyleType} from "./types.js";
 
 // TODO(kevinb): have an a version which uses exact object types
-export default function addStyle<T: React.ComponentType<*> | string>(
+export default function addStyle<T: React.AbstractComponent<*> | string>(
     Component: T,
     defaultStyle?: StyleType,
-): React.ComponentType<React.ElementProps<T> & {style: StyleType}> {
+): React.AbstractComponent<React.ElementConfig<T> & {style: StyleType}> {
     function StyleComponent(
         props: React.ElementConfig<T> & {style: StyleType},
     ) {
-        const {style, ...otherProps} = props;
+        const {style, ...tmpOtherProps} = props;
+        // EXPLAIN
+        const otherProps: React.ElementConfig<T> = (tmpOtherProps: any);
         const reset =
             typeof Component === "string" ? overrides[Component] : null;
 

--- a/packages/wonder-blocks-core/util/add-style.js
+++ b/packages/wonder-blocks-core/util/add-style.js
@@ -15,7 +15,8 @@ export default function addStyle<T: React.AbstractComponent<*> | string>(
         props: React.ElementConfig<T> & {style: StyleType},
     ) {
         const {style, ...tmpOtherProps} = props;
-        // EXPLAIN
+        // NOTE(jeresig): We need to cast the remaining props to be the right
+        // value to ensure that they're typed properly.
         const otherProps: React.ElementConfig<T> = (tmpOtherProps: any);
         const reset =
             typeof Component === "string" ? overrides[Component] : null;

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -187,6 +187,9 @@ type EventHandlers = {|
 |};
 
 // Props shared between Text and View components.
+// NOTE(jeresig): We want to leave the props for these open so that we can
+// handle uncommon props for elements (e.g. htmlFor for labels).
+// eslint-disable-next-line flowtype/require-exact-type
 export type TextViewSharedProps = {
     /**
      * Text to appear on the button.

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -10,8 +10,6 @@ export type StyleType =
     | Falsy
     | NestedArray<CSSProperties | Falsy>;
 
-export type TextTag = "span" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-
 // Source: https://www.w3.org/WAI/PF/aria-1.1/roles#role_definitions
 type roles =
     | "alert"
@@ -135,48 +133,48 @@ export type AriaProps = {|
 |};
 
 type MouseEvents = {|
-    onMouseDown?: (e: SyntheticMouseEvent<*>) => void,
-    onMouseUp?: (e: SyntheticMouseEvent<*>) => void,
-    onMouseMove?: (e: SyntheticMouseEvent<*>) => void,
-    onClick?: (e: SyntheticMouseEvent<*>) => void,
-    onDoubleClick?: (e: SyntheticMouseEvent<*>) => void,
-    onMouseEnter?: (e: SyntheticMouseEvent<*>) => void,
-    onMouseLeave?: (e: SyntheticMouseEvent<*>) => void,
-    onMouseOut?: (e: SyntheticMouseEvent<*>) => void,
-    onMouseOver?: (e: SyntheticMouseEvent<*>) => void,
-    onDrag?: (e: SyntheticMouseEvent<*>) => void,
-    onDragEnd?: (e: SyntheticMouseEvent<*>) => void,
-    onDragEnter?: (e: SyntheticMouseEvent<*>) => void,
-    onDragExit?: (e: SyntheticMouseEvent<*>) => void,
-    onDragLeave?: (e: SyntheticMouseEvent<*>) => void,
-    onDragOver?: (e: SyntheticMouseEvent<*>) => void,
-    onDragStart?: (e: SyntheticMouseEvent<*>) => void,
-    onDrop?: (e: SyntheticMouseEvent<*>) => void,
+    onMouseDown?: (e: SyntheticMouseEvent<*>) => mixed,
+    onMouseUp?: (e: SyntheticMouseEvent<*>) => mixed,
+    onMouseMove?: (e: SyntheticMouseEvent<*>) => mixed,
+    onClick?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDoubleClick?: (e: SyntheticMouseEvent<*>) => mixed,
+    onMouseEnter?: (e: SyntheticMouseEvent<*>) => mixed,
+    onMouseLeave?: (e: SyntheticMouseEvent<*>) => mixed,
+    onMouseOut?: (e: SyntheticMouseEvent<*>) => mixed,
+    onMouseOver?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDrag?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDragEnd?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDragEnter?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDragExit?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDragLeave?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDragOver?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDragStart?: (e: SyntheticMouseEvent<*>) => mixed,
+    onDrop?: (e: SyntheticMouseEvent<*>) => mixed,
 |};
 
 type KeyboardEvents = {|
-    onKeyDown?: (e: SyntheticKeyboardEvent<*>) => void,
-    onKeyPress?: (e: SyntheticKeyboardEvent<*>) => void,
-    onKeyUp?: (e: SyntheticKeyboardEvent<*>) => void,
+    onKeyDown?: (e: SyntheticKeyboardEvent<*>) => mixed,
+    onKeyPress?: (e: SyntheticKeyboardEvent<*>) => mixed,
+    onKeyUp?: (e: SyntheticKeyboardEvent<*>) => mixed,
 |};
 
 type InputEvents = {|
-    onChange?: (e: SyntheticInputEvent<*>) => void,
-    onInput?: (e: SyntheticInputEvent<*>) => void,
-    onInvalid?: (e: SyntheticInputEvent<*>) => void,
-    onSubmit?: (e: SyntheticInputEvent<*>) => void,
+    onChange?: (e: SyntheticInputEvent<*>) => mixed,
+    onInput?: (e: SyntheticInputEvent<*>) => mixed,
+    onInvalid?: (e: SyntheticInputEvent<*>) => mixed,
+    onSubmit?: (e: SyntheticInputEvent<*>) => mixed,
 |};
 
 type TouchEvents = {|
-    onTouchCancel?: (e: SyntheticTouchEvent<*>) => void,
-    onTouchEnd?: (e: SyntheticTouchEvent<*>) => void,
-    onTouchMove?: (e: SyntheticTouchEvent<*>) => void,
-    onTouchStart?: (e: SyntheticTouchEvent<*>) => void,
+    onTouchCancel?: (e: SyntheticTouchEvent<*>) => mixed,
+    onTouchEnd?: (e: SyntheticTouchEvent<*>) => mixed,
+    onTouchMove?: (e: SyntheticTouchEvent<*>) => mixed,
+    onTouchStart?: (e: SyntheticTouchEvent<*>) => mixed,
 |};
 
 type FocusEvents = {|
-    onFocus?: (e: SyntheticFocusEvent<*>) => void,
-    onBlur?: (e: SyntheticFocusEvent<*>) => void,
+    onFocus?: (e: SyntheticFocusEvent<*>) => mixed,
+    onBlur?: (e: SyntheticFocusEvent<*>) => mixed,
 |};
 
 type EventHandlers = {|
@@ -189,7 +187,7 @@ type EventHandlers = {|
 |};
 
 // Props shared between Text and View components.
-export type TextViewSharedProps = {|
+export type TextViewSharedProps = {
     /**
      * Text to appear on the button.
      */
@@ -218,7 +216,7 @@ export type TextViewSharedProps = {|
     ...AriaProps,
 
     ...EventHandlers,
-|};
+};
 
 export type MediaSize = "small" | "medium" | "large";
 

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -61,7 +61,7 @@ type ActionProps = {|
      * Note: onClick is optional if href is present, but must be defined if
      * href is not
      */
-    onClick?: () => void,
+    onClick?: () => mixed,
 
     /**
      * Whether this item should be indented to have menu items left-align in

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener.js
@@ -34,7 +34,7 @@ type Props = {|
     /**
      * Callback for when the opener is pressed.
      */
-    onOpenChanged: (open: boolean, keyboard: boolean) => void,
+    onOpenChanged: (open: boolean, keyboard: boolean) => mixed,
 |};
 
 export default class ActionMenuOpener extends React.Component<Props> {

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -27,7 +27,7 @@ type MenuProps = {|
      * A callback that returns items that are newly selected. Use only if this
      * menu contains select items (and make sure selectedValues is defined).
      */
-    onChange?: (selectedItems: Array<string>) => void,
+    onChange?: (selectedItems: Array<string>) => mixed,
 
     /**
      * The values of the items that are currently selected. Use only if this

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -165,7 +165,7 @@ export default class Dropdown extends React.Component<DropdownProps, State> {
             const itemRefs = [];
             for (let i = 0; i < props.items.length; i++) {
                 if (props.items[i].focusable) {
-                    const ref = React.createRef();
+                    const ref = React.createRef<null | HTMLDivElement>();
                     itemRefs.push({ref, originalIndex: i});
                 }
             }

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -44,7 +44,7 @@ type DropdownProps = {|
      * the dropdown menu should be open and whether a keyboard event triggered
      * the change.
      */
-    onOpenChanged: (open: boolean, keyboard?: boolean) => void,
+    onOpenChanged: (open: boolean, keyboard?: boolean) => mixed,
 
     /**
      * Whether the menu is open or not.

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -24,7 +24,7 @@ type Props = {|
      * Callback for when the selection changes. Parameter is an updated array of
      * the values that are now selected.
      */
-    onChange: (selectedValues: Array<string>) => void,
+    onChange: (selectedValues: Array<string>) => mixed,
 
     /**
      * The values of the items that are currently selected.

--- a/packages/wonder-blocks-dropdown/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/components/option-item.js
@@ -33,14 +33,14 @@ type OptionProps = {|
     /**
      * Optional user-supplied callback when this item is called.
      */
-    onClick?: () => void,
+    onClick?: () => mixed,
 
     /**
      * Callback for when this item is pressed to change its selection state.
      * Passes value of the item. Auto-populated by menu or select.
      * @ignore
      */
-    onToggle: (value: string) => void,
+    onToggle: (value: string) => mixed,
 
     /**
      * Whether this item is selected. Auto-populated by menu or select.

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -57,7 +57,7 @@ type SelectOpenerProps = {|
     /**
      * Callback for when the SelectOpener is pressed.
      */
-    onOpenChanged: (open: boolean, keyboard: boolean) => void,
+    onOpenChanged: (open: boolean, keyboard: boolean) => mixed,
 
     /**
      * Whether the dropdown is open.

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -22,7 +22,7 @@ type Props = {|
      * Callback for when the selection. Parameter is the value of the newly
      * selected item.
      */
-    onChange: (selectedValue: string) => void,
+    onChange: (selectedValue: string) => mixed,
 
     /**
      * Placeholder for the opening component when there are no items selected.

--- a/packages/wonder-blocks-form/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/components/checkbox-group.js
@@ -51,7 +51,7 @@ type CheckboxGroupProps = {|
      * Callback for when selection of the group has changed. Passes the newly
      * selected values.
      */
-    onChange: (selectedValues: Array<string>) => void,
+    onChange: (selectedValues: Array<string>) => mixed,
 
     /**
      * An array of the values of the selected values in this checkbox group.

--- a/packages/wonder-blocks-form/components/checkbox.js
+++ b/packages/wonder-blocks-form/components/checkbox.js
@@ -28,7 +28,7 @@ type ChoiceComponentProps = {|
      * Callback when this component is selected. The newCheckedState is the
      * new checked state of the component.
      */
-    onChange: (newCheckedState: boolean) => void,
+    onChange: (newCheckedState: boolean) => mixed,
 
     /**
      * Optional label for the field.

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -25,7 +25,7 @@ type Props = {|
     error: boolean,
 
     /** Returns the new checked state of the component. */
-    onChange: (newCheckedState: boolean) => void,
+    onChange: (newCheckedState: boolean) => mixed,
 
     /**
      * Used for accessibility purposes, where the label id should match the

--- a/packages/wonder-blocks-form/components/choice.js
+++ b/packages/wonder-blocks-form/components/choice.js
@@ -55,7 +55,7 @@ type Props = {|
      * Auto-populated by parent. Returns the new checked state of the component.
      * @ignore
      */
-    onChange?: (newCheckedState: boolean) => void,
+    onChange?: (newCheckedState: boolean) => mixed,
 
     /**
      * Auto-populated by parent.

--- a/packages/wonder-blocks-form/components/radio-group.js
+++ b/packages/wonder-blocks-form/components/radio-group.js
@@ -50,7 +50,7 @@ type RadioGroupProps = {|
     /**
      * Callback for when the selected value of the radio group has changed.
      */
-    onChange: (selectedValue: string) => void,
+    onChange: (selectedValue: string) => mixed,
 
     /**
      * Value of the selected radio item.

--- a/packages/wonder-blocks-form/components/radio.js
+++ b/packages/wonder-blocks-form/components/radio.js
@@ -28,7 +28,7 @@ type ChoiceComponentProps = {|
      * Callback when this component is selected. The newCheckedState is the
      * new checked state of the component.
      */
-    onChange: (newCheckedState: boolean) => void,
+    onChange: (newCheckedState: boolean) => mixed,
 
     /**
      * Optional label for the field.

--- a/packages/wonder-blocks-form/util/types.js
+++ b/packages/wonder-blocks-form/util/types.js
@@ -31,7 +31,7 @@ export type ChoiceComponentProps = {|
     ...ChoiceCoreProps,
     /** Callback when this component is selected. The newCheckedState is the
      * new checked state of the component. */
-    onChange: (newCheckedState: boolean) => void,
+    onChange: (newCheckedState: boolean) => mixed,
     /** Optional label for the field. */
     label?: string,
     /** Optional description for the field. */
@@ -64,14 +64,14 @@ export type SharedGroupProps = {|
 export type CheckboxGroupProps = {|
     /** Callback for when selection of the group has changed. Passes the newly
      * selected values. */
-    onChange: (selectedValues: Array<string>) => void,
+    onChange: (selectedValues: Array<string>) => mixed,
     /** An array of the values of the selected values in this checkbox group. */
     selectedValues: Array<string>,
 |};
 
 export type RadioGroupProps = {|
     /** Callback for when the selected value of the radio group has changed. */
-    onChange: (selectedValue: string) => void,
+    onChange: (selectedValue: string) => mixed,
     /** Value of the selected radio item. */
     selectedValue: string,
 |};

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -100,7 +100,7 @@ export type SharedProps = {|
      * Note: onClick is optional if href is present, but must be defined if
      * href is not
      */
-    onClick?: (e: SyntheticEvent<>) => void,
+    onClick?: (e: SyntheticEvent<>) => mixed,
 |};
 
 /**

--- a/packages/wonder-blocks-icon/index.js
+++ b/packages/wonder-blocks-icon/index.js
@@ -1,8 +1,8 @@
 // @flow
 import Icon from "./components/icon.js";
 import icons from "./util/icon-assets.js";
-import type {IconAsset} from "./util/icon-assets.js";
+import type {IconAsset, IconSize} from "./util/icon-assets.js";
 
-export type {IconAsset};
+export type {IconAsset, IconSize};
 export {icons};
 export default Icon;

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -42,6 +42,11 @@ export type SharedProps = {|
     visitable: boolean,
 
     /**
+     * A target destination window for a link to open in.
+     */
+    target?: string,
+
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string,
@@ -88,7 +93,7 @@ export type SharedProps = {|
      * handler will have its preventDefault() and stopPropagation() methods
      * stubbed out.
      */
-    onClick?: (e: SyntheticEvent<>) => void,
+    onClick?: (e: SyntheticEvent<>) => mixed,
 |};
 
 /**

--- a/packages/wonder-blocks-modal/components/close-button.js
+++ b/packages/wonder-blocks-modal/components/close-button.js
@@ -17,7 +17,7 @@ type Props = {|
     /**
      * Called when the close button is clicked.
      */
-    onClick?: () => void,
+    onClick?: () => mixed,
 |};
 
 /**

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -11,7 +11,7 @@ import type {ModalElement} from "../util/types.js";
 
 type Props = {|
     children: ModalElement,
-    onCloseModal: () => void,
+    onCloseModal: () => mixed,
 |};
 
 /**

--- a/packages/wonder-blocks-modal/components/modal-context.js
+++ b/packages/wonder-blocks-modal/components/modal-context.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 type ContextType = {|
-    closeModal?: () => void,
+    closeModal?: () => mixed,
 |};
 
 const defaultContext: ContextType = {

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -40,7 +40,7 @@ type Props = {|
      * prop. You probably want to use this instead of `onClose` on the modals
      * themselves, since this will capture a more complete set of close events.
      */
-    onClose?: () => void,
+    onClose?: () => mixed,
 
     /**
      * Renders the modal when true, renders nothing when false.
@@ -156,7 +156,7 @@ export default class ModalLauncher extends React.Component<Props, State> {
 
 /** A component that, when mounted, calls `onClose` when Escape is pressed. */
 class ModalLauncherKeypressListener extends React.Component<{
-    onClose: () => void,
+    onClose: () => mixed,
 }> {
     componentDidMount() {
         window.addEventListener("keyup", this._handleKeyup);

--- a/packages/wonder-blocks-modal/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.js
@@ -42,7 +42,7 @@ type Props = {|
      * Instead, to listen for when the modal closes, add an `onClose` handler
      * to the `ModalLauncher`.  Doing so will throw an error.
      */
-    onClose?: () => void,
+    onClose?: () => mixed,
 |};
 
 export default class ModalPanel extends React.Component<Props> {

--- a/packages/wonder-blocks-modal/components/one-column-modal.js
+++ b/packages/wonder-blocks-modal/components/one-column-modal.js
@@ -26,7 +26,7 @@ type BaseProps = {|
      * Instead, to listen for when the modal closes, add an `onClose` handler
      * to the `ModalLauncher`.  Doing so will result in a console.warn().
      */
-    onClose?: () => void,
+    onClose?: () => mixed,
 
     /**
      * Test ID used for e2e testing.

--- a/packages/wonder-blocks-modal/components/standard-modal.js
+++ b/packages/wonder-blocks-modal/components/standard-modal.js
@@ -55,7 +55,7 @@ type Props = {|
      * Instead, to listen for when the modal closes, add an `onClose` handler
      * to the `ModalLauncher`.  Doing so will result in a console.warn().
      */
-    onClose?: () => void,
+    onClose?: () => mixed,
 
     /**
      * Test ID used for e2e testing.

--- a/packages/wonder-blocks-modal/components/two-column-modal.js
+++ b/packages/wonder-blocks-modal/components/two-column-modal.js
@@ -33,7 +33,7 @@ type BaseProps = {|
      * Instead, to listen for when the modal closes, add an `onClose` handler
      * to the `ModalLauncher`.  Doing so will result in a console.warn().
      */
-    onClose?: () => void,
+    onClose?: () => mixed,
 
     /**
      * Test ID used for e2e testing.

--- a/packages/wonder-blocks-tooltip/components/tooltip-anchor.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-anchor.js
@@ -56,7 +56,7 @@ type Props = {|
      * `active` will be true whenever the anchor is hovered or focused and false
      * otherwise.
      */
-    onActiveChanged: (active: boolean) => void,
+    onActiveChanged: (active: boolean) => mixed,
 
     /**
      * Optional unique id factory.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,9 +4899,9 @@ flow-annotation-check@1.8.0:
     glob "7.1.1"
     load-pkg "^3.0.1"
 
-flow-bin@0.85:
-  version "0.85.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.85.0.tgz#a3ca80748a35a071d5bbb2fcd61d64d977fc53a6"
+flow-bin@0.93.0:
+  version "0.93.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.93.0.tgz#9192a08d88db2a8da0ff55e42420f44539791430"
 
 flow-coverage-report@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
This upgrades Wonder Blocks to Flow v0.93 and in the process fixes a number of issues that came up in Webapp. There were only a couple issues that were new as a result of the upgrade, thanks to Jeff for helping to identify solutions!

Webapp-specific Flow issues fixed:

1) Text/View/Typography components were made less strict, allowing any type of "tag" and allowing for other props (this allows people to do things like make labels with `htmlFor` props, for example).
2) The return type of all callback functions were turned to `mixed` instead of `void`, allowing devs to write stuff like: `onClick: () => something && onClick()` and have it not complain.
3) A `target` Flow type was added to Link. I know that we'll be adding something to replace it at some point, but for right now there are a lot of people using it and we should probably accommodate them until we switch.
4) I added an export for the IconSize type as it's used in some places.