### PR TITLE
lint against deprecated flow types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,10 @@
 <PROJECT_ROOT>/node_modules/findup
 <PROJECT_ROOT>/node_modules/editions
 
+[lints]
+deprecated-type=error
+deprecated-utility=error
+
 [options]
 server.max_workers=1
 

--- a/flow-typed/npm/enzyme_v3.x.x.js
+++ b/flow-typed/npm/enzyme_v3.x.x.js
@@ -1,0 +1,148 @@
+// flow-typed signature: 43ae578b930df44b55170ad70449a4c8
+// flow-typed version: c6154227d1/enzyme_v3.x.x/flow_>=v0.104.x
+
+declare module "enzyme" {
+    declare type PredicateFunction<T: Wrapper<*>> = (
+        wrapper: T,
+        index: number,
+    ) => boolean;
+    declare type UntypedSelector =
+        | string
+        | {[key: string]: number | string | boolean, ...};
+    declare type EnzymeSelector = UntypedSelector | React$ElementType;
+
+    // CheerioWrapper is a type alias for an actual cheerio instance
+    // TODO: Reference correct type from cheerio's type declarations
+    declare type CheerioWrapper = any;
+
+    declare class Wrapper<RootComponent> {
+        equals(node: React$Element<any>): boolean;
+        find(selector: UntypedSelector): this;
+        find<T: React$ElementType>(selector: T): ReactWrapper<T>;
+        findWhere(predicate: PredicateFunction<this>): this;
+        filter(selector: UntypedSelector): this;
+        filter<T: React$ElementType>(selector: T): ReactWrapper<T>;
+        filterWhere(predicate: PredicateFunction<this>): this;
+        hostNodes(): this;
+        contains(nodes: React$Node): boolean;
+        containsMatchingElement(node: React$Node): boolean;
+        containsAllMatchingElements(nodes: React$Node): boolean;
+        containsAnyMatchingElements(nodes: React$Node): boolean;
+        dive(option?: {context?: Object, ...}): this;
+        exists(selector?: EnzymeSelector): boolean;
+        isEmptyRender(): boolean;
+        matchesElement(node: React$Node): boolean;
+        hasClass(className: string): boolean;
+        is(selector: EnzymeSelector): boolean;
+        isEmpty(): boolean;
+        not(selector: EnzymeSelector): this;
+        children(selector?: UntypedSelector): this;
+        children<T: React$ElementType>(selector: T): ReactWrapper<T>;
+        childAt(index: number): this;
+        parents(selector?: UntypedSelector): this;
+        parents<T: React$ElementType>(selector: T): ReactWrapper<T>;
+        parent(): this;
+        closest(selector: UntypedSelector): this;
+        closest<T: React$ElementType>(selector: T): ReactWrapper<T>;
+        render(): CheerioWrapper;
+        renderProp(propName: string): (...args: Array<any>) => this;
+        unmount(): this;
+        text(): string;
+        html(): string;
+        get(index: number): React$Node;
+        getDOMNode(): HTMLElement | HTMLInputElement;
+        at(index: number): this;
+        first(): this;
+        last(): this;
+        state(key?: string): any;
+        context(key?: string): any;
+        props(): Object;
+        prop(key: string): any;
+        key(): string;
+        simulate(event: string, ...args: Array<any>): this;
+        simulateError(error: Error): this;
+        slice(begin?: number, end?: number): this;
+        setState(state: {...}, callback?: () => void): this;
+        setProps(props: {...}, callback?: () => void): this;
+        setContext(context: Object): this;
+        instance(): React$ElementRef<RootComponent>;
+        update(): this;
+        debug(options?: Object): string;
+        type(): string | Function | null;
+        name(): string;
+        forEach(fn: (node: this, index: number) => mixed): this;
+        map<T>(fn: (node: this, index: number) => T): Array<T>;
+        reduce<T>(
+            fn: (value: T, node: this, index: number) => T,
+            initialValue?: T,
+        ): Array<T>;
+        reduceRight<T>(
+            fn: (value: T, node: this, index: number) => T,
+            initialValue?: T,
+        ): Array<T>;
+        some(selector: EnzymeSelector): boolean;
+        someWhere(predicate: PredicateFunction<this>): boolean;
+        every(selector: EnzymeSelector): boolean;
+        everyWhere(predicate: PredicateFunction<this>): boolean;
+        length: number;
+    }
+
+    declare class ReactWrapper<T> extends Wrapper<T> {
+        constructor(
+            nodes: React$Element<T>,
+            root: any,
+            options?: ?Object,
+        ): ReactWrapper<T>;
+        mount(): this;
+        ref(refName: string): this;
+        detach(): void;
+    }
+
+    declare class ShallowWrapper<T> extends Wrapper<T> {
+        constructor(
+            nodes: React$Element<T>,
+            root: any,
+            options?: ?Object,
+        ): ShallowWrapper<T>;
+        equals(node: React$Node): boolean;
+        shallow(options?: {context?: Object, ...}): ShallowWrapper<T>;
+        getElement(): React$Node;
+        getElements(): Array<React$Node>;
+    }
+
+    declare function shallow<T>(
+        node: React$Element<T>,
+        options?: {
+            context?: Object,
+            disableLifecycleMethods?: boolean,
+            ...
+        },
+    ): ShallowWrapper<T>;
+    declare function mount<T>(
+        node: React$Element<T>,
+        options?: {
+            context?: Object,
+            attachTo?: HTMLElement,
+            childContextTypes?: Object,
+            ...
+        },
+    ): ReactWrapper<T>;
+    declare function render<T>(
+        node: React$Element<T>,
+        options?: {context?: Object, ...},
+    ): CheerioWrapper;
+
+    declare module.exports: {
+        configure(options: {
+            Adapter?: any,
+            disableLifecycleMethods?: boolean,
+            ...
+        }): void,
+        render: typeof render,
+        mount: typeof mount,
+        shallow: typeof shallow,
+        ShallowWrapper: typeof ShallowWrapper,
+        ReactWrapper: typeof ReactWrapper,
+        ...
+    };
+}

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 
 // NOTE: Potentially add to this as more cases come up.
 export type ClickableRole =
