### PR TITLE
WB-660.1: Add custom opener to ActionMenu

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1648,6 +1648,63 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
 exports[`wonder-blocks-dropdown example 11 1`] = `
 <div
   className=""
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "width": "fit-content",
+      "zIndex": 0,
+    }
+  }
+>
+  <span
+    className=""
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "20px",
+      }
+    }
+    tabIndex={0}
+  >
+    hey
+  </span>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 12 1`] = `
+<div
+  className=""
   style={
     Object {
       "alignItems": "stretch",
@@ -1783,7 +1840,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 12 1`] = `
+exports[`wonder-blocks-dropdown example 13 1`] = `
 <div
   className=""
   style={
@@ -1920,7 +1977,7 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 13 1`] = `
+exports[`wonder-blocks-dropdown example 14 1`] = `
 <div
   className=""
   style={
@@ -2056,7 +2113,7 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 14 1`] = `
+exports[`wonder-blocks-dropdown example 15 1`] = `
 <div
   className=""
   style={
@@ -2193,7 +2250,7 @@ exports[`wonder-blocks-dropdown example 14 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 15 1`] = `
+exports[`wonder-blocks-dropdown example 16 1`] = `
 <div
   className=""
   style={
@@ -2355,7 +2412,7 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 16 1`] = `
+exports[`wonder-blocks-dropdown example 17 1`] = `
 <div
   className=""
   style={
@@ -2492,7 +2549,7 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 17 1`] = `
+exports[`wonder-blocks-dropdown example 18 1`] = `
 <div
   className=""
   style={
@@ -2648,7 +2705,7 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 18 1`] = `
+exports[`wonder-blocks-dropdown example 19 1`] = `
 <div
   className=""
   style={
@@ -2882,7 +2939,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 19 1`] = `
+exports[`wonder-blocks-dropdown example 20 1`] = `
 <div
   className=""
   style={
@@ -3019,7 +3076,7 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 20 1`] = `
+exports[`wonder-blocks-dropdown example 21 1`] = `
 <div
   className=""
   style={
@@ -3155,7 +3212,7 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 21 1`] = `
+exports[`wonder-blocks-dropdown example 22 1`] = `
 <div
   className=""
   style={
@@ -3291,7 +3348,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 22 1`] = `
+exports[`wonder-blocks-dropdown example 23 1`] = `
 <div
   className=""
   style={
@@ -3386,7 +3443,7 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 23 1`] = `
+exports[`wonder-blocks-dropdown example 24 1`] = `
 <div
   className=""
   style={
@@ -3523,7 +3580,7 @@ exports[`wonder-blocks-dropdown example 23 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 24 1`] = `
+exports[`wonder-blocks-dropdown example 25 1`] = `
 <div
   className=""
   style={
@@ -3679,7 +3736,7 @@ exports[`wonder-blocks-dropdown example 24 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 25 1`] = `
+exports[`wonder-blocks-dropdown example 26 1`] = `
 <div
   className=""
   style={
@@ -3815,7 +3872,7 @@ exports[`wonder-blocks-dropdown example 25 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 26 1`] = `
+exports[`wonder-blocks-dropdown example 27 1`] = `
 <div
   className=""
   style={
@@ -4049,7 +4106,7 @@ exports[`wonder-blocks-dropdown example 26 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 27 1`] = `
+exports[`wonder-blocks-dropdown example 28 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1670,6 +1670,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
 >
   <span
     className=""
+    data-test-id="teacher-menu-custom-opener"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1697,7 +1697,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
     }
     tabIndex={0}
   >
-    hey
+    This is a label
   </span>
 </div>
 `;

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -230,7 +230,7 @@ export default class ActionMenu extends React.Component<Props, State> {
                 onClick={this.handleClick}
                 disabled={numItems === 0 || disabled}
                 anchorRef={this.onHandleOpenerRef}
-                testId={testId}
+                testId={opener ? undefined : testId}
             >
                 {opener
                     ? opener

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -268,3 +268,38 @@ class ControlledActionMenuExample extends React.Component {
 
 <ControlledActionMenuExample />
 ```
+
+### Example: ActionMenu with custom opener
+
+```js
+import {ActionMenu, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
+import {View} from "@khanacademy/wonder-blocks-core";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {icons} from "@khanacademy/wonder-blocks-icon";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+
+<ActionMenu
+    disabled={false}
+    menuText="Betsy Appleseed"
+    testId="teacher-menu"
+    opener={(eventState) => (
+        <LabelMedium
+            onClick={()=>{console.log('custom click!!!!!')}}
+        >hey</LabelMedium>
+    )}
+>
+    <ActionItem label="Profile" href="http://khanacademy.org/profile" testId="profile" />
+    <ActionItem label="Settings" onClick={() => console.log("user clicked on settings")} testId="settings" />
+    <ActionItem label="Help" disabled={true} onClick={() => console.log("this item is disabled...")} testId="help" />
+    <SeparatorItem />
+    <ActionItem label="Log out" href="http://khanacademy.org/logout" testId="logout" />
+    <OptionItem
+        label="Show homework assignments" value="homework"
+        onClick={() => console.log(`Show homework assignments toggled`)}
+    />
+    <OptionItem
+        label="Show in-class assignments" value="in-class"
+        onClick={() => console.log(`Show in-class assignments toggled`)}
+    />
+</ActionMenu>
+```

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -271,6 +271,8 @@ class ControlledActionMenuExample extends React.Component {
 
 ### Example: ActionMenu with custom opener
 
+In case you need to use a custom opener, you can use the `opener` property to achieve this:
+
 ```js
 import {ActionMenu, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -285,7 +287,7 @@ import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
     opener={(eventState) => (
         <LabelMedium
             onClick={()=>{console.log('custom click!!!!!')}}
-        >hey</LabelMedium>
+        >This is a label</LabelMedium>
     )}
 >
     <ActionItem label="Profile" href="http://khanacademy.org/profile" testId="profile" />

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -271,23 +271,52 @@ class ControlledActionMenuExample extends React.Component {
 
 ### Example: ActionMenu with custom opener
 
-In case you need to use a custom opener, you can use the `opener` property to achieve this:
+In case you need to use a custom opener, you can use the `opener` property to
+achieve this. In this example, the `opener` prop accepts a function with the
+`eventState` argument that lets you customize the style for different states,
+such as `pressed`, `hovered` and `focused`.
+
+**Note:** If you need to use a custom ID for testing the opener, make sure to
+pass the `testId` prop inside the opener component/element.
 
 ```js
 import {ActionMenu, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
+import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+
+const styles = StyleSheet.create({
+    focused: {
+        backgroundColor: Color.purple,
+        color: Color.white,
+    },
+    hovered: {
+        textDecoration: "underline",
+        color: Color.teal,
+    },
+    pressed: {
+        color: Color.blue,
+    },
+});
 
 <ActionMenu
     disabled={false}
     menuText="Betsy Appleseed"
-    testId="teacher-menu"
     opener={(eventState) => (
         <LabelMedium
             onClick={()=>{console.log('custom click!!!!!')}}
-        >This is a label</LabelMedium>
+            testId="teacher-menu-custom-opener"
+            style={[
+                eventState.focused && styles.focused,
+                eventState.hovered && styles.hovered,
+                eventState.pressed && styles.pressed
+            ]}
+        >
+            This is a label
+        </LabelMedium>
     )}
 >
     <ActionItem label="Profile" href="http://khanacademy.org/profile" testId="profile" />

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -1,13 +1,12 @@
 //@flow
 import React from "react";
-import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 import ActionItem from "./action-item.js";
 import OptionItem from "./option-item.js";
 import SeparatorItem from "./separator-item.js";
 import ActionMenu from "./action-menu.js";
+import DropdownOpener from "./dropdown-opener.js";
 import {keyCodes} from "../util/constants.js";
-import Dropdown from "./dropdown.js";
 
 jest.mock("./dropdown-core-virtualized.js");
 
@@ -15,21 +14,17 @@ describe("ActionMenu", () => {
     const onClick = jest.fn();
     const onToggle = jest.fn();
     const onChange = jest.fn();
-    let ClickableBehavior;
-
-    beforeEach(() => {
-        ClickableBehavior = getClickableBehavior();
-    });
 
     afterEach(() => {
         unmountAll();
     });
 
-    it("closes/opens the menu on mouse click, space, and enter", () => {
+    it("opens the menu on mouse click", () => {
+        // Arrange
         const menu = mount(
             <ActionMenu
                 menuText={"Action menu!"}
-                testId="fail-test"
+                testId="openTest"
                 onChange={onChange}
                 selectedValues={[]}
             >
@@ -39,22 +34,116 @@ describe("ActionMenu", () => {
             </ActionMenu>,
         );
 
-        const opener = menu.find(ClickableBehavior);
-        expect(menu.state("opened")).toEqual(false);
-
-        // Open menu with mouse
+        // Act
+        const opener = menu.find(DropdownOpener);
         opener.simulate("click");
-        expect(menu.find(Dropdown).state("opened")).toEqual(true);
 
-        // Close menu with space
-        opener.simulate("keydown", {keyCode: keyCodes.space});
-        opener.simulate("keyup", {keyCode: keyCodes.space});
-        expect(menu.find(Dropdown).state("opened")).toEqual(false);
+        // Assert
+        expect(menu.state("opened")).toBe(true);
+    });
 
-        // Open menu again with enter
+    it("opens the menu on enter", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        // Act
+        const opener = menu.find(DropdownOpener);
         opener.simulate("keydown", {keyCode: keyCodes.enter});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(menu.find(Dropdown).state("opened")).toEqual(true);
+
+        // Assert
+        expect(menu.state("opened")).toBe(true);
+    });
+
+    it("closes itself on escape", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        // Act
+        const opener = menu.find(DropdownOpener);
+        // open using the mouse
+        opener.simulate("click");
+        // use keyboard to simulate the ESC key
+        opener.simulate("keydown", {keyCode: keyCodes.escape});
+        opener.simulate("keyup", {keyCode: keyCodes.escape});
+
+        // Assert
+        expect(menu.state("opened")).toBe(false);
+    });
+
+    it("closes itself on tab", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        // Act
+        const opener = menu.find(DropdownOpener);
+        // open using the mouse
+        opener.simulate("click");
+        // use keyboard to simulate the TAB key
+        opener.simulate("keydown", {keyCode: keyCodes.tab});
+        opener.simulate("keyup", {keyCode: keyCodes.tab});
+
+        // Assert
+        expect(menu.state("opened")).toBe(false);
+    });
+
+    it("closes itself on an external mouse click", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        // Act
+        const opener = menu.find(DropdownOpener);
+        // open using the mouse
+        opener.simulate("click");
+        // trigger body click
+        document.dispatchEvent(new MouseEvent("mouseup"));
+
+        // Assert
+        expect(menu.state("opened")).toBe(false);
     });
 
     it("triggers actions", () => {
@@ -70,7 +159,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act
         // toggle second OptionItem
@@ -94,7 +183,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act
         const optionItem = menu.find(OptionItem).at(0);
@@ -117,7 +206,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act
         // toggle second OptionItem
@@ -139,7 +228,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act, Assert
         expect(() => {
@@ -163,7 +252,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act
         // toggle second OptionItem
@@ -181,7 +270,7 @@ describe("ActionMenu", () => {
                 <ActionItem label="Action" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Assert
         expect(menu.find(ActionItem)).toHaveLength(1);
@@ -190,7 +279,7 @@ describe("ActionMenu", () => {
     it("can have a menu with no items", () => {
         // Arrange, Act
         const menu = mount(<ActionMenu menuText={"Action menu!"} />);
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Assert
         expect(menu.find(ActionItem)).toHaveLength(0);
@@ -205,7 +294,7 @@ describe("ActionMenu", () => {
                 {showDeleteAction && <ActionItem label="Delete" />}
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Assert
         expect(menu.find(ActionItem)).toHaveLength(1);
@@ -221,7 +310,7 @@ describe("ActionMenu", () => {
         );
 
         // Act
-        const opener = menu.find(ClickableBehavior).find("button");
+        const opener = menu.find(DropdownOpener).find("button");
 
         // Assert
         expect(opener.prop("data-test-id")).toBe("some-test-id");
@@ -308,7 +397,7 @@ describe("ActionMenu", () => {
 
             // Act
             // click on the anchor
-            wrapper.find(ClickableBehavior).simulate("click");
+            wrapper.find(DropdownOpener).simulate("click");
 
             // Assert
             expect(wrapper.find(ActionMenu).prop("opened")).toBe(true);
@@ -329,6 +418,58 @@ describe("ActionMenu", () => {
 
             // Assert
             expect(wrapper.find(ActionMenu).prop("opened")).toBe(false);
+        });
+    });
+
+    describe("Custom Opener", () => {
+        it("opens the menu when clicking on the custom opener", () => {
+            // Arrange
+            const menu = mount(
+                <ActionMenu
+                    menuText={"Action menu!"}
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={[]}
+                    opener={(eventState) => (
+                        <button aria-label="Search" onClick={jest.fn()} />
+                    )}
+                >
+                    <ActionItem label="Action" onClick={onClick} />
+                </ActionMenu>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            opener.simulate("click");
+
+            // Assert
+            expect(menu.state("opened")).toBe(true);
+        });
+
+        it("calls the custom onClick handler", () => {
+            // Arrange
+            const onClickMock = jest.fn();
+
+            const menu = mount(
+                <ActionMenu
+                    menuText={"Action menu!"}
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={[]}
+                    opener={(eventState) => (
+                        <button aria-label="Search" onClick={onClickMock} />
+                    )}
+                >
+                    <ActionItem label="Action" onClick={onClick} />
+                </ActionMenu>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            opener.simulate("click");
+
+            // Assert
+            expect(onClickMock).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -430,7 +430,7 @@ describe("ActionMenu", () => {
                     testId="openTest"
                     onChange={onChange}
                     selectedValues={[]}
-                    opener={(eventState) => (
+                    opener={() => (
                         <button aria-label="Search" onClick={jest.fn()} />
                     )}
                 >

--- a/packages/wonder-blocks-dropdown/components/dropdown-opener.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-opener.js
@@ -1,0 +1,90 @@
+// @flow
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+import {ClickableBehavior} from "@khanacademy/wonder-blocks-core";
+
+import type {
+    AriaProps,
+    ClickableHandlers,
+    ClickableState,
+} from "@khanacademy/wonder-blocks-core";
+
+type Props = {|
+    ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,
+
+    /**
+     * The child function that returns the anchor the Dropdown will be activated
+     * by. This function takes `eventState`, which allows the opener element to
+     * access pointer event state.
+     */
+    children: (eventState: ClickableState) => React.Element<any>,
+
+    /**
+     * Whether the opener is disabled. If disabled, disallows interaction.
+     */
+    disabled: boolean,
+
+    /**
+     * Callback for when the opener is pressed.
+     */
+    onClick: (e: SyntheticEvent<>) => mixed,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+
+    /**
+     * Callback used to pass the childs Ref back up to the parent element
+     */
+    anchorRef: (?HTMLElement) => mixed,
+|};
+
+class DropdownOpener extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
+    componentDidMount() {
+        const anchorNode = ((ReactDOM.findDOMNode(this): any): ?HTMLElement);
+        this.props.anchorRef(anchorNode);
+    }
+
+    renderAnchorChildren(
+        eventState: ClickableState,
+        handlers: ClickableHandlers,
+    ) {
+        const renderedChildren = this.props.children(eventState);
+
+        return React.cloneElement(renderedChildren, {
+            ...handlers,
+            disabled: this.props.disabled,
+            "data-test-id": this.props.testId,
+            onClick: renderedChildren.props.onClick
+                ? (e: SyntheticMouseEvent<>) => {
+                      // This is done to avoid overriding a
+                      // custom onClick handler inside the
+                      // children node
+                      renderedChildren.props.onClick(e);
+                      handlers.onClick(e);
+                  }
+                : handlers.onClick,
+        });
+    }
+
+    render() {
+        return (
+            <ClickableBehavior
+                onClick={this.props.onClick}
+                disabled={this.props.disabled}
+            >
+                {(eventState, handlers) =>
+                    this.renderAnchorChildren(eventState, handlers)
+                }
+            </ClickableBehavior>
+        );
+    }
+}
+
+export default DropdownOpener;

--- a/packages/wonder-blocks-dropdown/components/dropdown-opener.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-opener.js
@@ -36,7 +36,7 @@ type Props = {|
     testId?: string,
 
     /**
-     * Callback used to pass the childs Ref back up to the parent element
+     * Callback used to pass the child's Ref back up to the parent element
      */
     anchorRef: (?HTMLElement) => mixed,
 |};

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -627,16 +627,34 @@ describe("wonder-blocks-dropdown", () => {
     });
 
     it("example 11", () => {
+        const styles = StyleSheet.create({
+            focused: {
+                backgroundColor: Color.purple,
+                color: Color.white,
+            },
+            hovered: {
+                textDecoration: "underline",
+                color: Color.teal,
+            },
+            pressed: {
+                color: Color.blue,
+            },
+        });
         const example = (
             <ActionMenu
                 disabled={false}
                 menuText="Betsy Appleseed"
-                testId="teacher-menu"
                 opener={(eventState) => (
                     <LabelMedium
                         onClick={() => {
                             console.log("custom click!!!!!");
                         }}
+                        testId="teacher-menu-custom-opener"
+                        style={[
+                            eventState.focused && styles.focused,
+                            eventState.hovered && styles.hovered,
+                            eventState.pressed && styles.pressed,
+                        ]}
                     >
                         This is a label
                     </LabelMedium>

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -638,7 +638,7 @@ describe("wonder-blocks-dropdown", () => {
                             console.log("custom click!!!!!");
                         }}
                     >
-                        hey
+                        This is a label
                     </LabelMedium>
                 )}
             >

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -23,6 +23,7 @@ import {icons} from "@khanacademy/wonder-blocks-icon";
 import {
     Title,
     HeadingSmall,
+    LabelMedium,
     LabelLarge,
 } from "@khanacademy/wonder-blocks-typography";
 import Color from "@khanacademy/wonder-blocks-color";
@@ -626,6 +627,64 @@ describe("wonder-blocks-dropdown", () => {
     });
 
     it("example 11", () => {
+        const example = (
+            <ActionMenu
+                disabled={false}
+                menuText="Betsy Appleseed"
+                testId="teacher-menu"
+                opener={(eventState) => (
+                    <LabelMedium
+                        onClick={() => {
+                            console.log("custom click!!!!!");
+                        }}
+                    >
+                        hey
+                    </LabelMedium>
+                )}
+            >
+                <ActionItem
+                    label="Profile"
+                    href="http://khanacademy.org/profile"
+                    testId="profile"
+                />
+                <ActionItem
+                    label="Settings"
+                    onClick={() => console.log("user clicked on settings")}
+                    testId="settings"
+                />
+                <ActionItem
+                    label="Help"
+                    disabled={true}
+                    onClick={() => console.log("this item is disabled...")}
+                    testId="help"
+                />
+                <SeparatorItem />
+                <ActionItem
+                    label="Log out"
+                    href="http://khanacademy.org/logout"
+                    testId="logout"
+                />
+                <OptionItem
+                    label="Show homework assignments"
+                    value="homework"
+                    onClick={() =>
+                        console.log(`Show homework assignments toggled`)
+                    }
+                />
+                <OptionItem
+                    label="Show in-class assignments"
+                    value="in-class"
+                    onClick={() =>
+                        console.log(`Show in-class assignments toggled`)
+                    }
+                />
+            </ActionMenu>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 12", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -698,7 +757,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 12", () => {
+    it("example 13", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -758,7 +817,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 13", () => {
+    it("example 14", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -810,7 +869,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 14", () => {
+    it("example 15", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -863,7 +922,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 15", () => {
+    it("example 16", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -933,7 +992,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 16", () => {
+    it("example 17", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -948,7 +1007,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 17", () => {
+    it("example 18", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -981,7 +1040,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 18", () => {
+    it("example 19", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1039,7 +1098,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 19", () => {
+    it("example 20", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1107,7 +1166,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 20", () => {
+    it("example 21", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1169,7 +1228,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 21", () => {
+    it("example 22", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1233,7 +1292,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 22", () => {
+    it("example 23", () => {
         const styles = StyleSheet.create({
             wrapper: {
                 alignItems: "center",
@@ -1327,7 +1386,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 23", () => {
+    it("example 24", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1342,7 +1401,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 24", () => {
+    it("example 25", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -1375,7 +1434,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 25", () => {
+    it("example 26", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1425,7 +1484,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 26", () => {
+    it("example 27", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1484,7 +1543,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 27", () => {
+    it("example 28", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",


### PR DESCRIPTION
## Summary

- Added a custom opener to the `ActionMenu` component.
- Created `DropdownOpener` to be reused across the multiple components.
- Added new example.

<img width="723" alt="Screen Shot 2019-12-13 at 4 00 25 PM" src="https://user-images.githubusercontent.com/843075/70831882-b3c2c080-1dc1-11ea-82b7-57320d279e3a.png">

**Note:** This is the first part of this work:

1. Add custom opener to ActionMenu **[current]**.
2. Add custom opener to SingleSelect.
3. Add custom opener to MultiSelect.