### PR TITLE
WB-98: docs(): Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installs project dependencies
 
 Runs the docs in dev mode
 
-Now you can open `http://localhost:6060` to view the docs. This page will
+Now you can open http://localhost:6060 to view the docs. This page will
 automatically update as you make changes to components.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -2,10 +2,42 @@
 
 [![CircleCI](https://circleci.com/gh/Khan/wonder-blocks.svg?style=svg)](https://circleci.com/gh/Khan/wonder-blocks) [![codecov](https://codecov.io/gh/Khan/wonder-blocks/branch/master/graph/badge.svg)](https://codecov.io/gh/Khan/wonder-blocks)
 
-The Khan Academy Wonder Blocks design system. This is work-in-progress and a lot of things are still in motion.
+The Khan Academy Wonder Blocks design system. This is work-in-progress and a lot
+of things are still in motion.
 
 More information: https://wonder-blocks.netlify.com/
 
+## Getting started
+
+### Prerequisites
+
+- [Node.JS v8](https://nodejs.org/download/release/v8.16.1/)
+- [Yarn](https://yarnpkg.com/lang/en/docs/install/)
+
+### Installation
+
+To install Wonder Blocks, you need to run the following commands:
+
+#### `yarn install`
+
+Installs project dependencies
+
+#### `yarn start`
+
+Runs the docs in dev mode
+
+Now you can open `http://localhost:6060` to view the docs. This page will
+automatically update as you make changes to components.
+
 ## Contributing
 
-Please note – before contributing ensure that any design changes you are wanting to make are reflected in the [Wonder Blocks project in Figma](https://www.figma.com/file/VbVu3h2BpBhH80niq101MHHE/Wonder-Blocks) or [Zeplin](https://zpl.io/bl1owd1).  We previously used Zeplin, but have since moved to Figma.  Please check Figma first — if a design isn't there please check Zeplin.  Moving forward we will be transitioning away from Zeplin, but in the interim you may need to check both.
+For a more detailed explanation about how to develop Wonder Blocks components,
+please refer to the [internal documentation](https://khanacademy.atlassian.net/wiki/spaces/FRONTEND/pages/100827261/Developing+wonder-blocks)
+
+Please note – before contributing ensure that any design changes you are wanting
+to make are reflected in the [Wonder Blocks project in
+Figma](https://www.figma.com/file/VbVu3h2BpBhH80niq101MHHE/Wonder-Blocks) or
+[Zeplin](https://zpl.io/bl1owd1).  We previously used Zeplin, but have since
+moved to Figma.  Please check Figma first — if a design isn't there please check
+Zeplin.  Moving forward we will be transitioning away from Zeplin, but in the
+interim you may need to check both.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ automatically update as you make changes to components.
 
 ## Contributing
 
+**Note for external contributors:** We are not accepting external contributions
+at this time. We are working to make this happen in the future, and we will let
+you know when this is possible!
+
 For a more detailed explanation about how to develop Wonder Blocks components,
 please refer to the [internal documentation](https://khanacademy.atlassian.net/wiki/spaces/FRONTEND/pages/100827261/Developing+wonder-blocks)
 


### PR DESCRIPTION
## Summary

Updated README.md to show a `getting started` section that includes short installation instructions and adds the URL to see the docs locally. Also, added a link to the confluence page for a more detailed explanation on the process.

Output: https://github.com/Khan/wonder-blocks/blob/internal/readme-docs/README.md