### PR TITLE
[dropdown:fix] use props.open in action-menu-opener-core.js instead of global open

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -44,7 +44,7 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
     }
   >
     <button
-      aria-expanded="true"
+      aria-expanded="false"
       aria-haspopup="menu"
       className=""
       data-test-id="teacher-menu"
@@ -62,7 +62,6 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      open={false}
       style={
         Object {
           "::MozFocusInner": Object {
@@ -248,7 +247,7 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
     }
   >
     <button
-      aria-expanded="true"
+      aria-expanded="false"
       aria-haspopup="menu"
       className=""
       disabled={false}
@@ -265,7 +264,6 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      open={false}
       style={
         Object {
           "::MozFocusInner": Object {
@@ -430,7 +428,7 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
     }
   >
     <button
-      aria-expanded="true"
+      aria-expanded="false"
       aria-haspopup="menu"
       className=""
       disabled={false}
@@ -447,7 +445,6 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      open={false}
       style={
         Object {
           "::MozFocusInner": Object {
@@ -612,7 +609,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
     }
   >
     <button
-      aria-expanded="true"
+      aria-expanded="false"
       aria-haspopup="menu"
       className=""
       disabled={true}
@@ -629,7 +626,6 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      open={false}
       style={
         Object {
           "::MozFocusInner": Object {
@@ -794,7 +790,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
     }
   >
     <button
-      aria-expanded="true"
+      aria-expanded="false"
       aria-haspopup="menu"
       className=""
       data-test-id="teacher-menu"
@@ -812,7 +808,6 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      open={false}
       style={
         Object {
           "::MozFocusInner": Object {

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -40,6 +40,7 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
             hovered,
             pressed,
             testId,
+            open,
             "aria-label": ariaLabel,
             ...handlers
         } = this.props;

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -845,7 +845,7 @@ exports[`wonder-blocks-modal example 6 1`] = `
     }
   >
     <button
-      aria-expanded="true"
+      aria-expanded="false"
       aria-haspopup="menu"
       className=""
       disabled={false}
@@ -862,7 +862,6 @@ exports[`wonder-blocks-modal example 6 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      open={false}
       style={
         Object {
           "::MozFocusInner": Object {


### PR DESCRIPTION
Jira: https://khanacademy.atlassian.net/browse/LP-5535

We were using the global `open` which is always truthy so `aria-expanded` was always being set to `"true"`.  This PR fixes this by using `props.open` instead.  The fixtures have been updated which should be sufficient to show that the issue has been fixed.