### PR TITLE
patch(dropdown, popover, tooltip): WB-651 Add mocked version of Popper.js

### DIFF
--- a/packages/wonder-blocks-dropdown/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core.js
@@ -19,6 +19,7 @@ import type {WithActionScheduler} from "@khanacademy/wonder-blocks-timing";
 // NOTE(jeff): Here we share some code for use with PopperJS. Long term,
 // we should either contribute this code to the PopperJS component, or its
 // own non-wonder-blocks package.
+// $FlowIgnore
 import visibilityModifierDefaultConfig from "../../../shared-unpackaged/visibility-modifier.js"; // eslint-disable-line import/no-restricted-paths
 import DropdownCoreVirtualized from "./dropdown-core-virtualized.js";
 import SeparatorItem from "./separator-item.js";

--- a/packages/wonder-blocks-popover/__mocks__/popper.js.js
+++ b/packages/wonder-blocks-popover/__mocks__/popper.js.js
@@ -1,0 +1,20 @@
+// @flow
+/**
+ * Mock to allow us to run tests that need react-popper or popper.js
+ *
+ * Inspired by:
+ *     https://github.com/FezVrasta/popper.js/issues/478#issuecomment-369446079
+ */
+import PopperJs from "popper.js";
+
+export default class Popper {
+    static placements = PopperJs.placements;
+    static Defaults = PopperJs.Defaults;
+
+    constructor() {
+        return {
+            destroy: () => {},
+            scheduleUpdate: () => {},
+        };
+    }
+}

--- a/packages/wonder-blocks-tooltip/components/tooltip-popper.js
+++ b/packages/wonder-blocks-tooltip/components/tooltip-popper.js
@@ -10,7 +10,7 @@ import type {PopperChildrenProps} from "react-popper";
 // NOTE(jeff): Here we share some code for use with PopperJS. Long term,
 // we should either contribute this code to the PopperJS component, or its
 // own non-wonder-blocks package.
-// $FlowIgnoreMe
+// $FlowIgnore
 import visibilityModifierDefaultConfig from "../../../shared-unpackaged/visibility-modifier.js"; // eslint-disable-line import/no-restricted-paths
 import RefTracker from "../util/ref-tracker.js";
 import type {Placement} from "../util/types.js";


### PR DESCRIPTION
## Summary
This PR adds a manual mock of Popper.js inside the `wonder-blocks-popover` package to avoid throwing the following message when adding tests on webapp:

```
(node:2048) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'nodeName' of undefined
```

Also, we replaced `$FlowIgnoreMe` to `$FlowIgnore` to have consistent flow comments across the codebase.

## Test Plan
`yarn test`
`yarn flow`