### PR TITLE
[feat:button,dropdown,form,icon] WB-580 Components should pass through all aria-props to their foundational inputs

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -21,7 +21,6 @@ exports[`wonder-blocks-button example 1 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -92,7 +91,6 @@ exports[`wonder-blocks-button example 1 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -166,7 +164,6 @@ exports[`wonder-blocks-button example 1 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -260,7 +257,6 @@ exports[`wonder-blocks-button example 2 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -331,7 +327,6 @@ exports[`wonder-blocks-button example 2 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -405,7 +400,6 @@ exports[`wonder-blocks-button example 2 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -500,7 +494,6 @@ exports[`wonder-blocks-button example 3 1`] = `
 >
   <button
     aria-disabled="true"
-    aria-label=""
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -572,7 +565,6 @@ exports[`wonder-blocks-button example 3 1`] = `
   </button>
   <button
     aria-disabled="true"
-    aria-label=""
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -647,7 +639,6 @@ exports[`wonder-blocks-button example 3 1`] = `
   </button>
   <button
     aria-disabled="true"
-    aria-label=""
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -742,7 +733,6 @@ exports[`wonder-blocks-button example 4 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -813,7 +803,6 @@ exports[`wonder-blocks-button example 4 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -887,7 +876,6 @@ exports[`wonder-blocks-button example 4 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -959,7 +947,6 @@ exports[`wonder-blocks-button example 4 1`] = `
   </button>
   <button
     aria-disabled="true"
-    aria-label=""
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -1031,7 +1018,6 @@ exports[`wonder-blocks-button example 4 1`] = `
   </button>
   <button
     aria-disabled="true"
-    aria-label=""
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -1106,7 +1092,6 @@ exports[`wonder-blocks-button example 4 1`] = `
   </button>
   <button
     aria-disabled="true"
-    aria-label=""
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -1200,7 +1185,6 @@ exports[`wonder-blocks-button example 5 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -1271,7 +1255,6 @@ exports[`wonder-blocks-button example 5 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -1345,7 +1328,6 @@ exports[`wonder-blocks-button example 5 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -1439,7 +1421,6 @@ exports[`wonder-blocks-button example 6 1`] = `
   }
 >
   <a
-    aria-label=""
     className=""
     href="#button-1"
     onBlur={[Function]}
@@ -1505,7 +1486,6 @@ exports[`wonder-blocks-button example 6 1`] = `
     </span>
   </a>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -1579,7 +1559,6 @@ exports[`wonder-blocks-button example 6 1`] = `
     </span>
   </button>
   <a
-    aria-label=""
     className=""
     href="#button-1"
     onBlur={[Function]}
@@ -1668,7 +1647,6 @@ exports[`wonder-blocks-button example 7 1`] = `
   }
 >
   <a
-    aria-label=""
     className=""
     href="/foo"
     onBlur={[Function]}
@@ -1734,7 +1712,6 @@ exports[`wonder-blocks-button example 7 1`] = `
     </span>
   </a>
   <a
-    aria-label=""
     className=""
     href="/foo"
     onBlur={[Function]}
@@ -2118,7 +2095,6 @@ exports[`wonder-blocks-button example 9 1`] = `
     }
   >
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -2209,7 +2185,6 @@ exports[`wonder-blocks-button example 9 1`] = `
       </span>
     </button>
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -2303,7 +2278,6 @@ exports[`wonder-blocks-button example 9 1`] = `
       </span>
     </button>
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -2415,7 +2389,6 @@ exports[`wonder-blocks-button example 9 1`] = `
     }
   >
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -2507,7 +2480,6 @@ exports[`wonder-blocks-button example 9 1`] = `
       </span>
     </button>
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -2602,7 +2574,6 @@ exports[`wonder-blocks-button example 9 1`] = `
       </span>
     </button>
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -2718,7 +2689,6 @@ exports[`wonder-blocks-button example 10 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -2830,7 +2800,6 @@ exports[`wonder-blocks-button example 11 1`] = `
     }
   >
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -2940,7 +2909,6 @@ exports[`wonder-blocks-button example 11 1`] = `
     }
   >
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -3034,7 +3002,6 @@ exports[`wonder-blocks-button example 12 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -3109,7 +3076,6 @@ exports[`wonder-blocks-button example 12 1`] = `
     </span>
   </button>
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -3223,7 +3189,6 @@ exports[`wonder-blocks-button example 13 1`] = `
     }
   >
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}
@@ -3294,7 +3259,6 @@ exports[`wonder-blocks-button example 13 1`] = `
       </span>
     </button>
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -3,11 +3,18 @@ import * as React from "react";
 import PropTypes from "prop-types";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 import ButtonCore from "./button-core.js";
 
 export type SharedProps = {|
+    /**
+     * aria-label should be used when `spinner={true}` to let people using screen
+     * readers that the action taken by clicking the button will take some
+     * time to complete.
+     */
+    ...AriaProps,
+
     /**
      * Text to appear on the button.
      */
@@ -26,13 +33,6 @@ export type SharedProps = {|
      * TODO(kevinb): support spinner + light once we have designs
      */
     spinner: boolean,
-
-    /**
-     * This should be use when `spinner={true}` to let people using screen
-     * readers that the action taken by clicking the button will take some
-     * time to complete.
-     */
-    "aria-label": string,
 
     /**
      * The color of the button, either blue or red.

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -158,7 +158,6 @@ export default class Button extends React.Component<SharedProps> {
         size: "medium",
         disabled: false,
         spinner: false,
-        "aria-label": "",
     };
 
     static contextTypes = {router: PropTypes.any};

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -213,7 +213,6 @@ exports[`wonder-blocks-core example 4 1`] = `
     }
   >
     <button
-      aria-label=""
       className=""
       disabled={false}
       onBlur={[Function]}

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -2353,7 +2353,6 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import ReactDOM from "react-dom";
 import {StyleSheet} from "aphrodite";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import Dropdown from "./dropdown.js";
 import ActionItem from "./action-item.js";
 import OptionItem from "./option-item.js";
@@ -13,6 +13,8 @@ import ActionMenuOpener from "./action-menu-opener.js";
 import type {Item, DropdownItem} from "../util/types.js";
 
 type MenuProps = {|
+    ...AriaProps,
+
     /**
      * The items in this dropdown.
      */
@@ -183,6 +185,14 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
             style,
             testId,
             dropdownStyle,
+            // the following props are being included here to avoid
+            // passing them down to the opener as part of sharedProps
+            /* eslint-disable no-unused-vars */
+            children,
+            onChange,
+            selectedValues,
+            /* eslint-enable no-unused-vars */
+            ...sharedProps
         } = this.props;
         const {open} = this.state;
 
@@ -190,6 +200,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
 
         const opener = (
             <ActionMenuOpener
+                {...sharedProps}
                 disabled={items.length === 0 || disabled}
                 onOpenChanged={this.handleOpenChanged}
                 open={open}

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -14,8 +14,13 @@ import {selectDropdownStyle} from "../util/constants.js";
 import typeof OptionItem from "./option-item.js";
 import type {DropdownItem} from "../util/types.js";
 
-type SelectOpenerProps = {|
+type Props = {|
     ...AriaProps,
+
+    /**
+     * The items in this select.
+     */
+    children?: Array<React.Element<OptionItem>>,
 
     /**
      * Whether this component is disabled. A disabled dropdown may not be opened
@@ -29,20 +34,6 @@ type SelectOpenerProps = {|
      * Used to match `<label>` with `<button>` elements for screenreaders.
      */
     id?: string,
-
-    /**
-     * Test ID used for e2e testing.
-     */
-    testId?: string,
-|};
-
-type Props = {|
-    ...SelectOpenerProps,
-
-    /**
-     * The items in this select.
-     */
-    children?: Array<React.Element<OptionItem>>,
 
     /**
      * Callback for when the selection changes. Parameter is an updated array of
@@ -89,6 +80,11 @@ type Props = {|
      * Optional styling to add to the opener component wrapper.
      */
     style?: StyleType,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 
     /**
      * Optional styling to add to the dropdown wrapper.

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -14,13 +14,14 @@ import {selectDropdownStyle} from "../util/constants.js";
 import typeof OptionItem from "./option-item.js";
 import type {DropdownItem} from "../util/types.js";
 
-type Props = {|
+type SelectOpenerProps = {|
     ...AriaProps,
 
     /**
-     * The items in this select.
+     * Whether this component is disabled. A disabled dropdown may not be opened
+     * and does not support interaction. Defaults to false.
      */
-    children?: Array<React.Element<OptionItem>>,
+    disabled: boolean,
 
     /**
      * Unique identifier attached to the field control. If used, we need to
@@ -28,6 +29,20 @@ type Props = {|
      * Used to match `<label>` with `<button>` elements for screenreaders.
      */
     id?: string,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+|};
+
+type Props = {|
+    ...SelectOpenerProps,
+
+    /**
+     * The items in this select.
+     */
+    children?: Array<React.Element<OptionItem>>,
 
     /**
      * Callback for when the selection changes. Parameter is an updated array of
@@ -65,12 +80,6 @@ type Props = {|
     alignment: "left" | "right",
 
     /**
-     * Whether this component is disabled. A disabled dropdown may not be opened
-     * and does not support interaction. Defaults to false.
-     */
-    disabled: boolean,
-
-    /**
      * Whether to display the "light" version of this component instead, for
      * use when the component is used on a dark background.
      */
@@ -80,11 +89,6 @@ type Props = {|
      * Optional styling to add to the opener component wrapper.
      */
     style?: StyleType,
-
-    /**
-     * Test ID used for e2e testing.
-     */
-    testId?: string,
 
     /**
      * Optional styling to add to the dropdown wrapper.
@@ -271,7 +275,6 @@ export default class MultiSelect extends React.Component<Props, State> {
     render() {
         const {
             alignment,
-            "aria-labelledby": ariaLabelledBy,
             disabled,
             id,
             light,
@@ -279,6 +282,16 @@ export default class MultiSelect extends React.Component<Props, State> {
             style,
             testId,
             dropdownStyle,
+            // the following props are being included here to avoid
+            // passing them down to the opener as part of sharedProps
+            /* eslint-disable no-unused-vars */
+            children,
+            onChange,
+            selectedValues,
+            selectItemType,
+            shortcuts,
+            /* eslint-enable no-unused-vars */
+            ...sharedProps
         } = this.props;
         const {open} = this.state;
 
@@ -288,7 +301,7 @@ export default class MultiSelect extends React.Component<Props, State> {
 
         const opener = (
             <SelectOpener
-                aria-labelledby={ariaLabelledBy}
+                {...sharedProps}
                 disabled={items.length === 0 || disabled}
                 id={id}
                 isPlaceholder={menuText === placeholder}

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -285,7 +285,7 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
-    <MultiSelect menuText="Empty" placeholder="empty" />
+    <MultiSelect placeholder="empty" />
 </View>
 ```
 

--- a/packages/wonder-blocks-dropdown/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/components/select-opener.js
@@ -94,7 +94,6 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
 
     render() {
         const {
-            "aria-labelledby": ariaLabelledBy,
             children,
             disabled,
             id,
@@ -102,6 +101,9 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
             light,
             open,
             testId,
+            // eslint-disable-next-line no-unused-vars
+            onOpenChanged,
+            ...sharedProps
         } = this.props;
 
         const ClickableBehavior = getClickableBehavior(this.context.router);
@@ -134,7 +136,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
 
                     return (
                         <StyledButton
-                            aria-labelledby={ariaLabelledBy}
+                            {...sharedProps}
                             aria-expanded={open ? "true" : "false"}
                             aria-haspopup="listbox"
                             data-test-id={testId}

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -175,7 +175,6 @@ export default class SingleSelect extends React.Component<Props, State> {
     render() {
         const {
             alignment,
-            "aria-labelledby": ariaLabelledBy,
             children,
             disabled,
             dropdownStyle,
@@ -185,6 +184,9 @@ export default class SingleSelect extends React.Component<Props, State> {
             selectedValue,
             style,
             testId,
+            // eslint-disable-next-line no-unused-vars
+            onChange,
+            ...sharedProps
         } = this.props;
         const {open} = this.state;
 
@@ -199,8 +201,8 @@ export default class SingleSelect extends React.Component<Props, State> {
 
         const opener = (
             <SelectOpener
+                {...sharedProps}
                 disabled={items.length === 0 || disabled}
-                aria-labelledby={ariaLabelledBy}
                 id={id}
                 isPlaceholder={!selectedItem}
                 light={light}

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -298,7 +298,7 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
-    <SingleSelect menuText="Empty" placeholder="empty" />
+    <SingleSelect placeholder="empty" />
 </View>
 ```
 

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -618,7 +618,7 @@ describe("wonder-blocks-dropdown", () => {
 
         const example = (
             <View style={styles.row}>
-                <SingleSelect menuText="Empty" placeholder="empty" />
+                <SingleSelect placeholder="empty" />
             </View>
         );
         const tree = renderer.create(example).toJSON();
@@ -960,7 +960,7 @@ describe("wonder-blocks-dropdown", () => {
 
         const example = (
             <View style={styles.row}>
-                <MultiSelect menuText="Empty" placeholder="empty" />
+                <MultiSelect placeholder="empty" />
             </View>
         );
         const tree = renderer.create(example).toJSON();

--- a/packages/wonder-blocks-form/components/checkbox-core.js
+++ b/packages/wonder-blocks-form/components/checkbox-core.js
@@ -38,7 +38,6 @@ export default class CheckboxCore extends React.Component<Props> {
 
     render() {
         const {
-            "aria-label": ariaLabel,
             checked,
             disabled,
             error,
@@ -48,6 +47,7 @@ export default class CheckboxCore extends React.Component<Props> {
             hovered,
             focused,
             pressed,
+            ...sharedProps
         } = this.props;
 
         const stateStyles = _generateStyles(checked, error);
@@ -70,9 +70,9 @@ export default class CheckboxCore extends React.Component<Props> {
         return (
             <React.Fragment>
                 <StyledInput
+                    {...sharedProps}
                     type="checkbox"
                     aria-checked={checked}
-                    aria-label={ariaLabel}
                     checked={checked}
                     disabled={disabled}
                     id={id}

--- a/packages/wonder-blocks-form/components/checkbox-group.test.js
+++ b/packages/wonder-blocks-form/components/checkbox-group.test.js
@@ -18,9 +18,9 @@ describe("CheckboxGroup", () => {
                 onChange={onChange}
                 selectedValues={["a", "b"]}
             >
-                <Choice label="a" value="a" />
-                <Choice label="b" value="b" />
-                <Choice label="c" value="c" />
+                <Choice label="a" value="a" aria-labelledby="test-a" />
+                <Choice label="b" value="b" aria-labelledby="test-b" />
+                <Choice label="c" value="c" aria-labelledby="test-c" />
             </CheckboxGroup>,
         );
     });
@@ -75,5 +75,14 @@ describe("CheckboxGroup", () => {
         const bTarget = b.find("ClickableBehavior");
         bTarget.simulate("click");
         expect(onChange).toHaveBeenCalledTimes(2);
+    });
+
+    it("checks that aria attributes have been added correctly", () => {
+        const a = group.find(Choice).at(0);
+        const b = group.find(Choice).at(1);
+        const c = group.find(Choice).at(2);
+        expect(a.find("input").prop("aria-labelledby")).toEqual("test-a");
+        expect(b.find("input").prop("aria-labelledby")).toEqual("test-b");
+        expect(c.find("input").prop("aria-labelledby")).toEqual("test-c");
     });
 });

--- a/packages/wonder-blocks-form/components/choice.js
+++ b/packages/wonder-blocks-form/components/choice.js
@@ -2,11 +2,13 @@
 
 import * as React from "react";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import Checkbox from "./checkbox.js";
 import Radio from "./radio.js";
 
 type Props = {|
+    ...AriaProps,
+
     /** User-defined. Label for the field. */
     label: string,
 

--- a/packages/wonder-blocks-form/components/radio-core.js
+++ b/packages/wonder-blocks-form/components/radio-core.js
@@ -29,7 +29,6 @@ const StyledInput = addStyle("input");
 
     render() {
         const {
-            "aria-label": ariaLabel,
             checked,
             disabled,
             error,
@@ -39,6 +38,7 @@ const StyledInput = addStyle("input");
             hovered,
             focused,
             pressed,
+            ...sharedProps
         } = this.props;
         const stateStyles = _generateStyles(checked, error);
         const defaultStyle = [
@@ -57,9 +57,9 @@ const StyledInput = addStyle("input");
         return (
             <React.Fragment>
                 <StyledInput
+                    {...sharedProps}
                     type="radio"
                     aria-checked={checked}
-                    aria-label={ariaLabel}
                     checked={checked}
                     disabled={disabled}
                     id={id}

--- a/packages/wonder-blocks-form/components/radio-group.test.js
+++ b/packages/wonder-blocks-form/components/radio-group.test.js
@@ -18,9 +18,9 @@ describe("RadioGroup", () => {
                 onChange={onChange}
                 selectedValue="a"
             >
-                <Choice label="a" value="a" />
-                <Choice label="b" value="b" />
-                <Choice label="c" value="c" />
+                <Choice label="a" value="a" aria-labelledby="test-a" />
+                <Choice label="b" value="b" aria-labelledby="test-b" />
+                <Choice label="c" value="c" aria-labelledby="test-c" />
             </RadioGroup>,
         );
     });
@@ -75,5 +75,14 @@ describe("RadioGroup", () => {
         const bTarget = b.find("ClickableBehavior");
         bTarget.simulate("click");
         expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("checks that aria attributes have been added correctly", () => {
+        const a = group.find(Choice).at(0);
+        const b = group.find(Choice).at(1);
+        const c = group.find(Choice).at(2);
+        expect(a.find("input").prop("aria-labelledby")).toEqual("test-a");
+        expect(b.find("input").prop("aria-labelledby")).toEqual("test-b");
+        expect(c.find("input").prop("aria-labelledby")).toEqual("test-c");
     });
 });

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -79,24 +79,17 @@ export default class Icon extends React.PureComponent<Props> {
     };
 
     render() {
-        // There is a weird thing where Flow will only recognize a string-quoted
-        // prop name if it's in single quotes, but our tooling normalizes it to
-        // double-quotes on commit. So the aria-label prop isn't included in
-        // props validation.
-        // eslint-disable-next-line react/prop-types
-        const {"aria-hidden": ariaHidden, "aria-label": ariaLabel} = this.props;
-        const {color, icon, size, style} = this.props;
+        const {color, icon, size, style, ...sharedProps} = this.props;
 
         const {assetSize, path} = getPathForIcon(icon, size);
         const pixelSize = viewportPixelsForSize(size);
         const viewboxPixelSize = viewportPixelsForSize(assetSize);
         return (
             <StyledSVG
+                {...sharedProps}
                 style={[styles.svg, style]}
                 width={pixelSize}
                 height={pixelSize}
-                aria-hidden={ariaHidden}
-                aria-label={ariaLabel}
                 viewBox={`0 0 ${viewboxPixelSize} ${viewboxPixelSize}`}
             >
                 <path fill={color} d={path} />

--- a/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
@@ -22,7 +22,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -119,7 +118,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
     }
   />
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -216,7 +214,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
     }
   />
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -308,7 +305,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
     }
   />
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -405,7 +401,6 @@ exports[`wonder-blocks-layout example 1 1`] = `
     }
   />
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -21,7 +21,6 @@ exports[`wonder-blocks-modal example 1 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -114,7 +113,6 @@ exports[`wonder-blocks-modal example 2 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -626,7 +624,6 @@ exports[`wonder-blocks-modal example 4 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -719,7 +716,6 @@ exports[`wonder-blocks-modal example 5 1`] = `
   }
 >
   <button
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}
@@ -1361,7 +1357,6 @@ exports[`wonder-blocks-modal example 7 1`] = `
             }
           >
             <button
-              aria-label=""
               className=""
               disabled={false}
               onBlur={[Function]}
@@ -1962,7 +1957,6 @@ exports[`wonder-blocks-modal example 8 1`] = `
               }
             >
               <button
-                aria-label=""
                 className=""
                 disabled={false}
                 onBlur={[Function]}
@@ -2033,7 +2027,6 @@ exports[`wonder-blocks-modal example 8 1`] = `
                 </span>
               </button>
               <button
-                aria-label=""
                 className=""
                 disabled={false}
                 onBlur={[Function]}
@@ -2104,7 +2097,6 @@ exports[`wonder-blocks-modal example 8 1`] = `
                 </span>
               </button>
               <button
-                aria-label=""
                 className=""
                 disabled={false}
                 onBlur={[Function]}
@@ -2580,7 +2572,6 @@ exports[`wonder-blocks-modal example 9 1`] = `
                 }
               >
                 <button
-                  aria-label=""
                   className=""
                   disabled={false}
                   onBlur={[Function]}
@@ -2676,7 +2667,6 @@ exports[`wonder-blocks-modal example 9 1`] = `
                   }
                 />
                 <button
-                  aria-label=""
                   className=""
                   disabled={false}
                   onBlur={[Function]}
@@ -3265,7 +3255,6 @@ exports[`wonder-blocks-modal example 10 1`] = `
                     }
                   />
                   <button
-                    aria-label=""
                     className=""
                     disabled={false}
                     onBlur={[Function]}

--- a/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
@@ -108,7 +108,6 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
       }
     >
       <button
-        aria-label=""
         className=""
         disabled={false}
         onBlur={[Function]}
@@ -205,7 +204,6 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
         }
       />
       <button
-        aria-label=""
         className=""
         disabled={false}
         onBlur={[Function]}
@@ -542,7 +540,6 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
       }
     >
       <button
-        aria-label=""
         className=""
         disabled={false}
         onBlur={[Function]}
@@ -787,7 +784,6 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
       }
     >
       <button
-        aria-label=""
         className=""
         disabled={false}
         onBlur={[Function]}
@@ -1334,7 +1330,6 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
       }
     >
       <button
-        aria-label=""
         className=""
         disabled={false}
         onBlur={[Function]}
@@ -1558,7 +1553,6 @@ exports[`wonder-blocks-toolbar example 6 1`] = `
         }
       />
       <button
-        aria-label=""
         className=""
         disabled={false}
         onBlur={[Function]}
@@ -1658,7 +1652,6 @@ exports[`wonder-blocks-toolbar example 6 1`] = `
         }
       />
       <button
-        aria-label=""
         className=""
         disabled={false}
         onBlur={[Function]}

--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -142,7 +142,6 @@ exports[`wonder-blocks-tooltip example 3 1`] = `
 
 exports[`wonder-blocks-tooltip example 4 1`] = `
 <button
-  aria-label=""
   className=""
   disabled={false}
   onBlur={[Function]}
@@ -398,7 +397,6 @@ exports[`wonder-blocks-tooltip example 6 1`] = `
 >
   <button
     aria-describedby="uid-tooltip-6-aria-content"
-    aria-label=""
     className=""
     disabled={false}
     onBlur={[Function]}


### PR DESCRIPTION
## Button, Dropdown, Form, Icon
- Added `aria-*` support to buttons, icons, selects, checkboxes and radioboxes.
- Added unit tests to check this new behavior (`<Checkbox />`, `<Radiobox />`).
- Modified some documentation that included a couple of unused props. 

### Test plan
1. Open the following examples:
    - Button: https://deploy-preview-411--wonder-blocks.netlify.com/#!/Button/1
    - ActionMenu: https://deploy-preview-411--wonder-blocks.netlify.com/#!/ActionMenu/1
    - SingleSelect: https://deploy-preview-411--wonder-blocks.netlify.com/#!/SingleSelect/13
    - MultiSelect: https://deploy-preview-411--wonder-blocks.netlify.com/#!/MultiSelect/11
    - Checkbox: https://deploy-preview-411--wonder-blocks.netlify.com/#!/CheckboxGroup/1
    - Radiobutton: https://deploy-preview-411--wonder-blocks.netlify.com/#!/RadioGroup/1
    - Icon: https://deploy-preview-411--wonder-blocks.netlify.com/#!/Icon/1

2. Click on `view code` and modify the code snippet by adding a `aria-*` attribute: (e.g.`aria-labelledby`).
3. Make sure that's correctly rendered in the output.