### PR TITLE
[WB-801] Make sure errors invalidate cache

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,7 @@
     "coverage-gutters.lcovname": "./coverage/lcov.info",
     "jest.enableSnapshotUpdateMessages": false,
     "jest.pathToConfig": "./config/jest/test.config.js",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
 }

--- a/packages/wonder-blocks-data/components/data.js
+++ b/packages/wonder-blocks-data/components/data.js
@@ -106,10 +106,13 @@ export default class Data<TOptions, TData> extends React.Component<
         const {getEntry} = ResponseCache.Default;
 
         const cachedData = getEntry(handler, options);
-        if (!Server.isServerSide() && cachedData == null) {
+        if (
+            !Server.isServerSide() &&
+            (cachedData == null || handler.refreshCache(options, cachedData))
+        ) {
             /**
-             * We're not on the server and the cache missed (either due to
-             * missing data or deliberate cache invalidation).
+             * We're not on the server, the cache missed, or our handler says
+             * we should refresh the cache.
              *
              * Therefore, we need to request data.
              *

--- a/packages/wonder-blocks-data/components/data.js
+++ b/packages/wonder-blocks-data/components/data.js
@@ -108,7 +108,8 @@ export default class Data<TOptions, TData> extends React.Component<
         const cachedData = getEntry(handler, options);
         if (
             !Server.isServerSide() &&
-            (cachedData == null || handler.refreshCache(options, cachedData))
+            (cachedData == null ||
+                handler.shouldRefreshCache(options, cachedData))
         ) {
             /**
              * We're not on the server, the cache missed, or our handler says

--- a/packages/wonder-blocks-data/components/data.md
+++ b/packages/wonder-blocks-data/components/data.md
@@ -147,6 +147,13 @@ class MyHandler extends RequestHandler {
             "If you're seeing this error, the examples are broken and data isn't in the cache that should be.",
         );
     }
+
+    invalidateCache(options, cachedEntry) {
+        /**
+         * For our purposes, the cache is always valid.
+         */
+        return false;
+    }
 }
 
 const handler = new MyHandler();

--- a/packages/wonder-blocks-data/components/data.md
+++ b/packages/wonder-blocks-data/components/data.md
@@ -148,9 +148,9 @@ class MyHandler extends RequestHandler {
         );
     }
 
-    invalidateCache(options, cachedEntry) {
+    refreshCache(options, cachedEntry) {
         /**
-         * For our purposes, the cache is always valid.
+         * For our purposes, the cache never needs a refresh.
          */
         return false;
     }

--- a/packages/wonder-blocks-data/components/data.md
+++ b/packages/wonder-blocks-data/components/data.md
@@ -148,7 +148,7 @@ class MyHandler extends RequestHandler {
         );
     }
 
