### PR TITLE
[feat:dropdown] WB-633: Fix controlled mode in Dropdown

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -26,6 +26,7 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
   <button
     aria-label="search"
     className=""
+    data-test-id="teacher-menu"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -269,6 +270,184 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       "boxSizing": "border-box",
       "display": "flex",
       "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": "fit-content",
+        "zIndex": 0,
+      }
+    }
+  >
+    <h4
+      className=""
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "cursor": "pointer",
+          "display": "block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 20,
+          "fontWeight": 700,
+          "lineHeight": "24px",
+          "marginBottom": 0,
+          "marginTop": 0,
+          "outline": "none",
+        }
+      }
+      tabIndex={0}
+    >
+      Open custom dropdown
+    </h4>
+  </div>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 16,
+        "MsFlexPreferredSize": 16,
+        "WebkitFlexBasis": 16,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 16,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 16,
+        "zIndex": 0,
+      }
+    }
+  />
+  <button
+    className=""
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    style={
+      Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "margin": 0,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "flex",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      Open dropdown programatically
+    </span>
+  </button>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 5 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
       "justifyContent": "flex-end",
       "margin": 0,
       "minHeight": 0,
@@ -305,7 +484,6 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       aria-expanded="false"
       aria-haspopup="menu"
       className=""
-      data-test-id="teacher-menu"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -441,7 +619,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 5 1`] = `
+exports[`wonder-blocks-dropdown example 6 1`] = `
 <div
   className=""
   style={
@@ -643,7 +821,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 6 1`] = `
+exports[`wonder-blocks-dropdown example 7 1`] = `
 <div
   className=""
   style={
@@ -824,7 +1002,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 7 1`] = `
+exports[`wonder-blocks-dropdown example 8 1`] = `
 <div
   className=""
   style={
@@ -1005,7 +1183,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 8 1`] = `
+exports[`wonder-blocks-dropdown example 9 1`] = `
 <div
   className=""
   style={
@@ -1051,7 +1229,6 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
       aria-expanded="false"
       aria-haspopup="menu"
       className=""
-      data-test-id="teacher-menu"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -1187,7 +1364,7 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 9 1`] = `
+exports[`wonder-blocks-dropdown example 10 1`] = `
 <div
   className=""
   style={
@@ -1325,7 +1502,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 10 1`] = `
+exports[`wonder-blocks-dropdown example 11 1`] = `
 <div
   className=""
   style={
@@ -1462,7 +1639,7 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 11 1`] = `
+exports[`wonder-blocks-dropdown example 12 1`] = `
 <div
   className=""
   style={
@@ -1598,7 +1775,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 12 1`] = `
+exports[`wonder-blocks-dropdown example 13 1`] = `
 <div
   className=""
   style={
@@ -1735,7 +1912,7 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 13 1`] = `
+exports[`wonder-blocks-dropdown example 14 1`] = `
 <div
   className=""
   style={
@@ -1897,7 +2074,7 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 14 1`] = `
+exports[`wonder-blocks-dropdown example 15 1`] = `
 <div
   className=""
   style={
@@ -2034,7 +2211,7 @@ exports[`wonder-blocks-dropdown example 14 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 15 1`] = `
+exports[`wonder-blocks-dropdown example 16 1`] = `
 <div
   className=""
   style={
@@ -2190,7 +2367,7 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 16 1`] = `
+exports[`wonder-blocks-dropdown example 17 1`] = `
 <div
   className=""
   style={
@@ -2327,7 +2504,7 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 17 1`] = `
+exports[`wonder-blocks-dropdown example 18 1`] = `
 <div
   className=""
   style={
@@ -2463,7 +2640,7 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 18 1`] = `
+exports[`wonder-blocks-dropdown example 19 1`] = `
 <div
   className=""
   style={
@@ -2599,7 +2776,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 19 1`] = `
+exports[`wonder-blocks-dropdown example 20 1`] = `
 <div
   className=""
   style={
@@ -2694,7 +2871,7 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 20 1`] = `
+exports[`wonder-blocks-dropdown example 21 1`] = `
 <div
   className=""
   style={
@@ -2831,7 +3008,7 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 21 1`] = `
+exports[`wonder-blocks-dropdown example 22 1`] = `
 <div
   className=""
   style={
@@ -2987,7 +3164,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 22 1`] = `
+exports[`wonder-blocks-dropdown example 23 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-dropdown/components/dropdown.md
+++ b/packages/wonder-blocks-dropdown/components/dropdown.md
@@ -249,8 +249,7 @@ class ControlledPopoverExample extends React.Component {
             selectedValues: ["kumail"],
         };
         this.handleChange = this.handleChange.bind(this);
-        this.handleClose = this.handleClose.bind(this);
-        this.openDropdown = this.openDropdown.bind(this);
+        this.toggleDropdown = this.toggleDropdown.bind(this);
     }
 
     handleChange(update) {
@@ -259,14 +258,10 @@ class ControlledPopoverExample extends React.Component {
         });
     }
 
-    handleClose() {
+    toggleDropdown() {
         this.setState({
-            opened: false,
+            opened: !this.state.opened,
         });
-    }
-
-    openDropdown() {
-        this.setState({opened: true});
     }
 
     render() {
@@ -287,7 +282,7 @@ class ControlledPopoverExample extends React.Component {
                     selectionType={"single"}
                     menuItems={dropdownItems}
                     onChange={this.handleChange}
-                    onClose={this.handleClose}
+                    onClose={this.toggleDropdown}
                     opened={this.state.opened}
                     selectedValues={this.state.selectedValues}
                 >
@@ -305,7 +300,7 @@ class ControlledPopoverExample extends React.Component {
                     )}
                 </Dropdown>
                 <Strut size={Spacing.medium} />
-                <Button onClick={this.openDropdown}>Open dropdown programatically</Button>
+                <Button onClick={this.toggleDropdown}>Open dropdown programatically</Button>
             </View>
         );
     }

--- a/packages/wonder-blocks-dropdown/components/dropdown.md
+++ b/packages/wonder-blocks-dropdown/components/dropdown.md
@@ -203,3 +203,113 @@ class MixedDropdownExample extends React.Component {
 </View>
 ```
 
+### Example: Opening a dropdown programmatically
+
+Sometimes you'll want to trigger a dropdown programmatically. This can be done by
+setting the `opened` prop to `true`. In this situation the `Dropdown` is a
+controlled component. The parent is responsible for managing the opening/closing
+of the dropdown when using this prop.
+
+This means that you'll also have to update `opened` for these situations:
+-  to `true`: inside the Dropdown children instance (dropdown anchor). See example
+   below.
+-  to `false`: in response to the `onClose` callback being triggered.
+
+```js
+import {Dropdown, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
+import Button from "@khanacademy/wonder-blocks-button";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+
+const styles = StyleSheet.create({
+    focused: {
+        border: "none",
+    },
+    hovered: {
+        textDecoration: "underline",
+    },
+    cursor: {
+        cursor: "pointer",
+        outline: "none",
+    },
+    row: {
+        flexDirection: "row",
+    }
+});
+
+class ControlledPopoverExample extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            opened: false,
+            selectedValues: ["kumail"],
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleClose = this.handleClose.bind(this);
+        this.openDropdown = this.openDropdown.bind(this);
+    }
+
+    handleChange(update) {
+        this.setState({
+            selectedValues: update,
+        });
+    }
+
+    handleClose() {
+        this.setState({
+            opened: false,
+        });
+    }
+
+    openDropdown() {
+        this.setState({opened: true});
+    }
+
+    render() {
+        const dropdownItems = [
+            <ActionItem label="Add new +" href="#!/Dropdown/7?new" />,
+            <SeparatorItem />,
+            <OptionItem label="Alex" value="alex" />,
+            <OptionItem label="Cathy" value="cathy" />,
+            <OptionItem label="Kumail" value="kumail" />,
+            <OptionItem label="Salman" value="salman" />,
+            <OptionItem label="Yan" value="yan" />,
+            <OptionItem label="Yash" value="yash" />,
+        ];
+
+        return (
+            <View style={styles.row}>
+                <Dropdown
+                    selectionType={"single"}
+                    menuItems={dropdownItems}
+                    onChange={this.handleChange}
+                    onClose={this.handleClose}
+                    opened={this.state.opened}
+                    selectedValues={this.state.selectedValues}
+                >
+                    {(eventState) => (
+                        <HeadingSmall
+                            onClick={() => this.setState({opened: !this.state.opened})}
+                            style={[
+                                styles.cursor,
+                                eventState.focused && styles.focused,
+                                eventState.hovered && styles.hovered,
+                            ]}
+                        >
+                            Open custom dropdown
+                        </HeadingSmall>
+                    )}
+                </Dropdown>
+                <Strut size={Spacing.medium} />
+                <Button onClick={this.openDropdown}>Open dropdown programatically</Button>
+            </View>
+        );
+    }
+}
+
+<ControlledPopoverExample />
+```

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -27,9 +27,11 @@ import {
 } from "@khanacademy/wonder-blocks-typography";
 import Color from "@khanacademy/wonder-blocks-color";
 import {StyleSheet} from "aphrodite";
-import {Spring} from "@khanacademy/wonder-blocks-layout";
-import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import Button from "@khanacademy/wonder-blocks-button";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {Strut, Spring} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 
 import DropdownCore from "./components/dropdown-core.js";
 
@@ -217,6 +219,105 @@ describe("wonder-blocks-dropdown", () => {
 
     it("example 4", () => {
         const styles = StyleSheet.create({
+            focused: {
+                border: "none",
+            },
+            hovered: {
+                textDecoration: "underline",
+            },
+            cursor: {
+                cursor: "pointer",
+                outline: "none",
+            },
+            row: {
+                flexDirection: "row",
+            },
+        });
+
+        class ControlledPopoverExample extends React.Component {
+            constructor() {
+                super();
+                this.state = {
+                    opened: false,
+                    selectedValues: ["kumail"],
+                };
+                this.handleChange = this.handleChange.bind(this);
+                this.handleClose = this.handleClose.bind(this);
+                this.openDropdown = this.openDropdown.bind(this);
+            }
+
+            handleChange(update) {
+                this.setState({
+                    selectedValues: update,
+                });
+            }
+
+            handleClose() {
+                this.setState({
+                    opened: false,
+                });
+            }
+
+            openDropdown() {
+                this.setState({
+                    opened: true,
+                });
+            }
+
+            render() {
+                const dropdownItems = [
+                    <ActionItem label="Add new +" href="#!/Dropdown/7?new" />,
+                    <SeparatorItem />,
+                    <OptionItem label="Alex" value="alex" />,
+                    <OptionItem label="Cathy" value="cathy" />,
+                    <OptionItem label="Kumail" value="kumail" />,
+                    <OptionItem label="Salman" value="salman" />,
+                    <OptionItem label="Yan" value="yan" />,
+                    <OptionItem label="Yash" value="yash" />,
+                ];
+                return (
+                    <View style={styles.row}>
+                        <Dropdown
+                            selectionType={"single"}
+                            menuItems={dropdownItems}
+                            onChange={this.handleChange}
+                            onClose={this.handleClose}
+                            opened={this.state.opened}
+                            selectedValues={this.state.selectedValues}
+                        >
+                            {(eventState) => (
+                                <HeadingSmall
+                                    onClick={() =>
+                                        this.setState({
+                                            opened: !this.state.opened,
+                                        })
+                                    }
+                                    style={[
+                                        styles.cursor,
+                                        eventState.focused && styles.focused,
+                                        eventState.hovered && styles.hovered,
+                                    ]}
+                                >
+                                    Open custom dropdown
+                                </HeadingSmall>
+                            )}
+                        </Dropdown>
+                        <Strut size={Spacing.medium} />
+                        <Button onClick={this.openDropdown}>
+                            Open dropdown programatically
+                        </Button>
+                    </View>
+                );
+            }
+        }
+
+        const example = <ControlledPopoverExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 5", () => {
+        const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
                 justifyContent: "flex-end",
@@ -269,7 +370,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 5", () => {
+    it("example 6", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -313,7 +414,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 6", () => {
+    it("example 7", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -398,7 +499,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 7", () => {
+    it("example 8", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -413,7 +514,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 8", () => {
+    it("example 9", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -469,7 +570,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 9", () => {
+    it("example 10", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -541,7 +642,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 10", () => {
+    it("example 11", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -601,7 +702,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 11", () => {
+    it("example 12", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -653,7 +754,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 12", () => {
+    it("example 13", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -706,7 +807,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 13", () => {
+    it("example 14", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -776,7 +877,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 14", () => {
+    it("example 15", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -791,7 +892,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 15", () => {
+    it("example 16", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -814,7 +915,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 16", () => {
+    it("example 17", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -882,7 +983,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 17", () => {
+    it("example 18", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -944,7 +1045,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 18", () => {
+    it("example 19", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1008,7 +1109,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 19", () => {
+    it("example 20", () => {
         const styles = StyleSheet.create({
             wrapper: {
                 alignItems: "center",
@@ -1102,7 +1203,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 20", () => {
+    it("example 21", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1117,7 +1218,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 21", () => {
+    it("example 22", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -1140,7 +1241,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 22", () => {
+    it("example 23", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -242,8 +242,7 @@ describe("wonder-blocks-dropdown", () => {
                     selectedValues: ["kumail"],
                 };
                 this.handleChange = this.handleChange.bind(this);
-                this.handleClose = this.handleClose.bind(this);
-                this.openDropdown = this.openDropdown.bind(this);
+                this.toggleDropdown = this.toggleDropdown.bind(this);
             }
 
             handleChange(update) {
@@ -252,15 +251,9 @@ describe("wonder-blocks-dropdown", () => {
                 });
             }
 
-            handleClose() {
+            toggleDropdown() {
                 this.setState({
-                    opened: false,
-                });
-            }
-
-            openDropdown() {
-                this.setState({
-                    opened: true,
+                    opened: !this.state.opened,
                 });
             }
 
@@ -281,7 +274,7 @@ describe("wonder-blocks-dropdown", () => {
                             selectionType={"single"}
                             menuItems={dropdownItems}
                             onChange={this.handleChange}
-                            onClose={this.handleClose}
+                            onClose={this.toggleDropdown}
                             opened={this.state.opened}
                             selectedValues={this.state.selectedValues}
                         >
@@ -303,7 +296,7 @@ describe("wonder-blocks-dropdown", () => {
                             )}
                         </Dropdown>
                         <Strut size={Spacing.medium} />
-                        <Button onClick={this.openDropdown}>
+                        <Button onClick={this.toggleDropdown}>
                             Open dropdown programatically
                         </Button>
                     </View>


### PR DESCRIPTION
## Summary
Fixes the `Dropdown` component to make it fully controllable.

## Features

### Dropdown
- Added `getDerivedStateFromProps` to sync the `opened` prop with the parent's state.
- Added `onClose` prop to sync up the `opened` prop within the parent component (similar to `ModalLauncher` and `Popover`).
- Added `onClick` prop to the Dropdown anchor to keep it in sync with the parent state.
- Added an example explaining this behavior.
- Updated unit tests.

### Test plan
1. Open https://deploy-preview-456--wonder-blocks.netlify.com/#dropdown-1
2. Go to the example: **Opening a dropdown programmatically** and check that works as expected.
3. Also, check the explanation is clear enough.

![dropdown-controlled](https://user-images.githubusercontent.com/843075/61964508-067b1780-af9c-11e9-8d68-b9868686b222.png)
