### PR TITLE
[fix:breadcrumbs] WB-562 WB-600: Breadcrumbs fixes > aria-current and testId

### DIFF
--- a/packages/wonder-blocks-breadcrumbs/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-breadcrumbs/__snapshots__/generated-snapshot.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`wonder-blocks-breadcrumbs example 1 1`] = `
 <nav
-  aria-label="Breadcrumb"
+  aria-label="Breadcrumbs"
 >
   <ol
     className=""

--- a/packages/wonder-blocks-breadcrumbs/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-breadcrumbs/__snapshots__/generated-snapshot.test.js.snap
@@ -133,6 +133,7 @@ exports[`wonder-blocks-breadcrumbs example 1 1`] = `
       </svg>
     </li>
     <li
+      aria-current="page"
       className=""
       style={
         Object {

--- a/packages/wonder-blocks-breadcrumbs/components/breadcrumbs-item.js
+++ b/packages/wonder-blocks-breadcrumbs/components/breadcrumbs-item.js
@@ -53,10 +53,14 @@ export default class BreadcrumbsItem extends React.Component<Props> {
     }
 
     render() {
-        const {children, showSeparator} = this.props;
+        const {children, showSeparator, testId, ...otherProps} = this.props;
 
         return (
-            <StyledListItem style={styles.item}>
+            <StyledListItem
+                {...otherProps}
+                style={styles.item}
+                data-test-id={testId}
+            >
                 {children}
                 {showSeparator && this._renderSeparator()}
             </StyledListItem>

--- a/packages/wonder-blocks-breadcrumbs/components/breadcrumbs.js
+++ b/packages/wonder-blocks-breadcrumbs/components/breadcrumbs.js
@@ -37,7 +37,7 @@ export default class Breadcrumbs extends React.Component<Props> {
     // Moved it here, in case we need to override the label for a different
     // language
     static defaultProps = {
-        "aria-label": "Breadcrumb",
+        "aria-label": "Breadcrumbs",
     };
 
     render() {

--- a/packages/wonder-blocks-breadcrumbs/components/breadcrumbs.js
+++ b/packages/wonder-blocks-breadcrumbs/components/breadcrumbs.js
@@ -34,21 +34,30 @@ const StyledList = addStyle("ol");
  * 2. Separator: Adds a separator between each item.
  */
 export default class Breadcrumbs extends React.Component<Props> {
+    // Moved it here, in case we need to override the label for a different
+    // language
+    static defaultProps = {
+        "aria-label": "Breadcrumb",
+    };
+
     render() {
-        const {children} = this.props;
+        const {children, testId, ...otherProps} = this.props;
         // using React.Children allows to deal with opaque data structures
         // e.g. children = 'string' vs children = []
         const lastChildIndex = React.Children.count(children) - 1;
 
         return (
-            <nav aria-label="Breadcrumb">
+            <nav {...otherProps} data-test-id={testId}>
                 <StyledList style={styles.container}>
-                    {React.Children.map(children, (item, index) =>
-                        React.cloneElement(item, {
+                    {React.Children.map(children, (item, index) => {
+                        const isLastChild = index === lastChildIndex;
+
+                        return React.cloneElement(item, {
                             ...item.props,
-                            showSeparator: index !== lastChildIndex,
-                        }),
-                    )}
+                            showSeparator: !isLastChild,
+                            ["aria-current"]: isLastChild ? "page" : undefined,
+                        });
+                    })}
                 </StyledList>
             </nav>
         );

--- a/packages/wonder-blocks-breadcrumbs/components/breadcrumbs.test.js
+++ b/packages/wonder-blocks-breadcrumbs/components/breadcrumbs.test.js
@@ -1,0 +1,27 @@
+// @flow
+import * as React from "react";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
+import Breadcrumbs from "./breadcrumbs.js";
+import BreadcrumbsItem from "./breadcrumbs-item.js";
+
+describe("Breadcrumbs", () => {
+    afterEach(() => {
+        unmountAll();
+    });
+
+    it("should set aria-current to the last item", () => {
+        // Arrange
+        const wrapper = mount(
+            <Breadcrumbs>
+                <BreadcrumbsItem>First</BreadcrumbsItem>
+                <BreadcrumbsItem>Last</BreadcrumbsItem>
+            </Breadcrumbs>,
+        );
+
+        // Act
+        const lastItem = wrapper.find(BreadcrumbsItem).last();
+
+        // Assert
+        expect(lastItem.prop("aria-current")).toBe("page");
+    });
+});

--- a/packages/wonder-blocks-breadcrumbs/components/breadcrumbs.test.js
+++ b/packages/wonder-blocks-breadcrumbs/components/breadcrumbs.test.js
@@ -24,4 +24,17 @@ describe("Breadcrumbs", () => {
         // Assert
         expect(lastItem.prop("aria-current")).toBe("page");
     });
+
+    it("should add data-test-id if testId is set", () => {
+        // Arrange, Act
+        const wrapper = mount(
+            <Breadcrumbs testId="test">
+                <BreadcrumbsItem>First</BreadcrumbsItem>
+                <BreadcrumbsItem>Last</BreadcrumbsItem>
+            </Breadcrumbs>,
+        );
+
+        // Assert
+        expect(wrapper.find(`[data-test-id="test"]`)).toExist();
+    });
 });

--- a/packages/wonder-blocks-breadcrumbs/docs.md
+++ b/packages/wonder-blocks-breadcrumbs/docs.md
@@ -9,7 +9,7 @@ const {BreadcrumbsItem} = require("@khanacademy/wonder-blocks-breadcrumbs");
     <BreadcrumbsItem>
         <Link href="https://khanacademy.org/about">About</Link>
     </BreadcrumbsItem>
-    <BreadcrumbsItem aria-current="page">Current page</BreadcrumbsItem>
+    <BreadcrumbsItem>Current page</BreadcrumbsItem>
 </Breadcrumbs>
 ```
 

--- a/packages/wonder-blocks-breadcrumbs/generated-snapshot.test.js
+++ b/packages/wonder-blocks-breadcrumbs/generated-snapshot.test.js
@@ -26,9 +26,7 @@ describe("wonder-blocks-breadcrumbs", () => {
                 <BreadcrumbsItem>
                     <Link href="https://khanacademy.org/about">About</Link>
                 </BreadcrumbsItem>
-                <BreadcrumbsItem aria-current="page">
-                    Current page
-                </BreadcrumbsItem>
+                <BreadcrumbsItem>Current page</BreadcrumbsItem>
             </Breadcrumbs>
         );
         const tree = renderer.create(example).toJSON();

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -100,6 +100,15 @@ export type AriaProps = {|
     "aria-busy"?: "true" | "false",
     "aria-checked"?: "false" | "mixed" | "true" | "undefined",
     "aria-controls"?: IdRefList,
+    // https://www.w3.org/TR/wai-aria-1.1/#aria-current
+    "aria-current"?:
+        | "false"
+        | "true"
+        | "page"
+        | "step"
+        | "location"
+        | "date"
+        | "time",
     "aria-describedat"?: string, // URI
     "aria-describedby"?: IdRefList,
     "aria-disabled"?: "false" | "true",

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -1738,7 +1738,7 @@ exports[`wonder-blocks-modal example 8 1`] = `
               }
             >
               <nav
-                aria-label="Breadcrumb"
+                aria-label="Breadcrumbs"
               >
                 <ol
                   className=""

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -1815,6 +1815,7 @@ exports[`wonder-blocks-modal example 8 1`] = `
                     </svg>
                   </li>
                   <li
+                    aria-current="page"
                     className=""
                     style={
                       Object {


### PR DESCRIPTION
## Breadcrumbs
- Changed `aria-current="page"` to be added automatically to the last breadcrumb item [WB-562]
- Added/fixed `testId` prop to work both Breadcrumb and BreadcrumbItem. [WB-600]

### Test plan
1. Open https://deploy-preview-441--wonder-blocks.netlify.com/#breadcrumbs
2. Make sure the example includes `aria-current="page"` automatically.
3. Add a `testId` in the source code example and check the HTML now includes `data-test-id="the-testId-value"`