### PR TITLE
[feature:modal] WB-636 Add testId prop to modal elements

### DIFF
--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -1057,6 +1057,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
       <div
         aria-labelledby="uid-modal-1-wb-id"
         className=""
+        data-test-id="one-pane-dialog-above"
         role="dialog"
         style={
           Object {
@@ -1081,6 +1082,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
       >
         <div
           className=""
+          data-test-id="one-pane-dialog-above-ModalPanel"
           style={
             Object {
               "alignItems": "stretch",
@@ -1106,6 +1108,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
           <button
             aria-label="Close modal"
             className=""
+            data-test-id="one-pane-dialog-above-CloseButton"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -1174,6 +1177,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
           </button>
           <div
             className=""
+            data-test-id="one-pane-dialog-above-ModalHeader"
             style={
               Object {
                 "alignItems": "stretch",
@@ -1195,6 +1199,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
           >
             <h3
               className=""
+              data-test-id="one-pane-dialog-above-ModalHeader-title"
               id="uid-modal-1-wb-id"
               style={
                 Object {
@@ -1220,6 +1225,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
             </h3>
             <span
               className=""
+              data-test-id="one-pane-dialog-above-ModalHeader-subtitle"
               style={
                 Object {
                   "MozOsxFontSmoothing": "grayscale",

--- a/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__snapshots__/generated-snapshot.test.js.snap
@@ -1082,7 +1082,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
       >
         <div
           className=""
-          data-test-id="one-pane-dialog-above-ModalPanel"
+          data-test-id="one-pane-dialog-above-panel"
           style={
             Object {
               "alignItems": "stretch",
@@ -1108,7 +1108,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
           <button
             aria-label="Close modal"
             className=""
-            data-test-id="one-pane-dialog-above-CloseButton"
+            data-test-id="one-pane-dialog-above-close"
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}

--- a/packages/wonder-blocks-modal/components/close-button.js
+++ b/packages/wonder-blocks-modal/components/close-button.js
@@ -20,11 +20,24 @@ type Props = {|
 
     /** Optional custom styles. */
     style?: StyleType,
+
+    /**
+     * Test ID used for e2e testing.
+     *
+     * In this case, this component is internal, so `testId` is composed with
+     * the `testId` passed down from the Dialog variant + a suffix to scope it
+     * to this component.
+     *
+     * @example
+     * For testId="some-random-id"
+     * The result will be: `some-random-id-modal-panel`
+     */
+    testId?: string,
 |};
 
 export default class CloseButton extends React.Component<Props> {
     render() {
-        const {light, onClick, style} = this.props;
+        const {light, onClick, style, testId} = this.props;
 
         return (
             <ModalContext.Consumer>
@@ -45,6 +58,7 @@ export default class CloseButton extends React.Component<Props> {
                             kind={light ? "primary" : "tertiary"}
                             light={light}
                             style={style}
+                            testId={testId}
                         />
                     );
                 }}

--- a/packages/wonder-blocks-modal/components/close-button.test.js
+++ b/packages/wonder-blocks-modal/components/close-button.test.js
@@ -1,11 +1,16 @@
 // @flow
 import * as React from "react";
 
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 import expectRenderError from "../../../utils/testing/expect-render-error.js";
 import CloseButton from "./close-button.js";
 import ModalContext from "./modal-context.js";
 
 describe("CloseButton", () => {
+    beforeEach(() => {
+        unmountAll();
+    });
+
     test("ModalContext.Provider and onClose should warn", () => {
         expectRenderError(
             <ModalContext.Provider value={{closeModal: () => {}}}>
@@ -13,5 +18,20 @@ describe("CloseButton", () => {
             </ModalContext.Provider>,
             "You've specified 'onClose' on a modal when using ModalLauncher.  Please specify 'onClose' on the ModalLauncher instead",
         );
+    });
+
+    test("testId should be set in the Icon element", () => {
+        // Arrange
+        const wrapper = mount(
+            <ModalContext.Provider value={{closeModal: () => {}}}>
+                <CloseButton testId="modal-example-close" />,
+            </ModalContext.Provider>,
+        );
+
+        // Act
+        const closeButton = wrapper.find(CloseButton);
+
+        // Assert
+        expect(closeButton.prop("testId")).toBe("modal-example-close");
     });
 });

--- a/packages/wonder-blocks-modal/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/components/modal-backdrop.js
@@ -17,6 +17,11 @@ type Props = {|
      * When not set, the first tabbable element within the dialog will be used.
      */
     initialFocusId?: string,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 /**
@@ -116,7 +121,7 @@ export default class ModalBackdrop extends React.Component<Props> {
     };
 
     render() {
-        const children = this.props.children;
+        const {children, testId} = this.props;
         const backdropProps = {
             [ModalLauncherPortalAttributeName]: true,
         };
@@ -125,6 +130,7 @@ export default class ModalBackdrop extends React.Component<Props> {
             <View
                 style={styles.modalPositioner}
                 onClick={this.handleClick}
+                testId={testId}
                 {...backdropProps}
             >
                 {children}

--- a/packages/wonder-blocks-modal/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/components/modal-dialog.js
@@ -36,6 +36,11 @@ type Props = {|
      * Custom styles
      */
     style?: StyleType,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 /**
@@ -55,6 +60,7 @@ export default class ModalDialog extends React.Component<Props> {
             below,
             style,
             children,
+            testId,
             "aria-labelledby": ariaLabelledBy,
         } = this.props;
 
@@ -73,6 +79,7 @@ export default class ModalDialog extends React.Component<Props> {
                                 role="dialog"
                                 aria-labelledby={ariaLabelledBy}
                                 style={styles.dialog}
+                                testId={testId}
                             >
                                 {children}
                             </View>

--- a/packages/wonder-blocks-modal/components/modal-header.js
+++ b/packages/wonder-blocks-modal/components/modal-header.js
@@ -29,6 +29,19 @@ type Common = {|
     titleId: string,
 
     /**
+     * Test ID used for e2e testing.
+     *
+     * In this case, this component is internal, so `testId` is composed with
+     * the `testId` passed down from the Dialog variant + a suffix to scope it
+     * to this component.
+     *
+     * @example
+     * For testId="some-random-id"
+     * The result will be: `some-random-id-modal-header`
+     */
+    testId?: string,
+
+    /**
      * Without these, flow complains about subtitle and breadcrumbs not being
      * available on props at all b/c these are exact object types, flow looks
      * for subtitle in each of Common, WithSubtitle and WithBreadcrumbs. I also
@@ -60,27 +73,36 @@ type WithBreadcrumbs = {|
 type Props = Common | WithSubtitle | WithBreadcrumbs;
 
 /**
- * This is a helper component that is never rendered by itself.
- * It is always pinned to the top of the dialog, is responsive using the same behavior as its parent dialog,
- * and has the following properties:
+ * This is a helper component that is never rendered by itself. It is always
+ * pinned to the top of the dialog, is responsive using the same behavior as its
+ * parent dialog, and has the following properties:
  * - title
  * - breadcrumb OR subtitle, but not both.
  *
  * **Accessibility notes:**
  *
- * - By default (e.g. using [OnePaneDialog](/#onepanedialog)), `titleId` is populated automatically by the parent container.
- * - If there is a custom Dialog implementation (e.g. `TwoPaneDialog`), the ModalHeader doesn’t have to have
- * the `titleId` prop however this is recommended. It should match the `aria-labelledby` prop of the [ModalDialog](/#modaldialog) component.
- * If you want to see an example of how to generate this ID, check [IDProvider](/#idprovider).
+ * - By default (e.g. using [OnePaneDialog](/#onepanedialog)), `titleId` is
+ *   populated automatically by the parent container.
+ * - If there is a custom Dialog implementation (e.g. `TwoPaneDialog`), the
+ *   ModalHeader doesn’t have to have the `titleId` prop however this is
+ *   recommended. It should match the `aria-labelledby` prop of the
+ *   [ModalDialog](/#modaldialog) component. If you want to see an example of
+ *   how to generate this ID, check [IDProvider](/#idprovider).
  *
  * **Implementation notes:**
  *
  * If you are creating a custom Dialog, make sure to follow these guidelines:
- * - Make sure to include it as part of [ModalPanel](/#modalpanel) by using the `header` prop.
+ * - Make sure to include it as part of [ModalPanel](/#modalpanel) by using the
+ *   `header` prop.
  * - Add a title (required).
  * - Optionally add a subtitle or breadcrumbs.
  * - We encourage you to add `titleId` (see Accessibility notes).
- * - If the `ModalPanel` has a dark background, make sure to set `light` to `false`.
+ * - If the `ModalPanel` has a dark background, make sure to set `light` to
+ *   `false`.
+ * - If you need to create e2e tests, make sure to pass a `testId` prop and
+ *   add a sufix to scope the testId to this component: e.g.
+ *   `some-random-id-ModalHeader`. This scope will also be passed to the title
+ *   and subtitle elements: e.g. `some-random-id-ModalHeader-title`.
  *
  * Example:
  *
@@ -99,7 +121,14 @@ export default class ModalHeader extends React.Component<Props> {
     };
 
     render() {
-        const {breadcrumbs, light, subtitle, title, titleId} = this.props;
+        const {
+            breadcrumbs,
+            light,
+            subtitle,
+            testId,
+            title,
+            titleId,
+        } = this.props;
 
         if (subtitle && breadcrumbs) {
             throw new Error(
@@ -110,15 +139,26 @@ export default class ModalHeader extends React.Component<Props> {
         return (
             <MediaLayout styleSheets={styleSheets}>
                 {({styles}) => (
-                    <View style={[styles.header, !light && styles.dark]}>
+                    <View
+                        style={[styles.header, !light && styles.dark]}
+                        testId={testId}
+                    >
                         {breadcrumbs && (
                             <View style={styles.breadcrumbs}>
                                 {breadcrumbs}
                             </View>
                         )}
-                        <HeadingMedium id={titleId}>{title}</HeadingMedium>
+                        <HeadingMedium
+                            id={titleId}
+                            testId={testId && `${testId}-title`}
+                        >
+                            {title}
+                        </HeadingMedium>
                         {subtitle && (
-                            <LabelMedium style={light && styles.subtitle}>
+                            <LabelMedium
+                                style={light && styles.subtitle}
+                                testId={testId && `${testId}-subtitle`}
+                            >
                                 {subtitle}
                             </LabelMedium>
                         )}

--- a/packages/wonder-blocks-modal/components/modal-header.test.js
+++ b/packages/wonder-blocks-modal/components/modal-header.test.js
@@ -6,6 +6,8 @@ import {
     Breadcrumbs,
     BreadcrumbsItem,
 } from "@khanacademy/wonder-blocks-breadcrumbs";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
+
 import ModalHeader from "./modal-header.js";
 
 const exampleBreadcrumbs: React.Element<typeof Breadcrumbs> = (
@@ -15,6 +17,10 @@ const exampleBreadcrumbs: React.Element<typeof Breadcrumbs> = (
 );
 
 describe("ModalHeader", () => {
+    beforeEach(() => {
+        unmountAll();
+    });
+
     test("renders the title by default", () => {
         // Arrange, Act
         const wrapper = shallow(
@@ -51,5 +57,29 @@ describe("ModalHeader", () => {
 
         // Assert
         expect(wrapper.exists()).toBe(true);
+    });
+
+    test("renders the title by default", () => {
+        // Arrange
+        const wrapper = mount(
+            <ModalHeader
+                title="Title"
+                subtitle="Subtitle"
+                testId="test-example-header"
+                titleId="modal-title"
+            />,
+        );
+
+        // Act
+        const title = wrapper.find(
+            `[data-test-id="test-example-header-title"]`,
+        );
+        const subtitle = wrapper.find(
+            `[data-test-id="test-example-header-subtitle"]`,
+        );
+
+        // Assert
+        expect(title).toHaveLength(1);
+        expect(subtitle).toHaveLength(1);
     });
 });

--- a/packages/wonder-blocks-modal/components/modal-header.test.js
+++ b/packages/wonder-blocks-modal/components/modal-header.test.js
@@ -59,7 +59,7 @@ describe("ModalHeader", () => {
         expect(wrapper.exists()).toBe(true);
     });
 
-    test("renders the title by default", () => {
+    test("testId should be added to the title", () => {
         // Arrange
         const wrapper = mount(
             <ModalHeader
@@ -74,12 +74,28 @@ describe("ModalHeader", () => {
         const title = wrapper.find(
             `[data-test-id="test-example-header-title"]`,
         );
+
+        // Assert
+        expect(title).toHaveLength(1);
+    });
+
+    test("testId should be added to the subtitle", () => {
+        // Arrange
+        const wrapper = mount(
+            <ModalHeader
+                title="Title"
+                subtitle="Subtitle"
+                testId="test-example-header"
+                titleId="modal-title"
+            />,
+        );
+
+        // Act
         const subtitle = wrapper.find(
             `[data-test-id="test-example-header-subtitle"]`,
         );
 
         // Assert
-        expect(title).toHaveLength(1);
         expect(subtitle).toHaveLength(1);
     });
 });

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -63,6 +63,11 @@ type Props = {|
      * When not set, the first tabbable element within the dialog will be used.
      */
     initialFocusId?: string,
+
+    /**
+     * Test ID used for e2e testing. It's set on the ModalBackdrop
+     */
+    testId?: string,
 |};
 
 type State = {|
@@ -179,6 +184,7 @@ export default class ModalLauncher extends React.Component<Props, State> {
                         <FocusTrap style={styles.container}>
                             <ModalBackdrop
                                 initialFocusId={this.props.initialFocusId}
+                                testId={this.props.testId}
                                 onCloseModal={
                                     this.props.backdropDismissEnabled
                                         ? this.handleCloseModal

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -275,4 +275,22 @@ describe("ModalLauncher", () => {
         // Assert
         expect(document.activeElement).toBe(lastButton);
     });
+
+    test("testId should be added to the Backdrop", () => {
+        // Arrange
+        const wrapper = mount(
+            <ModalLauncher
+                opened={true}
+                onClose={jest.fn()}
+                modal={<div role="dialog">dialog</div>}
+                testId="test-id-example"
+            />,
+        );
+
+        // Act
+        const backdrop = wrapper.find("[data-modal-launcher-portal]").first();
+
+        // Assert
+        expect(backdrop.prop("testId")).toBe("test-id-example");
+    });
 });

--- a/packages/wonder-blocks-modal/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.js
@@ -135,14 +135,14 @@ export default class ModalPanel extends React.Component<Props> {
         return (
             <View
                 style={[styles.wrapper, !light && styles.dark, style]}
-                testId={testId && `${testId}-ModalPanel`}
+                testId={testId && `${testId}-panel`}
             >
                 {closeButtonVisible && (
                     <CloseButton
                         light={!light}
                         onClick={onClose}
                         style={styles.closeButton}
-                        testId={testId && `${testId}-CloseButton`}
+                        testId={testId && `${testId}-close`}
                     />
                 )}
                 {header}

--- a/packages/wonder-blocks-modal/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.js
@@ -58,6 +58,14 @@ type Props = {|
      * to the `ModalLauncher`.  Doing so will throw an error.
      */
     onClose?: () => mixed,
+
+    /**
+     * Test ID used for e2e testing.
+     *
+     * In this case, this `testId` comes from the `testId` prop defined in the
+     * Dialog variant (e.g. OnePaneDialog).
+     */
+    testId?: string,
 |};
 
 /**
@@ -67,7 +75,12 @@ type Props = {|
  *
  * If you are creating a custom Dialog, make sure to follow these guidelines:
  * - Make sure to add this component inside the [ModalDialog](/#modaldialog).
- * - If needed, you can also add a [ModalHeader](/#modalheader) using the `header` prop. Same goes for [ModalFooter](/#modalfooter).
+ * - If needed, you can also add a [ModalHeader](/#modalheader) using the
+ *   `header` prop. Same goes for [ModalFooter](/#modalfooter).
+ * - If you need to create e2e tests, make sure to pass a `testId` prop. This
+ *   will be passed down to this component using a sufix: e.g.
+ *   `some-random-id-ModalPanel`. This scope will be propagated to the
+ *   CloseButton element as well: e.g. `some-random-id-CloseButton`.
  *
  * ```js
  * <ModalDialog>
@@ -114,17 +127,22 @@ export default class ModalPanel extends React.Component<Props> {
             light,
             onClose,
             style,
+            testId,
         } = this.props;
 
         const mainContent = this.renderMainContent();
 
         return (
-            <View style={[styles.wrapper, !light && styles.dark, style]}>
+            <View
+                style={[styles.wrapper, !light && styles.dark, style]}
+                testId={testId && `${testId}-ModalPanel`}
+            >
                 {closeButtonVisible && (
                     <CloseButton
                         light={!light}
                         onClick={onClose}
                         style={styles.closeButton}
+                        testId={testId && `${testId}-CloseButton`}
                     />
                 )}
                 {header}

--- a/packages/wonder-blocks-modal/components/modal-panel.test.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.test.js
@@ -1,11 +1,19 @@
 // @flow
 import React from "react";
 
+import {View} from "@khanacademy/wonder-blocks-core";
+
 import expectRenderError from "../../../utils/testing/expect-render-error.js";
+import {mount, unmountAll} from "../../../utils/testing/mount.js";
 import ModalPanel from "./modal-panel.js";
 import ModalContext from "./modal-context.js";
+import CloseButton from "./close-button.js";
 
 describe("ModalPanel", () => {
+    beforeEach(() => {
+        unmountAll();
+    });
+
     test("ModalContext.Provider and onClose should warn", () => {
         expectRenderError(
             <ModalContext.Provider value={{closeModal: () => {}}}>
@@ -17,5 +25,20 @@ describe("ModalPanel", () => {
             </ModalContext.Provider>,
             "You've specified 'onClose' on a modal when using ModalLauncher.  Please specify 'onClose' on the ModalLauncher instead",
         );
+    });
+
+    test("testId should be added to both ModalPanel and CloseButton elements", () => {
+        // Arrange
+        const wrapper = mount(
+            <ModalPanel content="dummy content" testId="test-id" />,
+        );
+
+        // Act
+        const mainElement = wrapper.find(View).first();
+        const closeButton = wrapper.find(CloseButton);
+
+        // Assert
+        expect(mainElement.prop("testId")).toBe("test-id-panel");
+        expect(closeButton.prop("testId")).toBe("test-id-close");
     });
 });

--- a/packages/wonder-blocks-modal/components/modal-panel.test.js
+++ b/packages/wonder-blocks-modal/components/modal-panel.test.js
@@ -27,7 +27,7 @@ describe("ModalPanel", () => {
         );
     });
 
-    test("testId should be added to both ModalPanel and CloseButton elements", () => {
+    test("testId should be added to the panel wrapper", () => {
         // Arrange
         const wrapper = mount(
             <ModalPanel content="dummy content" testId="test-id" />,
@@ -35,10 +35,21 @@ describe("ModalPanel", () => {
 
         // Act
         const mainElement = wrapper.find(View).first();
-        const closeButton = wrapper.find(CloseButton);
 
         // Assert
         expect(mainElement.prop("testId")).toBe("test-id-panel");
+    });
+
+    test("testId should be added to the CloseButton element", () => {
+        // Arrange
+        const wrapper = mount(
+            <ModalPanel content="dummy content" testId="test-id" />,
+        );
+
+        // Act
+        const closeButton = wrapper.find(CloseButton);
+
+        // Assert
         expect(closeButton.prop("testId")).toBe("test-id-close");
     });
 });

--- a/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.js
@@ -68,7 +68,7 @@ type Common = {|
     style?: StyleType,
 
     /**
-     * Test ID used for e2e testing.
+     * Test ID used for e2e testing. This ID will be passed down to the Dialog.
      */
     testId?: string,
 
@@ -121,7 +121,7 @@ export default class OnePaneDialog extends React.Component<Props> {
     };
 
     renderHeader(uniqueId: string): React.Element<typeof ModalHeader> {
-        const {title, subtitle, breadcrumbs} = this.props;
+        const {title, subtitle, breadcrumbs, testId} = this.props;
 
         if (breadcrumbs) {
             return (
@@ -139,6 +139,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                     title={title}
                     subtitle={(subtitle: string)}
                     titleId={uniqueId}
+                    testId={testId && `${testId}-ModalHeader`}
                 />
             );
         } else {
@@ -155,6 +156,7 @@ export default class OnePaneDialog extends React.Component<Props> {
             below,
             style,
             closeButtonVisible,
+            testId,
             titleId,
         } = this.props;
 
@@ -167,6 +169,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                                 style={[styles.dialog, style]}
                                 above={above}
                                 below={below}
+                                testId={testId}
                                 aria-labelledby={uniqueId}
                             >
                                 <ModalPanel
@@ -175,6 +178,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                                     content={content}
                                     footer={footer}
                                     closeButtonVisible={closeButtonVisible}
+                                    testId={testId}
                                 />
                             </ModalDialog>
                         )}

--- a/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.md
+++ b/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.md
@@ -49,6 +49,7 @@ const styles = StyleSheet.create({
         <OnePaneDialog
             title="Single-line title"
             subtitle="Subtitle that provides additional context to the title"
+            testId="one-pane-dialog-above"
             content={
                 <View style={styles.modalContent}>
                     <Body>

--- a/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.test.js
+++ b/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.test.js
@@ -1,0 +1,29 @@
+// @flow
+import * as React from "react";
+
+import {mount, unmountAll} from "../../../../utils/testing/mount.js";
+
+import OnePaneDialog from "./one-pane-dialog.js";
+
+describe("OnePaneDialog", () => {
+    beforeEach(() => {
+        unmountAll();
+    });
+
+    test("testId should be set in the Dialog element", () => {
+        // Arrange
+        const wrapper = mount(
+            <OnePaneDialog
+                title="Dialog with multi-step footer"
+                content="dummy content"
+                testId="one-pane-dialog-example"
+            />,
+        );
+
+        // Act
+        const dialog = wrapper.find(`[role="dialog"]`).first();
+
+        // Assert
+        expect(dialog.prop("testId")).toBe("one-pane-dialog-example");
+    });
+});

--- a/packages/wonder-blocks-modal/docs.md
+++ b/packages/wonder-blocks-modal/docs.md
@@ -56,6 +56,7 @@ const onePaneDialog = ({closeModal}) => (
         subtitle="You're reading the subtitle!"
         above={<View style={styles.above} />}
         below={<View style={styles.below} />}
+        testId="dialog-default-example"
         content={
             <View style={styles.modalContent}>
                 <Body tag="p">
@@ -74,7 +75,10 @@ const onePaneDialog = ({closeModal}) => (
 );
 
 <View style={styles.example}>
-    <ModalLauncher modal={onePaneDialog}>
+    <ModalLauncher
+        modal={onePaneDialog}
+        testId="modal-launcher-default-example"
+    >
         {({openModal}) => <Button onClick={openModal}>OnePaneDialog</Button>}
     </ModalLauncher>
 </View>;

--- a/packages/wonder-blocks-modal/generated-snapshot.test.js
+++ b/packages/wonder-blocks-modal/generated-snapshot.test.js
@@ -64,6 +64,7 @@ describe("wonder-blocks-modal", () => {
                 subtitle="You're reading the subtitle!"
                 above={<View style={styles.above} />}
                 below={<View style={styles.below} />}
+                testId="dialog-default-example"
                 content={
                     <View style={styles.modalContent}>
                         <Body tag="p">
@@ -79,7 +80,10 @@ describe("wonder-blocks-modal", () => {
 
         const example = (
             <View style={styles.example}>
-                <ModalLauncher modal={onePaneDialog}>
+                <ModalLauncher
+                    modal={onePaneDialog}
+                    testId="modal-launcher-default-example"
+                >
                     {({openModal}) => (
                         <Button onClick={openModal}>OnePaneDialog</Button>
                     )}
@@ -497,6 +501,7 @@ describe("wonder-blocks-modal", () => {
                     <OnePaneDialog
                         title="Single-line title"
                         subtitle="Subtitle that provides additional context to the title"
+                        testId="one-pane-dialog-above"
                         content={
                             <View style={styles.modalContent}>
                                 <Body>


### PR DESCRIPTION
## Summary
Adds the missing `testId` prop to the modal package.

## Features

### Public API
- **ModalLauncher**: Added `testId` prop to be passed down to the `ModalBackdrop` component.
- **OnePaneDialog**: Added `testId` prop to be passed down to the `ModalDialog` component.
- **ModalHeader**: Added `testId` prop to be used inside the main wrapper. Also, used for both title and subtitle elements.
    - **title**: For `<ModalHeader testId="some-id" />`, then title => e.g. `<h3 data-test-id="some-id-title" />`
    - **subtitle**: For `<ModalHeader testId="some-id" />`, then subtitle => e.g. `<h4 data-test-id="some-id-subtitle" />`
- **ModalPanel**: Added `testId` prop to be used inside the main wrapper. e.g `<div class="modal-panel" data-test-id"some-id-ModalPanel" />`

## Internal components
- CloseButton: Added `testId` prop combining the `testId` defined in the parent element + adding 
the `CloseButton` suffix => `some-id-CloseButton`.
- ModalBackdrop: Added `testId` prop combining the `testId` defined in the `ModalLauncher` + adding the `ModalBackdrop` suffix => `some-id-ModalBackdrop`.

### Test plan
1. Open https://deploy-preview-460--wonder-blocks.netlify.com/#!/Modal/1
2. Open the example source code.
3. Make sure the first example includes all the associated `testId` values.
