### PR TITLE
[fix:button,dropdown,icon-button] WB-478: Remove special highlight style on mobile

### DIFF
--- a/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/custom-snapshot.test.js.snap
@@ -25,6 +25,9 @@ exports[`ButtonCore kind:primary color:default size:medium light:false disabled 
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -97,6 +100,9 @@ exports[`ButtonCore kind:primary color:default size:medium light:false focused 1
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#1865f2",
@@ -172,6 +178,9 @@ exports[`ButtonCore kind:primary color:default size:medium light:false hovered 1
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#1865f2",
       "border": "none",
@@ -245,6 +254,9 @@ exports[`ButtonCore kind:primary color:default size:medium light:false pressed 1
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#1b50b3",
@@ -321,6 +333,9 @@ exports[`ButtonCore kind:primary color:default size:medium light:true disabled 1
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#b5cefb",
       "border": "none",
@@ -393,6 +408,9 @@ exports[`ButtonCore kind:primary color:default size:medium light:true focused 1`
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#ffffff",
@@ -468,6 +486,9 @@ exports[`ButtonCore kind:primary color:default size:medium light:true hovered 1`
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -541,6 +562,9 @@ exports[`ButtonCore kind:primary color:default size:medium light:true pressed 1`
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#b5cefb",
@@ -617,6 +641,9 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -689,6 +716,9 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#1865f2",
@@ -764,6 +794,9 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#1865f2",
       "border": "none",
@@ -837,6 +870,9 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#1b50b3",
@@ -913,6 +949,9 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#b5cefb",
       "border": "none",
@@ -985,6 +1024,9 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#ffffff",
@@ -1060,6 +1102,9 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -1133,6 +1178,9 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#b5cefb",
@@ -1209,6 +1257,9 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false disab
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -1281,6 +1332,9 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false focus
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#d92916",
@@ -1356,6 +1410,9 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false hover
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#d92916",
       "border": "none",
@@ -1429,6 +1486,9 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false press
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#9e271d",
@@ -1505,6 +1565,9 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true disabl
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#f3bbb4",
       "border": "none",
@@ -1577,6 +1640,9 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true focuse
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#ffffff",
@@ -1652,6 +1718,9 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true hovere
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -1725,6 +1794,9 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true presse
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#f3bbb4",
@@ -1801,6 +1873,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -1873,6 +1948,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#d92916",
@@ -1948,6 +2026,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#d92916",
       "border": "none",
@@ -2021,6 +2102,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#9e271d",
@@ -2097,6 +2181,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#f3bbb4",
       "border": "none",
@@ -2169,6 +2256,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#ffffff",
@@ -2244,6 +2334,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -2317,6 +2410,9 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#f3bbb4",
@@ -2392,6 +2488,9 @@ exports[`ButtonCore kind:primary size:medium spinner:true 1`] = `
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
@@ -2521,6 +2620,9 @@ exports[`ButtonCore kind:primary size:small spinner:true 1`] = `
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "rgba(33,36,44,0.32)",
       "border": "none",
@@ -2649,6 +2751,9 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false disable
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2724,6 +2829,9 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false focused
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#ffffff",
@@ -2801,6 +2909,9 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false hovered
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -2876,6 +2987,9 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false pressed
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#b5cefb",
@@ -2954,6 +3068,9 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true disabled
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3029,6 +3146,9 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true focused 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "transparent",
@@ -3106,6 +3226,9 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true hovered 
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -3181,6 +3304,9 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true pressed 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#1b50b3",
@@ -3259,6 +3385,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3334,6 +3463,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#ffffff",
@@ -3411,6 +3543,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -3486,6 +3621,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#b5cefb",
@@ -3564,6 +3702,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3639,6 +3780,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "transparent",
@@ -3716,6 +3860,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -3791,6 +3938,9 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#1b50b3",
@@ -3869,6 +4019,9 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false dis
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3944,6 +4097,9 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false foc
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#ffffff",
@@ -4021,6 +4177,9 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false hov
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -4096,6 +4255,9 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false pre
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#f3bbb4",
@@ -4174,6 +4336,9 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true disa
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4249,6 +4414,9 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true focu
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "transparent",
@@ -4326,6 +4494,9 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true hove
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -4401,6 +4572,9 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true pres
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#9e271d",
@@ -4479,6 +4653,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4554,6 +4731,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#ffffff",
@@ -4631,6 +4811,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#ffffff",
       "border": "none",
@@ -4706,6 +4889,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#f3bbb4",
@@ -4784,6 +4970,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4859,6 +5048,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "transparent",
@@ -4936,6 +5128,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "transparent",
       "border": "none",
@@ -5011,6 +5206,9 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "#9e271d",
@@ -5088,6 +5286,9 @@ exports[`ButtonCore kind:secondary size:medium spinner:true 1`] = `
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -5220,6 +5421,9 @@ exports[`ButtonCore kind:secondary size:small spinner:true 1`] = `
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5351,6 +5555,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false disabled
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5433,6 +5640,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false focused 
         "position": "absolute",
         "right": 0,
         "width": "calc(100% - 0px)",
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -5517,6 +5727,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false hovered 
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5600,6 +5813,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false pressed 
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5673,6 +5889,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true disabled 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -5757,6 +5976,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true focused 1
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5839,6 +6061,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true hovered 1
         "position": "absolute",
         "right": 0,
         "width": "calc(100% - 0px)",
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -5923,6 +6148,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true pressed 1
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -5996,6 +6224,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -6080,6 +6311,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -6162,6 +6396,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
         "position": "absolute",
         "right": 0,
         "width": "calc(100% - 0px)",
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -6246,6 +6483,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -6319,6 +6559,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -6403,6 +6646,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -6485,6 +6731,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
         "position": "absolute",
         "right": 0,
         "width": "calc(100% - 0px)",
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -6569,6 +6818,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -6642,6 +6894,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false disa
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -6726,6 +6981,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false focu
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -6808,6 +7066,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false hove
         "position": "absolute",
         "right": 0,
         "width": "calc(100% - 0px)",
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -6892,6 +7153,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false pres
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -6965,6 +7229,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true disab
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -7049,6 +7316,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true focus
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -7131,6 +7401,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true hover
         "position": "absolute",
         "right": 0,
         "width": "calc(100% - 0px)",
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -7215,6 +7488,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true press
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -7288,6 +7564,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -7372,6 +7651,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -7454,6 +7736,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
         "position": "absolute",
         "right": 0,
         "width": "calc(100% - 0px)",
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -7538,6 +7823,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -7611,6 +7899,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -7695,6 +7986,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -7777,6 +8071,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
         "position": "absolute",
         "right": 0,
         "width": "calc(100% - 0px)",
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -7861,6 +8158,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
         "right": 0,
         "width": "calc(100% - 0px)",
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -7934,6 +8234,9 @@ exports[`ButtonCore kind:tertiary size:medium spinner:true 1`] = `
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -8062,6 +8365,9 @@ exports[`ButtonCore kind:tertiary size:small spinner:true 1`] = `
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",

--- a/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__snapshots__/generated-snapshot.test.js.snap
@@ -42,6 +42,9 @@ exports[`wonder-blocks-button example 1 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -111,6 +114,9 @@ exports[`wonder-blocks-button example 1 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -184,6 +190,9 @@ exports[`wonder-blocks-button example 1 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -278,6 +287,9 @@ exports[`wonder-blocks-button example 2 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#d92916",
         "border": "none",
@@ -347,6 +359,9 @@ exports[`wonder-blocks-button example 2 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -420,6 +435,9 @@ exports[`wonder-blocks-button example 2 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -515,6 +533,9 @@ exports[`wonder-blocks-button example 3 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "rgba(33,36,44,0.32)",
         "border": "none",
@@ -585,6 +606,9 @@ exports[`wonder-blocks-button example 3 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -659,6 +683,9 @@ exports[`wonder-blocks-button example 3 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -754,6 +781,9 @@ exports[`wonder-blocks-button example 4 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#ffffff",
         "border": "none",
@@ -823,6 +853,9 @@ exports[`wonder-blocks-button example 4 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -897,6 +930,9 @@ exports[`wonder-blocks-button example 4 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -968,6 +1004,9 @@ exports[`wonder-blocks-button example 4 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#b5cefb",
         "border": "none",
@@ -1038,6 +1077,9 @@ exports[`wonder-blocks-button example 4 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -1112,6 +1154,9 @@ exports[`wonder-blocks-button example 4 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -1206,6 +1251,9 @@ exports[`wonder-blocks-button example 5 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -1275,6 +1323,9 @@ exports[`wonder-blocks-button example 5 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -1348,6 +1399,9 @@ exports[`wonder-blocks-button example 5 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -1439,6 +1493,9 @@ exports[`wonder-blocks-button example 6 1`] = `
     role="button"
     style={
       Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -1506,6 +1563,9 @@ exports[`wonder-blocks-button example 6 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",
@@ -1577,6 +1637,9 @@ exports[`wonder-blocks-button example 6 1`] = `
     role="button"
     style={
       Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -1665,6 +1728,9 @@ exports[`wonder-blocks-button example 7 1`] = `
     role="button"
     style={
       Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -1730,6 +1796,9 @@ exports[`wonder-blocks-button example 7 1`] = `
     role="button"
     style={
       Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -1822,6 +1891,9 @@ exports[`wonder-blocks-button example 8 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "rgba(33,36,44,0.32)",
@@ -1948,6 +2020,9 @@ exports[`wonder-blocks-button example 8 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "rgba(33,36,44,0.32)",
@@ -2116,6 +2191,9 @@ exports[`wonder-blocks-button example 9 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",
@@ -2205,6 +2283,9 @@ exports[`wonder-blocks-button example 9 1`] = `
         Object {
           "::MozFocusInner": Object {
             "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           },
           "alignItems": "center",
           "background": "none",
@@ -2298,6 +2379,9 @@ exports[`wonder-blocks-button example 9 1`] = `
         Object {
           "::MozFocusInner": Object {
             "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           },
           "alignItems": "center",
           "background": "none",
@@ -2410,6 +2494,9 @@ exports[`wonder-blocks-button example 9 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",
@@ -2500,6 +2587,9 @@ exports[`wonder-blocks-button example 9 1`] = `
         Object {
           "::MozFocusInner": Object {
             "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           },
           "alignItems": "center",
           "background": "none",
@@ -2594,6 +2684,9 @@ exports[`wonder-blocks-button example 9 1`] = `
         Object {
           "::MozFocusInner": Object {
             "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           },
           "alignItems": "center",
           "background": "none",
@@ -2710,6 +2803,9 @@ exports[`wonder-blocks-button example 10 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -2821,6 +2917,9 @@ exports[`wonder-blocks-button example 11 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",
@@ -2930,6 +3029,9 @@ exports[`wonder-blocks-button example 11 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",
@@ -3023,6 +3125,9 @@ exports[`wonder-blocks-button example 12 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -3096,6 +3201,9 @@ exports[`wonder-blocks-button example 12 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "#1865f2",
@@ -3210,6 +3318,9 @@ exports[`wonder-blocks-button example 13 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "none",
           "border": "none",
@@ -3279,6 +3390,9 @@ exports[`wonder-blocks-button example 13 1`] = `
         Object {
           "::MozFocusInner": Object {
             "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           },
           "alignItems": "center",
           "background": "#1865f2",
@@ -3373,6 +3487,9 @@ exports[`wonder-blocks-button example 14 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "#1865f2",

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -169,6 +169,7 @@ const sharedStyles = StyleSheet.create({
         touchAction: "manipulation",
         userSelect: "none",
         ":focus": {
+            // Mobile: Removes a blue highlight style shown when the user clicks a button
             WebkitTapHighlightColor: "rgba(0,0,0,0)",
         },
     },

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -168,6 +168,9 @@ const sharedStyles = StyleSheet.create({
         // "double-tap to zoom" shouldn't be used on this element.
         touchAction: "manipulation",
         userSelect: "none",
+        ":focus": {
+            WebkitTapHighlightColor: "rgba(0,0,0,0)",
+        },
     },
     withIcon: {
         // The left padding for the button with icon should have 4px less padding

--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -302,6 +302,9 @@ exports[`wonder-blocks-core example 6 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "#1865f2",
           "border": "none",

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -68,6 +68,9 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "none",
           "border": "none",
@@ -268,6 +271,9 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "none",
           "border": "none",
@@ -446,6 +452,9 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
         Object {
           "::MozFocusInner": Object {
             "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           },
           "alignItems": "center",
           "background": "none",
@@ -627,6 +636,9 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
           "::MozFocusInner": Object {
             "border": 0,
           },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
           "background": "none",
           "border": "none",
@@ -806,6 +818,9 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
         Object {
           "::MozFocusInner": Object {
             "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           },
           "alignItems": "center",
           "background": "none",
@@ -2373,6 +2388,9 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "#1865f2",

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -106,6 +106,9 @@ const sharedStyles = StyleSheet.create({
         // This removes the 300ms click delay on mobile browsers by indicating that
         // "double-tap to zoom" shouldn't be used on this element.
         touchAction: "manipulation",
+        ":focus": {
+            WebkitTapHighlightColor: "rgba(0,0,0,0)",
+        },
     },
     disabled: {
         cursor: "auto",

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -107,6 +107,7 @@ const sharedStyles = StyleSheet.create({
         // "double-tap to zoom" shouldn't be used on this element.
         touchAction: "manipulation",
         ":focus": {
+            // Mobile: Removes a blue highlight style shown when the user clicks a button
             WebkitTapHighlightColor: "rgba(0,0,0,0)",
         },
     },

--- a/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/custom-snapshot.test.js.snap
@@ -24,6 +24,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:false disa
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -89,6 +92,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:false focu
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -160,6 +166,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:false hove
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -229,6 +238,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -301,6 +313,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:true disab
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -366,6 +381,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:true focus
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -437,6 +455,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:true hover
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -506,6 +527,9 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -578,6 +602,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -643,6 +670,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -714,6 +744,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -783,6 +816,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -855,6 +891,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -920,6 +959,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -991,6 +1033,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1060,6 +1105,9 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -1132,6 +1180,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1197,6 +1248,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -1268,6 +1322,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1337,6 +1394,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -1409,6 +1469,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true d
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1474,6 +1537,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true f
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -1545,6 +1611,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true h
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1614,6 +1683,9 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -1686,6 +1758,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1751,6 +1826,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -1822,6 +1900,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -1891,6 +1972,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -1963,6 +2047,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2028,6 +2115,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -2099,6 +2189,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2168,6 +2261,9 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -2240,6 +2336,9 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false di
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2305,6 +2404,9 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false fo
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -2376,6 +2478,9 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false ho
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2445,6 +2550,9 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -2517,6 +2625,9 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2582,6 +2693,9 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -2653,6 +2767,9 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2722,6 +2839,9 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -2794,6 +2914,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2859,6 +2982,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -2930,6 +3056,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -2999,6 +3128,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -3071,6 +3203,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3136,6 +3271,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -3207,6 +3345,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3276,6 +3417,9 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -3348,6 +3492,9 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false dis
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3413,6 +3560,9 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false foc
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -3484,6 +3634,9 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false hov
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3553,6 +3706,9 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -3625,6 +3781,9 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3690,6 +3849,9 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -3761,6 +3923,9 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3830,6 +3995,9 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -3902,6 +4070,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -3967,6 +4138,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -4038,6 +4212,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4107,6 +4284,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -4179,6 +4359,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4244,6 +4427,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",
@@ -4315,6 +4501,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "none",
       "border": "none",
@@ -4384,6 +4573,9 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
     Object {
       "::MozFocusInner": Object {
         "border": 0,
+      },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
       "alignItems": "center",
       "background": "none",

--- a/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__snapshots__/generated-snapshot.test.js.snap
@@ -42,6 +42,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -131,6 +134,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -217,6 +223,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -306,6 +315,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -396,6 +408,9 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "none",
         "border": "none",
@@ -482,6 +497,9 @@ exports[`wonder-blocks-icon-button example 2 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -150,6 +150,7 @@ const sharedStyles = StyleSheet.create({
         // "double-tap to zoom" shouldn't be used on this element.
         touchAction: "manipulation",
         ":focus": {
+            // Mobile: Removes a blue highlight style shown when the user clicks a button
             WebkitTapHighlightColor: "rgba(0,0,0,0)",
         },
     },

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -149,6 +149,9 @@ const sharedStyles = StyleSheet.create({
         // This removes the 300ms click delay on mobile browsers by indicating that
         // "double-tap to zoom" shouldn't be used on this element.
         touchAction: "manipulation",
+        ":focus": {
+            WebkitTapHighlightColor: "rgba(0,0,0,0)",
+        },
     },
     disabled: {
         cursor: "default",

--- a/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-layout/__snapshots__/generated-snapshot.test.js.snap
@@ -43,6 +43,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -138,6 +141,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "#1865f2",
@@ -235,6 +241,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -325,6 +334,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "#1865f2",
@@ -421,6 +433,9 @@ exports[`wonder-blocks-layout example 1 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "#1865f2",

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -42,6 +42,9 @@ exports[`wonder-blocks-modal example 1 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -133,6 +136,9 @@ exports[`wonder-blocks-modal example 2 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "#1865f2",
@@ -375,6 +381,9 @@ exports[`wonder-blocks-modal example 3 1`] = `
               Object {
                 "::MozFocusInner": Object {
                   "border": 0,
+                },
+                ":focus": Object {
+                  "WebkitTapHighlightColor": "rgba(0,0,0,0)",
                 },
                 "alignItems": "center",
                 "background": "none",
@@ -645,6 +654,9 @@ exports[`wonder-blocks-modal example 4 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -736,6 +748,9 @@ exports[`wonder-blocks-modal example 5 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "#1865f2",
@@ -852,6 +867,9 @@ exports[`wonder-blocks-modal example 6 1`] = `
         Object {
           "::MozFocusInner": Object {
             "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
           },
           "alignItems": "center",
           "background": "none",
@@ -1107,6 +1125,9 @@ exports[`wonder-blocks-modal example 7 1`] = `
               Object {
                 "::MozFocusInner": Object {
                   "border": 0,
+                },
+                ":focus": Object {
+                  "WebkitTapHighlightColor": "rgba(0,0,0,0)",
                 },
                 "alignItems": "center",
                 "background": "none",
@@ -1378,6 +1399,9 @@ exports[`wonder-blocks-modal example 7 1`] = `
                   "::MozFocusInner": Object {
                     "border": 0,
                   },
+                  ":focus": Object {
+                    "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                  },
                   "alignItems": "center",
                   "background": "#1865f2",
                   "border": "none",
@@ -1624,6 +1648,9 @@ exports[`wonder-blocks-modal example 8 1`] = `
               Object {
                 "::MozFocusInner": Object {
                   "border": 0,
+                },
+                ":focus": Object {
+                  "WebkitTapHighlightColor": "rgba(0,0,0,0)",
                 },
                 "alignItems": "center",
                 "background": "none",
@@ -1978,6 +2005,9 @@ exports[`wonder-blocks-modal example 8 1`] = `
                     "::MozFocusInner": Object {
                       "border": 0,
                     },
+                    ":focus": Object {
+                      "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                    },
                     "alignItems": "center",
                     "background": "none",
                     "border": "none",
@@ -2048,6 +2078,9 @@ exports[`wonder-blocks-modal example 8 1`] = `
                     "::MozFocusInner": Object {
                       "border": 0,
                     },
+                    ":focus": Object {
+                      "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                    },
                     "alignItems": "center",
                     "background": "none",
                     "border": "none",
@@ -2117,6 +2150,9 @@ exports[`wonder-blocks-modal example 8 1`] = `
                   Object {
                     "::MozFocusInner": Object {
                       "border": 0,
+                    },
+                    ":focus": Object {
+                      "WebkitTapHighlightColor": "rgba(0,0,0,0)",
                     },
                     "alignItems": "center",
                     "background": "#1865f2",
@@ -2316,6 +2352,9 @@ exports[`wonder-blocks-modal example 9 1`] = `
               Object {
                 "::MozFocusInner": Object {
                   "border": 0,
+                },
+                ":focus": Object {
+                  "WebkitTapHighlightColor": "rgba(0,0,0,0)",
                 },
                 "alignItems": "center",
                 "background": "none",
@@ -2593,6 +2632,9 @@ exports[`wonder-blocks-modal example 9 1`] = `
                       "::MozFocusInner": Object {
                         "border": 0,
                       },
+                      ":focus": Object {
+                        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                      },
                       "alignItems": "center",
                       "background": "none",
                       "border": "none",
@@ -2687,6 +2729,9 @@ exports[`wonder-blocks-modal example 9 1`] = `
                     Object {
                       "::MozFocusInner": Object {
                         "border": 0,
+                      },
+                      ":focus": Object {
+                        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
                       },
                       "alignItems": "center",
                       "background": "#1865f2",
@@ -3084,6 +3129,9 @@ exports[`wonder-blocks-modal example 10 1`] = `
                   "::MozFocusInner": Object {
                     "border": 0,
                   },
+                  ":focus": Object {
+                    "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                  },
                   "alignItems": "center",
                   "background": "none",
                   "border": "none",
@@ -3275,6 +3323,9 @@ exports[`wonder-blocks-modal example 10 1`] = `
                       Object {
                         "::MozFocusInner": Object {
                           "border": 0,
+                        },
+                        ":focus": Object {
+                          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
                         },
                         "alignItems": "center",
                         "background": "#1865f2",

--- a/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__snapshots__/generated-snapshot.test.js.snap
@@ -129,6 +129,9 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
             "::MozFocusInner": Object {
               "border": 0,
             },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            },
             "alignItems": "center",
             "background": "#1865f2",
             "border": "none",
@@ -224,6 +227,9 @@ exports[`wonder-blocks-toolbar example 1 1`] = `
           Object {
             "::MozFocusInner": Object {
               "border": 0,
+            },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             },
             "alignItems": "center",
             "background": "none",
@@ -367,6 +373,9 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
             "::MozFocusInner": Object {
               "border": 0,
             },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            },
             "alignItems": "center",
             "background": "none",
             "border": "none",
@@ -454,6 +463,9 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
           Object {
             "::MozFocusInner": Object {
               "border": 0,
+            },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             },
             "alignItems": "center",
             "background": "none",
@@ -560,6 +572,9 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
           Object {
             "::MozFocusInner": Object {
               "border": 0,
+            },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             },
             "alignItems": "center",
             "background": "none",
@@ -699,6 +714,9 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
             "::MozFocusInner": Object {
               "border": 0,
             },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            },
             "alignItems": "center",
             "background": "none",
             "border": "none",
@@ -804,6 +822,9 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
           Object {
             "::MozFocusInner": Object {
               "border": 0,
+            },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             },
             "alignItems": "center",
             "background": "#1865f2",
@@ -942,6 +963,9 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
           Object {
             "::MozFocusInner": Object {
               "border": 0,
+            },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             },
             "alignItems": "center",
             "background": "none",
@@ -1181,6 +1205,9 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
             "::MozFocusInner": Object {
               "border": 0,
             },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            },
             "alignItems": "center",
             "background": "none",
             "border": "none",
@@ -1350,6 +1377,9 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
           Object {
             "::MozFocusInner": Object {
               "border": 0,
+            },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             },
             "alignItems": "center",
             "background": "#1865f2",
@@ -1574,6 +1604,9 @@ exports[`wonder-blocks-toolbar example 6 1`] = `
             "::MozFocusInner": Object {
               "border": 0,
             },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+            },
             "alignItems": "center",
             "background": "none",
             "border": "none",
@@ -1672,6 +1705,9 @@ exports[`wonder-blocks-toolbar example 6 1`] = `
           Object {
             "::MozFocusInner": Object {
               "border": 0,
+            },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             },
             "alignItems": "center",
             "background": "#1865f2",
@@ -1811,6 +1847,9 @@ exports[`wonder-blocks-toolbar example 7 1`] = `
           Object {
             "::MozFocusInner": Object {
               "border": 0,
+            },
+            ":focus": Object {
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
             },
             "alignItems": "center",
             "background": "none",

--- a/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__snapshots__/generated-snapshot.test.js.snap
@@ -163,6 +163,9 @@ exports[`wonder-blocks-tooltip example 4 1`] = `
       "::MozFocusInner": Object {
         "border": 0,
       },
+      ":focus": Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
       "alignItems": "center",
       "background": "#1865f2",
       "border": "none",
@@ -418,6 +421,9 @@ exports[`wonder-blocks-tooltip example 6 1`] = `
         "::MozFocusInner": Object {
           "border": 0,
         },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
         "alignItems": "center",
         "background": "#1865f2",
         "border": "none",
@@ -513,6 +519,9 @@ exports[`wonder-blocks-tooltip example 6 1`] = `
       Object {
         "::MozFocusInner": Object {
           "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
         },
         "alignItems": "center",
         "background": "none",


### PR DESCRIPTION
## Button, ActionMenu, IconButton
- Fixed: Removed blue highlight style shown when the user focuses/clicks a button on mobile devices.

### Test plan
1. Open the following links on a mobile device:
    - Button: https://deploy-preview-417--wonder-blocks.netlify.com/#!/Button/1
    - ActionMenu: https://deploy-preview-417--wonder-blocks.netlify.com/#!/ActionMenu/1
    - IconButton: https://deploy-preview-417--wonder-blocks.netlify.com/#!/IconButton/1
2. Click on any button on the examples.
3. Make sure the highlight don't appear anymore (this happens when the focus is activated for this clicked button).