### PR TITLE
add -layout as a dep of -modal, simplify creation of MediaQueryLists and addition/removal of listeners

### DIFF
--- a/packages/wonder-blocks-layout/components/media-layout.js
+++ b/packages/wonder-blocks-layout/components/media-layout.js
@@ -88,9 +88,11 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
 
     componentDidMount() {
         // TODO(WB-534): handle changes to mediaSpec prop
-        for (const [size, spec] of ((Object.entries(
-            this.props.mediaSpec,
-        ): any): Array<[MediaSize, {query: string}]>)) {
+        const entries = ((Object.entries(this.props.mediaSpec): any): Array<
+            [MediaSize, {query: string}],
+        >);
+
+        for (const [size, spec] of entries) {
             const mql = MEDIA_QUERY_LISTS[spec.query];
             // during SSR there are no MediaQueryLists
             if (!mql) {
@@ -107,7 +109,8 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
     }
 
     componentWillUnmount() {
-        this.cleanupThunks.map((thunk) => thunk());
+        // Remove our listeners.
+        this.cleanupThunks.forEach((cleaup) => cleaup());
     }
 
     getCurrentSize(spec: MediaSpec): MediaSize {
@@ -117,9 +120,11 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
         if (this.state.size) {
             return this.state.size;
         } else {
-            for (const [size, spec] of ((Object.entries(
-                this.props.mediaSpec,
-            ): any): Array<[MediaSize, {query: string}]>)) {
+            const entries = ((Object.entries(this.props.mediaSpec): any): Array<
+                [MediaSize, {query: string}],
+            >);
+
+            for (const [size, spec] of entries) {
                 const mql = MEDIA_QUERY_LISTS[spec.query];
                 if (mql.matches) {
                     return size;
@@ -199,8 +204,10 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
 
         // We need to create the MediaQueryLists during the first render in order
         // to query whether any of them match.
-        for (const query of queries) {
-            if (!MEDIA_QUERY_LISTS[query] && !this.isServerSide()) {
+        if (!this.isServerSide()) {
+            for (const query of queries.filter(
+                (query) => !MEDIA_QUERY_LISTS[query],
+            )) {
                 MEDIA_QUERY_LISTS[query] = window.matchMedia(query);
             }
         }

--- a/packages/wonder-blocks-layout/components/media-layout.js
+++ b/packages/wonder-blocks-layout/components/media-layout.js
@@ -4,9 +4,24 @@ import type {StyleDeclaration} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import MediaLayoutContext from "./media-layout-context.js";
-import {VALID_MEDIA_SIZES} from "../util/specs.js";
 import type {MediaSize, MediaSpec} from "../util/types.js";
 import type {Context} from "./media-layout-context.js";
+
+const queries = [
+    // normal queries
+    "(max-width: 767px)", // small
+    "(min-width: 768px) and (max-width: 1023px)", // medium
+    "(min-width: 1024px)", // large
+
+    // internal tools
+    "(min-width: 1px)", // large
+
+    // modal queries
+    "(max-width: 767px)", // small
+    "(min-width: 768px)", // large
+];
+
+const MEDIA_QUERY_LISTS: {[key: string]: MediaQueryList} = {};
 
 // eslint-disable-next-line flowtype/require-exact-type
 export type MockStyleSheet = {
@@ -52,104 +67,67 @@ type State = {|
 // fall back to this state.
 const DEFAULT_SIZE = "large";
 
+type CombinedProps = {|...Props, ...Context|};
+
 /**
  * `MediaLayout` is responsible for changing the rendering of contents at
  * differently sized viewports.  `MediaLayoutContext.Provider` can be used
  * to specify different breakpoint configurations.  By default it uses
  * `MEDIA_DEFAULT_SPEC`.  See media-layout-context.js for additiional options.
  */
-export default class MediaLayout extends React.Component<Props, State> {
-    watchHandlers: ?{
-        [query: string]: any,
-    };
+class MediaLayoutInternal extends React.Component<CombinedProps, State> {
+    cleanupThunks: Array<() => void>;
 
-    static WATCHERS: {
-        [query: string]: any,
-    } = {};
+    constructor(props: CombinedProps) {
+        super(props);
+        this.state = {
+            size: undefined,
+        };
+        this.cleanupThunks = [];
+    }
 
-    state = {
-        size: undefined,
-    };
-
-    componentWillUnmount() {
-        // We go through the component and remove all of the listeners
-        // that getCurrentSize attached.
-        for (const query of Object.keys(MediaLayout.WATCHERS)) {
-            const watcher = MediaLayout.WATCHERS[query];
-
-            if (watcher && this.watchHandlers) {
-                const {watchHandlers} = this;
-                const handler = this.watchHandlers[query];
-                watcher.removeListener(handler);
-                delete watchHandlers[query];
+    componentDidMount() {
+        // TODO(WB-534): handle changes to mediaSpec prop
+        for (const [size, spec] of ((Object.entries(
+            this.props.mediaSpec,
+        ): any): Array<[MediaSize, {query: string}]>)) {
+            const mql = MEDIA_QUERY_LISTS[spec.query];
+            // during SSR there are no MediaQueryLists
+            if (!mql) {
+                continue;
             }
+            const listener = (e) => {
+                if (e.matches) {
+                    this.setState({size});
+                }
+            };
+            mql.addListener(listener);
+            this.cleanupThunks.push(() => mql.removeListener(listener));
         }
     }
 
-    getCurrentSize(spec: MediaSpec) {
+    componentWillUnmount() {
+        this.cleanupThunks.map((thunk) => thunk());
+    }
+
+    getCurrentSize(spec: MediaSpec): MediaSize {
         // If we have a state with the current size in it then we always want
         // to use that. This will happen if the viewport changes sizes after
         // we've already initialized.
         if (this.state.size) {
             return this.state.size;
-        }
-
-        // watchHandlers should never be undefined when state.size is also
-        // undefined, but just in case we fall back to the default size
-        if (this.watchHandlers) {
-            return DEFAULT_SIZE;
-        }
-
-        // We then go through and set up matchMedia watchers for each breakpoint
-        // (if they haven't been created already) and we add listeners to
-        // watch for when the viewport changes size.
-        this.watchHandlers = {};
-
-        let matchedSize;
-
-        for (const size of VALID_MEDIA_SIZES) {
-            // Flow has issues with checking !spec[size] directly so we store
-            // spec[size] in a new variable to get around the issue.
-            const _spec = spec[size];
-            if (!_spec) {
-                continue;
-            }
-
-            const {query} = _spec;
-
-            // Don't watch sizes that don't have an associated query
-            if (!query) {
-                continue;
-            }
-
-            // Create a new matchMedia watcher if one doesn't exist yet
-            // TODO(kevinb): move this to componentWillMount
-            if (!MediaLayout.WATCHERS[query]) {
-                MediaLayout.WATCHERS[query] = window.matchMedia(query);
-            }
-
-            const watcher = MediaLayout.WATCHERS[query];
-
-            // Attach a handler that watches for the change, saving a
-            // references to it so we can remove it later
-            const handler = (this.watchHandlers[query] = (e) => {
-                if (e.matches) {
-                    this.setState({size});
+        } else {
+            for (const [size, spec] of ((Object.entries(
+                this.props.mediaSpec,
+            ): any): Array<[MediaSize, {query: string}]>)) {
+                const mql = MEDIA_QUERY_LISTS[spec.query];
+                if (mql.matches) {
+                    return size;
                 }
-            });
-
-            watcher.addListener(handler);
-
-            // If one of the watchers matches the current size, then save
-            // the size that was matched.
-            if (watcher.matches) {
-                matchedSize = size;
             }
         }
 
-        // If a size was never defined, or matched, then we return the default
-        // media layout size
-        return matchedSize || DEFAULT_SIZE;
+        return DEFAULT_SIZE;
     }
 
     // We assume that we're running on the server (or, at least, an unsupported
@@ -163,6 +141,7 @@ export default class MediaLayout extends React.Component<Props, State> {
     // We do this by looking at all of the stylesheets specified in the
     // styleSheets prop and then all of the individual styles. We merge the
     // styles together
+    // TODO(WB-533): move to util.js to make it easier to test
     getMockStyleSheet(mediaSize: MediaSize) {
         const {styleSheets} = this.props;
 
@@ -215,8 +194,16 @@ export default class MediaLayout extends React.Component<Props, State> {
         return mockStyleSheet;
     }
 
-    renderChildren({overrideSize, ssrSize, mediaSpec}: Context) {
-        const {children} = this.props;
+    render() {
+        const {children, mediaSpec, ssrSize, overrideSize} = this.props;
+
+        // We need to create the MediaQueryLists during the first render in order
+        // to query whether any of them match.
+        for (const query of queries) {
+            if (!MEDIA_QUERY_LISTS[query] && !this.isServerSide()) {
+                MEDIA_QUERY_LISTS[query] = window.matchMedia(query);
+            }
+        }
 
         // We need to figure out what the current media size is
         // If an override has been specified, we use that.
@@ -234,14 +221,24 @@ export default class MediaLayout extends React.Component<Props, State> {
 
         return children({mediaSize, mediaSpec, styles});
     }
+}
 
+// gen-snapshot-tests.js only understands `export default class ...`
+export default class MediaLayout extends React.Component<Props> {
     render() {
         // We listen to the MediaLayoutContext to see what defaults we're
         // being given (this can be overriden by wrapping this component in
         // a MediaLayoutContext.Consumer).
         return (
             <MediaLayoutContext.Consumer>
-                {(contextValue) => this.renderChildren(contextValue)}
+                {({overrideSize, ssrSize, mediaSpec}) => (
+                    <MediaLayoutInternal
+                        {...this.props}
+                        overrideSize={overrideSize}
+                        ssrSize={ssrSize}
+                        mediaSpec={mediaSpec}
+                    />
+                )}
             </MediaLayoutContext.Consumer>
         );
     }

--- a/packages/wonder-blocks-modal/components/__snapshots__/standard-modal.test.js.snap
+++ b/packages/wonder-blocks-modal/components/__snapshots__/standard-modal.test.js.snap
@@ -50,14 +50,52 @@ exports[`StandardModal desktop should match snapshot 1`] = `
       }
     }
   >
-    <ModalDialog
-      style={
-        Array [
-          undefined,
-          false,
-          false,
-          Array [
-            Object {
+    <MediaLayoutInternal
+      mediaSpec={
+        Object {
+          "large": Object {
+            "gutterWidth": 32,
+            "marginWidth": 24,
+            "maxWidth": 1168,
+            "query": "(min-width: 1024px)",
+            "totalColumns": 12,
+          },
+          "medium": Object {
+            "gutterWidth": 32,
+            "marginWidth": 24,
+            "query": "(min-width: 768px) and (max-width: 1023px)",
+            "totalColumns": 8,
+          },
+          "small": Object {
+            "gutterWidth": 16,
+            "marginWidth": 16,
+            "query": "(max-width: 767px)",
+            "totalColumns": 4,
+          },
+        }
+      }
+      ssrSize="large"
+      styleSheets={
+        Object {
+          "all": Object {
+            "preview": Object {
+              "_definition": Object {
+                "flex": "1 0 auto",
+                "maxWidth": 392,
+              },
+              "_len": 34,
+              "_name": "preview_11k7ba4",
+            },
+            "previewContent": Object {
+              "_definition": Object {
+                "padding": "0 64px 0 0",
+              },
+              "_len": 24,
+              "_name": "previewContent_q080uq",
+            },
+          },
+          "mdOrLarger": Object {
+            "wrapper": Object {
               "_definition": Object {
                 "height": "81.25%",
                 "maxHeight": 624,
@@ -67,50 +105,46 @@ exports[`StandardModal desktop should match snapshot 1`] = `
               "_len": 67,
               "_name": "wrapper_1xtsnd2",
             },
-            undefined,
-          ],
-        ]
+          },
+          "small": Object {
+            "preview": Object {
+              "_definition": Object {
+                "display": "none",
+              },
+              "_len": 18,
+              "_name": "preview_1u9fru1",
+            },
+          },
+        }
       }
     >
-      <MediaLayout
-        styleSheets={
-          Object {
-            "all": Object {
-              "wrapper": Object {
+      <ModalDialog
+        style={
+          Array [
+            undefined,
+            false,
+            false,
+            Array [
+              Object {
                 "_definition": Object {
-                  "alignItems": "stretch",
-                  "borderRadius": 4,
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "overflow": "hidden",
-                  "position": "relative",
+                  "height": "81.25%",
+                  "maxHeight": 624,
+                  "maxWidth": 960,
+                  "width": "93.75%",
                 },
-                "_len": 122,
-                "_name": "wrapper_5423lx",
+                "_len": 67,
+                "_name": "wrapper_1xtsnd2",
               },
-            },
-            "small": Object {
-              "wrapper": Object {
-                "_definition": Object {
-                  "borderRadius": 0,
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                },
-                "_len": 74,
-                "_name": "wrapper_1xnhgba",
-              },
-            },
-          }
+              undefined,
+            ],
+          ]
         }
       >
-        <View
-          aria-labelledby="wb-modal-title"
-          role="dialog"
-          style={
-            Array [
-              Array [
-                Object {
+        <MediaLayout
+          styleSheets={
+            Object {
+              "all": Object {
+                "wrapper": Object {
                   "_definition": Object {
                     "alignItems": "stretch",
                     "borderRadius": 4,
@@ -122,41 +156,44 @@ exports[`StandardModal desktop should match snapshot 1`] = `
                   "_len": 122,
                   "_name": "wrapper_5423lx",
                 },
-                false,
-                false,
-                Array [
-                  undefined,
-                  undefined,
-                ],
-              ],
-              Array [
-                undefined,
-                false,
-                false,
-                Array [
-                  Object {
-                    "_definition": Object {
-                      "height": "81.25%",
-                      "maxHeight": 624,
-                      "maxWidth": 960,
-                      "width": "93.75%",
-                    },
-                    "_len": 67,
-                    "_name": "wrapper_1xtsnd2",
+              },
+              "small": Object {
+                "wrapper": Object {
+                  "_definition": Object {
+                    "borderRadius": 0,
+                    "flexDirection": "column",
+                    "height": "100%",
+                    "width": "100%",
                   },
-                  undefined,
-                ],
-              ],
-            ]
+                  "_len": 74,
+                  "_name": "wrapper_1xnhgba",
+                },
+              },
+            }
           }
         >
-          <StyleComponent
-            aria-labelledby="wb-modal-title"
-            role="dialog"
-            style={
-              Array [
-                Array [
-                  Object {
+          <MediaLayoutInternal
+            mediaSpec={
+              Object {
+                "large": Object {
+                  "gutterWidth": 32,
+                  "marginWidth": 48,
+                  "query": "(min-width: 768px)",
+                  "totalColumns": 12,
+                },
+                "small": Object {
+                  "gutterWidth": 16,
+                  "marginWidth": 16,
+                  "query": "(max-width: 767px)",
+                  "totalColumns": 4,
+                },
+              }
+            }
+            ssrSize="large"
+            styleSheets={
+              Object {
+                "all": Object {
+                  "wrapper": Object {
                     "_definition": Object {
                       "alignItems": "stretch",
                       "borderRadius": 4,
@@ -168,230 +205,241 @@ exports[`StandardModal desktop should match snapshot 1`] = `
                     "_len": 122,
                     "_name": "wrapper_5423lx",
                   },
-                  false,
-                  false,
-                  Array [
-                    undefined,
-                    undefined,
-                  ],
-                ],
+                },
+                "small": Object {
+                  "wrapper": Object {
+                    "_definition": Object {
+                      "borderRadius": 0,
+                      "flexDirection": "column",
+                      "height": "100%",
+                      "width": "100%",
+                    },
+                    "_len": 74,
+                    "_name": "wrapper_1xnhgba",
+                  },
+                },
+              }
+            }
+          >
+            <View
+              aria-labelledby="wb-modal-title"
+              role="dialog"
+              style={
                 Array [
-                  undefined,
-                  false,
-                  false,
                   Array [
                     Object {
                       "_definition": Object {
-                        "height": "81.25%",
-                        "maxHeight": 624,
-                        "maxWidth": 960,
-                        "width": "93.75%",
+                        "alignItems": "stretch",
+                        "borderRadius": 4,
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "overflow": "hidden",
+                        "position": "relative",
                       },
-                      "_len": 67,
-                      "_name": "wrapper_1xtsnd2",
+                      "_len": 122,
+                      "_name": "wrapper_5423lx",
                     },
-                    undefined,
+                    false,
+                    false,
+                    Array [
+                      undefined,
+                      undefined,
+                    ],
                   ],
-                ],
-              ]
-            }
-          >
-            <div
-              aria-labelledby="wb-modal-title"
-              className=""
-              role="dialog"
-              style={
-                Object {
-                  "alignItems": "stretch",
-                  "borderRadius": 4,
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "boxSizing": "border-box",
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "height": "81.25%",
-                  "margin": 0,
-                  "maxHeight": 624,
-                  "maxWidth": 960,
-                  "minHeight": 0,
-                  "minWidth": 0,
-                  "overflow": "hidden",
-                  "padding": 0,
-                  "position": "relative",
-                  "width": "93.75%",
-                  "zIndex": 0,
-                }
+                  Array [
+                    undefined,
+                    false,
+                    false,
+                    Array [
+                      Object {
+                        "_definition": Object {
+                          "height": "81.25%",
+                          "maxHeight": 624,
+                          "maxWidth": 960,
+                          "width": "93.75%",
+                        },
+                        "_len": 67,
+                        "_name": "wrapper_1xtsnd2",
+                      },
+                      undefined,
+                    ],
+                  ],
+                ]
               }
             >
-              <ModalPanel
-                color="light"
-                content="Content"
-                footer="Footer"
-                scrollOverflow={true}
-                showCloseButton={false}
-                titleBar={
-                  <Toolbar
-                    color="light"
-                    leftContent={
-                      <MediaLayout
-                        styleSheets={
-                          Object {
-                            "all": Object {
-                              "preview": Object {
-                                "_definition": Object {
-                                  "flex": "1 0 auto",
-                                  "maxWidth": 392,
-                                },
-                                "_len": 34,
-                                "_name": "preview_11k7ba4",
-                              },
-                              "previewContent": Object {
-                                "_definition": Object {
-                                  "padding": "0 64px 0 0",
-                                },
-                                "_len": 24,
-                                "_name": "previewContent_q080uq",
-                              },
-                            },
-                            "mdOrLarger": Object {
-                              "wrapper": Object {
-                                "_definition": Object {
-                                  "height": "81.25%",
-                                  "maxHeight": 624,
-                                  "maxWidth": 960,
-                                  "width": "93.75%",
-                                },
-                                "_len": 67,
-                                "_name": "wrapper_1xtsnd2",
-                              },
-                            },
-                            "small": Object {
-                              "preview": Object {
-                                "_definition": Object {
-                                  "display": "none",
-                                },
-                                "_len": 18,
-                                "_name": "preview_1u9fru1",
-                              },
-                            },
-                          }
-                        }
-                      >
-                        [Function]
-                      </MediaLayout>
-                    }
-                    rightContent={null}
-                    size="medium"
-                    title="Title"
-                  />
+              <StyleComponent
+                aria-labelledby="wb-modal-title"
+                role="dialog"
+                style={
+                  Array [
+                    Array [
+                      Object {
+                        "_definition": Object {
+                          "alignItems": "stretch",
+                          "borderRadius": 4,
+                          "display": "flex",
+                          "flexDirection": "row",
+                          "overflow": "hidden",
+                          "position": "relative",
+                        },
+                        "_len": 122,
+                        "_name": "wrapper_5423lx",
+                      },
+                      false,
+                      false,
+                      Array [
+                        undefined,
+                        undefined,
+                      ],
+                    ],
+                    Array [
+                      undefined,
+                      false,
+                      false,
+                      Array [
+                        Object {
+                          "_definition": Object {
+                            "height": "81.25%",
+                            "maxHeight": 624,
+                            "maxWidth": 960,
+                            "width": "93.75%",
+                          },
+                          "_len": 67,
+                          "_name": "wrapper_1xtsnd2",
+                        },
+                        undefined,
+                      ],
+                    ],
+                  ]
                 }
               >
-                <MediaLayout
-                  styleSheets={
+                <div
+                  aria-labelledby="wb-modal-title"
+                  className=""
+                  role="dialog"
+                  style={
                     Object {
-                      "all": Object {
-                        "closeButton": Object {
-                          "_definition": Object {
-                            "left": 16,
-                            "position": "absolute",
-                            "top": 16,
-                            "zIndex": 1,
-                          },
-                          "_len": 53,
-                          "_name": "closeButton_zjmm3o",
-                        },
-                        "dark": Object {
-                          "_definition": Object {
-                            "background": "#0a2a66",
-                            "color": "#ffffff",
-                          },
-                          "_len": 42,
-                          "_name": "dark_10k9z0e",
-                        },
-                        "hasFooter": Object {
-                          "_definition": Object {
-                            "paddingBottom": 32,
-                          },
-                          "_len": 20,
-                          "_name": "hasFooter_1pn52au",
-                        },
-                        "hasTitleBar": Object {
-                          "_definition": Object {
-                            "paddingTop": 32,
-                          },
-                          "_len": 17,
-                          "_name": "hasTitleBar_15lzjb6",
-                        },
-                        "wrapper": Object {
-                          "_definition": Object {
-                            "background": "white",
-                            "boxSizing": "border-box",
-                            "display": "flex",
-                            "flex": "1 1 auto",
-                            "flexDirection": "column",
-                            "height": "100%",
-                            "position": "relative",
-                            "width": "100%",
-                          },
-                          "_len": 160,
-                          "_name": "wrapper_161dlb6",
-                        },
-                      },
-                      "small": Object {
-                        "closeButton": Object {
-                          "_definition": Object {
-                            "left": 16,
-                            "top": 16,
-                          },
-                          "_len": 20,
-                          "_name": "closeButton_1uu2ylb",
-                        },
-                        "withCloseButton": Object {
-                          "_definition": Object {
-                            "paddingTop": 64,
-                          },
-                          "_len": 17,
-                          "_name": "withCloseButton_1qowqp",
-                        },
-                      },
+                      "alignItems": "stretch",
+                      "borderRadius": 4,
+                      "borderStyle": "solid",
+                      "borderWidth": 0,
+                      "boxSizing": "border-box",
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "height": "81.25%",
+                      "margin": 0,
+                      "maxHeight": 624,
+                      "maxWidth": 960,
+                      "minHeight": 0,
+                      "minWidth": 0,
+                      "overflow": "hidden",
+                      "padding": 0,
+                      "position": "relative",
+                      "width": "93.75%",
+                      "zIndex": 0,
                     }
                   }
                 >
-                  <View
-                    style={
-                      Array [
-                        Array [
-                          Object {
-                            "_definition": Object {
-                              "background": "white",
-                              "boxSizing": "border-box",
-                              "display": "flex",
-                              "flex": "1 1 auto",
-                              "flexDirection": "column",
-                              "height": "100%",
-                              "position": "relative",
-                              "width": "100%",
-                            },
-                            "_len": 160,
-                            "_name": "wrapper_161dlb6",
-                          },
-                          false,
-                          false,
-                          Array [
-                            undefined,
-                            undefined,
-                          ],
-                        ],
-                        false,
-                        undefined,
-                      ]
+                  <ModalPanel
+                    color="light"
+                    content="Content"
+                    footer="Footer"
+                    scrollOverflow={true}
+                    showCloseButton={false}
+                    titleBar={
+                      <Toolbar
+                        color="light"
+                        leftContent={
+                          <MediaLayout
+                            styleSheets={
+                              Object {
+                                "all": Object {
+                                  "preview": Object {
+                                    "_definition": Object {
+                                      "flex": "1 0 auto",
+                                      "maxWidth": 392,
+                                    },
+                                    "_len": 34,
+                                    "_name": "preview_11k7ba4",
+                                  },
+                                  "previewContent": Object {
+                                    "_definition": Object {
+                                      "padding": "0 64px 0 0",
+                                    },
+                                    "_len": 24,
+                                    "_name": "previewContent_q080uq",
+                                  },
+                                },
+                                "mdOrLarger": Object {
+                                  "wrapper": Object {
+                                    "_definition": Object {
+                                      "height": "81.25%",
+                                      "maxHeight": 624,
+                                      "maxWidth": 960,
+                                      "width": "93.75%",
+                                    },
+                                    "_len": 67,
+                                    "_name": "wrapper_1xtsnd2",
+                                  },
+                                },
+                                "small": Object {
+                                  "preview": Object {
+                                    "_definition": Object {
+                                      "display": "none",
+                                    },
+                                    "_len": 18,
+                                    "_name": "preview_1u9fru1",
+                                  },
+                                },
+                              }
+                            }
+                          >
+                            [Function]
+                          </MediaLayout>
+                        }
+                        rightContent={null}
+                        size="medium"
+                        title="Title"
+                      />
                     }
                   >
-                    <StyleComponent
-                      style={
-                        Array [
-                          Array [
-                            Object {
+                    <MediaLayout
+                      styleSheets={
+                        Object {
+                          "all": Object {
+                            "closeButton": Object {
+                              "_definition": Object {
+                                "left": 16,
+                                "position": "absolute",
+                                "top": 16,
+                                "zIndex": 1,
+                              },
+                              "_len": 53,
+                              "_name": "closeButton_zjmm3o",
+                            },
+                            "dark": Object {
+                              "_definition": Object {
+                                "background": "#0a2a66",
+                                "color": "#ffffff",
+                              },
+                              "_len": 42,
+                              "_name": "dark_10k9z0e",
+                            },
+                            "hasFooter": Object {
+                              "_definition": Object {
+                                "paddingBottom": 32,
+                              },
+                              "_len": 20,
+                              "_name": "hasFooter_1pn52au",
+                            },
+                            "hasTitleBar": Object {
+                              "_definition": Object {
+                                "paddingTop": 32,
+                              },
+                              "_len": 17,
+                              "_name": "hasTitleBar_15lzjb6",
+                            },
+                            "wrapper": Object {
                               "_definition": Object {
                                 "background": "white",
                                 "boxSizing": "border-box",
@@ -405,827 +453,132 @@ exports[`StandardModal desktop should match snapshot 1`] = `
                               "_len": 160,
                               "_name": "wrapper_161dlb6",
                             },
-                            false,
-                            false,
-                            Array [
-                              undefined,
-                              undefined,
-                            ],
-                          ],
-                          false,
-                          undefined,
-                        ]
+                          },
+                          "small": Object {
+                            "closeButton": Object {
+                              "_definition": Object {
+                                "left": 16,
+                                "top": 16,
+                              },
+                              "_len": 20,
+                              "_name": "closeButton_1uu2ylb",
+                            },
+                            "withCloseButton": Object {
+                              "_definition": Object {
+                                "paddingTop": 64,
+                              },
+                              "_len": 17,
+                              "_name": "withCloseButton_1qowqp",
+                            },
+                          },
+                        }
                       }
                     >
-                      <div
-                        className=""
-                        style={
+                      <MediaLayoutInternal
+                        mediaSpec={
                           Object {
-                            "alignItems": "stretch",
-                            "background": "white",
-                            "borderStyle": "solid",
-                            "borderWidth": 0,
-                            "boxSizing": "border-box",
-                            "display": "flex",
-                            "flex": "1 1 auto",
-                            "flexDirection": "column",
-                            "height": "100%",
-                            "margin": 0,
-                            "minHeight": 0,
-                            "minWidth": 0,
-                            "padding": 0,
-                            "position": "relative",
-                            "width": "100%",
-                            "zIndex": 0,
+                            "large": Object {
+                              "gutterWidth": 32,
+                              "marginWidth": 48,
+                              "query": "(min-width: 768px)",
+                              "totalColumns": 12,
+                            },
+                            "small": Object {
+                              "gutterWidth": 16,
+                              "marginWidth": 16,
+                              "query": "(max-width: 767px)",
+                              "totalColumns": 4,
+                            },
+                          }
+                        }
+                        ssrSize="large"
+                        styleSheets={
+                          Object {
+                            "all": Object {
+                              "closeButton": Object {
+                                "_definition": Object {
+                                  "left": 16,
+                                  "position": "absolute",
+                                  "top": 16,
+                                  "zIndex": 1,
+                                },
+                                "_len": 53,
+                                "_name": "closeButton_zjmm3o",
+                              },
+                              "dark": Object {
+                                "_definition": Object {
+                                  "background": "#0a2a66",
+                                  "color": "#ffffff",
+                                },
+                                "_len": 42,
+                                "_name": "dark_10k9z0e",
+                              },
+                              "hasFooter": Object {
+                                "_definition": Object {
+                                  "paddingBottom": 32,
+                                },
+                                "_len": 20,
+                                "_name": "hasFooter_1pn52au",
+                              },
+                              "hasTitleBar": Object {
+                                "_definition": Object {
+                                  "paddingTop": 32,
+                                },
+                                "_len": 17,
+                                "_name": "hasTitleBar_15lzjb6",
+                              },
+                              "wrapper": Object {
+                                "_definition": Object {
+                                  "background": "white",
+                                  "boxSizing": "border-box",
+                                  "display": "flex",
+                                  "flex": "1 1 auto",
+                                  "flexDirection": "column",
+                                  "height": "100%",
+                                  "position": "relative",
+                                  "width": "100%",
+                                },
+                                "_len": 160,
+                                "_name": "wrapper_161dlb6",
+                              },
+                            },
+                            "small": Object {
+                              "closeButton": Object {
+                                "_definition": Object {
+                                  "left": 16,
+                                  "top": 16,
+                                },
+                                "_len": 20,
+                                "_name": "closeButton_1uu2ylb",
+                              },
+                              "withCloseButton": Object {
+                                "_definition": Object {
+                                  "paddingTop": 64,
+                                },
+                                "_len": 17,
+                                "_name": "withCloseButton_1qowqp",
+                              },
+                            },
                           }
                         }
                       >
-                        <Toolbar
-                          color="light"
-                          leftContent={
-                            <MediaLayout
-                              styleSheets={
-                                Object {
-                                  "all": Object {
-                                    "preview": Object {
-                                      "_definition": Object {
-                                        "flex": "1 0 auto",
-                                        "maxWidth": 392,
-                                      },
-                                      "_len": 34,
-                                      "_name": "preview_11k7ba4",
-                                    },
-                                    "previewContent": Object {
-                                      "_definition": Object {
-                                        "padding": "0 64px 0 0",
-                                      },
-                                      "_len": 24,
-                                      "_name": "previewContent_q080uq",
-                                    },
-                                  },
-                                  "mdOrLarger": Object {
-                                    "wrapper": Object {
-                                      "_definition": Object {
-                                        "height": "81.25%",
-                                        "maxHeight": 624,
-                                        "maxWidth": 960,
-                                        "width": "93.75%",
-                                      },
-                                      "_len": 67,
-                                      "_name": "wrapper_1xtsnd2",
-                                    },
-                                  },
-                                  "small": Object {
-                                    "preview": Object {
-                                      "_definition": Object {
-                                        "display": "none",
-                                      },
-                                      "_len": 18,
-                                      "_name": "preview_1u9fru1",
-                                    },
-                                  },
-                                }
-                              }
-                            >
-                              [Function]
-                            </MediaLayout>
-                          }
-                          rightContent={null}
-                          size="medium"
-                          title="Title"
-                        >
-                          <View
-                            style={
-                              Array [
-                                Object {
-                                  "_definition": Object {
-                                    "border": "1px solid rgba(33, 36, 44, 0.16)",
-                                    "display": "flex",
-                                    "flexDirection": "row",
-                                    "minHeight": 66,
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "position": "relative",
-                                    "width": "100%",
-                                  },
-                                  "_len": 171,
-                                  "_name": "container_hnrag4",
-                                },
-                                false,
-                                false,
-                              ]
-                            }
-                          >
-                            <StyleComponent
-                              style={
-                                Array [
-                                  Object {
-                                    "_definition": Object {
-                                      "border": "1px solid rgba(33, 36, 44, 0.16)",
-                                      "display": "flex",
-                                      "flexDirection": "row",
-                                      "minHeight": 66,
-                                      "paddingLeft": 16,
-                                      "paddingRight": 16,
-                                      "position": "relative",
-                                      "width": "100%",
-                                    },
-                                    "_len": 171,
-                                    "_name": "container_hnrag4",
-                                  },
-                                  false,
-                                  false,
-                                ]
-                              }
-                            >
-                              <div
-                                className=""
-                                style={
-                                  Object {
-                                    "alignItems": "stretch",
-                                    "border": "1px solid rgba(33, 36, 44, 0.16)",
-                                    "borderStyle": "solid",
-                                    "borderWidth": 0,
-                                    "boxSizing": "border-box",
-                                    "display": "flex",
-                                    "flexDirection": "row",
-                                    "margin": 0,
-                                    "minHeight": 66,
-                                    "minWidth": 0,
-                                    "padding": 0,
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "position": "relative",
-                                    "width": "100%",
-                                    "zIndex": 0,
-                                  }
-                                }
-                              >
-                                <View
-                                  style={
-                                    Object {
-                                      "_definition": Object {
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                      },
-                                      "_len": 36,
-                                      "_name": "column_sj6pid",
-                                    }
-                                  }
-                                >
-                                  <StyleComponent
-                                    style={
-                                      Object {
-                                        "_definition": Object {
-                                          "flex": 1,
-                                          "justifyContent": "center",
-                                        },
-                                        "_len": 36,
-                                        "_name": "column_sj6pid",
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className=""
-                                      style={
-                                        Object {
-                                          "alignItems": "stretch",
-                                          "borderStyle": "solid",
-                                          "borderWidth": 0,
-                                          "boxSizing": "border-box",
-                                          "display": "flex",
-                                          "flex": 1,
-                                          "flexDirection": "column",
-                                          "justifyContent": "center",
-                                          "margin": 0,
-                                          "minHeight": 0,
-                                          "minWidth": 0,
-                                          "padding": 0,
-                                          "position": "relative",
-                                          "zIndex": 0,
-                                        }
-                                      }
-                                    >
-                                      <View
-                                        style={
-                                          Object {
-                                            "_definition": Object {
-                                              "alignItems": "center",
-                                              "flexDirection": "row",
-                                              "justifyContent": "flex-start",
-                                            },
-                                            "_len": 75,
-                                            "_name": "leftColumn_bc5h0c",
-                                          }
-                                        }
-                                      >
-                                        <StyleComponent
-                                          style={
-                                            Object {
-                                              "_definition": Object {
-                                                "alignItems": "center",
-                                                "flexDirection": "row",
-                                                "justifyContent": "flex-start",
-                                              },
-                                              "_len": 75,
-                                              "_name": "leftColumn_bc5h0c",
-                                            }
-                                          }
-                                        >
-                                          <div
-                                            className=""
-                                            style={
-                                              Object {
-                                                "alignItems": "center",
-                                                "borderStyle": "solid",
-                                                "borderWidth": 0,
-                                                "boxSizing": "border-box",
-                                                "display": "flex",
-                                                "flexDirection": "row",
-                                                "justifyContent": "flex-start",
-                                                "margin": 0,
-                                                "minHeight": 0,
-                                                "minWidth": 0,
-                                                "padding": 0,
-                                                "position": "relative",
-                                                "zIndex": 0,
-                                              }
-                                            }
-                                          >
-                                            <MediaLayout
-                                              styleSheets={
-                                                Object {
-                                                  "all": Object {
-                                                    "preview": Object {
-                                                      "_definition": Object {
-                                                        "flex": "1 0 auto",
-                                                        "maxWidth": 392,
-                                                      },
-                                                      "_len": 34,
-                                                      "_name": "preview_11k7ba4",
-                                                    },
-                                                    "previewContent": Object {
-                                                      "_definition": Object {
-                                                        "padding": "0 64px 0 0",
-                                                      },
-                                                      "_len": 24,
-                                                      "_name": "previewContent_q080uq",
-                                                    },
-                                                  },
-                                                  "mdOrLarger": Object {
-                                                    "wrapper": Object {
-                                                      "_definition": Object {
-                                                        "height": "81.25%",
-                                                        "maxHeight": 624,
-                                                        "maxWidth": 960,
-                                                        "width": "93.75%",
-                                                      },
-                                                      "_len": 67,
-                                                      "_name": "wrapper_1xtsnd2",
-                                                    },
-                                                  },
-                                                  "small": Object {
-                                                    "preview": Object {
-                                                      "_definition": Object {
-                                                        "display": "none",
-                                                      },
-                                                      "_len": 18,
-                                                      "_name": "preview_1u9fru1",
-                                                    },
-                                                  },
-                                                }
-                                              }
-                                            >
-                                              <CloseButton
-                                                light={false}
-                                              >
-                                                <IconButton
-                                                  aria-label="Close modal"
-                                                  color="default"
-                                                  disabled={false}
-                                                  icon={
-                                                    Object {
-                                                      "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
-                                                      "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
-                                                    }
-                                                  }
-                                                  kind="tertiary"
-                                                  light={false}
-                                                >
-                                                  <ClickableBehavior
-                                                    disabled={false}
-                                                    role="button"
-                                                  >
-                                                    <IconButtonCore
-                                                      aria-label="Close modal"
-                                                      color="default"
-                                                      disabled={false}
-                                                      focused={false}
-                                                      hovered={false}
-                                                      icon={
-                                                        Object {
-                                                          "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
-                                                          "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
-                                                        }
-                                                      }
-                                                      kind="tertiary"
-                                                      light={false}
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onDragStart={[Function]}
-                                                      onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseEnter={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchCancel={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchStart={[Function]}
-                                                      pressed={false}
-                                                      tabIndex={0}
-                                                    >
-                                                      <StyleComponent
-                                                        aria-label="Close modal"
-                                                        disabled={false}
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragStart={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseEnter={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchCancel={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        style={
-                                                          Array [
-                                                            Array [
-                                                              Object {
-                                                                "_definition": Object {
-                                                                  "alignItems": "center",
-                                                                  "background": "none",
-                                                                  "border": "none",
-                                                                  "boxSizing": "border-box",
-                                                                  "cursor": "pointer",
-                                                                  "display": "inline-flex",
-                                                                  "height": 40,
-                                                                  "justifyContent": "center",
-                                                                  "margin": -8,
-                                                                  "outline": "none",
-                                                                  "padding": 0,
-                                                                  "position": "relative",
-                                                                  "textDecoration": "none",
-                                                                  "touchAction": "manipulation",
-                                                                  "width": 40,
-                                                                },
-                                                                "_len": 292,
-                                                                "_name": "shared_smh163",
-                                                              },
-                                                              false,
-                                                              Object {
-                                                                "_definition": Object {
-                                                                  "color": "rgba(33,36,44,0.64)",
-                                                                },
-                                                                "_len": 31,
-                                                                "_name": "default_7sq9ra",
-                                                              },
-                                                              false,
-                                                              false,
-                                                            ],
-                                                            undefined,
-                                                          ]
-                                                        }
-                                                        tabIndex={0}
-                                                        type="button"
-                                                      >
-                                                        <button
-                                                          aria-label="Close modal"
-                                                          className=""
-                                                          disabled={false}
-                                                          onBlur={[Function]}
-                                                          onClick={[Function]}
-                                                          onDragStart={[Function]}
-                                                          onFocus={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          onMouseDown={[Function]}
-                                                          onMouseEnter={[Function]}
-                                                          onMouseLeave={[Function]}
-                                                          onMouseUp={[Function]}
-                                                          onTouchCancel={[Function]}
-                                                          onTouchEnd={[Function]}
-                                                          onTouchStart={[Function]}
-                                                          style={
-                                                            Object {
-                                                              "::MozFocusInner": Object {
-                                                                "border": 0,
-                                                              },
-                                                              "alignItems": "center",
-                                                              "background": "none",
-                                                              "border": "none",
-                                                              "boxSizing": "border-box",
-                                                              "color": "rgba(33,36,44,0.64)",
-                                                              "cursor": "pointer",
-                                                              "display": "inline-flex",
-                                                              "height": 40,
-                                                              "justifyContent": "center",
-                                                              "margin": -8,
-                                                              "outline": "none",
-                                                              "padding": 0,
-                                                              "position": "relative",
-                                                              "textDecoration": "none",
-                                                              "touchAction": "manipulation",
-                                                              "width": 40,
-                                                            }
-                                                          }
-                                                          tabIndex={0}
-                                                          type="button"
-                                                        >
-                                                          <Icon
-                                                            color="currentColor"
-                                                            icon={
-                                                              Object {
-                                                                "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
-                                                                "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
-                                                              }
-                                                            }
-                                                            size="medium"
-                                                          >
-                                                            <StyleComponent
-                                                              height={24}
-                                                              style={
-                                                                Array [
-                                                                  Object {
-                                                                    "_definition": Object {
-                                                                      "display": "inline-block",
-                                                                      "flexGrow": 0,
-                                                                      "flexShrink": 0,
-                                                                      "verticalAlign": "text-bottom",
-                                                                    },
-                                                                    "_len": 84,
-                                                                    "_name": "svg_aeiopc",
-                                                                  },
-                                                                  undefined,
-                                                                ]
-                                                              }
-                                                              viewBox="0 0 24 24"
-                                                              width={24}
-                                                            >
-                                                              <svg
-                                                                className=""
-                                                                height={24}
-                                                                style={
-                                                                  Object {
-                                                                    "display": "inline-block",
-                                                                    "flexGrow": 0,
-                                                                    "flexShrink": 0,
-                                                                    "verticalAlign": "text-bottom",
-                                                                  }
-                                                                }
-                                                                viewBox="0 0 24 24"
-                                                                width={24}
-                                                              >
-                                                                <path
-                                                                  d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                                                                  fill="currentColor"
-                                                                />
-                                                              </svg>
-                                                            </StyleComponent>
-                                                          </Icon>
-                                                        </button>
-                                                      </StyleComponent>
-                                                    </IconButtonCore>
-                                                  </ClickableBehavior>
-                                                </IconButton>
-                                              </CloseButton>
-                                            </MediaLayout>
-                                          </div>
-                                        </StyleComponent>
-                                      </View>
-                                    </div>
-                                  </StyleComponent>
-                                </View>
-                                <View
-                                  style={
-                                    Array [
-                                      Object {
-                                        "_definition": Object {
-                                          "flex": 1,
-                                          "justifyContent": "center",
-                                        },
-                                        "_len": 36,
-                                        "_name": "column_sj6pid",
-                                      },
-                                      Object {
-                                        "_definition": Object {
-                                          "flexBasis": "50%",
-                                        },
-                                        "_len": 19,
-                                        "_name": "wideColumn_cczrfo",
-                                      },
-                                    ]
-                                  }
-                                >
-                                  <StyleComponent
-                                    style={
-                                      Array [
-                                        Object {
-                                          "_definition": Object {
-                                            "flex": 1,
-                                            "justifyContent": "center",
-                                          },
-                                          "_len": 36,
-                                          "_name": "column_sj6pid",
-                                        },
-                                        Object {
-                                          "_definition": Object {
-                                            "flexBasis": "50%",
-                                          },
-                                          "_len": 19,
-                                          "_name": "wideColumn_cczrfo",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                    <div
-                                      className=""
-                                      style={
-                                        Object {
-                                          "alignItems": "stretch",
-                                          "borderStyle": "solid",
-                                          "borderWidth": 0,
-                                          "boxSizing": "border-box",
-                                          "display": "flex",
-                                          "flex": 1,
-                                          "flexBasis": "50%",
-                                          "flexDirection": "column",
-                                          "justifyContent": "center",
-                                          "margin": 0,
-                                          "minHeight": 0,
-                                          "minWidth": 0,
-                                          "padding": 0,
-                                          "position": "relative",
-                                          "zIndex": 0,
-                                        }
-                                      }
-                                    >
-                                      <View
-                                        style={
-                                          Array [
-                                            Object {
-                                              "_definition": Object {
-                                                "padding": 12,
-                                              },
-                                              "_len": 14,
-                                              "_name": "titles_47hinf",
-                                            },
-                                            Object {
-                                              "_definition": Object {
-                                                "justifyContent": "center",
-                                              },
-                                              "_len": 27,
-                                              "_name": "verticalAlign_agrn11",
-                                            },
-                                            Object {
-                                              "_definition": Object {
-                                                "textAlign": "center",
-                                              },
-                                              "_len": 22,
-                                              "_name": "center_12to336",
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <StyleComponent
-                                          style={
-                                            Array [
-                                              Object {
-                                                "_definition": Object {
-                                                  "padding": 12,
-                                                },
-                                                "_len": 14,
-                                                "_name": "titles_47hinf",
-                                              },
-                                              Object {
-                                                "_definition": Object {
-                                                  "justifyContent": "center",
-                                                },
-                                                "_len": 27,
-                                                "_name": "verticalAlign_agrn11",
-                                              },
-                                              Object {
-                                                "_definition": Object {
-                                                  "textAlign": "center",
-                                                },
-                                                "_len": 22,
-                                                "_name": "center_12to336",
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <div
-                                            className=""
-                                            style={
-                                              Object {
-                                                "alignItems": "stretch",
-                                                "borderStyle": "solid",
-                                                "borderWidth": 0,
-                                                "boxSizing": "border-box",
-                                                "display": "flex",
-                                                "flexDirection": "column",
-                                                "justifyContent": "center",
-                                                "margin": 0,
-                                                "minHeight": 0,
-                                                "minWidth": 0,
-                                                "padding": 12,
-                                                "position": "relative",
-                                                "textAlign": "center",
-                                                "zIndex": 0,
-                                              }
-                                            }
-                                          >
-                                            <HeadingSmall
-                                              id="wb-toolbar-title"
-                                              tag="h4"
-                                            >
-                                              <Text
-                                                id="wb-toolbar-title"
-                                                style={
-                                                  Array [
-                                                    Object {
-                                                      "_definition": Object {
-                                                        "display": "block",
-                                                        "fontFamily": "Lato, sans-serif",
-                                                        "fontSize": 20,
-                                                        "fontWeight": 700,
-                                                        "lineHeight": "24px",
-                                                      },
-                                                      "_len": 102,
-                                                      "_name": "HeadingSmall_1c07c7n",
-                                                    },
-                                                    undefined,
-                                                  ]
-                                                }
-                                                tag="h4"
-                                              >
-                                                <h4
-                                                  className=""
-                                                  id="wb-toolbar-title"
-                                                  style={
-                                                    Object {
-                                                      "MozOsxFontSmoothing": "grayscale",
-                                                      "WebkitFontSmoothing": "antialiased",
-                                                      "display": "block",
-                                                      "fontFamily": "Lato, sans-serif",
-                                                      "fontSize": 20,
-                                                      "fontWeight": 700,
-                                                      "lineHeight": "24px",
-                                                      "marginBottom": 0,
-                                                      "marginTop": 0,
-                                                    }
-                                                  }
-                                                >
-                                                  Title
-                                                </h4>
-                                              </Text>
-                                            </HeadingSmall>
-                                          </div>
-                                        </StyleComponent>
-                                      </View>
-                                    </div>
-                                  </StyleComponent>
-                                </View>
-                                <View
-                                  style={
-                                    Object {
-                                      "_definition": Object {
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                      },
-                                      "_len": 36,
-                                      "_name": "column_sj6pid",
-                                    }
-                                  }
-                                >
-                                  <StyleComponent
-                                    style={
-                                      Object {
-                                        "_definition": Object {
-                                          "flex": 1,
-                                          "justifyContent": "center",
-                                        },
-                                        "_len": 36,
-                                        "_name": "column_sj6pid",
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className=""
-                                      style={
-                                        Object {
-                                          "alignItems": "stretch",
-                                          "borderStyle": "solid",
-                                          "borderWidth": 0,
-                                          "boxSizing": "border-box",
-                                          "display": "flex",
-                                          "flex": 1,
-                                          "flexDirection": "column",
-                                          "justifyContent": "center",
-                                          "margin": 0,
-                                          "minHeight": 0,
-                                          "minWidth": 0,
-                                          "padding": 0,
-                                          "position": "relative",
-                                          "zIndex": 0,
-                                        }
-                                      }
-                                    >
-                                      <View
-                                        style={
-                                          Object {
-                                            "_definition": Object {
-                                              "alignItems": "center",
-                                              "flexDirection": "row",
-                                              "justifyContent": "flex-end",
-                                            },
-                                            "_len": 73,
-                                            "_name": "rightColumn_1aelo9f",
-                                          }
-                                        }
-                                      >
-                                        <StyleComponent
-                                          style={
-                                            Object {
-                                              "_definition": Object {
-                                                "alignItems": "center",
-                                                "flexDirection": "row",
-                                                "justifyContent": "flex-end",
-                                              },
-                                              "_len": 73,
-                                              "_name": "rightColumn_1aelo9f",
-                                            }
-                                          }
-                                        >
-                                          <div
-                                            className=""
-                                            style={
-                                              Object {
-                                                "alignItems": "center",
-                                                "borderStyle": "solid",
-                                                "borderWidth": 0,
-                                                "boxSizing": "border-box",
-                                                "display": "flex",
-                                                "flexDirection": "row",
-                                                "justifyContent": "flex-end",
-                                                "margin": 0,
-                                                "minHeight": 0,
-                                                "minWidth": 0,
-                                                "padding": 0,
-                                                "position": "relative",
-                                                "zIndex": 0,
-                                              }
-                                            }
-                                          />
-                                        </StyleComponent>
-                                      </View>
-                                    </div>
-                                  </StyleComponent>
-                                </View>
-                              </div>
-                            </StyleComponent>
-                          </View>
-                        </Toolbar>
-                        <ModalContent
-                          scrollOverflow={true}
+                        <View
                           style={
                             Array [
                               Array [
                                 Object {
                                   "_definition": Object {
-                                    "paddingTop": 32,
+                                    "background": "white",
+                                    "boxSizing": "border-box",
+                                    "display": "flex",
+                                    "flex": "1 1 auto",
+                                    "flexDirection": "column",
+                                    "height": "100%",
+                                    "position": "relative",
+                                    "width": "100%",
                                   },
-                                  "_len": 17,
-                                  "_name": "hasTitleBar_15lzjb6",
-                                },
-                                false,
-                                false,
-                                Array [
-                                  undefined,
-                                  undefined,
-                                ],
-                              ],
-                              Array [
-                                Object {
-                                  "_definition": Object {
-                                    "paddingBottom": 32,
-                                  },
-                                  "_len": 20,
-                                  "_name": "hasFooter_1pn52au",
+                                  "_len": 160,
+                                  "_name": "wrapper_161dlb6",
                                 },
                                 false,
                                 false,
@@ -1239,96 +592,892 @@ exports[`StandardModal desktop should match snapshot 1`] = `
                             ]
                           }
                         >
-                          <MediaLayout
-                            styleSheets={
-                              Object {
-                                "all": Object {
-                                  "content": Object {
+                          <StyleComponent
+                            style={
+                              Array [
+                                Array [
+                                  Object {
                                     "_definition": Object {
+                                      "background": "white",
                                       "boxSizing": "border-box",
-                                      "flex": 1,
-                                      "minHeight": "100%",
-                                      "padding": 64,
+                                      "display": "flex",
+                                      "flex": "1 1 auto",
+                                      "flexDirection": "column",
+                                      "height": "100%",
+                                      "position": "relative",
+                                      "width": "100%",
                                     },
-                                    "_len": 67,
-                                    "_name": "content_9s1qwq",
+                                    "_len": 160,
+                                    "_name": "wrapper_161dlb6",
                                   },
-                                  "scrollOverflow": Object {
-                                    "_definition": Object {
-                                      "overflow": "auto",
-                                    },
-                                    "_len": 19,
-                                    "_name": "scrollOverflow_oowqdm",
-                                  },
-                                  "wrapper": Object {
-                                    "_definition": Object {
-                                      "display": "block",
-                                      "flex": 1,
-                                    },
-                                    "_len": 28,
-                                    "_name": "wrapper_12fltve",
-                                  },
-                                },
-                                "small": Object {
-                                  "content": Object {
-                                    "_definition": Object {
-                                      "padding": "32px 16px",
-                                    },
-                                    "_len": 23,
-                                    "_name": "content_1a04pla",
-                                  },
-                                },
-                              }
+                                  false,
+                                  false,
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ],
+                                ],
+                                false,
+                                undefined,
+                              ]
                             }
                           >
-                            <View
+                            <div
+                              className=""
                               style={
-                                Array [
-                                  Array [
-                                    Object {
-                                      "_definition": Object {
-                                        "display": "block",
-                                        "flex": 1,
-                                      },
-                                      "_len": 28,
-                                      "_name": "wrapper_12fltve",
-                                    },
-                                    false,
-                                    false,
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                    ],
-                                  ],
-                                  Array [
-                                    Object {
-                                      "_definition": Object {
-                                        "overflow": "auto",
-                                      },
-                                      "_len": 19,
-                                      "_name": "scrollOverflow_oowqdm",
-                                    },
-                                    false,
-                                    false,
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                    ],
-                                  ],
-                                ]
+                                Object {
+                                  "alignItems": "stretch",
+                                  "background": "white",
+                                  "borderStyle": "solid",
+                                  "borderWidth": 0,
+                                  "boxSizing": "border-box",
+                                  "display": "flex",
+                                  "flex": "1 1 auto",
+                                  "flexDirection": "column",
+                                  "height": "100%",
+                                  "margin": 0,
+                                  "minHeight": 0,
+                                  "minWidth": 0,
+                                  "padding": 0,
+                                  "position": "relative",
+                                  "width": "100%",
+                                  "zIndex": 0,
+                                }
                               }
                             >
-                              <StyleComponent
+                              <Toolbar
+                                color="light"
+                                leftContent={
+                                  <MediaLayout
+                                    styleSheets={
+                                      Object {
+                                        "all": Object {
+                                          "preview": Object {
+                                            "_definition": Object {
+                                              "flex": "1 0 auto",
+                                              "maxWidth": 392,
+                                            },
+                                            "_len": 34,
+                                            "_name": "preview_11k7ba4",
+                                          },
+                                          "previewContent": Object {
+                                            "_definition": Object {
+                                              "padding": "0 64px 0 0",
+                                            },
+                                            "_len": 24,
+                                            "_name": "previewContent_q080uq",
+                                          },
+                                        },
+                                        "mdOrLarger": Object {
+                                          "wrapper": Object {
+                                            "_definition": Object {
+                                              "height": "81.25%",
+                                              "maxHeight": 624,
+                                              "maxWidth": 960,
+                                              "width": "93.75%",
+                                            },
+                                            "_len": 67,
+                                            "_name": "wrapper_1xtsnd2",
+                                          },
+                                        },
+                                        "small": Object {
+                                          "preview": Object {
+                                            "_definition": Object {
+                                              "display": "none",
+                                            },
+                                            "_len": 18,
+                                            "_name": "preview_1u9fru1",
+                                          },
+                                        },
+                                      }
+                                    }
+                                  >
+                                    [Function]
+                                  </MediaLayout>
+                                }
+                                rightContent={null}
+                                size="medium"
+                                title="Title"
+                              >
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "_definition": Object {
+                                          "border": "1px solid rgba(33, 36, 44, 0.16)",
+                                          "display": "flex",
+                                          "flexDirection": "row",
+                                          "minHeight": 66,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "relative",
+                                          "width": "100%",
+                                        },
+                                        "_len": 171,
+                                        "_name": "container_hnrag4",
+                                      },
+                                      false,
+                                      false,
+                                    ]
+                                  }
+                                >
+                                  <StyleComponent
+                                    style={
+                                      Array [
+                                        Object {
+                                          "_definition": Object {
+                                            "border": "1px solid rgba(33, 36, 44, 0.16)",
+                                            "display": "flex",
+                                            "flexDirection": "row",
+                                            "minHeight": 66,
+                                            "paddingLeft": 16,
+                                            "paddingRight": 16,
+                                            "position": "relative",
+                                            "width": "100%",
+                                          },
+                                          "_len": 171,
+                                          "_name": "container_hnrag4",
+                                        },
+                                        false,
+                                        false,
+                                      ]
+                                    }
+                                  >
+                                    <div
+                                      className=""
+                                      style={
+                                        Object {
+                                          "alignItems": "stretch",
+                                          "border": "1px solid rgba(33, 36, 44, 0.16)",
+                                          "borderStyle": "solid",
+                                          "borderWidth": 0,
+                                          "boxSizing": "border-box",
+                                          "display": "flex",
+                                          "flexDirection": "row",
+                                          "margin": 0,
+                                          "minHeight": 66,
+                                          "minWidth": 0,
+                                          "padding": 0,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "relative",
+                                          "width": "100%",
+                                          "zIndex": 0,
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        style={
+                                          Object {
+                                            "_definition": Object {
+                                              "flex": 1,
+                                              "justifyContent": "center",
+                                            },
+                                            "_len": 36,
+                                            "_name": "column_sj6pid",
+                                          }
+                                        }
+                                      >
+                                        <StyleComponent
+                                          style={
+                                            Object {
+                                              "_definition": Object {
+                                                "flex": 1,
+                                                "justifyContent": "center",
+                                              },
+                                              "_len": 36,
+                                              "_name": "column_sj6pid",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className=""
+                                            style={
+                                              Object {
+                                                "alignItems": "stretch",
+                                                "borderStyle": "solid",
+                                                "borderWidth": 0,
+                                                "boxSizing": "border-box",
+                                                "display": "flex",
+                                                "flex": 1,
+                                                "flexDirection": "column",
+                                                "justifyContent": "center",
+                                                "margin": 0,
+                                                "minHeight": 0,
+                                                "minWidth": 0,
+                                                "padding": 0,
+                                                "position": "relative",
+                                                "zIndex": 0,
+                                              }
+                                            }
+                                          >
+                                            <View
+                                              style={
+                                                Object {
+                                                  "_definition": Object {
+                                                    "alignItems": "center",
+                                                    "flexDirection": "row",
+                                                    "justifyContent": "flex-start",
+                                                  },
+                                                  "_len": 75,
+                                                  "_name": "leftColumn_bc5h0c",
+                                                }
+                                              }
+                                            >
+                                              <StyleComponent
+                                                style={
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "alignItems": "center",
+                                                      "flexDirection": "row",
+                                                      "justifyContent": "flex-start",
+                                                    },
+                                                    "_len": 75,
+                                                    "_name": "leftColumn_bc5h0c",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className=""
+                                                  style={
+                                                    Object {
+                                                      "alignItems": "center",
+                                                      "borderStyle": "solid",
+                                                      "borderWidth": 0,
+                                                      "boxSizing": "border-box",
+                                                      "display": "flex",
+                                                      "flexDirection": "row",
+                                                      "justifyContent": "flex-start",
+                                                      "margin": 0,
+                                                      "minHeight": 0,
+                                                      "minWidth": 0,
+                                                      "padding": 0,
+                                                      "position": "relative",
+                                                      "zIndex": 0,
+                                                    }
+                                                  }
+                                                >
+                                                  <MediaLayout
+                                                    styleSheets={
+                                                      Object {
+                                                        "all": Object {
+                                                          "preview": Object {
+                                                            "_definition": Object {
+                                                              "flex": "1 0 auto",
+                                                              "maxWidth": 392,
+                                                            },
+                                                            "_len": 34,
+                                                            "_name": "preview_11k7ba4",
+                                                          },
+                                                          "previewContent": Object {
+                                                            "_definition": Object {
+                                                              "padding": "0 64px 0 0",
+                                                            },
+                                                            "_len": 24,
+                                                            "_name": "previewContent_q080uq",
+                                                          },
+                                                        },
+                                                        "mdOrLarger": Object {
+                                                          "wrapper": Object {
+                                                            "_definition": Object {
+                                                              "height": "81.25%",
+                                                              "maxHeight": 624,
+                                                              "maxWidth": 960,
+                                                              "width": "93.75%",
+                                                            },
+                                                            "_len": 67,
+                                                            "_name": "wrapper_1xtsnd2",
+                                                          },
+                                                        },
+                                                        "small": Object {
+                                                          "preview": Object {
+                                                            "_definition": Object {
+                                                              "display": "none",
+                                                            },
+                                                            "_len": 18,
+                                                            "_name": "preview_1u9fru1",
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                  >
+                                                    <MediaLayoutInternal
+                                                      mediaSpec={
+                                                        Object {
+                                                          "large": Object {
+                                                            "gutterWidth": 32,
+                                                            "marginWidth": 48,
+                                                            "query": "(min-width: 768px)",
+                                                            "totalColumns": 12,
+                                                          },
+                                                          "small": Object {
+                                                            "gutterWidth": 16,
+                                                            "marginWidth": 16,
+                                                            "query": "(max-width: 767px)",
+                                                            "totalColumns": 4,
+                                                          },
+                                                        }
+                                                      }
+                                                      ssrSize="large"
+                                                      styleSheets={
+                                                        Object {
+                                                          "all": Object {
+                                                            "preview": Object {
+                                                              "_definition": Object {
+                                                                "flex": "1 0 auto",
+                                                                "maxWidth": 392,
+                                                              },
+                                                              "_len": 34,
+                                                              "_name": "preview_11k7ba4",
+                                                            },
+                                                            "previewContent": Object {
+                                                              "_definition": Object {
+                                                                "padding": "0 64px 0 0",
+                                                              },
+                                                              "_len": 24,
+                                                              "_name": "previewContent_q080uq",
+                                                            },
+                                                          },
+                                                          "mdOrLarger": Object {
+                                                            "wrapper": Object {
+                                                              "_definition": Object {
+                                                                "height": "81.25%",
+                                                                "maxHeight": 624,
+                                                                "maxWidth": 960,
+                                                                "width": "93.75%",
+                                                              },
+                                                              "_len": 67,
+                                                              "_name": "wrapper_1xtsnd2",
+                                                            },
+                                                          },
+                                                          "small": Object {
+                                                            "preview": Object {
+                                                              "_definition": Object {
+                                                                "display": "none",
+                                                              },
+                                                              "_len": 18,
+                                                              "_name": "preview_1u9fru1",
+                                                            },
+                                                          },
+                                                        }
+                                                      }
+                                                    >
+                                                      <CloseButton
+                                                        light={false}
+                                                      >
+                                                        <IconButton
+                                                          aria-label="Close modal"
+                                                          color="default"
+                                                          disabled={false}
+                                                          icon={
+                                                            Object {
+                                                              "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
+                                                              "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
+                                                            }
+                                                          }
+                                                          kind="tertiary"
+                                                          light={false}
+                                                        >
+                                                          <ClickableBehavior
+                                                            disabled={false}
+                                                            role="button"
+                                                          >
+                                                            <IconButtonCore
+                                                              aria-label="Close modal"
+                                                              color="default"
+                                                              disabled={false}
+                                                              focused={false}
+                                                              hovered={false}
+                                                              icon={
+                                                                Object {
+                                                                  "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
+                                                                  "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
+                                                                }
+                                                              }
+                                                              kind="tertiary"
+                                                              light={false}
+                                                              onBlur={[Function]}
+                                                              onClick={[Function]}
+                                                              onDragStart={[Function]}
+                                                              onFocus={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              onKeyUp={[Function]}
+                                                              onMouseDown={[Function]}
+                                                              onMouseEnter={[Function]}
+                                                              onMouseLeave={[Function]}
+                                                              onMouseUp={[Function]}
+                                                              onTouchCancel={[Function]}
+                                                              onTouchEnd={[Function]}
+                                                              onTouchStart={[Function]}
+                                                              pressed={false}
+                                                              tabIndex={0}
+                                                            >
+                                                              <StyleComponent
+                                                                aria-label="Close modal"
+                                                                disabled={false}
+                                                                onBlur={[Function]}
+                                                                onClick={[Function]}
+                                                                onDragStart={[Function]}
+                                                                onFocus={[Function]}
+                                                                onKeyDown={[Function]}
+                                                                onKeyUp={[Function]}
+                                                                onMouseDown={[Function]}
+                                                                onMouseEnter={[Function]}
+                                                                onMouseLeave={[Function]}
+                                                                onMouseUp={[Function]}
+                                                                onTouchCancel={[Function]}
+                                                                onTouchEnd={[Function]}
+                                                                onTouchStart={[Function]}
+                                                                style={
+                                                                  Array [
+                                                                    Array [
+                                                                      Object {
+                                                                        "_definition": Object {
+                                                                          "alignItems": "center",
+                                                                          "background": "none",
+                                                                          "border": "none",
+                                                                          "boxSizing": "border-box",
+                                                                          "cursor": "pointer",
+                                                                          "display": "inline-flex",
+                                                                          "height": 40,
+                                                                          "justifyContent": "center",
+                                                                          "margin": -8,
+                                                                          "outline": "none",
+                                                                          "padding": 0,
+                                                                          "position": "relative",
+                                                                          "textDecoration": "none",
+                                                                          "touchAction": "manipulation",
+                                                                          "width": 40,
+                                                                        },
+                                                                        "_len": 292,
+                                                                        "_name": "shared_smh163",
+                                                                      },
+                                                                      false,
+                                                                      Object {
+                                                                        "_definition": Object {
+                                                                          "color": "rgba(33,36,44,0.64)",
+                                                                        },
+                                                                        "_len": 31,
+                                                                        "_name": "default_7sq9ra",
+                                                                      },
+                                                                      false,
+                                                                      false,
+                                                                    ],
+                                                                    undefined,
+                                                                  ]
+                                                                }
+                                                                tabIndex={0}
+                                                                type="button"
+                                                              >
+                                                                <button
+                                                                  aria-label="Close modal"
+                                                                  className=""
+                                                                  disabled={false}
+                                                                  onBlur={[Function]}
+                                                                  onClick={[Function]}
+                                                                  onDragStart={[Function]}
+                                                                  onFocus={[Function]}
+                                                                  onKeyDown={[Function]}
+                                                                  onKeyUp={[Function]}
+                                                                  onMouseDown={[Function]}
+                                                                  onMouseEnter={[Function]}
+                                                                  onMouseLeave={[Function]}
+                                                                  onMouseUp={[Function]}
+                                                                  onTouchCancel={[Function]}
+                                                                  onTouchEnd={[Function]}
+                                                                  onTouchStart={[Function]}
+                                                                  style={
+                                                                    Object {
+                                                                      "::MozFocusInner": Object {
+                                                                        "border": 0,
+                                                                      },
+                                                                      "alignItems": "center",
+                                                                      "background": "none",
+                                                                      "border": "none",
+                                                                      "boxSizing": "border-box",
+                                                                      "color": "rgba(33,36,44,0.64)",
+                                                                      "cursor": "pointer",
+                                                                      "display": "inline-flex",
+                                                                      "height": 40,
+                                                                      "justifyContent": "center",
+                                                                      "margin": -8,
+                                                                      "outline": "none",
+                                                                      "padding": 0,
+                                                                      "position": "relative",
+                                                                      "textDecoration": "none",
+                                                                      "touchAction": "manipulation",
+                                                                      "width": 40,
+                                                                    }
+                                                                  }
+                                                                  tabIndex={0}
+                                                                  type="button"
+                                                                >
+                                                                  <Icon
+                                                                    color="currentColor"
+                                                                    icon={
+                                                                      Object {
+                                                                        "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
+                                                                        "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
+                                                                      }
+                                                                    }
+                                                                    size="medium"
+                                                                  >
+                                                                    <StyleComponent
+                                                                      height={24}
+                                                                      style={
+                                                                        Array [
+                                                                          Object {
+                                                                            "_definition": Object {
+                                                                              "display": "inline-block",
+                                                                              "flexGrow": 0,
+                                                                              "flexShrink": 0,
+                                                                              "verticalAlign": "text-bottom",
+                                                                            },
+                                                                            "_len": 84,
+                                                                            "_name": "svg_aeiopc",
+                                                                          },
+                                                                          undefined,
+                                                                        ]
+                                                                      }
+                                                                      viewBox="0 0 24 24"
+                                                                      width={24}
+                                                                    >
+                                                                      <svg
+                                                                        className=""
+                                                                        height={24}
+                                                                        style={
+                                                                          Object {
+                                                                            "display": "inline-block",
+                                                                            "flexGrow": 0,
+                                                                            "flexShrink": 0,
+                                                                            "verticalAlign": "text-bottom",
+                                                                          }
+                                                                        }
+                                                                        viewBox="0 0 24 24"
+                                                                        width={24}
+                                                                      >
+                                                                        <path
+                                                                          d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                                                                          fill="currentColor"
+                                                                        />
+                                                                      </svg>
+                                                                    </StyleComponent>
+                                                                  </Icon>
+                                                                </button>
+                                                              </StyleComponent>
+                                                            </IconButtonCore>
+                                                          </ClickableBehavior>
+                                                        </IconButton>
+                                                      </CloseButton>
+                                                    </MediaLayoutInternal>
+                                                  </MediaLayout>
+                                                </div>
+                                              </StyleComponent>
+                                            </View>
+                                          </div>
+                                        </StyleComponent>
+                                      </View>
+                                      <View
+                                        style={
+                                          Array [
+                                            Object {
+                                              "_definition": Object {
+                                                "flex": 1,
+                                                "justifyContent": "center",
+                                              },
+                                              "_len": 36,
+                                              "_name": "column_sj6pid",
+                                            },
+                                            Object {
+                                              "_definition": Object {
+                                                "flexBasis": "50%",
+                                              },
+                                              "_len": 19,
+                                              "_name": "wideColumn_cczrfo",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <StyleComponent
+                                          style={
+                                            Array [
+                                              Object {
+                                                "_definition": Object {
+                                                  "flex": 1,
+                                                  "justifyContent": "center",
+                                                },
+                                                "_len": 36,
+                                                "_name": "column_sj6pid",
+                                              },
+                                              Object {
+                                                "_definition": Object {
+                                                  "flexBasis": "50%",
+                                                },
+                                                "_len": 19,
+                                                "_name": "wideColumn_cczrfo",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <div
+                                            className=""
+                                            style={
+                                              Object {
+                                                "alignItems": "stretch",
+                                                "borderStyle": "solid",
+                                                "borderWidth": 0,
+                                                "boxSizing": "border-box",
+                                                "display": "flex",
+                                                "flex": 1,
+                                                "flexBasis": "50%",
+                                                "flexDirection": "column",
+                                                "justifyContent": "center",
+                                                "margin": 0,
+                                                "minHeight": 0,
+                                                "minWidth": 0,
+                                                "padding": 0,
+                                                "position": "relative",
+                                                "zIndex": 0,
+                                              }
+                                            }
+                                          >
+                                            <View
+                                              style={
+                                                Array [
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "padding": 12,
+                                                    },
+                                                    "_len": 14,
+                                                    "_name": "titles_47hinf",
+                                                  },
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "justifyContent": "center",
+                                                    },
+                                                    "_len": 27,
+                                                    "_name": "verticalAlign_agrn11",
+                                                  },
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "textAlign": "center",
+                                                    },
+                                                    "_len": 22,
+                                                    "_name": "center_12to336",
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <StyleComponent
+                                                style={
+                                                  Array [
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "padding": 12,
+                                                      },
+                                                      "_len": 14,
+                                                      "_name": "titles_47hinf",
+                                                    },
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "justifyContent": "center",
+                                                      },
+                                                      "_len": 27,
+                                                      "_name": "verticalAlign_agrn11",
+                                                    },
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "textAlign": "center",
+                                                      },
+                                                      "_len": 22,
+                                                      "_name": "center_12to336",
+                                                    },
+                                                  ]
+                                                }
+                                              >
+                                                <div
+                                                  className=""
+                                                  style={
+                                                    Object {
+                                                      "alignItems": "stretch",
+                                                      "borderStyle": "solid",
+                                                      "borderWidth": 0,
+                                                      "boxSizing": "border-box",
+                                                      "display": "flex",
+                                                      "flexDirection": "column",
+                                                      "justifyContent": "center",
+                                                      "margin": 0,
+                                                      "minHeight": 0,
+                                                      "minWidth": 0,
+                                                      "padding": 12,
+                                                      "position": "relative",
+                                                      "textAlign": "center",
+                                                      "zIndex": 0,
+                                                    }
+                                                  }
+                                                >
+                                                  <HeadingSmall
+                                                    id="wb-toolbar-title"
+                                                    tag="h4"
+                                                  >
+                                                    <Text
+                                                      id="wb-toolbar-title"
+                                                      style={
+                                                        Array [
+                                                          Object {
+                                                            "_definition": Object {
+                                                              "display": "block",
+                                                              "fontFamily": "Lato, sans-serif",
+                                                              "fontSize": 20,
+                                                              "fontWeight": 700,
+                                                              "lineHeight": "24px",
+                                                            },
+                                                            "_len": 102,
+                                                            "_name": "HeadingSmall_1c07c7n",
+                                                          },
+                                                          undefined,
+                                                        ]
+                                                      }
+                                                      tag="h4"
+                                                    >
+                                                      <h4
+                                                        className=""
+                                                        id="wb-toolbar-title"
+                                                        style={
+                                                          Object {
+                                                            "MozOsxFontSmoothing": "grayscale",
+                                                            "WebkitFontSmoothing": "antialiased",
+                                                            "display": "block",
+                                                            "fontFamily": "Lato, sans-serif",
+                                                            "fontSize": 20,
+                                                            "fontWeight": 700,
+                                                            "lineHeight": "24px",
+                                                            "marginBottom": 0,
+                                                            "marginTop": 0,
+                                                          }
+                                                        }
+                                                      >
+                                                        Title
+                                                      </h4>
+                                                    </Text>
+                                                  </HeadingSmall>
+                                                </div>
+                                              </StyleComponent>
+                                            </View>
+                                          </div>
+                                        </StyleComponent>
+                                      </View>
+                                      <View
+                                        style={
+                                          Object {
+                                            "_definition": Object {
+                                              "flex": 1,
+                                              "justifyContent": "center",
+                                            },
+                                            "_len": 36,
+                                            "_name": "column_sj6pid",
+                                          }
+                                        }
+                                      >
+                                        <StyleComponent
+                                          style={
+                                            Object {
+                                              "_definition": Object {
+                                                "flex": 1,
+                                                "justifyContent": "center",
+                                              },
+                                              "_len": 36,
+                                              "_name": "column_sj6pid",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className=""
+                                            style={
+                                              Object {
+                                                "alignItems": "stretch",
+                                                "borderStyle": "solid",
+                                                "borderWidth": 0,
+                                                "boxSizing": "border-box",
+                                                "display": "flex",
+                                                "flex": 1,
+                                                "flexDirection": "column",
+                                                "justifyContent": "center",
+                                                "margin": 0,
+                                                "minHeight": 0,
+                                                "minWidth": 0,
+                                                "padding": 0,
+                                                "position": "relative",
+                                                "zIndex": 0,
+                                              }
+                                            }
+                                          >
+                                            <View
+                                              style={
+                                                Object {
+                                                  "_definition": Object {
+                                                    "alignItems": "center",
+                                                    "flexDirection": "row",
+                                                    "justifyContent": "flex-end",
+                                                  },
+                                                  "_len": 73,
+                                                  "_name": "rightColumn_1aelo9f",
+                                                }
+                                              }
+                                            >
+                                              <StyleComponent
+                                                style={
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "alignItems": "center",
+                                                      "flexDirection": "row",
+                                                      "justifyContent": "flex-end",
+                                                    },
+                                                    "_len": 73,
+                                                    "_name": "rightColumn_1aelo9f",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className=""
+                                                  style={
+                                                    Object {
+                                                      "alignItems": "center",
+                                                      "borderStyle": "solid",
+                                                      "borderWidth": 0,
+                                                      "boxSizing": "border-box",
+                                                      "display": "flex",
+                                                      "flexDirection": "row",
+                                                      "justifyContent": "flex-end",
+                                                      "margin": 0,
+                                                      "minHeight": 0,
+                                                      "minWidth": 0,
+                                                      "padding": 0,
+                                                      "position": "relative",
+                                                      "zIndex": 0,
+                                                    }
+                                                  }
+                                                />
+                                              </StyleComponent>
+                                            </View>
+                                          </div>
+                                        </StyleComponent>
+                                      </View>
+                                    </div>
+                                  </StyleComponent>
+                                </View>
+                              </Toolbar>
+                              <ModalContent
+                                scrollOverflow={true}
                                 style={
                                   Array [
                                     Array [
                                       Object {
                                         "_definition": Object {
-                                          "display": "block",
-                                          "flex": 1,
+                                          "paddingTop": 32,
                                         },
-                                        "_len": 28,
-                                        "_name": "wrapper_12fltve",
+                                        "_len": 17,
+                                        "_name": "hasTitleBar_15lzjb6",
                                       },
                                       false,
                                       false,
@@ -1340,10 +1489,10 @@ exports[`StandardModal desktop should match snapshot 1`] = `
                                     Array [
                                       Object {
                                         "_definition": Object {
-                                          "overflow": "auto",
+                                          "paddingBottom": 32,
                                         },
-                                        "_len": 19,
-                                        "_name": "scrollOverflow_oowqdm",
+                                        "_len": 20,
+                                        "_name": "hasFooter_1pn52au",
                                       },
                                       false,
                                       false,
@@ -1352,35 +1501,75 @@ exports[`StandardModal desktop should match snapshot 1`] = `
                                         undefined,
                                       ],
                                     ],
+                                    false,
+                                    undefined,
                                   ]
                                 }
                               >
-                                <div
-                                  className=""
-                                  style={
+                                <MediaLayout
+                                  styleSheets={
                                     Object {
-                                      "alignItems": "stretch",
-                                      "borderStyle": "solid",
-                                      "borderWidth": 0,
-                                      "boxSizing": "border-box",
-                                      "display": "block",
-                                      "flex": 1,
-                                      "flexDirection": "column",
-                                      "margin": 0,
-                                      "minHeight": 0,
-                                      "minWidth": 0,
-                                      "overflow": "auto",
-                                      "padding": 0,
-                                      "position": "relative",
-                                      "zIndex": 0,
+                                      "all": Object {
+                                        "content": Object {
+                                          "_definition": Object {
+                                            "boxSizing": "border-box",
+                                            "flex": 1,
+                                            "minHeight": "100%",
+                                            "padding": 64,
+                                          },
+                                          "_len": 67,
+                                          "_name": "content_9s1qwq",
+                                        },
+                                        "scrollOverflow": Object {
+                                          "_definition": Object {
+                                            "overflow": "auto",
+                                          },
+                                          "_len": 19,
+                                          "_name": "scrollOverflow_oowqdm",
+                                        },
+                                        "wrapper": Object {
+                                          "_definition": Object {
+                                            "display": "block",
+                                            "flex": 1,
+                                          },
+                                          "_len": 28,
+                                          "_name": "wrapper_12fltve",
+                                        },
+                                      },
+                                      "small": Object {
+                                        "content": Object {
+                                          "_definition": Object {
+                                            "padding": "32px 16px",
+                                          },
+                                          "_len": 23,
+                                          "_name": "content_1a04pla",
+                                        },
+                                      },
                                     }
                                   }
                                 >
-                                  <View
-                                    style={
-                                      Array [
-                                        Array [
-                                          Object {
+                                  <MediaLayoutInternal
+                                    mediaSpec={
+                                      Object {
+                                        "large": Object {
+                                          "gutterWidth": 32,
+                                          "marginWidth": 48,
+                                          "query": "(min-width: 768px)",
+                                          "totalColumns": 12,
+                                        },
+                                        "small": Object {
+                                          "gutterWidth": 16,
+                                          "marginWidth": 16,
+                                          "query": "(max-width: 767px)",
+                                          "totalColumns": 4,
+                                        },
+                                      }
+                                    }
+                                    ssrSize="large"
+                                    styleSheets={
+                                      Object {
+                                        "all": Object {
+                                          "content": Object {
                                             "_definition": Object {
                                               "boxSizing": "border-box",
                                               "flex": 1,
@@ -1390,63 +1579,45 @@ exports[`StandardModal desktop should match snapshot 1`] = `
                                             "_len": 67,
                                             "_name": "content_9s1qwq",
                                           },
-                                          false,
-                                          false,
-                                          Array [
-                                            undefined,
-                                            undefined,
-                                          ],
-                                        ],
-                                        Array [
-                                          Array [
-                                            Object {
-                                              "_definition": Object {
-                                                "paddingTop": 32,
-                                              },
-                                              "_len": 17,
-                                              "_name": "hasTitleBar_15lzjb6",
+                                          "scrollOverflow": Object {
+                                            "_definition": Object {
+                                              "overflow": "auto",
                                             },
-                                            false,
-                                            false,
-                                            Array [
-                                              undefined,
-                                              undefined,
-                                            ],
-                                          ],
-                                          Array [
-                                            Object {
-                                              "_definition": Object {
-                                                "paddingBottom": 32,
-                                              },
-                                              "_len": 20,
-                                              "_name": "hasFooter_1pn52au",
+                                            "_len": 19,
+                                            "_name": "scrollOverflow_oowqdm",
+                                          },
+                                          "wrapper": Object {
+                                            "_definition": Object {
+                                              "display": "block",
+                                              "flex": 1,
                                             },
-                                            false,
-                                            false,
-                                            Array [
-                                              undefined,
-                                              undefined,
-                                            ],
-                                          ],
-                                          false,
-                                          undefined,
-                                        ],
-                                      ]
+                                            "_len": 28,
+                                            "_name": "wrapper_12fltve",
+                                          },
+                                        },
+                                        "small": Object {
+                                          "content": Object {
+                                            "_definition": Object {
+                                              "padding": "32px 16px",
+                                            },
+                                            "_len": 23,
+                                            "_name": "content_1a04pla",
+                                          },
+                                        },
+                                      }
                                     }
                                   >
-                                    <StyleComponent
+                                    <View
                                       style={
                                         Array [
                                           Array [
                                             Object {
                                               "_definition": Object {
-                                                "boxSizing": "border-box",
+                                                "display": "block",
                                                 "flex": 1,
-                                                "minHeight": "100%",
-                                                "padding": 64,
                                               },
-                                              "_len": 67,
-                                              "_name": "content_9s1qwq",
+                                              "_len": 28,
+                                              "_name": "wrapper_12fltve",
                                             },
                                             false,
                                             false,
@@ -1456,171 +1627,330 @@ exports[`StandardModal desktop should match snapshot 1`] = `
                                             ],
                                           ],
                                           Array [
-                                            Array [
-                                              Object {
-                                                "_definition": Object {
-                                                  "paddingTop": 32,
-                                                },
-                                                "_len": 17,
-                                                "_name": "hasTitleBar_15lzjb6",
+                                            Object {
+                                              "_definition": Object {
+                                                "overflow": "auto",
                                               },
-                                              false,
-                                              false,
-                                              Array [
-                                                undefined,
-                                                undefined,
-                                              ],
-                                            ],
-                                            Array [
-                                              Object {
-                                                "_definition": Object {
-                                                  "paddingBottom": 32,
-                                                },
-                                                "_len": 20,
-                                                "_name": "hasFooter_1pn52au",
-                                              },
-                                              false,
-                                              false,
-                                              Array [
-                                                undefined,
-                                                undefined,
-                                              ],
-                                            ],
+                                              "_len": 19,
+                                              "_name": "scrollOverflow_oowqdm",
+                                            },
                                             false,
-                                            undefined,
+                                            false,
+                                            Array [
+                                              undefined,
+                                              undefined,
+                                            ],
                                           ],
                                         ]
                                       }
                                     >
-                                      <div
-                                        className=""
+                                      <StyleComponent
                                         style={
-                                          Object {
-                                            "alignItems": "stretch",
-                                            "borderStyle": "solid",
-                                            "borderWidth": 0,
-                                            "boxSizing": "border-box",
-                                            "display": "flex",
-                                            "flex": 1,
-                                            "flexDirection": "column",
-                                            "margin": 0,
-                                            "minHeight": "100%",
-                                            "minWidth": 0,
-                                            "padding": 64,
-                                            "paddingBottom": 32,
-                                            "paddingTop": 32,
-                                            "position": "relative",
-                                            "zIndex": 0,
-                                          }
+                                          Array [
+                                            Array [
+                                              Object {
+                                                "_definition": Object {
+                                                  "display": "block",
+                                                  "flex": 1,
+                                                },
+                                                "_len": 28,
+                                                "_name": "wrapper_12fltve",
+                                              },
+                                              false,
+                                              false,
+                                              Array [
+                                                undefined,
+                                                undefined,
+                                              ],
+                                            ],
+                                            Array [
+                                              Object {
+                                                "_definition": Object {
+                                                  "overflow": "auto",
+                                                },
+                                                "_len": 19,
+                                                "_name": "scrollOverflow_oowqdm",
+                                              },
+                                              false,
+                                              false,
+                                              Array [
+                                                undefined,
+                                                undefined,
+                                              ],
+                                            ],
+                                          ]
                                         }
                                       >
-                                        Content
-                                      </div>
-                                    </StyleComponent>
-                                  </View>
-                                </div>
-                              </StyleComponent>
-                            </View>
-                          </MediaLayout>
-                        </ModalContent>
-                        <ModalFooter>
-                          <View
-                            style={
-                              Array [
-                                Object {
-                                  "_definition": Object {
-                                    "alignItems": "center",
-                                    "borderTopColor": "rgba(33,36,44,0.16)",
-                                    "borderTopStyle": "solid",
-                                    "borderTopWidth": 1,
-                                    "boxSizing": "border-box",
-                                    "display": "flex",
-                                    "flex": "0 0 auto",
-                                    "flexDirection": "row",
-                                    "justifyContent": "flex-end",
-                                    "minHeight": 64,
-                                    "paddingBottom": 8,
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "paddingTop": 8,
-                                  },
-                                  "_len": 299,
-                                  "_name": "footer_b45ce1",
-                                },
-                                undefined,
-                              ]
-                            }
-                          >
-                            <StyleComponent
-                              style={
-                                Array [
-                                  Object {
-                                    "_definition": Object {
-                                      "alignItems": "center",
-                                      "borderTopColor": "rgba(33,36,44,0.16)",
-                                      "borderTopStyle": "solid",
-                                      "borderTopWidth": 1,
-                                      "boxSizing": "border-box",
-                                      "display": "flex",
-                                      "flex": "0 0 auto",
-                                      "flexDirection": "row",
-                                      "justifyContent": "flex-end",
-                                      "minHeight": 64,
-                                      "paddingBottom": 8,
-                                      "paddingLeft": 16,
-                                      "paddingRight": 16,
-                                      "paddingTop": 8,
-                                    },
-                                    "_len": 299,
-                                    "_name": "footer_b45ce1",
-                                  },
-                                  undefined,
-                                ]
-                              }
-                            >
-                              <div
-                                className=""
-                                style={
-                                  Object {
-                                    "alignItems": "center",
-                                    "borderStyle": "solid",
-                                    "borderTopColor": "rgba(33,36,44,0.16)",
-                                    "borderTopStyle": "solid",
-                                    "borderTopWidth": 1,
-                                    "borderWidth": 0,
-                                    "boxSizing": "border-box",
-                                    "display": "flex",
-                                    "flex": "0 0 auto",
-                                    "flexDirection": "row",
-                                    "justifyContent": "flex-end",
-                                    "margin": 0,
-                                    "minHeight": 64,
-                                    "minWidth": 0,
-                                    "padding": 0,
-                                    "paddingBottom": 8,
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "paddingTop": 8,
-                                    "position": "relative",
-                                    "zIndex": 0,
+                                        <div
+                                          className=""
+                                          style={
+                                            Object {
+                                              "alignItems": "stretch",
+                                              "borderStyle": "solid",
+                                              "borderWidth": 0,
+                                              "boxSizing": "border-box",
+                                              "display": "block",
+                                              "flex": 1,
+                                              "flexDirection": "column",
+                                              "margin": 0,
+                                              "minHeight": 0,
+                                              "minWidth": 0,
+                                              "overflow": "auto",
+                                              "padding": 0,
+                                              "position": "relative",
+                                              "zIndex": 0,
+                                            }
+                                          }
+                                        >
+                                          <View
+                                            style={
+                                              Array [
+                                                Array [
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "boxSizing": "border-box",
+                                                      "flex": 1,
+                                                      "minHeight": "100%",
+                                                      "padding": 64,
+                                                    },
+                                                    "_len": 67,
+                                                    "_name": "content_9s1qwq",
+                                                  },
+                                                  false,
+                                                  false,
+                                                  Array [
+                                                    undefined,
+                                                    undefined,
+                                                  ],
+                                                ],
+                                                Array [
+                                                  Array [
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "paddingTop": 32,
+                                                      },
+                                                      "_len": 17,
+                                                      "_name": "hasTitleBar_15lzjb6",
+                                                    },
+                                                    false,
+                                                    false,
+                                                    Array [
+                                                      undefined,
+                                                      undefined,
+                                                    ],
+                                                  ],
+                                                  Array [
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "paddingBottom": 32,
+                                                      },
+                                                      "_len": 20,
+                                                      "_name": "hasFooter_1pn52au",
+                                                    },
+                                                    false,
+                                                    false,
+                                                    Array [
+                                                      undefined,
+                                                      undefined,
+                                                    ],
+                                                  ],
+                                                  false,
+                                                  undefined,
+                                                ],
+                                              ]
+                                            }
+                                          >
+                                            <StyleComponent
+                                              style={
+                                                Array [
+                                                  Array [
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "boxSizing": "border-box",
+                                                        "flex": 1,
+                                                        "minHeight": "100%",
+                                                        "padding": 64,
+                                                      },
+                                                      "_len": 67,
+                                                      "_name": "content_9s1qwq",
+                                                    },
+                                                    false,
+                                                    false,
+                                                    Array [
+                                                      undefined,
+                                                      undefined,
+                                                    ],
+                                                  ],
+                                                  Array [
+                                                    Array [
+                                                      Object {
+                                                        "_definition": Object {
+                                                          "paddingTop": 32,
+                                                        },
+                                                        "_len": 17,
+                                                        "_name": "hasTitleBar_15lzjb6",
+                                                      },
+                                                      false,
+                                                      false,
+                                                      Array [
+                                                        undefined,
+                                                        undefined,
+                                                      ],
+                                                    ],
+                                                    Array [
+                                                      Object {
+                                                        "_definition": Object {
+                                                          "paddingBottom": 32,
+                                                        },
+                                                        "_len": 20,
+                                                        "_name": "hasFooter_1pn52au",
+                                                      },
+                                                      false,
+                                                      false,
+                                                      Array [
+                                                        undefined,
+                                                        undefined,
+                                                      ],
+                                                    ],
+                                                    false,
+                                                    undefined,
+                                                  ],
+                                                ]
+                                              }
+                                            >
+                                              <div
+                                                className=""
+                                                style={
+                                                  Object {
+                                                    "alignItems": "stretch",
+                                                    "borderStyle": "solid",
+                                                    "borderWidth": 0,
+                                                    "boxSizing": "border-box",
+                                                    "display": "flex",
+                                                    "flex": 1,
+                                                    "flexDirection": "column",
+                                                    "margin": 0,
+                                                    "minHeight": "100%",
+                                                    "minWidth": 0,
+                                                    "padding": 64,
+                                                    "paddingBottom": 32,
+                                                    "paddingTop": 32,
+                                                    "position": "relative",
+                                                    "zIndex": 0,
+                                                  }
+                                                }
+                                              >
+                                                Content
+                                              </div>
+                                            </StyleComponent>
+                                          </View>
+                                        </div>
+                                      </StyleComponent>
+                                    </View>
+                                  </MediaLayoutInternal>
+                                </MediaLayout>
+                              </ModalContent>
+                              <ModalFooter>
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "_definition": Object {
+                                          "alignItems": "center",
+                                          "borderTopColor": "rgba(33,36,44,0.16)",
+                                          "borderTopStyle": "solid",
+                                          "borderTopWidth": 1,
+                                          "boxSizing": "border-box",
+                                          "display": "flex",
+                                          "flex": "0 0 auto",
+                                          "flexDirection": "row",
+                                          "justifyContent": "flex-end",
+                                          "minHeight": 64,
+                                          "paddingBottom": 8,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "paddingTop": 8,
+                                        },
+                                        "_len": 299,
+                                        "_name": "footer_b45ce1",
+                                      },
+                                      undefined,
+                                    ]
                                   }
-                                }
-                              >
-                                Footer
-                              </div>
-                            </StyleComponent>
-                          </View>
-                        </ModalFooter>
-                      </div>
-                    </StyleComponent>
-                  </View>
-                </MediaLayout>
-              </ModalPanel>
-            </div>
-          </StyleComponent>
-        </View>
-      </MediaLayout>
-    </ModalDialog>
+                                >
+                                  <StyleComponent
+                                    style={
+                                      Array [
+                                        Object {
+                                          "_definition": Object {
+                                            "alignItems": "center",
+                                            "borderTopColor": "rgba(33,36,44,0.16)",
+                                            "borderTopStyle": "solid",
+                                            "borderTopWidth": 1,
+                                            "boxSizing": "border-box",
+                                            "display": "flex",
+                                            "flex": "0 0 auto",
+                                            "flexDirection": "row",
+                                            "justifyContent": "flex-end",
+                                            "minHeight": 64,
+                                            "paddingBottom": 8,
+                                            "paddingLeft": 16,
+                                            "paddingRight": 16,
+                                            "paddingTop": 8,
+                                          },
+                                          "_len": 299,
+                                          "_name": "footer_b45ce1",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <div
+                                      className=""
+                                      style={
+                                        Object {
+                                          "alignItems": "center",
+                                          "borderStyle": "solid",
+                                          "borderTopColor": "rgba(33,36,44,0.16)",
+                                          "borderTopStyle": "solid",
+                                          "borderTopWidth": 1,
+                                          "borderWidth": 0,
+                                          "boxSizing": "border-box",
+                                          "display": "flex",
+                                          "flex": "0 0 auto",
+                                          "flexDirection": "row",
+                                          "justifyContent": "flex-end",
+                                          "margin": 0,
+                                          "minHeight": 64,
+                                          "minWidth": 0,
+                                          "padding": 0,
+                                          "paddingBottom": 8,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "paddingTop": 8,
+                                          "position": "relative",
+                                          "zIndex": 0,
+                                        }
+                                      }
+                                    >
+                                      Footer
+                                    </div>
+                                  </StyleComponent>
+                                </View>
+                              </ModalFooter>
+                            </div>
+                          </StyleComponent>
+                        </View>
+                      </MediaLayoutInternal>
+                    </MediaLayout>
+                  </ModalPanel>
+                </div>
+              </StyleComponent>
+            </View>
+          </MediaLayoutInternal>
+        </MediaLayout>
+      </ModalDialog>
+    </MediaLayoutInternal>
   </MediaLayout>
 </StandardModal>
 `;
@@ -1675,58 +2005,92 @@ exports[`StandardModal mobile should match snapshot 1`] = `
       }
     }
   >
-    <ModalDialog
-      style={
-        Array [
-          undefined,
-          Array [
-            undefined,
-            undefined,
-          ],
-          false,
-          false,
-        ]
+    <MediaLayoutInternal
+      mediaSpec={
+        Object {
+          "large": Object {
+            "gutterWidth": 32,
+            "marginWidth": 24,
+            "maxWidth": 1168,
+            "query": "(min-width: 1024px)",
+            "totalColumns": 12,
+          },
+          "medium": Object {
+            "gutterWidth": 32,
+            "marginWidth": 24,
+            "query": "(min-width: 768px) and (max-width: 1023px)",
+            "totalColumns": 8,
+          },
+          "small": Object {
+            "gutterWidth": 16,
+            "marginWidth": 16,
+            "query": "(max-width: 767px)",
+            "totalColumns": 4,
+          },
+        }
+      }
+      ssrSize="small"
+      styleSheets={
+        Object {
+          "all": Object {
+            "preview": Object {
+              "_definition": Object {
+                "flex": "1 0 auto",
+                "maxWidth": 392,
+              },
+              "_len": 34,
+              "_name": "preview_11k7ba4",
+            },
+            "previewContent": Object {
+              "_definition": Object {
+                "padding": "0 64px 0 0",
+              },
+              "_len": 24,
+              "_name": "previewContent_q080uq",
+            },
+          },
+          "mdOrLarger": Object {
+            "wrapper": Object {
+              "_definition": Object {
+                "height": "81.25%",
+                "maxHeight": 624,
+                "maxWidth": 960,
+                "width": "93.75%",
+              },
+              "_len": 67,
+              "_name": "wrapper_1xtsnd2",
+            },
+          },
+          "small": Object {
+            "preview": Object {
+              "_definition": Object {
+                "display": "none",
+              },
+              "_len": 18,
+              "_name": "preview_1u9fru1",
+            },
+          },
+        }
       }
     >
-      <MediaLayout
-        styleSheets={
-          Object {
-            "all": Object {
-              "wrapper": Object {
-                "_definition": Object {
-                  "alignItems": "stretch",
-                  "borderRadius": 4,
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "overflow": "hidden",
-                  "position": "relative",
-                },
-                "_len": 122,
-                "_name": "wrapper_5423lx",
-              },
-            },
-            "small": Object {
-              "wrapper": Object {
-                "_definition": Object {
-                  "borderRadius": 0,
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                },
-                "_len": 74,
-                "_name": "wrapper_1xnhgba",
-              },
-            },
-          }
+      <ModalDialog
+        style={
+          Array [
+            undefined,
+            Array [
+              undefined,
+              undefined,
+            ],
+            false,
+            false,
+          ]
         }
       >
-        <View
-          aria-labelledby="wb-modal-title"
-          role="dialog"
-          style={
-            Array [
-              Array [
-                Object {
+        <MediaLayout
+          styleSheets={
+            Object {
+              "all": Object {
+                "wrapper": Object {
                   "_definition": Object {
                     "alignItems": "stretch",
                     "borderRadius": 4,
@@ -1738,32 +2102,44 @@ exports[`StandardModal mobile should match snapshot 1`] = `
                   "_len": 122,
                   "_name": "wrapper_5423lx",
                 },
-                false,
-                false,
-                Array [
-                  undefined,
-                  undefined,
-                ],
-              ],
-              Array [
-                undefined,
-                Array [
-                  undefined,
-                  undefined,
-                ],
-                false,
-                false,
-              ],
-            ]
+              },
+              "small": Object {
+                "wrapper": Object {
+                  "_definition": Object {
+                    "borderRadius": 0,
+                    "flexDirection": "column",
+                    "height": "100%",
+                    "width": "100%",
+                  },
+                  "_len": 74,
+                  "_name": "wrapper_1xnhgba",
+                },
+              },
+            }
           }
         >
-          <StyleComponent
-            aria-labelledby="wb-modal-title"
-            role="dialog"
-            style={
-              Array [
-                Array [
-                  Object {
+          <MediaLayoutInternal
+            mediaSpec={
+              Object {
+                "large": Object {
+                  "gutterWidth": 32,
+                  "marginWidth": 48,
+                  "query": "(min-width: 768px)",
+                  "totalColumns": 12,
+                },
+                "small": Object {
+                  "gutterWidth": 16,
+                  "marginWidth": 16,
+                  "query": "(max-width: 767px)",
+                  "totalColumns": 4,
+                },
+              }
+            }
+            ssrSize="large"
+            styleSheets={
+              Object {
+                "all": Object {
+                  "wrapper": Object {
                     "_definition": Object {
                       "alignItems": "stretch",
                       "borderRadius": 4,
@@ -1775,217 +2151,219 @@ exports[`StandardModal mobile should match snapshot 1`] = `
                     "_len": 122,
                     "_name": "wrapper_5423lx",
                   },
-                  false,
-                  false,
-                  Array [
-                    undefined,
-                    undefined,
-                  ],
-                ],
-                Array [
-                  undefined,
-                  Array [
-                    undefined,
-                    undefined,
-                  ],
-                  false,
-                  false,
-                ],
-              ]
+                },
+                "small": Object {
+                  "wrapper": Object {
+                    "_definition": Object {
+                      "borderRadius": 0,
+                      "flexDirection": "column",
+                      "height": "100%",
+                      "width": "100%",
+                    },
+                    "_len": 74,
+                    "_name": "wrapper_1xnhgba",
+                  },
+                },
+              }
             }
           >
-            <div
+            <View
               aria-labelledby="wb-modal-title"
-              className=""
               role="dialog"
               style={
-                Object {
-                  "alignItems": "stretch",
-                  "borderRadius": 4,
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "boxSizing": "border-box",
-                  "display": "flex",
-                  "flexDirection": "row",
-                  "margin": 0,
-                  "minHeight": 0,
-                  "minWidth": 0,
-                  "overflow": "hidden",
-                  "padding": 0,
-                  "position": "relative",
-                  "zIndex": 0,
-                }
+                Array [
+                  Array [
+                    Object {
+                      "_definition": Object {
+                        "alignItems": "stretch",
+                        "borderRadius": 4,
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "overflow": "hidden",
+                        "position": "relative",
+                      },
+                      "_len": 122,
+                      "_name": "wrapper_5423lx",
+                    },
+                    false,
+                    false,
+                    Array [
+                      undefined,
+                      undefined,
+                    ],
+                  ],
+                  Array [
+                    undefined,
+                    Array [
+                      undefined,
+                      undefined,
+                    ],
+                    false,
+                    false,
+                  ],
+                ]
               }
             >
-              <ModalPanel
-                color="light"
-                content="Content"
-                footer="Footer"
-                scrollOverflow={true}
-                showCloseButton={false}
-                titleBar={
-                  <Toolbar
-                    color="light"
-                    leftContent={
-                      <MediaLayout
-                        styleSheets={
-                          Object {
-                            "all": Object {
-                              "preview": Object {
-                                "_definition": Object {
-                                  "flex": "1 0 auto",
-                                  "maxWidth": 392,
-                                },
-                                "_len": 34,
-                                "_name": "preview_11k7ba4",
-                              },
-                              "previewContent": Object {
-                                "_definition": Object {
-                                  "padding": "0 64px 0 0",
-                                },
-                                "_len": 24,
-                                "_name": "previewContent_q080uq",
-                              },
-                            },
-                            "mdOrLarger": Object {
-                              "wrapper": Object {
-                                "_definition": Object {
-                                  "height": "81.25%",
-                                  "maxHeight": 624,
-                                  "maxWidth": 960,
-                                  "width": "93.75%",
-                                },
-                                "_len": 67,
-                                "_name": "wrapper_1xtsnd2",
-                              },
-                            },
-                            "small": Object {
-                              "preview": Object {
-                                "_definition": Object {
-                                  "display": "none",
-                                },
-                                "_len": 18,
-                                "_name": "preview_1u9fru1",
-                              },
-                            },
-                          }
-                        }
-                      >
-                        [Function]
-                      </MediaLayout>
-                    }
-                    rightContent={null}
-                    size="medium"
-                    title="Title"
-                  />
+              <StyleComponent
+                aria-labelledby="wb-modal-title"
+                role="dialog"
+                style={
+                  Array [
+                    Array [
+                      Object {
+                        "_definition": Object {
+                          "alignItems": "stretch",
+                          "borderRadius": 4,
+                          "display": "flex",
+                          "flexDirection": "row",
+                          "overflow": "hidden",
+                          "position": "relative",
+                        },
+                        "_len": 122,
+                        "_name": "wrapper_5423lx",
+                      },
+                      false,
+                      false,
+                      Array [
+                        undefined,
+                        undefined,
+                      ],
+                    ],
+                    Array [
+                      undefined,
+                      Array [
+                        undefined,
+                        undefined,
+                      ],
+                      false,
+                      false,
+                    ],
+                  ]
                 }
               >
-                <MediaLayout
-                  styleSheets={
+                <div
+                  aria-labelledby="wb-modal-title"
+                  className=""
+                  role="dialog"
+                  style={
                     Object {
-                      "all": Object {
-                        "closeButton": Object {
-                          "_definition": Object {
-                            "left": 16,
-                            "position": "absolute",
-                            "top": 16,
-                            "zIndex": 1,
-                          },
-                          "_len": 53,
-                          "_name": "closeButton_zjmm3o",
-                        },
-                        "dark": Object {
-                          "_definition": Object {
-                            "background": "#0a2a66",
-                            "color": "#ffffff",
-                          },
-                          "_len": 42,
-                          "_name": "dark_10k9z0e",
-                        },
-                        "hasFooter": Object {
-                          "_definition": Object {
-                            "paddingBottom": 32,
-                          },
-                          "_len": 20,
-                          "_name": "hasFooter_1pn52au",
-                        },
-                        "hasTitleBar": Object {
-                          "_definition": Object {
-                            "paddingTop": 32,
-                          },
-                          "_len": 17,
-                          "_name": "hasTitleBar_15lzjb6",
-                        },
-                        "wrapper": Object {
-                          "_definition": Object {
-                            "background": "white",
-                            "boxSizing": "border-box",
-                            "display": "flex",
-                            "flex": "1 1 auto",
-                            "flexDirection": "column",
-                            "height": "100%",
-                            "position": "relative",
-                            "width": "100%",
-                          },
-                          "_len": 160,
-                          "_name": "wrapper_161dlb6",
-                        },
-                      },
-                      "small": Object {
-                        "closeButton": Object {
-                          "_definition": Object {
-                            "left": 16,
-                            "top": 16,
-                          },
-                          "_len": 20,
-                          "_name": "closeButton_1uu2ylb",
-                        },
-                        "withCloseButton": Object {
-                          "_definition": Object {
-                            "paddingTop": 64,
-                          },
-                          "_len": 17,
-                          "_name": "withCloseButton_1qowqp",
-                        },
-                      },
+                      "alignItems": "stretch",
+                      "borderRadius": 4,
+                      "borderStyle": "solid",
+                      "borderWidth": 0,
+                      "boxSizing": "border-box",
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "margin": 0,
+                      "minHeight": 0,
+                      "minWidth": 0,
+                      "overflow": "hidden",
+                      "padding": 0,
+                      "position": "relative",
+                      "zIndex": 0,
                     }
                   }
                 >
-                  <View
-                    style={
-                      Array [
-                        Array [
-                          Object {
-                            "_definition": Object {
-                              "background": "white",
-                              "boxSizing": "border-box",
-                              "display": "flex",
-                              "flex": "1 1 auto",
-                              "flexDirection": "column",
-                              "height": "100%",
-                              "position": "relative",
-                              "width": "100%",
-                            },
-                            "_len": 160,
-                            "_name": "wrapper_161dlb6",
-                          },
-                          false,
-                          false,
-                          Array [
-                            undefined,
-                            undefined,
-                          ],
-                        ],
-                        false,
-                        undefined,
-                      ]
+                  <ModalPanel
+                    color="light"
+                    content="Content"
+                    footer="Footer"
+                    scrollOverflow={true}
+                    showCloseButton={false}
+                    titleBar={
+                      <Toolbar
+                        color="light"
+                        leftContent={
+                          <MediaLayout
+                            styleSheets={
+                              Object {
+                                "all": Object {
+                                  "preview": Object {
+                                    "_definition": Object {
+                                      "flex": "1 0 auto",
+                                      "maxWidth": 392,
+                                    },
+                                    "_len": 34,
+                                    "_name": "preview_11k7ba4",
+                                  },
+                                  "previewContent": Object {
+                                    "_definition": Object {
+                                      "padding": "0 64px 0 0",
+                                    },
+                                    "_len": 24,
+                                    "_name": "previewContent_q080uq",
+                                  },
+                                },
+                                "mdOrLarger": Object {
+                                  "wrapper": Object {
+                                    "_definition": Object {
+                                      "height": "81.25%",
+                                      "maxHeight": 624,
+                                      "maxWidth": 960,
+                                      "width": "93.75%",
+                                    },
+                                    "_len": 67,
+                                    "_name": "wrapper_1xtsnd2",
+                                  },
+                                },
+                                "small": Object {
+                                  "preview": Object {
+                                    "_definition": Object {
+                                      "display": "none",
+                                    },
+                                    "_len": 18,
+                                    "_name": "preview_1u9fru1",
+                                  },
+                                },
+                              }
+                            }
+                          >
+                            [Function]
+                          </MediaLayout>
+                        }
+                        rightContent={null}
+                        size="medium"
+                        title="Title"
+                      />
                     }
                   >
-                    <StyleComponent
-                      style={
-                        Array [
-                          Array [
-                            Object {
+                    <MediaLayout
+                      styleSheets={
+                        Object {
+                          "all": Object {
+                            "closeButton": Object {
+                              "_definition": Object {
+                                "left": 16,
+                                "position": "absolute",
+                                "top": 16,
+                                "zIndex": 1,
+                              },
+                              "_len": 53,
+                              "_name": "closeButton_zjmm3o",
+                            },
+                            "dark": Object {
+                              "_definition": Object {
+                                "background": "#0a2a66",
+                                "color": "#ffffff",
+                              },
+                              "_len": 42,
+                              "_name": "dark_10k9z0e",
+                            },
+                            "hasFooter": Object {
+                              "_definition": Object {
+                                "paddingBottom": 32,
+                              },
+                              "_len": 20,
+                              "_name": "hasFooter_1pn52au",
+                            },
+                            "hasTitleBar": Object {
+                              "_definition": Object {
+                                "paddingTop": 32,
+                              },
+                              "_len": 17,
+                              "_name": "hasTitleBar_15lzjb6",
+                            },
+                            "wrapper": Object {
                               "_definition": Object {
                                 "background": "white",
                                 "boxSizing": "border-box",
@@ -1999,827 +2377,132 @@ exports[`StandardModal mobile should match snapshot 1`] = `
                               "_len": 160,
                               "_name": "wrapper_161dlb6",
                             },
-                            false,
-                            false,
-                            Array [
-                              undefined,
-                              undefined,
-                            ],
-                          ],
-                          false,
-                          undefined,
-                        ]
+                          },
+                          "small": Object {
+                            "closeButton": Object {
+                              "_definition": Object {
+                                "left": 16,
+                                "top": 16,
+                              },
+                              "_len": 20,
+                              "_name": "closeButton_1uu2ylb",
+                            },
+                            "withCloseButton": Object {
+                              "_definition": Object {
+                                "paddingTop": 64,
+                              },
+                              "_len": 17,
+                              "_name": "withCloseButton_1qowqp",
+                            },
+                          },
+                        }
                       }
                     >
-                      <div
-                        className=""
-                        style={
+                      <MediaLayoutInternal
+                        mediaSpec={
                           Object {
-                            "alignItems": "stretch",
-                            "background": "white",
-                            "borderStyle": "solid",
-                            "borderWidth": 0,
-                            "boxSizing": "border-box",
-                            "display": "flex",
-                            "flex": "1 1 auto",
-                            "flexDirection": "column",
-                            "height": "100%",
-                            "margin": 0,
-                            "minHeight": 0,
-                            "minWidth": 0,
-                            "padding": 0,
-                            "position": "relative",
-                            "width": "100%",
-                            "zIndex": 0,
+                            "large": Object {
+                              "gutterWidth": 32,
+                              "marginWidth": 48,
+                              "query": "(min-width: 768px)",
+                              "totalColumns": 12,
+                            },
+                            "small": Object {
+                              "gutterWidth": 16,
+                              "marginWidth": 16,
+                              "query": "(max-width: 767px)",
+                              "totalColumns": 4,
+                            },
+                          }
+                        }
+                        ssrSize="large"
+                        styleSheets={
+                          Object {
+                            "all": Object {
+                              "closeButton": Object {
+                                "_definition": Object {
+                                  "left": 16,
+                                  "position": "absolute",
+                                  "top": 16,
+                                  "zIndex": 1,
+                                },
+                                "_len": 53,
+                                "_name": "closeButton_zjmm3o",
+                              },
+                              "dark": Object {
+                                "_definition": Object {
+                                  "background": "#0a2a66",
+                                  "color": "#ffffff",
+                                },
+                                "_len": 42,
+                                "_name": "dark_10k9z0e",
+                              },
+                              "hasFooter": Object {
+                                "_definition": Object {
+                                  "paddingBottom": 32,
+                                },
+                                "_len": 20,
+                                "_name": "hasFooter_1pn52au",
+                              },
+                              "hasTitleBar": Object {
+                                "_definition": Object {
+                                  "paddingTop": 32,
+                                },
+                                "_len": 17,
+                                "_name": "hasTitleBar_15lzjb6",
+                              },
+                              "wrapper": Object {
+                                "_definition": Object {
+                                  "background": "white",
+                                  "boxSizing": "border-box",
+                                  "display": "flex",
+                                  "flex": "1 1 auto",
+                                  "flexDirection": "column",
+                                  "height": "100%",
+                                  "position": "relative",
+                                  "width": "100%",
+                                },
+                                "_len": 160,
+                                "_name": "wrapper_161dlb6",
+                              },
+                            },
+                            "small": Object {
+                              "closeButton": Object {
+                                "_definition": Object {
+                                  "left": 16,
+                                  "top": 16,
+                                },
+                                "_len": 20,
+                                "_name": "closeButton_1uu2ylb",
+                              },
+                              "withCloseButton": Object {
+                                "_definition": Object {
+                                  "paddingTop": 64,
+                                },
+                                "_len": 17,
+                                "_name": "withCloseButton_1qowqp",
+                              },
+                            },
                           }
                         }
                       >
-                        <Toolbar
-                          color="light"
-                          leftContent={
-                            <MediaLayout
-                              styleSheets={
-                                Object {
-                                  "all": Object {
-                                    "preview": Object {
-                                      "_definition": Object {
-                                        "flex": "1 0 auto",
-                                        "maxWidth": 392,
-                                      },
-                                      "_len": 34,
-                                      "_name": "preview_11k7ba4",
-                                    },
-                                    "previewContent": Object {
-                                      "_definition": Object {
-                                        "padding": "0 64px 0 0",
-                                      },
-                                      "_len": 24,
-                                      "_name": "previewContent_q080uq",
-                                    },
-                                  },
-                                  "mdOrLarger": Object {
-                                    "wrapper": Object {
-                                      "_definition": Object {
-                                        "height": "81.25%",
-                                        "maxHeight": 624,
-                                        "maxWidth": 960,
-                                        "width": "93.75%",
-                                      },
-                                      "_len": 67,
-                                      "_name": "wrapper_1xtsnd2",
-                                    },
-                                  },
-                                  "small": Object {
-                                    "preview": Object {
-                                      "_definition": Object {
-                                        "display": "none",
-                                      },
-                                      "_len": 18,
-                                      "_name": "preview_1u9fru1",
-                                    },
-                                  },
-                                }
-                              }
-                            >
-                              [Function]
-                            </MediaLayout>
-                          }
-                          rightContent={null}
-                          size="medium"
-                          title="Title"
-                        >
-                          <View
-                            style={
-                              Array [
-                                Object {
-                                  "_definition": Object {
-                                    "border": "1px solid rgba(33, 36, 44, 0.16)",
-                                    "display": "flex",
-                                    "flexDirection": "row",
-                                    "minHeight": 66,
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "position": "relative",
-                                    "width": "100%",
-                                  },
-                                  "_len": 171,
-                                  "_name": "container_hnrag4",
-                                },
-                                false,
-                                false,
-                              ]
-                            }
-                          >
-                            <StyleComponent
-                              style={
-                                Array [
-                                  Object {
-                                    "_definition": Object {
-                                      "border": "1px solid rgba(33, 36, 44, 0.16)",
-                                      "display": "flex",
-                                      "flexDirection": "row",
-                                      "minHeight": 66,
-                                      "paddingLeft": 16,
-                                      "paddingRight": 16,
-                                      "position": "relative",
-                                      "width": "100%",
-                                    },
-                                    "_len": 171,
-                                    "_name": "container_hnrag4",
-                                  },
-                                  false,
-                                  false,
-                                ]
-                              }
-                            >
-                              <div
-                                className=""
-                                style={
-                                  Object {
-                                    "alignItems": "stretch",
-                                    "border": "1px solid rgba(33, 36, 44, 0.16)",
-                                    "borderStyle": "solid",
-                                    "borderWidth": 0,
-                                    "boxSizing": "border-box",
-                                    "display": "flex",
-                                    "flexDirection": "row",
-                                    "margin": 0,
-                                    "minHeight": 66,
-                                    "minWidth": 0,
-                                    "padding": 0,
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "position": "relative",
-                                    "width": "100%",
-                                    "zIndex": 0,
-                                  }
-                                }
-                              >
-                                <View
-                                  style={
-                                    Object {
-                                      "_definition": Object {
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                      },
-                                      "_len": 36,
-                                      "_name": "column_sj6pid",
-                                    }
-                                  }
-                                >
-                                  <StyleComponent
-                                    style={
-                                      Object {
-                                        "_definition": Object {
-                                          "flex": 1,
-                                          "justifyContent": "center",
-                                        },
-                                        "_len": 36,
-                                        "_name": "column_sj6pid",
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className=""
-                                      style={
-                                        Object {
-                                          "alignItems": "stretch",
-                                          "borderStyle": "solid",
-                                          "borderWidth": 0,
-                                          "boxSizing": "border-box",
-                                          "display": "flex",
-                                          "flex": 1,
-                                          "flexDirection": "column",
-                                          "justifyContent": "center",
-                                          "margin": 0,
-                                          "minHeight": 0,
-                                          "minWidth": 0,
-                                          "padding": 0,
-                                          "position": "relative",
-                                          "zIndex": 0,
-                                        }
-                                      }
-                                    >
-                                      <View
-                                        style={
-                                          Object {
-                                            "_definition": Object {
-                                              "alignItems": "center",
-                                              "flexDirection": "row",
-                                              "justifyContent": "flex-start",
-                                            },
-                                            "_len": 75,
-                                            "_name": "leftColumn_bc5h0c",
-                                          }
-                                        }
-                                      >
-                                        <StyleComponent
-                                          style={
-                                            Object {
-                                              "_definition": Object {
-                                                "alignItems": "center",
-                                                "flexDirection": "row",
-                                                "justifyContent": "flex-start",
-                                              },
-                                              "_len": 75,
-                                              "_name": "leftColumn_bc5h0c",
-                                            }
-                                          }
-                                        >
-                                          <div
-                                            className=""
-                                            style={
-                                              Object {
-                                                "alignItems": "center",
-                                                "borderStyle": "solid",
-                                                "borderWidth": 0,
-                                                "boxSizing": "border-box",
-                                                "display": "flex",
-                                                "flexDirection": "row",
-                                                "justifyContent": "flex-start",
-                                                "margin": 0,
-                                                "minHeight": 0,
-                                                "minWidth": 0,
-                                                "padding": 0,
-                                                "position": "relative",
-                                                "zIndex": 0,
-                                              }
-                                            }
-                                          >
-                                            <MediaLayout
-                                              styleSheets={
-                                                Object {
-                                                  "all": Object {
-                                                    "preview": Object {
-                                                      "_definition": Object {
-                                                        "flex": "1 0 auto",
-                                                        "maxWidth": 392,
-                                                      },
-                                                      "_len": 34,
-                                                      "_name": "preview_11k7ba4",
-                                                    },
-                                                    "previewContent": Object {
-                                                      "_definition": Object {
-                                                        "padding": "0 64px 0 0",
-                                                      },
-                                                      "_len": 24,
-                                                      "_name": "previewContent_q080uq",
-                                                    },
-                                                  },
-                                                  "mdOrLarger": Object {
-                                                    "wrapper": Object {
-                                                      "_definition": Object {
-                                                        "height": "81.25%",
-                                                        "maxHeight": 624,
-                                                        "maxWidth": 960,
-                                                        "width": "93.75%",
-                                                      },
-                                                      "_len": 67,
-                                                      "_name": "wrapper_1xtsnd2",
-                                                    },
-                                                  },
-                                                  "small": Object {
-                                                    "preview": Object {
-                                                      "_definition": Object {
-                                                        "display": "none",
-                                                      },
-                                                      "_len": 18,
-                                                      "_name": "preview_1u9fru1",
-                                                    },
-                                                  },
-                                                }
-                                              }
-                                            >
-                                              <CloseButton
-                                                light={false}
-                                              >
-                                                <IconButton
-                                                  aria-label="Close modal"
-                                                  color="default"
-                                                  disabled={false}
-                                                  icon={
-                                                    Object {
-                                                      "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
-                                                      "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
-                                                    }
-                                                  }
-                                                  kind="tertiary"
-                                                  light={false}
-                                                >
-                                                  <ClickableBehavior
-                                                    disabled={false}
-                                                    role="button"
-                                                  >
-                                                    <IconButtonCore
-                                                      aria-label="Close modal"
-                                                      color="default"
-                                                      disabled={false}
-                                                      focused={false}
-                                                      hovered={false}
-                                                      icon={
-                                                        Object {
-                                                          "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
-                                                          "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
-                                                        }
-                                                      }
-                                                      kind="tertiary"
-                                                      light={false}
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onDragStart={[Function]}
-                                                      onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseEnter={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchCancel={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchStart={[Function]}
-                                                      pressed={false}
-                                                      tabIndex={0}
-                                                    >
-                                                      <StyleComponent
-                                                        aria-label="Close modal"
-                                                        disabled={false}
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragStart={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseEnter={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchCancel={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        style={
-                                                          Array [
-                                                            Array [
-                                                              Object {
-                                                                "_definition": Object {
-                                                                  "alignItems": "center",
-                                                                  "background": "none",
-                                                                  "border": "none",
-                                                                  "boxSizing": "border-box",
-                                                                  "cursor": "pointer",
-                                                                  "display": "inline-flex",
-                                                                  "height": 40,
-                                                                  "justifyContent": "center",
-                                                                  "margin": -8,
-                                                                  "outline": "none",
-                                                                  "padding": 0,
-                                                                  "position": "relative",
-                                                                  "textDecoration": "none",
-                                                                  "touchAction": "manipulation",
-                                                                  "width": 40,
-                                                                },
-                                                                "_len": 292,
-                                                                "_name": "shared_smh163",
-                                                              },
-                                                              false,
-                                                              Object {
-                                                                "_definition": Object {
-                                                                  "color": "rgba(33,36,44,0.64)",
-                                                                },
-                                                                "_len": 31,
-                                                                "_name": "default_7sq9ra",
-                                                              },
-                                                              false,
-                                                              false,
-                                                            ],
-                                                            undefined,
-                                                          ]
-                                                        }
-                                                        tabIndex={0}
-                                                        type="button"
-                                                      >
-                                                        <button
-                                                          aria-label="Close modal"
-                                                          className=""
-                                                          disabled={false}
-                                                          onBlur={[Function]}
-                                                          onClick={[Function]}
-                                                          onDragStart={[Function]}
-                                                          onFocus={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          onMouseDown={[Function]}
-                                                          onMouseEnter={[Function]}
-                                                          onMouseLeave={[Function]}
-                                                          onMouseUp={[Function]}
-                                                          onTouchCancel={[Function]}
-                                                          onTouchEnd={[Function]}
-                                                          onTouchStart={[Function]}
-                                                          style={
-                                                            Object {
-                                                              "::MozFocusInner": Object {
-                                                                "border": 0,
-                                                              },
-                                                              "alignItems": "center",
-                                                              "background": "none",
-                                                              "border": "none",
-                                                              "boxSizing": "border-box",
-                                                              "color": "rgba(33,36,44,0.64)",
-                                                              "cursor": "pointer",
-                                                              "display": "inline-flex",
-                                                              "height": 40,
-                                                              "justifyContent": "center",
-                                                              "margin": -8,
-                                                              "outline": "none",
-                                                              "padding": 0,
-                                                              "position": "relative",
-                                                              "textDecoration": "none",
-                                                              "touchAction": "manipulation",
-                                                              "width": 40,
-                                                            }
-                                                          }
-                                                          tabIndex={0}
-                                                          type="button"
-                                                        >
-                                                          <Icon
-                                                            color="currentColor"
-                                                            icon={
-                                                              Object {
-                                                                "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
-                                                                "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
-                                                              }
-                                                            }
-                                                            size="medium"
-                                                          >
-                                                            <StyleComponent
-                                                              height={24}
-                                                              style={
-                                                                Array [
-                                                                  Object {
-                                                                    "_definition": Object {
-                                                                      "display": "inline-block",
-                                                                      "flexGrow": 0,
-                                                                      "flexShrink": 0,
-                                                                      "verticalAlign": "text-bottom",
-                                                                    },
-                                                                    "_len": 84,
-                                                                    "_name": "svg_aeiopc",
-                                                                  },
-                                                                  undefined,
-                                                                ]
-                                                              }
-                                                              viewBox="0 0 24 24"
-                                                              width={24}
-                                                            >
-                                                              <svg
-                                                                className=""
-                                                                height={24}
-                                                                style={
-                                                                  Object {
-                                                                    "display": "inline-block",
-                                                                    "flexGrow": 0,
-                                                                    "flexShrink": 0,
-                                                                    "verticalAlign": "text-bottom",
-                                                                  }
-                                                                }
-                                                                viewBox="0 0 24 24"
-                                                                width={24}
-                                                              >
-                                                                <path
-                                                                  d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
-                                                                  fill="currentColor"
-                                                                />
-                                                              </svg>
-                                                            </StyleComponent>
-                                                          </Icon>
-                                                        </button>
-                                                      </StyleComponent>
-                                                    </IconButtonCore>
-                                                  </ClickableBehavior>
-                                                </IconButton>
-                                              </CloseButton>
-                                            </MediaLayout>
-                                          </div>
-                                        </StyleComponent>
-                                      </View>
-                                    </div>
-                                  </StyleComponent>
-                                </View>
-                                <View
-                                  style={
-                                    Array [
-                                      Object {
-                                        "_definition": Object {
-                                          "flex": 1,
-                                          "justifyContent": "center",
-                                        },
-                                        "_len": 36,
-                                        "_name": "column_sj6pid",
-                                      },
-                                      Object {
-                                        "_definition": Object {
-                                          "flexBasis": "50%",
-                                        },
-                                        "_len": 19,
-                                        "_name": "wideColumn_cczrfo",
-                                      },
-                                    ]
-                                  }
-                                >
-                                  <StyleComponent
-                                    style={
-                                      Array [
-                                        Object {
-                                          "_definition": Object {
-                                            "flex": 1,
-                                            "justifyContent": "center",
-                                          },
-                                          "_len": 36,
-                                          "_name": "column_sj6pid",
-                                        },
-                                        Object {
-                                          "_definition": Object {
-                                            "flexBasis": "50%",
-                                          },
-                                          "_len": 19,
-                                          "_name": "wideColumn_cczrfo",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                    <div
-                                      className=""
-                                      style={
-                                        Object {
-                                          "alignItems": "stretch",
-                                          "borderStyle": "solid",
-                                          "borderWidth": 0,
-                                          "boxSizing": "border-box",
-                                          "display": "flex",
-                                          "flex": 1,
-                                          "flexBasis": "50%",
-                                          "flexDirection": "column",
-                                          "justifyContent": "center",
-                                          "margin": 0,
-                                          "minHeight": 0,
-                                          "minWidth": 0,
-                                          "padding": 0,
-                                          "position": "relative",
-                                          "zIndex": 0,
-                                        }
-                                      }
-                                    >
-                                      <View
-                                        style={
-                                          Array [
-                                            Object {
-                                              "_definition": Object {
-                                                "padding": 12,
-                                              },
-                                              "_len": 14,
-                                              "_name": "titles_47hinf",
-                                            },
-                                            Object {
-                                              "_definition": Object {
-                                                "justifyContent": "center",
-                                              },
-                                              "_len": 27,
-                                              "_name": "verticalAlign_agrn11",
-                                            },
-                                            Object {
-                                              "_definition": Object {
-                                                "textAlign": "center",
-                                              },
-                                              "_len": 22,
-                                              "_name": "center_12to336",
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <StyleComponent
-                                          style={
-                                            Array [
-                                              Object {
-                                                "_definition": Object {
-                                                  "padding": 12,
-                                                },
-                                                "_len": 14,
-                                                "_name": "titles_47hinf",
-                                              },
-                                              Object {
-                                                "_definition": Object {
-                                                  "justifyContent": "center",
-                                                },
-                                                "_len": 27,
-                                                "_name": "verticalAlign_agrn11",
-                                              },
-                                              Object {
-                                                "_definition": Object {
-                                                  "textAlign": "center",
-                                                },
-                                                "_len": 22,
-                                                "_name": "center_12to336",
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <div
-                                            className=""
-                                            style={
-                                              Object {
-                                                "alignItems": "stretch",
-                                                "borderStyle": "solid",
-                                                "borderWidth": 0,
-                                                "boxSizing": "border-box",
-                                                "display": "flex",
-                                                "flexDirection": "column",
-                                                "justifyContent": "center",
-                                                "margin": 0,
-                                                "minHeight": 0,
-                                                "minWidth": 0,
-                                                "padding": 12,
-                                                "position": "relative",
-                                                "textAlign": "center",
-                                                "zIndex": 0,
-                                              }
-                                            }
-                                          >
-                                            <HeadingSmall
-                                              id="wb-toolbar-title"
-                                              tag="h4"
-                                            >
-                                              <Text
-                                                id="wb-toolbar-title"
-                                                style={
-                                                  Array [
-                                                    Object {
-                                                      "_definition": Object {
-                                                        "display": "block",
-                                                        "fontFamily": "Lato, sans-serif",
-                                                        "fontSize": 20,
-                                                        "fontWeight": 700,
-                                                        "lineHeight": "24px",
-                                                      },
-                                                      "_len": 102,
-                                                      "_name": "HeadingSmall_1c07c7n",
-                                                    },
-                                                    undefined,
-                                                  ]
-                                                }
-                                                tag="h4"
-                                              >
-                                                <h4
-                                                  className=""
-                                                  id="wb-toolbar-title"
-                                                  style={
-                                                    Object {
-                                                      "MozOsxFontSmoothing": "grayscale",
-                                                      "WebkitFontSmoothing": "antialiased",
-                                                      "display": "block",
-                                                      "fontFamily": "Lato, sans-serif",
-                                                      "fontSize": 20,
-                                                      "fontWeight": 700,
-                                                      "lineHeight": "24px",
-                                                      "marginBottom": 0,
-                                                      "marginTop": 0,
-                                                    }
-                                                  }
-                                                >
-                                                  Title
-                                                </h4>
-                                              </Text>
-                                            </HeadingSmall>
-                                          </div>
-                                        </StyleComponent>
-                                      </View>
-                                    </div>
-                                  </StyleComponent>
-                                </View>
-                                <View
-                                  style={
-                                    Object {
-                                      "_definition": Object {
-                                        "flex": 1,
-                                        "justifyContent": "center",
-                                      },
-                                      "_len": 36,
-                                      "_name": "column_sj6pid",
-                                    }
-                                  }
-                                >
-                                  <StyleComponent
-                                    style={
-                                      Object {
-                                        "_definition": Object {
-                                          "flex": 1,
-                                          "justifyContent": "center",
-                                        },
-                                        "_len": 36,
-                                        "_name": "column_sj6pid",
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className=""
-                                      style={
-                                        Object {
-                                          "alignItems": "stretch",
-                                          "borderStyle": "solid",
-                                          "borderWidth": 0,
-                                          "boxSizing": "border-box",
-                                          "display": "flex",
-                                          "flex": 1,
-                                          "flexDirection": "column",
-                                          "justifyContent": "center",
-                                          "margin": 0,
-                                          "minHeight": 0,
-                                          "minWidth": 0,
-                                          "padding": 0,
-                                          "position": "relative",
-                                          "zIndex": 0,
-                                        }
-                                      }
-                                    >
-                                      <View
-                                        style={
-                                          Object {
-                                            "_definition": Object {
-                                              "alignItems": "center",
-                                              "flexDirection": "row",
-                                              "justifyContent": "flex-end",
-                                            },
-                                            "_len": 73,
-                                            "_name": "rightColumn_1aelo9f",
-                                          }
-                                        }
-                                      >
-                                        <StyleComponent
-                                          style={
-                                            Object {
-                                              "_definition": Object {
-                                                "alignItems": "center",
-                                                "flexDirection": "row",
-                                                "justifyContent": "flex-end",
-                                              },
-                                              "_len": 73,
-                                              "_name": "rightColumn_1aelo9f",
-                                            }
-                                          }
-                                        >
-                                          <div
-                                            className=""
-                                            style={
-                                              Object {
-                                                "alignItems": "center",
-                                                "borderStyle": "solid",
-                                                "borderWidth": 0,
-                                                "boxSizing": "border-box",
-                                                "display": "flex",
-                                                "flexDirection": "row",
-                                                "justifyContent": "flex-end",
-                                                "margin": 0,
-                                                "minHeight": 0,
-                                                "minWidth": 0,
-                                                "padding": 0,
-                                                "position": "relative",
-                                                "zIndex": 0,
-                                              }
-                                            }
-                                          />
-                                        </StyleComponent>
-                                      </View>
-                                    </div>
-                                  </StyleComponent>
-                                </View>
-                              </div>
-                            </StyleComponent>
-                          </View>
-                        </Toolbar>
-                        <ModalContent
-                          scrollOverflow={true}
+                        <View
                           style={
                             Array [
                               Array [
                                 Object {
                                   "_definition": Object {
-                                    "paddingTop": 32,
+                                    "background": "white",
+                                    "boxSizing": "border-box",
+                                    "display": "flex",
+                                    "flex": "1 1 auto",
+                                    "flexDirection": "column",
+                                    "height": "100%",
+                                    "position": "relative",
+                                    "width": "100%",
                                   },
-                                  "_len": 17,
-                                  "_name": "hasTitleBar_15lzjb6",
-                                },
-                                false,
-                                false,
-                                Array [
-                                  undefined,
-                                  undefined,
-                                ],
-                              ],
-                              Array [
-                                Object {
-                                  "_definition": Object {
-                                    "paddingBottom": 32,
-                                  },
-                                  "_len": 20,
-                                  "_name": "hasFooter_1pn52au",
+                                  "_len": 160,
+                                  "_name": "wrapper_161dlb6",
                                 },
                                 false,
                                 false,
@@ -2833,96 +2516,892 @@ exports[`StandardModal mobile should match snapshot 1`] = `
                             ]
                           }
                         >
-                          <MediaLayout
-                            styleSheets={
-                              Object {
-                                "all": Object {
-                                  "content": Object {
+                          <StyleComponent
+                            style={
+                              Array [
+                                Array [
+                                  Object {
                                     "_definition": Object {
+                                      "background": "white",
                                       "boxSizing": "border-box",
-                                      "flex": 1,
-                                      "minHeight": "100%",
-                                      "padding": 64,
+                                      "display": "flex",
+                                      "flex": "1 1 auto",
+                                      "flexDirection": "column",
+                                      "height": "100%",
+                                      "position": "relative",
+                                      "width": "100%",
                                     },
-                                    "_len": 67,
-                                    "_name": "content_9s1qwq",
+                                    "_len": 160,
+                                    "_name": "wrapper_161dlb6",
                                   },
-                                  "scrollOverflow": Object {
-                                    "_definition": Object {
-                                      "overflow": "auto",
-                                    },
-                                    "_len": 19,
-                                    "_name": "scrollOverflow_oowqdm",
-                                  },
-                                  "wrapper": Object {
-                                    "_definition": Object {
-                                      "display": "block",
-                                      "flex": 1,
-                                    },
-                                    "_len": 28,
-                                    "_name": "wrapper_12fltve",
-                                  },
-                                },
-                                "small": Object {
-                                  "content": Object {
-                                    "_definition": Object {
-                                      "padding": "32px 16px",
-                                    },
-                                    "_len": 23,
-                                    "_name": "content_1a04pla",
-                                  },
-                                },
-                              }
+                                  false,
+                                  false,
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ],
+                                ],
+                                false,
+                                undefined,
+                              ]
                             }
                           >
-                            <View
+                            <div
+                              className=""
                               style={
-                                Array [
-                                  Array [
-                                    Object {
-                                      "_definition": Object {
-                                        "display": "block",
-                                        "flex": 1,
-                                      },
-                                      "_len": 28,
-                                      "_name": "wrapper_12fltve",
-                                    },
-                                    false,
-                                    false,
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                    ],
-                                  ],
-                                  Array [
-                                    Object {
-                                      "_definition": Object {
-                                        "overflow": "auto",
-                                      },
-                                      "_len": 19,
-                                      "_name": "scrollOverflow_oowqdm",
-                                    },
-                                    false,
-                                    false,
-                                    Array [
-                                      undefined,
-                                      undefined,
-                                    ],
-                                  ],
-                                ]
+                                Object {
+                                  "alignItems": "stretch",
+                                  "background": "white",
+                                  "borderStyle": "solid",
+                                  "borderWidth": 0,
+                                  "boxSizing": "border-box",
+                                  "display": "flex",
+                                  "flex": "1 1 auto",
+                                  "flexDirection": "column",
+                                  "height": "100%",
+                                  "margin": 0,
+                                  "minHeight": 0,
+                                  "minWidth": 0,
+                                  "padding": 0,
+                                  "position": "relative",
+                                  "width": "100%",
+                                  "zIndex": 0,
+                                }
                               }
                             >
-                              <StyleComponent
+                              <Toolbar
+                                color="light"
+                                leftContent={
+                                  <MediaLayout
+                                    styleSheets={
+                                      Object {
+                                        "all": Object {
+                                          "preview": Object {
+                                            "_definition": Object {
+                                              "flex": "1 0 auto",
+                                              "maxWidth": 392,
+                                            },
+                                            "_len": 34,
+                                            "_name": "preview_11k7ba4",
+                                          },
+                                          "previewContent": Object {
+                                            "_definition": Object {
+                                              "padding": "0 64px 0 0",
+                                            },
+                                            "_len": 24,
+                                            "_name": "previewContent_q080uq",
+                                          },
+                                        },
+                                        "mdOrLarger": Object {
+                                          "wrapper": Object {
+                                            "_definition": Object {
+                                              "height": "81.25%",
+                                              "maxHeight": 624,
+                                              "maxWidth": 960,
+                                              "width": "93.75%",
+                                            },
+                                            "_len": 67,
+                                            "_name": "wrapper_1xtsnd2",
+                                          },
+                                        },
+                                        "small": Object {
+                                          "preview": Object {
+                                            "_definition": Object {
+                                              "display": "none",
+                                            },
+                                            "_len": 18,
+                                            "_name": "preview_1u9fru1",
+                                          },
+                                        },
+                                      }
+                                    }
+                                  >
+                                    [Function]
+                                  </MediaLayout>
+                                }
+                                rightContent={null}
+                                size="medium"
+                                title="Title"
+                              >
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "_definition": Object {
+                                          "border": "1px solid rgba(33, 36, 44, 0.16)",
+                                          "display": "flex",
+                                          "flexDirection": "row",
+                                          "minHeight": 66,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "relative",
+                                          "width": "100%",
+                                        },
+                                        "_len": 171,
+                                        "_name": "container_hnrag4",
+                                      },
+                                      false,
+                                      false,
+                                    ]
+                                  }
+                                >
+                                  <StyleComponent
+                                    style={
+                                      Array [
+                                        Object {
+                                          "_definition": Object {
+                                            "border": "1px solid rgba(33, 36, 44, 0.16)",
+                                            "display": "flex",
+                                            "flexDirection": "row",
+                                            "minHeight": 66,
+                                            "paddingLeft": 16,
+                                            "paddingRight": 16,
+                                            "position": "relative",
+                                            "width": "100%",
+                                          },
+                                          "_len": 171,
+                                          "_name": "container_hnrag4",
+                                        },
+                                        false,
+                                        false,
+                                      ]
+                                    }
+                                  >
+                                    <div
+                                      className=""
+                                      style={
+                                        Object {
+                                          "alignItems": "stretch",
+                                          "border": "1px solid rgba(33, 36, 44, 0.16)",
+                                          "borderStyle": "solid",
+                                          "borderWidth": 0,
+                                          "boxSizing": "border-box",
+                                          "display": "flex",
+                                          "flexDirection": "row",
+                                          "margin": 0,
+                                          "minHeight": 66,
+                                          "minWidth": 0,
+                                          "padding": 0,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "position": "relative",
+                                          "width": "100%",
+                                          "zIndex": 0,
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        style={
+                                          Object {
+                                            "_definition": Object {
+                                              "flex": 1,
+                                              "justifyContent": "center",
+                                            },
+                                            "_len": 36,
+                                            "_name": "column_sj6pid",
+                                          }
+                                        }
+                                      >
+                                        <StyleComponent
+                                          style={
+                                            Object {
+                                              "_definition": Object {
+                                                "flex": 1,
+                                                "justifyContent": "center",
+                                              },
+                                              "_len": 36,
+                                              "_name": "column_sj6pid",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className=""
+                                            style={
+                                              Object {
+                                                "alignItems": "stretch",
+                                                "borderStyle": "solid",
+                                                "borderWidth": 0,
+                                                "boxSizing": "border-box",
+                                                "display": "flex",
+                                                "flex": 1,
+                                                "flexDirection": "column",
+                                                "justifyContent": "center",
+                                                "margin": 0,
+                                                "minHeight": 0,
+                                                "minWidth": 0,
+                                                "padding": 0,
+                                                "position": "relative",
+                                                "zIndex": 0,
+                                              }
+                                            }
+                                          >
+                                            <View
+                                              style={
+                                                Object {
+                                                  "_definition": Object {
+                                                    "alignItems": "center",
+                                                    "flexDirection": "row",
+                                                    "justifyContent": "flex-start",
+                                                  },
+                                                  "_len": 75,
+                                                  "_name": "leftColumn_bc5h0c",
+                                                }
+                                              }
+                                            >
+                                              <StyleComponent
+                                                style={
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "alignItems": "center",
+                                                      "flexDirection": "row",
+                                                      "justifyContent": "flex-start",
+                                                    },
+                                                    "_len": 75,
+                                                    "_name": "leftColumn_bc5h0c",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className=""
+                                                  style={
+                                                    Object {
+                                                      "alignItems": "center",
+                                                      "borderStyle": "solid",
+                                                      "borderWidth": 0,
+                                                      "boxSizing": "border-box",
+                                                      "display": "flex",
+                                                      "flexDirection": "row",
+                                                      "justifyContent": "flex-start",
+                                                      "margin": 0,
+                                                      "minHeight": 0,
+                                                      "minWidth": 0,
+                                                      "padding": 0,
+                                                      "position": "relative",
+                                                      "zIndex": 0,
+                                                    }
+                                                  }
+                                                >
+                                                  <MediaLayout
+                                                    styleSheets={
+                                                      Object {
+                                                        "all": Object {
+                                                          "preview": Object {
+                                                            "_definition": Object {
+                                                              "flex": "1 0 auto",
+                                                              "maxWidth": 392,
+                                                            },
+                                                            "_len": 34,
+                                                            "_name": "preview_11k7ba4",
+                                                          },
+                                                          "previewContent": Object {
+                                                            "_definition": Object {
+                                                              "padding": "0 64px 0 0",
+                                                            },
+                                                            "_len": 24,
+                                                            "_name": "previewContent_q080uq",
+                                                          },
+                                                        },
+                                                        "mdOrLarger": Object {
+                                                          "wrapper": Object {
+                                                            "_definition": Object {
+                                                              "height": "81.25%",
+                                                              "maxHeight": 624,
+                                                              "maxWidth": 960,
+                                                              "width": "93.75%",
+                                                            },
+                                                            "_len": 67,
+                                                            "_name": "wrapper_1xtsnd2",
+                                                          },
+                                                        },
+                                                        "small": Object {
+                                                          "preview": Object {
+                                                            "_definition": Object {
+                                                              "display": "none",
+                                                            },
+                                                            "_len": 18,
+                                                            "_name": "preview_1u9fru1",
+                                                          },
+                                                        },
+                                                      }
+                                                    }
+                                                  >
+                                                    <MediaLayoutInternal
+                                                      mediaSpec={
+                                                        Object {
+                                                          "large": Object {
+                                                            "gutterWidth": 32,
+                                                            "marginWidth": 48,
+                                                            "query": "(min-width: 768px)",
+                                                            "totalColumns": 12,
+                                                          },
+                                                          "small": Object {
+                                                            "gutterWidth": 16,
+                                                            "marginWidth": 16,
+                                                            "query": "(max-width: 767px)",
+                                                            "totalColumns": 4,
+                                                          },
+                                                        }
+                                                      }
+                                                      ssrSize="large"
+                                                      styleSheets={
+                                                        Object {
+                                                          "all": Object {
+                                                            "preview": Object {
+                                                              "_definition": Object {
+                                                                "flex": "1 0 auto",
+                                                                "maxWidth": 392,
+                                                              },
+                                                              "_len": 34,
+                                                              "_name": "preview_11k7ba4",
+                                                            },
+                                                            "previewContent": Object {
+                                                              "_definition": Object {
+                                                                "padding": "0 64px 0 0",
+                                                              },
+                                                              "_len": 24,
+                                                              "_name": "previewContent_q080uq",
+                                                            },
+                                                          },
+                                                          "mdOrLarger": Object {
+                                                            "wrapper": Object {
+                                                              "_definition": Object {
+                                                                "height": "81.25%",
+                                                                "maxHeight": 624,
+                                                                "maxWidth": 960,
+                                                                "width": "93.75%",
+                                                              },
+                                                              "_len": 67,
+                                                              "_name": "wrapper_1xtsnd2",
+                                                            },
+                                                          },
+                                                          "small": Object {
+                                                            "preview": Object {
+                                                              "_definition": Object {
+                                                                "display": "none",
+                                                              },
+                                                              "_len": 18,
+                                                              "_name": "preview_1u9fru1",
+                                                            },
+                                                          },
+                                                        }
+                                                      }
+                                                    >
+                                                      <CloseButton
+                                                        light={false}
+                                                      >
+                                                        <IconButton
+                                                          aria-label="Close modal"
+                                                          color="default"
+                                                          disabled={false}
+                                                          icon={
+                                                            Object {
+                                                              "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
+                                                              "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
+                                                            }
+                                                          }
+                                                          kind="tertiary"
+                                                          light={false}
+                                                        >
+                                                          <ClickableBehavior
+                                                            disabled={false}
+                                                            role="button"
+                                                          >
+                                                            <IconButtonCore
+                                                              aria-label="Close modal"
+                                                              color="default"
+                                                              disabled={false}
+                                                              focused={false}
+                                                              hovered={false}
+                                                              icon={
+                                                                Object {
+                                                                  "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
+                                                                  "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
+                                                                }
+                                                              }
+                                                              kind="tertiary"
+                                                              light={false}
+                                                              onBlur={[Function]}
+                                                              onClick={[Function]}
+                                                              onDragStart={[Function]}
+                                                              onFocus={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              onKeyUp={[Function]}
+                                                              onMouseDown={[Function]}
+                                                              onMouseEnter={[Function]}
+                                                              onMouseLeave={[Function]}
+                                                              onMouseUp={[Function]}
+                                                              onTouchCancel={[Function]}
+                                                              onTouchEnd={[Function]}
+                                                              onTouchStart={[Function]}
+                                                              pressed={false}
+                                                              tabIndex={0}
+                                                            >
+                                                              <StyleComponent
+                                                                aria-label="Close modal"
+                                                                disabled={false}
+                                                                onBlur={[Function]}
+                                                                onClick={[Function]}
+                                                                onDragStart={[Function]}
+                                                                onFocus={[Function]}
+                                                                onKeyDown={[Function]}
+                                                                onKeyUp={[Function]}
+                                                                onMouseDown={[Function]}
+                                                                onMouseEnter={[Function]}
+                                                                onMouseLeave={[Function]}
+                                                                onMouseUp={[Function]}
+                                                                onTouchCancel={[Function]}
+                                                                onTouchEnd={[Function]}
+                                                                onTouchStart={[Function]}
+                                                                style={
+                                                                  Array [
+                                                                    Array [
+                                                                      Object {
+                                                                        "_definition": Object {
+                                                                          "alignItems": "center",
+                                                                          "background": "none",
+                                                                          "border": "none",
+                                                                          "boxSizing": "border-box",
+                                                                          "cursor": "pointer",
+                                                                          "display": "inline-flex",
+                                                                          "height": 40,
+                                                                          "justifyContent": "center",
+                                                                          "margin": -8,
+                                                                          "outline": "none",
+                                                                          "padding": 0,
+                                                                          "position": "relative",
+                                                                          "textDecoration": "none",
+                                                                          "touchAction": "manipulation",
+                                                                          "width": 40,
+                                                                        },
+                                                                        "_len": 292,
+                                                                        "_name": "shared_smh163",
+                                                                      },
+                                                                      false,
+                                                                      Object {
+                                                                        "_definition": Object {
+                                                                          "color": "rgba(33,36,44,0.64)",
+                                                                        },
+                                                                        "_len": 31,
+                                                                        "_name": "default_7sq9ra",
+                                                                      },
+                                                                      false,
+                                                                      false,
+                                                                    ],
+                                                                    undefined,
+                                                                  ]
+                                                                }
+                                                                tabIndex={0}
+                                                                type="button"
+                                                              >
+                                                                <button
+                                                                  aria-label="Close modal"
+                                                                  className=""
+                                                                  disabled={false}
+                                                                  onBlur={[Function]}
+                                                                  onClick={[Function]}
+                                                                  onDragStart={[Function]}
+                                                                  onFocus={[Function]}
+                                                                  onKeyDown={[Function]}
+                                                                  onKeyUp={[Function]}
+                                                                  onMouseDown={[Function]}
+                                                                  onMouseEnter={[Function]}
+                                                                  onMouseLeave={[Function]}
+                                                                  onMouseUp={[Function]}
+                                                                  onTouchCancel={[Function]}
+                                                                  onTouchEnd={[Function]}
+                                                                  onTouchStart={[Function]}
+                                                                  style={
+                                                                    Object {
+                                                                      "::MozFocusInner": Object {
+                                                                        "border": 0,
+                                                                      },
+                                                                      "alignItems": "center",
+                                                                      "background": "none",
+                                                                      "border": "none",
+                                                                      "boxSizing": "border-box",
+                                                                      "color": "rgba(33,36,44,0.64)",
+                                                                      "cursor": "pointer",
+                                                                      "display": "inline-flex",
+                                                                      "height": 40,
+                                                                      "justifyContent": "center",
+                                                                      "margin": -8,
+                                                                      "outline": "none",
+                                                                      "padding": 0,
+                                                                      "position": "relative",
+                                                                      "textDecoration": "none",
+                                                                      "touchAction": "manipulation",
+                                                                      "width": 40,
+                                                                    }
+                                                                  }
+                                                                  tabIndex={0}
+                                                                  type="button"
+                                                                >
+                                                                  <Icon
+                                                                    color="currentColor"
+                                                                    icon={
+                                                                      Object {
+                                                                        "medium": "M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z",
+                                                                        "small": "M8 6.586l3.293-3.293a1 1 0 0 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 1 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 1.414-1.414L8 6.586z",
+                                                                      }
+                                                                    }
+                                                                    size="medium"
+                                                                  >
+                                                                    <StyleComponent
+                                                                      height={24}
+                                                                      style={
+                                                                        Array [
+                                                                          Object {
+                                                                            "_definition": Object {
+                                                                              "display": "inline-block",
+                                                                              "flexGrow": 0,
+                                                                              "flexShrink": 0,
+                                                                              "verticalAlign": "text-bottom",
+                                                                            },
+                                                                            "_len": 84,
+                                                                            "_name": "svg_aeiopc",
+                                                                          },
+                                                                          undefined,
+                                                                        ]
+                                                                      }
+                                                                      viewBox="0 0 24 24"
+                                                                      width={24}
+                                                                    >
+                                                                      <svg
+                                                                        className=""
+                                                                        height={24}
+                                                                        style={
+                                                                          Object {
+                                                                            "display": "inline-block",
+                                                                            "flexGrow": 0,
+                                                                            "flexShrink": 0,
+                                                                            "verticalAlign": "text-bottom",
+                                                                          }
+                                                                        }
+                                                                        viewBox="0 0 24 24"
+                                                                        width={24}
+                                                                      >
+                                                                        <path
+                                                                          d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+                                                                          fill="currentColor"
+                                                                        />
+                                                                      </svg>
+                                                                    </StyleComponent>
+                                                                  </Icon>
+                                                                </button>
+                                                              </StyleComponent>
+                                                            </IconButtonCore>
+                                                          </ClickableBehavior>
+                                                        </IconButton>
+                                                      </CloseButton>
+                                                    </MediaLayoutInternal>
+                                                  </MediaLayout>
+                                                </div>
+                                              </StyleComponent>
+                                            </View>
+                                          </div>
+                                        </StyleComponent>
+                                      </View>
+                                      <View
+                                        style={
+                                          Array [
+                                            Object {
+                                              "_definition": Object {
+                                                "flex": 1,
+                                                "justifyContent": "center",
+                                              },
+                                              "_len": 36,
+                                              "_name": "column_sj6pid",
+                                            },
+                                            Object {
+                                              "_definition": Object {
+                                                "flexBasis": "50%",
+                                              },
+                                              "_len": 19,
+                                              "_name": "wideColumn_cczrfo",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <StyleComponent
+                                          style={
+                                            Array [
+                                              Object {
+                                                "_definition": Object {
+                                                  "flex": 1,
+                                                  "justifyContent": "center",
+                                                },
+                                                "_len": 36,
+                                                "_name": "column_sj6pid",
+                                              },
+                                              Object {
+                                                "_definition": Object {
+                                                  "flexBasis": "50%",
+                                                },
+                                                "_len": 19,
+                                                "_name": "wideColumn_cczrfo",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <div
+                                            className=""
+                                            style={
+                                              Object {
+                                                "alignItems": "stretch",
+                                                "borderStyle": "solid",
+                                                "borderWidth": 0,
+                                                "boxSizing": "border-box",
+                                                "display": "flex",
+                                                "flex": 1,
+                                                "flexBasis": "50%",
+                                                "flexDirection": "column",
+                                                "justifyContent": "center",
+                                                "margin": 0,
+                                                "minHeight": 0,
+                                                "minWidth": 0,
+                                                "padding": 0,
+                                                "position": "relative",
+                                                "zIndex": 0,
+                                              }
+                                            }
+                                          >
+                                            <View
+                                              style={
+                                                Array [
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "padding": 12,
+                                                    },
+                                                    "_len": 14,
+                                                    "_name": "titles_47hinf",
+                                                  },
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "justifyContent": "center",
+                                                    },
+                                                    "_len": 27,
+                                                    "_name": "verticalAlign_agrn11",
+                                                  },
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "textAlign": "center",
+                                                    },
+                                                    "_len": 22,
+                                                    "_name": "center_12to336",
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <StyleComponent
+                                                style={
+                                                  Array [
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "padding": 12,
+                                                      },
+                                                      "_len": 14,
+                                                      "_name": "titles_47hinf",
+                                                    },
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "justifyContent": "center",
+                                                      },
+                                                      "_len": 27,
+                                                      "_name": "verticalAlign_agrn11",
+                                                    },
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "textAlign": "center",
+                                                      },
+                                                      "_len": 22,
+                                                      "_name": "center_12to336",
+                                                    },
+                                                  ]
+                                                }
+                                              >
+                                                <div
+                                                  className=""
+                                                  style={
+                                                    Object {
+                                                      "alignItems": "stretch",
+                                                      "borderStyle": "solid",
+                                                      "borderWidth": 0,
+                                                      "boxSizing": "border-box",
+                                                      "display": "flex",
+                                                      "flexDirection": "column",
+                                                      "justifyContent": "center",
+                                                      "margin": 0,
+                                                      "minHeight": 0,
+                                                      "minWidth": 0,
+                                                      "padding": 12,
+                                                      "position": "relative",
+                                                      "textAlign": "center",
+                                                      "zIndex": 0,
+                                                    }
+                                                  }
+                                                >
+                                                  <HeadingSmall
+                                                    id="wb-toolbar-title"
+                                                    tag="h4"
+                                                  >
+                                                    <Text
+                                                      id="wb-toolbar-title"
+                                                      style={
+                                                        Array [
+                                                          Object {
+                                                            "_definition": Object {
+                                                              "display": "block",
+                                                              "fontFamily": "Lato, sans-serif",
+                                                              "fontSize": 20,
+                                                              "fontWeight": 700,
+                                                              "lineHeight": "24px",
+                                                            },
+                                                            "_len": 102,
+                                                            "_name": "HeadingSmall_1c07c7n",
+                                                          },
+                                                          undefined,
+                                                        ]
+                                                      }
+                                                      tag="h4"
+                                                    >
+                                                      <h4
+                                                        className=""
+                                                        id="wb-toolbar-title"
+                                                        style={
+                                                          Object {
+                                                            "MozOsxFontSmoothing": "grayscale",
+                                                            "WebkitFontSmoothing": "antialiased",
+                                                            "display": "block",
+                                                            "fontFamily": "Lato, sans-serif",
+                                                            "fontSize": 20,
+                                                            "fontWeight": 700,
+                                                            "lineHeight": "24px",
+                                                            "marginBottom": 0,
+                                                            "marginTop": 0,
+                                                          }
+                                                        }
+                                                      >
+                                                        Title
+                                                      </h4>
+                                                    </Text>
+                                                  </HeadingSmall>
+                                                </div>
+                                              </StyleComponent>
+                                            </View>
+                                          </div>
+                                        </StyleComponent>
+                                      </View>
+                                      <View
+                                        style={
+                                          Object {
+                                            "_definition": Object {
+                                              "flex": 1,
+                                              "justifyContent": "center",
+                                            },
+                                            "_len": 36,
+                                            "_name": "column_sj6pid",
+                                          }
+                                        }
+                                      >
+                                        <StyleComponent
+                                          style={
+                                            Object {
+                                              "_definition": Object {
+                                                "flex": 1,
+                                                "justifyContent": "center",
+                                              },
+                                              "_len": 36,
+                                              "_name": "column_sj6pid",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className=""
+                                            style={
+                                              Object {
+                                                "alignItems": "stretch",
+                                                "borderStyle": "solid",
+                                                "borderWidth": 0,
+                                                "boxSizing": "border-box",
+                                                "display": "flex",
+                                                "flex": 1,
+                                                "flexDirection": "column",
+                                                "justifyContent": "center",
+                                                "margin": 0,
+                                                "minHeight": 0,
+                                                "minWidth": 0,
+                                                "padding": 0,
+                                                "position": "relative",
+                                                "zIndex": 0,
+                                              }
+                                            }
+                                          >
+                                            <View
+                                              style={
+                                                Object {
+                                                  "_definition": Object {
+                                                    "alignItems": "center",
+                                                    "flexDirection": "row",
+                                                    "justifyContent": "flex-end",
+                                                  },
+                                                  "_len": 73,
+                                                  "_name": "rightColumn_1aelo9f",
+                                                }
+                                              }
+                                            >
+                                              <StyleComponent
+                                                style={
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "alignItems": "center",
+                                                      "flexDirection": "row",
+                                                      "justifyContent": "flex-end",
+                                                    },
+                                                    "_len": 73,
+                                                    "_name": "rightColumn_1aelo9f",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className=""
+                                                  style={
+                                                    Object {
+                                                      "alignItems": "center",
+                                                      "borderStyle": "solid",
+                                                      "borderWidth": 0,
+                                                      "boxSizing": "border-box",
+                                                      "display": "flex",
+                                                      "flexDirection": "row",
+                                                      "justifyContent": "flex-end",
+                                                      "margin": 0,
+                                                      "minHeight": 0,
+                                                      "minWidth": 0,
+                                                      "padding": 0,
+                                                      "position": "relative",
+                                                      "zIndex": 0,
+                                                    }
+                                                  }
+                                                />
+                                              </StyleComponent>
+                                            </View>
+                                          </div>
+                                        </StyleComponent>
+                                      </View>
+                                    </div>
+                                  </StyleComponent>
+                                </View>
+                              </Toolbar>
+                              <ModalContent
+                                scrollOverflow={true}
                                 style={
                                   Array [
                                     Array [
                                       Object {
                                         "_definition": Object {
-                                          "display": "block",
-                                          "flex": 1,
+                                          "paddingTop": 32,
                                         },
-                                        "_len": 28,
-                                        "_name": "wrapper_12fltve",
+                                        "_len": 17,
+                                        "_name": "hasTitleBar_15lzjb6",
                                       },
                                       false,
                                       false,
@@ -2934,10 +3413,10 @@ exports[`StandardModal mobile should match snapshot 1`] = `
                                     Array [
                                       Object {
                                         "_definition": Object {
-                                          "overflow": "auto",
+                                          "paddingBottom": 32,
                                         },
-                                        "_len": 19,
-                                        "_name": "scrollOverflow_oowqdm",
+                                        "_len": 20,
+                                        "_name": "hasFooter_1pn52au",
                                       },
                                       false,
                                       false,
@@ -2946,35 +3425,75 @@ exports[`StandardModal mobile should match snapshot 1`] = `
                                         undefined,
                                       ],
                                     ],
+                                    false,
+                                    undefined,
                                   ]
                                 }
                               >
-                                <div
-                                  className=""
-                                  style={
+                                <MediaLayout
+                                  styleSheets={
                                     Object {
-                                      "alignItems": "stretch",
-                                      "borderStyle": "solid",
-                                      "borderWidth": 0,
-                                      "boxSizing": "border-box",
-                                      "display": "block",
-                                      "flex": 1,
-                                      "flexDirection": "column",
-                                      "margin": 0,
-                                      "minHeight": 0,
-                                      "minWidth": 0,
-                                      "overflow": "auto",
-                                      "padding": 0,
-                                      "position": "relative",
-                                      "zIndex": 0,
+                                      "all": Object {
+                                        "content": Object {
+                                          "_definition": Object {
+                                            "boxSizing": "border-box",
+                                            "flex": 1,
+                                            "minHeight": "100%",
+                                            "padding": 64,
+                                          },
+                                          "_len": 67,
+                                          "_name": "content_9s1qwq",
+                                        },
+                                        "scrollOverflow": Object {
+                                          "_definition": Object {
+                                            "overflow": "auto",
+                                          },
+                                          "_len": 19,
+                                          "_name": "scrollOverflow_oowqdm",
+                                        },
+                                        "wrapper": Object {
+                                          "_definition": Object {
+                                            "display": "block",
+                                            "flex": 1,
+                                          },
+                                          "_len": 28,
+                                          "_name": "wrapper_12fltve",
+                                        },
+                                      },
+                                      "small": Object {
+                                        "content": Object {
+                                          "_definition": Object {
+                                            "padding": "32px 16px",
+                                          },
+                                          "_len": 23,
+                                          "_name": "content_1a04pla",
+                                        },
+                                      },
                                     }
                                   }
                                 >
-                                  <View
-                                    style={
-                                      Array [
-                                        Array [
-                                          Object {
+                                  <MediaLayoutInternal
+                                    mediaSpec={
+                                      Object {
+                                        "large": Object {
+                                          "gutterWidth": 32,
+                                          "marginWidth": 48,
+                                          "query": "(min-width: 768px)",
+                                          "totalColumns": 12,
+                                        },
+                                        "small": Object {
+                                          "gutterWidth": 16,
+                                          "marginWidth": 16,
+                                          "query": "(max-width: 767px)",
+                                          "totalColumns": 4,
+                                        },
+                                      }
+                                    }
+                                    ssrSize="large"
+                                    styleSheets={
+                                      Object {
+                                        "all": Object {
+                                          "content": Object {
                                             "_definition": Object {
                                               "boxSizing": "border-box",
                                               "flex": 1,
@@ -2984,63 +3503,45 @@ exports[`StandardModal mobile should match snapshot 1`] = `
                                             "_len": 67,
                                             "_name": "content_9s1qwq",
                                           },
-                                          false,
-                                          false,
-                                          Array [
-                                            undefined,
-                                            undefined,
-                                          ],
-                                        ],
-                                        Array [
-                                          Array [
-                                            Object {
-                                              "_definition": Object {
-                                                "paddingTop": 32,
-                                              },
-                                              "_len": 17,
-                                              "_name": "hasTitleBar_15lzjb6",
+                                          "scrollOverflow": Object {
+                                            "_definition": Object {
+                                              "overflow": "auto",
                                             },
-                                            false,
-                                            false,
-                                            Array [
-                                              undefined,
-                                              undefined,
-                                            ],
-                                          ],
-                                          Array [
-                                            Object {
-                                              "_definition": Object {
-                                                "paddingBottom": 32,
-                                              },
-                                              "_len": 20,
-                                              "_name": "hasFooter_1pn52au",
+                                            "_len": 19,
+                                            "_name": "scrollOverflow_oowqdm",
+                                          },
+                                          "wrapper": Object {
+                                            "_definition": Object {
+                                              "display": "block",
+                                              "flex": 1,
                                             },
-                                            false,
-                                            false,
-                                            Array [
-                                              undefined,
-                                              undefined,
-                                            ],
-                                          ],
-                                          false,
-                                          undefined,
-                                        ],
-                                      ]
+                                            "_len": 28,
+                                            "_name": "wrapper_12fltve",
+                                          },
+                                        },
+                                        "small": Object {
+                                          "content": Object {
+                                            "_definition": Object {
+                                              "padding": "32px 16px",
+                                            },
+                                            "_len": 23,
+                                            "_name": "content_1a04pla",
+                                          },
+                                        },
+                                      }
                                     }
                                   >
-                                    <StyleComponent
+                                    <View
                                       style={
                                         Array [
                                           Array [
                                             Object {
                                               "_definition": Object {
-                                                "boxSizing": "border-box",
+                                                "display": "block",
                                                 "flex": 1,
-                                                "minHeight": "100%",
-                                                "padding": 64,
                                               },
-                                              "_len": 67,
-                                              "_name": "content_9s1qwq",
+                                              "_len": 28,
+                                              "_name": "wrapper_12fltve",
                                             },
                                             false,
                                             false,
@@ -3050,171 +3551,330 @@ exports[`StandardModal mobile should match snapshot 1`] = `
                                             ],
                                           ],
                                           Array [
-                                            Array [
-                                              Object {
-                                                "_definition": Object {
-                                                  "paddingTop": 32,
-                                                },
-                                                "_len": 17,
-                                                "_name": "hasTitleBar_15lzjb6",
+                                            Object {
+                                              "_definition": Object {
+                                                "overflow": "auto",
                                               },
-                                              false,
-                                              false,
-                                              Array [
-                                                undefined,
-                                                undefined,
-                                              ],
-                                            ],
-                                            Array [
-                                              Object {
-                                                "_definition": Object {
-                                                  "paddingBottom": 32,
-                                                },
-                                                "_len": 20,
-                                                "_name": "hasFooter_1pn52au",
-                                              },
-                                              false,
-                                              false,
-                                              Array [
-                                                undefined,
-                                                undefined,
-                                              ],
-                                            ],
+                                              "_len": 19,
+                                              "_name": "scrollOverflow_oowqdm",
+                                            },
                                             false,
-                                            undefined,
+                                            false,
+                                            Array [
+                                              undefined,
+                                              undefined,
+                                            ],
                                           ],
                                         ]
                                       }
                                     >
-                                      <div
-                                        className=""
+                                      <StyleComponent
                                         style={
-                                          Object {
-                                            "alignItems": "stretch",
-                                            "borderStyle": "solid",
-                                            "borderWidth": 0,
-                                            "boxSizing": "border-box",
-                                            "display": "flex",
-                                            "flex": 1,
-                                            "flexDirection": "column",
-                                            "margin": 0,
-                                            "minHeight": "100%",
-                                            "minWidth": 0,
-                                            "padding": 64,
-                                            "paddingBottom": 32,
-                                            "paddingTop": 32,
-                                            "position": "relative",
-                                            "zIndex": 0,
-                                          }
+                                          Array [
+                                            Array [
+                                              Object {
+                                                "_definition": Object {
+                                                  "display": "block",
+                                                  "flex": 1,
+                                                },
+                                                "_len": 28,
+                                                "_name": "wrapper_12fltve",
+                                              },
+                                              false,
+                                              false,
+                                              Array [
+                                                undefined,
+                                                undefined,
+                                              ],
+                                            ],
+                                            Array [
+                                              Object {
+                                                "_definition": Object {
+                                                  "overflow": "auto",
+                                                },
+                                                "_len": 19,
+                                                "_name": "scrollOverflow_oowqdm",
+                                              },
+                                              false,
+                                              false,
+                                              Array [
+                                                undefined,
+                                                undefined,
+                                              ],
+                                            ],
+                                          ]
                                         }
                                       >
-                                        Content
-                                      </div>
-                                    </StyleComponent>
-                                  </View>
-                                </div>
-                              </StyleComponent>
-                            </View>
-                          </MediaLayout>
-                        </ModalContent>
-                        <ModalFooter>
-                          <View
-                            style={
-                              Array [
-                                Object {
-                                  "_definition": Object {
-                                    "alignItems": "center",
-                                    "borderTopColor": "rgba(33,36,44,0.16)",
-                                    "borderTopStyle": "solid",
-                                    "borderTopWidth": 1,
-                                    "boxSizing": "border-box",
-                                    "display": "flex",
-                                    "flex": "0 0 auto",
-                                    "flexDirection": "row",
-                                    "justifyContent": "flex-end",
-                                    "minHeight": 64,
-                                    "paddingBottom": 8,
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "paddingTop": 8,
-                                  },
-                                  "_len": 299,
-                                  "_name": "footer_b45ce1",
-                                },
-                                undefined,
-                              ]
-                            }
-                          >
-                            <StyleComponent
-                              style={
-                                Array [
-                                  Object {
-                                    "_definition": Object {
-                                      "alignItems": "center",
-                                      "borderTopColor": "rgba(33,36,44,0.16)",
-                                      "borderTopStyle": "solid",
-                                      "borderTopWidth": 1,
-                                      "boxSizing": "border-box",
-                                      "display": "flex",
-                                      "flex": "0 0 auto",
-                                      "flexDirection": "row",
-                                      "justifyContent": "flex-end",
-                                      "minHeight": 64,
-                                      "paddingBottom": 8,
-                                      "paddingLeft": 16,
-                                      "paddingRight": 16,
-                                      "paddingTop": 8,
-                                    },
-                                    "_len": 299,
-                                    "_name": "footer_b45ce1",
-                                  },
-                                  undefined,
-                                ]
-                              }
-                            >
-                              <div
-                                className=""
-                                style={
-                                  Object {
-                                    "alignItems": "center",
-                                    "borderStyle": "solid",
-                                    "borderTopColor": "rgba(33,36,44,0.16)",
-                                    "borderTopStyle": "solid",
-                                    "borderTopWidth": 1,
-                                    "borderWidth": 0,
-                                    "boxSizing": "border-box",
-                                    "display": "flex",
-                                    "flex": "0 0 auto",
-                                    "flexDirection": "row",
-                                    "justifyContent": "flex-end",
-                                    "margin": 0,
-                                    "minHeight": 64,
-                                    "minWidth": 0,
-                                    "padding": 0,
-                                    "paddingBottom": 8,
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "paddingTop": 8,
-                                    "position": "relative",
-                                    "zIndex": 0,
+                                        <div
+                                          className=""
+                                          style={
+                                            Object {
+                                              "alignItems": "stretch",
+                                              "borderStyle": "solid",
+                                              "borderWidth": 0,
+                                              "boxSizing": "border-box",
+                                              "display": "block",
+                                              "flex": 1,
+                                              "flexDirection": "column",
+                                              "margin": 0,
+                                              "minHeight": 0,
+                                              "minWidth": 0,
+                                              "overflow": "auto",
+                                              "padding": 0,
+                                              "position": "relative",
+                                              "zIndex": 0,
+                                            }
+                                          }
+                                        >
+                                          <View
+                                            style={
+                                              Array [
+                                                Array [
+                                                  Object {
+                                                    "_definition": Object {
+                                                      "boxSizing": "border-box",
+                                                      "flex": 1,
+                                                      "minHeight": "100%",
+                                                      "padding": 64,
+                                                    },
+                                                    "_len": 67,
+                                                    "_name": "content_9s1qwq",
+                                                  },
+                                                  false,
+                                                  false,
+                                                  Array [
+                                                    undefined,
+                                                    undefined,
+                                                  ],
+                                                ],
+                                                Array [
+                                                  Array [
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "paddingTop": 32,
+                                                      },
+                                                      "_len": 17,
+                                                      "_name": "hasTitleBar_15lzjb6",
+                                                    },
+                                                    false,
+                                                    false,
+                                                    Array [
+                                                      undefined,
+                                                      undefined,
+                                                    ],
+                                                  ],
+                                                  Array [
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "paddingBottom": 32,
+                                                      },
+                                                      "_len": 20,
+                                                      "_name": "hasFooter_1pn52au",
+                                                    },
+                                                    false,
+                                                    false,
+                                                    Array [
+                                                      undefined,
+                                                      undefined,
+                                                    ],
+                                                  ],
+                                                  false,
+                                                  undefined,
+                                                ],
+                                              ]
+                                            }
+                                          >
+                                            <StyleComponent
+                                              style={
+                                                Array [
+                                                  Array [
+                                                    Object {
+                                                      "_definition": Object {
+                                                        "boxSizing": "border-box",
+                                                        "flex": 1,
+                                                        "minHeight": "100%",
+                                                        "padding": 64,
+                                                      },
+                                                      "_len": 67,
+                                                      "_name": "content_9s1qwq",
+                                                    },
+                                                    false,
+                                                    false,
+                                                    Array [
+                                                      undefined,
+                                                      undefined,
+                                                    ],
+                                                  ],
+                                                  Array [
+                                                    Array [
+                                                      Object {
+                                                        "_definition": Object {
+                                                          "paddingTop": 32,
+                                                        },
+                                                        "_len": 17,
+                                                        "_name": "hasTitleBar_15lzjb6",
+                                                      },
+                                                      false,
+                                                      false,
+                                                      Array [
+                                                        undefined,
+                                                        undefined,
+                                                      ],
+                                                    ],
+                                                    Array [
+                                                      Object {
+                                                        "_definition": Object {
+                                                          "paddingBottom": 32,
+                                                        },
+                                                        "_len": 20,
+                                                        "_name": "hasFooter_1pn52au",
+                                                      },
+                                                      false,
+                                                      false,
+                                                      Array [
+                                                        undefined,
+                                                        undefined,
+                                                      ],
+                                                    ],
+                                                    false,
+                                                    undefined,
+                                                  ],
+                                                ]
+                                              }
+                                            >
+                                              <div
+                                                className=""
+                                                style={
+                                                  Object {
+                                                    "alignItems": "stretch",
+                                                    "borderStyle": "solid",
+                                                    "borderWidth": 0,
+                                                    "boxSizing": "border-box",
+                                                    "display": "flex",
+                                                    "flex": 1,
+                                                    "flexDirection": "column",
+                                                    "margin": 0,
+                                                    "minHeight": "100%",
+                                                    "minWidth": 0,
+                                                    "padding": 64,
+                                                    "paddingBottom": 32,
+                                                    "paddingTop": 32,
+                                                    "position": "relative",
+                                                    "zIndex": 0,
+                                                  }
+                                                }
+                                              >
+                                                Content
+                                              </div>
+                                            </StyleComponent>
+                                          </View>
+                                        </div>
+                                      </StyleComponent>
+                                    </View>
+                                  </MediaLayoutInternal>
+                                </MediaLayout>
+                              </ModalContent>
+                              <ModalFooter>
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "_definition": Object {
+                                          "alignItems": "center",
+                                          "borderTopColor": "rgba(33,36,44,0.16)",
+                                          "borderTopStyle": "solid",
+                                          "borderTopWidth": 1,
+                                          "boxSizing": "border-box",
+                                          "display": "flex",
+                                          "flex": "0 0 auto",
+                                          "flexDirection": "row",
+                                          "justifyContent": "flex-end",
+                                          "minHeight": 64,
+                                          "paddingBottom": 8,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "paddingTop": 8,
+                                        },
+                                        "_len": 299,
+                                        "_name": "footer_b45ce1",
+                                      },
+                                      undefined,
+                                    ]
                                   }
-                                }
-                              >
-                                Footer
-                              </div>
-                            </StyleComponent>
-                          </View>
-                        </ModalFooter>
-                      </div>
-                    </StyleComponent>
-                  </View>
-                </MediaLayout>
-              </ModalPanel>
-            </div>
-          </StyleComponent>
-        </View>
-      </MediaLayout>
-    </ModalDialog>
+                                >
+                                  <StyleComponent
+                                    style={
+                                      Array [
+                                        Object {
+                                          "_definition": Object {
+                                            "alignItems": "center",
+                                            "borderTopColor": "rgba(33,36,44,0.16)",
+                                            "borderTopStyle": "solid",
+                                            "borderTopWidth": 1,
+                                            "boxSizing": "border-box",
+                                            "display": "flex",
+                                            "flex": "0 0 auto",
+                                            "flexDirection": "row",
+                                            "justifyContent": "flex-end",
+                                            "minHeight": 64,
+                                            "paddingBottom": 8,
+                                            "paddingLeft": 16,
+                                            "paddingRight": 16,
+                                            "paddingTop": 8,
+                                          },
+                                          "_len": 299,
+                                          "_name": "footer_b45ce1",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <div
+                                      className=""
+                                      style={
+                                        Object {
+                                          "alignItems": "center",
+                                          "borderStyle": "solid",
+                                          "borderTopColor": "rgba(33,36,44,0.16)",
+                                          "borderTopStyle": "solid",
+                                          "borderTopWidth": 1,
+                                          "borderWidth": 0,
+                                          "boxSizing": "border-box",
+                                          "display": "flex",
+                                          "flex": "0 0 auto",
+                                          "flexDirection": "row",
+                                          "justifyContent": "flex-end",
+                                          "margin": 0,
+                                          "minHeight": 64,
+                                          "minWidth": 0,
+                                          "padding": 0,
+                                          "paddingBottom": 8,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "paddingTop": 8,
+                                          "position": "relative",
+                                          "zIndex": 0,
+                                        }
+                                      }
+                                    >
+                                      Footer
+                                    </div>
+                                  </StyleComponent>
+                                </View>
+                              </ModalFooter>
+                            </div>
+                          </StyleComponent>
+                        </View>
+                      </MediaLayoutInternal>
+                    </MediaLayout>
+                  </ModalPanel>
+                </div>
+              </StyleComponent>
+            </View>
+          </MediaLayoutInternal>
+        </MediaLayout>
+      </ModalDialog>
+    </MediaLayoutInternal>
   </MediaLayout>
 </StandardModal>
 `;

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -19,6 +19,7 @@
     "@khanacademy/wonder-blocks-core": "^2.2.0",
     "@khanacademy/wonder-blocks-icon": "^1.1.2",
     "@khanacademy/wonder-blocks-icon-button": "^3.1.2",
+    "@khanacademy/wonder-blocks-layout": "^1.3.0",
     "@khanacademy/wonder-blocks-toolbar": "^2.1.2",
     "@khanacademy/wonder-blocks-typography": "^1.1.2"
   },


### PR DESCRIPTION
This is in response to a bug I noticed yesterday when trying to update wonder-blocks in webapp.  From slack:
> The behavior I’m seeing is bizarre and I have yet to explain it, but when I click anywhere on the modal, it resizes the modal once, and if I click it again, it gets small, then if I click it stops and I can actually click the cancel button.  This only happens when in its mobile size.  I’m unable to reproduce this on wonder-blocks.netlify.com.  It feels like it has something to with MediaLayout re-rendering a child when it shouldn’t though I can’t say for sure and I don’t know how clicking would trigger this.

It turns out there were two copies of wonder-blocks-layout in code.  Adding `wonder-blocks-layout` as a dep of `wonder-blocks-modal` will remove the additional copy b/c our build setup will make it as external and not include it in `wonder-blocks-modal`.  

In debugging the issue I only noticed that one copy of `MediaLayout` was being used so I don't think having two copies is what was causing the issues I observed.  This is why I decided to make some additional changes to simplify the creation of MediaListQueries and addition/removal of listeners on those query list objects.

To make sure this works, I'm going to try using `yarn link` and see if that works otherwise I might have to publish to test this inside of webapp.