### PR TITLE
Part 3: Implement deferring to custom cache

### DIFF
--- a/packages/wonder-blocks-data/docs.md
+++ b/packages/wonder-blocks-data/docs.md
@@ -47,6 +47,44 @@ initializeCache(sourceCache: $ReadOnly<ResponseCache>): void;
 | --- | --- | --- | --- |
 | `sourceData` | `$ReadOnly<ResponseCache>` | _Required_ | The source cache that will be used to initialize the response cache. |
 
+## removeFromCache
+
+Removes an entry from the framework cache and any custom cache associated to the given handler. The given handler and options identify the entry to be removed.
+
+If an item is removed, this returns `true`; otherwise, `false`.
+
+### Usage
+
+```js static
+removeFromCache(handler: IRequestHandler<TOptions, TData>, options: TOptions): boolean;
+```
+
+#### Function arguments
+
+| Argument | Flow&nbsp;Type | Default | Description |
+| --- | --- | --- | --- |
+| `handler` | `IRequestHandler<TOptions, TData>` | _Required_ | The handler type for the data to be removed. |
+| `options` | `TOptions` | _Required_ | The options that identify the cached request data to be removed. |
+
+## removeAllFromCache
+
+Removes all entries that match a given predicate from the framework cache and any custom cache associated to the given handler. If no predicate is given, all cached entries for the given handler are removed.
+
+This returns the count of entries removed.
+
+### Usage
+
+```js static
+removeAllFromCache(handler: IRequestHandler<TOptions, TData>, predicate: (key: string, entry: $ReadOnly<CacheEntry<TData>>) => boolean): number;
+```
+
+#### Function arguments
+
+| Argument | Flow&nbsp;Type | Default | Description |
+| --- | --- | --- | --- |
+| `handler` | `IRequestHandler<TOptions, TData>` | _Required_ | The handler type for the data to be removed. |
+| `predicate` | `(key: string, entry: $ReadOnly<CacheEntry<TData>>) => boolean)` | _Optional_ | A predicate to identify which entries to remove. If absent, all data for the handler type is removed; if present, any entries for which the predicate returns `true` will be returned. |
+
 ## Types
 
 ### ResponseCache

--- a/packages/wonder-blocks-data/index.js
+++ b/packages/wonder-blocks-data/index.js
@@ -2,6 +2,8 @@
 import {ResponseCache as ResCache} from "./util/response-cache.js";
 import {RequestTracker} from "./util/request-tracking.js";
 
+import type {CacheEntry, IRequestHandler} from "./util/types.js";
+
 export type {Cache, CacheEntry, Result, IRequestHandler} from "./util/types.js";
 
 export type ResponseCache = $ReadOnly<Cache>;
@@ -11,6 +13,19 @@ export const initializeCache = (source: ResponseCache): void =>
 
 export const fulfillAllDataRequests = (): Promise<ResponseCache> =>
     RequestTracker.Default.fulfillTrackedRequests();
