### PR TITLE
Use flow to enforce invalid props in ModalLauncher

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -112,6 +112,18 @@ export default class ModalLauncher extends React.Component<Props, State> {
     };
 
     static getDerivedStateFromProps(props: Props, state: State) {
+        if (typeof props.opened === "boolean" && props.children) {
+            // eslint-disable-next-line no-console
+            console.warn("'children' and 'opened' can't be used together");
+        }
+        if (typeof props.opened === "boolean" && !props.onClose) {
+            // eslint-disable-next-line no-console
+            console.warn("'onClose' should be used with 'opened'");
+        }
+        if (typeof props.opened !== "boolean" && !props.children) {
+            // eslint-disable-next-line no-console
+            console.warn("either 'children' or 'opened' must be set");
+        }
         return {
             opened:
                 typeof props.opened === "boolean" ? props.opened : state.opened,

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -112,9 +112,6 @@ export default class ModalLauncher extends React.Component<Props, State> {
     };
 
     static getDerivedStateFromProps(props: Props, state: State) {
-        if (typeof props.opened === "boolean" && !props.onClose) {
-            throw new Error("'onClose' should be used with 'opened'");
-        }
         return {
             opened:
                 typeof props.opened === "boolean" ? props.opened : state.opened,

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -9,7 +9,7 @@ import ScrollDisabler from "./scroll-disabler.js";
 import type {ModalElement} from "../util/types.js";
 import ModalContext from "./modal-context.js";
 
-type Props = {|
+type CommonProps = {|
     /**
      * The modal to render.
      *
@@ -26,32 +26,11 @@ type Props = {|
     modal: ModalElement | (({closeModal: () => void}) => ModalElement),
 
     /**
-     * Use the children-as-function pattern to pass a openModal function for
-     * use anywhere within children. This provides a lot of flexibility in
-     * terms of what actions may trigger the ModalLauncher to launch the modal.
-     *
-     * Note: Don't call `openModal` while rendering! It should be used to
-     * respond to user intearction, like `onClick`.
-     */
-    children?: ({openModal: () => void}) => React.Node,
-
-    /**
      * If the parent needs to be notified when the modal is closed, use this
      * prop. You probably want to use this instead of `onClose` on the modals
      * themselves, since this will capture a more complete set of close events.
      */
     onClose?: () => mixed,
-
-    /**
-     * Renders the modal when true, renders nothing when false.
-     *
-     * Using this prop makes the component behave as an uncontrolled component.
-     * The parent is responsible for managing the opening/closing of the modal
-     * when using this prop.  `onClose` should always be used and `children`
-     * should never be used with this prop.  Not doing so will result in an
-     * error being thrown.
-     */
-    opened?: boolean,
 
     /**
      * Enables the backdrop to dismiss the modal on click/tap
@@ -69,6 +48,36 @@ type Props = {|
      */
     testId?: string,
 |};
+
+type ControlledProps = {|
+    ...CommonProps,
+    /**
+     * Renders the modal when true, renders nothing when false.
+     *
+     * Using this prop makes the component behave as a controlled component.
+     * The parent is responsible for managing the opening/closing of the modal
+     * when using this prop.  `onClose` should always be used and `children`
+     * should never be used with this prop.  Not doing so will result in an
+     * error being thrown.
+     */
+    opened: boolean,
+
+    /**
+     * Called when the modal needs notifies the parent component that it should
+     * be closed.
+     *
+     * This prop must be used when the component is being used as a controlled
+     * component.
+     */
+    onClose: () => mixed,
+|};
+
+type UncontrolledProps = {|
+    ...CommonProps,
+    children: ({openModal: () => mixed}) => React.Node,
+|};
+
+type Props = ControlledProps | UncontrolledProps;
 
 type State = {|
     /** Whether the modal should currently be open. */
@@ -103,14 +112,8 @@ export default class ModalLauncher extends React.Component<Props, State> {
     };
 
     static getDerivedStateFromProps(props: Props, state: State) {
-        if (typeof props.opened === "boolean" && props.children) {
-            throw new Error("'children' and 'opened' can't be used together");
-        }
         if (typeof props.opened === "boolean" && !props.onClose) {
             throw new Error("'onClose' should be used with 'opened'");
-        }
-        if (typeof props.opened !== "boolean" && !props.children) {
-            throw new Error("either 'children' or 'opened' must be set");
         }
         return {
             opened:
@@ -121,9 +124,8 @@ export default class ModalLauncher extends React.Component<Props, State> {
     state = {opened: false};
 
     componentDidUpdate(prevProps: Props) {
-        const {opened} = this.props;
         // ensures the element is stored only when the modal is opened
-        if (!prevProps.opened && opened) {
+        if (!prevProps.opened && this.props.opened) {
             this._saveLastElementFocused();
         }
     }

--- a/packages/wonder-blocks-modal/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.js
@@ -63,7 +63,7 @@ type ControlledProps = {|
     opened: boolean,
 
     /**
-     * Called when the modal needs notifies the parent component that it should
+     * Called when the modal needs to notify the parent component that it should
      * be closed.
      *
      * This prop must be used when the component is being used as a controlled

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -162,6 +162,59 @@ describe("ModalLauncher", () => {
         expect(wrapper.find("ScrollDisabler")).toHaveLength(0);
     });
 
+    test("using `opened` and `children` should warn", () => {
+        // Arrange
+        jest.spyOn(console, "warn");
+
+        // Act
+        shallow(
+            // $FlowExpectError
+            <ModalLauncher
+                modal={exampleModal}
+                opened={false}
+                onClose={() => {}}
+            >
+                {({openModal}) => <button onClick={openModal} />}
+            </ModalLauncher>,
+        );
+
+        // Assert
+        // eslint-disable-next-line no-console
+        expect(console.warn).toHaveBeenCalledWith(
+            "'children' and 'opened' can't be used together",
+        );
+    });
+
+    test("using `opened` without `onClose` should throw", () => {
+        // Arrange
+        jest.spyOn(console, "warn");
+
+        // Act
+        // $FlowExpectError
+        shallow(<ModalLauncher modal={exampleModal} opened={false} />);
+
+        // Assert
+        // eslint-disable-next-line no-console
+        expect(console.warn).toHaveBeenCalledWith(
+            "'onClose' should be used with 'opened'",
+        );
+    });
+
+    test("using neither `opened` nor `children` should throw", () => {
+        // Arrange
+        jest.spyOn(console, "warn");
+
+        // Act
+        // $FlowExpectError
+        shallow(<ModalLauncher modal={exampleModal} />);
+
+        // Assert
+        // eslint-disable-next-line no-console
+        expect(console.warn).toHaveBeenCalledWith(
+            "either 'children' or 'opened' must be set",
+        );
+    });
+
     test("If backdropDismissEnabled set to false, clicking the backdrop does not trigger `onClose`", () => {
         const onClose = jest.fn();
 

--- a/packages/wonder-blocks-modal/components/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/components/modal-launcher.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import {shallow} from "enzyme";
 
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
-import expectRenderError from "../../../utils/testing/expect-render-error.js";
 import ModalLauncher from "./modal-launcher.js";
 import OnePaneDialog from "./one-pane-dialog/one-pane-dialog.js";
 
@@ -161,33 +160,6 @@ describe("ModalLauncher", () => {
 
         // Now that the modal is closed, there should be no ScrollDisabler.
         expect(wrapper.find("ScrollDisabler")).toHaveLength(0);
-    });
-
-    test("using `opened` and `children` should throw", () => {
-        expectRenderError(
-            <ModalLauncher
-                modal={exampleModal}
-                opened={false}
-                onClose={() => {}}
-            >
-                {({openModal}) => <button onClick={openModal} />}
-            </ModalLauncher>,
-            "'children' and 'opened' can't be used together",
-        );
-    });
-
-    test("using `opened` without `onClose` should throw", () => {
-        expectRenderError(
-            <ModalLauncher modal={exampleModal} opened={false} />,
-            "'onClose' should be used with 'opened'",
-        );
-    });
-
-    test("using neither `opened` nor `children` should throw", () => {
-        expectRenderError(
-            <ModalLauncher modal={exampleModal} />,
-            "either 'children' or 'opened' must be set",
-        );
     });
 
     test("If backdropDismissEnabled set to false, clicking the backdrop does not trigger `onClose`", () => {


### PR DESCRIPTION
This change was motivated by https://phabricator.khanacademy.org/D57666.  We can use flow to enforce the prop constraints we were previously throw exceptions for.  This change though won't fix the issue fixed in D57666 so we should look at updating all uses of -v1 modals to -v2 modals.

While making this change I found myself a little confused about the various usages of ModalLauncher.  I think we should consider splitting ModalLauncher into two components:
- one that requires children and is always uncontrolled
- one that doesn't use children and is always controlled

I think that should cover all of our use cases and be less confusing both in terms of implementation but also in terms of use.