### PR TITLE
[fix: modal] WB-564 Modal returns to previous focused element

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -81,6 +81,12 @@ type State = {|
  * the `modal` prop.
  */
 export default class ModalLauncher extends React.Component<Props, State> {
+    /**
+     * The most recent element _outside this component_ that received focus.
+     * Be default, it captures the element that triggered the modal opening
+     */
+    lastElementFocusedOutsideModal: ?HTMLElement;
+
     static defaultProps = {
         backdropDismissEnabled: true,
     };
@@ -103,13 +109,32 @@ export default class ModalLauncher extends React.Component<Props, State> {
 
     state = {opened: false};
 
+    componentDidUpdate(prevProps: Props) {
+        const {opened} = this.props;
+        // ensures the element is stored only when the modal is opened
+        if (!prevProps.opened && opened) {
+            this._saveLastElementFocused();
+        }
+    }
+
+    _saveLastElementFocused = () => {
+        // keep a reference of the element that triggers the modal
+        this.lastElementFocusedOutsideModal = document.activeElement;
+    };
+
     _openModal = () => {
+        this._saveLastElementFocused();
         this.setState({opened: true});
     };
 
     handleCloseModal = () => {
         this.setState({opened: false}, () => {
             this.props.onClose && this.props.onClose();
+
+            if (this.lastElementFocusedOutsideModal != null) {
+                // return focus to the element that triggered the modal
+                this.lastElementFocusedOutsideModal.focus();
+            }
         });
     };
 

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -210,7 +210,34 @@ describe("ModalLauncher", () => {
         expect(onClose).not.toHaveBeenCalled();
     });
 
-    test("return focus to the last element focused outside the modal", async () => {
+    test("if modal is launched, move focus inside the modal", async () => {
+        // Arrange
+        const wrapper = mount(
+            <ModalLauncher modal={exampleModal}>
+                {({openModal}) => (
+                    <button onClick={openModal} data-last-focused-button />
+                )}
+            </ModalLauncher>,
+        );
+
+        const lastButton = wrapper
+            .find("[data-last-focused-button]")
+            .getDOMNode();
+        // force focus
+        lastButton.focus();
+
+        // Act
+        // Launch the modal.
+        wrapper.find("button").simulate("click");
+
+        // wait for styles to be applied
+        await sleep();
+
+        // Assert
+        expect(document.activeElement).not.toBe(lastButton);
+    });
+
+    test("if modal is closed, return focus to the last element focused outside the modal", async () => {
         // Arrange
         let savedCloseModal = () => {
             throw new Error(`closeModal wasn't saved`);
@@ -229,7 +256,6 @@ describe("ModalLauncher", () => {
             </ModalLauncher>,
         );
 
-        // Act
         const lastButton = wrapper
             .find("[data-last-focused-button]")
             .getDOMNode();
@@ -242,15 +268,11 @@ describe("ModalLauncher", () => {
         // wait for styles to be applied
         await sleep();
 
-        // focus has been moved inside the modal
-        expect(document.activeElement).not.toBe(lastButton);
-
-        // Close the modal.
-        savedCloseModal();
+        // Act
+        savedCloseModal(); // close the modal
         wrapper.update();
 
         // Assert
-        // check that focus is returned to the parent element
         expect(document.activeElement).toBe(lastButton);
     });
 });


### PR DESCRIPTION
When a dialog closes, focus now returns to the element that invoked the dialog.

Test Plan:
1) `yarn start` and open http://localhost:6060/#!/ModalLauncher/1
2) Click on **OnePaneDialog** button
3) Close the modal
4) Check that the focus is returned to the **OnePaneDialog** button

