### PR TITLE
WB-623: Implement single select OptionItems in Dropdown 

### DIFF
--- a/packages/wonder-blocks-clickable/docs.md
+++ b/packages/wonder-blocks-clickable/docs.md
@@ -1,4 +1,4 @@
-The Clickable component allows you to easily turn any custom compoent into a clickable one with consistent behavior and accesibility features.
+The Clickable component allows you to easily turn any custom component into a clickable one with consistent behavior and accesibility features.
 
 **Clickable allows your components to:**
 - Handle mouse / touch / keyboard events

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -38,7 +38,7 @@ type Props = {|
      * Closes the Dropdown when an OptionItem is selected, use this
      * prop if you want single-select OptionItems
      */
-    closeOnOptionSelect?: boolean,
+    singleSelectOption?: boolean,
 
     /**
      * A callback that returns items that are newly selected. Use only if this
@@ -128,7 +128,7 @@ export default class Dropdown extends React.Component<Props, State> {
     };
 
     handleOptionSelected = (selectedValue: string) => {
-        const {onChange, selectedValues} = this.props;
+        const {onChange, selectedValues, singleSelectOption} = this.props;
 
         if (!onChange || !selectedValues) {
             return;
@@ -140,13 +140,17 @@ export default class Dropdown extends React.Component<Props, State> {
                 ...selectedValues.slice(0, index),
                 ...selectedValues.slice(index + 1),
             ];
-            onChange(updatedSelection);
+            onChange(singleSelectOption ? [selectedValue] : updatedSelection);
         } else {
             // Item was newly selected
-            onChange([...selectedValues, selectedValue]);
+            onChange(
+                singleSelectOption
+                    ? [selectedValue]
+                    : [...selectedValues, selectedValue],
+            );
         }
 
-        this.props.closeOnOptionSelect
+        singleSelectOption
             ? this.handleOpenChanged(false)
             : this.handleItemSelected();
     };

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -9,12 +9,13 @@ import type {
     ClickableState,
 } from "@khanacademy/wonder-blocks-core";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
-import DropdownCore from "./dropdown-core.js";
-import type {Item, DropdownItem} from "../util/types.js";
 import ActionItem from "./action-item.js";
 import OptionItem from "./option-item.js";
+import DropdownCore from "./dropdown-core.js";
 import DropdownAnchor from "./dropdown-anchor.js";
+import type {Item, DropdownItem} from "../util/types.js";
 
+type SelectType = "single" | "multi";
 type Props = {|
     ...AriaProps,
 
@@ -38,7 +39,7 @@ type Props = {|
      * Closes the Dropdown when an OptionItem is selected, use this
      * prop if you want single-select OptionItems
      */
-    singleSelectOption?: boolean,
+    selectionType?: SelectType,
 
     /**
      * A callback that returns items that are newly selected. Use only if this
@@ -97,6 +98,7 @@ export default class Dropdown extends React.Component<Props, State> {
 
     static defaultProps = {
         alignment: "left",
+        selectionType: "multi",
     };
 
     constructor(props: Props) {
@@ -128,8 +130,8 @@ export default class Dropdown extends React.Component<Props, State> {
     };
 
     handleOptionSelected = (selectedValue: string) => {
-        const {onChange, selectedValues, singleSelectOption} = this.props;
-
+        const {onChange, selectedValues, selectionType} = this.props;
+        const singleSelect = selectionType === "single";
         if (!onChange || !selectedValues) {
             return;
         }
@@ -140,17 +142,17 @@ export default class Dropdown extends React.Component<Props, State> {
                 ...selectedValues.slice(0, index),
                 ...selectedValues.slice(index + 1),
             ];
-            onChange(singleSelectOption ? [selectedValue] : updatedSelection);
+            onChange(singleSelect ? [selectedValue] : updatedSelection);
         } else {
             // Item was newly selected
             onChange(
-                singleSelectOption
+                singleSelect
                     ? [selectedValue]
                     : [...selectedValues, selectedValue],
             );
         }
 
-        singleSelectOption
+        singleSelect
             ? this.handleOpenChanged(false)
             : this.handleItemSelected();
     };

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -35,6 +35,12 @@ type Props = {|
     menuItems: Array<Item> | Item,
 
     /**
+     * Closes the Dropdown when an OptionItem is selected, use this
+     * prop if you want single-select OptionItems
+     */
+    closeOnOptionSelect?: boolean,
+
+    /**
      * A callback that returns items that are newly selected. Use only if this
      * menu contains select items (and make sure selectedValues is defined).
      */
@@ -101,6 +107,12 @@ export default class Dropdown extends React.Component<Props, State> {
         };
     }
 
