### PR TITLE
WB-660.4: Add text argument to the new opener prop

### DIFF
--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -2963,8 +2963,7 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
     }
   }
 >
-  <button
-    aria-label="Search"
+  <h2
     className=""
     data-test-id="single-select-custom-opener"
     disabled={false}
@@ -2983,53 +2982,27 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
     onTouchStart={[Function]}
     style={
       Object {
-        "::MozFocusInner": Object {
-          "border": 0,
+        "@media (maxWidth: 1023px)": Object {
+          "fontSize": 24,
+          "lineHeight": "28px",
         },
-        ":focus": Object {
-          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        "@media (minWidth: 1024px)": Object {
+          "fontSize": 28,
+          "lineHeight": "32px",
         },
-        "alignItems": "center",
-        "background": "none",
-        "border": "none",
-        "boxSizing": "border-box",
-        "color": "#1865f2",
-        "cursor": "pointer",
-        "display": "inline-flex",
-        "height": 40,
-        "justifyContent": "center",
-        "margin": -8,
-        "outline": "none",
-        "padding": 0,
-        "position": "relative",
-        "textDecoration": "none",
-        "touchAction": "manipulation",
-        "width": 40,
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontWeight": 700,
+        "marginBottom": 0,
+        "marginTop": 0,
       }
     }
     tabIndex={0}
-    type="button"
   >
-    <svg
-      className=""
-      height={24}
-      style={
-        Object {
-          "display": "inline-block",
-          "flexGrow": 0,
-          "flexShrink": 0,
-          "verticalAlign": "text-bottom",
-        }
-      }
-      viewBox="0 0 24 24"
-      width={24}
-    >
-      <path
-        d="M17.293 8.293a1 1 0 0 1 1.414 1.414l-6 6a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 1.414-1.414L12 13.586l5.293-5.293z"
-        fill="currentColor"
-      />
-    </svg>
-  </button>
+    This is a heading
+  </h2>
 </div>
 `;
 

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1692,13 +1692,13 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
         "display": "block",
         "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
         "fontSize": 16,
-        "fontWeight": 400,
+        "fontWeight": 700,
         "lineHeight": "20px",
       }
     }
     tabIndex={0}
   >
-    This is a label
+    Custom opener
   </span>
 </div>
 `;
@@ -3001,7 +3001,7 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
     }
     tabIndex={0}
   >
-    This is a heading
+    Choose a juice
   </h2>
 </div>
 `;

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1648,6 +1648,63 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
 exports[`wonder-blocks-dropdown example 11 1`] = `
 <div
   className=""
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "width": "fit-content",
+      "zIndex": 0,
+    }
+  }
+>
+  <span
+    className=""
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "20px",
+      }
+    }
+    tabIndex={0}
+  >
+    hey
+  </span>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 12 1`] = `
+<div
+  className=""
   style={
     Object {
       "alignItems": "stretch",
@@ -1783,7 +1840,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 12 1`] = `
+exports[`wonder-blocks-dropdown example 13 1`] = `
 <div
   className=""
   style={
@@ -1920,7 +1977,7 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 13 1`] = `
+exports[`wonder-blocks-dropdown example 14 1`] = `
 <div
   className=""
   style={
@@ -2056,7 +2113,7 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 14 1`] = `
+exports[`wonder-blocks-dropdown example 15 1`] = `
 <div
   className=""
   style={
@@ -2193,7 +2250,7 @@ exports[`wonder-blocks-dropdown example 14 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 15 1`] = `
+exports[`wonder-blocks-dropdown example 16 1`] = `
 <div
   className=""
   style={
@@ -2355,7 +2412,7 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 16 1`] = `
+exports[`wonder-blocks-dropdown example 17 1`] = `
 <div
   className=""
   style={
@@ -2492,7 +2549,7 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 17 1`] = `
+exports[`wonder-blocks-dropdown example 18 1`] = `
 <div
   className=""
   style={
@@ -2648,7 +2705,7 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 18 1`] = `
+exports[`wonder-blocks-dropdown example 19 1`] = `
 <div
   className=""
   style={
@@ -2882,7 +2939,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 19 1`] = `
+exports[`wonder-blocks-dropdown example 20 1`] = `
 <div
   className=""
   style={
@@ -3019,7 +3076,7 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 20 1`] = `
+exports[`wonder-blocks-dropdown example 21 1`] = `
 <div
   className=""
   style={
@@ -3155,7 +3212,7 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 21 1`] = `
+exports[`wonder-blocks-dropdown example 22 1`] = `
 <div
   className=""
   style={
@@ -3291,7 +3348,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 22 1`] = `
+exports[`wonder-blocks-dropdown example 23 1`] = `
 <div
   className=""
   style={
@@ -3386,7 +3443,7 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 23 1`] = `
+exports[`wonder-blocks-dropdown example 24 1`] = `
 <div
   className=""
   style={
@@ -3523,7 +3580,7 @@ exports[`wonder-blocks-dropdown example 23 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 24 1`] = `
+exports[`wonder-blocks-dropdown example 25 1`] = `
 <div
   className=""
   style={
@@ -3679,7 +3736,7 @@ exports[`wonder-blocks-dropdown example 24 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 25 1`] = `
+exports[`wonder-blocks-dropdown example 26 1`] = `
 <div
   className=""
   style={
@@ -3815,7 +3872,7 @@ exports[`wonder-blocks-dropdown example 25 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 26 1`] = `
+exports[`wonder-blocks-dropdown example 27 1`] = `
 <div
   className=""
   style={
@@ -4049,7 +4106,7 @@ exports[`wonder-blocks-dropdown example 26 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 27 1`] = `
+exports[`wonder-blocks-dropdown example 28 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -4308,3 +4308,69 @@ exports[`wonder-blocks-dropdown example 29 1`] = `
   </div>
 </div>
 `;
+
+exports[`wonder-blocks-dropdown example 30 1`] = `
+<div
+  className=""
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "width": "fit-content",
+      "zIndex": 0,
+    }
+  }
+>
+  <h2
+    className=""
+    data-test-id="multi-select-custom-opener"
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    style={
+      Object {
+        "@media (maxWidth: 1023px)": Object {
+          "fontSize": 24,
+          "lineHeight": "28px",
+        },
+        "@media (minWidth: 1024px)": Object {
+          "fontSize": 28,
+          "lineHeight": "32px",
+        },
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontWeight": 700,
+        "marginBottom": 0,
+        "marginTop": 0,
+      }
+    }
+    tabIndex={0}
+  >
+    MultiSelect with custom opener
+  </h2>
+</div>
+`;

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -2942,6 +2942,99 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
 exports[`wonder-blocks-dropdown example 20 1`] = `
 <div
   className=""
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "width": "fit-content",
+      "zIndex": 0,
+    }
+  }
+>
+  <button
+    aria-label="Search"
+    className=""
+    data-test-id="single-select-custom-opener"
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    style={
+      Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "none",
+        "border": "none",
+        "boxSizing": "border-box",
+        "color": "#1865f2",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "margin": -8,
+        "outline": "none",
+        "padding": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "width": 40,
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <svg
+      className=""
+      height={24}
+      style={
+        Object {
+          "display": "inline-block",
+          "flexGrow": 0,
+          "flexShrink": 0,
+          "verticalAlign": "text-bottom",
+        }
+      }
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M17.293 8.293a1 1 0 0 1 1.414 1.414l-6 6a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 1.414-1.414L12 13.586l5.293-5.293z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`wonder-blocks-dropdown example 21 1`] = `
+<div
+  className=""
   style={
     Object {
       "alignItems": "stretch",
@@ -3076,7 +3169,7 @@ exports[`wonder-blocks-dropdown example 20 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 21 1`] = `
+exports[`wonder-blocks-dropdown example 22 1`] = `
 <div
   className=""
   style={
@@ -3212,7 +3305,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 22 1`] = `
+exports[`wonder-blocks-dropdown example 23 1`] = `
 <div
   className=""
   style={
@@ -3348,7 +3441,7 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 23 1`] = `
+exports[`wonder-blocks-dropdown example 24 1`] = `
 <div
   className=""
   style={
@@ -3443,7 +3536,7 @@ exports[`wonder-blocks-dropdown example 23 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 24 1`] = `
+exports[`wonder-blocks-dropdown example 25 1`] = `
 <div
   className=""
   style={
@@ -3580,7 +3673,7 @@ exports[`wonder-blocks-dropdown example 24 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 25 1`] = `
+exports[`wonder-blocks-dropdown example 26 1`] = `
 <div
   className=""
   style={
@@ -3736,7 +3829,7 @@ exports[`wonder-blocks-dropdown example 25 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 26 1`] = `
+exports[`wonder-blocks-dropdown example 27 1`] = `
 <div
   className=""
   style={
@@ -3872,7 +3965,7 @@ exports[`wonder-blocks-dropdown example 26 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 27 1`] = `
+exports[`wonder-blocks-dropdown example 28 1`] = `
 <div
   className=""
   style={
@@ -4106,7 +4199,7 @@ exports[`wonder-blocks-dropdown example 27 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-dropdown example 28 1`] = `
+exports[`wonder-blocks-dropdown example 29 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__snapshots__/generated-snapshot.test.js.snap
@@ -1697,7 +1697,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
     }
     tabIndex={0}
   >
-    hey
+    This is a label
   </span>
 </div>
 `;

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -214,7 +214,7 @@ export default class ActionMenu extends React.Component<Props, State> {
         });
     }
 
