### PR TITLE
WB-591: Add detailed documentation for Timing package

### DIFF
--- a/packages/wonder-blocks-timing/components/with-action-scheduler.md
+++ b/packages/wonder-blocks-timing/components/with-action-scheduler.md
@@ -1,150 +1,19 @@
-This is a higher order component that attaches the given component to an
-`IScheduleActions` instance. Any actions scheduled will automatically be
+This is a higher order component (HOC) that attaches the given component to an
+[`IScheduleActions`](#ischeduleactions) instance. Any actions scheduled will automatically be
 cleared on unmount. This allows for "set it and forget it" behavior that won't
 leave timers dangling when the component's lifecycle ends.
 
-For example, the following component, `MyNaughtyComponent`, will keep spamming
-our pretend log even after it was unmounted.
+For more details on using this component and the [`IScheduleActions`](#ischeduleactions) interface,
+see the [API overview](#timing-api-overview).
 
-```jsx
-const Button = require("@khanacademy/wonder-blocks-button").default;
-const {IDProvider, View} = require("@khanacademy/wonder-blocks-core");
+### Flow Types
+If you are using Flow typing, you can use the `WithActionScheduler<TProps>`
+generic type to build the props for the component that you will pass to the
+`withActionScheduler` function, where `TProps` represents all the props your
+component uses other than the `schedule` prop that will get added.
 
+The added `schedule` prop is of type [`IScheduleActions`](#ischeduleactions). This is what the
+`withActionScheduler` function injects to your component.
 
-class Unmounter extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            mountKids: true,
-        };
-    }
-
-    maybeRenderKids() {
-        if (this.state.mountKids) {
-            return (
-                <React.Fragment>
-                    <Button onClick={() => this.onClick()}>Unmount</Button>
-                    {this.props.children}
-                </React.Fragment>
-            );
-        } else {
-            return "Children unmounted";
-        }
-    }
-
-    onClick() {
-        this.setState({mountKids: false});
-    }
-
-    render() {
-        return (
-            <View>
-                {this.maybeRenderKids()}
-            </View>
-        );
-    }
-}
-
-class MyNaughtyComponent extends React.Component {
-    componentDidMount() {
-        const {targetId} = this.props;
-        let counter = 0;
-        const domElement = document.getElementById(targetId);
-        setInterval(() => {
-            domElement.innerText = "Naughty interval logged: " + counter++;
-        }, 200);
-    }
-
-    render() {
-        return <View>NaughtyComponent here</View>;
-    }
-}
-
-
-<IDProvider>
-    {id => (
-        <View>
-            <Unmounter>
-                <MyNaughtyComponent targetId={id} />
-            </Unmounter>
-            <View>
-                <View id={id}></View>
-            </View>
-        </View>
-    )}
-</IDProvider>
-```
-
-But if we use `withActionScheduler` and the `interval` method, everything is
-just fine. Unmount the component, and the logging stops.
-
-```jsx
-const {withActionScheduler} = require("@khanacademy/wonder-blocks-timing");
-const Button = require("@khanacademy/wonder-blocks-button").default;
-const {IDProvider, View} = require("@khanacademy/wonder-blocks-core");
-
-
-class Unmounter extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            mountKids: true,
-        };
-    }
-
-    maybeRenderKids() {
-        if (this.state.mountKids) {
-            return (
-                <React.Fragment>
-                    <Button onClick={() => this.onClick()}>Unmount</Button>
-                    {this.props.children}
-                </React.Fragment>
-            );
-        } else {
-            return "Children unmounted";
-        }
-    }
-
-    onClick() {
-        this.setState({mountKids: false});
-    }
-
-    render() {
-        return (
-            <View>
-                {this.maybeRenderKids()}
-            </View>
-        );
-    }
-}
-
-class MyGoodComponent extends React.Component {
-    componentDidMount() {
-        const {targetId, schedule} = this.props;
-        let counter = 0;
-        const domElement = document.getElementById(targetId);
-        schedule.interval(() => {
-            domElement.innerText = "Naughty interval logged: " + counter++;
-        }, 200);
-    }
-
-    render() {
-        return <View>GoodComponent here</View>;
-    }
-}
-
-const MyGoodComponentWithScheduler = withActionScheduler(MyGoodComponent);
-
-<IDProvider>
-    {id => (
-        <View>
-            <Unmounter>
-                <MyGoodComponentWithScheduler targetId={id} />
-            </Unmounter>
-            <View>
-                <View id={id}></View>
-            </View>
-        </View>
-    )}
-</IDProvider>
-```
+The returned value from `withActionScheduler` is a React component with props of
+type `TProps`.

--- a/packages/wonder-blocks-timing/docs.md
+++ b/packages/wonder-blocks-timing/docs.md
@@ -1,11 +1,398 @@
 Abstractions for common timing APIs like `setTimeout`, `setInterval` and
-`requestAnimationFrame`.
+`requestAnimationFrame` that are aware of React component lifecycles, ensuring
+that scheduled timer actions are not unexpectedly dangling after a component
+unmounts.
 
-## Migration
+Access to the timing API is provided via the `withActionScheduler` higher order
+component.
+
+### Timing API Usage Example
+
+The following component, `MyNaughtyComponent`, will keep spamming our pretend
+log even after it was unmounted.
+
+```jsx
+const Button = require("@khanacademy/wonder-blocks-button").default;
+const {IDProvider, View} = require("@khanacademy/wonder-blocks-core");
+
+
+class Unmounter extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            mountKids: true,
+        };
+    }
+
+    maybeRenderKids() {
+        if (this.state.mountKids) {
+            return (
+                <React.Fragment>
+                    <Button onClick={() => this.onClick()}>Unmount</Button>
+                    {this.props.children}
+                </React.Fragment>
+            );
+        } else {
+            return "Children unmounted";
+        }
+    }
+
+    onClick() {
+        this.setState({mountKids: false});
+    }
+
+    render() {
+        return (
+            <View>
+                {this.maybeRenderKids()}
+            </View>
+        );
+    }
+}
+
+class MyNaughtyComponent extends React.Component {
+    componentDidMount() {
+        const {targetId} = this.props;
+        let counter = 0;
+        const domElement = document.getElementById(targetId);
+        setInterval(() => {
+            domElement.innerText = "Naughty interval logged: " + counter++;
+        }, 200);
+    }
+
+    render() {
+        return <View>NaughtyComponent here</View>;
+    }
+}
+
+
+<IDProvider>
+    {id => (
+        <View>
+            <Unmounter>
+                <MyNaughtyComponent targetId={id} />
+            </Unmounter>
+            <View>
+                <View id={id}></View>
+            </View>
+        </View>
+    )}
+</IDProvider>
+```
+
+But if we use `withActionScheduler` and the `interval` method, everything is
+just fine. Unmount the component, and the logging stops.
+
+```jsx
+const {withActionScheduler} = require("@khanacademy/wonder-blocks-timing");
+const Button = require("@khanacademy/wonder-blocks-button").default;
+const {IDProvider, View} = require("@khanacademy/wonder-blocks-core");
+
+
+class Unmounter extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            mountKids: true,
+        };
+    }
+
+    maybeRenderKids() {
+        if (this.state.mountKids) {
+            return (
+                <React.Fragment>
+                    <Button onClick={() => this.onClick()}>Unmount</Button>
+                    {this.props.children}
+                </React.Fragment>
+            );
+        } else {
+            return "Children unmounted";
+        }
+    }
+
+    onClick() {
+        this.setState({mountKids: false});
+    }
+
+    render() {
+        return (
+            <View>
+                {this.maybeRenderKids()}
+            </View>
+        );
+    }
+}
+
+class MyGoodComponent extends React.Component {
+    componentDidMount() {
+        const {targetId, schedule} = this.props;
+        let counter = 0;
+        const domElement = document.getElementById(targetId);
+        schedule.interval(() => {
+            domElement.innerText = "Naughty interval logged: " + counter++;
+        }, 200);
+    }
+
+    render() {
+        return <View>GoodComponent here</View>;
+    }
+}
+
+const MyGoodComponentWithScheduler = withActionScheduler(MyGoodComponent);
+
+<IDProvider>
+    {id => (
+        <View>
+            <Unmounter>
+                <MyGoodComponentWithScheduler targetId={id} />
+            </Unmounter>
+            <View>
+                <View id={id}></View>
+            </View>
+        </View>
+    )}
+</IDProvider>
+```
+
+<!-- Styleguidist doesn't support the extended syntax for custom header IDs.
+     If that ever changes, this should be:
+         `### API Overiview {#timing-api-overview}`
+-->
+<h3 id="timing-api-overview">API Overview</h3>
+
+#### IScheduleActions
+
+The `IScheduleActions` interface provides 4 (four) different functions:
+
+* [`timeout`](#timeout)
+* [`interval`](#interval)
+* [`animationFrame`](#animationframe)
+* [`clearAll`](#clearall)
+
+##### timeout
+
+```js static
+    timeout(
+        action: () => mixed,
+        period: number,
+        autoSchedule?: boolean,
+        resolveOnClear?: boolean,
+    ): ITimeout;
+```
+
+The `timeout` function replaces the `setTimeout` and `clearTimeout` functions
+in the standard timer API.
+
+Unless indicated otherwise, all timeouts scheduled this way will be cleared on component unmount.
+
+| | Flow&nbsp;Type | Default | Description |
+| --- | --- | --- | --- |
+| `action` | `()`&nbsp;`=>`&nbsp;`void` | _Required_ | The action to be invoked when the timeout period is reached. |
+| `period` | `number` | _Required_ | The timeout period in milliseconds. The action will be invoked after this period has passed since the timeout was set. This value must be greater than or equal to zero. |
+| `autoSchedule` | `boolean` | `true` | Whether or not to set the timeout as soon as this call is made, or wait until `set` is explicitly called. Defaults to `true`. |
+| `resolveOnClear` | `boolean` | `false` | Whether or not the associated action will be invoked if it is still pending at the point the timeout is cleared. Defaults to `false`. This only takes effect when the [clearAll](#clearall) is invoked on parent the `IScheduleActions` instance, such as when unmounting; this does not affect calls to the `clear` method on the returned `ITimeout` interface. |
+| _returns_ | [`ITimeout`](#itimeout) | | An interface for manipulating the created timeout. |
+
+##### interval
+
+```js static
+    interval(
+        action: () => mixed,
+        period: number,
+        autoSchedule?: boolean,
+        resolveOnClear?: boolean,
+    ): IInterval;
+```
+
+| | Flow&nbsp;Type | Default | Description |
+| --- | --- | --- | --- |
+| `action` | `()`&nbsp;`=>`&nbsp;`void` | _Required_ | The action to be invoked when the interval period occurs. |
+| `period` | `number` | _Required_ | The interval period in milliseconds. The action will be invoked each time this period has passed since the interval was set or last occurred. This value must be greater than zero. |
+| `autoSchedule` | `boolean` | `true` | Whether or not to set the interval as soon as this call is made, or wait until `set` is explicitly called. Defaults to `true`. |
+| `resolveOnClear` | `boolean` | `false` |  Whether or not the associated action will be invoked at the point the interval is cleared if the interval is running at that time. Defaults to `false`. This only takes effect when the [clearAll](#clearall) is invoked on parent the `IScheduleActions` instance, such as when unmounting; this does not affect calls to the `clear` method on the returned `IInterval` interface. |
+| _returns_ | [`IInterval`](#iinterval) | | An interface for manipulating the created interval. |
+
+##### animationFrame
+
+```js static
+    animationFrame(
+        action: () => void,
+        autoSchedule?: boolean,
+        resolveOnClear?: boolean,
+    ): IAnimationFrame;
+```
+
+| | Flow&nbsp;Type | Default | Description |
+| --- | --- | --- | --- |
+| `action` | `()`&nbsp;`=>`&nbsp;`void` | _Required_ | The action to be invoked before the repaint. |
+| `autoSchedule` | `boolean` | `true` | Whether or not to make the request as soon as this call is made, or wait until `set` is explicitly called. Defaults to `true`. |
+| `resolveOnClear` | `boolean` | `false` |  Whether or not the associated action will be invoked at the point the request is cleared if it has not yet executed. Defaults to `false`. This only takes effect when the [clearAll](#clearall) is invoked on parent the `IScheduleActions` instance, such as when unmounting; this does not affect calls to the `clear` method on the returned `IAnimationFrame` interface. |
+| _returns_ | [`IAnimationFrame`](#ianimationframe) | | An interface for manipulating the created request. |
+
+##### clearAll
+
+```js static
+    clearAll(): void;
+```
+
+Clears all timeouts, intervals, and animation frame requests that were made with this scheduler.
+
+#### Types
+
+##### ITimeout
+
+```js static
+interface ITimeout {
+    get isSet(): boolean;
+    set(): void;
+    clear(resolve?: boolean): void;
+}
+```
+
+The `ITimeout` interface provides additional calls to manipulate a timeout, if so required.
+
+| | Flow&nbsp;Type | Description |
+| --- | --- | --- |
+| `isSet` | `boolean` | A read-only property for determining if the timeout is set or not. Returns `true` if the timeout is set (aka pending), otherwise `false`. |
+| `set` | `()`&nbsp;`=>`&nbsp;`void` | If the timeout is pending, this cancels that pending timeout and starts the timeout afresh. If the timeout is not pending, this starts the timeout. Can be used to re-schedule an already invoked or cleared timeout. |
+| `clear` | `(resolve?:`&nbsp;`boolean)`&nbsp;`=>`&nbsp;`void` | If the timeout is pending, this cancels that pending timeout. If no timeout is pending, this does nothing. When the optional `resolve` argument is `true`, and the timeout was in the set state when called, the timeout action is invoked after cancelling the timeout. The `resolve` parameter defaults to `false`. This call does nothing if there was no pending timeout (i.e. when `isSet` is `false`). |
+
+##### IInterval
+
+```js static
+interface IInterval {
+    get isSet(): boolean;
+    set(): void;
+    clear(resolve?: boolean): void;
+}
+```
+
+The `IInterval` interface provides additional calls to manipulate an interval, if so required.
+
+| | Flow&nbsp;Type | Description |
+| --- | --- | --- |
+| `isSet` | `boolean` | A read-only property for determining if the interval is active or not. Returns `true` if the interval is active, otherwise `false`. |
+| `set` | `()`&nbsp;`=>`&nbsp;`void` | If the interval is active, this cancels that interval and restarts it afresh. If the interval is not active, this starts the interval. Can be used to re-schedule a cleared interval. |
+| `clear` | `(resolve?:`&nbsp;`boolean)`&nbsp;`=>`&nbsp;`void` | If the interval is active, this cancels that interval. If the interval is not active, this does nothing. When the optional `resolve` argument is `true`, and the interval was in the active state when called, the associated action is invoked after cancelling the interval. The `resolve` parameter defaults to `false`. This call does nothing if there was no pending interval (i.e. when `isSet` is `false`). |
+
+##### IAnimationFrame
+
+```js static
+interface IAnimationFrame {
+    get isSet(): boolean;
+    set(): void;
+    clear(resolve?: boolean): void;
+}
+```
+
+The `IAnimationFrame` interface provides additional calls to manipulate an animation frame request, if so required.
+
+| | Flow&nbsp;Type | Description |
+| --- | --- | --- |
+| `isSet` | `boolean` | A read-only property for determining if the request is set (aka pending). Returns `true` if the animation frame is set, otherwise `false`. |
+| `set` | `()`&nbsp;`=>`&nbsp;`void` | If the request is pending, this cancels that pending request and starts a request afresh. If the request is not pending, this starts the request. Can be used to re-request an already invokd or cleared request. |
+| `clear` | `(resolve?:`&nbsp;`boolean)`&nbsp;`=>`&nbsp;`void` | If the request is pending, this cancels that pending request. If no request is pending, this does nothing. When the optional `resolve` argument is `true`, and the request was in the active state when called, the associated action is invoked after cancelling the request. The `resolve` parameter defaults to `false`. This call does nothing if there was no pending request (i.e. when `isSet` is `false`). |
+
+### Migration from standard API
 
 Migrating from the standard API is as simple as:
 
-1. Wrapping your component with the `withActionScheduler` HOC
-2. Using the `WithActionScheduler<TOwnProps>` type to extend your components props
-3. Use the new `schedule` prop in your component instead of `setTimeout`, `setInterval` and `requestAnimationFrame`
+1. Wrapping your component with the `withActionScheduler` HOC (and, if using Flow, using the `WithActionScheduler<TOwnProps>` type to extend your components props)
+2. Using the new `schedule` prop in your component instead of `setTimeout`, `setInterval` and `requestAnimationFrame`
 
+#### Migration Example
+
+Let's imagine we have a component that uses `setTimeout` like this:
+
+```js static
+type Props = {||};
+
+type State = {
+    timerFired: boolean,
+}
+
+class MyLegacyComponent extends React.Component<Props, State> {
+    _timeoutID: TimeoutID;
+
+    state = {
+        timerFired: false;
+    };
+
+    componentDidMount() {
+        this.timeoutID = setTimeout(
+            () => this.setState({timerFired: true}),
+            2000,
+        );
+    }
+
+    componentWillUnmount() {
+        /* 0 is a valid ID for a timeout */
+        if (this.timeoutID != null) {
+            clearTimeout(this.timeoutID);
+        }
+    }
+
+    renderState() {
+        const {timerFired} = this.state;
+        if (timerFired) {
+            return "...fired!";
+        }
+        return "pending...";
+    }
+
+    render() {
+        return <View>Legacy Component {this.renderState()}</View>;
+    }
+}
+```
+
+We can rewrite it to use the Wonder Blocks Timing API like this:
+
+```js static
+/**
+ * These are the props that consumers of your component will see.
+ */
+type OwnProps = {||};
+
+/**
+ * These are the props that your component actually uses. We use the
+ * WithActionScheduler<TOwnProps> generic type to augment `OwnProps` with the
+ * props injected by the withActionScheduler HOC.
+ */
+type Props = WithActionScheduler<OwnProps>;
+
+type State = {
+    timerFired: boolean,
+}
+
+class MyWonderBlocksComponentImpl extends React.Component<Props, State> {
+    state = {
+        timerFired: false;
+    };
+
+    componentDidMount() {
+        const {schedule} = this.props;
+        schedule.timeout(() => this.setState({timerFired: true}), 2000);
+    }
+
+    renderState() {
+        const {timerFired} = this.state;
+        if (timerFired) {
+            return "...fired!";
+        }
+        return "pending...";
+    }
+
+    render() {
+        return <View>Wonder Blocks Component {this.renderState()}</View>;
+    }
+}
+
+/**
+ * The component that you would export as a drop-in replacement for your
+ * legacy component.
+ */
+const MyWonderBlocksComponent: React.AbstractComponent<
+    OwnProps,
+> = withActionScheduler(MyWonderBlocksComponentImpl);
+```

--- a/packages/wonder-blocks-timing/docs.md
+++ b/packages/wonder-blocks-timing/docs.md
@@ -181,8 +181,6 @@ The `IScheduleActions` interface provides 4 (four) different functions:
 The `timeout` function replaces the `setTimeout` and `clearTimeout` functions
 in the standard timer API.
 
-Unless indicated otherwise, all timeouts scheduled this way will be cleared on component unmount.
-
 | | Flow&nbsp;Type | Default | Description |
 | --- | --- | --- | --- |
 | `action` | `()`&nbsp;`=>`&nbsp;`void` | _Required_ | The action to be invoked when the timeout period is reached. |
@@ -202,6 +200,9 @@ Unless indicated otherwise, all timeouts scheduled this way will be cleared on c
     ): IInterval;
 ```
 
+The `interval` function replaces the `setInterval` and `clearInterval` functions
+in the standard timer API.
+
 | | Flow&nbsp;Type | Default | Description |
 | --- | --- | --- | --- |
 | `action` | `()`&nbsp;`=>`&nbsp;`void` | _Required_ | The action to be invoked when the interval period occurs. |
@@ -219,6 +220,9 @@ Unless indicated otherwise, all timeouts scheduled this way will be cleared on c
         resolveOnClear?: boolean,
     ): IAnimationFrame;
 ```
+
+The `animationFrame` function replaces the `requestAnimationFrame` and `cancelAnimationFrame` functions
+in the standard timer API.
 
 | | Flow&nbsp;Type | Default | Description |
 | --- | --- | --- | --- |

--- a/packages/wonder-blocks-timing/docs.md
+++ b/packages/wonder-blocks-timing/docs.md
@@ -12,9 +12,8 @@ The following component, `MyNaughtyComponent`, will keep spamming our pretend
 log even after it was unmounted.
 
 ```jsx
-const Button = require("@khanacademy/wonder-blocks-button").default;
-const {IDProvider, View} = require("@khanacademy/wonder-blocks-core");
-
+import Button from "@khanacademy/wonder-blocks-button";
+import {IDProvider, View} from "@khanacademy/wonder-blocks-core";
 
 class Unmounter extends React.Component {
     constructor() {
@@ -84,10 +83,9 @@ But if we use `withActionScheduler` and the `interval` method, everything is
 just fine. Unmount the component, and the logging stops.
 
 ```jsx
-const {withActionScheduler} = require("@khanacademy/wonder-blocks-timing");
-const Button = require("@khanacademy/wonder-blocks-button").default;
-const {IDProvider, View} = require("@khanacademy/wonder-blocks-core");
-
+import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
+import Button from "@khanacademy/wonder-blocks-button";
+import {IDProvider, View} from "@khanacademy/wonder-blocks-core";
 
 class Unmounter extends React.Component {
     constructor() {

--- a/packages/wonder-blocks-timing/generated-snapshot.test.js
+++ b/packages/wonder-blocks-timing/generated-snapshot.test.js
@@ -8,13 +8,12 @@ import renderer from "react-test-renderer";
 
 // Mock react-dom as jest doesn't like findDOMNode.
 jest.mock("react-dom");
+import Button from "@khanacademy/wonder-blocks-button";
+import {IDProvider, View} from "@khanacademy/wonder-blocks-core";
+import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
 
 describe("wonder-blocks-timing", () => {
     it("example 1", () => {
-        const Button = require("@khanacademy/wonder-blocks-button").default;
-
-        const {IDProvider, View} = require("@khanacademy/wonder-blocks-core");
-
         class Unmounter extends React.Component {
             constructor() {
                 super();
@@ -84,14 +83,6 @@ describe("wonder-blocks-timing", () => {
     });
 
     it("example 2", () => {
-        const {
-            withActionScheduler,
-        } = require("@khanacademy/wonder-blocks-timing");
-
-        const Button = require("@khanacademy/wonder-blocks-button").default;
-
-        const {IDProvider, View} = require("@khanacademy/wonder-blocks-core");
-
         class Unmounter extends React.Component {
             constructor() {
                 super();

--- a/packages/wonder-blocks-timing/package.json
+++ b/packages/wonder-blocks-timing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khanacademy/wonder-blocks-timing",
-  "private": true,
+  "private": false,
   "version": "0.0.3",
   "design": "v1",
   "publishConfig": {

--- a/packages/wonder-blocks-timing/package.json
+++ b/packages/wonder-blocks-timing/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.3",
   "design": "v1",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "description": "",
   "main": "dist/index.js",

--- a/packages/wonder-blocks-timing/util/types.js
+++ b/packages/wonder-blocks-timing/util/types.js
@@ -65,7 +65,7 @@ export interface IInterval {
      * Set the interval.
      *
      * If the interval is active, this cancels that interval and restarts it
-     * afresh. If the timeout is not active, this starts the interval.
+     * afresh. If the interval is not active, this starts the interval.
      *
      * @memberof IInterval
      */
@@ -154,10 +154,10 @@ export interface IScheduleActions {
      * This value must be greater than or equal to zero.
      * @param {boolean} [autoSchedule] Whether or not to set the timeout as soon
      * as this call is made, or wait until `set` is explicitly called. Defaults
-     * to true.
+     * to `true`.
      * @param {boolean} [resolveOnClear] Whether or not the associated action
      * will be invoked if it is still pending at the point the timeout is
-     * cleared. Defaults to false.
+     * cleared. Defaults to `false`.
      * @returns {ITimeout} A interface for manipulating the created timeout.
      * @memberof IScheduleActions
      */
@@ -174,18 +174,18 @@ export interface IScheduleActions {
      * An interval will invoke a given action each time the given period has
      * passed until the interval is cleared.
      *
-     * @param {() => void} action The action to be invoked when the timeout
-     * period is reached.
+     * @param {() => void} action The action to be invoked when the interval
+     * period occurs.
      * @param {number} period The interval period in milliseconds. The action
      * will be invoked each time this period has passed since the interval was
      * set or last occurred.
      * This value must be greater than zero.
      * @param {boolean} [autoSchedule] Whether or not to set the interval as soon
      * as this call is made, or wait until `set` is explicitly called. Defaults
-     * to true.
+     * to `true`.
      * @param {boolean} [resolveOnClear] Whether or not the associated action
      * will be invoked at the point the interval is cleared if the interval
-     * is running at that time. Defaults to false.
+     * is running at that time. Defaults to `false`.
      * @returns {IInterval} An interface for manipulating the created interval.
      * @memberof IScheduleActions
      */
@@ -206,10 +206,10 @@ export interface IScheduleActions {
      * @param {() => void} action The action to be invoked before the repaint.
      * @param {boolean} [autoSchedule] Whether or not to make the request as soon
      * as this call is made, or wait until `set` is explicitly called. Defaults
-     * to true.
+     * to `true`.
      * @param {boolean} [resolveOnClear] Whether or not the associated action
      * will be invoked at the point the request is cleared if it has not yet
-     * executed. Defaults to false.
+     * executed. Defaults to `false`.
      * @returns {IAnimationFrame} An interface for manipulating the created
      * request.
      * @memberof IScheduleActions

--- a/utils/gen-snapshot-tests.js
+++ b/utils/gen-snapshot-tests.js
@@ -290,7 +290,19 @@ function readExamplesFromDocument(documentPath) {
     const content = fs.readFileSync(documentPath, "utf8");
     const tokens = marked.lexer(content);
     const examples = tokens
+        /**
+         * We only want code snippets.
+         */
         .filter((token) => token.type === "code")
+        /**
+         * Any snippet that doesn't have a language is not something we want
+         * here.
+         *
+         * NOTE(somewhatabstract): Long term, we should probably check for
+         * js/jsx etc. so that we don't try to compile examples from bash
+         * scripts or CSS snippets, etc.
+         */
+        .filter((token) => token.lang)
         .map((token) => token.text);
 
     return examples;


### PR DESCRIPTION
Closes WB-591.

This makes the following changes:

1. Makes the Wonder Blocks Timing package public
2. Adds detailed documentation for the Timing API, including migration example
3. Updates the snapshot generation to cope with static code examples (so that they aren't compiled for snapshot testing)