-    refreshCache(options, cachedEntry) {
+    shouldRefreshCache(options, cachedEntry) {
         /**
          * For our purposes, the cache never needs a refresh.
          */

--- a/packages/wonder-blocks-data/components/data.test.js
+++ b/packages/wonder-blocks-data/components/data.test.js
@@ -54,7 +54,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -77,7 +77,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(() => Promise.resolve("data")),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -101,7 +101,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -128,7 +128,7 @@ describe("./data.js", () => {
                         () => new Promise((resolve, reject) => {}),
                     ),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -162,7 +162,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.reject(new Error("OH NOES!")),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -196,7 +196,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("YAY! DATA!"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -229,7 +229,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("YAY!"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -263,13 +263,13 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.reject(new Error("OH NOES!")),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "TYPE1",
                 };
                 const fakeHandler2: IRequestHandler<string, string> = {
                     fulfillRequest: () => new Promise(() => {}),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "TYPE2",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -306,7 +306,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("HELLO!"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -348,7 +348,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -371,7 +371,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -387,12 +387,36 @@ describe("./data.js", () => {
                 expect(fakeHandler.fulfillRequest).not.toHaveBeenCalled();
             });
 
+            it("should request data if refreshCache returns true", () => {
+                // Arrange
+                const fakeHandler: IRequestHandler<string, string> = {
+                    fulfillRequest: jest.fn(() => Promise.resolve("data")),
+                    getKey: (o) => o,
+                    refreshCache: () => true,
+                    type: "MY_HANDLER",
+                };
+                const fakeChildrenFn = jest.fn(() => null);
+
+                // Act
+                shallow(
+                    <Data handler={fakeHandler} options={"options"}>
+                        {fakeChildrenFn}
+                    </Data>,
+                );
+
+                // Assert
+                expect(fakeHandler.fulfillRequest).toHaveBeenCalledWith(
+                    "options",
+                );
+                expect(fakeHandler.fulfillRequest).toHaveBeenCalledTimes(1);
+            });
+
             it("should render first time with the cached data", () => {
                 // Arrange
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -416,13 +440,13 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.reject(new Error("OH NOES!")),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "TYPE1",
                 };
                 const fakeHandler2: IRequestHandler<string, string> = {
                     fulfillRequest: () => new Promise(() => {}),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "TYPE2",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -455,7 +479,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("Not called!"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -505,7 +529,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(() => Promise.resolve("data")),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -526,7 +550,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -555,7 +579,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -590,7 +614,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(() => Promise.resolve("data")),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -611,7 +635,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -640,7 +664,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -670,7 +694,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);

--- a/packages/wonder-blocks-data/components/data.test.js
+++ b/packages/wonder-blocks-data/components/data.test.js
@@ -54,7 +54,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -77,7 +77,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(() => Promise.resolve("data")),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -101,7 +101,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -128,7 +128,7 @@ describe("./data.js", () => {
                         () => new Promise((resolve, reject) => {}),
                     ),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -162,7 +162,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.reject(new Error("OH NOES!")),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -196,7 +196,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("YAY! DATA!"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -229,7 +229,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("YAY!"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -263,13 +263,13 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.reject(new Error("OH NOES!")),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "TYPE1",
                 };
                 const fakeHandler2: IRequestHandler<string, string> = {
                     fulfillRequest: () => new Promise(() => {}),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "TYPE2",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -306,7 +306,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("HELLO!"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -348,7 +348,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -371,7 +371,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -387,12 +387,12 @@ describe("./data.js", () => {
                 expect(fakeHandler.fulfillRequest).not.toHaveBeenCalled();
             });
 
-            it("should request data if refreshCache returns true", () => {
+            it("should request data if shouldRefreshCache returns true", () => {
                 // Arrange
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(() => Promise.resolve("data")),
                     getKey: (o) => o,
-                    refreshCache: () => true,
+                    shouldRefreshCache: () => true,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -416,7 +416,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -440,13 +440,13 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.reject(new Error("OH NOES!")),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "TYPE1",
                 };
                 const fakeHandler2: IRequestHandler<string, string> = {
                     fulfillRequest: () => new Promise(() => {}),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "TYPE2",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -479,7 +479,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("Not called!"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -529,7 +529,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(() => Promise.resolve("data")),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -550,7 +550,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -579,7 +579,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -614,7 +614,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: jest.fn(() => Promise.resolve("data")),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -635,7 +635,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -664,7 +664,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);
@@ -694,7 +694,7 @@ describe("./data.js", () => {
                 const fakeHandler: IRequestHandler<string, string> = {
                     fulfillRequest: () => Promise.resolve("data"),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                 };
                 const fakeChildrenFn = jest.fn(() => null);

--- a/packages/wonder-blocks-data/generated-snapshot.test.js
+++ b/packages/wonder-blocks-data/generated-snapshot.test.js
@@ -160,9 +160,9 @@ describe("wonder-blocks-data", () => {
                 );
             }
 
-            invalidateCache(options, cachedEntry) {
+            refreshCache(options, cachedEntry) {
                 /**
-                 * For our purposes, the cache is always valid.
+                 * For our purposes, the cache never needs a refresh.
                  */
                 return false;
             }

--- a/packages/wonder-blocks-data/generated-snapshot.test.js
+++ b/packages/wonder-blocks-data/generated-snapshot.test.js
@@ -160,7 +160,7 @@ describe("wonder-blocks-data", () => {
                 );
             }
 
-            refreshCache(options, cachedEntry) {
+            shouldRefreshCache(options, cachedEntry) {
                 /**
                  * For our purposes, the cache never needs a refresh.
                  */

--- a/packages/wonder-blocks-data/generated-snapshot.test.js
+++ b/packages/wonder-blocks-data/generated-snapshot.test.js
@@ -159,6 +159,13 @@ describe("wonder-blocks-data", () => {
                     "If you're seeing this error, the examples are broken and data isn't in the cache that should be.",
                 );
             }
+
+            invalidateCache(options, cachedEntry) {
+                /**
+                 * For our purposes, the cache is always valid.
+                 */
+                return false;
+            }
         }
 
         const handler = new MyHandler();

--- a/packages/wonder-blocks-data/index.js
+++ b/packages/wonder-blocks-data/index.js
@@ -2,15 +2,15 @@
 import {ResponseCache as ResCache} from "./util/response-cache.js";
 import {RequestTracker} from "./util/request-tracking.js";
 
-import type {ResponseCache as Cache} from "./util/types.js";
-
-export opaque type ResponseCache = Cache;
+import type {Cache} from "./util/types.js";
 
 export type {Result, IRequestHandler} from "./util/types.js";
 
-export const initializeCache = ResCache.Default.initialize;
-export const fulfillAllDataRequests =
-    RequestTracker.Default.fulfillTrackedRequests;
+export opaque type ResponseCache = Cache;
+export const initializeCache = (source: ResponseCache): void =>
+    ResCache.Default.initialize(source);
+export const fulfillAllDataRequests = (): ResponseCache =>
+    RequestTracker.Default.fulfillTrackedRequests();
 
 export {default as RequestHandler} from "./util/request-handler.js";
 export {default as TrackData} from "./components/track-data.js";

--- a/packages/wonder-blocks-data/index.test.js
+++ b/packages/wonder-blocks-data/index.test.js
@@ -1,6 +1,12 @@
 // @flow
+import {initializeCache, fulfillAllDataRequests} from "./index.js";
+import {ResponseCache} from "./util/response-cache.js";
+import {RequestTracker} from "./util/request-tracking.js";
+
+import type {ResponseCache as Cache} from "./index.js";
+
 describe("@khanacademy/wonder-blocks-data", () => {
-    test("package exports default", async () => {
+    test("package exports what we expect", async () => {
         // Arrange
         const importedModule = import("./index.js");
 
@@ -17,5 +23,38 @@ describe("@khanacademy/wonder-blocks-data", () => {
                 "initializeCache",
             ].sort(),
         );
+    });
+
+    describe("#initializeCache", () => {
+        test("invokes ResponseCache.Default.initialize", () => {
+            // Arrange
+            const initializeSpy = jest.spyOn(
+                ResponseCache.Default,
+                "initialize",
+            );
+            const cache: Cache = ({}: any);
+
+            // Act
+            initializeCache(cache);
+
+            // Assert
+            expect(initializeSpy).toHaveBeenCalledWith(cache);
+        });
+    });
+
+    describe("#fulfillAllDataRequests", () => {
+        test("invokes RequestTracker.Default.fulfillTrackedRequests", () => {
+            // Arrange
+            const fulfillTrackedRequests = jest.spyOn(
+                RequestTracker.Default,
+                "fulfillTrackedRequests",
+            );
+
+            // Act
+            fulfillAllDataRequests();
+
+            // Assert
+            expect(fulfillTrackedRequests).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/wonder-blocks-data/util/request-fulfillment.test.js
+++ b/packages/wonder-blocks-data/util/request-fulfillment.test.js
@@ -26,7 +26,7 @@ describe("RequestFulfillment", () => {
                     throw new Error("OH NO!");
                 },
                 getKey: jest.fn().mockReturnValue("MY_KEY"),
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 type: "MY_TYPE",
             };
 
@@ -51,7 +51,7 @@ describe("RequestFulfillment", () => {
                 fulfillRequest: () =>
                     new Promise((resolve, reject) => reject("OH NO!")),
                 getKey: (o) => o,
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 type: "BAD_REQUEST",
             };
 
@@ -75,7 +75,7 @@ describe("RequestFulfillment", () => {
             const fakeRequestHandler: IRequestHandler<string, any> = {
                 fulfillRequest: () => Promise.resolve("DATA!"),
                 getKey: (o) => o,
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 type: "VALID_REQUEST",
             };
 
@@ -99,7 +99,7 @@ describe("RequestFulfillment", () => {
             const fakeRequestHandler: IRequestHandler<string, any> = {
                 fulfillRequest: () => Promise.resolve("DATA!"),
                 getKey: (o) => o,
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 type: "VALID_REQUEST",
             };
 
@@ -122,7 +122,7 @@ describe("RequestFulfillment", () => {
             const fakeRequestHandler: IRequestHandler<string, any> = {
                 fulfillRequest: () => Promise.resolve("DATA!"),
                 getKey: (o) => o,
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 type: "VALID_REQUEST",
             };
 
@@ -147,7 +147,7 @@ describe("RequestFulfillment", () => {
             const fakeRequestHandler: IRequestHandler<string, any> = {
                 fulfillRequest: () => Promise.resolve("DATA!"),
                 getKey: (o) => o,
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 type: "VALID_REQUEST",
             };
 

--- a/packages/wonder-blocks-data/util/request-fulfillment.test.js
+++ b/packages/wonder-blocks-data/util/request-fulfillment.test.js
@@ -34,7 +34,7 @@ describe("RequestFulfillment", () => {
             await requestFulfillment.fulfill(fakeBadHandler, "OPTIONS");
 
             // Assert
-            expect(responseCache.clone()).toStrictEqual({
+            expect(responseCache.cloneCachedData()).toStrictEqual({
                 MY_TYPE: {
                     MY_KEY: {
                         error: "OH NO!",
@@ -59,7 +59,7 @@ describe("RequestFulfillment", () => {
             await requestFulfillment.fulfill(fakeBadRequestHandler, "OPTIONS");
 
             // Assert
-            expect(responseCache.clone()).toStrictEqual({
+            expect(responseCache.cloneCachedData()).toStrictEqual({
                 BAD_REQUEST: {
                     OPTIONS: {
                         error: "OH NO!",
@@ -83,7 +83,7 @@ describe("RequestFulfillment", () => {
             await requestFulfillment.fulfill(fakeRequestHandler, "OPTIONS");
 
             // Assert
-            expect(responseCache.clone()).toStrictEqual({
+            expect(responseCache.cloneCachedData()).toStrictEqual({
                 VALID_REQUEST: {
                     OPTIONS: {
                         data: "DATA!",

--- a/packages/wonder-blocks-data/util/request-fulfillment.test.js
+++ b/packages/wonder-blocks-data/util/request-fulfillment.test.js
@@ -26,7 +26,7 @@ describe("RequestFulfillment", () => {
                     throw new Error("OH NO!");
                 },
                 getKey: jest.fn().mockReturnValue("MY_KEY"),
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 type: "MY_TYPE",
             };
 
@@ -51,7 +51,7 @@ describe("RequestFulfillment", () => {
                 fulfillRequest: () =>
                     new Promise((resolve, reject) => reject("OH NO!")),
                 getKey: (o) => o,
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 type: "BAD_REQUEST",
             };
 
@@ -75,7 +75,7 @@ describe("RequestFulfillment", () => {
             const fakeRequestHandler: IRequestHandler<string, any> = {
                 fulfillRequest: () => Promise.resolve("DATA!"),
                 getKey: (o) => o,
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
             };
 
@@ -99,7 +99,7 @@ describe("RequestFulfillment", () => {
             const fakeRequestHandler: IRequestHandler<string, any> = {
                 fulfillRequest: () => Promise.resolve("DATA!"),
                 getKey: (o) => o,
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
             };
 
@@ -122,7 +122,7 @@ describe("RequestFulfillment", () => {
             const fakeRequestHandler: IRequestHandler<string, any> = {
                 fulfillRequest: () => Promise.resolve("DATA!"),
                 getKey: (o) => o,
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
             };
 
@@ -147,7 +147,7 @@ describe("RequestFulfillment", () => {
             const fakeRequestHandler: IRequestHandler<string, any> = {
                 fulfillRequest: () => Promise.resolve("DATA!"),
                 getKey: (o) => o,
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
             };
 

--- a/packages/wonder-blocks-data/util/request-handler.js
+++ b/packages/wonder-blocks-data/util/request-handler.js
@@ -1,5 +1,5 @@
 // @flow
-import type {IRequestHandler} from "./types.js";
+import type {CacheEntry, IRequestHandler} from "./types.js";
 
 /**
  * Base implementation for creating a request handler.
@@ -19,11 +19,17 @@ export default class RequestHandler<TOptions, TData>
         return this._type;
     }
 
-    invalidateCache(options: TOptions): boolean {
+    invalidateCache(
+        options: TOptions,
+        cachedEntry: ?CacheEntry<TData>,
+    ): boolean {
         /**
-         * By default, the cache is always valid.
+         * By default, the cache is invalid if the current entry is an error.
+         * This means that an error will mean a re-request on render.
+         * Useful if the server rendered an error, as it means the client
+         * will update after a new request.
          */
-        return false;
+        return cachedEntry == null || cachedEntry.error != null;
     }
 
     getKey(options: TOptions): string {

--- a/packages/wonder-blocks-data/util/request-handler.js
+++ b/packages/wonder-blocks-data/util/request-handler.js
@@ -19,15 +19,17 @@ export default class RequestHandler<TOptions, TData>
         return this._type;
     }
 
-    invalidateCache(
+    refreshCache(
         options: TOptions,
-        cachedEntry: ?CacheEntry<TData>,
+        cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
     ): boolean {
         /**
-         * By default, the cache is invalid if the current entry is an error.
-         * This means that an error will mean a re-request on render.
+         * By default, the cache needs a refresh if the current entry is an
+         * error.
+         *
+         * This means that an error will cause a re-request on render.
          * Useful if the server rendered an error, as it means the client
-         * will update after a new request.
+         * will update after rehydration.
          */
         return cachedEntry == null || cachedEntry.error != null;
     }

--- a/packages/wonder-blocks-data/util/request-handler.js
+++ b/packages/wonder-blocks-data/util/request-handler.js
@@ -19,7 +19,7 @@ export default class RequestHandler<TOptions, TData>
         return this._type;
     }
 
-    refreshCache(
+    shouldRefreshCache(
         options: TOptions,
         cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
     ): boolean {

--- a/packages/wonder-blocks-data/util/request-handler.test.js
+++ b/packages/wonder-blocks-data/util/request-handler.test.js
@@ -70,12 +70,34 @@ describe("./request-handler.js", () => {
     });
 
     describe("#invalidateCache", () => {
-        it("should return false", () => {
+        it("should return true if no current cached entry", () => {
             // Arrange
             const handler = new RequestHandler("MY_TYPE");
 
             // Act
-            const result = handler.invalidateCache({});
+            const result = handler.invalidateCache({}, null);
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it("should return true if cached entry has error", () => {
+            // Arrange
+            const handler = new RequestHandler("MY_TYPE");
+
+            // Act
+            const result = handler.invalidateCache({}, {error: "oops!"});
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it("should return false if cached entry is data", () => {
+            // Arrange
+            const handler = new RequestHandler("MY_TYPE");
+
+            // Act
+            const result = handler.invalidateCache({}, {data: "yay! data"});
 
             // Assert
             expect(result).toBeFalsy();

--- a/packages/wonder-blocks-data/util/request-handler.test.js
+++ b/packages/wonder-blocks-data/util/request-handler.test.js
@@ -69,13 +69,13 @@ describe("./request-handler.js", () => {
         });
     });
 
-    describe("#refreshCache", () => {
+    describe("#shouldRefreshCache", () => {
         it("should return true if no current cached entry", () => {
             // Arrange
             const handler = new RequestHandler("MY_TYPE");
 
             // Act
-            const result = handler.refreshCache({}, null);
+            const result = handler.shouldRefreshCache({}, null);
 
             // Assert
             expect(result).toBeTruthy();
@@ -86,7 +86,7 @@ describe("./request-handler.js", () => {
             const handler = new RequestHandler("MY_TYPE");
 
             // Act
-            const result = handler.refreshCache({}, {error: "oops!"});
+            const result = handler.shouldRefreshCache({}, {error: "oops!"});
 
             // Assert
             expect(result).toBeTruthy();
@@ -97,7 +97,7 @@ describe("./request-handler.js", () => {
             const handler = new RequestHandler("MY_TYPE");
 
             // Act
-            const result = handler.refreshCache({}, {data: "yay! data"});
+            const result = handler.shouldRefreshCache({}, {data: "yay! data"});
 
             // Assert
             expect(result).toBeFalsy();

--- a/packages/wonder-blocks-data/util/request-handler.test.js
+++ b/packages/wonder-blocks-data/util/request-handler.test.js
@@ -69,13 +69,13 @@ describe("./request-handler.js", () => {
         });
     });
 
-    describe("#invalidateCache", () => {
+    describe("#refreshCache", () => {
         it("should return true if no current cached entry", () => {
             // Arrange
             const handler = new RequestHandler("MY_TYPE");
 
             // Act
-            const result = handler.invalidateCache({}, null);
+            const result = handler.refreshCache({}, null);
 
             // Assert
             expect(result).toBeTruthy();
@@ -86,7 +86,7 @@ describe("./request-handler.js", () => {
             const handler = new RequestHandler("MY_TYPE");
 
             // Act
-            const result = handler.invalidateCache({}, {error: "oops!"});
+            const result = handler.refreshCache({}, {error: "oops!"});
 
             // Assert
             expect(result).toBeTruthy();
@@ -97,7 +97,7 @@ describe("./request-handler.js", () => {
             const handler = new RequestHandler("MY_TYPE");
 
             // Act
-            const result = handler.invalidateCache({}, {data: "yay! data"});
+            const result = handler.refreshCache({}, {data: "yay! data"});
 
             // Assert
             expect(result).toBeFalsy();

--- a/packages/wonder-blocks-data/util/request-tracking.js
+++ b/packages/wonder-blocks-data/util/request-tracking.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {ResponseCache} from "./response-cache.js";
 import {RequestFulfillment} from "./request-fulfillment.js";
 
-import type {ResponseCache as Cache, IRequestHandler} from "./types.js";
+import type {Cache, IRequestHandler} from "./types.js";
 
 type TrackerFn = (handler: IRequestHandler<any, any>, options: any) => void;
 

--- a/packages/wonder-blocks-data/util/request-tracking.js
+++ b/packages/wonder-blocks-data/util/request-tracking.js
@@ -157,6 +157,8 @@ export class RequestTracker {
         /**
          * Let's wait for everything to fulfill, and then clone the cached data.
          */
-        return Promise.all(promises).then(() => this._responseCache.clone());
+        return Promise.all(promises).then(() =>
+            this._responseCache.cloneCachedData(),
+        );
     };
 }

--- a/packages/wonder-blocks-data/util/request-tracking.test.js
+++ b/packages/wonder-blocks-data/util/request-tracking.test.js
@@ -45,7 +45,7 @@ describe("./request-tracking.js", () => {
                 const fakeHandler: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(() => Promise.resolve(null)),
                     getKey: jest.fn(),
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 const options = {these: "are options"};
@@ -63,7 +63,7 @@ describe("./request-tracking.js", () => {
                 const fakeHandler: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(),
                     getKey: jest.fn().mockReturnValue("MY_KEY"),
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 const options = {these: "are options"};
@@ -85,7 +85,7 @@ describe("./request-tracking.js", () => {
                 const fakeHandler: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(() => Promise.resolve(null)),
                     getKey: (options) => JSON.stringify(options),
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 const options1 = {these: "are options"};
@@ -110,13 +110,13 @@ describe("./request-tracking.js", () => {
                 const fakeHandler1: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(),
                     getKey: jest.fn().mockReturnValue("MY_KEY1"),
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: handlerType,
                 };
                 const fakeHandler2: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(),
                     getKey: jest.fn().mockReturnValue("MY_KEY2"),
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: handlerType,
                 };
                 const options1 = {these: "are options"};
@@ -159,7 +159,7 @@ describe("./request-tracking.js", () => {
                         throw new Error("OH NO!");
                     },
                     getKey: jest.fn().mockReturnValue("MY_KEY"),
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 requestTracker.trackDataRequest(fakeBadHandler, "OPTIONS");
@@ -184,7 +184,7 @@ describe("./request-tracking.js", () => {
                     fulfillRequest: () =>
                         new Promise((resolve, reject) => reject("OH NO!")),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "BAD_REQUEST",
                 };
                 requestTracker.trackDataRequest(
@@ -217,7 +217,7 @@ describe("./request-tracking.js", () => {
                     fulfillRequest: () =>
                         new Promise((resolve, reject) => reject("OH NO!")),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "BAD_REQUEST",
                 };
                 const fakeBadHandler: IRequestHandler<string, any> = {
@@ -225,7 +225,7 @@ describe("./request-tracking.js", () => {
                         throw new Error("OH NO!");
                     },
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "BAD_HANDLER",
                 };
                 const fakeValidHandler: IRequestHandler<string, any> = {
@@ -237,7 +237,7 @@ describe("./request-tracking.js", () => {
                         };
                     })(),
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "VALID",
                 };
                 requestTracker.trackDataRequest(
@@ -281,7 +281,7 @@ describe("./request-tracking.js", () => {
                 const fakeStaticHandler: IRequestHandler<string, any> = {
                     fulfillRequest: fakeFulfiller,
                     getKey: (o) => o,
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "STATIC",
                 };
                 requestTracker.trackDataRequest(fakeStaticHandler, "1");
@@ -305,7 +305,7 @@ describe("./request-tracking.js", () => {
                 const fakeHandler: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(() => Promise.resolve(null)),
                     getKey: jest.fn().mockReturnValue("MY_KEY"),
-                    refreshCache: () => false,
+                    shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 requestTracker.trackDataRequest(fakeHandler, "OPTIONS");

--- a/packages/wonder-blocks-data/util/request-tracking.test.js
+++ b/packages/wonder-blocks-data/util/request-tracking.test.js
@@ -45,7 +45,7 @@ describe("./request-tracking.js", () => {
                 const fakeHandler: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(() => Promise.resolve(null)),
                     getKey: jest.fn(),
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 const options = {these: "are options"};
@@ -63,7 +63,7 @@ describe("./request-tracking.js", () => {
                 const fakeHandler: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(),
                     getKey: jest.fn().mockReturnValue("MY_KEY"),
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 const options = {these: "are options"};
@@ -85,7 +85,7 @@ describe("./request-tracking.js", () => {
                 const fakeHandler: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(() => Promise.resolve(null)),
                     getKey: (options) => JSON.stringify(options),
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 const options1 = {these: "are options"};
@@ -110,13 +110,13 @@ describe("./request-tracking.js", () => {
                 const fakeHandler1: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(),
                     getKey: jest.fn().mockReturnValue("MY_KEY1"),
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: handlerType,
                 };
                 const fakeHandler2: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(),
                     getKey: jest.fn().mockReturnValue("MY_KEY2"),
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: handlerType,
                 };
                 const options1 = {these: "are options"};
@@ -159,7 +159,7 @@ describe("./request-tracking.js", () => {
                         throw new Error("OH NO!");
                     },
                     getKey: jest.fn().mockReturnValue("MY_KEY"),
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 requestTracker.trackDataRequest(fakeBadHandler, "OPTIONS");
@@ -184,7 +184,7 @@ describe("./request-tracking.js", () => {
                     fulfillRequest: () =>
                         new Promise((resolve, reject) => reject("OH NO!")),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "BAD_REQUEST",
                 };
                 requestTracker.trackDataRequest(
@@ -217,7 +217,7 @@ describe("./request-tracking.js", () => {
                     fulfillRequest: () =>
                         new Promise((resolve, reject) => reject("OH NO!")),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "BAD_REQUEST",
                 };
                 const fakeBadHandler: IRequestHandler<string, any> = {
@@ -225,7 +225,7 @@ describe("./request-tracking.js", () => {
                         throw new Error("OH NO!");
                     },
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "BAD_HANDLER",
                 };
                 const fakeValidHandler: IRequestHandler<string, any> = {
@@ -237,7 +237,7 @@ describe("./request-tracking.js", () => {
                         };
                     })(),
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "VALID",
                 };
                 requestTracker.trackDataRequest(
@@ -281,7 +281,7 @@ describe("./request-tracking.js", () => {
                 const fakeStaticHandler: IRequestHandler<string, any> = {
                     fulfillRequest: fakeFulfiller,
                     getKey: (o) => o,
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "STATIC",
                 };
                 requestTracker.trackDataRequest(fakeStaticHandler, "1");
@@ -305,7 +305,7 @@ describe("./request-tracking.js", () => {
                 const fakeHandler: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(() => Promise.resolve(null)),
                     getKey: jest.fn().mockReturnValue("MY_KEY"),
-                    invalidateCache: () => false,
+                    refreshCache: () => false,
                     type: "MY_TYPE",
                 };
                 requestTracker.trackDataRequest(fakeHandler, "OPTIONS");

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -1,9 +1,5 @@
 // @flow
-import type {
-    CacheEntry,
-    ResponseCache as Cache,
-    IRequestHandler,
-} from "./types.js";
+import type {CacheEntry, Cache, IRequestHandler} from "./types.js";
 
 function deepClone<T: {...}>(source: T | $ReadOnly<T>): $ReadOnly<T> {
     /**

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -125,19 +125,20 @@ export class ResponseCache {
         }
 
         const key = handler.getKey(options);
-        if (handler.invalidateCache(options)) {
+        const entry = handlerCache[key];
+        if (handler.invalidateCache(options, entry)) {
             delete handlerCache[key];
+            return null;
         }
 
         // Get the response.
-        const entry = handlerCache[key];
         return entry == null ? null : entry;
     };
 
     /**
      * Deep clone the cache.
      */
-    clone = (): $ReadOnly<Cache> => {
+    cloneCachedData = (): $ReadOnly<Cache> => {
         try {
             return deepClone(this._cache);
         } catch (e) {

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -125,13 +125,9 @@ export class ResponseCache {
         }
 
         const key = handler.getKey(options);
-        const entry = handlerCache[key];
-        if (handler.invalidateCache(options, entry)) {
-            delete handlerCache[key];
-            return null;
-        }
 
         // Get the response.
+        const entry = handlerCache[key];
         return entry == null ? null : entry;
     };
 

--- a/packages/wonder-blocks-data/util/response-cache.test.js
+++ b/packages/wonder-blocks-data/util/response-cache.test.js
@@ -23,7 +23,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -67,7 +67,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
             const sourceData = {
@@ -115,7 +115,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -137,7 +137,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -157,7 +157,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -179,7 +179,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -199,7 +199,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -220,7 +220,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -241,7 +241,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -251,41 +251,9 @@ describe("./response-cache.js", () => {
             // Assert
             expect(result).toStrictEqual({data: "data!"});
         });
-
-        it("should delete the cached entry if invalidateCache returns true", () => {
-            // Arrange
-            const cache = new ResponseCache({
-                MY_HANDLER: {
-                    MY_KEY: {data: "data!"},
-                },
-            });
-            const fakeInvalidatorHandler: IRequestHandler<string, string> = {
-                getKey: () => "MY_KEY",
-                type: "MY_HANDLER",
-                invalidateCache: () => true,
-                fulfillRequest: jest.fn(),
-            };
-            const fakeHandler: IRequestHandler<string, string> = {
-                getKey: () => "MY_KEY",
-                type: "MY_HANDLER",
-                invalidateCache: () => false,
-                fulfillRequest: jest.fn(),
-            };
-
-            // Act
-            const invalidated = cache.getEntry(
-                fakeInvalidatorHandler,
-                "options",
-            );
-            const result = cache.getEntry(fakeHandler, "options");
-
-            // Assert
-            expect(invalidated).toBeNull();
-            expect(result).toBeNull();
-        });
     });
 
-    describe("#clone", () => {
+    describe("#cloneCachedData", () => {
         it("should deep clone the cached data and errors", () => {
             // Arrange
             const initCache = {
@@ -297,7 +265,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: (options) => options,
                 type: "MY_HANDLER",
-                invalidateCache: () => false,
+                refreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
             // Let's add to the initialized state to check that everything

--- a/packages/wonder-blocks-data/util/response-cache.test.js
+++ b/packages/wonder-blocks-data/util/response-cache.test.js
@@ -23,7 +23,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -67,7 +67,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
             const sourceData = {
@@ -115,7 +115,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -137,7 +137,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -157,7 +157,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -179,7 +179,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -199,7 +199,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -220,7 +220,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -241,7 +241,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
 
@@ -265,7 +265,7 @@ describe("./response-cache.js", () => {
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: (options) => options,
                 type: "MY_HANDLER",
-                refreshCache: () => false,
+                shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
             };
             // Let's add to the initialized state to check that everything

--- a/packages/wonder-blocks-data/util/response-cache.test.js
+++ b/packages/wonder-blocks-data/util/response-cache.test.js
@@ -306,7 +306,7 @@ describe("./response-cache.js", () => {
             cache.cacheError(fakeHandler, "OPTIONS2", new Error("OH NO!"));
 
             // Act
-            const result = cache.clone();
+            const result = cache.cloneCachedData();
             // Update the cache so that it should be different from the clone.
             cache.cacheData(fakeHandler, "OPTIONS1", "SOME_NEW_DATA");
 
@@ -335,7 +335,7 @@ describe("./response-cache.js", () => {
             });
 
             // Act
-            const underTest = () => cache.clone();
+            const underTest = () => cache.cloneCachedData();
 
             // Assert
             expect(underTest).toThrowErrorMatchingInlineSnapshot(

--- a/packages/wonder-blocks-data/util/types.js
+++ b/packages/wonder-blocks-data/util/types.js
@@ -55,7 +55,7 @@ export interface IRequestHandler<TOptions, TData> {
      * If this returns true, the framework will fulfill a new request by
      * calling `fulfillRequest`.
      */
-    refreshCache(
+    shouldRefreshCache(
         options: TOptions,
         cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
     ): boolean;

--- a/packages/wonder-blocks-data/util/types.js
+++ b/packages/wonder-blocks-data/util/types.js
@@ -26,7 +26,7 @@ type HandlerSubcache = {
     ...,
 };
 
-export type ResponseCache = {
+export type Cache = {
     [key: string]: HandlerSubcache,
     ...,
 };

--- a/packages/wonder-blocks-data/util/types.js
+++ b/packages/wonder-blocks-data/util/types.js
@@ -50,14 +50,14 @@ export interface IRequestHandler<TOptions, TData> {
     get type(): string;
 
     /**
-     * Determine if the cached data should be invalidated.
+     * Determine if the cached data should be refreshed.
      *
      * If this returns true, the framework will fulfill a new request by
      * calling `fulfillRequest`.
      */
-    invalidateCache(
+    refreshCache(
         options: TOptions,
-        cachedEntry: ?CacheEntry<TData>,
+        cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
     ): boolean;
 
     /**

--- a/packages/wonder-blocks-data/util/types.js
+++ b/packages/wonder-blocks-data/util/types.js
@@ -55,7 +55,10 @@ export interface IRequestHandler<TOptions, TData> {
      * If this returns true, the framework will fulfill a new request by
      * calling `fulfillRequest`.
      */
-    invalidateCache(options: TOptions): boolean;
+    invalidateCache(
+        options: TOptions,
+        cachedEntry: ?CacheEntry<TData>,
+    ): boolean;
 
     /**
      * Get the key to use for a given request. This should be idempotent for a

--- a/yarn.lock
+++ b/yarn.lock
@@ -12161,9 +12161,9 @@ rollup@^0.66.4:
     "@types/node" "*"
 
 rollup@^1.23.1:
-  version "1.27.11"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.11.tgz#95d190432e3edbcf757d921857df01ad1596ef97"
-  integrity sha512-ENXdvXk8tjtkNTvIvjRzOEu+vv54va7PiDR7VwP8TD+In6J87gKzzFmQMawQixEL2y9rsPEgomUS7ZVkq47Tww==
+  version "1.27.12"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.12.tgz#cf84db4b4edaf187eaba95232f34de7cd4d22d9c"
+  integrity sha512-51iR7n6NQfdQJlRrIktaGmkdt395A8Vue7CdnlrK6UhY9DY2GaKsTdljWeXisJuZh+w90Gz8VFNh5X+yxP20oQ==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"


### PR DESCRIPTION
Here we change `invalidateCache` to `refreshCache` and its default implementation. We also change how it is called.

1. We now pass the current `CachedEntry` so that refresh decisions can be made based on the current value in the cache.
2. The default implementation now returns that the cache should be refreshed if the cached entry is an error.

This has the effect of causing the client-side to re-request data that error'd when requested server-side. This is great in that we rehydrate with the error that the SSR rendered, but a new request to update the
data is made.

We also update the `clone` call on our `ResponseCache` class to be `cloneCachedData` to make it clearer what we're cloning, and the exports have been updated so that to the outside world, the cache object type is opaque.