### PR TITLE
[feat:core,modal] WB-576: Create IDprovider component

### DIFF
--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -6,6 +6,40 @@ exports[`wonder-blocks-core example 1 1`] = `
   style={
     Object {
       "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <label
+    htmlFor="uid-field-0-wb-id"
+  >
+    Label with ID 
+    uid-field-0-wb-id
+    :
+    <input
+      id="uid-field-0-wb-id"
+      type="text"
+    />
+  </label>
+</div>
+`;
+
+exports[`wonder-blocks-core example 2 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
       "backgroundColor": "plum",
       "borderStyle": "solid",
       "borderWidth": 0,
@@ -59,7 +93,7 @@ exports[`wonder-blocks-core example 1 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 2 1`] = `
+exports[`wonder-blocks-core example 3 1`] = `
 <div
   className=""
   style={
@@ -116,7 +150,7 @@ exports[`wonder-blocks-core example 2 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 3 1`] = `
+exports[`wonder-blocks-core example 4 1`] = `
 <div
   className=""
   style={
@@ -173,7 +207,7 @@ exports[`wonder-blocks-core example 3 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 4 1`] = `
+exports[`wonder-blocks-core example 5 1`] = `
 <div
   className=""
   style={
@@ -384,13 +418,13 @@ exports[`wonder-blocks-core example 4 1`] = `
       Render 
       0
       : 
-      uid--0-my-unique-id
+      uid--1-my-unique-id
     </span>
   </div>
 </div>
 `;
 
-exports[`wonder-blocks-core example 5 1`] = `
+exports[`wonder-blocks-core example 6 1`] = `
 <div
   className=""
   style={
@@ -560,7 +594,7 @@ exports[`wonder-blocks-core example 5 1`] = `
       }
     >
       get("an-id"): 
-      uid--1-an-id
+      uid--2-an-id
     </span>
     <span
       className=""
@@ -577,13 +611,13 @@ exports[`wonder-blocks-core example 5 1`] = `
       }
     >
       get("something"): 
-      uid--1-something
+      uid--2-something
     </span>
   </div>
 </div>
 `;
 
-exports[`wonder-blocks-core example 6 1`] = `
+exports[`wonder-blocks-core example 7 1`] = `
 <div
   className=""
   style={
@@ -655,7 +689,7 @@ exports[`wonder-blocks-core example 6 1`] = `
       }
     >
       The id returned for "my-identifier": 
-      uid-first-2-my-identifier
+      uid-first-3-my-identifier
     </span>
   </div>
   <h4
@@ -710,13 +744,13 @@ exports[`wonder-blocks-core example 6 1`] = `
       }
     >
       The id returned for "my-identifier": 
