### PR TITLE
run only related tests in the pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start": "concurrently --kill-others-on-fail \"yarn run styleguidist\" \"webpack --config build-settings/webpack.config.js -w\" \"rollup -c build-settings/rollup.config.js -w\"",
     "test:common": "yarn run build:all && yarn run lint && yarn run alex && yarn run gen-snapshot-tests && yarn run flow",
     "test:coverage": "yarn run test:common && yarn run jest --coverage",
+    "test:fast": "yarn build:cjs && yarn jest --findRelatedTests `git diff --cached --name-only --diff-filter=ACM | grep '\\.js$'`",
     "test": "yarn run test:common && yarn run jest",
     "watch:cjs": "webpack --config build-settings/webpack.config.js -w"
   },
@@ -110,8 +111,8 @@
   ],
   "pre-commit": [
     "lint",
-    "test",
     "git-add-snapshot-tests",
+    "test:fast",
     "pretty-quick"
   ]
 }

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -205,3 +205,5 @@ export default class Button extends React.Component<SharedProps> {
         );
     }
 }
+
+// trivial change to trigger tests


### PR DESCRIPTION
We could make the check even faster if we skipped the build step, but then we'd have to modify the module mapper settings in the jest config.  TBH, I'm not sure how much value we get from testing the built versions of the packages.

Test Plan:
- `yarn test:fast`, see that only the commonjs modules are built and that only a subset of the tests run
- `git commit -a -m ...`, see that the same output as for `yarn test:fast`