@@ -51,7 +51,7 @@ type Props = {|
     children: (
         state: ClickableState,
         handlers: ClickableHandlers,
-    ) => React$Element<*>,
+    ) => React.Node,
 
     /**
      * Whether the component is disabled.
@@ -125,10 +125,10 @@ export type ClickableHandlers = {|
     onTouchStart: () => mixed,
     onTouchEnd: () => mixed,
     onTouchCancel: () => mixed,
-    onKeyDown: (e: SyntheticKeyboardEvent<*>) => mixed,
-    onKeyUp: (e: SyntheticKeyboardEvent<*>) => mixed,
-    onFocus: (e: SyntheticFocusEvent<*>) => mixed,
-    onBlur: (e: SyntheticFocusEvent<*>) => mixed,
+    onKeyDown: (e: SyntheticKeyboardEvent<>) => mixed,
+    onKeyUp: (e: SyntheticKeyboardEvent<>) => mixed,
+    onFocus: (e: SyntheticFocusEvent<>) => mixed,
+    onBlur: (e: SyntheticFocusEvent<>) => mixed,
     tabIndex: number,
 |};
 
@@ -326,7 +326,7 @@ export default class ClickableBehavior extends React.Component<
         this.waitingForClick = true;
     };
 
-    handleKeyDown = (e: SyntheticKeyboardEvent<*>) => {
+    handleKeyDown = (e: SyntheticKeyboardEvent<>) => {
         const keyCode = e.which || e.keyCode;
         const {triggerOnEnter, triggerOnSpace} = getAppropriateTriggersForRole(
             this.props.role,
@@ -348,7 +348,7 @@ export default class ClickableBehavior extends React.Component<
         }
     };
 
-    handleKeyUp = (e: SyntheticKeyboardEvent<*>) => {
+    handleKeyUp = (e: SyntheticKeyboardEvent<>) => {
         const keyCode = e.which || e.keyCode;
         const {triggerOnEnter, triggerOnSpace} = getAppropriateTriggersForRole(
             this.props.role,
@@ -374,11 +374,11 @@ export default class ClickableBehavior extends React.Component<
         }
     };
 
-    handleFocus = (e: SyntheticFocusEvent<*>) => {
+    handleFocus = (e: SyntheticFocusEvent<>) => {
         this.setState({focused: true});
     };
 
-    handleBlur = (e: SyntheticFocusEvent<*>) => {
+    handleBlur = (e: SyntheticFocusEvent<>) => {
         this.setState({focused: false, pressed: false});
     };
 

--- a/packages/wonder-blocks-core/util/add-style.js
+++ b/packages/wonder-blocks-core/util/add-style.js
@@ -7,7 +7,7 @@ import {processStyleList} from "./util.js";
 import type {StyleType} from "./types.js";
 
 // TODO(kevinb): have an a version which uses exact object types
-export default function addStyle<T: React.AbstractComponent<*> | string>(
+export default function addStyle<T: React.AbstractComponent<any> | string>(
     Component: T,
     defaultStyle?: StyleType,
 ): React.AbstractComponent<React.ElementConfig<T> & {style: StyleType}> {

--- a/packages/wonder-blocks-core/util/types.js
+++ b/packages/wonder-blocks-core/util/types.js
@@ -142,48 +142,48 @@ export type AriaProps = {|
 |};
 
 type MouseEvents = {|
-    onMouseDown?: (e: SyntheticMouseEvent<*>) => mixed,
-    onMouseUp?: (e: SyntheticMouseEvent<*>) => mixed,
-    onMouseMove?: (e: SyntheticMouseEvent<*>) => mixed,
-    onClick?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDoubleClick?: (e: SyntheticMouseEvent<*>) => mixed,
-    onMouseEnter?: (e: SyntheticMouseEvent<*>) => mixed,
-    onMouseLeave?: (e: SyntheticMouseEvent<*>) => mixed,
-    onMouseOut?: (e: SyntheticMouseEvent<*>) => mixed,
-    onMouseOver?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDrag?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDragEnd?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDragEnter?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDragExit?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDragLeave?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDragOver?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDragStart?: (e: SyntheticMouseEvent<*>) => mixed,
-    onDrop?: (e: SyntheticMouseEvent<*>) => mixed,
+    onMouseDown?: (e: SyntheticMouseEvent<>) => mixed,
+    onMouseUp?: (e: SyntheticMouseEvent<>) => mixed,
+    onMouseMove?: (e: SyntheticMouseEvent<>) => mixed,
+    onClick?: (e: SyntheticMouseEvent<>) => mixed,
+    onDoubleClick?: (e: SyntheticMouseEvent<>) => mixed,
+    onMouseEnter?: (e: SyntheticMouseEvent<>) => mixed,
+    onMouseLeave?: (e: SyntheticMouseEvent<>) => mixed,
+    onMouseOut?: (e: SyntheticMouseEvent<>) => mixed,
+    onMouseOver?: (e: SyntheticMouseEvent<>) => mixed,
+    onDrag?: (e: SyntheticMouseEvent<>) => mixed,
+    onDragEnd?: (e: SyntheticMouseEvent<>) => mixed,
+    onDragEnter?: (e: SyntheticMouseEvent<>) => mixed,
+    onDragExit?: (e: SyntheticMouseEvent<>) => mixed,
+    onDragLeave?: (e: SyntheticMouseEvent<>) => mixed,
+    onDragOver?: (e: SyntheticMouseEvent<>) => mixed,
+    onDragStart?: (e: SyntheticMouseEvent<>) => mixed,
+    onDrop?: (e: SyntheticMouseEvent<>) => mixed,
 |};
 
 type KeyboardEvents = {|
-    onKeyDown?: (e: SyntheticKeyboardEvent<*>) => mixed,
-    onKeyPress?: (e: SyntheticKeyboardEvent<*>) => mixed,
-    onKeyUp?: (e: SyntheticKeyboardEvent<*>) => mixed,
+    onKeyDown?: (e: SyntheticKeyboardEvent<>) => mixed,
+    onKeyPress?: (e: SyntheticKeyboardEvent<>) => mixed,
+    onKeyUp?: (e: SyntheticKeyboardEvent<>) => mixed,
 |};
 
 type InputEvents = {|
-    onChange?: (e: SyntheticInputEvent<*>) => mixed,
-    onInput?: (e: SyntheticInputEvent<*>) => mixed,
-    onInvalid?: (e: SyntheticInputEvent<*>) => mixed,
-    onSubmit?: (e: SyntheticInputEvent<*>) => mixed,
+    onChange?: (e: SyntheticInputEvent<>) => mixed,
+    onInput?: (e: SyntheticInputEvent<>) => mixed,
+    onInvalid?: (e: SyntheticInputEvent<>) => mixed,
+    onSubmit?: (e: SyntheticInputEvent<>) => mixed,
 |};
 
 type TouchEvents = {|
-    onTouchCancel?: (e: SyntheticTouchEvent<*>) => mixed,
-    onTouchEnd?: (e: SyntheticTouchEvent<*>) => mixed,
-    onTouchMove?: (e: SyntheticTouchEvent<*>) => mixed,
-    onTouchStart?: (e: SyntheticTouchEvent<*>) => mixed,
+    onTouchCancel?: (e: SyntheticTouchEvent<>) => mixed,
+    onTouchEnd?: (e: SyntheticTouchEvent<>) => mixed,
+    onTouchMove?: (e: SyntheticTouchEvent<>) => mixed,
+    onTouchStart?: (e: SyntheticTouchEvent<>) => mixed,
 |};
 
 type FocusEvents = {|
-    onFocus?: (e: SyntheticFocusEvent<*>) => mixed,
-    onBlur?: (e: SyntheticFocusEvent<*>) => mixed,
+    onFocus?: (e: SyntheticFocusEvent<>) => mixed,
+    onBlur?: (e: SyntheticFocusEvent<>) => mixed,
 |};
 
 type EventHandlers = {|

--- a/packages/wonder-blocks-dropdown/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core.js
@@ -54,7 +54,7 @@ type DropdownProps = {|
     /**
      * The component that opens the menu.
      */
