### PR TITLE
Add warning about using 'Text' component

### DIFF
--- a/packages/wonder-blocks-core/components/text.md
+++ b/packages/wonder-blocks-core/components/text.md
@@ -1,3 +1,10 @@
+**WARNING:** `Text` is meant for internal use only.  Please use the typogrpahy
+components from `@khanacademy/wonder-blocks-typography` for all text.  The
+`font-weight` and `font-style` of these components can be customized using the
+`style` prop.  If you need to create type styles that are different sizes and/or font
+families than those in `@khanacademy/wonder-block-typography` please create custom
+type components that wrap `Text`.
+
 ```js
 const {StyleSheet} = require("aphrodite");
 

--- a/packages/wonder-blocks-core/components/text.md
+++ b/packages/wonder-blocks-core/components/text.md
@@ -1,4 +1,4 @@
-**WARNING:** `Text` is meant for internal use only.  Please use the typogrpahy
+**WARNING:** `Text` is meant for internal use only.  Please use the typography
 components from `@khanacademy/wonder-blocks-typography` for all text.  The
 `font-weight` and `font-style` of these components can be customized using the
 `style` prop.  If you need to create type styles that are different sizes and/or font

--- a/packages/wonder-blocks-core/components/text.md
+++ b/packages/wonder-blocks-core/components/text.md
@@ -1,9 +1,10 @@
-**WARNING:** `Text` is meant for internal use only.  Please use the typography
-components from `@khanacademy/wonder-blocks-typography` for all text.  The
-`font-weight` and `font-style` of these components can be customized using the
-`style` prop.  If you need to create type styles that are different sizes and/or font
-families than those in `@khanacademy/wonder-block-typography` please create custom
-type components that wrap `Text`.
+**WARNING:** `Text` is meant for for use as a building block within typography
+components only, rather than direct use.  Please use the typography components 
+from `@khanacademy/wonder-blocks-typography` for all text.  The `font-weight` 
+and `font-style` of these components can be customized using the `style` prop.
+If you need to create type styles that are different sizes and/or font families 
+than those in `@khanacademy/wonder-block-typography` please create custom type
+components that wrap `Text`.
 
 ```js
 const {StyleSheet} = require("aphrodite");


### PR DESCRIPTION
I'm going to add something to Confluence too, but I thought I'd start here first. 