+    componentDidMount() {
+        if (this.props.opened === true || this.props.opened === false) {
+            this.handleOpenChanged(this.props.opened);
+        }
+    }
+
     handleItemSelected = () => {
         // Bring focus back to the opener element.
         if (this.openerElement) {
@@ -133,7 +145,10 @@ export default class Dropdown extends React.Component<Props, State> {
             // Item was newly selected
             onChange([...selectedValues, selectedValue]);
         }
-        this.handleItemSelected();
+
+        this.props.closeOnOptionSelect
+            ? this.handleOpenChanged(false)
+            : this.handleItemSelected();
     };
 
     handleClick = (e: SyntheticEvent<>) => {
@@ -213,16 +228,16 @@ export default class Dropdown extends React.Component<Props, State> {
 
         return (
             <DropdownCore
+                role="menu"
+                style={style}
+                opener={opener}
                 alignment={alignment}
+                open={this.state.opened}
                 items={this._getMenuItems()}
                 keyboard={this.state.keyboard}
-                style={style}
-                dropdownStyle={[styles.menuTopSpace, dropdownStyle]}
-                onOpenChanged={this.handleOpenChanged}
-                open={this.state.opened}
-                opener={opener}
                 openerElement={this.openerElement}
-                role="menu"
+                onOpenChanged={this.handleOpenChanged}
+                dropdownStyle={[styles.menuTopSpace, dropdownStyle]}
             />
         );
     }

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -108,7 +108,7 @@ export default class Dropdown extends React.Component<Props, State> {
     }
 
     componentDidMount() {
-        if (this.props.opened === true || this.props.opened === false) {
+        if (this.props.opened != null) {
             this.handleOpenChanged(this.props.opened);
         }
     }

--- a/packages/wonder-blocks-dropdown/components/dropdown.md
+++ b/packages/wonder-blocks-dropdown/components/dropdown.md
@@ -127,7 +127,7 @@ const dropdownItems = [
 
 ### Mixture of Items in Dropdown
 
-The Dropdown can also be used to attach more complex Dropdowns to custom openers, in this example we have a Dropdown containing ActionItems and OptionItems attached to a HeadingSmall component.
+The Dropdown can also be used to attach more complex Dropdowns to custom openers, in this example we have a Dropdown containing ActionItems and OptionItems attached to a HeadingSmall component. The `closeOnOptionSelect` prop can be passed to Dropdown if you need to close the Dropdown when an OptionItem is selected.
 
 ```js
 const {ActionItem, OptionItem, SeparatorItem} = require("@khanacademy/wonder-blocks-dropdown");

--- a/packages/wonder-blocks-dropdown/components/dropdown.md
+++ b/packages/wonder-blocks-dropdown/components/dropdown.md
@@ -127,7 +127,7 @@ const dropdownItems = [
 
 ### Mixture of Items in Dropdown
 
-The Dropdown can also be used to attach more complex Dropdowns to custom openers, in this example we have a Dropdown containing ActionItems and OptionItems attached to a HeadingSmall component. The `singleSelectOption` prop can be passed to Dropdown if you need to close the Dropdown when an OptionItem is selected.
+The Dropdown can also be used to attach more complex Dropdowns to custom openers, in this example we have a Dropdown containing ActionItems and OptionItems attached to a HeadingSmall component. The `selectionType` prop can be set to either "single" or "multi" to change the behavior of selecting OptionItems.
 
 ```js
 const {ActionItem, OptionItem, SeparatorItem} = require("@khanacademy/wonder-blocks-dropdown");
@@ -176,7 +176,7 @@ class MixedDropdownExample extends React.Component {
 
         return (
             <Dropdown
-                singleSelectOption
+                selectionType={"single"}
                 menuItems={dropdownItems}
                 onChange={this.handleChange}
                 selectedValues={this.state.selectedValues}

--- a/packages/wonder-blocks-dropdown/components/dropdown.md
+++ b/packages/wonder-blocks-dropdown/components/dropdown.md
@@ -127,7 +127,7 @@ const dropdownItems = [
 
 ### Mixture of Items in Dropdown
 
-The Dropdown can also be used to attach more complex Dropdowns to custom openers, in this example we have a Dropdown containing ActionItems and OptionItems attached to a HeadingSmall component. The `closeOnOptionSelect` prop can be passed to Dropdown if you need to close the Dropdown when an OptionItem is selected.
+The Dropdown can also be used to attach more complex Dropdowns to custom openers, in this example we have a Dropdown containing ActionItems and OptionItems attached to a HeadingSmall component. The `singleSelectOption` prop can be passed to Dropdown if you need to close the Dropdown when an OptionItem is selected.
 
 ```js
 const {ActionItem, OptionItem, SeparatorItem} = require("@khanacademy/wonder-blocks-dropdown");
@@ -176,6 +176,7 @@ class MixedDropdownExample extends React.Component {
 
         return (
             <Dropdown
+                singleSelectOption
                 menuItems={dropdownItems}
                 onChange={this.handleChange}
                 selectedValues={this.state.selectedValues}

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -12,6 +12,7 @@ import {keyCodes} from "../util/constants.js";
 
 type Props = {|
     singleSelectOption?: boolean,
+    opened?: boolean,
 |};
 type State = {|
     selectedValues: Array<*>,
@@ -190,6 +191,7 @@ describe("Dropdown", () => {
                 return (
                     <Dropdown
                         menuItems={dropdownItems}
+                        opened={this.props.opened}
                         onChange={this.handleChange}
                         selectedValues={this.state.selectedValues}
                         singleSelectOption={this.props.singleSelectOption}
@@ -295,6 +297,22 @@ describe("Dropdown", () => {
             // Assert
             expect(controlledComponent.find(Dropdown).state("opened")).toBe(
                 false,
+            );
+        });
+
+        it("override the Dropdowns state if the opened prop is set", () => {
+            // Arrange
+            const controlledComponent = mount(
+                <ControlledComponent opened={true} />,
+            );
+
+            // Act
+            const optionItem = controlledComponent.find(OptionItem).at(0);
+            optionItem.simulate("click");
+
+            // Assert
+            expect(controlledComponent.find(Dropdown).state("opened")).toBe(
+                true,
             );
         });
     });

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -10,7 +10,9 @@ import DropdownCore from "./dropdown-core.js";
 import Dropdown from "./dropdown.js";
 import {keyCodes} from "../util/constants.js";
 
-type Props = {||};
+type Props = {|
+    singleSelectOption?: boolean,
+|};
 type State = {|
     selectedValues: Array<*>,
 |};
@@ -167,8 +169,6 @@ describe("Dropdown", () => {
     describe("use controlled components", () => {
         window.scrollTo = jest.fn();
         window.getComputedStyle = jest.fn();
-        let controlledComponent;
-
         class ControlledComponent extends React.Component<Props, State> {
             state = {
                 selectedValues: ["A"],
@@ -192,6 +192,7 @@ describe("Dropdown", () => {
                         menuItems={dropdownItems}
                         onChange={this.handleChange}
                         selectedValues={this.state.selectedValues}
+                        singleSelectOption={this.props.singleSelectOption}
                     >
                         {(state) => <h1>Manage students</h1>}
                     </Dropdown>
@@ -199,15 +200,12 @@ describe("Dropdown", () => {
             }
         }
 
-        beforeEach(() => {
-            controlledComponent = mount(<ControlledComponent />);
-        });
-
         afterEach(() => {
             unmountAll();
         });
         it("updates selectedValues when OptionItem clicked", () => {
             // Arrange
+            const controlledComponent = mount(<ControlledComponent />);
             controlledComponent.simulate("click");
             const dropdownCore = controlledComponent.find(DropdownCore);
 
@@ -256,6 +254,48 @@ describe("Dropdown", () => {
 
             // Assert
             expect(controlledComponent.state("selectedValues")).toBeFalsy();
+        });
+
+        it("only single selects OptionItems if singleSelectOption is passed", () => {
+            // Arrange
+            const controlledComponent = mount(
+                <ControlledComponent singleSelectOption />,
+            );
+            controlledComponent.simulate("click");
+            controlledComponent.setState({selectedValues: ["B"]});
+            const dropdownCore = controlledComponent.find(DropdownCore);
+
+            // Act
+            dropdownCore.simulate("keydown", {keyCode: keyCodes.down});
+            dropdownCore.simulate("keyup", {keyCode: keyCodes.down});
+
+            const optionItem = controlledComponent.find(OptionItem).at(0);
+            optionItem.simulate("click");
+
+            // Assert
+            expect(controlledComponent.state("selectedValues")).toHaveLength(1);
+        });
+
+        it("closes Dropdown if an OptionItem is selected when singleSelectOption is passed", () => {
+            // Arrange
+            const controlledComponent = mount(
+                <ControlledComponent singleSelectOption />,
+            );
+            controlledComponent.simulate("click");
+            controlledComponent.setState({selectedValues: ["B"]});
+            const dropdownCore = controlledComponent.find(DropdownCore);
+
+            // Act
+            dropdownCore.simulate("keydown", {keyCode: keyCodes.down});
+            dropdownCore.simulate("keyup", {keyCode: keyCodes.down});
+
+            const optionItem = controlledComponent.find(OptionItem).at(0);
+            optionItem.simulate("click");
+
+            // Assert
+            expect(controlledComponent.find(Dropdown).state("opened")).toBe(
+                false,
+            );
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -11,7 +11,7 @@ import Dropdown from "./dropdown.js";
 import {keyCodes} from "../util/constants.js";
 
 type Props = {|
-    singleSelectOption?: boolean,
+    selectionType?: "single" | "multi",
     opened?: boolean,
 |};
 type State = {|
@@ -193,8 +193,8 @@ describe("Dropdown", () => {
                         menuItems={dropdownItems}
                         opened={this.props.opened}
                         onChange={this.handleChange}
+                        selectionType={this.props.selectionType}
                         selectedValues={this.state.selectedValues}
-                        singleSelectOption={this.props.singleSelectOption}
                     >
                         {(state) => <h1>Manage students</h1>}
                     </Dropdown>
@@ -261,7 +261,7 @@ describe("Dropdown", () => {
         it("only single selects OptionItems if singleSelectOption is passed", () => {
             // Arrange
             const controlledComponent = mount(
-                <ControlledComponent singleSelectOption />,
+                <ControlledComponent selectionType={"single"} />,
             );
             controlledComponent.simulate("click");
             controlledComponent.setState({selectedValues: ["B"]});
@@ -281,16 +281,16 @@ describe("Dropdown", () => {
         it("closes Dropdown if an OptionItem is selected when singleSelectOption is passed", () => {
             // Arrange
             const controlledComponent = mount(
-                <ControlledComponent singleSelectOption />,
+                <ControlledComponent selectionType={"single"} />,
             );
             controlledComponent.simulate("click");
             controlledComponent.setState({selectedValues: ["B"]});
             const dropdownCore = controlledComponent.find(DropdownCore);
 
-            // Act
             dropdownCore.simulate("keydown", {keyCode: keyCodes.down});
             dropdownCore.simulate("keyup", {keyCode: keyCodes.down});
 
+            // Act
             const optionItem = controlledComponent.find(OptionItem).at(0);
             optionItem.simulate("click");
 

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -198,7 +198,7 @@ describe("wonder-blocks-dropdown", () => {
 
                 return (
                     <Dropdown
-                        singleSelectOption
+                        selectionType={"single"}
                         menuItems={dropdownItems}
                         onChange={this.handleChange}
                         selectedValues={this.state.selectedValues}

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -198,6 +198,7 @@ describe("wonder-blocks-dropdown", () => {
 
                 return (
                     <Dropdown
+                        singleSelectOption
                         menuItems={dropdownItems}
                         onChange={this.handleChange}
                         selectedValues={this.state.selectedValues}


### PR DESCRIPTION
Added the ability to override the opened state of Dropdown and implemented a new prop to treat OptionItems as single selects (select only one & close dropdown when clicked)