### PR TITLE
Part 5: The NoCache cache

### DIFF
--- a/packages/wonder-blocks-data/components/data.md
+++ b/packages/wonder-blocks-data/components/data.md
@@ -23,8 +23,8 @@ returns `null`, the framework will look for a corresponding in-memory entry with
 which the framework has been initialzied, and if there, store the entry in the
 custom cache and then return it.
 
-`remove` and `removeAll` methods are also provided for removing values from the
-in-memory cache.
+`removeFromCache` and `removeAllFromCache` methods are also provided for
+removing values from the in-memory amnd custom caches.
 
 #### Client-side behavior
 

--- a/packages/wonder-blocks-data/generated-snapshot.test.js
+++ b/packages/wonder-blocks-data/generated-snapshot.test.js
@@ -24,6 +24,8 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
 import Button from "@khanacademy/wonder-blocks-button";
 
+import NoCache from "./util/no-cache.js";
+
 describe("wonder-blocks-data", () => {
     it("example 1", () => {
         class MyValidHandler extends RequestHandler {

--- a/packages/wonder-blocks-data/index.js
+++ b/packages/wonder-blocks-data/index.js
@@ -38,3 +38,4 @@ export {default as TrackData} from "./components/track-data.js";
 export {default as Data} from "./components/data.js";
 export {default as InterceptData} from "./components/intercept-data.js";
 export {default as InterceptCache} from "./components/intercept-cache.js";
+export {default as NoCache} from "./util/no-cache.js";

--- a/packages/wonder-blocks-data/index.test.js
+++ b/packages/wonder-blocks-data/index.test.js
@@ -24,6 +24,7 @@ describe("@khanacademy/wonder-blocks-data", () => {
                 "Data",
                 "InterceptCache",
                 "InterceptData",
+                "NoCache",
                 "RequestHandler",
                 "TrackData",
                 "fulfillAllDataRequests",

--- a/packages/wonder-blocks-data/util/memory-cache.js
+++ b/packages/wonder-blocks-data/util/memory-cache.js
@@ -131,7 +131,7 @@ export default class MemoryCache<TOptions, TData: ValidData>
             key: string,
             cachedEntry: $ReadOnly<CacheEntry<TData>>,
         ) => boolean,
-    ) => {
+    ): number => {
         const requestType = handler.type;
 
         // Get the internal subcache for the handler.

--- a/packages/wonder-blocks-data/util/no-cache.js
+++ b/packages/wonder-blocks-data/util/no-cache.js
@@ -3,6 +3,14 @@ import type {ValidData, ICache, CacheEntry, IRequestHandler} from "./types.js";
 
 /**
  * A cache implementation to use when no caching is wanted.
+ *
+ * Use this with your request handler if you want to support server-side
+ * rendering of your data requests, but want to ensure data is never cached
+ * on the client-side.
+ *
+ * This is better than having `shouldRefreshCache` always return `true` in the
+ * handler as this ensures that cache space and memory are never used for the
+ * requested data after hydration has finished.
  */
 export default class NoCache<TOptions, TData: ValidData>
     implements ICache<TOptions, TData> {

--- a/packages/wonder-blocks-data/util/no-cache.js
+++ b/packages/wonder-blocks-data/util/no-cache.js
@@ -1,0 +1,34 @@
+// @flow
+import type {ValidData, ICache, CacheEntry, IRequestHandler} from "./types.js";
+
+/**
+ * A cache implementation to use when no caching is wanted.
+ */
+export default class NoCache<TOptions, TData: ValidData>
+    implements ICache<TOptions, TData> {
+    store = <TOptions, TData: ValidData>(
+        handler: IRequestHandler<TOptions, TData>,
+        options: TOptions,
+        entry: CacheEntry<TData>,
+    ): void => {
+        /* empty */
+    };
+
+    retrieve = <TOptions, TData: ValidData>(
+        handler: IRequestHandler<TOptions, TData>,
+        options: TOptions,
+    ): ?CacheEntry<TData> => null;
+
+    remove = <TOptions, TData: ValidData>(
+        handler: IRequestHandler<TOptions, TData>,
+        options: TOptions,
+    ): boolean => false;
+
+    removeAll = <TOptions, TData: ValidData>(
+        handler: IRequestHandler<TOptions, TData>,
+        predicate?: (
+            key: string,
+            cachedEntry: $ReadOnly<CacheEntry<TData>>,
+        ) => boolean,
+    ): number => 0;
+}

--- a/packages/wonder-blocks-data/util/no-cache.test.js
+++ b/packages/wonder-blocks-data/util/no-cache.test.js
@@ -1,0 +1,105 @@
+// @flow
+import NoCache from "./no-cache.js";
+
+import type {IRequestHandler} from "./types.js";
+
+describe("NoCache", () => {
+    describe("#store", () => {
+        it("should not throw", () => {
+            // Arrange
+            const cache = new NoCache();
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const underTest = () =>
+                cache.store(fakeHandler, "options", {data: "data"});
+
+            // Assert
+            expect(underTest).not.toThrow();
+        });
+    });
+
+    describe("#retrieve", () => {
+        it("should return null", () => {
+            // Arrange
+            const cache = new NoCache();
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.retrieve(fakeHandler, "options");
+
+            // Assert
+            expect(result).toBeNull();
+        });
+    });
+
+    describe("#remove", () => {
+        it("should return false", () => {
+            // Arrange
+            const cache = new NoCache();
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.remove(fakeHandler, "options");
+
+            // Assert
+            expect(result).toBeFalsy();
+        });
+    });
+
+    describe("#removeAll", () => {
+        it("should return 0 without predicate", () => {
+            // Arrange
+            const cache = new NoCache();
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.removeAll(fakeHandler);
+
+            // Assert
+            expect(result).toBe(0);
+        });
+
+        it("should return 0 with predicate", () => {
+            // Arrange
+            const cache = new NoCache();
+            const fakeHandler: IRequestHandler<string, string> = {
+                getKey: () => "MY_KEY",
+                type: "MY_HANDLER",
+                shouldRefreshCache: () => false,
+                fulfillRequest: jest.fn(),
+                cache: null,
+            };
+
+            // Act
+            const result = cache.removeAll(fakeHandler, () => true);
+
+            // Assert
+            expect(result).toBe(0);
+        });
+    });
+});

--- a/packages/wonder-blocks-data/util/request-handler.md
+++ b/packages/wonder-blocks-data/util/request-handler.md
@@ -15,6 +15,12 @@ interface IRequestHandler<TOptions, TData> {
     get type(): string;
 
     /**
+     * A custom cache to use with data that this handler requests.
+     * This only affects client-side caching of data.
+     */
+    get cache(): ?ICache<TOptions, TData>;
+
+    /**
      * Determine if the cached data should be refreshed.
      *
      * If this returns true, the framework will use the currently cached value
@@ -36,6 +42,10 @@ interface IRequestHandler<TOptions, TData> {
 The constructor requires a `type` to identify your handler. This should be unique
 among the handlers that are used across your application, otherwise, requests
 may be fulfilled by the wrong handler.
+
+There is also an optional constructor argument, `cache`, which can be used to
+provide a custom cache for use with data the handler fulfills. Custom caches
+must implement the `ICache<TOptions, TData>` interface.
 
 The `fulfillRequest` method of this class is not implemented and will throw if
 called. Subclasses will need to implement this method.

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -59,6 +59,7 @@ module.exports = {
                 "packages/wonder-blocks-data/components/intercept-data.js",
                 "packages/wonder-blocks-data/components/track-data.js",
                 "packages/wonder-blocks-data/util/request-handler.js",
+                "packages/wonder-blocks-data/util/no-cache.js",
             ],
         },
         {


### PR DESCRIPTION
For WB-833.

The first of our exported cache strategies; the `NoCache`. A simple example where we can configure a handler to never cache data. This allows us to use the framework cache to support SSR but then once hydrated, never cache, thus avoiding using up memory and just have the client always request new data after the initial hydration.