### PR TITLE
WB-581 Add aria-hidden prop to Icon and SelectOpener

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1033,6 +1033,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
         Choose a fruit
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -1169,6 +1170,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
         Choose a pet
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -1304,6 +1306,7 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
         Banana juice
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -1440,6 +1443,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
         Banana juice
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -1600,6 +1604,7 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
           Boba order
         </span>
         <svg
+          aria-hidden="true"
           className=""
           height={16}
           style={
@@ -1737,6 +1742,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
         empty
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -1892,6 +1898,7 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
         Accessible SingleSelect
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -2028,6 +2035,7 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
         Color palette
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -2163,6 +2171,7 @@ exports[`wonder-blocks-dropdown example 14 1`] = `
         Solar system
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -2298,6 +2307,7 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
         Sophie
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -2527,6 +2537,7 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
         empty
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={
@@ -2682,6 +2693,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
         Accessible MultiSelect
       </span>
       <svg
+        aria-hidden="true"
         className=""
         height={16}
         style={

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -152,6 +152,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                                 color={iconColor}
                                 size="small"
                                 style={styles.caret}
+                                aria-hidden="true"
                             />
                         </StyledButton>
                     );

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -84,7 +84,7 @@ export default class Icon extends React.PureComponent<Props> {
         // double-quotes on commit. So the aria-label prop isn't included in
         // props validation.
         // eslint-disable-next-line react/prop-types
-        const {"aria-label": ariaLabel} = this.props;
+        const {"aria-hidden": ariaHidden, "aria-label": ariaLabel} = this.props;
         const {color, icon, size, style} = this.props;
 
         const {assetSize, path} = getPathForIcon(icon, size);
@@ -95,6 +95,7 @@ export default class Icon extends React.PureComponent<Props> {
                 style={[styles.svg, style]}
                 width={pixelSize}
                 height={pixelSize}
+                aria-hidden={ariaHidden}
                 aria-label={ariaLabel}
                 viewBox={`0 0 ${viewboxPixelSize} ${viewboxPixelSize}`}
             >


### PR DESCRIPTION
## Icon
- Added `aria-hidden` as prop (`false` by default).

## Dropdown
- Modified **<SelectOpener />** to pass `aria-hidden="true"` to its internal `Icon` instance.

### Test plan

#### Staging env:
1. Open https://deploy-preview-406--wonder-blocks.netlify.com/#!/SingleSelect/13
2. Inspect the `svg` icon element and make sure it includes `aria-hidden="true"`.