### PR TITLE
[feat:link] WB-582 Allow children to accept all typography components

### DIFF
--- a/packages/wonder-blocks-link/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__snapshots__/generated-snapshot.test.js.snap
@@ -234,7 +234,7 @@ exports[`wonder-blocks-link example 2 1`] = `
         }
       }
     >
-      Heading with link
+      Heading inside a Link element
     </h4>
   </a>
 </div>

--- a/packages/wonder-blocks-link/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__snapshots__/generated-snapshot.test.js.snap
@@ -171,3 +171,71 @@ exports[`wonder-blocks-link example 1 1`] = `
   </p>
 </div>
 `;
+
+exports[`wonder-blocks-link example 2 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <a
+    className=""
+    href="#nonexistent-link"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    style={
+      Object {
+        "color": "#1865f2",
+        "cursor": "pointer",
+        "outline": "none",
+        "textDecoration": "none",
+      }
+    }
+    tabIndex={0}
+  >
+    <h4
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "display": "block",
+          "fontFamily": "Lato, sans-serif",
+          "fontSize": 20,
+          "fontWeight": 700,
+          "lineHeight": "24px",
+          "marginBottom": 0,
+          "marginTop": 0,
+        }
+      }
+    >
+      Heading with link
+    </h4>
+  </a>
+</div>
+`;

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -11,7 +11,7 @@ export type SharedProps = {|
     ...AriaProps,
 
     /**
-     * Text to appear on the link.
+     * Text to appear on the link. It can be a plain text or a Typography element.
      */
     children: string | React.Element<Typography>,
 

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+import type {Typography} from "@khanacademy/wonder-blocks-typography";
 import LinkCore from "./link-core.js";
 
 export type SharedProps = {|
@@ -12,7 +13,7 @@ export type SharedProps = {|
     /**
      * Text to appear on the link.
      */
-    children: string,
+    children: string | React.Element<Typography>,
 
     /**
      * URL to navigate to.

--- a/packages/wonder-blocks-link/components/link.md
+++ b/packages/wonder-blocks-link/components/link.md
@@ -19,3 +19,16 @@ const {View} = require("@khanacademy/wonder-blocks-core");
     </p>
 </View>
 ```
+
+Link with Typhography element:
+
+```js
+const {HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
+const {View} = require("@khanacademy/wonder-blocks-core");
+
+<View>
+    <Link href="#nonexistent-link">
+        <HeadingSmall>Heading with link</HeadingSmall>
+    </Link>
+</View>
+```

--- a/packages/wonder-blocks-link/components/link.md
+++ b/packages/wonder-blocks-link/components/link.md
@@ -1,4 +1,4 @@
-Link example:
+### Example: Link
 
 ```js
 const Color = require("@khanacademy/wonder-blocks-color").default;
@@ -20,7 +20,9 @@ const {View} = require("@khanacademy/wonder-blocks-core");
 </View>
 ```
 
-Link with Typhography element:
+### Example: Link with Typography element
+
+You can also use a Typography element instead of just plain text.
 
 ```js
 const {HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
@@ -28,7 +30,7 @@ const {View} = require("@khanacademy/wonder-blocks-core");
 
 <View>
     <Link href="#nonexistent-link">
-        <HeadingSmall>Heading with link</HeadingSmall>
+        <HeadingSmall>Heading inside a Link element</HeadingSmall>
     </Link>
 </View>
 ```

--- a/packages/wonder-blocks-link/generated-snapshot.test.js
+++ b/packages/wonder-blocks-link/generated-snapshot.test.js
@@ -54,4 +54,18 @@ describe("wonder-blocks-link", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+    it("example 2", () => {
+        const {HeadingSmall} = require("@khanacademy/wonder-blocks-typography");
+        const {View} = require("@khanacademy/wonder-blocks-core");
+
+        const example = (
+            <View>
+                <Link href="#nonexistent-link">
+                    <HeadingSmall>Heading with link</HeadingSmall>
+                </Link>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/packages/wonder-blocks-link/generated-snapshot.test.js
+++ b/packages/wonder-blocks-link/generated-snapshot.test.js
@@ -61,7 +61,7 @@ describe("wonder-blocks-link", () => {
         const example = (
             <View>
                 <Link href="#nonexistent-link">
-                    <HeadingSmall>Heading with link</HeadingSmall>
+                    <HeadingSmall>Heading inside a Link element</HeadingSmall>
                 </Link>
             </View>
         );


### PR DESCRIPTION
## Link
- Link's `children` prop is now able to accept all typography components.

### Test plan
1. Open https://deploy-preview-431--wonder-blocks.netlify.com/#!/Link/3
2. Check the Link example includes a Typography component.