### PR TITLE
Make sure state is built from the right props

### DIFF
--- a/packages/wonder-blocks-data/components/data.js
+++ b/packages/wonder-blocks-data/components/data.js
@@ -58,7 +58,7 @@ export default class Data<TOptions, TData> extends React.Component<
     constructor(props: Props<TOptions, TData>) {
         super(props);
 
-        this.state = this._buildStateAndfulfillNeeds();
+        this.state = this._buildStateAndfulfillNeeds(props);
     }
 
     componentDidMount() {
@@ -76,7 +76,7 @@ export default class Data<TOptions, TData> extends React.Component<
          * or we got new data/error.
          */
         if (!this._propsMatch(nextProps)) {
-            const newState = this._buildStateAndfulfillNeeds();
+            const newState = this._buildStateAndfulfillNeeds(nextProps);
             this.setState(newState);
         }
 
@@ -100,12 +100,13 @@ export default class Data<TOptions, TData> extends React.Component<
         );
     }
 
-    _buildStateAndfulfillNeeds(): State<TData> {
-        const propsAtFulfillment = this.props;
+    _buildStateAndfulfillNeeds(
+        propsAtFulfillment: $ReadOnly<Props<TOptions, TData>>,
+    ): State<TData> {
         const {handler, options} = propsAtFulfillment;
         const {getEntry} = ResponseCache.Default;
 
-        const cachedData = getEntry(handler, options);
+        const cachedData = getEntry<TOptions, TData>(handler, options);
         if (
             !Server.isServerSide() &&
             (cachedData == null ||


### PR DESCRIPTION
Before this change, if the props changed, it was properly detected but the state was updated from the incorrect props state and so things did not do the right thing; they were always a step behind and it caused some interesting issues.

Now, state is properly based off the props being used.

I haven't updated any tests for this yet as I am still thinking of the nicest way to cleanly test this. I may postpone that for a later diff while I mull it over.