### PR TITLE
[fix:button,dropdown,icon-button] WB-535: Remove aria-disabled when disabled is present

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`ButtonCore kind:primary color:default size:medium light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -298,7 +297,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:false pressed 1
 
 exports[`ButtonCore kind:primary color:default size:medium light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -594,7 +592,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:true pressed 1`
 
 exports[`ButtonCore kind:primary color:default size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -890,7 +887,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
 
 exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -1186,7 +1182,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
 
 exports[`ButtonCore kind:primary color:destructive size:medium light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -1482,7 +1477,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false press
 
 exports[`ButtonCore kind:primary color:destructive size:medium light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -1778,7 +1772,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true presse
 
 exports[`ButtonCore kind:primary color:destructive size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -2074,7 +2067,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
 
 exports[`ButtonCore kind:primary color:destructive size:small light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -2370,7 +2362,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
 
 exports[`ButtonCore kind:primary size:medium spinner:true 1`] = `
 <button
-  aria-disabled="true"
   aria-label="loading"
   className=""
   disabled={true}
@@ -2498,7 +2489,6 @@ exports[`ButtonCore kind:primary size:medium spinner:true 1`] = `
 
 exports[`ButtonCore kind:primary size:small spinner:true 1`] = `
 <button
-  aria-disabled="true"
   aria-label="loading"
   className=""
   disabled={true}
@@ -2626,7 +2616,6 @@ exports[`ButtonCore kind:primary size:small spinner:true 1`] = `
 
 exports[`ButtonCore kind:secondary color:default size:medium light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -2931,7 +2920,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false pressed
 
 exports[`ButtonCore kind:secondary color:default size:medium light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -3236,7 +3224,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true pressed 
 
 exports[`ButtonCore kind:secondary color:default size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -3541,7 +3528,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
 
 exports[`ButtonCore kind:secondary color:default size:small light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -3846,7 +3832,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
 
 exports[`ButtonCore kind:secondary color:destructive size:medium light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -4151,7 +4136,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false pre
 
 exports[`ButtonCore kind:secondary color:destructive size:medium light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -4456,7 +4440,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true pres
 
 exports[`ButtonCore kind:secondary color:destructive size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -4761,7 +4744,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
 
 exports[`ButtonCore kind:secondary color:destructive size:small light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -5066,7 +5048,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
 
 exports[`ButtonCore kind:secondary size:medium spinner:true 1`] = `
 <button
-  aria-disabled="true"
   aria-label="loading"
   className=""
   disabled={true}
@@ -5197,7 +5178,6 @@ exports[`ButtonCore kind:secondary size:medium spinner:true 1`] = `
 
 exports[`ButtonCore kind:secondary size:small spinner:true 1`] = `
 <button
-  aria-disabled="true"
   aria-label="loading"
   className=""
   disabled={true}
@@ -5328,7 +5308,6 @@ exports[`ButtonCore kind:secondary size:small spinner:true 1`] = `
 
 exports[`ButtonCore kind:tertiary color:default size:medium light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -5651,7 +5630,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false pressed 
 
 exports[`ButtonCore kind:tertiary color:default size:medium light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -5974,7 +5952,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true pressed 1
 
 exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -6297,7 +6274,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
 
 exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -6620,7 +6596,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
 
 exports[`ButtonCore kind:tertiary color:destructive size:medium light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -6943,7 +6918,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false pres
 
 exports[`ButtonCore kind:tertiary color:destructive size:medium light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -7266,7 +7240,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true press
 
 exports[`ButtonCore kind:tertiary color:destructive size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -7589,7 +7562,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
 
 exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label=""
   className=""
   disabled={true}
@@ -7912,7 +7884,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
 
 exports[`ButtonCore kind:tertiary size:medium spinner:true 1`] = `
 <button
-  aria-disabled="true"
   aria-label="loading"
   className=""
   disabled={true}
@@ -8040,7 +8011,6 @@ exports[`ButtonCore kind:tertiary size:medium spinner:true 1`] = `
 
 exports[`ButtonCore kind:tertiary size:small spinner:true 1`] = `
 <button
-  aria-disabled="true"
   aria-label="loading"
   className=""
   disabled={true}

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -493,7 +493,6 @@ exports[`wonder-blocks-button example 3 1`] = `
   }
 >
   <button
-    aria-disabled="true"
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -564,7 +563,6 @@ exports[`wonder-blocks-button example 3 1`] = `
     </span>
   </button>
   <button
-    aria-disabled="true"
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -638,7 +636,6 @@ exports[`wonder-blocks-button example 3 1`] = `
     </span>
   </button>
   <button
-    aria-disabled="true"
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -946,7 +943,6 @@ exports[`wonder-blocks-button example 4 1`] = `
     </span>
   </button>
   <button
-    aria-disabled="true"
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -1017,7 +1013,6 @@ exports[`wonder-blocks-button example 4 1`] = `
     </span>
   </button>
   <button
-    aria-disabled="true"
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -1091,7 +1086,6 @@ exports[`wonder-blocks-button example 4 1`] = `
     </span>
   </button>
   <button
-    aria-disabled="true"
     className=""
     disabled={true}
     onBlur={[Function]}
@@ -1800,7 +1794,6 @@ exports[`wonder-blocks-button example 8 1`] = `
   }
 >
   <button
-    aria-disabled="true"
     aria-label="loading"
     className=""
     disabled={true}
@@ -1926,7 +1919,6 @@ exports[`wonder-blocks-button example 8 1`] = `
     </div>
   </button>
   <button
-    aria-disabled="true"
     aria-label="loading"
     className=""
     disabled={true}

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -90,13 +90,10 @@ export default class ButtonCore extends React.Component<Props> {
         };
 
         if (commonProps["aria-disabled"]) {
-            // eslint-disable-next-line no-console
-            console.warn(
-                "wb-button: <button> supports the 'disabled' attribute. You don't need to use the 'aria-disabled' attribute.",
-            );
-
             // WB-535: Allows only to use `disabled` (even if is set from the parent component)
-            commonProps["aria-disabled"] = undefined;
+            throw new Error(
+                "wb-button: <button> supports the 'disabled' attribute. You should not use the 'aria-disabled' attribute.",
+            );
         }
 
         const Label = size === "small" ? LabelSmall : LabelLarge;

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -83,11 +83,22 @@ export default class ButtonCore extends React.Component<Props> {
         ];
 
         const commonProps = {
+            "aria-disabled": undefined,
             "data-test-id": testId,
             role: "button",
             style: [defaultStyle, style],
             ...handlers,
         };
+
+        if (commonProps["aria-disabled"]) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                "wb-button: <button> supports the 'disabled' attribute. You don't need to use the 'aria-disabled' attribute.",
+            );
+
+            // WB-535: Allows only to use `disabled` (even if is set from the parent component)
+            commonProps["aria-disabled"] = undefined;
+        }
 
         const Label = size === "small" ? LabelSmall : LabelLarge;
 
@@ -136,8 +147,6 @@ export default class ButtonCore extends React.Component<Props> {
                     type="button"
                     {...commonProps}
                     disabled={disabled}
-                    // WB-535: Allows only to use `disabled`
-                    aria-disabled={undefined}
                 >
                     {contents}
                 </StyledButton>

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -83,7 +83,6 @@ export default class ButtonCore extends React.Component<Props> {
         ];
 
         const commonProps = {
-            "aria-disabled": undefined,
             "data-test-id": testId,
             role: "button",
             style: [defaultStyle, style],

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -50,7 +50,6 @@ export default class ButtonCore extends React.Component<Props> {
             testId,
             spinner,
             icon,
-            "aria-label": ariaLabel,
             ...handlers
         } = this.props;
         const {router} = this.context;
@@ -84,8 +83,6 @@ export default class ButtonCore extends React.Component<Props> {
         ];
 
         const commonProps = {
-            "aria-disabled": disabled ? "true" : undefined,
-            "aria-label": ariaLabel,
             "data-test-id": testId,
             role: "button",
             style: [defaultStyle, style],
@@ -139,6 +136,8 @@ export default class ButtonCore extends React.Component<Props> {
                     type="button"
                     {...commonProps}
                     disabled={disabled}
+                    // WB-535: Allows only to use `disabled`
+                    aria-disabled={undefined}
                 >
                     {contents}
                 </StyledButton>

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -89,13 +89,6 @@ export default class ButtonCore extends React.Component<Props> {
             ...handlers,
         };
 
-        if (commonProps["aria-disabled"]) {
-            // WB-535: Allows only to use `disabled` (even if is set from the parent component)
-            throw new Error(
-                "wb-button: <button> supports the 'disabled' attribute. You should not use the 'aria-disabled' attribute.",
-            );
-        }
-
         const Label = size === "small" ? LabelSmall : LabelLarge;
 
         const label = (

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -13,7 +13,7 @@ export type SharedProps = {|
      * readers that the action taken by clicking the button will take some
      * time to complete.
      */
-    ...AriaProps,
+    ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,
 
     /**
      * Text to appear on the button.

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-Buttons can be `disabled`.
+Buttons can be `disabled` (**Note:** you don't need to add `aria-disabled`):
 ```jsx
 const {View} = require("@khanacademy/wonder-blocks-core");
 const {StyleSheet} = require("aphrodite");

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -1,3 +1,5 @@
+#### Example: kind
+
 There are three `kind`s of buttons: `"primary"` (default), `"secondary"`, and
 `"tertiary"`:
 ```jsx
@@ -37,8 +39,10 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-Buttons have a `color` that is either `"default"` (the default, as shown
-above) or `"destructive"` (as can seen below):
+#### Example: color
+
+Buttons have a `color` that is either `"default"` (the default, as shown above) or `"destructive"` (as can seen below):
+
 ```jsx
 const {View} = require("@khanacademy/wonder-blocks-core");
 const {StyleSheet} = require("aphrodite");
@@ -79,7 +83,19 @@ const styles = StyleSheet.create({
 </View>
 ```
 
+#### Example: disabled
+
 Buttons can be `disabled`:
+
+⚠️ Buttons do not need an `aria-disabled` attribute, if it also has a `disabled` attribute.
+Users operating the web page through a screen reader may not be able to fully evaluate the implied
+behaviors of the button element itself.
+
+Links:
+- [Implicit ARIA semantics](https://www.w3.org/TR/wai-aria-1.1/#implicit_semantics)
+- [Document conformance requirements](https://www.w3.org/TR/html-aria/#document-conformance-requirements-for-use-of-aria-attributes-in-html)
+
+
 ```jsx
 const {View} = require("@khanacademy/wonder-blocks-core");
 const {StyleSheet} = require("aphrodite");
@@ -120,7 +136,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-**Note:** If you are adding `disabled` you don't need to add `aria-disabled`. Doing so will result in a console.warn().
+#### Example: dark
 
 Buttons on a `darkBlue` background should set `light` to `true`.
 ```jsx
@@ -192,6 +208,8 @@ const styles = StyleSheet.create({
 </View>
 ```
 
+#### Example: size
+
 Buttons have a `size` that's either `"medium"` (default) or `"small"`.
 ```js
 const {View} = require("@khanacademy/wonder-blocks-core");
@@ -232,6 +250,8 @@ const styles = StyleSheet.create({
     </Button>
 </View>
 ```
+
+#### Example: Navigation
 
 Buttons can have an `href` or an `onClick` handler or both.
 
@@ -276,6 +296,8 @@ const styles = StyleSheet.create({
 </View>
 ```
 
+#### Example: Navigation with React Router
+
 Buttons do client-side navigation by default, if React Router exists:
 ```jsx
 const {StyleSheet} = require("aphrodite");
@@ -310,6 +332,8 @@ const styles = StyleSheet.create({
 </MemoryRouter>
 ```
 
+#### Example: spinner
+
 Buttons can show a `spinner`.  This is useful when indicating to a user that
 their input has been recognized but that the operation will take some time.
 While the `spinner` property is set to `true` the button is disabled.
@@ -337,6 +361,8 @@ const styles = StyleSheet.create({
     </Button>
 </View>
 ```
+
+#### Example: style
 
 Buttons can have a `style` props which supports width, position, margin,
 and flex styles.

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-Buttons can be `disabled` (**Note:** you don't need to add `aria-disabled`):
+Buttons can be `disabled`:
 ```jsx
 const {View} = require("@khanacademy/wonder-blocks-core");
 const {StyleSheet} = require("aphrodite");
@@ -119,6 +119,8 @@ const styles = StyleSheet.create({
     </Button>
 </View>
 ```
+
+**Note:** If you are adding `disabled` you don't need to add `aria-disabled`. Doing so will result in a console.warn().
 
 Buttons on a `darkBlue` background should set `light` to `true`.
 ```jsx

--- a/packages/wonder-blocks-button/components/button.test.js
+++ b/packages/wonder-blocks-button/components/button.test.js
@@ -108,4 +108,28 @@ describe("Button", () => {
         // Assert
         expect(wrapper.find("#foo").exists()).toBe(false);
     });
+
+    test("checks that aria-disabled is not added when disabled is set", () => {
+        // Arrange
+        // Prevent jest to output warnings when running tests
+        const consoleWarnMockFn = jest
+            .spyOn(global.console, "warn")
+            .mockImplementationOnce(() => jest.fn());
+
+        const wrapper = mount(
+            <Button disabled={true} aria-disabled="true">
+                Disabled button
+            </Button>,
+        );
+        // Act
+        const buttonWrapper = wrapper.find("button").first();
+
+        // Assert
+        expect(buttonWrapper.prop("disabled")).toEqual(true);
+        // we should expect to throw a warning to devs
+        expect(consoleWarnMockFn).toHaveBeenCalled();
+        expect(buttonWrapper.prop("aria-disabled")).not.toBeDefined();
+
+        consoleWarnMockFn.mockRestore();
+    });
 });

--- a/packages/wonder-blocks-button/components/button.test.js
+++ b/packages/wonder-blocks-button/components/button.test.js
@@ -3,6 +3,8 @@ import React from "react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
+import expectRenderError from "../../../utils/testing/expect-render-error.js";
+
 import Button from "./button.js";
 
 describe("Button", () => {
@@ -110,26 +112,11 @@ describe("Button", () => {
     });
 
     test("checks that aria-disabled is not added when disabled is set", () => {
-        // Arrange
-        // Prevent jest to output warnings when running tests
-        const consoleWarnMockFn = jest
-            .spyOn(global.console, "warn")
-            .mockImplementationOnce(() => jest.fn());
-
-        const wrapper = mount(
+        expectRenderError(
             <Button disabled={true} aria-disabled="true">
                 Disabled button
             </Button>,
+            "wb-button: <button> supports the 'disabled' attribute. You should not use the 'aria-disabled' attribute.",
         );
-        // Act
-        const buttonWrapper = wrapper.find("button").first();
-
-        // Assert
-        expect(buttonWrapper.prop("disabled")).toEqual(true);
-        // we should expect to throw a warning to devs
-        expect(consoleWarnMockFn).toHaveBeenCalled();
-        expect(buttonWrapper.prop("aria-disabled")).not.toBeDefined();
-
-        consoleWarnMockFn.mockRestore();
     });
 });

--- a/packages/wonder-blocks-button/components/button.test.js
+++ b/packages/wonder-blocks-button/components/button.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
-import expectRenderError from "../../../utils/testing/expect-render-error.js";
 
 import Button from "./button.js";
 
@@ -109,14 +108,5 @@ describe("Button", () => {
 
         // Assert
         expect(wrapper.find("#foo").exists()).toBe(false);
-    });
-
-    test("checks that aria-disabled is not added when disabled is set", () => {
-        expectRenderError(
-            <Button disabled={true} aria-disabled="true">
-                Disabled button
-            </Button>,
-            "wb-button: <button> supports the 'disabled' attribute. You should not use the 'aria-disabled' attribute.",
-        );
     });
 });

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -603,7 +603,6 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
     }
   >
     <button
-      aria-disabled="true"
       aria-expanded="true"
       aria-haspopup="menu"
       className=""

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -62,7 +62,6 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
 
         return (
             <StyledButton
-                aria-disabled={disabled ? "true" : undefined}
                 aria-expanded={open ? "true" : "false"}
                 aria-haspopup="menu"
                 aria-label={ariaLabel}

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener.js
@@ -6,7 +6,7 @@ import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import ActionMenuOpenerCore from "./action-menu-opener-core.js";
 
 export type SharedProps = {|
-    ...AriaProps,
+    ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,
 
     /**
      * Display text for the opener.

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -191,6 +191,7 @@ export default class ActionMenu extends React.Component<MenuProps, State> {
             children,
             onChange,
             selectedValues,
+            "aria-disabled": ariaDisabled, // WB-535 avoids passing this prop to the opener
             /* eslint-enable no-unused-vars */
             ...sharedProps
         } = this.props;

--- a/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`IconButtonCore kind:primary color:default size:default light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -279,7 +278,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
 
 exports[`IconButtonCore kind:primary color:default size:default light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -556,7 +554,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
 
 exports[`IconButtonCore kind:primary color:default size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -833,7 +830,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
 
 exports[`IconButtonCore kind:primary color:default size:small light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -1110,7 +1106,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
 
 exports[`IconButtonCore kind:primary color:destructive size:default light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -1387,7 +1382,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
 
 exports[`IconButtonCore kind:primary color:destructive size:default light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -1664,7 +1658,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
 
 exports[`IconButtonCore kind:primary color:destructive size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -1941,7 +1934,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
 
 exports[`IconButtonCore kind:primary color:destructive size:small light:true disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -2218,7 +2210,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
 
 exports[`IconButtonCore kind:secondary color:default size:default light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -2495,7 +2486,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
 
 exports[`IconButtonCore kind:secondary color:default size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -2772,7 +2762,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
 
 exports[`IconButtonCore kind:secondary color:destructive size:default light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -3049,7 +3038,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
 
 exports[`IconButtonCore kind:secondary color:destructive size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -3326,7 +3314,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
 
 exports[`IconButtonCore kind:tertiary color:default size:default light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -3603,7 +3590,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
 
 exports[`IconButtonCore kind:tertiary color:default size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -3880,7 +3866,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
 
 exports[`IconButtonCore kind:tertiary color:destructive size:default light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}
@@ -4157,7 +4142,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
 
 exports[`IconButtonCore kind:tertiary color:destructive size:small light:false disabled 1`] = `
 <button
-  aria-disabled="true"
   aria-label="search"
   className=""
   disabled={true}

--- a/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
@@ -284,7 +284,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     }
   />
   <button
-    aria-disabled="true"
     aria-label="search"
     className=""
     disabled={true}
@@ -374,7 +373,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     }
   />
   <button
-    aria-disabled="true"
     aria-label="search"
     className=""
     disabled={true}

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -61,7 +61,6 @@ export default class IconButtonCore extends React.Component<Props> {
     render() {
         const {
             skipClientNav,
-            "aria-label": ariaLabel,
             color,
             disabled,
             focused,
@@ -98,9 +97,6 @@ export default class IconButtonCore extends React.Component<Props> {
         const child = <Icon size="medium" color="currentColor" icon={icon} />;
 
         const commonProps = {
-            // TODO(kevinb): figure out a better way of forward ARIA props
-            "aria-disabled": disabled ? "true" : undefined,
-            "aria-label": ariaLabel,
             "data-test-id": testId,
             style: [defaultStyle, style],
             ...handlers,
@@ -122,6 +118,8 @@ export default class IconButtonCore extends React.Component<Props> {
                     type="button"
                     {...commonProps}
                     disabled={disabled}
+                    // WB-535: Allows only to use `disabled`
+                    aria-disabled={undefined}
                 >
                     {child}
                 </StyledButton>

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -102,16 +102,6 @@ export default class IconButtonCore extends React.Component<Props> {
             ...handlers,
         };
 
-        if (commonProps["aria-disabled"]) {
-            // eslint-disable-next-line no-console
-            console.warn(
-                "wb-icon-button: <button> supports the 'disabled' attribute. You don't need to use the 'aria-disabled' attribute.",
-            );
-
-            // WB-535: Allows only to use `disabled` (even if is set from the parent component)
-            commonProps["aria-disabled"] = undefined;
-        }
-
         if (href && !disabled) {
             return router && !skipClientNav ? (
                 <StyledLink {...commonProps} to={href}>

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -102,6 +102,16 @@ export default class IconButtonCore extends React.Component<Props> {
             ...handlers,
         };
 
+        if (commonProps["aria-disabled"]) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                "wb-icon-button: <button> supports the 'disabled' attribute. You don't need to use the 'aria-disabled' attribute.",
+            );
+
+            // WB-535: Allows only to use `disabled` (even if is set from the parent component)
+            commonProps["aria-disabled"] = undefined;
+        }
+
         if (href && !disabled) {
             return router && !skipClientNav ? (
                 <StyledLink {...commonProps} to={href}>
@@ -118,8 +128,6 @@ export default class IconButtonCore extends React.Component<Props> {
                     type="button"
                     {...commonProps}
                     disabled={disabled}
-                    // WB-535: Allows only to use `disabled`
-                    aria-disabled={undefined}
                 >
                     {child}
                 </StyledButton>

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -8,7 +8,7 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import IconButtonCore from "./icon-button-core.js";
 
 export type SharedProps = {|
-    ...AriaProps,
+    ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,
 
     /**
      * A Wonder Blocks icon asset, an object specifing paths for one or more of

--- a/packages/wonder-blocks-icon-button/components/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.test.js
@@ -157,31 +157,4 @@ describe("IconButton", () => {
         // Assert
         expect(wrapper.find("#foo").exists()).toBe(false);
     });
-
-    test("checks that aria-disabled is not added when disabled is set", () => {
-        // Arrange
-        // Prevent jest to output warnings when running tests
-        const consoleWarnMockFn = jest
-            .spyOn(global.console, "warn")
-            .mockImplementationOnce(() => jest.fn());
-
-        const wrapper = mount(
-            <IconButton
-                icon={icons.search}
-                disabled={true}
-                aria-disabled="true"
-            />,
-        );
-
-        // Act
-        const buttonWrapper = wrapper.find("button").first();
-
-        // Assert
-        expect(buttonWrapper.prop("disabled")).toEqual(true);
-        // we should expect to throw a warning to devs
-        expect(consoleWarnMockFn).toHaveBeenCalled();
-        expect(buttonWrapper.prop("aria-disabled")).not.toBeDefined();
-
-        consoleWarnMockFn.mockRestore();
-    });
 });

--- a/packages/wonder-blocks-icon-button/components/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.test.js
@@ -157,4 +157,31 @@ describe("IconButton", () => {
         // Assert
         expect(wrapper.find("#foo").exists()).toBe(false);
     });
+
+    test("checks that aria-disabled is not added when disabled is set", () => {
+        // Arrange
+        // Prevent jest to output warnings when running tests
+        const consoleWarnMockFn = jest
+            .spyOn(global.console, "warn")
+            .mockImplementationOnce(() => jest.fn());
+
+        const wrapper = mount(
+            <IconButton
+                icon={icons.search}
+                disabled={true}
+                aria-disabled="true"
+            />,
+        );
+
+        // Act
+        const buttonWrapper = wrapper.find("button").first();
+
+        // Assert
+        expect(buttonWrapper.prop("disabled")).toEqual(true);
+        // we should expect to throw a warning to devs
+        expect(consoleWarnMockFn).toHaveBeenCalled();
+        expect(buttonWrapper.prop("aria-disabled")).not.toBeDefined();
+
+        consoleWarnMockFn.mockRestore();
+    });
 });


### PR DESCRIPTION
## Button, Dropdown, IconButton
Removed `aria-disabled` as prop when the `disabled` attribute is present.

### Test plan
`yarn test`