-      uid-second-3-my-identifier
+      uid-second-4-my-identifier
     </span>
   </div>
 </div>
 `;
 
-exports[`wonder-blocks-core example 7 1`] = `
+exports[`wonder-blocks-core example 8 1`] = `
 <div
   className=""
   style={
@@ -833,7 +867,7 @@ exports[`wonder-blocks-core example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 8 1`] = `
+exports[`wonder-blocks-core example 9 1`] = `
 <div
   className=""
   style={
@@ -892,7 +926,7 @@ exports[`wonder-blocks-core example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 9 1`] = `
+exports[`wonder-blocks-core example 10 1`] = `
 <div
   className=""
   style={
@@ -949,7 +983,7 @@ exports[`wonder-blocks-core example 9 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 10 1`] = `
+exports[`wonder-blocks-core example 11 1`] = `
 <div
   className=""
   style={
@@ -973,7 +1007,7 @@ exports[`wonder-blocks-core example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 11 1`] = `
+exports[`wonder-blocks-core example 12 1`] = `
 <div
   className=""
   style={
@@ -997,7 +1031,7 @@ exports[`wonder-blocks-core example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 12 1`] = `
+exports[`wonder-blocks-core example 13 1`] = `
 <div
   className=""
   style={
@@ -1076,7 +1110,7 @@ exports[`wonder-blocks-core example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 13 1`] = `
+exports[`wonder-blocks-core example 14 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -40,6 +40,40 @@ exports[`wonder-blocks-core example 2 1`] = `
   style={
     Object {
       "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <label
+    htmlFor="some-user-id"
+  >
+    Label with ID 
+    some-user-id
+    :
+    <input
+      id="some-user-id"
+      type="text"
+    />
+  </label>
+</div>
+`;
+
+exports[`wonder-blocks-core example 3 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
       "backgroundColor": "plum",
       "borderStyle": "solid",
       "borderWidth": 0,
@@ -93,7 +127,7 @@ exports[`wonder-blocks-core example 2 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 3 1`] = `
+exports[`wonder-blocks-core example 4 1`] = `
 <div
   className=""
   style={
@@ -150,7 +184,7 @@ exports[`wonder-blocks-core example 3 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 4 1`] = `
+exports[`wonder-blocks-core example 5 1`] = `
 <div
   className=""
   style={
@@ -207,7 +241,7 @@ exports[`wonder-blocks-core example 4 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 5 1`] = `
+exports[`wonder-blocks-core example 6 1`] = `
 <div
   className=""
   style={
@@ -424,7 +458,7 @@ exports[`wonder-blocks-core example 5 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 6 1`] = `
+exports[`wonder-blocks-core example 7 1`] = `
 <div
   className=""
   style={
@@ -617,7 +651,7 @@ exports[`wonder-blocks-core example 6 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 7 1`] = `
+exports[`wonder-blocks-core example 8 1`] = `
 <div
   className=""
   style={
@@ -750,7 +784,7 @@ exports[`wonder-blocks-core example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 8 1`] = `
+exports[`wonder-blocks-core example 9 1`] = `
 <div
   className=""
   style={
@@ -867,7 +901,7 @@ exports[`wonder-blocks-core example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 9 1`] = `
+exports[`wonder-blocks-core example 10 1`] = `
 <div
   className=""
   style={
@@ -926,7 +960,7 @@ exports[`wonder-blocks-core example 9 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 10 1`] = `
+exports[`wonder-blocks-core example 11 1`] = `
 <div
   className=""
   style={
@@ -983,7 +1017,7 @@ exports[`wonder-blocks-core example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 11 1`] = `
+exports[`wonder-blocks-core example 12 1`] = `
 <div
   className=""
   style={
@@ -1007,7 +1041,7 @@ exports[`wonder-blocks-core example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 12 1`] = `
+exports[`wonder-blocks-core example 13 1`] = `
 <div
   className=""
   style={
@@ -1031,7 +1065,7 @@ exports[`wonder-blocks-core example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 13 1`] = `
+exports[`wonder-blocks-core example 14 1`] = `
 <div
   className=""
   style={
@@ -1110,7 +1144,7 @@ exports[`wonder-blocks-core example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 14 1`] = `
+exports[`wonder-blocks-core example 15 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-core/components/id-provider.js
+++ b/packages/wonder-blocks-core/components/id-provider.js
@@ -1,14 +1,15 @@
 // @flow
 import * as React from "react";
 
-import {UniqueIDProvider} from "@khanacademy/wonder-blocks-core";
-import type {IIdentifierFactory} from "@khanacademy/wonder-blocks-core";
+import UniqueIDProvider from "./unique-id-provider.js";
+
+import type {IIdentifierFactory} from "../util/types.js";
 
 type Props = {|
     /**
      * Use the children-as-function pattern to pass a uniqueId string for
-     * use anywhere within children. This provides a way of adding a unique title
-     * to an existant modal variation (OnePaneDialog) or a custom modal implementation.
+     * use anywhere within children. This provides a way of adding a unique identifier
+     * to a given component for a11y purposes.
      */
     children: (uniqueId: string) => React.Node,
 
@@ -30,24 +31,25 @@ type Props = {|
 |};
 
 /**
- * This is a Dialog wrapper that returns a unique Modal Title for A11Y purposes.
- * This way, the wrapped Dialog will receive this custom ID and will use it to refer to a
- * visible dialog title.
+ * This is a wrapper that returns a unique Identifier for A11Y purposes.
+ * This way, the wrapped component will receive this custom ID and will use it to connect
+ * different elements.
  *
- * @see https://www.w3.org/TR/wai-aria-practices/#dialog_roles_states_props
+ * e.g. It uses the same generated id to connect a Dialog with its main title, or form label
+ * with the associated input element, etc.
  */
-export default class UniqueDialog extends React.Component<Props> {
-    static defaultTitleId = "wb-title";
+export default class IDProvider extends React.Component<Props> {
+    static defaultId = "wb-id";
 
     renderChildren(ids?: IIdentifierFactory) {
         const {id, children} = this.props;
-        const titleId = ids ? ids.get(UniqueDialog.defaultTitleId) : id;
+        const uniqueId = ids ? ids.get(IDProvider.defaultId) : id;
 
-        if (!titleId) {
+        if (!uniqueId) {
             throw new Error("Did not get an identifier factory nor a id prop");
         }
 
-        return children(titleId);
+        return children(uniqueId);
     }
 
     render() {

--- a/packages/wonder-blocks-core/components/id-provider.js
+++ b/packages/wonder-blocks-core/components/id-provider.js
@@ -32,6 +32,10 @@ type Props = {|
 
 /**
  * This is a wrapper that returns a unique Identifier for A11Y purposes.
+ *
+ * The main difference with UniqueIDProvider is that IDProvider has a single responsibility,
+ * to return an identifier that can by used by the children that are rendered internally.
+ *
  * This way, the wrapped component will receive this custom ID and will use it to connect
  * different elements.
  *

--- a/packages/wonder-blocks-core/components/id-provider.js
+++ b/packages/wonder-blocks-core/components/id-provider.js
@@ -31,7 +31,9 @@ type Props = {|
 |};
 
 /**
- * This is a wrapper that returns a unique Identifier for A11Y purposes.
+ * This is a wrapper that returns an identifier. If the `id` prop is set, the component will
+ * return the same id to be consumed by its children. Otherwise, a unique id will be provided.
+ * This is beneficial for accessibility purpuses, among other things.
  *
  * The main difference with UniqueIDProvider is that IDProvider has a single responsibility,
  * to return an identifier that can by used by the children that are rendered internally.

--- a/packages/wonder-blocks-core/components/id-provider.md
+++ b/packages/wonder-blocks-core/components/id-provider.md
@@ -3,16 +3,14 @@
 This example allows you to generate an unique ID and make it available to associate the `<label>` and `<input>` elements. To see this example in action, check that `label[for]` and `input[id]` are using the same id.
 
 ```jsx
-const children = (uniqueId) => (
-    <label htmlFor={uniqueId}>
-        Label with ID {uniqueId}:
-        <input type="text" id={uniqueId} />
-    </label>
-);
-
 <View>
     <IDProvider scope="field">
-        {children}
+        {(uniqueId) => (
+            <label htmlFor={uniqueId}>
+                Label with ID {uniqueId}:
+                <input type="text" id={uniqueId} />
+            </label>
+        )}
     </IDProvider>
 </View>
 ```

--- a/packages/wonder-blocks-core/components/id-provider.md
+++ b/packages/wonder-blocks-core/components/id-provider.md
@@ -14,3 +14,20 @@ This example allows you to generate an unique ID and make it available to associ
     </IDProvider>
 </View>
 ```
+
+### Example: Identifier provided by parent component
+
+In some cases, a parent component using `IDProvider` could have an identifier as well. For this particular scenario, we can reuse this ID and pass it down to `IDProvider`. This will avoid generating a unique identifier, and it will reuse the passed identifier instead.
+
+```jsx
+<View>
+    <IDProvider scope="field" id="some-user-id">
+        {(uniqueId) => (
+            <label htmlFor={uniqueId}>
+                Label with ID {uniqueId}:
+                <input type="text" id={uniqueId} />
+            </label>
+        )}
+    </IDProvider>
+</View>
+```

--- a/packages/wonder-blocks-core/components/id-provider.md
+++ b/packages/wonder-blocks-core/components/id-provider.md
@@ -1,0 +1,18 @@
+### Example: Usage with form fields
+
+This example allows you to generate an unique ID and make it available to associate the `<label>` and `<input>` elements. To see this example in action, check that `label[for]` and `input[id]` are using the same id.
+
+```jsx
+const children = (uniqueId) => (
+    <label htmlFor={uniqueId}>
+        Label with ID {uniqueId}:
+        <input type="text" id={uniqueId} />
+    </label>
+);
+
+<View>
+    <IDProvider scope="field">
+        {children}
+    </IDProvider>
+</View>
+```

--- a/packages/wonder-blocks-core/components/id-provider.test.js
+++ b/packages/wonder-blocks-core/components/id-provider.test.js
@@ -2,9 +2,9 @@
 import React from "react";
 import {mount, shallow} from "enzyme";
 
-import UniqueDialog from "./unique-dialog.js";
+import IDProvider from "./id-provider.js";
 
-const mockIDENTIFIER = `uid-modal-0-${UniqueDialog.defaultTitleId}`;
+const mockIDENTIFIER = `uid-component-0-${IDProvider.defaultId}`;
 
 jest.mock("@khanacademy/wonder-blocks-core", () => {
     const Core = jest.requireActual("@khanacademy/wonder-blocks-core");
@@ -26,9 +26,9 @@ describe("UniqueDialog", () => {
 
         // Act
         shallow(
-            <UniqueDialog id={titleId} scope="modal">
+            <IDProvider id={titleId} scope="component">
                 {renderDialogFn}
-            </UniqueDialog>,
+            </IDProvider>,
         );
 
         // Assert
@@ -40,7 +40,7 @@ describe("UniqueDialog", () => {
         const renderDialogFn = jest.fn(() => <div />);
 
         // Act
-        mount(<UniqueDialog scope="modal">{renderDialogFn}</UniqueDialog>);
+        mount(<IDProvider scope="component">{renderDialogFn}</IDProvider>);
 
         // Assert
         expect(renderDialogFn).toHaveBeenCalledWith(mockIDENTIFIER);

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -33,6 +33,22 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
     it("example 2", () => {
+        const example = (
+            <View>
+                <IDProvider scope="field" id="some-user-id">
+                    {(uniqueId) => (
+                        <label htmlFor={uniqueId}>
+                            Label with ID {uniqueId}:
+                            <input type="text" id={uniqueId} />
+                        </label>
+                    )}
+                </IDProvider>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 3", () => {
         const {StyleSheet} = require("aphrodite");
 
         const styles = StyleSheet.create({
@@ -62,7 +78,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 3", () => {
+    it("example 4", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -75,7 +91,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 4", () => {
+    it("example 5", () => {
         const example = (
             <View>
                 <View testId="foo">Foo</View>
@@ -85,7 +101,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 5", () => {
+    it("example 6", () => {
         const {
             Body,
             HeadingSmall,
@@ -136,7 +152,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 6", () => {
+    it("example 7", () => {
         const {
             Body,
             BodyMonospace,
@@ -179,7 +195,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 7", () => {
+    it("example 8", () => {
         const {
             Body,
             HeadingSmall,
@@ -210,7 +226,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 8", () => {
+    it("example 9", () => {
         const {
             BodyMonospace,
         } = require("@khanacademy/wonder-blocks-typography");
@@ -234,7 +250,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 9", () => {
+    it("example 10", () => {
         const {StyleSheet} = require("aphrodite");
 
         const styles = StyleSheet.create({
@@ -264,7 +280,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 10", () => {
+    it("example 11", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -277,7 +293,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 11", () => {
+    it("example 12", () => {
         const example = (
             <WithSSRPlaceholder
                 placeholder={() => (
@@ -298,7 +314,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 12", () => {
+    it("example 13", () => {
         const example = (
             <WithSSRPlaceholder placeholder={null}>
                 {() => (
@@ -312,7 +328,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 13", () => {
+    it("example 14", () => {
         const {
             Body,
             BodyMonospace,
@@ -391,7 +407,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 14", () => {
+    it("example 15", () => {
         const {
             Body,
             BodyMonospace,

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -17,6 +17,22 @@ import WithSSRPlaceholder from "./components/with-ssr-placeholder.js";
 
 describe("wonder-blocks-core", () => {
     it("example 1", () => {
+        const children = (uniqueId) => (
+            <label htmlFor={uniqueId}>
+                Label with ID {uniqueId}:
+                <input type="text" id={uniqueId} />
+            </label>
+        );
+
+        const example = (
+            <View>
+                <IDProvider scope="field">{children}</IDProvider>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 2", () => {
         const {StyleSheet} = require("aphrodite");
 
         const styles = StyleSheet.create({
@@ -46,7 +62,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 2", () => {
+    it("example 3", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -59,7 +75,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 3", () => {
+    it("example 4", () => {
         const example = (
             <View>
                 <View testId="foo">Foo</View>
@@ -69,7 +85,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 4", () => {
+    it("example 5", () => {
         const {
             Body,
             HeadingSmall,
@@ -120,7 +136,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 5", () => {
+    it("example 6", () => {
         const {
             Body,
             BodyMonospace,
@@ -163,7 +179,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 6", () => {
+    it("example 7", () => {
         const {
             Body,
             HeadingSmall,
@@ -194,7 +210,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 7", () => {
+    it("example 8", () => {
         const {
             BodyMonospace,
         } = require("@khanacademy/wonder-blocks-typography");
@@ -218,7 +234,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 8", () => {
+    it("example 9", () => {
         const {StyleSheet} = require("aphrodite");
 
         const styles = StyleSheet.create({
@@ -248,7 +264,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 9", () => {
+    it("example 10", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -261,7 +277,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 10", () => {
+    it("example 11", () => {
         const example = (
             <WithSSRPlaceholder
                 placeholder={() => (
@@ -282,7 +298,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 11", () => {
+    it("example 12", () => {
         const example = (
             <WithSSRPlaceholder placeholder={null}>
                 {() => (
@@ -296,7 +312,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 12", () => {
+    it("example 13", () => {
         const {
             Body,
             BodyMonospace,
@@ -375,7 +391,7 @@ describe("wonder-blocks-core", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 13", () => {
+    it("example 14", () => {
         const {
             Body,
             BodyMonospace,

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -17,16 +17,16 @@ import WithSSRPlaceholder from "./components/with-ssr-placeholder.js";
 
 describe("wonder-blocks-core", () => {
     it("example 1", () => {
-        const children = (uniqueId) => (
-            <label htmlFor={uniqueId}>
-                Label with ID {uniqueId}:
-                <input type="text" id={uniqueId} />
-            </label>
-        );
-
         const example = (
             <View>
-                <IDProvider scope="field">{children}</IDProvider>
+                <IDProvider scope="field">
+                    {(uniqueId) => (
+                        <label htmlFor={uniqueId}>
+                            Label with ID {uniqueId}:
+                            <input type="text" id={uniqueId} />
+                        </label>
+                    )}
+                </IDProvider>
             </View>
         );
         const tree = renderer.create(example).toJSON();

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -9,6 +9,7 @@ import renderer from "react-test-renderer";
 // Mock react-dom as jest doesn't like findDOMNode.
 jest.mock("react-dom");
 import ClickableBehavior from "./components/clickable-behavior.js";
+import IDProvider from "./components/id-provider.js";
 import Text from "./components/text.js";
 import UniqueIDProvider from "./components/unique-id-provider.js";
 import View from "./components/view.js";

--- a/packages/wonder-blocks-core/index.js
+++ b/packages/wonder-blocks-core/index.js
@@ -9,6 +9,7 @@ export {default as View} from "./components/view.js";
 export {
     default as WithSSRPlaceholder,
 } from "./components/with-ssr-placeholder.js";
+export {default as IDProvider} from "./components/id-provider.js";
 export {default as UniqueIDProvider} from "./components/unique-id-provider.js";
 export {default as addStyle} from "./util/add-style.js";
 export {

--- a/packages/wonder-blocks-core/index.test.js
+++ b/packages/wonder-blocks-core/index.test.js
@@ -17,6 +17,7 @@ describe("@khanacademy/wonder-blocks-core", () => {
                 "addStyle",
                 "getClickableBehavior",
                 "getElementIntersection",
+                "IDProvider",
                 "UniqueIDProvider",
             ].sort(),
         );

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -308,7 +308,7 @@ exports[`wonder-blocks-modal example 3 1`] = `
         />
       </div>
       <div
-        aria-labelledby="uid-modal-0-wb-title"
+        aria-labelledby="uid-modal-0-wb-id"
         className=""
         role="dialog"
         style={
@@ -445,7 +445,7 @@ exports[`wonder-blocks-modal example 3 1`] = `
           >
             <h3
               className=""
-              id="uid-modal-0-wb-title"
+              id="uid-modal-0-wb-id"
               style={
                 Object {
                   "@media (maxWidth: 1023px)": Object {
@@ -1042,7 +1042,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
       }
     >
       <div
-        aria-labelledby="uid-modal-1-wb-title"
+        aria-labelledby="uid-modal-1-wb-id"
         className=""
         role="dialog"
         style={
@@ -1179,7 +1179,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
           >
             <h3
               className=""
-              id="uid-modal-1-wb-title"
+              id="uid-modal-1-wb-id"
               style={
                 Object {
                   "@media (maxWidth: 1023px)": Object {
@@ -1560,7 +1560,7 @@ exports[`wonder-blocks-modal example 8 1`] = `
       }
     >
       <div
-        aria-labelledby="uid-modal-2-wb-title"
+        aria-labelledby="uid-modal-2-wb-id"
         className=""
         role="dialog"
         style={
@@ -1811,7 +1811,7 @@ exports[`wonder-blocks-modal example 8 1`] = `
             </div>
             <h3
               className=""
-              id="uid-modal-2-wb-title"
+              id="uid-modal-2-wb-id"
               style={
                 Object {
                   "@media (maxWidth: 1023px)": Object {
@@ -2255,7 +2255,7 @@ exports[`wonder-blocks-modal example 9 1`] = `
       }
     >
       <div
-        aria-labelledby="uid-modal-3-wb-title"
+        aria-labelledby="uid-modal-3-wb-id"
         className=""
         role="dialog"
         style={
@@ -2392,7 +2392,7 @@ exports[`wonder-blocks-modal example 9 1`] = `
           >
             <h3
               className=""
-              id="uid-modal-3-wb-title"
+              id="uid-modal-3-wb-id"
               style={
                 Object {
                   "@media (maxWidth: 1023px)": Object {

--- a/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.js
@@ -5,10 +5,10 @@ import {Breadcrumbs} from "@khanacademy/wonder-blocks-breadcrumbs";
 import {MediaLayout} from "@khanacademy/wonder-blocks-layout";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
+import {IDProvider} from "@khanacademy/wonder-blocks-core";
 import ModalDialog from "../modal-dialog.js";
 import ModalPanel from "../modal-panel.js";
 import ModalHeader from "../modal-header.js";
-import UniqueDialog from "../unique-dialog.js";
 
 type Props = {|
     ...AriaProps,
@@ -118,7 +118,7 @@ export default class OnePaneDialog extends React.Component<Props> {
         return (
             <MediaLayout styleSheets={styleSheets}>
                 {({styles}) => (
-                    <UniqueDialog id={titleId} scope="modal">
+                    <IDProvider id={titleId} scope="modal">
                         {(uniqueId) => (
                             <ModalDialog
                                 style={[styles.dialog, style]}
@@ -142,7 +142,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                                 />
                             </ModalDialog>
                         )}
-                    </UniqueDialog>
+                    </IDProvider>
                 )}
             </MediaLayout>
         );


### PR DESCRIPTION
## Core - IDProvider
- Moved `UniqueDialog` from `modal` to `core` and renamed it to `IDProvider`.
- Refactored `IDProvider` to be used by different components/packages.
- Added documentation example.
- Updated unit tests.

## Test plan
1. Run `yarn test`.
2. Open `http://localhost:6060/#!/IDProvider/1` and make sure the example works as expected.