### PR TITLE
Fix disjoint union prop types

### DIFF
--- a/packages/wonder-blocks-modal/components/modal-header.js
+++ b/packages/wonder-blocks-modal/components/modal-header.js
@@ -40,16 +40,6 @@ type Common = {|
      * The result will be: `some-random-id-modal-header`
      */
     testId?: string,
-
-    /**
-     * Without these, flow complains about subtitle and breadcrumbs not being
-     * available on props at all b/c these are exact object types, flow looks
-     * for subtitle in each of Common, WithSubtitle and WithBreadcrumbs. I also
-     * tried making the types inexact and flow still complains when destructuring
-     * which is a little odd.
-     */
-    subtitle?: void,
-    breadcrumbs?: void,
 |};
 
 type WithSubtitle = {|
@@ -122,9 +112,9 @@ export default class ModalHeader extends React.Component<Props> {
 
     render() {
         const {
-            breadcrumbs,
+            breadcrumbs = undefined,
             light,
-            subtitle,
+            subtitle = undefined,
             testId,
             title,
             titleId,

--- a/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.js
@@ -78,15 +78,8 @@ type Common = {|
      */
     titleId?: string,
 
-    /**
-     * Without these, flow complains about subtitle and breadcrumbs not being
-     * available on props at all b/c these are exact object types, flow looks
-     * for subtitle in each of Common, WithSubtitle and WithBreadcrumbs. I also
-     * tried making the types inexact and flow still complains when destructuring
-     * which is a little odd.
-     */
-    subtitle?: void,
-    breadcrumbs?: void,
+    // subtitle: void,
+    // breadcrumbs: void,
 |};
 
 type WithSubtitle = {|
@@ -95,7 +88,7 @@ type WithSubtitle = {|
     /**
      * The subtitle of the modal, appearing in the titlebar, below the title.
      */
-    subtitle?: string,
+    subtitle: string,
 |};
 
 type WithBreadcrumbs = {|
@@ -104,7 +97,7 @@ type WithBreadcrumbs = {|
     /**
      * Adds a breadcrumb-trail, appearing in the ModalHeader, above the title.
      */
-    breadcrumbs?: React.Element<Breadcrumbs>,
+    breadcrumbs: React.Element<Breadcrumbs>,
 |};
 
 type Props = Common | WithSubtitle | WithBreadcrumbs;
@@ -121,7 +114,12 @@ export default class OnePaneDialog extends React.Component<Props> {
     };
 
     renderHeader(uniqueId: string): React.Element<typeof ModalHeader> {
-        const {title, subtitle, breadcrumbs, testId} = this.props;
+        const {
+            title,
+            breadcrumbs = undefined,
+            subtitle = undefined,
+            testId,
+        } = this.props;
 
         if (breadcrumbs) {
             return (

--- a/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/components/one-pane-dialog/one-pane-dialog.js
@@ -77,9 +77,6 @@ type Common = {|
      * not provided, a unique id will be generated.
      */
     titleId?: string,
-
-    // subtitle: void,
-    // breadcrumbs: void,
 |};
 
 type WithSubtitle = {|

--- a/packages/wonder-blocks-popover/components/popover-content.js
+++ b/packages/wonder-blocks-popover/components/popover-content.js
@@ -66,12 +66,6 @@ type CommonProps = {|
      * the same time with icon.
      */
     image?: React.Element<"img"> | React.Element<"svg">,
-
-    /**
-     * Without this, flow complains about emphasized not being available on
-     * props at all b/c these are exact object types.
-     */
-    emphasized?: void,
 |};
 
 type WithEmphasized = {|
@@ -186,7 +180,7 @@ export default class PopoverContent extends React.Component<Props> {
             closeButtonLabel,
             closeButtonVisible,
             content,
-            emphasized,
+            emphasized = undefined,
             icon,
             image,
             style,

--- a/packages/wonder-blocks-tooltip/generated-snapshot.test.js
+++ b/packages/wonder-blocks-tooltip/generated-snapshot.test.js
@@ -8,8 +8,8 @@ import renderer from "react-test-renderer";
 
 // Mock react-dom as jest doesn't like findDOMNode.
 jest.mock("react-dom");
-import {View, Text} from "@khanacademy/wonder-blocks-core";
 import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
+import {View, Text} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import {Body, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";


### PR DESCRIPTION
Summary:
Flow gets confused when an optional prop exists in multiple variants of a
disjoint union.  This diff ensures that optional props only exist in a single
variant and that they are not optional in that variant.  To keep flow happy
we need to provide default values for these props when destructuring.

Test Plan:
- load localhost:6060
- see that OnePaneDialog is working correctly

I also, tested the theory behind this change in the flow playground to make sure it would fix the issue we're seeing in webapp.

https://flow.org/try/#0PTAEAEDMBsHsHcBQBLAtgB1gJwC6gFSgCGAzqAEoCmRAxnpFrKqAERbV0sDciiOAnukqgAwk1SwAdqAC8oAN4AfRIoC+PPoOEAxWLFkLloUADozY1BMkAaRMch6AXKBI4sySQHNbajQKGgAEJEWAZKdqbm4lK2xgBGIc6SAK6ocZRYPuq8-sIACozoZHIWVqCKoLr6FcFYGjTQpGRVtaCUAB44lJIAJmRUtDgmFpiS3TgAPAWwRQB8ChHsvRkAFACUC8bGNFKuCg76csnLkB6UPdagCaFHJ2c9qgY4ABbIJCbohSQ8W6DsOMksNIWAAJSjQOCXeDYaA9ACE3AiqkQyMQO0kewA+gYVq4sM48R5PGsCW4ibJ5nieNBKHgiAZMSsWEQepAWGsePS5ABWam0q4GFgARgATABmRFxAxCgAM9V29D01yFBgmLRCoAOMnkjJYXVc7MewFmPHRewO1xFqvVoWu2t1+pwhtAxp4QA