### PR TITLE
Part 4: Refactor internal cache to use new MemoryCache class

### DIFF
--- a/packages/wonder-blocks-data/components/data.js
+++ b/packages/wonder-blocks-data/components/data.js
@@ -11,6 +11,7 @@ import type {
     Interceptor,
     Result,
     IRequestHandler,
+    ValidData,
 } from "../util/types.js";
 
 type Props<
@@ -52,7 +53,7 @@ type Props<
  * We have the ability to override handlers and the cache for testing and such
  * so we export this component, and it then wraps the real data component.
  */
-export default class Data<TOptions, TData> extends React.Component<
+export default class Data<TOptions, TData: ValidData> extends React.Component<
     Props<TOptions, TData>,
 > {
     _getHandlerFromInterceptor(
@@ -104,7 +105,7 @@ export default class Data<TOptions, TData> extends React.Component<
             return ResponseCache.Default.getEntry;
         }
 
-        return <TOptions, TData>(
+        return <TOptions, TData: ValidData>(
             handler: IRequestHandler<TOptions, TData>,
             options: TOptions,
         ) => {

--- a/packages/wonder-blocks-data/components/intercept-cache.js
+++ b/packages/wonder-blocks-data/components/intercept-cache.js
@@ -3,7 +3,11 @@ import * as React from "react";
 
 import InterceptContext from "./intercept-context.js";
 
-import type {IRequestHandler, InterceptCacheFn} from "../util/types.js";
+import type {
+    ValidData,
+    IRequestHandler,
+    InterceptCacheFn,
+} from "../util/types.js";
 
 type Props<TOptions, TData> = {|
     /**
@@ -46,9 +50,10 @@ type Props<TOptions, TData> = {|
  * rendered within this one that intercepts the same handler type, then that
  * new instance will replace this interceptor for its children.
  */
-export default class InterceptCache<TOptions, TData> extends React.Component<
-    Props<TOptions, TData>,
-> {
+export default class InterceptCache<
+    TOptions,
+    TData: ValidData,
+> extends React.Component<Props<TOptions, TData>> {
     render() {
         return (
             <InterceptContext.Consumer>

--- a/packages/wonder-blocks-data/components/intercept-data.js
+++ b/packages/wonder-blocks-data/components/intercept-data.js
@@ -4,6 +4,7 @@ import * as React from "react";
 import InterceptContext from "./intercept-context.js";
 
 import type {
+    ValidData,
     IRequestHandler,
     InterceptFulfillRequestFn,
     InterceptShouldRefreshCacheFn,
@@ -77,9 +78,10 @@ type Props<TOptions, TData> =
  * new instance will replace this interceptor for its children. All methods
  * will be replaced.
  */
-export default class InterceptData<TOptions, TData> extends React.Component<
-    Props<TOptions, TData>,
-> {
+export default class InterceptData<
+    TOptions,
+    TData: ValidData,
+> extends React.Component<Props<TOptions, TData>> {
     render() {
         return (
             <InterceptContext.Consumer>

--- a/packages/wonder-blocks-data/components/internal-data.js
+++ b/packages/wonder-blocks-data/components/internal-data.js
@@ -5,7 +5,12 @@ import {Server} from "@khanacademy/wonder-blocks-core";
 import {RequestFulfillment} from "../util/request-fulfillment.js";
 import {TrackerContext} from "../util/request-tracking.js";
 
-import type {CacheEntry, Result, IRequestHandler} from "../util/types.js";
+import type {
+    ValidData,
+    CacheEntry,
+    Result,
+    IRequestHandler,
+} from "../util/types.js";
 
 type Props<TOptions, TData> = {|
     handler: IRequestHandler<TOptions, TData>,
@@ -29,10 +34,10 @@ type State<TData> = {|
  *
  * INTERNAL USE ONLY
  */
-export default class InternalData<TOptions, TData> extends React.Component<
-    Props<TOptions, TData>,
-    State<TData>,
-> {
+export default class InternalData<
+    TOptions,
+    TData: ValidData,
+> extends React.Component<Props<TOptions, TData>, State<TData>> {
     _mounted: boolean;
 
     constructor(props: Props<TOptions, TData>) {

--- a/packages/wonder-blocks-data/index.js
+++ b/packages/wonder-blocks-data/index.js
@@ -2,7 +2,7 @@
 import {ResponseCache as ResCache} from "./util/response-cache.js";
 import {RequestTracker} from "./util/request-tracking.js";
 
-import type {CacheEntry, IRequestHandler} from "./util/types.js";
+import type {ValidData, CacheEntry, IRequestHandler} from "./util/types.js";
 
 export type {Cache, CacheEntry, Result, IRequestHandler} from "./util/types.js";
 
@@ -14,12 +14,12 @@ export const initializeCache = (source: ResponseCache): void =>
 export const fulfillAllDataRequests = (): Promise<ResponseCache> =>
     RequestTracker.Default.fulfillTrackedRequests();
 
-export const removeFromCache = <TOptions, TData>(
+export const removeFromCache = <TOptions, TData: ValidData>(
     handler: IRequestHandler<TOptions, TData>,
     options: TOptions,
 ): boolean => ResCache.Default.remove<TOptions, TData>(handler, options);
 
-export const removeAllFromCache = <TOptions, TData>(
+export const removeAllFromCache = <TOptions, TData: ValidData>(
     handler: IRequestHandler<TOptions, TData>,
     predicate?: (
         key: string,

--- a/packages/wonder-blocks-data/util/memory-cache.js
+++ b/packages/wonder-blocks-data/util/memory-cache.js
@@ -33,7 +33,7 @@ export default class MemoryCache<TOptions, TData: ValidData>
     implements ICache<TOptions, TData> {
     _cache: Cache;
 
-    constructor(source: ?$ReadOnly<Cache> = undefined) {
+    constructor(source: ?$ReadOnly<Cache> = null) {
         this._cache = {};
         if (source != null) {
             try {

--- a/packages/wonder-blocks-data/util/memory-cache.js
+++ b/packages/wonder-blocks-data/util/memory-cache.js
@@ -1,0 +1,166 @@
+// @flow
+import type {
+    ValidData,
+    ICache,
+    CacheEntry,
+    Cache,
+    IRequestHandler,
+} from "./types.js";
+
+function deepClone<T: {...}>(source: T | $ReadOnly<T>): $ReadOnly<T> {
+    /**
+     * We want to deep clone the source cache to dodge mutations by external
+     * references. So we serialize the source cache to JSON and parse it
+     * back into a new object.
+     *
+     * NOTE: This doesn't work for get/set property accessors.
+     */
+    const serializedInitCache = JSON.stringify(source);
+    const cloneInitCache = JSON.parse(serializedInitCache);
+    return Object.freeze(cloneInitCache);
+}
+
+/**
+ * INTERNAL USE ONLY
+ *
+ * Special case cache implementation for the memory cache.
+ *
+ * This is only used within our framework. Handlers don't need to
+ * provide this as a custom cache as the framework will default to this in the
+ * absence of a custom cache. We use this for SSR too (see ./response-cache.js).
+ */
+export default class MemoryCache<TOptions, TData: ValidData>
+    implements ICache<TOptions, TData> {
+    _cache: Cache;
+
+    constructor(source: ?$ReadOnly<Cache> = undefined) {
+        this._cache = {};
+        if (source != null) {
+            try {
+                /**
+                 * Object.assign only performs a shallow clone.
+                 * So we deep clone it and then assign the clone values to our
+                 * internal cache.
+                 */
+                const cloneInitCache = deepClone(source);
+                Object.assign(this._cache, cloneInitCache);
+            } catch (e) {
+                throw new Error(
+                    `An error occurred trying to initialize from a response cache snapshot: ${e}`,
+                );
+            }
+        }
+    }
+
+    get inUse() {
+        return Object.keys(this._cache).length > 0;
+    }
+
+    store = <TOptions, TData: ValidData>(
+        handler: IRequestHandler<TOptions, TData>,
+        options: TOptions,
+        entry: CacheEntry<TData>,
+    ): void => {
+        const requestType = handler.type;
+
+        const frozenEntry = Object.isFrozen(entry)
+            ? entry
+            : Object.freeze(entry);
+
+        // Ensure we have a cache location for this handler type.
+        this._cache[requestType] = this._cache[requestType] || {};
+
+        // Cache the data.
+        const key = handler.getKey(options);
+        this._cache[requestType][key] = frozenEntry;
+    };
+
+    retrieve = <TOptions, TData: ValidData>(
+        handler: IRequestHandler<TOptions, TData>,
+        options: TOptions,
+    ): ?CacheEntry<TData> => {
+        const requestType = handler.type;
+
+        // Get the internal subcache for the handler.
+        const handlerCache = this._cache[requestType];
+        if (!handlerCache) {
+            return null;
+        }
+
+        // Get the response.
+        const key = handler.getKey(options);
+        const internalEntry = handlerCache[key];
+        if (internalEntry == null) {
+            return null;
+        }
+
+        return internalEntry;
+    };
+
+    remove = <TOptions, TData: ValidData>(
+        handler: IRequestHandler<TOptions, TData>,
+        options: TOptions,
+    ): boolean => {
+        const requestType = handler.type;
+
+        // NOTE(somewhatabstract): We could invoke removeAll with a predicate
+        // to match the key of the entry we're removing, but that's an
+        // inefficient way to remove a single item, so let's not do that.
+
+        // Get the internal subcache for the handler.
+        const handlerCache = this._cache[requestType];
+        if (!handlerCache) {
+            return false;
+        }
+
+        // Get the entry.
+        const key = handler.getKey(options);
+        const internalEntry = handlerCache[key];
+        if (internalEntry == null) {
+            return false;
+        }
+
+        // Delete the entry.
+        delete handlerCache[key];
+        return true;
+    };
+
+    removeAll = <TOptions, TData: ValidData>(
+        handler: IRequestHandler<TOptions, TData>,
+        predicate?: (
+            key: string,
+            cachedEntry: $ReadOnly<CacheEntry<TData>>,
+        ) => boolean,
+    ) => {
+        const requestType = handler.type;
+
+        // Get the internal subcache for the handler.
+        const handlerCache = this._cache[requestType];
+        if (!handlerCache) {
+            return 0;
+        }
+
+        // Apply the predicate to what we have cached.
+        let removedCount = 0;
+        for (const [key, entry] of Object.entries(handlerCache)) {
+            if (
+                typeof predicate !== "function" ||
+                predicate(key, (entry: any))
+            ) {
+                removedCount++;
+                delete handlerCache[key];
+            }
+        }
+        return removedCount;
+    };
+
+    cloneData = (): $ReadOnly<Cache> => {
+        try {
+            return deepClone(this._cache);
+        } catch (e) {
+            throw new Error(
+                `An error occurred while trying to clone the cache: ${e}`,
+            );
+        }
+    };
+}

--- a/packages/wonder-blocks-data/util/memory-cache.test.js
+++ b/packages/wonder-blocks-data/util/memory-cache.test.js
@@ -1,0 +1,333 @@
+// @flow
+import MemoryCache from "./memory-cache.js";
+
+import type {IRequestHandler} from "./types.js";
+
+describe("MemoryCache", () => {
+    afterEach(() => {
+        /**
+         * This is needed or the JSON.stringify mocks need to be
+         * mockImplementationOnce. This is because if the snapshots need
+         * to update, they write the inline snapshot and that appears to invoke
+         * prettier which in turn, calls JSON.stringify. And if that mock
+         * throws, then boom. No snapshot update and a big old confusing test
+         * failure.
+         */
+        jest.restoreAllMocks();
+    });
+
+    describe("#constructor", () => {
+        it("should throw if the cloning fails", () => {
+            // Arrange
+            jest.spyOn(JSON, "stringify").mockImplementation(() => {
+                throw new Error("BANG!");
+            });
+
+            // Act
+            const underTest = () =>
+                new MemoryCache({
+                    BAD: {
+                        BAD: {data: "FOOD"},
+                    },
+                });
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"An error occurred trying to initialize from a response cache snapshot: Error: BANG!"`,
+            );
+        });
+
+        it("should deep clone the passed source data", () => {
+            // Arrange
+            const sourceData = {
+                MY_HANDLER: {
+                    MY_KEY: {data: "THE_DATA"},
+                },
+            };
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const cache = new MemoryCache(sourceData);
+            // Try to mutate the cache.
+            sourceData["MY_HANDLER"]["MY_KEY"] = {data: "SOME_NEW_DATA"};
+            const result = cache.retrieve(fakeHandler, "options");
+
+            // Assert
+            expect(result).toStrictEqual({data: "THE_DATA"});
+        });
+    });
+
+    describe("#store", () => {
+        it("should store the entry in the cache", () => {
+            // Arrange
+            const cache = new MemoryCache();
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            cache.store(fakeHandler, "options", {data: "data"});
+            const result = cache.retrieve(fakeHandler, "options");
+
+            // Assert
+            expect(result).toStrictEqual({data: "data"});
+        });
+
+        it("should replace the entry in the handler subcache", () => {
+            // Arrange
+            const cache = new MemoryCache({
+                MY_HANDLER: {
+                    MY_KEY: {error: "Oh no!"},
+                },
+            });
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            cache.store(fakeHandler, "options", {data: "other_data"});
+            const result = cache.retrieve(fakeHandler, "options");
+
+            // Assert
+            expect(result).toStrictEqual({data: "other_data"});
+        });
+    });
+
+    describe("#retrieve", () => {
+        it("should return null if the handler subcache is absent", () => {
+            // Arrange
+            const cache = new MemoryCache();
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.retrieve(fakeHandler, "options");
+
+            // Assert
+            expect(result).toBeNull();
+        });
+
+        it("should return null if the request key is absent from the subcache", () => {
+            // Arrange
+            const cache = new MemoryCache({
+                MY_HANDLER: {
+                    SOME_OTHER_KEY: {data: "data we don't want"},
+                },
+            });
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.retrieve(fakeHandler, "options");
+
+            // Assert
+            expect(result).toBeNull();
+        });
+
+        it("should return the entry if it exists", () => {
+            // Arrange
+            const cache = new MemoryCache({
+                MY_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                },
+            });
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.retrieve(fakeHandler, "options");
+
+            // Assert
+            expect(result).toStrictEqual({data: "data!"});
+        });
+    });
+
+    describe("#remove", () => {
+        it("should return false if the handler subcache does not exist", () => {
+            // Arrange
+            const cache = new MemoryCache();
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.remove(fakeHandler, "options");
+
+            // Assert
+            expect(result).toBeFalsy();
+        });
+
+        it("should return false if the item does not exist in the subcache", () => {
+            // Arrange
+            const cache = new MemoryCache({
+                MY_HANDLER: {},
+            });
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.remove(fakeHandler, "options");
+
+            // Assert
+            expect(result).toBeFalsy();
+        });
+
+        it("should return true if the entry was removed", () => {
+            // Arrange
+            const cache = new MemoryCache({
+                MY_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                },
+            });
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.remove(fakeHandler, "options");
+
+            // Assert
+            expect(result).toBeTruthy();
+        });
+
+        it("should remove the entry", () => {
+            // Arrange
+            const cache = new MemoryCache({
+                MY_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                },
+            });
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            cache.remove(fakeHandler, "options");
+            const result = cache.retrieve(fakeHandler, "options");
+
+            // Assert
+            expect(result).toBeNull();
+        });
+    });
+
+    describe("#removeAll", () => {
+        it("should remove matching entries from handler subcache", () => {
+            const cache = new MemoryCache({
+                MY_HANDLER: {
+                    MY_KEY: {data: "2"},
+                    MY_KEY2: {data: "1"},
+                    MY_KEY3: {data: "2"},
+                },
+                OTHER_HANDLER: {
+                    MY_KEY: {data: "1"},
+                },
+            });
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.removeAll(
+                fakeHandler,
+                (k, d) => d.data === "2",
+            );
+            const after = cache.cloneData();
+
+            // Assert
+            expect(result).toBe(2);
+            expect(after).toStrictEqual({
+                MY_HANDLER: {
+                    MY_KEY2: {data: "1"},
+                },
+                OTHER_HANDLER: {
+                    MY_KEY: {data: "1"},
+                },
+            });
+        });
+
+        it("should remove all entries from handler subcache if no predicate", () => {
+            const cache = new MemoryCache({
+                MY_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                    MY_KEY2: {data: "data!"},
+                    MY_KEY3: {data: "data!"},
+                },
+                OTHER_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                },
+            });
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.removeAll(fakeHandler);
+            const after = cache.cloneData();
+
+            // Assert
+            expect(result).toBe(3);
+            expect(after).toStrictEqual({
+                MY_HANDLER: {},
+                OTHER_HANDLER: {
+                    MY_KEY: {data: "data!"},
+                },
+            });
+        });
+    });
+
+    describe("#cloneData", () => {});
+});

--- a/packages/wonder-blocks-data/util/request-fulfillment.js
+++ b/packages/wonder-blocks-data/util/request-fulfillment.js
@@ -1,7 +1,7 @@
 // @flow
 import {ResponseCache} from "./response-cache.js";
 
-import type {CacheEntry, IRequestHandler} from "./types.js";
+import type {ValidData, CacheEntry, IRequestHandler} from "./types.js";
 
 type Subcache = {
     [key: string]: Promise<any>,
@@ -30,7 +30,7 @@ export class RequestFulfillment {
         this._responseCache = responseCache || ResponseCache.Default;
     }
 
-    _getHandlerSubcache = <TOptions, TData>(
+    _getHandlerSubcache = <TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
     ): Subcache => {
         if (!this._requests[handler.type]) {
@@ -45,7 +45,7 @@ export class RequestFulfillment {
      * This will return an inflight request if one exists, otherwise it will
      * make a new request. Inflight requests are deleted once they resolve.
      */
-    fulfill = <TOptions, TData>(
+    fulfill = <TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,
     ): Promise<CacheEntry<TData>> => {

--- a/packages/wonder-blocks-data/util/request-handler.js
+++ b/packages/wonder-blocks-data/util/request-handler.js
@@ -1,5 +1,5 @@
 // @flow
-import type {CacheEntry, IRequestHandler, ICache} from "./types.js";
+import type {ValidData, CacheEntry, IRequestHandler, ICache} from "./types.js";
 
 /**
  * Base implementation for creating a request handler.
@@ -7,7 +7,7 @@ import type {CacheEntry, IRequestHandler, ICache} from "./types.js";
  * Provides a base implementation of the `IRequestHandler` base class for
  * use with the Wonder Blocks Data framework.
  */
-export default class RequestHandler<TOptions, TData>
+export default class RequestHandler<TOptions, TData: ValidData>
     implements IRequestHandler<TOptions, TData> {
     _type: string;
     _cache: ?ICache<TOptions, TData>;

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -1,19 +1,8 @@
 // @flow
 import {Server} from "@khanacademy/wonder-blocks-core";
-import type {CacheEntry, Cache, IRequestHandler} from "./types.js";
+import MemoryCache from "./memory-cache.js";
 
-function deepClone<T: {...}>(source: T | $ReadOnly<T>): $ReadOnly<T> {
-    /**
-     * We want to deep clone the source cache to dodge mutations by external
-     * references. So we serialize the source cache to JSON and parse it
-     * back into a new object.
-     *
-     * NOTE: This doesn't work for get/set property accessors.
-     */
-    const serializedInitCache = JSON.stringify(source);
-    const cloneInitCache = JSON.parse(serializedInitCache);
-    return Object.freeze(cloneInitCache);
-}
+import type {ValidData, CacheEntry, Cache, IRequestHandler} from "./types.js";
 
 /**
  * The default instance is stored here.
@@ -34,21 +23,17 @@ export class ResponseCache {
         return _default;
     }
 
-    _cache: Cache = {};
+    _cache: MemoryCache<any, any>;
 
-    constructor(source: ?Cache = undefined) {
-        if (source != null) {
-            this.initialize(source);
-        }
+    constructor(memoryCache: ?MemoryCache<any, any> = undefined) {
+        this._cache = memoryCache || new MemoryCache();
     }
 
-    _setCacheEntry<TOptions, TData>(
+    _setCacheEntry<TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,
         entry: CacheEntry<TData>,
     ): CacheEntry<TData> {
-        const requestType = handler.type;
-
         // We don't support custom caches during SSR.
         const customCache = Server.isServerSide() ? null : handler.cache;
         const frozenEntry = Object.freeze(entry);
@@ -57,12 +42,7 @@ export class ResponseCache {
         if (customCache != null) {
             customCache.store(handler, options, frozenEntry);
         } else {
-            // Ensure we have a cache location for this handler type.
-            this._cache[requestType] = this._cache[requestType] || {};
-
-            // Cache the data.
-            const key = handler.getKey(options);
-            this._cache[requestType][key] = frozenEntry;
+            this._cache.store(handler, options, frozenEntry);
         }
         return frozenEntry;
     }
@@ -73,20 +53,14 @@ export class ResponseCache {
      * This can only be called if the cache is not already in use.
      */
     initialize = (source: $ReadOnly<Cache>): void => {
-        if (Object.keys(this._cache).length !== 0) {
+        if (this._cache.inUse) {
             throw new Error(
                 "Cannot initialize data response cache more than once",
             );
         }
 
         try {
-            /**
-             * Object.assign only performs a shallow clone.
-             * So we deep clone it and then assign the clone values to our
-             * internal cache.
-             */
-            const cloneInitCache = deepClone(source);
-            Object.assign(this._cache, cloneInitCache);
+            this._cache = new MemoryCache(source);
         } catch (e) {
             throw new Error(
                 `An error occurred trying to initialize the data response cache: ${e}`,
@@ -97,7 +71,7 @@ export class ResponseCache {
     /**
      * Cache data for a specific response.
      */
-    cacheData = <TOptions, TData>(
+    cacheData = <TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,
         data: TData,
@@ -108,7 +82,7 @@ export class ResponseCache {
     /**
      * Cache an error for a specific response.
      */
-    cacheError = <TOptions, TData>(
+    cacheError = <TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,
         error: Error | string,
@@ -120,12 +94,10 @@ export class ResponseCache {
     /**
      * Retrieve data from our cache.
      */
-    getEntry = <TOptions, TData>(
+    getEntry = <TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,
     ): ?$ReadOnly<CacheEntry<TData>> => {
-        const requestType = handler.type;
-
         // We don't use custom caches during SSR.
         const customCache = Server.isServerSide() ? null : handler.cache;
         const entry = customCache && customCache.retrieve(handler, options);
@@ -134,21 +106,14 @@ export class ResponseCache {
             return entry;
         }
 
-        // Get the internal subcache for the handler.
-        const handlerCache = this._cache[requestType];
-        if (!handlerCache) {
-            return null;
-        }
-
-        // Get the response.
-        const key = handler.getKey(options);
-        const internalEntry = handlerCache[key];
-        if (internalEntry == null) {
-            return null;
-        }
+        // Get the internal entry for the handler.
+        const internalEntry = this._cache.retrieve<TOptions, TData>(
+            handler,
+            options,
+        );
 
         // If we have a custom cache on the handler, make sure it has the entry.
-        if (customCache != null) {
+        if (customCache != null && internalEntry != null) {
             // Yes, if this throws, we will have a problem. We want that.
             // Bad cache implementations should be overt.
             customCache.store(handler, options, internalEntry);
@@ -157,7 +122,7 @@ export class ResponseCache {
             // This does mean that if another handler of the same type but
             // without a custom cache won't get the value, but that's not an
             // expected valid usage of this framework.
-            delete handlerCache[key];
+            this._cache.remove(handler, options);
         }
         return internalEntry;
     };
@@ -170,12 +135,10 @@ export class ResponseCache {
      *
      * Returns true if something was removed from any cache; otherwise, false.
      */
-    remove = <TOptions, TData>(
+    remove = <TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,
     ): boolean => {
-        const requestType = handler.type;
-
         // NOTE(somewhatabstract): We could invoke removeAll with a predicate
         // to match the key of the entry we're removing, but that's an
         // inefficient way to remove a single item, so let's not do that.
@@ -186,22 +149,8 @@ export class ResponseCache {
             customCache && customCache.remove(handler, options)
         );
 
-        // Get the internal subcache for the handler.
-        const handlerCache = this._cache[requestType];
-        if (!handlerCache) {
-            return removedCustom;
-        }
-
-        // Get the entry.
-        const key = handler.getKey(options);
-        const internalEntry = handlerCache[key];
-        if (internalEntry == null) {
-            return removedCustom;
-        }
-
-        // Delete the entry.
-        delete handlerCache[key];
-        return true;
+        // Delete the entry from our internal cache.
+        return this._cache.remove(handler, options) || removedCustom;
     };
 
     /**
@@ -214,37 +163,20 @@ export class ResponseCache {
      * keys, but of unique entries. So if the same key is removed from both the
      * framework and custom caches, that will be 2 records removed.
      */
-    removeAll = <TOptions, TData>(
+    removeAll = <TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
         predicate?: (
             key: string,
             cachedEntry: $ReadOnly<CacheEntry<TData>>,
         ) => boolean,
     ): number => {
-        const requestType = handler.type;
-
         // We don't use custom caches during SSR.
         const customCache = Server.isServerSide() ? null : handler.cache;
         const removedCountCustom: number =
             (customCache && customCache.removeAll(handler, predicate)) || 0;
 
-        // Get the internal subcache for the handler.
-        const handlerCache = this._cache[requestType];
-        if (!handlerCache) {
-            return removedCountCustom;
-        }
-
-        // Apply the predicate to what we have cached.
-        let removedCount = 0;
-        for (const [key, entry] of Object.entries(handlerCache)) {
-            if (
-                typeof predicate !== "function" ||
-                predicate(key, (entry: any))
-            ) {
-                removedCount++;
-                delete handlerCache[key];
-            }
-        }
+        // Apply the predicate to what we have in ourn internal cached.
+        const removedCount = this._cache.removeAll(handler, predicate);
         return removedCount + removedCountCustom;
     };
 
@@ -254,12 +186,6 @@ export class ResponseCache {
      * By design, this does not clone anything held in custom caches.
      */
     cloneCachedData = (): $ReadOnly<Cache> => {
-        try {
-            return deepClone(this._cache);
-        } catch (e) {
-            throw new Error(
-                `An error occurred while trying to clone the cache: ${e}`,
-            );
-        }
+        return this._cache.cloneData();
     };
 }

--- a/packages/wonder-blocks-data/util/response-cache.js
+++ b/packages/wonder-blocks-data/util/response-cache.js
@@ -25,7 +25,7 @@ export class ResponseCache {
 
     _cache: MemoryCache<any, any>;
 
-    constructor(memoryCache: ?MemoryCache<any, any> = undefined) {
+    constructor(memoryCache: ?MemoryCache<any, any> = null) {
         this._cache = memoryCache || new MemoryCache();
     }
 

--- a/packages/wonder-blocks-data/util/types.js
+++ b/packages/wonder-blocks-data/util/types.js
@@ -1,5 +1,7 @@
 // @flow
-export type Result<TData> =
+export type ValidData = string | boolean | number | {...};
+
+export type Result<TData: ValidData> =
     | {|
           loading: true,
           data?: void,
@@ -11,7 +13,7 @@ export type Result<TData> =
           error?: string,
       |};
 
-export type CacheEntry<TData> =
+export type CacheEntry<TData: ValidData> =
     | {|
           error: string,
           data?: ?void,
@@ -26,16 +28,16 @@ type HandlerSubcache = {
     ...,
 };
 
-export type InterceptCacheFn<TOptions, TData> = (
+export type InterceptCacheFn<TOptions, TData: ValidData> = (
     options: TOptions,
     cacheEntry: ?$ReadOnly<CacheEntry<TData>>,
 ) => ?$ReadOnly<CacheEntry<TData>>;
 
-export type InterceptFulfillRequestFn<TOptions, TData> = (
+export type InterceptFulfillRequestFn<TOptions, TData: ValidData> = (
     options: TOptions,
 ) => ?Promise<TData>;
 
-export type InterceptShouldRefreshCacheFn<TOptions, TData> = (
+export type InterceptShouldRefreshCacheFn<TOptions, TData: ValidData> = (
     options: TOptions,
     cachedEntry: ?$ReadOnly<CacheEntry<TData>>,
 ) => ?boolean;
@@ -56,7 +58,7 @@ export type Cache = {
     ...,
 };
 
-export interface ICache<TOptions, TData> {
+export interface ICache<TOptions, TData: ValidData> {
     /**
      * Stores a value in the cache for the given handler and options.
      */
@@ -72,7 +74,7 @@ export interface ICache<TOptions, TData> {
     retrieve(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,
-    ): ?CacheEntry<TData>;
+    ): ?$ReadOnly<CacheEntry<TData>>;
 
     /**
      * Remove the cached entry for the given handler and options.
@@ -103,7 +105,7 @@ export interface ICache<TOptions, TData> {
 /**
  * A handler for data requests.
  */
-export interface IRequestHandler<TOptions, TData> {
+export interface IRequestHandler<TOptions, TData: ValidData> {
     /**
      * Fulfill a given request.
      *


### PR DESCRIPTION
For WB-833

This adds a new `MemoryCache` class that implements the `ICache` interface. This is not for use outside of Wonder Blocks Data. It implements the internal cache used for SSR and hydration. This simplifies the `ResponseCache` code a bit, identifies some improvements to flow types, and makes things overall easier to reason about.

The next diffs will add actual implementations for export that code can then use to modify caching for their data handlers.