### PR TITLE
[docs:core] WB-394: Add docs for addStyle

### DIFF
--- a/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__snapshots__/generated-snapshot.test.js.snap
@@ -1,6 +1,207 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`wonder-blocks-core example 1 1`] = `
+<input
+  className=""
+  placeholder="Lorem ipsum"
+  style={
+    Object {
+      "background": "#ffffff",
+      "border": "1px solid rgba(33,36,44,0.16)",
+      "borderRadius": 4,
+      "fontSize": 16,
+      "padding": 8,
+    }
+  }
+  type="text"
+/>
+`;
+
+exports[`wonder-blocks-core example 2 1`] = `
+<input
+  className=""
+  placeholder="Lorem ipsum"
+  style={
+    Object {
+      "background": "rgba(217,41,22,0.16)",
+      "border": "1px solid rgba(33,36,44,0.16)",
+      "borderColor": "#d92916",
+      "borderRadius": 4,
+      "fontSize": 16,
+      "padding": 8,
+    }
+  }
+  type="text"
+/>
+`;
+
+exports[`wonder-blocks-core example 3 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className=""
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "alignItems": "flex-start",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "row",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "outline": "none",
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+      tabIndex={-1}
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className=""
+        disabled={false}
+        onChange={[Function]}
+        style={
+          Object {
+            "MozAppearance": "none",
+            "WebkitAppearance": "none",
+            "appearance": "none",
+            "backgroundColor": "#ffffff",
+            "borderColor": "rgba(33,36,44,0.50)",
+            "borderRadius": 3,
+            "borderStyle": "solid",
+            "borderWidth": 1,
+            "boxSizing": "border-box",
+            "height": 16,
+            "margin": 0,
+            "minHeight": 16,
+            "minWidth": 16,
+            "outline": "none",
+            "width": 16,
+          }
+        }
+        type="checkbox"
+      />
+      <div
+        aria-hidden="true"
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 8,
+            "MsFlexPreferredSize": 8,
+            "WebkitFlexBasis": 8,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 8,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "width": 8,
+            "zIndex": 0,
+          }
+        }
+      />
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "20px",
+            "marginTop": -2,
+            "userSelect": "none",
+          }
+        }
+      >
+        <label
+          onClick={[Function]}
+        >
+          Click here to add the error style to the input
+        </label>
+      </span>
+    </div>
+  </div>
+  <input
+    className=""
+    placeholder="Lorem ipsum"
+    style={
+      Object {
+        "border": "1px solid rgba(33,36,44,0.16)",
+        "borderRadius": 4,
+        "fontSize": 16,
+        "padding": 8,
+      }
+    }
+    type="text"
+  />
+</div>
+`;
+
+exports[`wonder-blocks-core example 4 1`] = `
 <div
   className=""
   style={
@@ -34,7 +235,7 @@ exports[`wonder-blocks-core example 1 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 2 1`] = `
+exports[`wonder-blocks-core example 5 1`] = `
 <div
   className=""
   style={
@@ -68,7 +269,7 @@ exports[`wonder-blocks-core example 2 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 3 1`] = `
+exports[`wonder-blocks-core example 6 1`] = `
 <div
   className=""
   style={
@@ -127,7 +328,7 @@ exports[`wonder-blocks-core example 3 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 4 1`] = `
+exports[`wonder-blocks-core example 7 1`] = `
 <div
   className=""
   style={
@@ -184,7 +385,7 @@ exports[`wonder-blocks-core example 4 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 5 1`] = `
+exports[`wonder-blocks-core example 8 1`] = `
 <div
   className=""
   style={
@@ -241,7 +442,7 @@ exports[`wonder-blocks-core example 5 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 6 1`] = `
+exports[`wonder-blocks-core example 9 1`] = `
 <div
   className=""
   style={
@@ -460,7 +661,7 @@ exports[`wonder-blocks-core example 6 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 7 1`] = `
+exports[`wonder-blocks-core example 10 1`] = `
 <div
   className=""
   style={
@@ -653,7 +854,7 @@ exports[`wonder-blocks-core example 7 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 8 1`] = `
+exports[`wonder-blocks-core example 11 1`] = `
 <div
   className=""
   style={
@@ -786,7 +987,7 @@ exports[`wonder-blocks-core example 8 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 9 1`] = `
+exports[`wonder-blocks-core example 12 1`] = `
 <div
   className=""
   style={
@@ -903,7 +1104,7 @@ exports[`wonder-blocks-core example 9 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 10 1`] = `
+exports[`wonder-blocks-core example 13 1`] = `
 <div
   className=""
   style={
@@ -962,7 +1163,7 @@ exports[`wonder-blocks-core example 10 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 11 1`] = `
+exports[`wonder-blocks-core example 14 1`] = `
 <div
   className=""
   style={
@@ -1019,7 +1220,7 @@ exports[`wonder-blocks-core example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 12 1`] = `
+exports[`wonder-blocks-core example 15 1`] = `
 <div
   className=""
   style={
@@ -1043,7 +1244,7 @@ exports[`wonder-blocks-core example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 13 1`] = `
+exports[`wonder-blocks-core example 16 1`] = `
 <div
   className=""
   style={
@@ -1067,7 +1268,7 @@ exports[`wonder-blocks-core example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 14 1`] = `
+exports[`wonder-blocks-core example 17 1`] = `
 <div
   className=""
   style={
@@ -1146,7 +1347,7 @@ exports[`wonder-blocks-core example 14 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-core example 15 1`] = `
+exports[`wonder-blocks-core example 18 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-core/generated-snapshot.test.js
+++ b/packages/wonder-blocks-core/generated-snapshot.test.js
@@ -8,14 +8,18 @@ import renderer from "react-test-renderer";
 
 // Mock react-dom as jest doesn't like findDOMNode.
 jest.mock("react-dom");
+import {StyleSheet} from "aphrodite";
+import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {
-    IDProvider,
+    addStyle,
     View,
+    IDProvider,
     UniqueIDProvider,
     Text,
     WithSSRPlaceholder,
 } from "@khanacademy/wonder-blocks-core";
-import {StyleSheet} from "aphrodite";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {
     Body,
     HeadingSmall,
@@ -28,6 +32,107 @@ import ClickableBehavior from "./components/clickable-behavior.js";
 
 describe("wonder-blocks-core", () => {
     it("example 1", () => {
+        const styles = StyleSheet.create({
+            // default style for all instances of StyledInput
+            input: {
+                background: Color.white,
+                border: `1px solid ${Color.offBlack16}`,
+                borderRadius: Spacing.xxxSmall,
+                fontSize: Spacing.medium,
+                padding: Spacing.xSmall,
+            },
+        });
+        const StyledInput = addStyle("input", styles.input);
+        const example = <StyledInput type="text" placeholder="Lorem ipsum" />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 2", () => {
+        const styles = StyleSheet.create({
+            // default style for all instances of StyledInput
+            input: {
+                background: Color.white,
+                border: `1px solid ${Color.offBlack16}`,
+                borderRadius: Spacing.xxxSmall,
+                fontSize: Spacing.medium,
+                padding: Spacing.xSmall,
+            },
+            error: {
+                background: fade(Color.red, 0.16),
+                borderColor: Color.red,
+            },
+        });
+        const StyledInput = addStyle("input", styles.input);
+        const example = (
+            <StyledInput
+                style={styles.error}
+                type="text"
+                placeholder="Lorem ipsum"
+            />
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 3", () => {
+        const StyledInput = addStyle("input");
+
+        class DynamicStyles extends React.Component {
+            constructor() {
+                super();
+                this.state = {
+                    error: false,
+                };
+                this.handleChange = this.handleChange.bind(this);
+            }
+
+            handleChange(checked) {
+                this.setState({
+                    error: checked,
+                });
+            }
+
+            render() {
+                return (
+                    <View>
+                        <Checkbox
+                            label="Click here to add the error style to the input"
+                            checked={this.state.error}
+                            onChange={this.handleChange}
+                        />
+                        <StyledInput
+                            style={[
+                                styles.input,
+                                this.state.error && styles.error,
+                            ]}
+                            type="text"
+                            placeholder="Lorem ipsum"
+                        />
+                    </View>
+                );
+            }
+        }
+
+        const styles = StyleSheet.create({
+            // default style for all instances of StyledInput
+            input: {
+                border: `1px solid ${Color.offBlack16}`,
+                borderRadius: Spacing.xxxSmall,
+                fontSize: Spacing.medium,
+                padding: Spacing.xSmall,
+            },
+            error: {
+                background: fade(Color.red, 0.16),
+                borderColor: Color.red,
+            },
+        });
+        const example = <DynamicStyles />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 4", () => {
         const example = (
             <View>
                 <IDProvider scope="field">
@@ -44,7 +149,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 2", () => {
+    it("example 5", () => {
         const example = (
             <View>
                 <IDProvider scope="field" id="some-user-id">
@@ -61,7 +166,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 3", () => {
+    it("example 6", () => {
         const styles = StyleSheet.create({
             container: {
                 padding: 32,
@@ -92,7 +197,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 4", () => {
+    it("example 7", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -106,7 +211,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 5", () => {
+    it("example 8", () => {
         const example = (
             <View>
                 <View testId="foo">Foo</View>
@@ -117,7 +222,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 6", () => {
+    it("example 9", () => {
         let providerRef = null;
         const renders = [];
         const provider = (
@@ -165,7 +270,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 7", () => {
+    it("example 10", () => {
         let firstId = null;
         let secondId = null;
 
@@ -202,7 +307,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 8", () => {
+    it("example 11", () => {
         const children = ({get}) => (
             <View>
                 <Body>
@@ -227,7 +332,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 9", () => {
+    it("example 12", () => {
         // TODO(somewhatabstract): Update this to be nice once we can get BodyMonospace
         // to allow us to properly preserve whitespace or have an alternative. Or remove
         // this entirely when our styleguide renders our interface definitions.
@@ -251,7 +356,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 10", () => {
+    it("example 13", () => {
         const styles = StyleSheet.create({
             container: {
                 padding: 32,
@@ -282,7 +387,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 11", () => {
+    it("example 14", () => {
         const example = (
             <View>
                 <View onClick={() => alert("Clicked!")}>Click me!</View>
@@ -296,7 +401,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 12", () => {
+    it("example 15", () => {
         const example = (
             <WithSSRPlaceholder
                 placeholder={() => (
@@ -318,7 +423,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 13", () => {
+    it("example 16", () => {
         const example = (
             <WithSSRPlaceholder placeholder={null}>
                 {() => (
@@ -333,7 +438,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 14", () => {
+    it("example 17", () => {
         const trackingArray = [];
         const resultsId = "nossr-example-2-results";
 
@@ -411,7 +516,7 @@ describe("wonder-blocks-core", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 15", () => {
+    it("example 18", () => {
         const trackingArray = [];
         const resultsId = "nossr-example-3-results";
 

--- a/packages/wonder-blocks-core/util/add-style.md
+++ b/packages/wonder-blocks-core/util/add-style.md
@@ -14,10 +14,10 @@ addStyle(
 ): React.Element;
 ```
 
-The `addStyle` function is a HOC returns a **React Component** or a **DOM**
+The `addStyle` function is a HOC that accepts a **React Component** or a **DOM**
 **intrinsic** ("div", "span", etc.) as its first argument and optional default
-styles as its second argument. This HOC returns a React Element with a `style`
-prop included ready to be rendered.
+styles as its second argument. This HOC returns a **React Component** with a
+`style` prop included ready to be rendered.
 
 #### Function arguments
 
@@ -39,6 +39,9 @@ export type StyleType =
     | Falsy
     | NestedArray<CSSProperties | Falsy>;
 ```
+
+**Note:** `StyleType` can contain a combination of style rules from an Aphrodite
+StyleSheet as well inline style objects (see example 4).
 
 #### CSSProperties
 
@@ -220,50 +223,28 @@ class CustomComponent extends React.Component {
 const styles = StyleSheet.create({
     // default styles
     default: {
-        background: Color.lightBlue,
+        background: Color.white,
         color: Color.white,
-        padding: Spacing.xxLarge,
+        padding: Spacing.medium,
     },
     // style to be passed as a prop
     customStyle: {
-        background: Color.darkBlue,
+        background: Color.lightBlue,
     },
 });
 
-class UsingStyleExample extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            showCustomStyle: false,
-        };
-        this.handleChange = this.handleChange.bind(this);
-    }
+<CustomComponent
+    style={[
+        // you can pass style rules from an Aphrodite StyleSheet
+        styles.customStyle,
+        // and pass inline styles as well
+        {
+            border: `1px solid ${Color.darkBlue}`,
+            padding: Spacing.xxLarge,
+        }
+    ]}
+/>
 
-    handleChange(checked) {
-        this.setState({
-            showCustomStyle: checked,
-        });
-    }
-
-    render() {
-        return (
-            <View>
-                <Checkbox
-                    label="Click here to toggle the custom style inside the custom component"
-                    checked={this.state.showCustomStyle}
-                    onChange={this.handleChange}
-                    style={{
-                        marginBottom: Spacing.medium,
-                    }}
-                />
-                <CustomComponent
-                    style={this.state.showCustomStyle && styles.customStyle}
-                />
-            </View>
-        );
-    }
-}
-<UsingStyleExample />
 ```
 
 **Warning:** In the case of React components from other packages, they may not

--- a/packages/wonder-blocks-core/util/add-style.md
+++ b/packages/wonder-blocks-core/util/add-style.md
@@ -1,0 +1,130 @@
+Adds a `style` property to components. A component can be either a custom React
+Component (e.g. Link, Button) or a JSX intrinsic (e.g. "div", "span").
+This helps you to manipulate and extend styles more easily by using the `styles`
+prop as an array of different style objects.
+
+### Example: Adding default styles
+
+You can create a new styled component by using the `addStyle` function. Note
+here that you can also define default styles for this component by passing an
+initial style object to this function.
+
+```jsx
+import {StyleSheet} from "aphrodite";
+import Color from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
+
+const styles = StyleSheet.create({
+    // default style for all instances of StyledInput
+    input: {
+        background: Color.white,
+        border: `1px solid ${Color.offBlack16}`,
+        borderRadius: Spacing.xxxSmall,
+        fontSize: Spacing.medium,
+        padding: Spacing.xSmall,
+    }
+});
+
+const StyledInput = addStyle("input", styles.input);
+
+<StyledInput type="text" placeholder="Lorem ipsum"/>;
+```
+
+### Example: Overriding a default style
+
+After defining default styles, you can also customize the instance by adding
+and/or merging styles using the `style` prop in your newly created styled component.
+
+```jsx
+import {StyleSheet} from "aphrodite";
+import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
+
+const styles = StyleSheet.create({
+    // default style for all instances of StyledInput
+    input: {
+        background: Color.white,
+        border: `1px solid ${Color.offBlack16}`,
+        borderRadius: Spacing.xxxSmall,
+        fontSize: Spacing.medium,
+        padding: Spacing.xSmall,
+    },
+    error: {
+        background: fade(Color.red, 0.16),
+        borderColor: Color.red,
+    }
+});
+
+const StyledInput = addStyle("input", styles.input);
+
+<StyledInput style={styles.error} type="text" placeholder="Lorem ipsum"/>;
+```
+
+### Example: Adding styles dynamically
+
+This example shows that you can dynamically create styles by adding them to the
+`style` prop only when you need them.
+
+```jsx
+import {StyleSheet} from "aphrodite";
+import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+
+const StyledInput = addStyle("input");
+
+class DynamicStyles extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            error: false,
+        };
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(checked) {
+        this.setState({
+            error: checked,
+        });
+    }
+
+    render() {
+        return (
+            <View>
+                <Checkbox
+                    label="Click here to add the error style to the input"
+                    checked={this.state.error}
+                    onChange={this.handleChange}
+                />
+                <StyledInput
+                    style={[
+                        styles.input,
+                        this.state.error && styles.error,
+                    ]}
+                    type="text"
+                    placeholder="Lorem ipsum"
+                />
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    // default style for all instances of StyledInput
+    input: {
+        border: `1px solid ${Color.offBlack16}`,
+        borderRadius: Spacing.xxxSmall,
+        fontSize: Spacing.medium,
+        padding: Spacing.xSmall,
+    },
+    error: {
+        background: fade(Color.red, 0.16),
+        borderColor: Color.red,
+    },
+});
+
+<DynamicStyles />
+```

--- a/packages/wonder-blocks-core/util/add-style.md
+++ b/packages/wonder-blocks-core/util/add-style.md
@@ -1,9 +1,46 @@
-Adds a `style` property to components. A component can be either a custom React
-Component (e.g. Link, Button) or a JSX intrinsic (e.g. "div", "span").
-This helps you to manipulate and extend styles more easily by using the `styles`
-prop as an array of different style objects.
+Adds a `style` property to a component. A component can be either a custom React
+Component (e.g. Link, Button) or a DOM intrinsic (e.g. "div", "span"). This
+helps you to manipulate and extend styles more easily by using the `styles`
+prop. For more context on this, check the [StyleType](#styletype) type
+definition below.
 
-### Example: Adding default styles
+### Usage
+
+```js static
+addStyle(
+    Component: React.Element | "string",
+    defaultStyle?: StyleType
+): React.Element;
+```
+
+The `addStyle` function is a HOC that accepts a **React Component** or a **DOM**
+**intrinsic** ("div", "span", etc.) as its first argument and optional default
+styles as its second argument. This HOC returns a React Element with a `style`
+prop included ready to be rendered.
+
+#### Function arguments
+
+| Argument | Flow&nbsp;Type | Default | Description |
+| --- | --- | --- | --- |
+| `Component` | `React.Element`, `string` | _Required_ | The component that will be decorated. |
+| `defaultStyle` | `StyleType` | null | The initial styles to be applied. |
+
+### Types
+
+#### StyleType
+
+```js static
+CSSProperties | Falsy | Array<CSSProperties | Falsy>
+```
+
+#### CSSProperties
+
+[See source file](https://github.com/Khan/wonder-blocks/blob/master/flow-typed/aphrodite.flow.js#L13)
+
+
+### Examples
+
+#### 1. Adding default styles
 
 You can create a new styled component by using the `addStyle` function. Note
 here that you can also define default styles for this component by passing an
@@ -31,7 +68,7 @@ const StyledInput = addStyle("input", styles.input);
 <StyledInput type="text" placeholder="Lorem ipsum"/>;
 ```
 
-### Example: Overriding a default style
+#### 2. Overriding a default style
 
 After defining default styles, you can also customize the instance by adding
 and/or merging styles using the `style` prop in your newly created styled component.
@@ -62,7 +99,7 @@ const StyledInput = addStyle("input", styles.input);
 <StyledInput style={styles.error} type="text" placeholder="Lorem ipsum"/>;
 ```
 
-### Example: Adding styles dynamically
+#### 3. Adding styles dynamically
 
 This example shows that you can dynamically create styles by adding them to the
 `style` prop only when you need them.

--- a/packages/wonder-blocks-core/util/add-style.md
+++ b/packages/wonder-blocks-core/util/add-style.md
@@ -1,8 +1,9 @@
-Adds a `style` property to a component. A component can be either a custom React
-Component (e.g. Link, Button) or a DOM intrinsic (e.g. "div", "span"). This
-helps you to manipulate and extend styles more easily by using the `styles`
-prop. For more context on this, check the [StyleType](#styletype) type
-definition below.
+Adds a `style` property to a component. A component can be a Wonder Blocks
+Component (e.g. Link, Button), a custom React Component (see example 4. Using
+the `Style` prop) or
+a DOM intrinsic (e.g. "div", "span"). This helps you to manipulate and extend
+styles more easily by using the `styles` prop. For more context on this, check
+the [StyleType](#styletype) type definition below.
 
 ### Usage
 
@@ -13,7 +14,7 @@ addStyle(
 ): React.Element;
 ```
 
-The `addStyle` function is a HOC that accepts a **React Component** or a **DOM**
+The `addStyle` function is a HOC returns a **React Component** or a **DOM**
 **intrinsic** ("div", "span", etc.) as its first argument and optional default
 styles as its second argument. This HOC returns a React Element with a `style`
 prop included ready to be rendered.
@@ -30,7 +31,13 @@ prop included ready to be rendered.
 #### StyleType
 
 ```js static
-CSSProperties | Falsy | Array<CSSProperties | Falsy>
+type NestedArray<T> = $ReadOnlyArray<T | NestedArray<T>>;
+type Falsy = false | 0 | null | void;
+
+export type StyleType =
+    | CSSProperties
+    | Falsy
+    | NestedArray<CSSProperties | Falsy>;
 ```
 
 #### CSSProperties
@@ -71,7 +78,8 @@ const StyledInput = addStyle("input", styles.input);
 #### 2. Overriding a default style
 
 After defining default styles, you can also customize the instance by adding
-and/or merging styles using the `style` prop in your newly created styled component.
+and/or merging styles using the `style` prop in your newly created styled
+component.
 
 ```jsx
 import {StyleSheet} from "aphrodite";
@@ -165,3 +173,99 @@ const styles = StyleSheet.create({
 
 <DynamicStyles />
 ```
+
+#### 4. Using the `style` prop
+
+There are some cases where you don't need to use `addStyle`. For example, if you
+need to create a custom component that is using a Wonder Blocks component, you
+can create a `style` prop and pass it down to the WB component itself.
+
+**NOTE:** Make sure to import the `StyleType` type definition and assign it to
+the prop:
+
+```js static
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+type Props = {
+    style: StyleType,
+    // add the other props here
+};
+```
+
+```jsx
+import {StyleSheet} from "aphrodite";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {Title} from "@khanacademy/wonder-blocks-typography";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+
+// you'll need to import the type definition here
+// import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+class CustomComponent extends React.Component {
+    render() {
+        return (
+            <View style={[
+                styles.default,
+                // this `style` prop should be of type `StyleType`
+                this.props.style,
+            ]}>
+                <Title>Lorem ipsum</Title>
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    // default styles
+    default: {
+        background: Color.lightBlue,
+        color: Color.white,
+        padding: Spacing.xxLarge,
+    },
+    // style to be passed as a prop
+    customStyle: {
+        background: Color.darkBlue,
+    },
+});
+
+class UsingStyleExample extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            showCustomStyle: false,
+        };
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(checked) {
+        this.setState({
+            showCustomStyle: checked,
+        });
+    }
+
+    render() {
+        return (
+            <View>
+                <Checkbox
+                    label="Click here to toggle the custom style inside the custom component"
+                    checked={this.state.showCustomStyle}
+                    onChange={this.handleChange}
+                    style={{
+                        marginBottom: Spacing.medium,
+                    }}
+                />
+                <CustomComponent
+                    style={this.state.showCustomStyle && styles.customStyle}
+                />
+            </View>
+        );
+    }
+}
+<UsingStyleExample />
+```
+
+**Warning:** In the case of React components from other packages, they may not
+handle `className` or `style` in which case wrapping them in `addStyle` won't do
+anything.

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -38,7 +38,15 @@ module.exports = {
         {
             name: "Core",
             content: "packages/wonder-blocks-core/docs.md",
-            components: "packages/wonder-blocks-core/components/*.js",
+            components: [
+                "packages/wonder-blocks-core/util/add-style.js",
+                "packages/wonder-blocks-core/components/clickable-behavior.js",
+                "packages/wonder-blocks-core/components/id-provider.js",
+                "packages/wonder-blocks-core/components/text.js",
+                "packages/wonder-blocks-core/components/unique-id-provider.js",
+                "packages/wonder-blocks-core/components/view.js",
+                "packages/wonder-blocks-core/components/with-ssr-placeholder.js",
+            ],
         },
         {
             name: "Dropdown",

--- a/utils/gen-snapshot-tests.js
+++ b/utils/gen-snapshot-tests.js
@@ -435,10 +435,3 @@ function tryGenerateSectionTests(section) {
 for (const section of styleguideConfig.sections) {
     tryGenerateSectionTests(section);
 }
-
-// tryGenerateSectionTests({
-//     name: "Layout",
-//     content: "packages/wonder-blocks-layout/docs.md",
-//     components:
-//         "packages/wonder-blocks-layout/components/media-layout-context.js",
-// });

--- a/utils/gen-snapshot-tests.js
+++ b/utils/gen-snapshot-tests.js
@@ -321,20 +321,30 @@ function extractExamplesAndComponentsForFile(sourceFile, componentFileMap) {
     componentFileMap = componentFileMap || {};
 
     const src = fs.readFileSync(sourceFile, "utf8");
-    const match =
-        src.match(/export default class \s*(\w+)/) ||
-        src.match(/export default \s*\w+\(\s*(\w+)/);
+
+    const ast = parse(src, options);
+
+    // get the default exported module
+    const defaultExport = ast.program.body
+        .filter(
+            (node) =>
+                node.type === "ExportDefaultDeclaration" &&
+                (node.declaration.type === "FunctionDeclaration" ||
+                    node.declaration.type === "ClassDeclaration"),
+        )
+        .map((node) => node.declaration.id.name)
+        .join();
 
     // Guard against files without default exports.
-    if (!match) {
+    if (!defaultExport) {
         return {examples: [], componentFileMap};
     }
 
-    const alreadyCollated = componentFileMap[match[1]] === sourceFile;
+    const alreadyCollated = componentFileMap[defaultExport] === sourceFile;
     if (!alreadyCollated) {
         // Only gather examples for this component file if
         // we didn't see it already.
-        componentFileMap[match[1]] = sourceFile;
+        componentFileMap[defaultExport] = sourceFile;
 
         const componentDoc =
             path.join(
@@ -425,3 +435,10 @@ function tryGenerateSectionTests(section) {
 for (const section of styleguideConfig.sections) {
     tryGenerateSectionTests(section);
 }
+
+// tryGenerateSectionTests({
+//     name: "Layout",
+//     content: "packages/wonder-blocks-layout/docs.md",
+//     components:
+//         "packages/wonder-blocks-layout/components/media-layout-context.js",
+// });


### PR DESCRIPTION
## Summary
Adds documentation and examples to the `addStyle` util.

## Features

### Core
- Added docs and examples to `addStyle`.

### Internal
- Fixed `gen-snapshot-tests.js` script to allow adding flow typed functions to the examples.
e.g. `export default function addStyle<T: React.AbstractComponent<*> | string>(`

### Test plan
1. Open https://deploy-preview-463--wonder-blocks.netlify.com/#!/AddStyle
2. Check the documentation and examples are clear and concise.

![core-addStyle](https://user-images.githubusercontent.com/843075/62302454-619f8500-b448-11e9-9af5-76486c8e2bcf.png)