### PR TITLE
Add dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # <img width="32" src="./static/logo.svg"> Wonder Blocks
 
 [![CircleCI](https://circleci.com/gh/Khan/wonder-blocks.svg?style=svg)](https://circleci.com/gh/Khan/wonder-blocks) [![codecov](https://codecov.io/gh/Khan/wonder-blocks/branch/master/graph/badge.svg)](https://codecov.io/gh/Khan/wonder-blocks)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=Khan/wonder-blocks)](https://dependabot.com)
 
 The Khan Academy Wonder Blocks design system. This is work-in-progress and a lot of things are still in motion.
 


### PR DESCRIPTION
I'm not sure why the badge is showing up as `inactive`.