### PR TITLE
Add onOpen and onClose callbacks to dropdowns

### DIFF
--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -27,6 +27,16 @@ type Props = {|
     onChange: (selectedValues: Array<string>) => mixed,
 
     /**
+     * Callback for when the dropdown is opened.
+     */
+    onOpen?: () => mixed,
+
+    /**
+     * Callback for when the dropdown is closed.
+     */
+    onClose?: () => mixed,
+
+    /**
      * The values of the items that are currently selected.
      */
     selectedValues: Array<string>,
@@ -126,6 +136,12 @@ export default class MultiSelect extends React.Component<Props, State> {
             open,
             keyboard,
         });
+
+        if (open) {
+            this.props.onOpen && this.props.onOpen();
+        } else {
+            this.props.onClose && this.props.onClose();
+        }
     };
 
     handleToggle = (selectedValue: string) => {

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -15,8 +15,13 @@ describe("MultiSelect", () => {
         allChanges.push(update);
     };
     const onChange = jest.fn();
+    const onOpen = jest.fn();
+    const onClose = jest.fn();
 
     beforeEach(() => {
+        onChange.mockClear();
+        onOpen.mockClear();
+        onClose.mockClear();
         window.scrollTo = jest.fn();
         select = mount(
             <MultiSelect
@@ -24,6 +29,8 @@ describe("MultiSelect", () => {
                     saveUpdate(selectedValues);
                     onChange();
                 }}
+                onOpen={onOpen}
+                onClose={onClose}
                 placeholder="Choose"
                 selectItemType="students"
                 selectedValues={["2"]}
@@ -41,7 +48,7 @@ describe("MultiSelect", () => {
         unmountAll();
     });
 
-    it("closes/opens the select on mouse click, space, and enter", () => {
+    it("closes/opens the select on mouse click", () => {
         const opener = select.find(SelectOpener);
         expect(select.state("open")).toEqual(false);
 
@@ -50,16 +57,76 @@ describe("MultiSelect", () => {
         opener.simulate("mouseup");
         opener.simulate("click");
         expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(0);
+
+        // Close select with mouse
+        opener.simulate("mousedown");
+        opener.simulate("mouseup");
+        opener.simulate("click");
+        expect(select.state("open")).toEqual(false);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+
+        // Open select with mouse
+        opener.simulate("mousedown");
+        opener.simulate("mouseup");
+        opener.simulate("click");
+        expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(2);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes/opens the select on space", () => {
+        const opener = select.find(SelectOpener);
+        expect(select.state("open")).toEqual(false);
+
+        // Open select with space
+        opener.simulate("keydown", {keyCode: keyCodes.space});
+        opener.simulate("keyup", {keyCode: keyCodes.space});
+        expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(0);
 
         // Close select with space
         opener.simulate("keydown", {keyCode: keyCodes.space});
         opener.simulate("keyup", {keyCode: keyCodes.space});
         expect(select.state("open")).toEqual(false);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
 
-        // Should open with enter
+        // Open select with space
+        opener.simulate("keydown", {keyCode: keyCodes.space});
+        opener.simulate("keyup", {keyCode: keyCodes.space});
+        expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(2);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes/opens the select on enter", () => {
+        const opener = select.find(SelectOpener);
+        expect(select.state("open")).toEqual(false);
+
+        // Open select with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
         expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(0);
+
+        // Close select with enter
+        opener.simulate("keydown", {keyCode: keyCodes.enter});
+        opener.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(select.state("open")).toEqual(false);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+
+        // Open select with enter
+        opener.simulate("keydown", {keyCode: keyCodes.enter});
+        opener.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(2);
+        expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it("selects items as expected", () => {

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -25,6 +25,16 @@ type Props = {|
     onChange: (selectedValue: string) => mixed,
 
     /**
+     * Callback for when the dropdown is opened.
+     */
+    onOpen?: () => mixed,
+
+    /**
+     * Callback for when the dropdown is closed.
+     */
+    onClose?: () => mixed,
+
+    /**
      * Placeholder for the opening component when there are no items selected.
      */
     placeholder: string,
@@ -111,6 +121,12 @@ export default class SingleSelect extends React.Component<Props, State> {
             open,
             keyboard,
         });
+
+        if (open) {
+            this.props.onOpen && this.props.onOpen();
+        } else {
+            this.props.onClose && this.props.onClose();
+        }
     };
 
     handleToggle = (selectedValue: string) => {

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -10,11 +10,21 @@ import {keyCodes} from "../util/constants.js";
 describe("SingleSelect", () => {
     let select;
     const onChange = jest.fn();
+    const onOpen = jest.fn();
+    const onClose = jest.fn();
 
     beforeEach(() => {
+        onChange.mockClear();
+        onOpen.mockClear();
+        onClose.mockClear();
         window.scrollTo = jest.fn();
         select = mount(
-            <SingleSelect onChange={onChange} placeholder="Choose">
+            <SingleSelect
+                onChange={onChange}
+                onOpen={onOpen}
+                onClose={onClose}
+                placeholder="Choose"
+            >
                 <OptionItem label="item 1" value="1" />
                 <OptionItem label="item 2" value="2" />
                 <OptionItem label="item 3" value="3" />
@@ -27,7 +37,7 @@ describe("SingleSelect", () => {
         unmountAll();
     });
 
-    it("closes/opens the select on mouse click, space, and enter", () => {
+    it("closes/opens the select on mouse click", () => {
         const opener = select.find(SelectOpener);
         expect(select.state("open")).toEqual(false);
 
@@ -36,16 +46,76 @@ describe("SingleSelect", () => {
         opener.simulate("mouseup");
         opener.simulate("click");
         expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(0);
+
+        // Close select with mouse
+        opener.simulate("mousedown");
+        opener.simulate("mouseup");
+        opener.simulate("click");
+        expect(select.state("open")).toEqual(false);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+
+        // Open select with mouse
+        opener.simulate("mousedown");
+        opener.simulate("mouseup");
+        opener.simulate("click");
+        expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(2);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes/opens the select on space", () => {
+        const opener = select.find(SelectOpener);
+        expect(select.state("open")).toEqual(false);
+
+        // Open select with space
+        opener.simulate("keydown", {keyCode: keyCodes.space});
+        opener.simulate("keyup", {keyCode: keyCodes.space});
+        expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(0);
 
         // Close select with space
         opener.simulate("keydown", {keyCode: keyCodes.space});
         opener.simulate("keyup", {keyCode: keyCodes.space});
         expect(select.state("open")).toEqual(false);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
 
-        // Should open with enter
+        // Open select with space
+        opener.simulate("keydown", {keyCode: keyCodes.space});
+        opener.simulate("keyup", {keyCode: keyCodes.space});
+        expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(2);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes/opens the select on enter", () => {
+        const opener = select.find(SelectOpener);
+        expect(select.state("open")).toEqual(false);
+
+        // Open select with enter
         opener.simulate("keydown", {keyCode: keyCodes.enter});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
         expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(0);
+
+        // Close select with enter
+        opener.simulate("keydown", {keyCode: keyCodes.enter});
+        opener.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(select.state("open")).toEqual(false);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+
+        // Open select with enter
+        opener.simulate("keydown", {keyCode: keyCodes.enter});
+        opener.simulate("keyup", {keyCode: keyCodes.enter});
+        expect(select.state("open")).toEqual(true);
+        expect(onOpen).toHaveBeenCalledTimes(2);
+        expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it("displays selected item label as expected", () => {


### PR DESCRIPTION
I'm working on a feature that I think requires knowing whether the dropdown is open or closed. So, I tried adding these `onOpen` and `onClose` callbacks. What do you think?

(Specifically, I'm building filters for the district dashboards, and we're tracking which filter values are selected in the URL's query string. If the user makes multiple changes to the dropdown in a row, i.e. they check a bunch of boxes at once, I want to treat that as an atomic action and use `replaceState`, to avoid creating a new history entry for each individual box they checked. But, once the user closes the dropdown, I want to "finalize" their input and make a permanent history entry for it. I can talk through this in more detail as needed! This isn't super-urgent though; for now, I'll just use `pushState` and accept the worser history experience.)