+
+export const removeFromCache = <TOptions, TData>(
+    handler: IRequestHandler<TOptions, TData>,
+    options: TOptions,
+): boolean => ResCache.Default.remove<TOptions, TData>(handler, options);
+
+export const removeAllFromCache = <TOptions, TData>(
+    handler: IRequestHandler<TOptions, TData>,
+    predicate?: (
+        key: string,
+        cacheEntry: ?$ReadOnly<CacheEntry<TData>>,
+    ) => boolean,
+): number => ResCache.Default.removeAll<TOptions, TData>(handler, predicate);
 
 /**
  * TODO(somewhatabstract): Export each cache type we implement.

--- a/packages/wonder-blocks-data/index.test.js
+++ b/packages/wonder-blocks-data/index.test.js
@@ -1,9 +1,14 @@
 // @flow
-import {initializeCache, fulfillAllDataRequests} from "./index.js";
+import {
+    initializeCache,
+    fulfillAllDataRequests,
+    removeFromCache,
+    removeAllFromCache,
+} from "./index.js";
 import {ResponseCache} from "./util/response-cache.js";
 import {RequestTracker} from "./util/request-tracking.js";
 
-import type {ResponseCache as Cache} from "./index.js";
+import type {IRequestHandler, ResponseCache as Cache} from "./index.js";
 
 describe("@khanacademy/wonder-blocks-data", () => {
     test("package exports what we expect", async () => {
@@ -23,6 +28,8 @@ describe("@khanacademy/wonder-blocks-data", () => {
                 "TrackData",
                 "fulfillAllDataRequests",
                 "initializeCache",
+                "removeFromCache",
+                "removeAllFromCache",
             ].sort(),
         );
     });
@@ -57,6 +64,35 @@ describe("@khanacademy/wonder-blocks-data", () => {
 
             // Assert
             expect(fulfillTrackedRequests).toHaveBeenCalled();
+        });
+    });
+
+    describe("#removeFromCache", () => {
+        test("invokes ResponseCache.Default.remove", () => {
+            // Arrange
+            const removeSpy = jest.spyOn(ResponseCache.Default, "remove");
+            const fakeHandler: IRequestHandler<string, string> = ({}: any);
+
+            // Act
+            removeFromCache(fakeHandler, "REMOVE");
+
+            // Assert
+            expect(removeSpy).toHaveBeenCalledWith(fakeHandler, "REMOVE");
+        });
+    });
+
+    describe("#removeAllFromCache", () => {
+        test("invokes ResponseCache.Default.removeAll", () => {
+            // Arrange
+            const removeAllSpy = jest.spyOn(ResponseCache.Default, "removeAll");
+            const fakeHandler: IRequestHandler<string, string> = ({}: any);
+            const predicate = () => false;
+
+            // Act
+            removeAllFromCache(fakeHandler, predicate);
+
+            // Assert
+            expect(removeAllSpy).toHaveBeenCalledWith(fakeHandler, predicate);
         });
     });
 });

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -42,7 +42,7 @@ export class ResponseCache {
         }
     }
 
-    // TODO(somewhatabstract): remove/removeAll and tests
+    // TODO(somewhatabstract): tests for remove/removeAll
     // TODO(somewhatabstract): tests for store to custom on retrieve
     // TODO(somewhatabstract): tests for store to custom on store
     // TODO(somewhatabstract): tets for retrieve from custom on retrieve
@@ -131,8 +131,6 @@ export class ResponseCache {
     ): ?$ReadOnly<CacheEntry<TData>> => {
         const requestType = handler.type;
 
-        const key = handler.getKey(options);
-
         // We don't use custom caches during SSR.
         const customCache = Server.isServerSide() ? null : handler.cache;
         const entry = customCache && customCache.retrieve(handler, options);
@@ -148,6 +146,7 @@ export class ResponseCache {
         }
 
         // Get the response.
+        const key = handler.getKey(options);
         const internalEntry = handlerCache[key];
         if (internalEntry == null) {
             return null;
@@ -155,9 +154,103 @@ export class ResponseCache {
 
         // If we have a custom cache on the handler, make sure it has the entry.
         if (customCache != null) {
+            // Yes, if this throws, we will have a problem. We want that.
+            // Bad cache implementations should be overt.
             customCache.store(handler, options, internalEntry);
+
+            // We now delete this from our in-memory cache as we don't need it.
+            // This does mean that if another handler of the same type but
+            // without a custom cache won't get the value, but that's not an
+            // expected valid usage of this framework.
+            delete handlerCache[key];
         }
         return internalEntry;
+    };
+
+    /**
+     * Remove from cache, the entry matching the given handler and options.
+     *
+     * This will, if present therein, remove the value from the custom cache
+     * associated with the handler and the framework in-memory cache.
+     *
+     * Returns true if something was removed from any cache; otherwise, false.
+     */
+    remove = <TOptions, TData>(
+        handler: IRequestHandler<TOptions, TData>,
+        options: TOptions,
+    ): boolean => {
+        const requestType = handler.type;
+
+        // NOTE(somewhatabstract): We could invoke removeAll with a predicate
+        // to match the key of the entry we're removing, but that's an
+        // inefficient way to remove a single item, so let's not do that.
+
+        // We don't use custom caches during SSR.
+        const customCache = Server.isServerSide() ? null : handler.cache;
+        const removedCustom: boolean = !!(
+            customCache && customCache.remove(handler, options)
+        );
+
+        // Get the internal subcache for the handler.
+        const handlerCache = this._cache[requestType];
+        if (!handlerCache) {
+            return removedCustom;
+        }
+
+        // Get the entry.
+        const key = handler.getKey(options);
+        const internalEntry = handlerCache[key];
+        if (internalEntry == null) {
+            return removedCustom;
+        }
+
+        // Delete the entry.
+        delete handlerCache[key];
+        return true;
+    };
+
+    /**
+     * Remove from cache, any entries matching the given handler and predicate.
+     *
+     * This will, if present therein, remove matching values from the custom
+     * cache associated with the handler and the framework in-memory cache.
+     *
+     * It returns a count of all records removed. This is not a count of unique
+     * keys, but of unique entries. So if the same key is removed from both the
+     * framework and custom caches, that will be 2 records removed.
+     */
+    removeAll = <TOptions, TData>(
+        handler: IRequestHandler<TOptions, TData>,
+        predicate?: (
+            key: string,
+            cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
+        ) => boolean,
+    ): number => {
+        const requestType = handler.type;
+
+        // We don't use custom caches during SSR.
+        const customCache = Server.isServerSide() ? null : handler.cache;
+        const removedCountCustom: number =
+            (customCache && customCache.removeAll(handler, predicate)) || 0;
+
+        // Get the internal subcache for the handler.
+        const handlerCache = this._cache[requestType];
+        if (!handlerCache) {
+            return removedCountCustom;
+        }
+
+        // Apply the predicate to what we have cached.
+        let removedCount = 0;
+        for (const [key, entry] of Object.entries(handlerCache)) {
+            if (
+                typeof predicate !== "function" ||
+                predicate(key, (entry: any))
+            ) {
+                removedCount++;
+                delete handlerCache[key];
+            }
+        }
+        return removedCount + removedCountCustom;
     };
 
     /**

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -42,11 +42,6 @@ export class ResponseCache {
         }
     }
 
-    // TODO(somewhatabstract): tests for remove/removeAll
-    // TODO(somewhatabstract): tests for store to custom on retrieve
-    // TODO(somewhatabstract): tests for store to custom on store
-    // TODO(somewhatabstract): tets for retrieve from custom on retrieve
-
     _setCacheEntry<TOptions, TData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -51,21 +51,20 @@ export class ResponseCache {
 
         // We don't support custom caches during SSR.
         const customCache = Server.isServerSide() ? null : handler.cache;
+        const frozenEntry = Object.freeze(entry);
 
         // If we have a custom cache, use that and skip our own.
         if (customCache != null) {
-            const frozenEntry = Object.freeze(entry);
             customCache.store(handler, options, frozenEntry);
-            return frozenEntry;
+        } else {
+            // Ensure we have a cache location for this handler type.
+            this._cache[requestType] = this._cache[requestType] || {};
+
+            // Cache the data.
+            const key = handler.getKey(options);
+            this._cache[requestType][key] = frozenEntry;
         }
-
-        // Ensure we have a cache location for this handler type.
-        this._cache[requestType] = this._cache[requestType] || {};
-
-        // Cache the data.
-        const key = handler.getKey(options);
-        this._cache[requestType][key] = Object.freeze(entry);
-        return this._cache[requestType][key];
+        return frozenEntry;
     }
 
     /**

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -42,6 +42,11 @@ export class ResponseCache {
         }
     }
 
+    // TODO(somewhatabstract): remove/removeAll and tests
+    // TODO(somewhatabstract): tests for store to custom on retrieve
+    // TODO(somewhatabstract): tests for store to custom on store
+    // TODO(somewhatabstract): tets for retrieve from custom on retrieve
+
     _setCacheEntry<TOptions, TData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -223,7 +223,7 @@ export class ResponseCache {
         handler: IRequestHandler<TOptions, TData>,
         predicate?: (
             key: string,
-            cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
+            cachedEntry: $ReadOnly<CacheEntry<TData>>,
         ) => boolean,
     ): number => {
         const requestType = handler.type;
@@ -255,6 +255,8 @@ export class ResponseCache {
 
     /**
      * Deep clone the cache.
+     *
+     * By design, this does not clone anything held in custom caches.
      */
     cloneCachedData = (): $ReadOnly<Cache> => {
         try {

--- a/packages/wonder-blocks-data/util/response-cache.test.js
+++ b/packages/wonder-blocks-data/util/response-cache.test.js
@@ -606,27 +606,27 @@ describe("./response-cache.js", () => {
 
         it("should return true if something was removed from custom cache", () => {
             // Arrange
-            const cache = new ResponseCache({
-                MY_HANDLER: {
-                    MY_OTHER_KEY: {data: "data!"},
-                },
-            });
+            const cache = new ResponseCache();
             const customCache = {
                 store: jest.fn(),
                 retrieve: jest.fn(),
+                /**
+                 * We're testing that this mocked valiue propagates to the
+                 * framework response cache `remove` call.
+                 */
                 remove: jest.fn().mockReturnValue(true),
                 removeAll: jest.fn(),
             };
             const fakeHandler: IRequestHandler<string, string> = {
-                getKey: () => "MY_KEY",
-                type: "MY_HANDLER",
+                getKey: () => "IGNORED",
+                type: "IGNORED",
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: customCache,
             };
 
             // Act
-            const result = cache.remove(fakeHandler, "optionsA");
+            const result = cache.remove(fakeHandler, "PRETEND_KEY");
 
             // Assert
             expect(result).toBeTruthy();

--- a/packages/wonder-blocks-data/util/response-cache.test.js
+++ b/packages/wonder-blocks-data/util/response-cache.test.js
@@ -1,4 +1,5 @@
 // @flow
+import {Server} from "@khanacademy/wonder-blocks-core";
 import {ResponseCache} from "./response-cache.js";
 
 import type {IRequestHandler} from "./types.js";
@@ -111,117 +112,597 @@ describe("./response-cache.js", () => {
     });
 
     describe("#cacheData", () => {
-        it("should add the entry to the cache", () => {
-            // Arrange
-            const cache = new ResponseCache();
-            const fakeHandler: IRequestHandler<string, string> = {
-                getKey: () => "MY_KEY",
-                type: "MY_HANDLER",
-                shouldRefreshCache: () => false,
-                fulfillRequest: jest.fn(),
-                cache: null,
-            };
+        describe("no custom cache", () => {
+            it("should add the entry to the cache", () => {
+                // Arrange
+                const cache = new ResponseCache();
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                };
 
-            // Act
-            cache.cacheData(fakeHandler, "options", "data");
-            const result = cache.getEntry(fakeHandler, "options");
+                // Act
+                cache.cacheData(fakeHandler, "options", "data");
+                const result = cache.getEntry(fakeHandler, "options");
 
-            // Assert
-            expect(result).toStrictEqual({data: "data"});
+                // Assert
+                expect(result).toStrictEqual({data: "data"});
+            });
+
+            it("should replace the entry in the handler subcache", () => {
+                // Arrange
+                const cache = new ResponseCache({
+                    MY_HANDLER: {
+                        MY_KEY: {error: "Oh no!"},
+                    },
+                });
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                };
+
+                // Act
+                cache.cacheData(fakeHandler, "options", "other_data");
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toStrictEqual({data: "other_data"});
+            });
         });
 
-        it("should replace the entry in the handler subcache", () => {
-            // Arrange
-            const cache = new ResponseCache({
-                MY_HANDLER: {
-                    MY_KEY: {error: "Oh no!"},
-                },
+        describe("with custom cache", () => {
+            it("SSR should use the framework cache, not the custom cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const cache = new ResponseCache();
+                const customCache = {
+                    store: jest.fn(),
+                    retrieve: jest.fn(),
+                    remove: jest.fn(),
+                    removeAll: jest.fn(),
+                };
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: customCache,
+                };
+
+                // Act
+                cache.cacheData(fakeHandler, "options", "data");
+                /**
+                 * We want to bypass the custom stuff and grab from the real
+                 * storage so we can validate without side-effects.
+                 *
+                 * TODO(somewhatabstract): Isolate framework cache.
+                 * We should probably isolate the framework cache itself better
+                 * to fix this.
+                 */
+                const result = cache._cache["MY_HANDLER"]["MY_KEY"];
+
+                // Assert
+                expect(customCache.store).not.toHaveBeenCalled();
+                expect(result).toStrictEqual({data: "data"});
             });
-            const fakeHandler: IRequestHandler<string, string> = {
-                getKey: () => "MY_KEY",
-                type: "MY_HANDLER",
-                shouldRefreshCache: () => false,
-                fulfillRequest: jest.fn(),
-                cache: null,
-            };
 
-            // Act
-            cache.cacheData(fakeHandler, "options", "other_data");
-            const result = cache.getEntry(fakeHandler, "options");
+            it("CSR should use the custom cache, not the framework cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(false);
+                const cache = new ResponseCache();
+                const customCache = {
+                    store: jest.fn(),
+                    retrieve: jest.fn(),
+                    remove: jest.fn(),
+                    removeAll: jest.fn(),
+                };
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: customCache,
+                };
 
-            // Assert
-            expect(result).toStrictEqual({data: "other_data"});
+                // Act
+                cache.cacheData(fakeHandler, "options", "data");
+                /**
+                 * We want to bypass the custom stuff and grab from the real
+                 * storage so we can validate without side-effects.
+                 *
+                 * TODO(somewhatabstract): Isolate framework cache.
+                 * We should probably isolate the framework cache itself better
+                 * to fix this.
+                 */
+                const result = cache._cache["MY_HANDLER"];
+
+                // Assert
+                expect(customCache.store).toHaveBeenCalledWith(
+                    fakeHandler,
+                    "options",
+                    {data: "data"},
+                );
+                expect(result).toBeUndefined();
+            });
         });
     });
 
     describe("#cacheError", () => {
-        it("should add the entry to the cache", () => {
-            // Arrange
-            const cache = new ResponseCache();
-            const fakeHandler: IRequestHandler<string, string> = {
-                getKey: () => "MY_KEY",
-                type: "MY_HANDLER",
-                shouldRefreshCache: () => false,
-                fulfillRequest: jest.fn(),
-                cache: null,
-            };
+        describe("no custom cache", () => {
+            it("should add the entry to the cache", () => {
+                // Arrange
+                const cache = new ResponseCache();
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                };
 
-            // Act
-            cache.cacheError(fakeHandler, "options", new Error("Ooops!"));
-            const result = cache.getEntry(fakeHandler, "options");
+                // Act
+                cache.cacheError(fakeHandler, "options", new Error("Ooops!"));
+                const result = cache.getEntry(fakeHandler, "options");
 
-            // Assert
-            expect(result).toStrictEqual({error: "Ooops!"});
+                // Assert
+                expect(result).toStrictEqual({error: "Ooops!"});
+            });
+
+            it("should replace the entry in the handler subcache", () => {
+                // Arrange
+                const cache = new ResponseCache({
+                    MY_HANDLER: {
+                        MY_KEY: {data: {some: "data"}},
+                    },
+                });
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                };
+
+                // Act
+                cache.cacheError(fakeHandler, "options", new Error("Oh no!"));
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toStrictEqual({error: "Oh no!"});
+            });
         });
 
-        it("should replace the entry in the handler subcache", () => {
-            // Arrange
-            const cache = new ResponseCache({
-                MY_HANDLER: {
-                    MY_KEY: {data: {some: "data"}},
-                },
+        describe("with custom cache", () => {
+            it("SSR should use the framework cache, not the custom cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const cache = new ResponseCache();
+                const customCache = {
+                    store: jest.fn(),
+                    retrieve: jest.fn(),
+                    remove: jest.fn(),
+                    removeAll: jest.fn(),
+                };
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: customCache,
+                };
+
+                // Act
+                cache.cacheError(fakeHandler, "options", new Error("Ooops!"));
+                /**
+                 * We want to bypass the custom stuff and grab from the real
+                 * storage so we can validate without side-effects.
+                 *
+                 * TODO(somewhatabstract): Isolate framework cache.
+                 * We should probably isolate the framework cache itself better
+                 * to fix this.
+                 */
+                const result = cache._cache["MY_HANDLER"]["MY_KEY"];
+
+                // Assert
+                expect(result).toStrictEqual({error: "Ooops!"});
+                expect(customCache.store).not.toHaveBeenCalled();
             });
-            const fakeHandler: IRequestHandler<string, string> = {
-                getKey: () => "MY_KEY",
-                type: "MY_HANDLER",
-                shouldRefreshCache: () => false,
-                fulfillRequest: jest.fn(),
-                cache: null,
-            };
 
-            // Act
-            cache.cacheError(fakeHandler, "options", new Error("Oh no!"));
-            const result = cache.getEntry(fakeHandler, "options");
+            it("CSR should use the custom cache, not the framework cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(false);
+                const cache = new ResponseCache();
+                const customCache = {
+                    store: jest.fn(),
+                    retrieve: jest.fn(),
+                    remove: jest.fn(),
+                    removeAll: jest.fn(),
+                };
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: customCache,
+                };
 
-            // Assert
-            expect(result).toStrictEqual({error: "Oh no!"});
+                // Act
+                cache.cacheError(fakeHandler, "options", new Error("Ooops!"));
+                /**
+                 * We want to bypass the custom stuff and grab from the real
+                 * storage so we can validate without side-effects.
+                 *
+                 * TODO(somewhatabstract): Isolate framework cache.
+                 * We should probably isolate the framework cache itself better
+                 * to fix this.
+                 */
+                const result = cache._cache["MY_HANDLER"];
+
+                // Assert
+                expect(customCache.store).toHaveBeenCalledWith(
+                    fakeHandler,
+                    "options",
+                    {error: "Ooops!"},
+                );
+                expect(result).toBeUndefined();
+            });
         });
     });
 
     describe("#getEntry", () => {
-        it("should return null if the handler subcache is absent", () => {
+        describe("no custom cache", () => {
+            it("should return null if the handler subcache is absent", () => {
+                // Arrange
+                const cache = new ResponseCache();
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                };
+
+                // Act
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toBeNull();
+            });
+
+            it("should return null if the request key is absent from the subcache", () => {
+                // Arrange
+                const cache = new ResponseCache({
+                    MY_HANDLER: {
+                        SOME_OTHER_KEY: {data: "data we don't want"},
+                    },
+                });
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                };
+
+                // Act
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toBeNull();
+            });
+
+            it("should return the cached entry", () => {
+                // Arrange
+                const cache = new ResponseCache({
+                    MY_HANDLER: {
+                        MY_KEY: {data: "data!"},
+                    },
+                });
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                };
+
+                // Act
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toStrictEqual({data: "data!"});
+            });
+        });
+
+        describe("with custom cache", () => {
+            it("SSR should use framework cache, not custom cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const cache = new ResponseCache({
+                    MY_HANDLER: {
+                        MY_KEY: {data: "data!"},
+                    },
+                });
+                const customCache = {
+                    store: jest.fn(),
+                    retrieve: jest.fn(),
+                    remove: jest.fn(),
+                    removeAll: jest.fn(),
+                };
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: customCache,
+                };
+
+                // Act
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toStrictEqual({data: "data!"});
+                expect(customCache.retrieve).not.toHaveBeenCalled();
+            });
+
+            it("CSR should return custom cached entry", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(false);
+                const cache = new ResponseCache({
+                    MY_HANDLER: {
+                        MY_KEY: {data: "data!"},
+                    },
+                });
+                const customCache = {
+                    store: jest.fn(),
+                    retrieve: jest.fn().mockReturnValue({data: "custom data!"}),
+                    remove: jest.fn(),
+                    removeAll: jest.fn(),
+                };
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: customCache,
+                };
+
+                // Act
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toStrictEqual({data: "custom data!"});
+            });
+
+            it("CSR should store framework entry in custom cache when custom cache misses", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(false);
+                const cache = new ResponseCache({
+                    MY_HANDLER: {
+                        MY_KEY: {data: "data!"},
+                    },
+                });
+                const customCache = {
+                    store: jest.fn(),
+                    retrieve: jest.fn(),
+                    remove: jest.fn(),
+                    removeAll: jest.fn(),
+                };
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: customCache,
+                };
+
+                // Act
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toStrictEqual({data: "data!"});
+                expect(customCache.store).toBeCalledWith(
+                    fakeHandler,
+                    "options",
+                    {data: "data!"},
+                );
+            });
+
+            it("CSR should remove framework entry when custom cache misses", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(false);
+                const cache = new ResponseCache({
+                    MY_HANDLER: {
+                        MY_KEY: {data: "data!"},
+                    },
+                });
+                const customCache = {
+                    store: jest.fn(),
+                    retrieve: jest.fn(),
+                    remove: jest.fn(),
+                    removeAll: jest.fn(),
+                };
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: customCache,
+                };
+
+                // Act
+                const result = cache.getEntry(fakeHandler, "options");
+
+                // Assert
+                expect(result).toStrictEqual({data: "data!"});
+                // TODO(somewhatabstract): Abstract away need to poke insides
+                expect(cache._cache["MY_HANDLER"]["MY_KEY"]).toBeUndefined();
+            });
+        });
+    });
+
+    describe("#remove", () => {
+        it("should return false if nothing was removed", () => {
             // Arrange
-            const cache = new ResponseCache();
+            const cache = new ResponseCache({
+                MY_HANDLER: {
+                    MY_OTHER_KEY: {data: "data!"},
+                },
+            });
+            const customCache = {
+                store: jest.fn(),
+                retrieve: jest.fn(),
+                remove: jest.fn(),
+                removeAll: jest.fn(),
+            };
             const fakeHandler: IRequestHandler<string, string> = {
                 getKey: () => "MY_KEY",
                 type: "MY_HANDLER",
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
-                cache: null,
+                cache: customCache,
             };
 
             // Act
-            const result = cache.getEntry(fakeHandler, "options");
+            const result = cache.remove(fakeHandler, "optionsA");
 
             // Assert
-            expect(result).toBeNull();
+            expect(result).toBeFalsy();
         });
 
-        it("should return null if the request key is absent from the subcache", () => {
+        it("should return true if something was removed from framework cache", () => {
             // Arrange
             const cache = new ResponseCache({
                 MY_HANDLER: {
-                    SOME_OTHER_KEY: {data: "data we don't want"},
+                    MY_KEY: {data: "data!"},
+                },
+            });
+            const customCache = {
+                store: jest.fn(),
+                retrieve: jest.fn(),
+                remove: jest.fn(),
+                removeAll: jest.fn(),
+            };
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: customCache,
+            };
+
+            // Act
+            const result = cache.remove(fakeHandler, "optionsA");
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it("should return true if something was removed from custom cache", () => {
+            // Arrange
+            const cache = new ResponseCache({
+                MY_HANDLER: {
+                    MY_OTHER_KEY: {data: "data!"},
+                },
+            });
+            const customCache = {
+                store: jest.fn(),
+                retrieve: jest.fn(),
+                remove: jest.fn().mockReturnValue(true),
+                removeAll: jest.fn(),
+            };
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: customCache,
+            };
+
+            // Act
+            const result = cache.remove(fakeHandler, "optionsA");
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it("SSR should not call custom cache", () => {
+            // Arrange
+            jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+            const cache = new ResponseCache({
+                MY_HANDLER: {
+                    MY_OTHER_KEY: {data: "data!"},
+                },
+            });
+            const customCache = {
+                store: jest.fn(),
+                retrieve: jest.fn(),
+                remove: jest.fn(),
+                removeAll: jest.fn(),
+            };
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: customCache,
+            };
+
+            // Act
+            cache.remove(fakeHandler, "optionsA");
+
+            // Assert
+            expect(customCache.remove).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("#removeAll", () => {
+        it("CSR should call removeAll on custom cache", () => {
+            const cache = new ResponseCache({
+                MY_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                },
+            });
+            const customCache = {
+                store: jest.fn(),
+                retrieve: jest.fn(),
+                remove: jest.fn(),
+                removeAll: jest.fn(),
+            };
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: customCache,
+            };
+            const predicate = () => false;
+
+            // Act
+            cache.removeAll(fakeHandler, predicate);
+
+            // Assert
+            expect(customCache.removeAll).toHaveBeenCalledWith(
+                fakeHandler,
+                predicate,
+            );
+        });
+
+        it("should remove matching entries from handler subcache", () => {
+            const cache = new ResponseCache({
+                MY_HANDLER: {
+                    MY_KEY: {data: "2"},
+                    MY_KEY2: {data: "1"},
+                    MY_KEY3: {data: "2"},
+                },
+                OTHER_HANDLER: {
+                    MY_KEY: {data: "1"},
                 },
             });
             const fakeHandler: IRequestHandler<string, string> = {
@@ -233,16 +714,32 @@ describe("./response-cache.js", () => {
             };
 
             // Act
-            const result = cache.getEntry(fakeHandler, "options");
+            const result = cache.removeAll(
+                fakeHandler,
+                (k, d) => d.data === "2",
+            );
+            const after = cache.cloneCachedData();
 
             // Assert
-            expect(result).toBeNull();
+            expect(result).toBe(2);
+            expect(after).toStrictEqual({
+                MY_HANDLER: {
+                    MY_KEY2: {data: "1"},
+                },
+                OTHER_HANDLER: {
+                    MY_KEY: {data: "1"},
+                },
+            });
         });
 
-        it("should return the cached entry", () => {
-            // Arrange
+        it("should remove all entries from handler subcache if no predicate", () => {
             const cache = new ResponseCache({
                 MY_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                    MY_KEY2: {data: "data!"},
+                    MY_KEY3: {data: "data!"},
+                },
+                OTHER_HANDLER: {
                     MY_KEY: {data: "data!"},
                 },
             });
@@ -255,10 +752,73 @@ describe("./response-cache.js", () => {
             };
 
             // Act
-            const result = cache.getEntry(fakeHandler, "options");
+            const result = cache.removeAll(fakeHandler);
+            const after = cache.cloneCachedData();
 
             // Assert
-            expect(result).toStrictEqual({data: "data!"});
+            expect(result).toBe(3);
+            expect(after).toStrictEqual({
+                MY_HANDLER: {},
+                OTHER_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                },
+            });
+        });
+
+        it("should return total number of entries removed", () => {
+            const cache = new ResponseCache({
+                MY_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                },
+            });
+            const customCache = {
+                store: jest.fn(),
+                retrieve: jest.fn(),
+                remove: jest.fn(),
+                removeAll: jest.fn().mockReturnValue(1),
+            };
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: customCache,
+            };
+
+            // Act
+            const result = cache.removeAll(fakeHandler);
+
+            // Assert
+            expect(result).toBe(2);
+        });
+
+        it("SSR should not call custom cache", () => {
+            // Arrange
+            jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+            const cache = new ResponseCache({
+                MY_HANDLER: {
+                    MY_OTHER_KEY: {data: "data!"},
+                },
+            });
+            const customCache = {
+                store: jest.fn(),
+                retrieve: jest.fn(),
+                remove: jest.fn(),
+                removeAll: jest.fn(),
+            };
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: customCache,
+            };
+
+            // Act
+            cache.removeAll(fakeHandler);
+
+            // Assert
+            expect(customCache.removeAll).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/wonder-blocks-data/util/types.js
+++ b/packages/wonder-blocks-data/util/types.js
@@ -77,13 +77,13 @@ export interface ICache<TOptions, TData> {
     /**
      * Remove the cached entry for the given handler and options.
      *
-     * If the item exists in the cache, the cached entry is deleted and the
-     * entry is returned. Otherwise, this returns null.
+     * If the item exists in the cache, the cached entry is deleted and true
+     * is returned. Otherwise, this returns false.
      */
     remove(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,
-    ): ?$ReadOnly<CacheEntry<TData>>;
+    ): boolean;
 
     /**
      * Remove all cached entries for the given handler that, optionally, match
@@ -94,7 +94,7 @@ export interface ICache<TOptions, TData> {
     removeAll(
         handler: IRequestHandler<TOptions, TData>,
         predicate?: (
-            options: TOptions,
+            key: string,
             cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
         ) => boolean,
     ): number;

--- a/packages/wonder-blocks-data/util/types.js
+++ b/packages/wonder-blocks-data/util/types.js
@@ -95,7 +95,7 @@ export interface ICache<TOptions, TData> {
         handler: IRequestHandler<TOptions, TData>,
         predicate?: (
             key: string,
-            cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
+            cachedEntry: $ReadOnly<CacheEntry<TData>>,
         ) => boolean,
     ): number;
 }


### PR DESCRIPTION
See WB-832 and WB-833

This is the main architectural change in how caching works. Here we weave the custom cache that can be optionally provided by handler into our `ResponseCache` behavior.

NOTE: This code and especially the tests will be nicer once the framework cache has a separate implementation.

There are four places:

1. `getEntry`
- If server-side, we ignore the custom cache
- If client-side,
    - We defer to any value in the custom cache
    - If custom cache is a miss, but framework cache is not, we add the framework cache entry to the custom cache, delete the framework cache version, and then return that value

2. `cacheError` and `cacheData`
- These both call the same function which, when client-side, will write to the custom cache rather than the framework cache

3. `remove`
- A new method that will remove matching entries from both the handler's custom cache and from the framework cache. This differs from `removeAll` in that it targets a single record rather than those matching a predicate.

4. `removeAll`
- A new method that will remove matching entries from both the handler's custom cache and from the framework cache. This uses a predicate to find records to delete.