-    opener: React.Element<*>,
+    opener: React.Element<any>,
 
     /**
      * Ref to the opener element.

--- a/packages/wonder-blocks-dropdown/components/dropdown.test.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown.test.js
@@ -16,7 +16,7 @@ type Props = {|
     onToggle?: (opened: boolean) => mixed,
 |};
 type State = {|
-    selectedValues: Array<*>,
+    selectedValues: Array<string>,
     opened?: boolean,
 |};
 

--- a/packages/wonder-blocks-modal/util/maybe-get-portal-mounted-modal-host-element.test.js
+++ b/packages/wonder-blocks-modal/util/maybe-get-portal-mounted-modal-host-element.test.js
@@ -30,10 +30,12 @@ describe("maybeGetPortalMountedModalHostElement", () => {
             </div>
         );
         const wrapper = mount(nodes);
-        const candidateElement = wrapper.find("button")[0];
+        const candidateElement = wrapper.find("button").at(0);
 
         // Act
-        const result = maybeGetPortalMountedModalHostElement(candidateElement);
+        const result = maybeGetPortalMountedModalHostElement(
+            candidateElement.getDOMNode(),
+        );
 
         // Assert
         expect(result).toBeFalsy();
@@ -61,11 +63,11 @@ describe("maybeGetPortalMountedModalHostElement", () => {
             );
 
             const wrapper = mount(modal);
-            const candidateElement = wrapper.find("button")[0];
+            const candidateElement = wrapper.find("button").at(0);
 
             // Act
             const result = maybeGetPortalMountedModalHostElement(
-                candidateElement,
+                candidateElement.getDOMNode(),
             );
 
             // Assert

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.test.js
@@ -11,7 +11,7 @@ import TooltipPopper from "./tooltip-popper.js";
  * A little wrapper for the TooltipPopper so that we can provide an anchor
  * element reference and test that the children get rendered.
  */
