### PR TITLE
Change github-actions name to match actual name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*   @kevinbarabash @jeresig @somewhatabstract @jandrade @github-actions
+*   @kevinbarabash @jeresig @somewhatabstract @jandrade @github-actions[bot]
 packages/wonder-blocks-breadcrumbs/*   @jandrade @kevinbarabash @jeresig
 packages/wonder-blocks-button/*   @kevinbarabash @jeresig
 packages/wonder-blocks-color/*   @jangmi-jo @kevinbarabash @jeresig


### PR DESCRIPTION
Turns out bots have a hidden "[bot]" at the end of their name so the CODEOWNERS wasn't matching! I think this will work now?