### PR TITLE
[feat:modal]WB-585: Add building blocks to public API

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-content.js
+++ b/packages/wonder-blocks-modal/components/modal-content.js
@@ -16,6 +16,9 @@ type Props = {|
     style?: StyleType,
 |};
 
+/**
+ * The Modal content included after the header
+ */
 export default class ModalContent extends React.Component<Props> {
     static defaultProps = {
         scrollOverflow: true,

--- a/packages/wonder-blocks-modal/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/components/modal-dialog.js
@@ -38,6 +38,16 @@ type Props = {|
     style?: StyleType,
 |};
 
+/**
+ * `ModalDialog` is a component that contains these elements:
+ * - The visual dialog element itself (`<div role="dialog"/>`)
+ * - The custom contents below and/or above the Dialog itself (e.g. decorative graphics).
+ *
+ * **Accessibility notes:**
+ * - By default (e.g. using `OnePaneDialog`), `aria-labelledby` is populated automatically using the dialog title `id`.
+ * - If there is a custom Dialog implementation (e.g. `TwoPaneDialog`), the dialog element doesn’t have to have
+ * the `aria-labelledby` attribute however this is recommended. It should match the `id` of the dialog title.
+ */
 export default class ModalDialog extends React.Component<Props> {
     render() {
         const {

--- a/packages/wonder-blocks-modal/components/modal-footer.js
+++ b/packages/wonder-blocks-modal/components/modal-footer.js
@@ -9,6 +9,15 @@ type Props = {|
     children: React.Node,
 |};
 
+/**
+ * Modal footer included after the content.
+ *
+ * **Implementation notes**:
+ *
+ * If you are creating a custom Dialog, make sure to follow these guidelines:
+ * - Make sure to include it as part of `<ModalPanel />` by using the `footer` prop.
+ * - The footer is completely flexible. Meaning the developer needs to add its own custom layout to match design specs.
+ */
 export default class ModalFooter extends React.Component<Props> {
     static __IS_MODAL_FOOTER__ = true;
     static isClassOf(instance: any) {

--- a/packages/wonder-blocks-modal/components/modal-footer.js
+++ b/packages/wonder-blocks-modal/components/modal-footer.js
@@ -15,7 +15,7 @@ type Props = {|
  * **Implementation notes**:
  *
  * If you are creating a custom Dialog, make sure to follow these guidelines:
- * - Make sure to include it as part of `<ModalPanel />` by using the `footer` prop.
+ * - Make sure to include it as part of [ModalPanel](/#modalpanel) by using the `footer` prop.
  * - The footer is completely flexible. Meaning the developer needs to add its own custom layout to match design specs.
  */
 export default class ModalFooter extends React.Component<Props> {

--- a/packages/wonder-blocks-modal/components/modal-header.js
+++ b/packages/wonder-blocks-modal/components/modal-header.js
@@ -48,7 +48,7 @@ type Props = {|
  *
  * **Accessibility notes:**
  *
- * - By default (e.g. using [OnePaneDialog](/#onepanedialog)), `titleId` is populated automaticallyby the parent container.
+ * - By default (e.g. using [OnePaneDialog](/#onepanedialog)), `titleId` is populated automatically by the parent container.
  * - If there is a custom Dialog implementation (e.g. `TwoPaneDialog`), the ModalHeader doesn’t have to have
  * the `titleId` prop however this is recommended. It should match the `aria-labelledby` prop of the [ModalDialog](/#modaldialog) component.
  * If you want to see an example of how to generate this ID, check [IDProvider](/#idprovider).

--- a/packages/wonder-blocks-modal/components/modal-header.js
+++ b/packages/wonder-blocks-modal/components/modal-header.js
@@ -39,6 +39,39 @@ type Props = {|
     titleId: string,
 |};
 
+/**
+ * This is a helper component that is never rendered by itself.
+ * It is always pinned to the top of the dialog, is responsive using the same behavior as its parent dialog,
+ * and has the following properties:
+ * - title
+ * - breadcrumb OR 2B subtitle, but not both.
+ *
+ * **Accessibility notes:**
+ *
+ * - By default (e.g. using `OnePaneDialog`), `titleId` is populated automaticallyby the parent container.
+ * - If there is a custom Dialog implementation (e.g. `TwoPaneDialog`), the ModalHeader doesn’t have to have
+ * the `titleId` prop however this is recommended. It should match the `aria-labelledby` prop of the ModalDialog component.
+ *
+ * **Implementation notes:**
+ *
+ * If you are creating a custom Dialog, make sure to follow these guidelines:
+ * - Make sure to include it as part of `<ModalPanel />` by using the `header` prop.
+ * - Add a title (required).
+ * -  Optionally add a subtitle or breadcrumbs.
+ * - We encourage you to add `titleId` (see Accessibility notes).
+ * - If the `ModalPanel` has a dark background, make sure to set `light` to `false`.
+ *
+ * Example:
+ *
+ * ```js
+ * <ModalHeader
+ *      title="Sidebar using ModalHeader"
+ *      subtitle="subtitle"
+ *      titleId="uniqueTitleId"
+ *      light={false}
+ *  />
+ * ```
+ */
 export default class ModalHeader extends React.Component<Props> {
     static defaultProps = {
         light: true,

--- a/packages/wonder-blocks-modal/components/modal-header.js
+++ b/packages/wonder-blocks-modal/components/modal-header.js
@@ -44,20 +44,21 @@ type Props = {|
  * It is always pinned to the top of the dialog, is responsive using the same behavior as its parent dialog,
  * and has the following properties:
  * - title
- * - breadcrumb OR 2B subtitle, but not both.
+ * - breadcrumb OR subtitle, but not both.
  *
  * **Accessibility notes:**
  *
- * - By default (e.g. using `OnePaneDialog`), `titleId` is populated automaticallyby the parent container.
+ * - By default (e.g. using [OnePaneDialog](/#onepanedialog)), `titleId` is populated automaticallyby the parent container.
  * - If there is a custom Dialog implementation (e.g. `TwoPaneDialog`), the ModalHeader doesn’t have to have
- * the `titleId` prop however this is recommended. It should match the `aria-labelledby` prop of the ModalDialog component.
+ * the `titleId` prop however this is recommended. It should match the `aria-labelledby` prop of the [ModalDialog](/#modaldialog) component.
+ * If you want to see an example of how to generate this ID, check [IDProvider](/#idprovider).
  *
  * **Implementation notes:**
  *
  * If you are creating a custom Dialog, make sure to follow these guidelines:
- * - Make sure to include it as part of `<ModalPanel />` by using the `header` prop.
+ * - Make sure to include it as part of [ModalPanel](/#modalpanel) by using the `header` prop.
  * - Add a title (required).
- * -  Optionally add a subtitle or breadcrumbs.
+ * - Optionally add a subtitle or breadcrumbs.
  * - We encourage you to add `titleId` (see Accessibility notes).
  * - If the `ModalPanel` has a dark background, make sure to set `light` to `false`.
  *

--- a/packages/wonder-blocks-modal/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.js
@@ -66,8 +66,8 @@ type Props = {|
  * **Implementation notes:**
  *
  * If you are creating a custom Dialog, make sure to follow these guidelines:
- * - Make sure to add this component inside the **ModalDialog**.
- * - If needed, you can also add a **ModalHeader** using the `header` prop. Same goes for **ModalFooter**.
+ * - Make sure to add this component inside the [ModalDialog](/#modaldialog).
+ * - If needed, you can also add a [ModalHeader](/#modalheader) using the `header` prop. Same goes for [ModalFooter](/#modalfooter).
  *
  * ```js
  * <ModalDialog>

--- a/packages/wonder-blocks-modal/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.js
@@ -60,6 +60,21 @@ type Props = {|
     onClose?: () => mixed,
 |};
 
+/**
+ * ModalPanel is  the content container.
+ *
+ * **Implementation notes:**
+ *
+ * If you are creating a custom Dialog, make sure to follow these guidelines:
+ * - Make sure to add this component inside the **ModalDialog**.
+ * - If needed, you can also add a **ModalHeader** using the `header` prop. Same goes for **ModalFooter**.
+ *
+ * ```js
+ * <ModalDialog>
+ *      <ModalPanel content={"custom content goes here"} />
+ * </ModalDialog>
+ * ```
+ */
 export default class ModalPanel extends React.Component<Props> {
     static defaultProps = {
         closeButtonVisible: true,

--- a/packages/wonder-blocks-modal/generated-snapshot.test.js
+++ b/packages/wonder-blocks-modal/generated-snapshot.test.js
@@ -12,7 +12,6 @@ import ModalLauncher from "./components/modal-launcher.js";
 import OnePaneDialog from "./components/one-pane-dialog/one-pane-dialog.js";
 import ModalDialog from "./components/modal-dialog.js";
 import ModalPanel from "./components/modal-panel.js";
-import ModalContent from "./components/modal-content.js";
 import ModalHeader from "./components/modal-header.js";
 import ModalFooter from "./components/modal-footer.js";
 

--- a/packages/wonder-blocks-modal/index.js
+++ b/packages/wonder-blocks-modal/index.js
@@ -1,6 +1,18 @@
 // @flow
+import ModalDialog from "./components/modal-dialog.js";
+import ModalFooter from "./components/modal-footer.js";
+import ModalHeader from "./components/modal-header.js";
 import ModalLauncher from "./components/modal-launcher.js";
+import ModalPanel from "./components/modal-panel.js";
 import OnePaneDialog from "./components/one-pane-dialog/one-pane-dialog.js";
 import maybeGetPortalMountedModalHostElement from "./util/maybe-get-portal-mounted-modal-host-element.js";
 
-export {ModalLauncher, OnePaneDialog, maybeGetPortalMountedModalHostElement};
+export {
+    ModalHeader,
+    ModalFooter,
+    ModalDialog,
+    ModalPanel,
+    ModalLauncher,
+    OnePaneDialog,
+    maybeGetPortalMountedModalHostElement,
+};

--- a/packages/wonder-blocks-modal/index.test.js
+++ b/packages/wonder-blocks-modal/index.test.js
@@ -10,6 +10,10 @@ describe("@khanacademy/wonder-blocks-modal", () => {
         // Assert
         expect(Object.keys(result).sort()).toEqual(
             [
+                "ModalDialog",
+                "ModalFooter",
+                "ModalHeader",
+                "ModalPanel",
                 "ModalLauncher",
                 "OnePaneDialog",
                 "maybeGetPortalMountedModalHostElement",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -130,14 +130,11 @@ module.exports = {
                     ],
                 },
                 {
-                    // NOTE(jeresig): Not ready to be used yet, need docs.
-                    private: true,
                     name: "Building Blocks",
                     content: "packages/wonder-blocks-modal/building-blocks.md",
                     components: [
                         "packages/wonder-blocks-modal/components/modal-dialog.js",
                         "packages/wonder-blocks-modal/components/modal-panel.js",
-                        "packages/wonder-blocks-modal/components/modal-content.js",
                         "packages/wonder-blocks-modal/components/modal-header.js",
                         "packages/wonder-blocks-modal/components/modal-footer.js",
                     ],


### PR DESCRIPTION
## Modals
- Added `ModalDialog, ModalHeader, ModalFooter, ModalPanel` to the public API.
- Included `Modals > Building blocks` section into the documentation website.
- Added descriptions to: `ModalDialog, ModalHeader, ModalFooter, ModalPanel`

### Test plan
- Open https://deploy-preview-413--wonder-blocks.netlify.com/#!/Building%20Blocks