### PR TITLE
Add import to Tooltip example

### DIFF
--- a/packages/wonder-blocks-tooltip/components/tooltip.md
+++ b/packages/wonder-blocks-tooltip/components/tooltip.md
@@ -1,6 +1,8 @@
 ### Text anchor & text tooltip & placement right
 
 ```js
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
+
 <Tooltip content="This is a text tooltip on the right" placement="right">
     Some text
 </Tooltip>


### PR DESCRIPTION
The first example for Tooltip didn't have an import. It's maybe obvious for folks who've used WB for a while, but I had to hunt a bit for the right syntax.  So this PR adds the import.

*Before*

<img width="981" alt="image" src="https://user-images.githubusercontent.com/77138/67973561-f17ed780-fbcd-11e9-8444-b088329fecc6.png">