-class TestHarness extends React.Component<*, {ref: ?HTMLElement}> {
+class TestHarness extends React.Component<any, {ref: ?HTMLElement}> {
     state = {
         ref: null,
     };

--- a/packages/wonder-blocks-tooltip/util/ref-tracker.js
+++ b/packages/wonder-blocks-tooltip/util/ref-tracker.js
@@ -15,7 +15,7 @@ export default class RefTracker {
     _lastRef: ?HTMLElement;
     _targetFn: ?(?HTMLElement) => void;
 
-    updateRef = (ref: ?(React.Component<*> | Element)) => {
+    updateRef = (ref: ?(React.Component<any> | Element)) => {
         if (ref) {
             // We only want to update the reference if it is
             // actually changed. Otherwise, we can trigger another render that

--- a/packages/wonder-blocks-tooltip/util/types.js
+++ b/packages/wonder-blocks-tooltip/util/types.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-export type getRefFn = (?(React.Component<*> | Element)) => void;
+export type getRefFn = (?(React.Component<any> | Element)) => void;
 
 export type Offset = {|
     top: number,

--- a/utils/testing/mount.js
+++ b/utils/testing/mount.js
@@ -1,6 +1,6 @@
 // @flow
-import * as React from "react";
 import {mount as enzymeMount} from "enzyme";
+import type {ReactWrapper} from "enzyme";
 
 /**
  * Enzyme doesn't unmount mounted things and all tests share the same DOM
@@ -21,11 +21,11 @@ const unmountAll = () => {
     }
 };
 
-const mount = (nodes: React.Node) => {
-    const wrapper = enzymeMount(nodes);
+function mount<T>(nodes: React$Element<T>): ReactWrapper<T> {
+    const wrapper = enzymeMount<T>(nodes);
     const identity = ACTIVE_WRAPPERS.length;
     ACTIVE_WRAPPERS[identity] = wrapper;
     return wrapper;
-};
+}
 
 export {mount, unmountAll};


### PR DESCRIPTION
I thought I'd try out some of the lint rules that flow has to offer.  This commit originally also included sketchy null checks as well but it turns out those are easier to fix if you have null coalescing which was easy to add but fixing them was still a bit of a pain so I scaled this back to just fix up deprecated types, namely `*`, `$Supertype`, and `$Subtype`.  I also decided to add flow types for enzyme which brought out batch coverage up from about 85% to 95%.