### PR TITLE
Add github-actions to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*   @kevinbarabash @jeresig @somewhatabstract @jandrade
+*   @kevinbarabash @jeresig @somewhatabstract @jandrade @github-actions
 packages/wonder-blocks-breadcrumbs/*   @jandrade @kevinbarabash @jeresig
 packages/wonder-blocks-button/*   @kevinbarabash @jeresig
 packages/wonder-blocks-color/*   @jangmi-jo @kevinbarabash @jeresig


### PR DESCRIPTION
Hopefully this will make it so that the Gihub Actions bot can auto-approve the dependabot PRs now.

Test plan:
Will land and see if the dependabot PRs start getting auto-landed!