### PR TITLE
[feature:dropdown] WB-632 - Add controlled mode to ActionMenu, SingleSelect and MultiSelect

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -2680,6 +2680,240 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
         "flexDirection": "column",
         "margin": 0,
         "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": "fit-content",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          "alignItems": "center",
+          "backgroundColor": "#ffffff",
+          "borderColor": "rgba(33,36,44,0.16)",
+          "borderRadius": 4,
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "boxSizing": "border-box",
+          "color": "rgba(33,36,44,0.64)",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "space-between",
+          "margin": 0,
+          "outline": "none",
+          "paddingLeft": 16,
+          "paddingRight": 12,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "whiteSpace": "nowrap",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+            "marginRight": 8,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Choose
+      </span>
+      <svg
+        aria-hidden="true"
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "minWidth": 16,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="rgba(33,36,44,0.64)"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 16,
+        "MsFlexPreferredSize": 16,
+        "WebkitFlexBasis": 16,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 16,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 16,
+        "zIndex": 0,
+      }
+    }
+  />
+  <button
+    className=""
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    style={
+      Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "margin": 0,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "flex",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      Open SingleSelect programatically
+    </span>
+  </button>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 19 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
         "minWidth": 170,
         "padding": 0,
         "position": "relative",
@@ -2783,7 +3017,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 19 1`] = `
+exports[`wonder-blocks-dropdown example 20 1`] = `
 <div
   className=""
   style={
@@ -2919,7 +3153,7 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 20 1`] = `
+exports[`wonder-blocks-dropdown example 21 1`] = `
 <div
   className=""
   style={
@@ -3055,7 +3289,7 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 21 1`] = `
+exports[`wonder-blocks-dropdown example 22 1`] = `
 <div
   className=""
   style={
@@ -3150,7 +3384,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 22 1`] = `
+exports[`wonder-blocks-dropdown example 23 1`] = `
 <div
   className=""
   style={
@@ -3287,7 +3521,7 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 23 1`] = `
+exports[`wonder-blocks-dropdown example 24 1`] = `
 <div
   className=""
   style={
@@ -3443,7 +3677,7 @@ exports[`wonder-blocks-dropdown example 23 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 24 1`] = `
+exports[`wonder-blocks-dropdown example 25 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -3812,3 +3812,237 @@ exports[`wonder-blocks-dropdown example 25 1`] = `
   </div>
 </div>
 `;
+
+exports[`wonder-blocks-dropdown example 26 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": "fit-content",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          "alignItems": "center",
+          "backgroundColor": "#ffffff",
+          "borderColor": "rgba(33,36,44,0.16)",
+          "borderRadius": 4,
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "boxSizing": "border-box",
+          "color": "#21242c",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "space-between",
+          "margin": 0,
+          "outline": "none",
+          "paddingLeft": 16,
+          "paddingRight": 12,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "whiteSpace": "nowrap",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+            "marginRight": 8,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
+            "userSelect": "none",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        0 fruits
+      </span>
+      <svg
+        aria-hidden="true"
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "minWidth": 16,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="rgba(33,36,44,0.64)"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 16,
+        "MsFlexPreferredSize": 16,
+        "WebkitFlexBasis": 16,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 16,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 16,
+        "zIndex": 0,
+      }
+    }
+  />
+  <button
+    className=""
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    style={
+      Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "margin": 0,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "flex",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      Open SingleSelect programatically
+    </span>
+  </button>
+</div>
+`;

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1397,6 +1397,285 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
         "display": "flex",
         "flexDirection": "column",
         "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": "fit-content",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="menu"
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": 0,
+          "outline": "none",
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexDirection": "column",
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <span
+          className=""
+          style={
+            Object {
+              "MozOsxFontSmoothing": "grayscale",
+              "WebkitFontSmoothing": "antialiased",
+              "alignItems": "center",
+              "display": "inline-block",
+              "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+              "fontSize": 16,
+              "fontWeight": "bold",
+              "lineHeight": "20px",
+              "overflow": "hidden",
+              "pointerEvents": "none",
+              "textAlign": "left",
+              "textOverflow": "ellipsis",
+              "userSelect": "none",
+              "whiteSpace": "nowrap",
+            }
+          }
+        >
+          Betsy Appleseed
+        </span>
+      </div>
+      <div
+        aria-hidden="true"
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 4,
+            "MsFlexPreferredSize": 4,
+            "WebkitFlexBasis": 4,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 4,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "width": 4,
+            "zIndex": 0,
+          }
+        }
+      />
+      <svg
+        className=""
+        height={16}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={16}
+      >
+        <path
+          d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 16,
+        "MsFlexPreferredSize": 16,
+        "WebkitFlexBasis": 16,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 16,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 16,
+        "zIndex": 0,
+      }
+    }
+  />
+  <button
+    className=""
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    style={
+      Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "margin": 0,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "flex",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      Open ActionMenu programatically
+    </span>
+  </button>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 11 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
         "maxWidth": 190,
         "minHeight": 0,
         "minWidth": 170,
@@ -1502,7 +1781,7 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 11 1`] = `
+exports[`wonder-blocks-dropdown example 12 1`] = `
 <div
   className=""
   style={
@@ -1639,7 +1918,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 12 1`] = `
+exports[`wonder-blocks-dropdown example 13 1`] = `
 <div
   className=""
   style={
@@ -1775,7 +2054,7 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 13 1`] = `
+exports[`wonder-blocks-dropdown example 14 1`] = `
 <div
   className=""
   style={
@@ -1912,7 +2191,7 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 14 1`] = `
+exports[`wonder-blocks-dropdown example 15 1`] = `
 <div
   className=""
   style={
@@ -2074,7 +2353,7 @@ exports[`wonder-blocks-dropdown example 14 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 15 1`] = `
+exports[`wonder-blocks-dropdown example 16 1`] = `
 <div
   className=""
   style={
@@ -2211,7 +2490,7 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 16 1`] = `
+exports[`wonder-blocks-dropdown example 17 1`] = `
 <div
   className=""
   style={
@@ -2367,7 +2646,7 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 17 1`] = `
+exports[`wonder-blocks-dropdown example 18 1`] = `
 <div
   className=""
   style={
@@ -2504,7 +2783,7 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 18 1`] = `
+exports[`wonder-blocks-dropdown example 19 1`] = `
 <div
   className=""
   style={
@@ -2640,7 +2919,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 19 1`] = `
+exports[`wonder-blocks-dropdown example 20 1`] = `
 <div
   className=""
   style={
@@ -2776,7 +3055,7 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 20 1`] = `
+exports[`wonder-blocks-dropdown example 21 1`] = `
 <div
   className=""
   style={
@@ -2871,7 +3150,7 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 21 1`] = `
+exports[`wonder-blocks-dropdown example 22 1`] = `
 <div
   className=""
   style={
@@ -3008,7 +3287,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 22 1`] = `
+exports[`wonder-blocks-dropdown example 23 1`] = `
 <div
   className=""
   style={
@@ -3164,7 +3443,7 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 23 1`] = `
+exports[`wonder-blocks-dropdown example 24 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -187,3 +187,86 @@ const styles = StyleSheet.create({
     </ActionMenu>
 </View>
 ```
+
+### Example: Opening an ActionMenu programmatically
+
+Sometimes you'll want to trigger a dropdown programmatically. This can be done by
+setting the `opened` prop to `true`. In this situation the `ActionMenu` is a
+controlled component. The parent is responsible for managing the opening/closing
+of the dropdown when using this prop.
+
+This means that you'll also have to update `opened` for these situations:
+-  to `true`: inside the Dropdown children instance (dropdown anchor). See example
+   below.
+-  to `false`: in response to the `onClose` callback being triggered.
+
+```js
+import {Dropdown, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {StyleSheet} from "aphrodite";
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    }
+});
+
+class ControlledActionMenuExample extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            opened: false,
+            selectedValues: ["kumail"],
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.toggleMenu = this.toggleMenu.bind(this);
+    }
+
+    handleChange(update) {
+        this.setState({
+            selectedValues: update,
+        });
+    }
+
+    toggleMenu(opened) {
+        console.log("🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥");
+        console.log('should toggle!!!', opened);
+        this.setState({
+            opened: opened,
+        });
+    }
+
+    render() {
+        return (
+            <View style={styles.row}>
+                <ActionMenu
+                    menuText="Betsy Appleseed"
+                    onChange={this.handleChange}
+                    onToggle={(opened) => {
+                        console.log('toggle called!!!! ', opened);
+                        this.toggleMenu(opened);
+                    }}
+                    opened={this.state.opened}
+                    selectedValues={this.state.selectedValues}
+                >
+                    <ActionItem label="Add new +" />
+                    <SeparatorItem />
+                    <OptionItem label="Alex" value="alex" />
+                    <OptionItem label="Cathy" value="cathy" />
+                    <OptionItem label="Kumail" value="kumail" />
+                    <OptionItem label="Salman" value="salman" />
+                    <OptionItem label="Yan" value="yan" />
+                    <OptionItem label="Yash" value="yash" />
+                </ActionMenu>
+                <Strut size={Spacing.medium} />
+                <Button onClick={() => this.toggleMenu(true)}>Open ActionMenu programatically</Button>
+            </View>
+        );
+    }
+}
+
+<ControlledActionMenuExample />
+```

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -191,7 +191,7 @@ const styles = StyleSheet.create({
 ### Example: Opening an ActionMenu programmatically
 
 Sometimes you'll want to trigger a dropdown programmatically. This can be done by
-setting the `opened` prop to `true`. In this situation the `ActionMenu` is a
+setting a value to the `opened` prop (`true` or `false`). In this situation the `ActionMenu` is a
 controlled component. The parent is responsible for managing the opening/closing
 of the dropdown when using this prop.
 
@@ -231,7 +231,7 @@ class ControlledActionMenuExample extends React.Component {
 
     toggleMenu(opened) {
         this.setState({
-            opened: opened,
+            opened,
         });
     }
 

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -195,13 +195,11 @@ setting the `opened` prop to `true`. In this situation the `ActionMenu` is a
 controlled component. The parent is responsible for managing the opening/closing
 of the dropdown when using this prop.
 
-This means that you'll also have to update `opened` for these situations:
--  to `true`: inside the Dropdown children instance (dropdown anchor). See example
-   below.
--  to `false`: in response to the `onClose` callback being triggered.
+This means that you'll also have to update `opened` to the value triggered by
+the `onToggle` prop.
 
 ```js
-import {Dropdown, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
+import {ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
@@ -232,8 +230,6 @@ class ControlledActionMenuExample extends React.Component {
     }
 
     toggleMenu(opened) {
-        console.log("🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥");
-        console.log('should toggle!!!', opened);
         this.setState({
             opened: opened,
         });

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -220,7 +220,7 @@ class ControlledActionMenuExample extends React.Component {
             selectedValues: ["kumail"],
         };
         this.handleChange = this.handleChange.bind(this);
-        this.toggleMenu = this.toggleMenu.bind(this);
+        this.handleToggleMenu = this.handleToggleMenu.bind(this);
     }
 
     handleChange(update) {
@@ -229,7 +229,7 @@ class ControlledActionMenuExample extends React.Component {
         });
     }
 
-    toggleMenu(opened) {
+    handleToggleMenu(opened) {
         this.setState({
             opened,
         });
@@ -243,7 +243,7 @@ class ControlledActionMenuExample extends React.Component {
                     onChange={this.handleChange}
                     onToggle={(opened) => {
                         console.log('toggle called!!!! ', opened);
-                        this.toggleMenu(opened);
+                        this.handleToggleMenu(opened);
                     }}
                     opened={this.state.opened}
                     selectedValues={this.state.selectedValues}
@@ -258,7 +258,9 @@ class ControlledActionMenuExample extends React.Component {
                     <OptionItem label="Yash" value="yash" />
                 </ActionMenu>
                 <Strut size={Spacing.medium} />
-                <Button onClick={() => this.toggleMenu(true)}>Open ActionMenu programatically</Button>
+                <Button onClick={() => this.handleToggleMenu(true)}>
+                    Open ActionMenu programatically
+                </Button>
             </View>
         );
     }

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -29,6 +29,7 @@ describe("ActionMenu", () => {
         const menu = mount(
             <ActionMenu
                 menuText={"Action menu!"}
+                testId="fail-test"
                 onChange={onChange}
                 selectedValues={[]}
             >
@@ -209,5 +210,81 @@ describe("ActionMenu", () => {
         // Assert
         expect(menu.find(ActionItem)).toHaveLength(1);
         expect(menu.find(ActionItem).first()).toHaveProp("label", "Create");
+    });
+
+    describe("Controlled component", () => {
+        type Props = {|
+            opened?: boolean,
+            onToggle?: (opened: boolean) => mixed,
+        |};
+
+        type State = {|
+            opened?: boolean,
+        |};
+        class ControlledComponent extends React.Component<Props, State> {
+            state = {
+                opened: this.props.opened,
+            };
+
+            handleToggle = (opened) => {
+                this.setState({
+                    opened: opened,
+                });
+
+                this.props.onToggle && this.props.onToggle(opened);
+            };
+
+            render() {
+                return (
+                    <React.Fragment>
+                        <ActionMenu
+                            opened={this.state.opened}
+                            onToggle={this.handleToggle}
+                            menuText={"Action menu!"}
+                        >
+                            <ActionItem label="Create" />
+                            <ActionItem label="Delete" />
+                        </ActionMenu>
+                        <button
+                            data-test-id="parent-button"
+                            onClick={() => this.handleToggle(true)}
+                        />
+                    </React.Fragment>
+                );
+            }
+        }
+
+        it("opens the menu when the parent updates its state", () => {
+            // Arrange
+            const onToggleMock = jest.fn();
+            const wrapper = mount(
+                <ControlledComponent onToggle={onToggleMock} />,
+            );
+
+            // Act
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+
+            // Assert
+            expect(onToggleMock).toHaveBeenCalledWith(true);
+        });
+
+        it("closes the menu when the parent updates its state", () => {
+            const onToggleMock = jest.fn();
+            const wrapper = mount(
+                <ControlledComponent onToggle={onToggleMock} />,
+            );
+
+            // Act
+            // open the menu from the outside
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+            // click on first item
+            wrapper
+                .find(ActionItem)
+                .at(0)
+                .simulate("click");
+
+            // Assert
+            expect(onToggleMock).toHaveBeenCalledWith(false);
+        });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -226,7 +226,7 @@ describe("ActionMenu", () => {
                 opened: this.props.opened,
             };
 
-            handleToggle = (opened) => {
+            handleToggleMenu = (opened) => {
                 this.setState({
                     opened: opened,
                 });
@@ -239,7 +239,7 @@ describe("ActionMenu", () => {
                     <React.Fragment>
                         <ActionMenu
                             opened={this.state.opened}
-                            onToggle={this.handleToggle}
+                            onToggle={this.handleToggleMenu}
                             menuText={"Action menu!"}
                         >
                             <ActionItem label="Create" />
@@ -247,7 +247,7 @@ describe("ActionMenu", () => {
                         </ActionMenu>
                         <button
                             data-test-id="parent-button"
-                            onClick={() => this.handleToggle(true)}
+                            onClick={() => this.handleToggleMenu(true)}
                         />
                     </React.Fragment>
                 );
@@ -285,6 +285,35 @@ describe("ActionMenu", () => {
 
             // Assert
             expect(onToggleMock).toHaveBeenCalledWith(false);
+        });
+
+        it("opens the menu when the anchor is clicked once", () => {
+            // Arrange
+            const wrapper = mount(<ControlledComponent />);
+
+            // Act
+            // click on the anchor
+            wrapper.find(ClickableBehavior).simulate("click");
+
+            // Assert
+            expect(wrapper.find(ActionMenu).prop("opened")).toBe(true);
+        });
+
+        it("closes the menu when an option is clicked", () => {
+            // Arrange
+            const wrapper = mount(<ControlledComponent />);
+
+            // Act
+            // open the menu from the outside
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+            // pick an option to close the menu
+            wrapper
+                .find(ActionItem)
+                .at(0)
+                .simulate("click");
+
+            // Assert
+            expect(wrapper.find(ActionMenu).prop("opened")).toBe(false);
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/dropdown.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.js
@@ -32,9 +32,10 @@ type Props = {|
     opened?: boolean,
 
     /**
-     * Called when the menu closes
+     * In controlled mode, use this prop in case the parent needs to be notified
+     * when the menu opens/closes.
      */
-    onClose?: () => mixed,
+    onToggle?: (opened: boolean) => mixed,
 
     /**
      * The items present in the Dropdown
@@ -139,8 +140,8 @@ export default class Dropdown extends React.Component<Props, State> {
             keyboard,
         });
 
-        if (!opened && this.props.onClose) {
-            this.props.onClose();
+        if (this.props.onToggle) {
+            this.props.onToggle(opened);
         }
     };
 

--- a/packages/wonder-blocks-dropdown/components/dropdown.md
+++ b/packages/wonder-blocks-dropdown/components/dropdown.md
@@ -206,7 +206,7 @@ class MixedDropdownExample extends React.Component {
 ### Example: Opening a dropdown programmatically
 
 Sometimes you'll want to trigger a dropdown programmatically. This can be done by
-setting the `opened` prop to `true`. In this situation the `Dropdown` is a
+setting a value to the `opened` prop (`true` or `false`). In this situation the `Dropdown` is a
 controlled component. The parent is responsible for managing the opening/closing
 of the dropdown when using this prop.
 
@@ -258,7 +258,7 @@ class ControlledDropdownExample extends React.Component {
 
     toggleDropdown(opened) {
         this.setState({
-            opened: opened,
+            opened,
         });
     }
 

--- a/packages/wonder-blocks-dropdown/components/dropdown.md
+++ b/packages/wonder-blocks-dropdown/components/dropdown.md
@@ -247,7 +247,7 @@ class ControlledDropdownExample extends React.Component {
             selectedValues: ["kumail"],
         };
         this.handleChange = this.handleChange.bind(this);
-        this.toggleDropdown = this.toggleDropdown.bind(this);
+        this.handleToggleMenu = this.handleToggleMenu.bind(this);
     }
 
     handleChange(update) {
@@ -256,7 +256,7 @@ class ControlledDropdownExample extends React.Component {
         });
     }
 
-    toggleDropdown(opened) {
+    handleToggleMenu(opened) {
         this.setState({
             opened,
         });
@@ -283,7 +283,7 @@ class ControlledDropdownExample extends React.Component {
                     selectionType={"single"}
                     menuItems={dropdownItems}
                     onChange={this.handleChange}
-                    onToggle={this.toggleDropdown}
+                    onToggle={this.handleToggleMenu}
                     opened={this.state.opened}
                     selectedValues={this.state.selectedValues}
                 >
@@ -300,7 +300,9 @@ class ControlledDropdownExample extends React.Component {
                     )}
                 </Dropdown>
                 <Strut size={Spacing.medium} />
-                <Button onClick={() => this.toggleDropdown(true)}>Open dropdown programatically</Button>
+                <Button onClick={() => this.handleToggleMenu(true)}>
+                    Open dropdown programatically
+                </Button>
             </View>
         );
     }

--- a/packages/wonder-blocks-dropdown/components/dropdown.md
+++ b/packages/wonder-blocks-dropdown/components/dropdown.md
@@ -210,10 +210,8 @@ setting the `opened` prop to `true`. In this situation the `Dropdown` is a
 controlled component. The parent is responsible for managing the opening/closing
 of the dropdown when using this prop.
 
-This means that you'll also have to update `opened` for these situations:
--  to `true`: inside the Dropdown children instance (dropdown anchor). See example
-   below.
--  to `false`: in response to the `onClose` callback being triggered.
+This means that you'll also have to update `opened` to the value triggered by
+the `onToggle` prop.
 
 ```js
 import {Dropdown, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
@@ -241,7 +239,7 @@ const styles = StyleSheet.create({
     }
 });
 
-class ControlledPopoverExample extends React.Component {
+class ControlledDropdownExample extends React.Component {
     constructor() {
         super();
         this.state = {
@@ -258,15 +256,18 @@ class ControlledPopoverExample extends React.Component {
         });
     }
 
-    toggleDropdown() {
+    toggleDropdown(opened) {
         this.setState({
-            opened: !this.state.opened,
+            opened: opened,
         });
     }
 
     render() {
         const dropdownItems = [
-            <ActionItem label="Add new +" href="#!/Dropdown/7?new" />,
+            <ActionItem
+                label="Add new +"
+                onClick={() => console.log("Add new clicked...")}
+            />,
             <SeparatorItem />,
             <OptionItem label="Alex" value="alex" />,
             <OptionItem label="Cathy" value="cathy" />,
@@ -282,13 +283,12 @@ class ControlledPopoverExample extends React.Component {
                     selectionType={"single"}
                     menuItems={dropdownItems}
                     onChange={this.handleChange}
-                    onClose={this.toggleDropdown}
+                    onToggle={this.toggleDropdown}
                     opened={this.state.opened}
                     selectedValues={this.state.selectedValues}
                 >
                     {(eventState) => (
                         <HeadingSmall
-                            onClick={() => this.setState({opened: !this.state.opened})}
                             style={[
                                 styles.cursor,
                                 eventState.focused && styles.focused,
@@ -300,11 +300,11 @@ class ControlledPopoverExample extends React.Component {
                     )}
                 </Dropdown>
                 <Strut size={Spacing.medium} />
-                <Button onClick={this.toggleDropdown}>Open dropdown programatically</Button>
+                <Button onClick={() => this.toggleDropdown(true)}>Open dropdown programatically</Button>
             </View>
         );
     }
 }
 
-<ControlledPopoverExample />
+<ControlledDropdownExample />
 ```

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -13,7 +13,7 @@ import {keyCodes} from "../util/constants.js";
 type Props = {|
     selectionType?: "single" | "multi",
     opened?: boolean,
-    onClose?: () => mixed,
+    onToggle?: (opened: boolean) => mixed,
 |};
 type State = {|
     selectedValues: Array<*>,
@@ -184,12 +184,12 @@ describe("Dropdown", () => {
                     selectedValues: update,
                 });
 
-            handleClose = () => {
+            handleToggle = (opened) => {
                 this.setState({
-                    opened: false,
+                    opened: opened,
                 });
 
-                this.props.onClose && this.props.onClose();
+                this.props.onToggle && this.props.onToggle(opened);
             };
 
             render() {
@@ -204,16 +204,14 @@ describe("Dropdown", () => {
                     <Dropdown
                         menuItems={dropdownItems}
                         opened={this.state.opened}
-                        onClose={this.handleClose}
+                        onToggle={this.handleToggle}
                         onChange={this.handleChange}
                         selectionType={this.props.selectionType}
                         selectedValues={this.state.selectedValues}
                         testId="dropdown"
                     >
                         {(state) => (
-                            <h1 onClick={() => this.setState({opened: true})}>
-                                Manage students
-                            </h1>
+                            <h1 onClick={this.handleToggle}>Manage students</h1>
                         )}
                     </Dropdown>
                 );
@@ -351,12 +349,12 @@ describe("Dropdown", () => {
             );
         });
 
-        it("calls onClose after the menu is closed", () => {
+        it("calls onToggleMock after the menu is closed", () => {
             // Arrange
-            const onCloseMock = jest.fn();
+            const onToggleMock = jest.fn();
 
             const controlledComponent = mount(
-                <ControlledComponent opened={true} onClose={onCloseMock} />,
+                <ControlledComponent opened={true} onToggle={onToggleMock} />,
             );
 
             // Act
@@ -364,7 +362,7 @@ describe("Dropdown", () => {
             optionItem.simulate("click");
 
             // Assert
-            expect(onCloseMock).toHaveBeenCalled();
+            expect(onToggleMock).toHaveBeenCalledWith(false);
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -186,7 +186,7 @@ describe("Dropdown", () => {
 
             handleToggleMenu = (opened) => {
                 this.setState({
-                    opened: opened,
+                    opened,
                 });
 
                 this.props.onToggle && this.props.onToggle(opened);

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -184,7 +184,7 @@ describe("Dropdown", () => {
                     selectedValues: update,
                 });
 
-            handleToggle = (opened) => {
+            handleToggleMenu = (opened) => {
                 this.setState({
                     opened: opened,
                 });
@@ -204,14 +204,16 @@ describe("Dropdown", () => {
                     <Dropdown
                         menuItems={dropdownItems}
                         opened={this.state.opened}
-                        onToggle={this.handleToggle}
+                        onToggle={this.handleToggleMenu}
                         onChange={this.handleChange}
                         selectionType={this.props.selectionType}
                         selectedValues={this.state.selectedValues}
                         testId="dropdown"
                     >
                         {(state) => (
-                            <h1 onClick={this.handleToggle}>Manage students</h1>
+                            <h1 onClick={this.handleToggleMenu}>
+                                Manage students
+                            </h1>
                         )}
                     </Dropdown>
                 );

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -42,6 +42,17 @@ type Props = {|
     onChange: (selectedValues: Array<string>) => mixed,
 
     /**
+     * Can be used to override the state of the ActionMenu by parent elements
+     */
+    opened?: boolean,
+
+    /**
+     * In controlled mode, use this prop in case the parent needs to be notified
+     * when the menu opens/closes.
+     */
+    onToggle?: (opened: boolean) => mixed,
+
+    /**
      * The values of the items that are currently selected.
      */
     selectedValues: Array<string>,
@@ -136,11 +147,25 @@ export default class MultiSelect extends React.Component<Props, State> {
         };
     }
 
-    handleOpenChanged = (open: boolean, keyboard?: boolean) => {
+    /**
+     * Used to sync the `opened` state when this component acts as a controlled
+     * component
+     */
+    static getDerivedStateFromProps(props: Props, state: State) {
+        return {
+            open: typeof props.opened === "boolean" ? props.opened : state.open,
+        };
+    }
+
+    handleOpenChanged = (opened: boolean, keyboard?: boolean) => {
         this.setState({
-            open,
+            open: opened,
             keyboard,
         });
+
+        if (this.props.onToggle) {
+            this.props.onToggle(opened);
+        }
     };
 
     handleToggle = (selectedValue: string) => {
@@ -296,6 +321,8 @@ export default class MultiSelect extends React.Component<Props, State> {
             /* eslint-disable no-unused-vars */
             children,
             onChange,
+            onToggle,
+            opened,
             selectedValues,
             selectItemType,
             implicitAllEnabled,

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -375,7 +375,7 @@ class ImplicitAllEnabledExample extends React.Component {
 ### Example: Opening a MultiSelect programmatically
 
 Sometimes you'll want to trigger a dropdown programmatically. This can be done by
-setting the `opened` prop to `true`. In this situation the `MultiSelect` is a
+setting a value to the `opened` prop (`true` or `false`). In this situation the `MultiSelect` is a
 controlled component. The parent is responsible for managing the opening/closing
 of the dropdown when using this prop.
 
@@ -415,7 +415,7 @@ class ControlledMultiSelectExample extends React.Component {
 
     toggleMenu(opened) {
         this.setState({
-            opened: opened,
+            opened,
         });
     }
 

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -404,7 +404,7 @@ class ControlledMultiSelectExample extends React.Component {
             selectedValues: [],
         };
         this.handleChange = this.handleChange.bind(this);
-        this.toggleMenu = this.toggleMenu.bind(this);
+        this.handleToggleMenu = this.handleToggleMenu.bind(this);
     }
 
     handleChange(update) {
@@ -413,7 +413,7 @@ class ControlledMultiSelectExample extends React.Component {
         });
     }
 
-    toggleMenu(opened) {
+    handleToggleMenu(opened) {
         this.setState({
             opened,
         });
@@ -426,7 +426,7 @@ class ControlledMultiSelectExample extends React.Component {
                     selectItemType="fruits"
                     onChange={this.handleChange}
                     opened={this.state.opened}
-                    onToggle={this.toggleMenu}
+                    onToggle={this.handleToggleMenu}
                     selectedValues={this.state.selectedValues}
                 >
                     <OptionItem label="Nectarine" value="nectarine" />
@@ -435,7 +435,7 @@ class ControlledMultiSelectExample extends React.Component {
                     <OptionItem label="Pineapples" value="pineapples" />
                 </MultiSelect>
                 <Strut size={Spacing.medium} />
-                <Button onClick={() => this.toggleMenu(true)}>
+                <Button onClick={() => this.handleToggleMenu(true)}>
                     Open SingleSelect programatically
                 </Button>
             </View>

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -371,3 +371,77 @@ class ImplicitAllEnabledExample extends React.Component {
     <ImplicitAllEnabledExample />
 </View>
 ```
+
+### Example: Opening a MultiSelect programmatically
+
+Sometimes you'll want to trigger a dropdown programmatically. This can be done by
+setting the `opened` prop to `true`. In this situation the `MultiSelect` is a
+controlled component. The parent is responsible for managing the opening/closing
+of the dropdown when using this prop.
+
+This means that you'll also have to update `opened` to the value triggered by
+the `onToggle` prop.
+
+```js
+import {OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {StyleSheet} from "aphrodite";
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    }
+});
+
+class ControlledMultiSelectExample extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            opened: false,
+            selectedValues: [],
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.toggleMenu = this.toggleMenu.bind(this);
+    }
+
+    handleChange(update) {
+        this.setState({
+           selectedValues: update,
+        });
+    }
+
+    toggleMenu(opened) {
+        this.setState({
+            opened: opened,
+        });
+    }
+
+    render() {
+        return (
+            <View style={styles.row}>
+                <MultiSelect
+                    selectItemType="fruits"
+                    onChange={this.handleChange}
+                    opened={this.state.opened}
+                    onToggle={this.toggleMenu}
+                    selectedValues={this.state.selectedValues}
+                >
+                    <OptionItem label="Nectarine" value="nectarine" />
+                    <OptionItem label="Plum" value="plum" />
+                    <OptionItem label="Cantaloupe" value="cantaloupe" />
+                    <OptionItem label="Pineapples" value="pineapples" />
+                </MultiSelect>
+                <Strut size={Spacing.medium} />
+                <Button onClick={() => this.toggleMenu(true)}>
+                    Open SingleSelect programatically
+                </Button>
+            </View>
+        );
+    }
+}
+
+<ControlledMultiSelectExample />
+```

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -142,4 +142,94 @@ describe("MultiSelect", () => {
         // Assert
         expect(opener.text()).toEqual("All students");
     });
+
+    describe("Controlled component", () => {
+        type Props = {|
+            opened?: boolean,
+            onToggle?: (opened: boolean) => mixed,
+        |};
+
+        type State = {|
+            opened?: boolean,
+        |};
+        class ControlledComponent extends React.Component<Props, State> {
+            state = {
+                opened: this.props.opened,
+            };
+
+            handleToggle = (opened) => {
+                this.setState({
+                    opened: opened,
+                });
+
+                this.props.onToggle && this.props.onToggle(opened);
+            };
+
+            render() {
+                return (
+                    <React.Fragment>
+                        <MultiSelect
+                            selectItemType="fruits"
+                            onChange={onChange}
+                            opened={this.state.opened}
+                            onToggle={this.handleToggle}
+                        >
+                            <OptionItem label="item 1" value="1" />
+                            <OptionItem label="item 2" value="2" />
+                            <OptionItem label="item 3" value="3" />
+                        </MultiSelect>
+                        <button
+                            data-test-id="parent-button"
+                            onClick={() => this.handleToggle(true)}
+                        />
+                    </React.Fragment>
+                );
+            }
+        }
+
+        it("opens the menu when the parent updates its state", () => {
+            // Arrange
+            const onToggleMock = jest.fn();
+            const wrapper = mount(
+                <ControlledComponent onToggle={onToggleMock} />,
+            );
+
+            // Act
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+
+            // Assert
+            expect(onToggleMock).toHaveBeenCalledWith(true);
+        });
+
+        it("closes the menu when the parent updates its state", () => {
+            // Arrange
+            const onToggleMock = jest.fn();
+            const wrapper = mount(
+                <ControlledComponent onToggle={onToggleMock} />,
+            );
+
+            // Act
+            // open the menu from the outside
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+            // click on the opener
+            wrapper.find(SelectOpener).simulate("click");
+
+            // Assert
+            expect(onToggleMock).toHaveBeenCalledWith(false);
+        });
+
+        it("should still allow the opener to open the menu", () => {
+            // Arrange
+            const onToggleMock = jest.fn();
+            const wrapper = mount(
+                <ControlledComponent onToggle={onToggleMock} />,
+            );
+
+            // Act
+            wrapper.find(SelectOpener).simulate("click");
+
+            // Assert
+            expect(onToggleMock).toHaveBeenCalledWith(true);
+        });
+    });
 });

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -152,12 +152,13 @@ describe("MultiSelect", () => {
         type State = {|
             opened?: boolean,
         |};
+
         class ControlledComponent extends React.Component<Props, State> {
             state = {
                 opened: this.props.opened,
             };
 
-            handleToggle = (opened) => {
+            handleToggleMenu = (opened) => {
                 this.setState({
                     opened: opened,
                 });
@@ -172,7 +173,7 @@ describe("MultiSelect", () => {
                             selectItemType="fruits"
                             onChange={onChange}
                             opened={this.state.opened}
-                            onToggle={this.handleToggle}
+                            onToggle={this.handleToggleMenu}
                         >
                             <OptionItem label="item 1" value="1" />
                             <OptionItem label="item 2" value="2" />
@@ -180,7 +181,7 @@ describe("MultiSelect", () => {
                         </MultiSelect>
                         <button
                             data-test-id="parent-button"
-                            onClick={() => this.handleToggle(true)}
+                            onClick={() => this.handleToggleMenu(true)}
                         />
                     </React.Fragment>
                 );
@@ -230,6 +231,32 @@ describe("MultiSelect", () => {
 
             // Assert
             expect(onToggleMock).toHaveBeenCalledWith(true);
+        });
+
+        it("opens the menu when the anchor is clicked once", () => {
+            // Arrange
+            const wrapper = mount(<ControlledComponent />);
+
+            // Act
+            // click on the anchor
+            wrapper.find(SelectOpener).simulate("click");
+
+            // Assert
+            expect(wrapper.find(MultiSelect).prop("opened")).toBe(true);
+        });
+
+        it("closes the menu when the anchor is clicked", () => {
+            // Arrange
+            const wrapper = mount(<ControlledComponent />);
+
+            // Act
+            // open the menu from the outside
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+            // click on the dropdown anchor to hide the menu
+            wrapper.find(SelectOpener).simulate("click");
+
+            // Assert
+            expect(wrapper.find(MultiSelect).prop("opened")).toBe(false);
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -365,7 +365,7 @@ class ControlledSingleSelectExample extends React.Component {
             selectedValue: null,
         };
         this.handleChange = this.handleChange.bind(this);
-        this.toggleMenu = this.toggleMenu.bind(this);
+        this.handleToggleMenu = this.handleToggleMenu.bind(this);
     }
 
     handleChange(selected) {
@@ -374,7 +374,7 @@ class ControlledSingleSelectExample extends React.Component {
         });
     }
 
-    toggleMenu(opened) {
+    handleToggleMenu(opened) {
         this.setState({
             opened,
         });
@@ -385,7 +385,7 @@ class ControlledSingleSelectExample extends React.Component {
             <View style={styles.row}>
                 <SingleSelect
                     opened={this.state.opened}
-                    onToggle={this.toggleMenu}
+                    onToggle={this.handleToggleMenu}
                     onChange={this.handleChange}
                     selectedValue={this.state.selectedValue}
                     placeholder="Choose"
@@ -395,7 +395,7 @@ class ControlledSingleSelectExample extends React.Component {
                     <OptionItem label="item 3" value="3" />
                 </SingleSelect>
                 <Strut size={Spacing.medium} />
-                <Button onClick={() => this.toggleMenu(true)}>
+                <Button onClick={() => this.handleToggleMenu(true)}>
                     Open SingleSelect programatically
                 </Button>
             </View>

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -336,7 +336,7 @@ import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 ### Example: Opening a SingleSelect programmatically
 
 Sometimes you'll want to trigger a dropdown programmatically. This can be done by
-setting the `opened` prop to `true`. In this situation the `SingleSelect` is a
+setting a value to the `opened` prop (`true` or `false`). In this situation the `SingleSelect` is a
 controlled component. The parent is responsible for managing the opening/closing
 of the dropdown when using this prop.
 
@@ -376,7 +376,7 @@ class ControlledSingleSelectExample extends React.Component {
 
     toggleMenu(opened) {
         this.setState({
-            opened: opened,
+            opened,
         });
     }
 

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -39,6 +39,7 @@ class ExampleWithPlaceholder extends React.Component {
     render() {
         return <SingleSelect
             onChange={this.handleChange}
+            onToggle={(opened) => console.log('toggle: ', opened)}
             placeholder="Choose a fruit"
             selectedValue={this.state.selectedValue}
             style={styles.setWidth}
@@ -330,4 +331,77 @@ import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
         <OptionItem label="some value" value="" />
     </SingleSelect>
 </View>
+```
+
+### Example: Opening a SingleSelect programmatically
+
+Sometimes you'll want to trigger a dropdown programmatically. This can be done by
+setting the `opened` prop to `true`. In this situation the `SingleSelect` is a
+controlled component. The parent is responsible for managing the opening/closing
+of the dropdown when using this prop.
+
+This means that you'll also have to update `opened` to the value triggered by
+the `onToggle` prop.
+
+```js
+import {OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {StyleSheet} from "aphrodite";
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    }
+});
+
+class ControlledSingleSelectExample extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            opened: false,
+            selectedValue: null,
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.toggleMenu = this.toggleMenu.bind(this);
+    }
+
+    handleChange(selected) {
+        this.setState({
+            selectedValue: selected,
+        });
+    }
+
+    toggleMenu(opened) {
+        this.setState({
+            opened: opened,
+        });
+    }
+
+    render() {
+        return (
+            <View style={styles.row}>
+                <SingleSelect
+                    opened={this.state.opened}
+                    onToggle={this.toggleMenu}
+                    onChange={this.handleChange}
+                    selectedValue={this.state.selectedValue}
+                    placeholder="Choose"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>
+                <Strut size={Spacing.medium} />
+                <Button onClick={() => this.toggleMenu(true)}>
+                    Open SingleSelect programatically
+                </Button>
+            </View>
+        );
+    }
+}
+
+<ControlledSingleSelectExample />
 ```

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -91,6 +91,7 @@ describe("SingleSelect", () => {
         type State = {|
             opened?: boolean,
         |};
+
         class ControlledComponent extends React.Component<Props, State> {
             state = {
                 opened: this.props.opened,

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -96,7 +96,7 @@ describe("SingleSelect", () => {
                 opened: this.props.opened,
             };
 
-            handleToggle = (opened) => {
+            handleToggleMenu = (opened) => {
                 this.setState({
                     opened: opened,
                 });
@@ -109,7 +109,7 @@ describe("SingleSelect", () => {
                     <React.Fragment>
                         <SingleSelect
                             opened={this.state.opened}
-                            onToggle={this.handleToggle}
+                            onToggle={this.handleToggleMenu}
                             onChange={onChange}
                             placeholder="Choose"
                         >
@@ -119,7 +119,7 @@ describe("SingleSelect", () => {
                         </SingleSelect>
                         <button
                             data-test-id="parent-button"
-                            onClick={() => this.handleToggle(true)}
+                            onClick={() => this.handleToggleMenu(true)}
                         />
                     </React.Fragment>
                 );
@@ -172,6 +172,32 @@ describe("SingleSelect", () => {
 
             // Assert
             expect(onToggleMock).toHaveBeenCalledWith(true);
+        });
+
+        it("opens the menu when the anchor is clicked once", () => {
+            // Arrange
+            const wrapper = mount(<ControlledComponent />);
+
+            // Act
+            // click on the anchor
+            wrapper.find(SelectOpener).simulate("click");
+
+            // Assert
+            expect(wrapper.find(SingleSelect).prop("opened")).toBe(true);
+        });
+
+        it("closes the menu when the anchor is clicked", () => {
+            // Arrange
+            const wrapper = mount(<ControlledComponent />);
+
+            // Act
+            // open the menu from the outside
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+            // click on the dropdown anchor to hide the menu
+            wrapper.find(SelectOpener).simulate("click");
+
+            // Assert
+            expect(wrapper.find(SingleSelect).prop("opened")).toBe(false);
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -81,4 +81,97 @@ describe("SingleSelect", () => {
         // instead of the placeholder
         expect(opener.text()).toEqual("item 2");
     });
+
+    describe("Controlled component", () => {
+        type Props = {|
+            opened?: boolean,
+            onToggle?: (opened: boolean) => mixed,
+        |};
+
+        type State = {|
+            opened?: boolean,
+        |};
+        class ControlledComponent extends React.Component<Props, State> {
+            state = {
+                opened: this.props.opened,
+            };
+
+            handleToggle = (opened) => {
+                this.setState({
+                    opened: opened,
+                });
+
+                this.props.onToggle && this.props.onToggle(opened);
+            };
+
+            render() {
+                return (
+                    <React.Fragment>
+                        <SingleSelect
+                            opened={this.state.opened}
+                            onToggle={this.handleToggle}
+                            onChange={onChange}
+                            placeholder="Choose"
+                        >
+                            <OptionItem label="item 1" value="1" />
+                            <OptionItem label="item 2" value="2" />
+                            <OptionItem label="item 3" value="3" />
+                        </SingleSelect>
+                        <button
+                            data-test-id="parent-button"
+                            onClick={() => this.handleToggle(true)}
+                        />
+                    </React.Fragment>
+                );
+            }
+        }
+
+        it("opens the menu when the parent updates its state", () => {
+            // Arrange
+            const onToggleMock = jest.fn();
+            const wrapper = mount(
+                <ControlledComponent onToggle={onToggleMock} />,
+            );
+
+            // Act
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+
+            // Assert
+            expect(onToggleMock).toHaveBeenCalledWith(true);
+        });
+
+        it("closes the menu when the parent updates its state", () => {
+            // Arrange
+            const onToggleMock = jest.fn();
+            const wrapper = mount(
+                <ControlledComponent onToggle={onToggleMock} />,
+            );
+
+            // Act
+            // open the menu from the outside
+            wrapper.find(`[data-test-id="parent-button"]`).simulate("click");
+            // click on first item
+            wrapper
+                .find(OptionItem)
+                .at(0)
+                .simulate("click");
+
+            // Assert
+            expect(onToggleMock).toHaveBeenCalledWith(false);
+        });
+
+        it("should still allow the opener to open the menu", () => {
+            // Arrange
+            const onToggleMock = jest.fn();
+            const wrapper = mount(
+                <ControlledComponent onToggle={onToggleMock} />,
+            );
+
+            // Act
+            wrapper.find(SelectOpener).simulate("click");
+
+            // Assert
+            expect(onToggleMock).toHaveBeenCalledWith(true);
+        });
+    });
 });

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -242,7 +242,7 @@ describe("wonder-blocks-dropdown", () => {
                     selectedValues: ["kumail"],
                 };
                 this.handleChange = this.handleChange.bind(this);
-                this.toggleDropdown = this.toggleDropdown.bind(this);
+                this.handleToggleMenu = this.handleToggleMenu.bind(this);
             }
 
             handleChange(update) {
@@ -251,7 +251,7 @@ describe("wonder-blocks-dropdown", () => {
                 });
             }
 
-            toggleDropdown(opened) {
+            handleToggleMenu(opened) {
                 this.setState({
                     opened,
                 });
@@ -277,7 +277,7 @@ describe("wonder-blocks-dropdown", () => {
                             selectionType={"single"}
                             menuItems={dropdownItems}
                             onChange={this.handleChange}
-                            onToggle={this.toggleDropdown}
+                            onToggle={this.handleToggleMenu}
                             opened={this.state.opened}
                             selectedValues={this.state.selectedValues}
                         >
@@ -294,7 +294,7 @@ describe("wonder-blocks-dropdown", () => {
                             )}
                         </Dropdown>
                         <Strut size={Spacing.medium} />
-                        <Button onClick={() => this.toggleDropdown(true)}>
+                        <Button onClick={() => this.handleToggleMenu(true)}>
                             Open dropdown programatically
                         </Button>
                     </View>
@@ -576,7 +576,7 @@ describe("wonder-blocks-dropdown", () => {
                     selectedValues: ["kumail"],
                 };
                 this.handleChange = this.handleChange.bind(this);
-                this.toggleMenu = this.toggleMenu.bind(this);
+                this.handleToggleMenu = this.handleToggleMenu.bind(this);
             }
 
             handleChange(update) {
@@ -585,7 +585,7 @@ describe("wonder-blocks-dropdown", () => {
                 });
             }
 
-            toggleMenu(opened) {
+            handleToggleMenu(opened) {
                 this.setState({
                     opened,
                 });
@@ -599,7 +599,7 @@ describe("wonder-blocks-dropdown", () => {
                             onChange={this.handleChange}
                             onToggle={(opened) => {
                                 console.log("toggle called!!!! ", opened);
-                                this.toggleMenu(opened);
+                                this.handleToggleMenu(opened);
                             }}
                             opened={this.state.opened}
                             selectedValues={this.state.selectedValues}
@@ -614,7 +614,7 @@ describe("wonder-blocks-dropdown", () => {
                             <OptionItem label="Yash" value="yash" />
                         </ActionMenu>
                         <Strut size={Spacing.medium} />
-                        <Button onClick={() => this.toggleMenu(true)}>
+                        <Button onClick={() => this.handleToggleMenu(true)}>
                             Open ActionMenu programatically
                         </Button>
                     </View>
@@ -988,7 +988,7 @@ describe("wonder-blocks-dropdown", () => {
                     selectedValue: null,
                 };
                 this.handleChange = this.handleChange.bind(this);
-                this.toggleMenu = this.toggleMenu.bind(this);
+                this.handleToggleMenu = this.handleToggleMenu.bind(this);
             }
 
             handleChange(selected) {
@@ -997,7 +997,7 @@ describe("wonder-blocks-dropdown", () => {
                 });
             }
 
-            toggleMenu(opened) {
+            handleToggleMenu(opened) {
                 this.setState({
                     opened,
                 });
@@ -1008,7 +1008,7 @@ describe("wonder-blocks-dropdown", () => {
                     <View style={styles.row}>
                         <SingleSelect
                             opened={this.state.opened}
-                            onToggle={this.toggleMenu}
+                            onToggle={this.handleToggleMenu}
                             onChange={this.handleChange}
                             selectedValue={this.state.selectedValue}
                             placeholder="Choose"
@@ -1018,7 +1018,7 @@ describe("wonder-blocks-dropdown", () => {
                             <OptionItem label="item 3" value="3" />
                         </SingleSelect>
                         <Strut size={Spacing.medium} />
-                        <Button onClick={() => this.toggleMenu(true)}>
+                        <Button onClick={() => this.handleToggleMenu(true)}>
                             Open SingleSelect programatically
                         </Button>
                     </View>
@@ -1422,7 +1422,7 @@ describe("wonder-blocks-dropdown", () => {
                     selectedValues: [],
                 };
                 this.handleChange = this.handleChange.bind(this);
-                this.toggleMenu = this.toggleMenu.bind(this);
+                this.handleToggleMenu = this.handleToggleMenu.bind(this);
             }
 
             handleChange(update) {
@@ -1431,7 +1431,7 @@ describe("wonder-blocks-dropdown", () => {
                 });
             }
 
-            toggleMenu(opened) {
+            handleToggleMenu(opened) {
                 this.setState({
                     opened,
                 });
@@ -1444,7 +1444,7 @@ describe("wonder-blocks-dropdown", () => {
                             selectItemType="fruits"
                             onChange={this.handleChange}
                             opened={this.state.opened}
-                            onToggle={this.toggleMenu}
+                            onToggle={this.handleToggleMenu}
                             selectedValues={this.state.selectedValues}
                         >
                             <OptionItem label="Nectarine" value="nectarine" />
@@ -1453,7 +1453,7 @@ describe("wonder-blocks-dropdown", () => {
                             <OptionItem label="Pineapples" value="pineapples" />
                         </MultiSelect>
                         <Strut size={Spacing.medium} />
-                        <Button onClick={() => this.toggleMenu(true)}>
+                        <Button onClick={() => this.handleToggleMenu(true)}>
                             Open SingleSelect programatically
                         </Button>
                     </View>

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -234,7 +234,7 @@ describe("wonder-blocks-dropdown", () => {
             },
         });
 
-        class ControlledPopoverExample extends React.Component {
+        class ControlledDropdownExample extends React.Component {
             constructor() {
                 super();
                 this.state = {
@@ -251,15 +251,18 @@ describe("wonder-blocks-dropdown", () => {
                 });
             }
 
-            toggleDropdown() {
+            toggleDropdown(opened) {
                 this.setState({
-                    opened: !this.state.opened,
+                    opened: opened,
                 });
             }
 
             render() {
                 const dropdownItems = [
-                    <ActionItem label="Add new +" href="#!/Dropdown/7?new" />,
+                    <ActionItem
+                        label="Add new +"
+                        onClick={() => console.log("Add new clicked...")}
+                    />,
                     <SeparatorItem />,
                     <OptionItem label="Alex" value="alex" />,
                     <OptionItem label="Cathy" value="cathy" />,
@@ -274,17 +277,12 @@ describe("wonder-blocks-dropdown", () => {
                             selectionType={"single"}
                             menuItems={dropdownItems}
                             onChange={this.handleChange}
-                            onClose={this.toggleDropdown}
+                            onToggle={this.toggleDropdown}
                             opened={this.state.opened}
                             selectedValues={this.state.selectedValues}
                         >
                             {(eventState) => (
                                 <HeadingSmall
-                                    onClick={() =>
-                                        this.setState({
-                                            opened: !this.state.opened,
-                                        })
-                                    }
                                     style={[
                                         styles.cursor,
                                         eventState.focused && styles.focused,
@@ -296,7 +294,7 @@ describe("wonder-blocks-dropdown", () => {
                             )}
                         </Dropdown>
                         <Strut size={Spacing.medium} />
-                        <Button onClick={this.toggleDropdown}>
+                        <Button onClick={() => this.toggleDropdown(true)}>
                             Open dropdown programatically
                         </Button>
                     </View>
@@ -304,7 +302,7 @@ describe("wonder-blocks-dropdown", () => {
             }
         }
 
-        const example = <ControlledPopoverExample />;
+        const example = <ControlledDropdownExample />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
@@ -568,28 +566,82 @@ describe("wonder-blocks-dropdown", () => {
             row: {
                 flexDirection: "row",
             },
+        });
+
+        class ControlledActionMenuExample extends React.Component {
+            constructor() {
+                super();
+                this.state = {
+                    opened: false,
+                    selectedValues: ["kumail"],
+                };
+                this.handleChange = this.handleChange.bind(this);
+                this.toggleMenu = this.toggleMenu.bind(this);
+            }
+
+            handleChange(update) {
+                this.setState({
+                    selectedValues: update,
+                });
+            }
+
+            toggleMenu(opened) {
+                console.log("🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥");
+                console.log("should toggle!!!", opened);
+                this.setState({opened: opened});
+            }
+            render() {
+                return (
+                    <View style={styles.row}>
+                        <ActionMenu
+                            menuText="Betsy Appleseed"
+                            onChange={this.handleChange}
+                            onToggle={(opened) => {
+                                console.log("toggle called!!!! ", opened);
+                                this.toggleMenu(opened);
+                            }}
+                            opened={this.state.opened}
+                            selectedValues={this.state.selectedValues}
+                        >
+                            <ActionItem label="Add new +" />
+                            <SeparatorItem />
+                            <OptionItem label="Alex" value="alex" />
+                            <OptionItem label="Cathy" value="cathy" />
+                            <OptionItem label="Kumail" value="kumail" />
+                            <OptionItem label="Salman" value="salman" />
+                            <OptionItem label="Yan" value="yan" />
+                            <OptionItem label="Yash" value="yash" />
+                        </ActionMenu>
+                        <Strut size={Spacing.medium} />
+                        <Button onClick={() => this.toggleMenu(true)}>
+                            Open ActionMenu programatically
+                        </Button>
+                    </View>
+                );
+            }
+        }
+        const example = <ControlledActionMenuExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+    it("example 11", () => {
+        const styles = StyleSheet.create({
+            row: {flexDirection: "row"},
             setWidth: {
                 minWidth: 170,
                 maxWidth: 190,
             },
         });
-
         class ExampleWithPlaceholder extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValue: null,
-                };
+                this.state = {selectedValue: null};
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({
-                    selectedValue: selected,
-                });
+                this.setState({selectedValue: selected});
             }
-
             render() {
                 return (
                     <SingleSelect
@@ -625,7 +677,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <ExampleWithPlaceholder />
@@ -634,12 +685,9 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 11", () => {
+    it("example 12", () => {
         const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
+            row: {flexDirection: "row"},
             setWidth: {
                 minWidth: 170,
                 maxWidth: 190,
@@ -648,23 +696,16 @@ describe("wonder-blocks-dropdown", () => {
                 maxHeight: 240,
             },
         });
-
         class ExampleWithDropdownStyles extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValue: null,
-                };
+                this.state = {selectedValue: null};
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({
-                    selectedValue: selected,
-                });
+                this.setState({selectedValue: selected});
             }
-
             render() {
                 return (
                     <SingleSelect
@@ -685,7 +726,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <ExampleWithDropdownStyles />
@@ -694,31 +734,18 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 12", () => {
-        const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
-        });
-
+    it("example 13", () => {
+        const styles = StyleSheet.create({row: {flexDirection: "row"}});
         class ExampleWithStartingSelection extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValue: "banana",
-                }; // Styleguidist doesn't support arrow functions in class field properties
-
+                this.state = {selectedValue: "banana"}; // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({
-                    selectedValue: selected,
-                });
+                this.setState({selectedValue: selected});
             }
-
             render() {
                 return (
                     <SingleSelect
@@ -737,7 +764,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <ExampleWithStartingSelection />
@@ -746,31 +772,18 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 13", () => {
-        const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
-        });
-
+    it("example 14", () => {
+        const styles = StyleSheet.create({row: {flexDirection: "row"}});
         class DisabledExample extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValue: "banana",
-                }; // Styleguidist doesn't support arrow functions in class field properties
-
+                this.state = {selectedValue: "banana"}; // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({
-                    selectedValue: selected,
-                });
+                this.setState({selectedValue: selected});
             }
-
             render() {
                 return (
                     <SingleSelect
@@ -790,7 +803,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <DisabledExample />
@@ -799,12 +811,9 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 14", () => {
+    it("example 15", () => {
         const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
+            row: {flexDirection: "row"},
             darkBackgroundWrapper: {
                 flexDirection: "row",
                 justifyContent: "flex-end",
@@ -815,24 +824,16 @@ describe("wonder-blocks-dropdown", () => {
                 paddingTop: 10,
             },
         });
-
         class LightRightAlignedExample extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValue: null,
-                }; // Styleguidist doesn't support arrow functions in class field properties
-
+                this.state = {selectedValue: null}; // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({
-                    selectedValue: selected,
-                });
+                this.setState({selectedValue: selected});
             }
-
             render() {
                 return (
                     <SingleSelect
@@ -858,7 +859,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <View style={styles.darkBackgroundWrapper}>
@@ -869,13 +869,8 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 15", () => {
-        const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
-        });
+    it("example 16", () => {
+        const styles = StyleSheet.create({row: {flexDirection: "row"}});
         const example = (
             <View style={styles.row}>
                 <SingleSelect placeholder="empty" />
@@ -884,8 +879,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 16", () => {
+    it("example 17", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -907,34 +901,23 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 17", () => {
+    it("example 18", () => {
         const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
+            row: {flexDirection: "row"},
             setWidth: {
                 minWidth: 170,
             },
         });
-
         class ExampleNoneSelected extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValues: [],
-                }; // Styleguidist doesn't support arrow functions in class field properties
-
+                this.state = {selectedValues: []}; // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({
-                    selectedValues: update,
-                });
+                this.setState({selectedValues: update});
             }
-
             render() {
                 return (
                     <MultiSelect
@@ -966,7 +949,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <ExampleNoneSelected />
@@ -975,37 +957,24 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 18", () => {
+    it("example 19", () => {
         const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
+            row: {flexDirection: "row"},
             setWidth: {
                 minWidth: 170,
             },
-            dropdownHeight: {
-                maxHeight: 200,
-            },
+            dropdownHeight: {maxHeight: 200},
         });
-
         class ExampleScrolling extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValues: [],
-                }; // Styleguidist doesn't support arrow functions in class field properties
-
+                this.state = {selectedValues: []}; // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({
-                    selectedValues: update,
-                });
+                this.setState({selectedValues: update});
             }
-
             render() {
                 return (
                     <MultiSelect
@@ -1028,7 +997,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <ExampleScrolling />
@@ -1037,31 +1005,18 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 19", () => {
-        const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
-        });
-
+    it("example 20", () => {
+        const styles = StyleSheet.create({row: {flexDirection: "row"}});
         class ExampleWithShortcuts extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValues: ["wonderblocks 4ever"],
-                }; // Styleguidist doesn't support arrow functions in class field properties
-
+                this.state = {selectedValues: ["wonderblocks 4ever"]}; // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({
-                    selectedValues: update,
-                });
+                this.setState({selectedValues: update});
             }
-
             render() {
                 return (
                     <MultiSelect
@@ -1092,7 +1047,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <ExampleWithShortcuts />
@@ -1101,8 +1055,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 20", () => {
+    it("example 21", () => {
         const styles = StyleSheet.create({
             wrapper: {
                 alignItems: "center",
@@ -1119,24 +1072,16 @@ describe("wonder-blocks-dropdown", () => {
                 minWidth: 170,
             },
         });
-
         class SimpleMultiSelect extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValues: [],
-                }; // Styleguidist doesn't support arrow functions in class field properties
-
+                this.state = {selectedValues: []}; // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({
-                    selectedValues: update,
-                });
+                this.setState({selectedValues: update});
             }
-
             render() {
                 return (
                     <MultiSelect
@@ -1158,19 +1103,10 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const modalContent = (
-            <View
-                style={{
-                    height: "200vh",
-                }}
-            >
+            <View style={{height: "200vh"}}>
                 <View style={styles.scrolledWrapper}>
-                    <View
-                        style={{
-                            minHeight: "100vh",
-                        }}
-                    >
+                    <View style={{minHeight: "100vh"}}>
                         <SimpleMultiSelect />
                     </View>
                 </View>
@@ -1195,13 +1131,8 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 21", () => {
-        const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
-        });
+    it("example 22", () => {
+        const styles = StyleSheet.create({row: {flexDirection: "row"}});
         const example = (
             <View style={styles.row}>
                 <MultiSelect placeholder="empty" />
@@ -1210,8 +1141,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 22", () => {
+    it("example 23", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -1233,31 +1163,18 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    it("example 23", () => {
-        const styles = StyleSheet.create({
-            row: {
-                flexDirection: "row",
-            },
-        });
-
+    it("example 24", () => {
+        const styles = StyleSheet.create({row: {flexDirection: "row"}});
         class ImplicitAllEnabledExample extends React.Component {
             constructor() {
                 super();
-                this.state = {
-                    selectedValues: [],
-                }; // Styleguidist doesn't support arrow functions in class field properties
-
+                this.state = {selectedValues: []}; // Styleguidist doesn't support arrow functions in class field properties
                 this.handleChange = this.handleChange.bind(this);
             }
-
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({
-                    selectedValues: update,
-                });
+                this.setState({selectedValues: update});
             }
-
             render() {
                 return (
                     <MultiSelect
@@ -1274,7 +1191,6 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
-
         const example = (
             <View style={styles.row}>
                 <ImplicitAllEnabledExample />

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -586,10 +586,11 @@ describe("wonder-blocks-dropdown", () => {
             }
 
             toggleMenu(opened) {
-                console.log("🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥");
-                console.log("should toggle!!!", opened);
-                this.setState({opened: opened});
+                this.setState({
+                    opened: opened,
+                });
             }
+
             render() {
                 return (
                     <View style={styles.row}>
@@ -620,32 +621,44 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = <ControlledActionMenuExample />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
     it("example 11", () => {
         const styles = StyleSheet.create({
-            row: {flexDirection: "row"},
+            row: {
+                flexDirection: "row",
+            },
             setWidth: {
                 minWidth: 170,
                 maxWidth: 190,
             },
         });
+
         class ExampleWithPlaceholder extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValue: null};
+                this.state = {
+                    selectedValue: null,
+                };
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({selectedValue: selected});
+                this.setState({
+                    selectedValue: selected,
+                });
             }
+
             render() {
                 return (
                     <SingleSelect
                         onChange={this.handleChange}
+                        onToggle={(opened) => console.log("toggle: ", opened)}
                         placeholder="Choose a fruit"
                         selectedValue={this.state.selectedValue}
                         style={styles.setWidth}
@@ -677,6 +690,7 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <ExampleWithPlaceholder />
@@ -685,9 +699,12 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
     it("example 12", () => {
         const styles = StyleSheet.create({
-            row: {flexDirection: "row"},
+            row: {
+                flexDirection: "row",
+            },
             setWidth: {
                 minWidth: 170,
                 maxWidth: 190,
@@ -696,16 +713,23 @@ describe("wonder-blocks-dropdown", () => {
                 maxHeight: 240,
             },
         });
+
         class ExampleWithDropdownStyles extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValue: null};
+                this.state = {
+                    selectedValue: null,
+                };
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({selectedValue: selected});
+                this.setState({
+                    selectedValue: selected,
+                });
             }
+
             render() {
                 return (
                     <SingleSelect
@@ -726,6 +750,7 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <ExampleWithDropdownStyles />
@@ -734,18 +759,31 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
     it("example 13", () => {
-        const styles = StyleSheet.create({row: {flexDirection: "row"}});
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
         class ExampleWithStartingSelection extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValue: "banana"}; // Styleguidist doesn't support arrow functions in class field properties
+                this.state = {
+                    selectedValue: "banana",
+                }; // Styleguidist doesn't support arrow functions in class field properties
+
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({selectedValue: selected});
+                this.setState({
+                    selectedValue: selected,
+                });
             }
+
             render() {
                 return (
                     <SingleSelect
@@ -764,6 +802,7 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <ExampleWithStartingSelection />
@@ -772,18 +811,31 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
     it("example 14", () => {
-        const styles = StyleSheet.create({row: {flexDirection: "row"}});
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
         class DisabledExample extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValue: "banana"}; // Styleguidist doesn't support arrow functions in class field properties
+                this.state = {
+                    selectedValue: "banana",
+                }; // Styleguidist doesn't support arrow functions in class field properties
+
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({selectedValue: selected});
+                this.setState({
+                    selectedValue: selected,
+                });
             }
+
             render() {
                 return (
                     <SingleSelect
@@ -803,6 +855,7 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <DisabledExample />
@@ -811,9 +864,12 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
     it("example 15", () => {
         const styles = StyleSheet.create({
-            row: {flexDirection: "row"},
+            row: {
+                flexDirection: "row",
+            },
             darkBackgroundWrapper: {
                 flexDirection: "row",
                 justifyContent: "flex-end",
@@ -824,16 +880,24 @@ describe("wonder-blocks-dropdown", () => {
                 paddingTop: 10,
             },
         });
+
         class LightRightAlignedExample extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValue: null}; // Styleguidist doesn't support arrow functions in class field properties
+                this.state = {
+                    selectedValue: null,
+                }; // Styleguidist doesn't support arrow functions in class field properties
+
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(selected) {
                 console.log(`${selected} was selected!`);
-                this.setState({selectedValue: selected});
+                this.setState({
+                    selectedValue: selected,
+                });
             }
+
             render() {
                 return (
                     <SingleSelect
@@ -859,6 +923,7 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <View style={styles.darkBackgroundWrapper}>
@@ -869,8 +934,13 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
     it("example 16", () => {
-        const styles = StyleSheet.create({row: {flexDirection: "row"}});
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
         const example = (
             <View style={styles.row}>
                 <SingleSelect placeholder="empty" />
@@ -879,6 +949,7 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
     it("example 17", () => {
         const example = (
             <View>
@@ -901,23 +972,92 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
     it("example 18", () => {
         const styles = StyleSheet.create({
-            row: {flexDirection: "row"},
+            row: {
+                flexDirection: "row",
+            },
+        });
+
+        class ControlledSingleSelectExample extends React.Component {
+            constructor() {
+                super();
+                this.state = {
+                    opened: false,
+                    selectedValue: null,
+                };
+                this.handleChange = this.handleChange.bind(this);
+                this.toggleMenu = this.toggleMenu.bind(this);
+            }
+
+            handleChange(selected) {
+                this.setState({
+                    selectedValue: selected,
+                });
+            }
+
+            toggleMenu(opened) {
+                this.setState({
+                    opened: opened,
+                });
+            }
+
+            render() {
+                return (
+                    <View style={styles.row}>
+                        <SingleSelect
+                            opened={this.state.opened}
+                            onToggle={this.toggleMenu}
+                            onChange={this.handleChange}
+                            selectedValue={this.state.selectedValue}
+                            placeholder="Choose"
+                        >
+                            <OptionItem label="item 1" value="1" />
+                            <OptionItem label="item 2" value="2" />
+                            <OptionItem label="item 3" value="3" />
+                        </SingleSelect>
+                        <Strut size={Spacing.medium} />
+                        <Button onClick={() => this.toggleMenu(true)}>
+                            Open SingleSelect programatically
+                        </Button>
+                    </View>
+                );
+            }
+        }
+
+        const example = <ControlledSingleSelectExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 19", () => {
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
             setWidth: {
                 minWidth: 170,
             },
         });
+
         class ExampleNoneSelected extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValues: []}; // Styleguidist doesn't support arrow functions in class field properties
+                this.state = {
+                    selectedValues: [],
+                }; // Styleguidist doesn't support arrow functions in class field properties
+
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({selectedValues: update});
+                this.setState({
+                    selectedValues: update,
+                });
             }
+
             render() {
                 return (
                     <MultiSelect
@@ -949,6 +1089,7 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <ExampleNoneSelected />
@@ -957,24 +1098,37 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 19", () => {
+
+    it("example 20", () => {
         const styles = StyleSheet.create({
-            row: {flexDirection: "row"},
+            row: {
+                flexDirection: "row",
+            },
             setWidth: {
                 minWidth: 170,
             },
-            dropdownHeight: {maxHeight: 200},
+            dropdownHeight: {
+                maxHeight: 200,
+            },
         });
+
         class ExampleScrolling extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValues: []}; // Styleguidist doesn't support arrow functions in class field properties
+                this.state = {
+                    selectedValues: [],
+                }; // Styleguidist doesn't support arrow functions in class field properties
+
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({selectedValues: update});
+                this.setState({
+                    selectedValues: update,
+                });
             }
+
             render() {
                 return (
                     <MultiSelect
@@ -997,6 +1151,7 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <ExampleScrolling />
@@ -1005,18 +1160,31 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 20", () => {
-        const styles = StyleSheet.create({row: {flexDirection: "row"}});
+
+    it("example 21", () => {
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
         class ExampleWithShortcuts extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValues: ["wonderblocks 4ever"]}; // Styleguidist doesn't support arrow functions in class field properties
+                this.state = {
+                    selectedValues: ["wonderblocks 4ever"],
+                }; // Styleguidist doesn't support arrow functions in class field properties
+
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({selectedValues: update});
+                this.setState({
+                    selectedValues: update,
+                });
             }
+
             render() {
                 return (
                     <MultiSelect
@@ -1047,6 +1215,7 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <ExampleWithShortcuts />
@@ -1055,7 +1224,8 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 21", () => {
+
+    it("example 22", () => {
         const styles = StyleSheet.create({
             wrapper: {
                 alignItems: "center",
@@ -1072,16 +1242,24 @@ describe("wonder-blocks-dropdown", () => {
                 minWidth: 170,
             },
         });
+
         class SimpleMultiSelect extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValues: []}; // Styleguidist doesn't support arrow functions in class field properties
+                this.state = {
+                    selectedValues: [],
+                }; // Styleguidist doesn't support arrow functions in class field properties
+
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({selectedValues: update});
+                this.setState({
+                    selectedValues: update,
+                });
             }
+
             render() {
                 return (
                     <MultiSelect
@@ -1103,10 +1281,19 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const modalContent = (
-            <View style={{height: "200vh"}}>
+            <View
+                style={{
+                    height: "200vh",
+                }}
+            >
                 <View style={styles.scrolledWrapper}>
-                    <View style={{minHeight: "100vh"}}>
+                    <View
+                        style={{
+                            minHeight: "100vh",
+                        }}
+                    >
                         <SimpleMultiSelect />
                     </View>
                 </View>
@@ -1131,8 +1318,13 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 22", () => {
-        const styles = StyleSheet.create({row: {flexDirection: "row"}});
+
+    it("example 23", () => {
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
         const example = (
             <View style={styles.row}>
                 <MultiSelect placeholder="empty" />
@@ -1141,7 +1333,8 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 23", () => {
+
+    it("example 24", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -1163,18 +1356,31 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
-    it("example 24", () => {
-        const styles = StyleSheet.create({row: {flexDirection: "row"}});
+
+    it("example 25", () => {
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
         class ImplicitAllEnabledExample extends React.Component {
             constructor() {
                 super();
-                this.state = {selectedValues: []}; // Styleguidist doesn't support arrow functions in class field properties
+                this.state = {
+                    selectedValues: [],
+                }; // Styleguidist doesn't support arrow functions in class field properties
+
                 this.handleChange = this.handleChange.bind(this);
             }
+
             handleChange(update) {
                 console.log("changes happened!");
-                this.setState({selectedValues: update});
+                this.setState({
+                    selectedValues: update,
+                });
             }
+
             render() {
                 return (
                     <MultiSelect
@@ -1191,11 +1397,71 @@ describe("wonder-blocks-dropdown", () => {
                 );
             }
         }
+
         const example = (
             <View style={styles.row}>
                 <ImplicitAllEnabledExample />
             </View>
         );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 26", () => {
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+            },
+        });
+
+        class ControlledMultiSelectExample extends React.Component {
+            constructor() {
+                super();
+                this.state = {
+                    opened: false,
+                    selectedValues: [],
+                };
+                this.handleChange = this.handleChange.bind(this);
+                this.toggleMenu = this.toggleMenu.bind(this);
+            }
+
+            handleChange(update) {
+                this.setState({
+                    selectedValues: update,
+                });
+            }
+
+            toggleMenu(opened) {
+                this.setState({
+                    opened: opened,
+                });
+            }
+
+            render() {
+                return (
+                    <View style={styles.row}>
+                        <MultiSelect
+                            selectItemType="fruits"
+                            onChange={this.handleChange}
+                            opened={this.state.opened}
+                            onToggle={this.toggleMenu}
+                            selectedValues={this.state.selectedValues}
+                        >
+                            <OptionItem label="Nectarine" value="nectarine" />
+                            <OptionItem label="Plum" value="plum" />
+                            <OptionItem label="Cantaloupe" value="cantaloupe" />
+                            <OptionItem label="Pineapples" value="pineapples" />
+                        </MultiSelect>
+                        <Strut size={Spacing.medium} />
+                        <Button onClick={() => this.toggleMenu(true)}>
+                            Open SingleSelect programatically
+                        </Button>
+                    </View>
+                );
+            }
+        }
+
+        const example = <ControlledMultiSelectExample />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -253,7 +253,7 @@ describe("wonder-blocks-dropdown", () => {
 
             toggleDropdown(opened) {
                 this.setState({
-                    opened: opened,
+                    opened,
                 });
             }
 
@@ -587,7 +587,7 @@ describe("wonder-blocks-dropdown", () => {
 
             toggleMenu(opened) {
                 this.setState({
-                    opened: opened,
+                    opened,
                 });
             }
 
@@ -999,7 +999,7 @@ describe("wonder-blocks-dropdown", () => {
 
             toggleMenu(opened) {
                 this.setState({
-                    opened: opened,
+                    opened,
                 });
             }
 
@@ -1433,7 +1433,7 @@ describe("wonder-blocks-dropdown", () => {
 
             toggleMenu(opened) {
                 this.setState({
-                    opened: opened,
+                    opened,
                 });
             }
 


### PR DESCRIPTION
## Summary
Adds a "controlled" mode to all the dropdown variants. To make this mode work, you need to add the `opened` and `onToggle` props to the component instance. The dropdown openers still work on this mode due to the dropdown/select nature.

## Features

### Dropdown
- Changed `onClose` to `onToggle` for better understanding on the controlled mode. This means that `onToggle` will be triggered every time the menu is open or closed.

### ActionMenu, SingleSelect, MultiSelect
- Added `getDerivedStateFromProps` to sync the `opened` prop with the parent's state.
- Added `onToggle` prop to sync up the `opened` prop within the parent component.
- Updated unit tests.
- Added examples.

### Test plan
1. Open https://deploy-preview-457--wonder-blocks.netlify.com/#section-dropdown
2. Check the documentation is clear enough.
3. Go to the examples related to controlled components and check that everything works as expected:
    - ActionMenu: https://deploy-preview-457--wonder-blocks.netlify.com/#!/ActionMenu/11
    - SingleSelect: https://deploy-preview-457--wonder-blocks.netlify.com/#!/SingleSelect/15
    - MultiSelect: https://deploy-preview-457--wonder-blocks.netlify.com/#!/MultiSelect/15