### PR TITLE
Fix type issue with withActionScheduler

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,3 +11,17 @@
 
 [options]
 server.max_workers=1
+
+# $FlowFixMe
+# This suppression hould be used to suppress an issue that requires additional
+# effort to be resolved. That effort should be recorded in our issue tracking
+# system for follow-up. Usually, this suppression is added by tooling during
+# flow upgrades and should not be used directly by developers. If it is
+# necessary, make sure to raise the corresponding issue and add the issue
+# number to a TODO comment associated with the suppression.
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
+
+# $FlowExpectError
+# This suppression is used in flow test files to indicate that we expect
+# some code to raise a flow error.
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError

--- a/packages/wonder-blocks-timing/components/with-action-scheduler.js
+++ b/packages/wonder-blocks-timing/components/with-action-scheduler.js
@@ -14,7 +14,7 @@ import type {IScheduleActions, WithActionScheduler} from "../util/types.js";
  * the additional action scheduler prop. To attach the additional prop to
  * these props use the `WithActionScheduler` type.
  */
-function withActionScheduler<TOwnProps: {||}>(
+function withActionScheduler<TOwnProps: {}>(
     Component: React.AbstractComponent<WithActionScheduler<TOwnProps>>,
 ): React.AbstractComponent<TOwnProps> {
     return (props: TOwnProps): React.Node => (

--- a/packages/wonder-blocks-timing/util/types.flowtest.js
+++ b/packages/wonder-blocks-timing/util/types.flowtest.js
@@ -58,8 +58,8 @@ const HOCComponent2: React.AbstractComponent<Props2> = withActionScheduler(
 
 /**
  * Case 3: Incorrect Usage
- * The withActionScheduler call is returning a component of type OwnProps2; the
- * variable assigned however is incorrectly specified as Props2.
+ * The withActionScheduler call is being passed a component that isn't set up
+ * to be used with it as it doesn't have all the props necessary.
  */
 type OwnProps3 = {|
     test: string,

--- a/packages/wonder-blocks-timing/util/types.flowtest.js
+++ b/packages/wonder-blocks-timing/util/types.flowtest.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-unused-vars */
+// @flow
+/**
+ * This file ensures that our flow types are working right.
+ */
+import * as React from "react";
+import withActionScheduler from "../components/with-action-scheduler.js";
+
+import type {WithActionScheduler} from "./types.js";
+
+/**
+ * Test WithActionScheduler and withActionScheduler usage.
+ */
+/**
+ * Case 1: Correct usage
+ * Given a react component with action scheduler props, we receive an
+ * abstract component of `OwnProps1`.
+ */
+type OwnProps1 = {|
+    test: string,
+|};
+
+type Props1 = WithActionScheduler<OwnProps1>;
+
+const InnerComponent1: React.AbstractComponent<Props1> = (
+    props: Props1,
+): React.Node => props.test;
+
+const HOCComponent1: React.AbstractComponent<OwnProps1> = withActionScheduler(
+    InnerComponent1,
+);
+
+/**
+ * Case 2: Incorrect Usage
+ * The withActionScheduler call is returning a component of type OwnProps2; the
+ * variable assigned however is incorrectly specified as Props2.
+ */
+type OwnProps2 = {|
+    test: string,
+|};
+
+type Props2 = WithActionScheduler<OwnProps2>;
+
+const InnerComponent2: React.AbstractComponent<Props2> = (
+    props: Props2,
+): React.Node => props.test;
+
+/**
+ * Cannot assign `withActionScheduler(...)` to `HOCComponent2` because property
+ * `schedule` is missing in `OwnProps2` [1] but exists in `WithActionScheduler`
+ * [2] in type argument  `Config` [3].
+ *
+ * $FlowExpectError
+ */
+const HOCComponent2: React.AbstractComponent<Props2> = withActionScheduler(
+    InnerComponent2,
+);
+
+/**
+ * Case 3: Incorrect Usage
+ * The withActionScheduler call is returning a component of type OwnProps2; the
+ * variable assigned however is incorrectly specified as Props2.
+ */
+type OwnProps3 = {|
+    test: string,
+|};
+
+const InnerComponent3: React.AbstractComponent<OwnProps3> = (
+    props: OwnProps3,
+): React.Node => props.test;
+
+const HOCComponent3: React.AbstractComponent<OwnProps3> = withActionScheduler(
+    /**
+     * Cannot call `withActionScheduler` with `InnerComponent3` bound to
+     * `Component` because property `schedule` is missing in `OwnProps3` [1]
+     * but exists in  `WithActionScheduler` [2] in type argument  `Config` [3].
+     *
+     * $FlowExpectError
+     */
+    InnerComponent3,
+);

--- a/packages/wonder-blocks-timing/util/types.js
+++ b/packages/wonder-blocks-timing/util/types.js
@@ -234,7 +234,7 @@ export interface IScheduleActions {
  * order component will inject.
  */
 export type WithActionScheduler<TOwnProps: {}> = {|
-    ...TOwnProps,
+    ...$Exact<TOwnProps>,
 
     /**
      * An instance of the `IScheduleActions` API to use for scheduling


### PR DESCRIPTION
This fixes an issue with the type expected by `withActionScheduler` and also adds some flow-only test cases that setup the expectations we have around how the types should work.