### PR TITLE
WB-529: Add support for tag prop in View component

### DIFF
--- a/packages/wonder-blocks-core/components/__snapshots__/view.test.js.snap
+++ b/packages/wonder-blocks-core/components/__snapshots__/view.test.js.snap
@@ -1,6 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`View Should set the tag to be article 1`] = `
+<article
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+/>
+`;
+
+exports[`View Should set the tag to be aside 1`] = `
+<aside
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+/>
+`;
+
+exports[`View Should set the tag to be div 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+/>
+`;
+
+exports[`View Should set the tag to be nav 1`] = `
+<nav
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+/>
+`;
+
 exports[`View Should set the tag to be section 1`] = `
+<section
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+/>
+`;
+
+exports[`View Should set the tag to be section 2`] = `
 <section
   className=""
   style={

--- a/packages/wonder-blocks-core/components/__snapshots__/view.test.js.snap
+++ b/packages/wonder-blocks-core/components/__snapshots__/view.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`View Should set the tag to be section 1`] = `
+<section
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+/>
+`;

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -29,7 +29,7 @@ type ValidViewTags = "div" | "article" | "aside" | "nav" | "section";
 // eslint-disable-next-line flowtype/require-exact-type
 type Props = {
     ...TextViewSharedProps,
-    tag?: ValidViewTags,
+    tag: ValidViewTags,
 };
 
 const StyledDiv = addStyle<"div">("div", styles.default);
@@ -52,6 +52,10 @@ const StyledSection = addStyle<"section">("section", styles.default);
  * - An array combining the above
  */
 export default class View extends React.Component<Props> {
+    static defaultProps = {
+        tag: "div",
+    };
+
     render() {
         const {testId, tag, ...restProps} = this.props;
         switch (tag) {
@@ -63,6 +67,8 @@ export default class View extends React.Component<Props> {
                 return <StyledNav data-test-id={testId} {...restProps} />;
             case "section":
                 return <StyledSection data-test-id={testId} {...restProps} />;
+            case "div":
+                return <StyledDiv data-test-id={testId} {...restProps} />;
             default:
                 return <StyledDiv data-test-id={testId} {...restProps} />;
         }

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -25,7 +25,18 @@ const styles = StyleSheet.create({
     },
 });
 
-let StyledDiv = addStyle<"div">("div", styles.default);
+type ValidViewTags = "div" | "article" | "aside" | "nav" | "section";
+// eslint-disable-next-line flowtype/require-exact-type
+type Props = {
+    ...TextViewSharedProps,
+    tag?: ValidViewTags,
+};
+
+const StyledDiv = addStyle<"div">("div", styles.default);
+const StyledArticle = addStyle<"article">("article", styles.default);
+const StyledAside = addStyle<"aside">("aside", styles.default);
+const StyledNav = addStyle<"nav">("nav", styles.default);
+const StyledSection = addStyle<"section">("section", styles.default);
 
 /**
  * View is a building block for constructing other components. `View` roughly
@@ -40,13 +51,20 @@ let StyledDiv = addStyle<"div">("div", styles.default);
  * - An `aphrodite` StyleSheet style
  * - An array combining the above
  */
-export default class View extends React.Component<TextViewSharedProps> {
+export default class View extends React.Component<Props> {
     render() {
-        if (this.props.tag) {
-            StyledDiv = addStyle<string>(this.props.tag, styles.default);
-        }
-        /* eslint-disable no-unused-vars */
         const {testId, tag, ...restProps} = this.props;
-        return <StyledDiv data-test-id={testId} {...restProps} />;
+        switch (tag) {
+            case "article":
+                return <StyledArticle data-test-id={testId} {...restProps} />;
+            case "aside":
+                return <StyledAside data-test-id={testId} {...restProps} />;
+            case "nav":
+                return <StyledNav data-test-id={testId} {...restProps} />;
+            case "section":
+                return <StyledSection data-test-id={testId} {...restProps} />;
+            default:
+                return <StyledDiv data-test-id={testId} {...restProps} />;
+        }
     }
 }

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -70,7 +70,11 @@ export default class View extends React.Component<Props> {
             case "div":
                 return <StyledDiv data-test-id={testId} {...restProps} />;
             default:
-                return <StyledDiv data-test-id={testId} {...restProps} />;
+                // eslint-disable-next-line no-unused-expressions
+                (tag: empty);
+                throw Error(
+                    `${tag} is not an allowed value for the 'tag' prop`,
+                );
         }
     }
 }

--- a/packages/wonder-blocks-core/components/view.js
+++ b/packages/wonder-blocks-core/components/view.js
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const StyledDiv = addStyle<"div">("div", styles.default);
+let StyledDiv = addStyle<"div">("div", styles.default);
 
 /**
  * View is a building block for constructing other components. `View` roughly
@@ -42,7 +42,11 @@ const StyledDiv = addStyle<"div">("div", styles.default);
  */
 export default class View extends React.Component<TextViewSharedProps> {
     render() {
-        const {testId, ...restProps} = this.props;
+        if (this.props.tag) {
+            StyledDiv = addStyle<string>(this.props.tag, styles.default);
+        }
+        /* eslint-disable no-unused-vars */
+        const {testId, tag, ...restProps} = this.props;
         return <StyledDiv data-test-id={testId} {...restProps} />;
     }
 }

--- a/packages/wonder-blocks-core/components/view.test.js
+++ b/packages/wonder-blocks-core/components/view.test.js
@@ -12,4 +12,49 @@ describe("View", () => {
         // Assert
         expect(tree).toMatchSnapshot();
     });
+
+    it("Should set the tag to be section", () => {
+        // Arrage, Act
+        const view = <View tag="section" />;
+        const tree = renderer.create(view).toJSON();
+
+        // Assert
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("Should set the tag to be article", () => {
+        // Arrage, Act
+        const view = <View tag="article" />;
+        const tree = renderer.create(view).toJSON();
+
+        // Assert
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("Should set the tag to be aside", () => {
+        // Arrage, Act
+        const view = <View tag="aside" />;
+        const tree = renderer.create(view).toJSON();
+
+        // Assert
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("Should set the tag to be nav", () => {
+        // Arrage, Act
+        const view = <View tag="nav" />;
+        const tree = renderer.create(view).toJSON();
+
+        // Assert
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("Should set the tag to be div", () => {
+        // Arrage, Act
+        const view = <View />;
+        const tree = renderer.create(view).toJSON();
+
+        // Assert
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/packages/wonder-blocks-core/components/view.test.js
+++ b/packages/wonder-blocks-core/components/view.test.js
@@ -1,0 +1,15 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import View from "./view.js";
+
+describe("View", () => {
+    it("Should set the tag to be section", () => {
+        // Arrage, Act
+        const view = <View tag="section" />;
+        const tree = renderer.create(view).toJSON();
+
+        // Assert
+        expect(tree).toMatchSnapshot();
+    });
+});

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -210,8 +210,6 @@ export type TextViewSharedProps = {
 
     id?: string,
 
-    tag?: string,
-
     // TODO(kevinb) remove the need for this
     "data-modal-launcher-portal"?: boolean,
 

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -210,6 +210,8 @@ export type TextViewSharedProps = {
 
     id?: string,
 
+    tag?: string,
+
     // TODO(kevinb) remove the need for this
     "data-modal-launcher-portal"?: boolean,
 


### PR DESCRIPTION
Added support for the 'tag' prop in view components to override the default div tag if needed. Changed StyledDiv declaration from const to let because I reassign it later if the tag prop is present. Pulled out tag prop from restProps for child safety once the StyledDiv is adjusted (although I don't know if this is necessary).