-    onHandleOpenerRef = (node: any) => {
+    handleOpenerRef = (node: any) => {
         this.openerElement = ((ReactDOM.findDOMNode(node): any): HTMLElement);
     };
 
@@ -229,7 +229,7 @@ export default class ActionMenu extends React.Component<Props, State> {
             <DropdownOpener
                 onClick={this.handleClick}
                 disabled={numItems === 0 || disabled}
-                anchorRef={this.onHandleOpenerRef}
+                ref={this.handleOpenerRef}
                 testId={opener ? undefined : testId}
             >
                 {opener

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -229,6 +229,7 @@ export default class ActionMenu extends React.Component<Props, State> {
             <DropdownOpener
                 onClick={this.handleClick}
                 disabled={numItems === 0 || disabled}
+                text={menuText}
                 ref={this.handleOpenerRef}
                 testId={opener ? undefined : testId}
             >

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -268,3 +268,38 @@ class ControlledActionMenuExample extends React.Component {
 
 <ControlledActionMenuExample />
 ```
+
+### Example: ActionMenu with custom opener
+
+```js
+import {ActionMenu, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
+import {View} from "@khanacademy/wonder-blocks-core";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {icons} from "@khanacademy/wonder-blocks-icon";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+
+<ActionMenu
+    disabled={false}
+    menuText="Betsy Appleseed"
+    testId="teacher-menu"
+    opener={(eventState) => (
+        <LabelMedium
+            onClick={()=>{console.log('custom click!!!!!')}}
+        >hey</LabelMedium>
+    )}
+>
+    <ActionItem label="Profile" href="http://khanacademy.org/profile" testId="profile" />
+    <ActionItem label="Settings" onClick={() => console.log("user clicked on settings")} testId="settings" />
+    <ActionItem label="Help" disabled={true} onClick={() => console.log("this item is disabled...")} testId="help" />
+    <SeparatorItem />
+    <ActionItem label="Log out" href="http://khanacademy.org/logout" testId="logout" />
+    <OptionItem
+        label="Show homework assignments" value="homework"
+        onClick={() => console.log(`Show homework assignments toggled`)}
+    />
+    <OptionItem
+        label="Show in-class assignments" value="in-class"
+        onClick={() => console.log(`Show in-class assignments toggled`)}
+    />
+</ActionMenu>
+```

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -271,6 +271,8 @@ class ControlledActionMenuExample extends React.Component {
 
 ### Example: ActionMenu with custom opener
 
+In case you need to use a custom opener, you can use the `opener` property to achieve this:
+
 ```js
 import {ActionMenu, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -285,7 +287,7 @@ import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
     opener={(eventState) => (
         <LabelMedium
             onClick={()=>{console.log('custom click!!!!!')}}
-        >hey</LabelMedium>
+        >This is a label</LabelMedium>
     )}
 >
     <ActionItem label="Profile" href="http://khanacademy.org/profile" testId="profile" />

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -272,9 +272,13 @@ class ControlledActionMenuExample extends React.Component {
 ### Example: ActionMenu with custom opener
 
 In case you need to use a custom opener, you can use the `opener` property to
-achieve this. In this example, the `opener` prop accepts a function with the
-`eventState` argument that lets you customize the style for different states,
-such as `pressed`, `hovered` and `focused`.
+achieve this. In this example, the `opener` prop accepts a
+function with the following arguments:
+
+- `eventState`: lets you customize the style for different states, such as
+  `pressed`, `hovered` and `focused`.
+- `text`: Passes the menu label defined in the parent component. This value is
+  passed using the `placeholder` prop set in the `ActionMenu` component.
 
 **Note:** If you need to use a custom ID for testing the opener, make sure to
 pass the `testId` prop inside the opener component/element.
@@ -283,19 +287,17 @@ pass the `testId` prop inside the opener component/element.
 import {ActionMenu, ActionItem, OptionItem, SeparatorItem} from "@khanacademy/wonder-blocks-dropdown";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {icons} from "@khanacademy/wonder-blocks-icon";
-import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 
 const styles = StyleSheet.create({
     focused: {
-        backgroundColor: Color.purple,
-        color: Color.white,
+        color: Color.purple,
     },
     hovered: {
         textDecoration: "underline",
-        color: Color.teal,
+        color: Color.purple,
+        cursor: "pointer",
     },
     pressed: {
         color: Color.blue,
@@ -304,9 +306,9 @@ const styles = StyleSheet.create({
 
 <ActionMenu
     disabled={false}
-    menuText="Betsy Appleseed"
-    opener={(eventState) => (
-        <LabelMedium
+    menuText="Custom opener"
+    opener={(eventState, text) => (
+        <LabelLarge
             onClick={()=>{console.log('custom click!!!!!')}}
             testId="teacher-menu-custom-opener"
             style={[
@@ -315,8 +317,8 @@ const styles = StyleSheet.create({
                 eventState.pressed && styles.pressed
             ]}
         >
-            This is a label
-        </LabelMedium>
+            {text}
+        </LabelLarge>
     )}
 >
     <ActionItem label="Profile" href="http://khanacademy.org/profile" testId="profile" />

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -471,5 +471,83 @@ describe("ActionMenu", () => {
             // Assert
             expect(onClickMock).toHaveBeenCalledTimes(1);
         });
+
+        it("verifies testId is passed from the custom opener", () => {
+            // Arrange
+            const menu = mount(
+                <ActionMenu
+                    onChange={onChange}
+                    menuText="Action menu!"
+                    opener={() => (
+                        <button
+                            data-test-id="custom-opener"
+                            aria-label="Custom opener"
+                        />
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </ActionMenu>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener).find("button");
+
+            // Assert
+            expect(opener.prop("data-test-id")).toBe("custom-opener");
+        });
+
+        it("verifies testId is not passed from the parent element", () => {
+            // Arrange
+            const menu = mount(
+                <ActionMenu
+                    onChange={onChange}
+                    menuText="Action menu!"
+                    testId="custom-opener"
+                    opener={() => <button aria-label="Custom opener" />}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </ActionMenu>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener).find("button");
+
+            // Assert
+            expect(opener.prop("data-test-id")).not.toBeDefined();
+        });
+
+        it("passes the menu text to the custom opener", () => {
+            // Arrange
+            const menu = mount(
+                <ActionMenu
+                    menuText="Action menu!"
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={[]}
+                    opener={(eventState, text) => (
+                        <button
+                            onClick={jest.fn()}
+                            data-test-id="custom-opener"
+                        >
+                            {text}
+                        </button>
+                    )}
+                >
+                    <OptionItem label="Toggle A" value="toggle_a" />
+                    <OptionItem label="Toggle B" value="toggle_b" />
+                </ActionMenu>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            // open dropdown
+            opener.simulate("click");
+            const openerElement = menu.find(`[data-test-id="custom-opener"]`);
+
+            // Assert
+            expect(openerElement).toHaveText("Action menu!");
+        });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.test.js
@@ -1,13 +1,12 @@
 //@flow
 import React from "react";
-import {getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 import ActionItem from "./action-item.js";
 import OptionItem from "./option-item.js";
 import SeparatorItem from "./separator-item.js";
 import ActionMenu from "./action-menu.js";
+import DropdownOpener from "./dropdown-opener.js";
 import {keyCodes} from "../util/constants.js";
-import Dropdown from "./dropdown.js";
 
 jest.mock("./dropdown-core-virtualized.js");
 
@@ -15,21 +14,17 @@ describe("ActionMenu", () => {
     const onClick = jest.fn();
     const onToggle = jest.fn();
     const onChange = jest.fn();
-    let ClickableBehavior;
-
-    beforeEach(() => {
-        ClickableBehavior = getClickableBehavior();
-    });
 
     afterEach(() => {
         unmountAll();
     });
 
-    it("closes/opens the menu on mouse click, space, and enter", () => {
+    it("opens the menu on mouse click", () => {
+        // Arrange
         const menu = mount(
             <ActionMenu
                 menuText={"Action menu!"}
-                testId="fail-test"
+                testId="openTest"
                 onChange={onChange}
                 selectedValues={[]}
             >
@@ -39,22 +34,116 @@ describe("ActionMenu", () => {
             </ActionMenu>,
         );
 
-        const opener = menu.find(ClickableBehavior);
-        expect(menu.state("opened")).toEqual(false);
-
-        // Open menu with mouse
+        // Act
+        const opener = menu.find(DropdownOpener);
         opener.simulate("click");
-        expect(menu.find(Dropdown).state("opened")).toEqual(true);
 
-        // Close menu with space
-        opener.simulate("keydown", {keyCode: keyCodes.space});
-        opener.simulate("keyup", {keyCode: keyCodes.space});
-        expect(menu.find(Dropdown).state("opened")).toEqual(false);
+        // Assert
+        expect(menu.state("opened")).toBe(true);
+    });
 
-        // Open menu again with enter
+    it("opens the menu on enter", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        // Act
+        const opener = menu.find(DropdownOpener);
         opener.simulate("keydown", {keyCode: keyCodes.enter});
         opener.simulate("keyup", {keyCode: keyCodes.enter});
-        expect(menu.find(Dropdown).state("opened")).toEqual(true);
+
+        // Assert
+        expect(menu.state("opened")).toBe(true);
+    });
+
+    it("closes itself on escape", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        // Act
+        const opener = menu.find(DropdownOpener);
+        // open using the mouse
+        opener.simulate("click");
+        // use keyboard to simulate the ESC key
+        opener.simulate("keydown", {keyCode: keyCodes.escape});
+        opener.simulate("keyup", {keyCode: keyCodes.escape});
+
+        // Assert
+        expect(menu.state("opened")).toBe(false);
+    });
+
+    it("closes itself on tab", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        // Act
+        const opener = menu.find(DropdownOpener);
+        // open using the mouse
+        opener.simulate("click");
+        // use keyboard to simulate the TAB key
+        opener.simulate("keydown", {keyCode: keyCodes.tab});
+        opener.simulate("keyup", {keyCode: keyCodes.tab});
+
+        // Assert
+        expect(menu.state("opened")).toBe(false);
+    });
+
+    it("closes itself on an external mouse click", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        // Act
+        const opener = menu.find(DropdownOpener);
+        // open using the mouse
+        opener.simulate("click");
+        // trigger body click
+        document.dispatchEvent(new MouseEvent("mouseup"));
+
+        // Assert
+        expect(menu.state("opened")).toBe(false);
     });
 
     it("triggers actions", () => {
@@ -70,7 +159,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act
         // toggle second OptionItem
@@ -94,7 +183,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act
         const optionItem = menu.find(OptionItem).at(0);
@@ -117,7 +206,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act
         // toggle second OptionItem
@@ -139,7 +228,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act, Assert
         expect(() => {
@@ -163,7 +252,7 @@ describe("ActionMenu", () => {
                 <OptionItem label="Toggle B" value="toggle_b" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Act
         // toggle second OptionItem
@@ -181,7 +270,7 @@ describe("ActionMenu", () => {
                 <ActionItem label="Action" />
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Assert
         expect(menu.find(ActionItem)).toHaveLength(1);
@@ -190,7 +279,7 @@ describe("ActionMenu", () => {
     it("can have a menu with no items", () => {
         // Arrange, Act
         const menu = mount(<ActionMenu menuText={"Action menu!"} />);
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Assert
         expect(menu.find(ActionItem)).toHaveLength(0);
@@ -205,7 +294,7 @@ describe("ActionMenu", () => {
                 {showDeleteAction && <ActionItem label="Delete" />}
             </ActionMenu>,
         );
-        menu.find(ClickableBehavior).simulate("click");
+        menu.find(DropdownOpener).simulate("click");
 
         // Assert
         expect(menu.find(ActionItem)).toHaveLength(1);
@@ -221,7 +310,7 @@ describe("ActionMenu", () => {
         );
 
         // Act
-        const opener = menu.find(ClickableBehavior).find("button");
+        const opener = menu.find(DropdownOpener).find("button");
 
         // Assert
         expect(opener.prop("data-test-id")).toBe("some-test-id");
@@ -308,7 +397,7 @@ describe("ActionMenu", () => {
 
             // Act
             // click on the anchor
-            wrapper.find(ClickableBehavior).simulate("click");
+            wrapper.find(DropdownOpener).simulate("click");
 
             // Assert
             expect(wrapper.find(ActionMenu).prop("opened")).toBe(true);
@@ -329,6 +418,58 @@ describe("ActionMenu", () => {
 
             // Assert
             expect(wrapper.find(ActionMenu).prop("opened")).toBe(false);
+        });
+    });
+
+    describe("Custom Opener", () => {
+        it("opens the menu when clicking on the custom opener", () => {
+            // Arrange
+            const menu = mount(
+                <ActionMenu
+                    menuText={"Action menu!"}
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={[]}
+                    opener={(eventState) => (
+                        <button aria-label="Search" onClick={jest.fn()} />
+                    )}
+                >
+                    <ActionItem label="Action" onClick={onClick} />
+                </ActionMenu>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            opener.simulate("click");
+
+            // Assert
+            expect(menu.state("opened")).toBe(true);
+        });
+
+        it("calls the custom onClick handler", () => {
+            // Arrange
+            const onClickMock = jest.fn();
+
+            const menu = mount(
+                <ActionMenu
+                    menuText={"Action menu!"}
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={[]}
+                    opener={(eventState) => (
+                        <button aria-label="Search" onClick={onClickMock} />
+                    )}
+                >
+                    <ActionItem label="Action" onClick={onClick} />
+                </ActionMenu>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            opener.simulate("click");
+
+            // Assert
+            expect(onClickMock).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/dropdown-opener.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-opener.js
@@ -1,0 +1,90 @@
+// @flow
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+import {ClickableBehavior} from "@khanacademy/wonder-blocks-core";
+
+import type {
+    AriaProps,
+    ClickableHandlers,
+    ClickableState,
+} from "@khanacademy/wonder-blocks-core";
+
+type Props = {|
+    ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,
+
+    /**
+     * The child function that returns the anchor the Dropdown will be activated
+     * by. This function takes `eventState`, which allows the opener element to
+     * access pointer event state.
+     */
+    children: (eventState: ClickableState) => React.Element<any>,
+
+    /**
+     * Whether the opener is disabled. If disabled, disallows interaction.
+     */
+    disabled: boolean,
+
+    /**
+     * Callback for when the opener is pressed.
+     */
+    onClick: (e: SyntheticEvent<>) => mixed,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
+
+    /**
+     * Callback used to pass the childs Ref back up to the parent element
+     */
+    anchorRef: (?HTMLElement) => mixed,
+|};
+
+class DropdownOpener extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
+    componentDidMount() {
+        const anchorNode = ((ReactDOM.findDOMNode(this): any): ?HTMLElement);
+        this.props.anchorRef(anchorNode);
+    }
+
+    renderAnchorChildren(
+        eventState: ClickableState,
+        handlers: ClickableHandlers,
+    ) {
+        const renderedChildren = this.props.children(eventState);
+
+        return React.cloneElement(renderedChildren, {
+            ...handlers,
+            disabled: this.props.disabled,
+            "data-test-id": this.props.testId,
+            onClick: renderedChildren.props.onClick
+                ? (e: SyntheticMouseEvent<>) => {
+                      // This is done to avoid overriding a
+                      // custom onClick handler inside the
+                      // children node
+                      renderedChildren.props.onClick(e);
+                      handlers.onClick(e);
+                  }
+                : handlers.onClick,
+        });
+    }
+
+    render() {
+        return (
+            <ClickableBehavior
+                onClick={this.props.onClick}
+                disabled={this.props.disabled}
+            >
+                {(eventState, handlers) =>
+                    this.renderAnchorChildren(eventState, handlers)
+                }
+            </ClickableBehavior>
+        );
+    }
+}
+
+export default DropdownOpener;

--- a/packages/wonder-blocks-dropdown/components/dropdown-opener.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-opener.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 import {ClickableBehavior} from "@khanacademy/wonder-blocks-core";
 
@@ -34,22 +33,12 @@ type Props = {|
      * Test ID used for e2e testing.
      */
     testId?: string,
-
-    /**
-     * Callback used to pass the child's Ref back up to the parent element
-     */
-    anchorRef: (?HTMLElement) => mixed,
 |};
 
 class DropdownOpener extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
-
-    componentDidMount() {
-        const anchorNode = ((ReactDOM.findDOMNode(this): any): ?HTMLElement);
-        this.props.anchorRef(anchorNode);
-    }
 
     renderAnchorChildren(
         eventState: ClickableState,

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -455,6 +455,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 onClick={this.handleClick}
                 disabled={numOptions === 0 || disabled}
                 ref={this.handleOpenerRef}
+                text={menuText}
             >
                 {opener}
             </DropdownOpener>

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -513,3 +513,91 @@ class ExampleWithShortcuts extends React.Component {
 </View>
 ```
 
+### Example: MultiSelect with custom opener
+
+In case you need to use a custom opener with the MultiSelect, you can use the
+`opener` property to achieve this. In this example, the `opener` prop accepts a
+function with the `eventState` argument that lets you customize the style for
+different states, such as `pressed`, `hovered` and `focused`.
+
+**Note:** If you need to use a custom ID for testing the opener, make sure to
+pass the `testId` prop inside the opener component/element.
+
+```js
+import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+import Color from "@khanacademy/wonder-blocks-color";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+
+const styles = StyleSheet.create({
+    focused: {
+        color: Color.purple,
+    },
+    hovered: {
+        textDecoration: "underline",
+        color: Color.purple,
+        cursor: "pointer",
+    },
+    pressed: {
+        color: Color.blue,
+    },
+});
+
+class CustomOpenerExample extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            opened: false,
+            selectedValues: [],
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleToggleMenu = this.handleToggleMenu.bind(this);
+    }
+
+    handleChange(update) {
+        this.setState({
+           selectedValues: update,
+        });
+    }
+
+    handleToggleMenu(opened) {
+        this.setState({
+            opened,
+        });
+    }
+
+    render() {
+        return (
+            <MultiSelect
+                selectItemType="fruits"
+                onChange={this.handleChange}
+                opened={this.state.opened}
+                onToggle={this.handleToggleMenu}
+                selectedValues={this.state.selectedValues}
+                testId="multi-select-custom-opener"
+                opener={(eventState) => (
+                    <HeadingLarge
+                        onClick={()=>{console.log('custom click!!!!!')}}
+                        testId="multi-select-custom-opener"
+                        style={[
+                            eventState.focused && styles.focused,
+                            eventState.hovered && styles.hovered,
+                            eventState.pressed && styles.pressed
+                        ]}
+                    >
+                        MultiSelect with custom opener
+                    </HeadingLarge>
+                )}
+            >
+                <OptionItem label="Nectarine" value="nectarine" />
+                <OptionItem label="Plum" value="plum" />
+                <OptionItem label="Cantaloupe" value="cantaloupe" />
+                <OptionItem label="Pineapples" value="pineapples" />
+            </MultiSelect>
+        );
+    }
+}
+
+<CustomOpenerExample />
+```

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -517,8 +517,13 @@ class ExampleWithShortcuts extends React.Component {
 
 In case you need to use a custom opener with the MultiSelect, you can use the
 `opener` property to achieve this. In this example, the `opener` prop accepts a
-function with the `eventState` argument that lets you customize the style for
-different states, such as `pressed`, `hovered` and `focused`.
+function with the following arguments:
+
+- `eventState`: lets you customize the style for different states, such as
+  `pressed`, `hovered` and `focused`.
+- `text`: Passes the menu label defined in the parent component. By default,
+  `text` will be initialized with the value of the `placeholder` prop set in the
+  `MultiSelect` component.
 
 **Note:** If you need to use a custom ID for testing the opener, make sure to
 pass the `testId` prop inside the opener component/element.
@@ -574,9 +579,10 @@ class CustomOpenerExample extends React.Component {
                 onChange={this.handleChange}
                 opened={this.state.opened}
                 onToggle={this.handleToggleMenu}
+                placeholder="MultiSelect with custom opener"
                 selectedValues={this.state.selectedValues}
                 testId="multi-select-custom-opener"
-                opener={(eventState) => (
+                opener={(eventState, text) => (
                     <HeadingLarge
                         onClick={()=>{console.log('custom click!!!!!')}}
                         testId="multi-select-custom-opener"
@@ -586,7 +592,7 @@ class CustomOpenerExample extends React.Component {
                             eventState.pressed && styles.pressed
                         ]}
                     >
-                        MultiSelect with custom opener
+                        {text}
                     </HeadingLarge>
                 )}
             >

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -531,5 +531,192 @@ describe("MultiSelect", () => {
             // Assert
             expect(onClickMock).toHaveBeenCalledTimes(1);
         });
+
+        it("verifies testId is passed from the custom opener", () => {
+            // Arrange
+            const menu = mount(
+                <MultiSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    selectItemType="items"
+                    opener={() => (
+                        <button
+                            data-test-id="custom-opener"
+                            aria-label="Custom opener"
+                        />
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener).find("button");
+
+            // Assert
+            expect(opener.prop("data-test-id")).toBe("custom-opener");
+        });
+
+        it("verifies testId is not passed from the parent element", () => {
+            // Arrange
+            const menu = mount(
+                <MultiSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    selectItemType="items"
+                    testId="custom-opener"
+                    opener={() => <button aria-label="Custom opener" />}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener).find("button");
+
+            // Assert
+            expect(opener.prop("data-test-id")).not.toBeDefined();
+        });
+
+        it("passes the current label to the custom opener (no items selected)", () => {
+            // Arrange
+            const menu = mount(
+                <MultiSelect
+                    placeholder="Custom placeholder"
+                    selectItemType="items"
+                    testId="openTest"
+                    onChange={jest.fn()}
+                    opener={(eventState, text) => (
+                        <button
+                            onClick={jest.fn()}
+                            data-test-id="custom-opener"
+                        >
+                            {text}
+                        </button>
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            // open dropdown
+            opener.simulate("click");
+            const openerElement = menu.find(`[data-test-id="custom-opener"]`);
+
+            // Assert
+            expect(openerElement).toHaveText("Custom placeholder");
+        });
+
+        it("passes the current label to the custom opener (1 item selected)", () => {
+            // Arrange
+            const menu = mount(
+                <MultiSelect
+                    placeholder="Custom placeholder"
+                    selectItemType="items"
+                    testId="openTest"
+                    onChange={jest.fn()}
+                    opener={(eventState, text) => (
+                        <button
+                            onClick={jest.fn()}
+                            data-test-id="custom-opener"
+                        >
+                            {text}
+                        </button>
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            // open dropdown
+            opener.simulate("click");
+            // select the first item manually via selectedValues on MultiSelect
+            menu.setProps({selectedValues: ["1"]});
+            const openerElement = menu.find(`[data-test-id="custom-opener"]`);
+
+            // Assert
+            expect(openerElement).toHaveText("item 1");
+        });
+
+        it("passes the current label to the custom opener (2 items selected)", () => {
+            // Arrange
+            const menu = mount(
+                <MultiSelect
+                    placeholder="Custom placeholder"
+                    selectItemType="items"
+                    testId="openTest"
+                    onChange={jest.fn()}
+                    opener={(eventState, text) => (
+                        <button
+                            onClick={jest.fn()}
+                            data-test-id="custom-opener"
+                        >
+                            {text}
+                        </button>
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            // open dropdown
+            opener.simulate("click");
+            // select the first and second items manually via selectedValues on
+            // MultiSelect
+            menu.setProps({selectedValues: ["1", "2"]});
+            const openerElement = menu.find(`[data-test-id="custom-opener"]`);
+
+            // Assert
+            expect(openerElement).toHaveText("2 items");
+        });
+
+        it("passes the current label to the custom opener (all items selected)", () => {
+            // Arrange
+            const menu = mount(
+                <MultiSelect
+                    placeholder="Custom placeholder"
+                    selectItemType="items"
+                    testId="openTest"
+                    onChange={jest.fn()}
+                    opener={(eventState, text) => (
+                        <button
+                            onClick={jest.fn()}
+                            data-test-id="custom-opener"
+                        >
+                            {text}
+                        </button>
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            // open dropdown
+            opener.simulate("click");
+            // select all items manually via selectedValues on MultiSelect
+            menu.setProps({selectedValues: ["1", "2", "3"]});
+            const openerElement = menu.find(`[data-test-id="custom-opener"]`);
+
+            // Assert
+            expect(openerElement).toHaveText("All items");
+        });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.test.js
@@ -4,6 +4,7 @@ import React from "react";
 import {ClickableBehavior} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
+import DropdownOpener from "./dropdown-opener.js";
 import SelectOpener from "./select-opener.js";
 import ActionItem from "./action-item.js";
 import OptionItem from "./option-item.js";
@@ -476,5 +477,59 @@ describe("MultiSelect", () => {
 
         // Assert
         expect(select.state("searchText")).toEqual("");
+    });
+
+    describe("Custom Opener", () => {
+        it("opens the menu when clicking on the custom opener", () => {
+            // Arrange
+            const wrapper = mount(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    placeholder="custom opener"
+                    selectItemType="items"
+                    opener={(eventState) => (
+                        <button aria-label="Search" onClick={jest.fn()} />
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const opener = wrapper.find(DropdownOpener);
+            opener.simulate("click");
+
+            // Assert
+            expect(wrapper.state("open")).toBe(true);
+        });
+
+        it("calls the custom onClick handler", () => {
+            // Arrange
+            const onClickMock = jest.fn();
+
+            const wrapper = mount(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    placeholder="custom opener"
+                    selectItemType="items"
+                    opener={(eventState) => (
+                        <button aria-label="Search" onClick={onClickMock} />
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const opener = wrapper.find(DropdownOpener);
+            opener.simulate("click");
+
+            // Assert
+            expect(onClickMock).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -252,7 +252,6 @@ export default class SingleSelect extends React.Component<Props, State> {
                 onClick={this.handleClick}
                 disabled={numItems === 0 || disabled}
                 ref={this.handleOpenerRef}
-                testId={testId}
             >
                 {opener}
             </DropdownOpener>

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -209,7 +209,7 @@ export default class SingleSelect extends React.Component<Props, State> {
             });
     }
 
-    onHandleOpenerRef = (node: any) => {
+    handleOpenerRef = (node: any) => {
         this.openerElement = ((ReactDOM.findDOMNode(node): any): HTMLElement);
     };
 
@@ -251,7 +251,7 @@ export default class SingleSelect extends React.Component<Props, State> {
             <DropdownOpener
                 onClick={this.handleClick}
                 disabled={numItems === 0 || disabled}
-                anchorRef={this.onHandleOpenerRef}
+                ref={this.handleOpenerRef}
                 testId={testId}
             >
                 {opener}
@@ -265,7 +265,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                 light={light}
                 onOpenChanged={this.handleOpenChanged}
                 open={this.state.open}
-                ref={this.onHandleOpenerRef}
+                ref={this.handleOpenerRef}
                 testId={testId}
             >
                 {menuText}
@@ -276,9 +276,7 @@ export default class SingleSelect extends React.Component<Props, State> {
 
     render() {
         const {alignment, dropdownStyle, light, style} = this.props;
-
         const items = this.getMenuItems();
-
         const opener = this.renderOpener(items.length);
 
         return (

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -3,9 +3,14 @@
 import * as React from "react";
 import ReactDOM from "react-dom";
 
-import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+import type {
+    AriaProps,
+    ClickableState,
+    StyleType,
+} from "@khanacademy/wonder-blocks-core";
 
 import DropdownCore from "./dropdown-core.js";
+import DropdownOpener from "./dropdown-opener.js";
 import SelectOpener from "./select-opener.js";
 import {selectDropdownStyle} from "../util/constants.js";
 
@@ -86,6 +91,13 @@ type Props = {|
      * Optional styling to add to the dropdown wrapper.
      */
     dropdownStyle?: StyleType,
+
+    /**
+     * The child function that returns the anchor the ActionMenu will be
+     * activated by. This function takes eventState, which allows the opener
+     * element to access pointer event state.
+     */
+    opener?: (eventState: ClickableState) => React.Element<any>,
 |};
 
 type State = {|
@@ -197,28 +209,33 @@ export default class SingleSelect extends React.Component<Props, State> {
             });
     }
 
-    handleOpenerRef = (node: any) => {
+    onHandleOpenerRef = (node: any) => {
         this.openerElement = ((ReactDOM.findDOMNode(node): any): HTMLElement);
     };
 
-    render() {
+    handleClick = (e: SyntheticEvent<>) => {
+        return this.handleOpenChanged(!this.state.open, e.type === "keyup");
+    };
+
+    renderOpener(numItems: number) {
         const {
-            alignment,
             children,
             disabled,
-            dropdownStyle,
             id,
             light,
+            opener,
             placeholder,
             selectedValue,
-            style,
             testId,
             // the following props are being included here to avoid
             // passing them down to the opener as part of sharedProps
             /* eslint-disable no-unused-vars */
+            alignment,
+            dropdownStyle,
             onChange,
             onToggle,
             opened,
+            style,
             /* eslint-enable no-unused-vars */
             ...sharedProps
         } = this.props;
@@ -230,23 +247,39 @@ export default class SingleSelect extends React.Component<Props, State> {
         // item in the menu, use the placeholder.
         const menuText = selectedItem ? selectedItem.props.label : placeholder;
 
-        const items = this.getMenuItems();
-
-        const opener = (
+        const dropdownOpener = opener ? (
+            <DropdownOpener
+                onClick={this.handleClick}
+                disabled={numItems === 0 || disabled}
+                anchorRef={this.onHandleOpenerRef}
+                testId={testId}
+            >
+                {opener}
+            </DropdownOpener>
+        ) : (
             <SelectOpener
                 {...sharedProps}
-                disabled={items.length === 0 || disabled}
+                disabled={numItems === 0 || disabled}
                 id={id}
                 isPlaceholder={!selectedItem}
                 light={light}
                 onOpenChanged={this.handleOpenChanged}
                 open={this.state.open}
-                ref={this.handleOpenerRef}
+                ref={this.onHandleOpenerRef}
                 testId={testId}
             >
                 {menuText}
             </SelectOpener>
         );
+        return dropdownOpener;
+    }
+
+    render() {
+        const {alignment, dropdownStyle, light, style} = this.props;
+
+        const items = this.getMenuItems();
+
+        const opener = this.renderOpener(items.length);
 
         return (
             <DropdownCore

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -252,6 +252,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                 onClick={this.handleClick}
                 disabled={numItems === 0 || disabled}
                 ref={this.handleOpenerRef}
+                text={menuText}
             >
                 {opener}
             </DropdownOpener>

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -413,3 +413,30 @@ class ControlledSingleSelectExample extends React.Component {
 
 <ControlledSingleSelectExample />
 ```
+
+### Example: SingleSelect with custom opener
+
+In case you need to use a custom opener with the SingleSelect, you can use the `opener` property to achieve this:
+
+```js
+import {SingleSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+import {View} from "@khanacademy/wonder-blocks-core";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {icons} from "@khanacademy/wonder-blocks-icon";
+
+<SingleSelect
+    placeholder="Choose a juice"
+    opener={(eventState) => (
+        <IconButton
+            icon={icons.caretDown}
+            aria-label="Search"
+            onClick={()=>{console.log('custom click!!!!!')}}
+        />
+    )}
+    testId="single-select-custom-opener"
+>
+    <OptionItem label="Banana juice" value="banana" />
+    <OptionItem label="Guava juice" value="guava" disabled />
+    <OptionItem label="White grape juice" value="grape" />
+</SingleSelect>
+```

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -416,24 +416,51 @@ class ControlledSingleSelectExample extends React.Component {
 
 ### Example: SingleSelect with custom opener
 
-In case you need to use a custom opener with the SingleSelect, you can use the `opener` property to achieve this:
+In case you need to use a custom opener with the SingleSelect, you can use the
+`opener` property to achieve this. In this example, the `opener` prop accepts a
+function with the `eventState` argument that lets you customize the style for
+different states, such as `pressed`, `hovered` and `focused`.
+
+**Note:** If you need to use a custom ID for testing the opener, make sure to
+pass the `testId` prop inside the opener component/element.
 
 ```js
 import {SingleSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+
+const styles = StyleSheet.create({
+    focused: {
+        color: Color.purple,
+    },
+    hovered: {
+        textDecoration: "underline",
+        color: Color.purple,
+        cursor: "pointer",
+    },
+    pressed: {
+        color: Color.blue,
+    },
+});
 
 <SingleSelect
     placeholder="Choose a juice"
     opener={(eventState) => (
-        <IconButton
-            icon={icons.caretDown}
-            aria-label="Search"
+        <HeadingLarge
             onClick={()=>{console.log('custom click!!!!!')}}
-        />
+            testId="single-select-custom-opener"
+            style={[
+                eventState.focused && styles.focused,
+                eventState.hovered && styles.hovered,
+                eventState.pressed && styles.pressed
+            ]}
+        >
+            This is a heading
+        </HeadingLarge>
     )}
-    testId="single-select-custom-opener"
+
 >
     <OptionItem label="Banana juice" value="banana" />
     <OptionItem label="Guava juice" value="guava" disabled />

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -445,25 +445,59 @@ const styles = StyleSheet.create({
     },
 });
 
-<SingleSelect
-    placeholder="Choose a juice"
-    opener={(eventState) => (
-        <HeadingLarge
-            onClick={()=>{console.log('custom click!!!!!')}}
-            testId="single-select-custom-opener"
-            style={[
-                eventState.focused && styles.focused,
-                eventState.hovered && styles.hovered,
-                eventState.pressed && styles.pressed
-            ]}
-        >
-            This is a heading
-        </HeadingLarge>
-    )}
+class SingleSelectWithCustomOpener extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            opened: false,
+            selectedValue: null,
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleToggleMenu = this.handleToggleMenu.bind(this);
+    }
 
->
-    <OptionItem label="Banana juice" value="banana" />
-    <OptionItem label="Guava juice" value="guava" disabled />
-    <OptionItem label="White grape juice" value="grape" />
-</SingleSelect>
+    handleChange(selected) {
+        this.setState({
+            selectedValue: selected,
+        });
+    }
+
+    handleToggleMenu(opened) {
+        this.setState({
+            opened,
+        });
+    }
+
+    render() {
+        return (
+            <SingleSelect
+                placeholder="Choose a juice"
+                opened={this.state.opened}
+                onChange={this.handleChange}
+                onToggle={this.handleToggleMenu}
+                selectedValue={this.state.selectedValue}
+                opener={(eventState) => (
+                    <HeadingLarge
+                        onClick={()=>{console.log('custom click!!!!!')}}
+                        testId="single-select-custom-opener"
+                        style={[
+                            eventState.focused && styles.focused,
+                            eventState.hovered && styles.hovered,
+                            eventState.pressed && styles.pressed
+                        ]}
+                    >
+                        This is a heading
+                    </HeadingLarge>
+                )}
+
+            >
+                <OptionItem label="Banana juice" value="banana" />
+                <OptionItem label="Guava juice" value="guava" disabled />
+                <OptionItem label="White grape juice" value="grape" />
+            </SingleSelect>
+        );
+    }
+}
+
+<SingleSelectWithCustomOpener />
 ```

--- a/packages/wonder-blocks-dropdown/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/components/single-select.md
@@ -418,8 +418,13 @@ class ControlledSingleSelectExample extends React.Component {
 
 In case you need to use a custom opener with the SingleSelect, you can use the
 `opener` property to achieve this. In this example, the `opener` prop accepts a
-function with the `eventState` argument that lets you customize the style for
-different states, such as `pressed`, `hovered` and `focused`.
+function with the following arguments:
+
+- `eventState`: lets you customize the style for different states, such as
+  `pressed`, `hovered` and `focused`.
+- `text`: Passes the menu label defined in the parent component. By default,
+  `text` will be initialized with the value of the `placeholder` prop set in the
+  `SingleSelect` component.
 
 **Note:** If you need to use a custom ID for testing the opener, make sure to
 pass the `testId` prop inside the opener component/element.
@@ -476,7 +481,7 @@ class SingleSelectWithCustomOpener extends React.Component {
                 onChange={this.handleChange}
                 onToggle={this.handleToggleMenu}
                 selectedValue={this.state.selectedValue}
-                opener={(eventState) => (
+                opener={(eventState, text) => (
                     <HeadingLarge
                         onClick={()=>{console.log('custom click!!!!!')}}
                         testId="single-select-custom-opener"
@@ -486,7 +491,7 @@ class SingleSelectWithCustomOpener extends React.Component {
                             eventState.pressed && styles.pressed
                         ]}
                     >
-                        This is a heading
+                        {text}
                     </HeadingLarge>
                 )}
 

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -259,9 +259,12 @@ describe("SingleSelect", () => {
                 <SingleSelect
                     onChange={jest.fn()}
                     placeholder="custom opener"
-                    testId="openTest"
-                    opener={(eventState) => (
-                        <button aria-label="Search" onClick={onClickMock} />
+                    opener={() => (
+                        <button
+                            data-test-id="custom-opener"
+                            aria-label="Custom opener"
+                            onClick={onClickMock}
+                        />
                     )}
                 >
                     <OptionItem label="item 1" value="1" />
@@ -276,6 +279,116 @@ describe("SingleSelect", () => {
 
             // Assert
             expect(onClickMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("verifies testId is passed from the custom opener", () => {
+            // Arrange
+            const menu = mount(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    opener={() => (
+                        <button
+                            data-test-id="custom-opener"
+                            aria-label="Custom opener"
+                        />
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </SingleSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener).find("button");
+
+            // Assert
+            expect(opener.prop("data-test-id")).toBe("custom-opener");
+        });
+
+        it("verifies testId is not passed from the parent element", () => {
+            // Arrange
+            const menu = mount(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    testId="custom-opener"
+                    opener={() => <button aria-label="Custom opener" />}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </SingleSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener).find("button");
+
+            // Assert
+            expect(opener.prop("data-test-id")).not.toBeDefined();
+        });
+
+        it("passes the placeholder text to the custom opener", () => {
+            // Arrange
+            const menu = mount(
+                <SingleSelect
+                    placeholder="Custom placeholder"
+                    testId="openTest"
+                    onChange={jest.fn()}
+                    opener={(eventState, text) => (
+                        <button
+                            onClick={jest.fn()}
+                            data-test-id="custom-opener"
+                        >
+                            {text}
+                        </button>
+                    )}
+                >
+                    <OptionItem label="Toggle A" value="toggle_a" />
+                    <OptionItem label="Toggle B" value="toggle_b" />
+                </SingleSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            // open dropdown
+            opener.simulate("click");
+            const openerElement = menu.find(`[data-test-id="custom-opener"]`);
+
+            // Assert
+            expect(openerElement).toHaveText("Custom placeholder");
+        });
+
+        it("passes the selected label to the custom opener", () => {
+            // Arrange
+            const menu = mount(
+                <SingleSelect
+                    placeholder="Custom placeholder"
+                    testId="openTest"
+                    onChange={jest.fn()}
+                    opener={(eventState, text) => (
+                        <button
+                            onClick={jest.fn()}
+                            data-test-id="custom-opener"
+                        >
+                            {text}
+                        </button>
+                    )}
+                >
+                    <OptionItem label="Toggle A" value="toggle_a" />
+                    <OptionItem label="Toggle B" value="toggle_b" />
+                </SingleSelect>,
+            );
+
+            // Act
+            const opener = menu.find(DropdownOpener);
+            // open dropdown
+            opener.simulate("click");
+            // select the second item manually via selectedValue on SingleSelect
+            menu.setProps({selectedValue: "toggle_b"});
+            const openerElement = menu.find(`[data-test-id="custom-opener"]`);
+
+            // Assert
+            expect(openerElement).toHaveText("Toggle B");
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/components/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.test.js
@@ -2,6 +2,7 @@
 import React from "react";
 import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
+import DropdownOpener from "./dropdown-opener.js";
 import SelectOpener from "./select-opener.js";
 import OptionItem from "./option-item.js";
 import SingleSelect from "./single-select.js";
@@ -221,6 +222,60 @@ describe("SingleSelect", () => {
 
             // Assert
             expect(wrapper.find(SingleSelect).prop("opened")).toBe(false);
+        });
+    });
+
+    describe("Custom Opener", () => {
+        it("opens the menu when clicking on the custom opener", () => {
+            // Arrange
+            const wrapper = mount(
+                <SingleSelect
+                    onChange={jest.fn()}
+                    placeholder="custom opener"
+                    testId="openTest"
+                    opener={(eventState) => (
+                        <button aria-label="Search" onClick={jest.fn()} />
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+
+            // Act
+            const opener = wrapper.find(DropdownOpener);
+            opener.simulate("click");
+
+            // Assert
+            expect(wrapper.state("open")).toBe(true);
+        });
+
+        it("calls the custom onClick handler", () => {
+            // Arrange
+            const onClickMock = jest.fn();
+
+            const wrapper = mount(
+                <SingleSelect
+                    onChange={jest.fn()}
+                    placeholder="custom opener"
+                    testId="openTest"
+                    opener={(eventState) => (
+                        <button aria-label="Search" onClick={onClickMock} />
+                    )}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+
+            // Act
+            const opener = wrapper.find(DropdownOpener);
+            opener.simulate("click");
+
+            // Assert
+            expect(onClickMock).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -25,6 +25,7 @@ import {
     HeadingSmall,
     LabelMedium,
     LabelLarge,
+    HeadingLarge,
 } from "@khanacademy/wonder-blocks-typography";
 import Color from "@khanacademy/wonder-blocks-color";
 import {StyleSheet} from "aphrodite";
@@ -1117,19 +1118,37 @@ describe("wonder-blocks-dropdown", () => {
     });
 
     it("example 20", () => {
+        const styles = StyleSheet.create({
+            focused: {
+                color: Color.purple,
+            },
+            hovered: {
+                textDecoration: "underline",
+                color: Color.purple,
+                cursor: "pointer",
+            },
+            pressed: {
+                color: Color.blue,
+            },
+        });
         const example = (
             <SingleSelect
                 placeholder="Choose a juice"
                 opener={(eventState) => (
-                    <IconButton
-                        icon={icons.caretDown}
-                        aria-label="Search"
+                    <HeadingLarge
                         onClick={() => {
                             console.log("custom click!!!!!");
                         }}
-                    />
+                        testId="single-select-custom-opener"
+                        style={[
+                            eventState.focused && styles.focused,
+                            eventState.hovered && styles.hovered,
+                            eventState.pressed && styles.pressed,
+                        ]}
+                    >
+                        This is a heading
+                    </HeadingLarge>
                 )}
-                testId="single-select-custom-opener"
             >
                 <OptionItem label="Banana juice" value="banana" />
                 <OptionItem label="Guava juice" value="guava" disabled />

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -638,7 +638,7 @@ describe("wonder-blocks-dropdown", () => {
                             console.log("custom click!!!!!");
                         }}
                     >
-                        hey
+                        This is a label
                     </LabelMedium>
                 )}
             >

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -1099,6 +1099,30 @@ describe("wonder-blocks-dropdown", () => {
     });
 
     it("example 20", () => {
+        const example = (
+            <SingleSelect
+                placeholder="Choose a juice"
+                opener={(eventState) => (
+                    <IconButton
+                        icon={icons.caretDown}
+                        aria-label="Search"
+                        onClick={() => {
+                            console.log("custom click!!!!!");
+                        }}
+                    />
+                )}
+                testId="single-select-custom-opener"
+            >
+                <OptionItem label="Banana juice" value="banana" />
+                <OptionItem label="Guava juice" value="guava" disabled />
+                <OptionItem label="White grape juice" value="grape" />
+            </SingleSelect>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 21", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1166,7 +1190,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 21", () => {
+    it("example 22", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1228,7 +1252,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 22", () => {
+    it("example 23", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1292,7 +1316,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 23", () => {
+    it("example 24", () => {
         const styles = StyleSheet.create({
             wrapper: {
                 alignItems: "center",
@@ -1386,7 +1410,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 24", () => {
+    it("example 25", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1401,7 +1425,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 25", () => {
+    it("example 26", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -1434,7 +1458,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 26", () => {
+    it("example 27", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1484,7 +1508,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 27", () => {
+    it("example 28", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1543,7 +1567,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 28", () => {
+    it("example 29", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -1131,30 +1131,67 @@ describe("wonder-blocks-dropdown", () => {
                 color: Color.blue,
             },
         });
-        const example = (
-            <SingleSelect
-                placeholder="Choose a juice"
-                opener={(eventState) => (
-                    <HeadingLarge
-                        onClick={() => {
-                            console.log("custom click!!!!!");
-                        }}
-                        testId="single-select-custom-opener"
-                        style={[
-                            eventState.focused && styles.focused,
-                            eventState.hovered && styles.hovered,
-                            eventState.pressed && styles.pressed,
-                        ]}
+
+        class SingleSelectWithCustomOpener extends React.Component {
+            constructor() {
+                super();
+                this.state = {
+                    opened: false,
+                    selectedValue: null,
+                };
+                this.handleChange = this.handleChange.bind(this);
+                this.handleToggleMenu = this.handleToggleMenu.bind(this);
+            }
+
+            handleChange(selected) {
+                this.setState({
+                    selectedValue: selected,
+                });
+            }
+
+            handleToggleMenu(opened) {
+                this.setState({
+                    opened,
+                });
+            }
+
+            render() {
+                return (
+                    <SingleSelect
+                        placeholder="Choose a juice"
+                        opened={this.state.opened}
+                        onChange={this.handleChange}
+                        onToggle={this.handleToggleMenu}
+                        selectedValue={this.state.selectedValue}
+                        opener={(eventState) => (
+                            <HeadingLarge
+                                onClick={() => {
+                                    console.log("custom click!!!!!");
+                                }}
+                                testId="single-select-custom-opener"
+                                style={[
+                                    eventState.focused && styles.focused,
+                                    eventState.hovered && styles.hovered,
+                                    eventState.pressed && styles.pressed,
+                                ]}
+                            >
+                                This is a heading
+                            </HeadingLarge>
+                        )}
                     >
-                        This is a heading
-                    </HeadingLarge>
-                )}
-            >
-                <OptionItem label="Banana juice" value="banana" />
-                <OptionItem label="Guava juice" value="guava" disabled />
-                <OptionItem label="White grape juice" value="grape" />
-            </SingleSelect>
-        );
+                        <OptionItem label="Banana juice" value="banana" />
+                        <OptionItem
+                            label="Guava juice"
+                            value="guava"
+                            disabled
+                        />
+                        <OptionItem label="White grape juice" value="grape" />
+                    </SingleSelect>
+                );
+            }
+        }
+
+        const example = <SingleSelectWithCustomOpener />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -23,7 +23,6 @@ import {icons} from "@khanacademy/wonder-blocks-icon";
 import {
     Title,
     HeadingSmall,
-    LabelMedium,
     LabelLarge,
     HeadingLarge,
 } from "@khanacademy/wonder-blocks-typography";
@@ -630,12 +629,12 @@ describe("wonder-blocks-dropdown", () => {
     it("example 11", () => {
         const styles = StyleSheet.create({
             focused: {
-                backgroundColor: Color.purple,
-                color: Color.white,
+                color: Color.purple,
             },
             hovered: {
                 textDecoration: "underline",
-                color: Color.teal,
+                color: Color.purple,
+                cursor: "pointer",
             },
             pressed: {
                 color: Color.blue,
@@ -644,9 +643,9 @@ describe("wonder-blocks-dropdown", () => {
         const example = (
             <ActionMenu
                 disabled={false}
-                menuText="Betsy Appleseed"
-                opener={(eventState) => (
-                    <LabelMedium
+                menuText="Custom opener"
+                opener={(eventState, text) => (
+                    <LabelLarge
                         onClick={() => {
                             console.log("custom click!!!!!");
                         }}
@@ -657,8 +656,8 @@ describe("wonder-blocks-dropdown", () => {
                             eventState.pressed && styles.pressed,
                         ]}
                     >
-                        This is a label
-                    </LabelMedium>
+                        {text}
+                    </LabelLarge>
                 )}
             >
                 <ActionItem
@@ -1163,7 +1162,7 @@ describe("wonder-blocks-dropdown", () => {
                         onChange={this.handleChange}
                         onToggle={this.handleToggleMenu}
                         selectedValue={this.state.selectedValue}
-                        opener={(eventState) => (
+                        opener={(eventState, text) => (
                             <HeadingLarge
                                 onClick={() => {
                                     console.log("custom click!!!!!");
@@ -1175,7 +1174,7 @@ describe("wonder-blocks-dropdown", () => {
                                     eventState.pressed && styles.pressed,
                                 ]}
                             >
-                                This is a heading
+                                {text}
                             </HeadingLarge>
                         )}
                     >
@@ -1743,9 +1742,10 @@ describe("wonder-blocks-dropdown", () => {
                         onChange={this.handleChange}
                         opened={this.state.opened}
                         onToggle={this.handleToggleMenu}
+                        placeholder="MultiSelect with custom opener"
                         selectedValues={this.state.selectedValues}
                         testId="multi-select-custom-opener"
-                        opener={(eventState) => (
+                        opener={(eventState, text) => (
                             <HeadingLarge
                                 onClick={() => {
                                     console.log("custom click!!!!!");
@@ -1757,7 +1757,7 @@ describe("wonder-blocks-dropdown", () => {
                                     eventState.pressed && styles.pressed,
                                 ]}
                             >
-                                MultiSelect with custom opener
+                                {text}
                             </HeadingLarge>
                         )}
                     >

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -23,6 +23,7 @@ import {icons} from "@khanacademy/wonder-blocks-icon";
 import {
     Title,
     HeadingSmall,
+    LabelMedium,
     LabelLarge,
 } from "@khanacademy/wonder-blocks-typography";
 import Color from "@khanacademy/wonder-blocks-color";
@@ -626,6 +627,64 @@ describe("wonder-blocks-dropdown", () => {
     });
 
     it("example 11", () => {
+        const example = (
+            <ActionMenu
+                disabled={false}
+                menuText="Betsy Appleseed"
+                testId="teacher-menu"
+                opener={(eventState) => (
+                    <LabelMedium
+                        onClick={() => {
+                            console.log("custom click!!!!!");
+                        }}
+                    >
+                        hey
+                    </LabelMedium>
+                )}
+            >
+                <ActionItem
+                    label="Profile"
+                    href="http://khanacademy.org/profile"
+                    testId="profile"
+                />
+                <ActionItem
+                    label="Settings"
+                    onClick={() => console.log("user clicked on settings")}
+                    testId="settings"
+                />
+                <ActionItem
+                    label="Help"
+                    disabled={true}
+                    onClick={() => console.log("this item is disabled...")}
+                    testId="help"
+                />
+                <SeparatorItem />
+                <ActionItem
+                    label="Log out"
+                    href="http://khanacademy.org/logout"
+                    testId="logout"
+                />
+                <OptionItem
+                    label="Show homework assignments"
+                    value="homework"
+                    onClick={() =>
+                        console.log(`Show homework assignments toggled`)
+                    }
+                />
+                <OptionItem
+                    label="Show in-class assignments"
+                    value="in-class"
+                    onClick={() =>
+                        console.log(`Show in-class assignments toggled`)
+                    }
+                />
+            </ActionMenu>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 12", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -698,7 +757,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 12", () => {
+    it("example 13", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -758,7 +817,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 13", () => {
+    it("example 14", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -810,7 +869,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 14", () => {
+    it("example 15", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -863,7 +922,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 15", () => {
+    it("example 16", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -933,7 +992,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 16", () => {
+    it("example 17", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -948,7 +1007,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 17", () => {
+    it("example 18", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -981,7 +1040,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 18", () => {
+    it("example 19", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1039,7 +1098,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 19", () => {
+    it("example 20", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1107,7 +1166,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 20", () => {
+    it("example 21", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1169,7 +1228,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 21", () => {
+    it("example 22", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1233,7 +1292,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 22", () => {
+    it("example 23", () => {
         const styles = StyleSheet.create({
             wrapper: {
                 alignItems: "center",
@@ -1327,7 +1386,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 23", () => {
+    it("example 24", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1342,7 +1401,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 24", () => {
+    it("example 25", () => {
         const example = (
             <View>
                 <LabelLarge
@@ -1375,7 +1434,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 25", () => {
+    it("example 26", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1425,7 +1484,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 26", () => {
+    it("example 27", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -1484,7 +1543,7 @@ describe("wonder-blocks-dropdown", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 27", () => {
+    it("example 28", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -1697,4 +1697,81 @@ describe("wonder-blocks-dropdown", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
+    it("example 30", () => {
+        const styles = StyleSheet.create({
+            focused: {
+                color: Color.purple,
+            },
+            hovered: {
+                textDecoration: "underline",
+                color: Color.purple,
+                cursor: "pointer",
+            },
+            pressed: {
+                color: Color.blue,
+            },
+        });
+
+        class CustomOpenerExample extends React.Component {
+            constructor() {
+                super();
+                this.state = {
+                    opened: false,
+                    selectedValues: [],
+                };
+                this.handleChange = this.handleChange.bind(this);
+                this.handleToggleMenu = this.handleToggleMenu.bind(this);
+            }
+
+            handleChange(update) {
+                this.setState({
+                    selectedValues: update,
+                });
+            }
+
+            handleToggleMenu(opened) {
+                this.setState({
+                    opened,
+                });
+            }
+
+            render() {
+                return (
+                    <MultiSelect
+                        selectItemType="fruits"
+                        onChange={this.handleChange}
+                        opened={this.state.opened}
+                        onToggle={this.handleToggleMenu}
+                        selectedValues={this.state.selectedValues}
+                        testId="multi-select-custom-opener"
+                        opener={(eventState) => (
+                            <HeadingLarge
+                                onClick={() => {
+                                    console.log("custom click!!!!!");
+                                }}
+                                testId="multi-select-custom-opener"
+                                style={[
+                                    eventState.focused && styles.focused,
+                                    eventState.hovered && styles.hovered,
+                                    eventState.pressed && styles.pressed,
+                                ]}
+                            >
+                                MultiSelect with custom opener
+                            </HeadingLarge>
+                        )}
+                    >
+                        <OptionItem label="Nectarine" value="nectarine" />
+                        <OptionItem label="Plum" value="plum" />
+                        <OptionItem label="Cantaloupe" value="cantaloupe" />
+                        <OptionItem label="Pineapples" value="pineapples" />
+                    </MultiSelect>
+                );
+            }
+        }
+
+        const example = <CustomOpenerExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12161,9 +12161,9 @@ rollup@^0.66.4:
     "@types/node" "*"
 
 rollup@^1.23.1:
-  version "1.27.10"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.10.tgz#e0814c1401e7658b679d617d3511f0a4ffaea019"
-  integrity sha512-5PjBSKney8zLu7tTn/y4iVBL3OyK+G9rA/wfkcY78bZ9kAMtgNqb8nOfR5KpoDYyt8Vs5o2o8DyDjf9RpwYbAg==
+  version "1.27.11"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.11.tgz#95d190432e3edbcf757d921857df01ad1596ef97"
+  integrity sha512-ENXdvXk8tjtkNTvIvjRzOEu+vv54va7PiDR7VwP8TD+In6J87gKzzFmQMawQixEL2y9rsPEgomUS7ZVkq47Tww==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12161,9 +12161,9 @@ rollup@^0.66.4:
     "@types/node" "*"
 
 rollup@^1.23.1:
-  version "1.27.11"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.11.tgz#95d190432e3edbcf757d921857df01ad1596ef97"
-  integrity sha512-ENXdvXk8tjtkNTvIvjRzOEu+vv54va7PiDR7VwP8TD+In6J87gKzzFmQMawQixEL2y9rsPEgomUS7ZVkq47Tww==
+  version "1.27.12"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.12.tgz#cf84db4b4edaf187eaba95232f34de7cd4d22d9c"
+  integrity sha512-51iR7n6NQfdQJlRrIktaGmkdt395A8Vue7CdnlrK6UhY9DY2GaKsTdljWeXisJuZh+w90Gz8VFNh5X+yxP20oQ==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"


### PR DESCRIPTION
## Summary

- Fixed `testId` avoid using it from the parent component (`ActionMenu, SingleSelect and MultiSelect`).

- Added a new `text` argument as part of the `opener` prop (`ActionMenu, SingleSelect and MultiSelect`). This will allow people to optionally re-use the dropdown's current label in case they need it.

### Before
```
<MultiSelect
  opener={(eventState) => (
    <LabelLarge styles={[eventState.hovered && styles.customHoveredStyles]}>
        Hard-coded label for opener
    </LabelLarge>
  )}
/>
```
![custom-opener-before](https://user-images.githubusercontent.com/843075/70943991-292bcc80-2020-11ea-85f8-bad13e322444.gif)

### After
```
<MultiSelect
  opener={(eventState, text) => (
    <LabelLarge styles={[eventState.hovered && styles.customHoveredStyles]}>
        {text}
    </LabelLarge>
  )}
/>
```
![custom-opener-after](https://user-images.githubusercontent.com/843075/70944006-3052da80-2020-11ea-9eae-2a78d42ca456.gif)
