### PR TITLE
General grammar and typo fixes in the layouts documentation

### DIFF
--- a/packages/wonder-blocks-layout/docs.md
+++ b/packages/wonder-blocks-layout/docs.md
@@ -2,7 +2,7 @@
 
 `Spring` and `Strut` are two components that can make certain layouts easier to implement.
 `Spring` is infinitely compressible and expands to fill available space while `Strut`
-is uncompressible and occupies a fixed amount of space specified by its `size` prop.
+is incompressible and occupies a fixed amount of space specified by its `size` prop.
 
 ```js
 import {StyleSheet} from "aphrodite";
@@ -37,10 +37,10 @@ const styles = StyleSheet.create({
 
 ## MediaLayout
 
-`MediaLayout` is a container component takes in a `styleSheets` object whose keys are
-media sizes.  I listens for changes to the current media size and passes the current
-`mediaSize`, `mediaSpec`, and `styles` to `children` which is a render function taking
-those three values as object.
+`MediaLayout` is a container component that accepts a `styleSheets` object, whose keys are
+media sizes.  It listens for changes to the current media size and passes the current
+`mediaSize`, `mediaSpec`, and `styles` to `children`, which is a render function taking
+those three values as an object.
 
 Valid keys for the `styleSheets` object are (in order of precedence):
 - `small`, `medium`, `large`


### PR DESCRIPTION
Before:
![Screen Shot 2019-09-18 at 11 57 43 AM](https://user-images.githubusercontent.com/7761701/65177499-a2a92400-da0b-11e9-86a6-9313305cc9a7.png)

After:
![Screen Shot 2019-09-18 at 11 58 17 AM](https://user-images.githubusercontent.com/7761701/65177508-a76dd800-da0b-11e9-99f1-bca5014a21ae.png)
