### PR TITLE
Create .flowconfig-ci with server.max_workers=1 for CI operation only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           paths:
             - node_modules
       - run: yarn run lint
-      - run: yarn run flow
+      - run: yarn run flow-ci
   test:
     docker:
       - image: circleci/node:8-browsers

--- a/.flowconfig-ci
+++ b/.flowconfig-ci
@@ -14,6 +14,8 @@ deprecated-type=error
 deprecated-utility=error
 
 [options]
+server.max_workers=1
+
 # $FlowFixMe
 # This suppression hould be used to suppress an issue that requires additional
 # effort to be resolved. That effort should be recorded in our issue tracking

--- a/.flowconfig-ci
+++ b/.flowconfig-ci
@@ -14,6 +14,9 @@ deprecated-type=error
 deprecated-utility=error
 
 [options]
+# We use a single work on CI because the free tier of CircleCI that we use
+# to run the tests only have access to a single core.  This avoids issues
+# with Flow failing to start sometimes.
 server.max_workers=1
 
 # $FlowFixMe

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 *.md
 docs
 *.css
+*.yml

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:all": "yarn build:cjs && yarn build:es6",
     "watch:cjs": "webpack --config build-settings/webpack.config.js -w",
     "flow": "flow",
+    "flow-ci": "flow --flowconfig-name .flowconfig-ci",
     "flow-coverage": "flow-coverage-report -t text -t html -f ./node_modules/.bin/flow -i 'packages/wonder-blocks-*/**/*.js' -x 'packages/wonder-blocks-*/dist/*.js' -x '**/*.test.js' -x '**/node_modules/**/*.js'",
     "gen-snapshot-tests": "node utils/gen-snapshot-tests.js && prettier --write packages/*/generated-snapshot.test.js",
     "gen-styleguide-prod-config": "node utils/gen-styleguide-prod-config.js && prettier --write styleguide.prod.config.js",


### PR DESCRIPTION
Flow is slow running locally because it was only using a single worker.  This fixes that.

The reason why we only use one worker when running on CI to avoid situations where flow has trouble launching.  This can happen on CI because the free version of CircleCI using single core machines.  See https://circleci.com/gh/Khan/wonder-blocks/2076?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link for an example of the error.