### PR TITLE
fix issue with jest config and non-wonder-blocks @khanacademy modules

### DIFF
--- a/config/jest/test.config.js
+++ b/config/jest/test.config.js
@@ -16,8 +16,8 @@ module.exports = {
     testMatch: ["<rootDir>/**/*.test.js"],
     setupFilesAfterEnv: ["<rootDir>/config/jest/test-setup.js"],
     moduleNameMapper: {
-        "^@khanacademy/(.*)$":
-            "<rootDir>/node_modules/@khanacademy/$1/index.js",
+        "^@khanacademy/wonder-blocks-(.*)$":
+            "<rootDir>/node_modules/@khanacademy/wonder-blocks-$1/index.js",
     },
     collectCoverageFrom: [
         "packages/**/*.js",


### PR DESCRIPTION
While I wasn't able to reproduce the issue, I can definitely see why @jandrade was getting the following error:
```
 Configuration error:
    Could not locate module @khanacademy/eslint-config/.prettierrc.js mapped as:
    /Users/juanandrade/khan/wonder-blocks/node_modules/@khanacademy/eslint-config/.prettierrc.js/index.js.
    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/^@khanacademy\/(.*)$/": "/Users/juanandrade/khan/wonder-blocks/node_modules/@khanacademy/$1/index.js"
      },
      "resolver": null
    }
```

This diff restricts the modules affected by `moduleNameMapper` to `wonder-block-*` modules only.

Test Plan: `yarn test`