### PR TITLE
WB-835: Update withActionScheduler to match webapp's HOC pattern

### DIFF
--- a/config/jest/test.config.js
+++ b/config/jest/test.config.js
@@ -17,7 +17,7 @@ module.exports = {
     setupFilesAfterEnv: ["<rootDir>/config/jest/test-setup.js"],
     moduleNameMapper: {
         "^@khanacademy/wonder-blocks-(.*)$":
-            "<rootDir>/node_modules/@khanacademy/wonder-blocks-$1/index.js",
+            "<rootDir>/packages/wonder-blocks-$1/index.js",
     },
     collectCoverageFrom: [
         "packages/**/*.js",

--- a/packages/wonder-blocks-dropdown/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core-virtualized.js
@@ -4,7 +4,7 @@ import ReactDOM from "react-dom";
 import {VariableSizeList as List} from "react-window";
 import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
 
-import type {WithActionScheduler} from "@khanacademy/wonder-blocks-timing";
+import type {WithActionSchedulerProps} from "@khanacademy/wonder-blocks-timing";
 
 import DropdownVirtualizedItem from "./dropdown-core-virtualized-item.js";
 import SearchTextInput from "./search-text-input.js";
@@ -18,7 +18,7 @@ import {
     SEPARATOR_ITEM_HEIGHT,
 } from "../util/constants.js";
 
-type OwnProps = {|
+type Props = {|
     /**
      * The complete list of items that will be virtualized.
      */
@@ -36,9 +36,9 @@ type OwnProps = {|
      * An optional fixed width that will be passed to the react-window instance
      */
     width?: ?number,
-|};
 
-type Props = WithActionScheduler<OwnProps>;
+    ...WithActionSchedulerProps,
+|};
 
 type State = {|
     /**
@@ -236,4 +236,4 @@ class DropdownCoreVirtualized extends React.Component<Props, State> {
     }
 }
 
-export default withActionScheduler<OwnProps>(DropdownCoreVirtualized);
+export default withActionScheduler(DropdownCoreVirtualized);

--- a/packages/wonder-blocks-dropdown/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core.js
@@ -15,7 +15,7 @@ import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import type {WithActionScheduler} from "@khanacademy/wonder-blocks-timing";
+import type {WithActionSchedulerProps} from "@khanacademy/wonder-blocks-timing";
 // NOTE(jeff): Here we share some code for use with PopperJS. Long term,
 // we should either contribute this code to the PopperJS component, or its
 // own non-wonder-blocks package.
@@ -59,7 +59,7 @@ type DefaultProps = {|
     light: boolean,
 |};
 
-type OwnProps = {|
+type Props = {|
     ...DefaultProps,
     /**
      * Items for the menu.
@@ -123,9 +123,9 @@ type OwnProps = {|
      * The aria "role" applied to the dropdown container.
      */
     role: "listbox" | "menu",
-|};
 
-type Props = WithActionScheduler<OwnProps>;
+    ...WithActionSchedulerProps,
+|};
 
 type State = {|
     /**
@@ -795,6 +795,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default withActionScheduler<React.Config<OwnProps, DefaultProps>>(
-    DropdownCore,
-);
+export default withActionScheduler(DropdownCore);

--- a/packages/wonder-blocks-timing/components/with-action-scheduler.js
+++ b/packages/wonder-blocks-timing/components/with-action-scheduler.js
@@ -3,7 +3,13 @@ import * as React from "react";
 
 import ActionSchedulerProvider from "./action-scheduler-provider.js";
 
-import type {IScheduleActions, WithActionScheduler} from "../util/types.js";
+import type {
+    IScheduleActions,
+    WithActionSchedulerProps,
+    WithActionScheduler,
+} from "../util/types.js";
+
+type WithoutActionScheduler<T> = $Exact<$Diff<T, WithActionSchedulerProps>>;
 
 /**
  * A higher order component that attaches the given component to an
@@ -14,16 +20,17 @@ import type {IScheduleActions, WithActionScheduler} from "../util/types.js";
  * the additional action scheduler prop. To attach the additional prop to
  * these props use the `WithActionScheduler` type.
  */
-function withActionScheduler<TOwnProps: {...}>(
-    Component: React.AbstractComponent<WithActionScheduler<TOwnProps>>,
-): React.AbstractComponent<TOwnProps> {
-    return (props: TOwnProps): React.Node => (
+export default function withActionScheduler<
+    Config: {...},
+    Component: React.ComponentType<WithActionScheduler<Config>>,
+>(
+    WrappedComponent: Component,
+): React.ComponentType<WithoutActionScheduler<React.ElementConfig<Component>>> {
+    return React.forwardRef((props, ref) => (
         <ActionSchedulerProvider>
             {(schedule: IScheduleActions) => (
-                <Component {...props} schedule={schedule} />
+                <WrappedComponent {...props} ref={ref} schedule={schedule} />
             )}
         </ActionSchedulerProvider>
-    );
+    ));
 }
-
-export default withActionScheduler;

--- a/packages/wonder-blocks-timing/components/with-action-scheduler.md
+++ b/packages/wonder-blocks-timing/components/with-action-scheduler.md
@@ -7,10 +7,9 @@ For more details on using this component and the [`IScheduleActions`](#ischedule
 see the [API overview](#timing-api-overview).
 
 ### Flow Types
-If you are using Flow typing, you can use the `WithActionScheduler<TProps>`
-generic type to build the props for the component that you will pass to the
-`withActionScheduler` function, where `TProps` represents all the props your
-component uses other than the `schedule` prop that will get added.
+If you are using Flow typing, you can use the `WithActionSchedulerProps` type
+to build the props for the component that you will pass to the `withActionScheduler`
+function by spreading the type into your component's `Props` type.
 
 The added `schedule` prop is of type [`IScheduleActions`](#ischeduleactions). This is what the
 `withActionScheduler` function injects to your component.

--- a/packages/wonder-blocks-timing/components/with-action-scheduler.test.js
+++ b/packages/wonder-blocks-timing/components/with-action-scheduler.test.js
@@ -5,6 +5,8 @@ import {mount, unmountAll} from "../../../utils/testing/mount.js";
 
 import withActionScheduler from "./with-action-scheduler.js";
 
+import type {WithActionSchedulerProps} from "../util/types.js";
+
 describe("withActionScheduler", () => {
     afterEach(() => {
         unmountAll();
@@ -21,5 +23,22 @@ describe("withActionScheduler", () => {
 
         // Assert
         expect(wrapper.text()).toBe("true");
+    });
+
+    it("should forward a ref", () => {
+        // Arrange
+        class Component extends React.Component<WithActionSchedulerProps> {
+            render() {
+                return <div>Hello, world!</div>;
+            }
+        }
+        const TestComponent = withActionScheduler(Component);
+        let ref: mixed = null;
+
+        // Act
+        mount(<TestComponent ref={(node) => (ref = node)} />);
+
+        // Assert
+        expect(ref).toBeInstanceOf(Component);
     });
 });

--- a/packages/wonder-blocks-timing/docs.md
+++ b/packages/wonder-blocks-timing/docs.md
@@ -299,7 +299,8 @@ The `IAnimationFrame` interface provides additional calls to manipulate an anima
 
 Migrating from the standard API can be done by:
 
-1. Wrapping your component with the `withActionScheduler` HOC (and, if using Flow, using the `WithActionScheduler<TOwnProps>` type to extend your components props)
+1. Wrapping your component with the `withActionScheduler` HOC (and, if using Flow, using the `WithActionSchedulerProps` type to extend your components props by spreading the type into
+ your component's `Props` type)
 2. Using the new `schedule` prop in your component instead of `setTimeout`, `setInterval` and `requestAnimationFrame`
 
 #### Migration Example
@@ -351,17 +352,14 @@ class MyLegacyComponent extends React.Component<Props, State> {
 We can rewrite it to use the Wonder Blocks Timing API like this:
 
 ```js static
-/**
- * These are the props that consumers of your component will see.
- */
-type OwnProps = {||};
-
-/**
- * These are the props that your component actually uses. We use the
- * WithActionScheduler<TOwnProps> generic type to augment `OwnProps` with the
- * props injected by the withActionScheduler HOC.
- */
-type Props = WithActionScheduler<OwnProps>;
+type Props = {|
+    /**
+     * These props will be injected into your component.  They won't appear
+     * as part of the public props of the component since `withActionSceduler`
+     * will excluding them from the props of the component it returns.
+     */
+    ...withActionSchedulerProps
+|};
 
 type State = {
     timerFired: boolean,
@@ -394,7 +392,5 @@ class MyWonderBlocksComponentImpl extends React.Component<Props, State> {
  * The component that you would export as a drop-in replacement for your
  * legacy component.
  */
-const MyWonderBlocksComponent: React.AbstractComponent<
-    OwnProps,
-> = withActionScheduler(MyWonderBlocksComponentImpl);
+const MyWonderBlocksComponent = withActionScheduler(MyWonderBlocksComponentImpl);
 ```

--- a/packages/wonder-blocks-timing/index.js
+++ b/packages/wonder-blocks-timing/index.js
@@ -5,6 +5,7 @@ import type {
     IScheduleActions,
     ITimeout,
     WithActionScheduler,
+    WithActionSchedulerProps,
 } from "./util/types.js";
 
 export type {
@@ -13,6 +14,7 @@ export type {
     IScheduleActions,
     ITimeout,
     WithActionScheduler,
+    WithActionSchedulerProps,
 };
 
 export {default as withActionScheduler} from "./components/with-action-scheduler.js";

--- a/packages/wonder-blocks-timing/util/types.flowtest.js
+++ b/packages/wonder-blocks-timing/util/types.flowtest.js
@@ -6,7 +6,7 @@
 import * as React from "react";
 import withActionScheduler from "../components/with-action-scheduler.js";
 
-import type {WithActionScheduler} from "./types.js";
+import type {WithActionSchedulerProps} from "./types.js";
 
 /**
  * Test WithActionScheduler and withActionScheduler usage.
@@ -16,34 +16,26 @@ import type {WithActionScheduler} from "./types.js";
  * Given a react component with action scheduler props, we receive an
  * abstract component of `OwnProps1`.
  */
-type OwnProps1 = {|
+type Props1 = {|
     test: string,
+    ...WithActionSchedulerProps,
 |};
 
-type Props1 = WithActionScheduler<OwnProps1>;
+const InnerComponent1 = (props: Props1): React.Node => props.test;
 
-const InnerComponent1: React.AbstractComponent<Props1> = (
-    props: Props1,
-): React.Node => props.test;
-
-const HOCComponent1: React.AbstractComponent<OwnProps1> = withActionScheduler(
-    InnerComponent1,
-);
+const HOCComponent1 = withActionScheduler(InnerComponent1);
 
 /**
  * Case 2: Incorrect Usage
  * The withActionScheduler call is returning a component of type OwnProps2; the
  * variable assigned however is incorrectly specified as Props2.
  */
-type OwnProps2 = {|
+type Props2 = {|
     test: string,
+    ...WithActionSchedulerProps,
 |};
 
-type Props2 = WithActionScheduler<OwnProps2>;
-
-const InnerComponent2: React.AbstractComponent<Props2> = (
-    props: Props2,
-): React.Node => props.test;
+const InnerComponent2 = (props: Props2): React.Node => props.test;
 
 /**
  * Cannot assign `withActionScheduler(...)` to `HOCComponent2` because property
@@ -52,24 +44,21 @@ const InnerComponent2: React.AbstractComponent<Props2> = (
  *
  * $ExpectError
  */
-const HOCComponent2: React.AbstractComponent<Props2> = withActionScheduler(
-    InnerComponent2,
-);
+const HOCComponent2 = withActionScheduler(InnerComponent2);
 
 /**
  * Case 3: Incorrect Usage
  * The withActionScheduler call is being passed a component that isn't set up
  * to be used with it as it doesn't have all the props necessary.
  */
-type OwnProps3 = {|
+type Props3 = {|
     test: string,
+    ...WithActionSchedulerProps,
 |};
 
-const InnerComponent3: React.AbstractComponent<OwnProps3> = (
-    props: OwnProps3,
-): React.Node => props.test;
+const InnerComponent3 = (props: Props3): React.Node => props.test;
 
-const HOCComponent3: React.AbstractComponent<OwnProps3> = withActionScheduler(
+const HOCComponent3 = withActionScheduler(
     /**
      * Cannot call `withActionScheduler` with `InnerComponent3` bound to
      * `Component` because property `schedule` is missing in `OwnProps3` [1]

--- a/packages/wonder-blocks-timing/util/types.js
+++ b/packages/wonder-blocks-timing/util/types.js
@@ -230,15 +230,22 @@ export interface IScheduleActions {
 }
 
 /**
- * Extends the given props with props that the `withActionScheduler` higher
- * order component will inject.
+ * A props object type that can be spread into the a componenet wrapped with
+ * the `withActionScheduler` higher order component.
  */
-export type WithActionScheduler<TOwnProps: {...}> = {|
-    ...$Exact<TOwnProps>,
-
+export type WithActionSchedulerProps = {|
     /**
      * An instance of the `IScheduleActions` API to use for scheduling
      * intervals, timeouts, and animation frame requests.
      */
     schedule: IScheduleActions,
+|};
+
+/**
+ * Extends the given props with props that the `withActionScheduler` higher
+ * order component will inject.
+ */
+export type WithActionScheduler<TOwnProps: {...}> = {|
+    ...$Exact<TOwnProps>,
+    ...WithActionSchedulerProps,
 |};


### PR DESCRIPTION
Using this pattern adds support for default props and ref forwarding.  This will allow us to compose `withActionScheduler` with the HOCs defined in webapp.  It also means that all of our HOCs from wonder-blocks and webapp will have a consistent API as well as consistent behavior.