### PR TITLE
Delete .npmignore files

### DIFF
--- a/packages/wonder-blocks-button/.npmignore
+++ b/packages/wonder-blocks-button/.npmignore
@@ -1,2 +1,0 @@
-index_stories.js
-index_test.js

--- a/packages/wonder-blocks-core/.npmignore
+++ b/packages/wonder-blocks-core/.npmignore
@@ -1,1 +1,0 @@
-index_stories.js

--- a/packages/wonder-blocks-icon-button/.npmignore
+++ b/packages/wonder-blocks-icon-button/.npmignore
@@ -1,2 +1,0 @@
-index_stories.js
-index_test.js

--- a/packages/wonder-blocks-link/.npmignore
+++ b/packages/wonder-blocks-link/.npmignore
@@ -1,2 +1,0 @@
-index_stories.js
-index_test.js

--- a/packages/wonder-blocks-tooltip/.npmignore
+++ b/packages/wonder-blocks-tooltip/.npmignore
@@ -1,2 +1,0 @@
-index_stories.js
-index_test.js

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -8,8 +8,8 @@ import renderer from "react-test-renderer";
 
 // Mock react-dom as jest doesn't like findDOMNode.
 jest.mock("react-dom");
-import {View, Text} from "@khanacademy/wonder-blocks-core";
 import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
+import {View, Text} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import {Body, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";

--- a/packages/wonder-blocks-typography/.npmignore
+++ b/packages/wonder-blocks-typography/.npmignore
@@ -1,1 +1,0 @@
-index_stories.js


### PR DESCRIPTION
They aren't useful anymore and `.npmignore` is generally a dangerous file to have around:

https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d

There's also a snapshot file change here. I think it's down to the lint rules ordering imports. 