### PR TITLE
Try again to prevent dependabot PRs from running chromatic

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,13 +1,11 @@
 name: Node CI
 
-on:
-  push:
-    branches:
-      - '!dependabot/**'
+on: [push]
 
 jobs:
   chromatic:
     runs-on: ubuntu-latest
+    if: "!contains(github.ref, 'dependabot/')"
     env:
       CI: true
     steps:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   chromatic:
-    if: "!contains(github.ref, 'dependabot/')"
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     env:
       CI: true

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -16,6 +16,9 @@ jobs:
         run: echo ${{github.ref}}
       - name: Echo head.ref
         run: echo ${{github.payload.pull_request.head.ref}}
+      - name: Decider
+        if: contains(github.ref, 'dependabot/')
+        run: Echo "abort"
       # - name: Use Node.js 12.x
       #   uses: actions/setup-node@v1
       #   with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   chromatic:
-    if: github.actor != 'dependabot-preview'
+    if: github.actor != 'kevinbarabash'
     runs-on: ubuntu-latest
     env:
       CI: true

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,45 +4,38 @@ on: [push]
 
 jobs:
   chromatic:
-    # if: ! contains(github.ref, 'dependabot/')
     runs-on: ubuntu-latest
     env:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: Echo actor
-        run: echo ${{github.actor}}
-      - name: Echo ref
-        run: echo ${{github.ref}}
-      - name: Echo head.ref
-        run: echo ${{github.payload.pull_request.head.ref}}
-      - name: Decider
+      - name: Exit early for dependabot PRs
         if: contains(github.ref, 'dependabot/')
-        run: Echo "abort"
-      # - name: Use Node.js 12.x
-      #   uses: actions/setup-node@v1
-      #   with:
-      #     node-version: 12.x
-      # - name: Get yarn cache
-      #   id: yarn-cache
-      #   run: echo "::set-output name=dir::$(yarn cache dir)"
-      # - uses: actions/cache@v1
-      #   with:
-      #     path: ${{ steps.yarn-cache.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-yarn-
-      # - name: Cache node modules
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: node_modules
-      #     key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.OS }}-node_modules-
-      # - name: yarn install
-      #   run: yarn install
-      # - uses: chromaui/action@v1
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     appCode: ${{ secrets.CHROMATIC_APP_CODE }}
-      #     autoAcceptChanges: "master"
+        run: exit 0
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-node_modules-
+      - name: yarn install
+        run: yarn install
+      - uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          appCode: ${{ secrets.CHROMATIC_APP_CODE }}
+          autoAcceptChanges: "master"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v1
       - name: Echo actor
         run: echo ${{github.actor}}
-      - name: Echo head_ref
-        run: echo ${{github.head_ref}}
+      - name: Echo ref
+        run: echo ${{github.ref}}
       # - name: Use Node.js 12.x
       #   uses: actions/setup-node@v1
       #   with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   chromatic:
-    if: ! ${{ contains(github.ref, 'dependabot/') }}
+    # if: ! contains(github.ref, 'dependabot/')
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -14,6 +14,8 @@ jobs:
         run: echo ${{github.actor}}
       - name: Echo ref
         run: echo ${{github.ref}}
+      - name: Echo head.ref
+        run: echo ${{github.payload.pull_request.head.ref}}
       # - name: Use Node.js 12.x
       #   uses: actions/setup-node@v1
       #   with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   chromatic:
-    if: github.actor != 'kevinbarabash'
+    if: ! contains(github.ref, 'dependabot/')
     runs-on: ubuntu-latest
     env:
       CI: true

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -14,30 +14,30 @@ jobs:
         run: echo ${{github.actor}}
       - name: Echo head_ref
         run: echo ${{github.head_ref}}
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Cache node modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-node_modules-
-      - name: yarn install
-        run: yarn install
-      - uses: chromaui/action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          appCode: ${{ secrets.CHROMATIC_APP_CODE }}
-          autoAcceptChanges: "master"
+      # - name: Use Node.js 12.x
+      #   uses: actions/setup-node@v1
+      #   with:
+      #     node-version: 12.x
+      # - name: Get yarn cache
+      #   id: yarn-cache
+      #   run: echo "::set-output name=dir::$(yarn cache dir)"
+      # - uses: actions/cache@v1
+      #   with:
+      #     path: ${{ steps.yarn-cache.outputs.dir }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-yarn-
+      # - name: Cache node modules
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.OS }}-node_modules-
+      # - name: yarn install
+      #   run: yarn install
+      # - uses: chromaui/action@v1
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     appCode: ${{ secrets.CHROMATIC_APP_CODE }}
+      #     autoAcceptChanges: "master"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   chromatic:
-    if: ! contains(github.ref, 'dependabot/')
+    if: ${{ ! contains(github.ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     env:
       CI: true

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -10,23 +10,23 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js 12.x
-        if: ! contains(github.ref, 'dependabot/')
+        if: ${{!contains(github.ref, 'dependabot/')}}
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
       - name: Get yarn cache
-        if: ! contains(github.ref, 'dependabot/')
+        if: ${{!contains(github.ref, 'dependabot/')}}
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
-        if: ! contains(github.ref, 'dependabot/')
+        if: ${{!contains(github.ref, 'dependabot/')}}
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Cache node modules
-        if: ! contains(github.ref, 'dependabot/')
+        if: ${{!contains(github.ref, 'dependabot/')}}
         uses: actions/cache@v1
         with:
           path: node_modules
@@ -34,10 +34,10 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-node_modules-
       - name: yarn install
-        if: ! contains(github.ref, 'dependabot/')
+        if: ${{!contains(github.ref, 'dependabot/')}}
         run: yarn install
       - uses: chromaui/action@v1
-        if: ! contains(github.ref, 'dependabot/')
+        if: ${{!contains(github.ref, 'dependabot/')}}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           appCode: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,6 +1,9 @@
 name: Node CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - '!dependabot/**'
 
 jobs:
   chromatic:
@@ -10,23 +13,19 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js 12.x
-        if: ${{!contains(github.ref, 'dependabot/')}}
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
       - name: Get yarn cache
-        if: ${{!contains(github.ref, 'dependabot/')}}
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
-        if: ${{!contains(github.ref, 'dependabot/')}}
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Cache node modules
-        if: ${{!contains(github.ref, 'dependabot/')}}
         uses: actions/cache@v1
         with:
           path: node_modules
@@ -34,10 +33,8 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-node_modules-
       - name: yarn install
-        if: ${{!contains(github.ref, 'dependabot/')}}
         run: yarn install
       - uses: chromaui/action@v1
-        if: ${{!contains(github.ref, 'dependabot/')}}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           appCode: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -9,23 +9,24 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: Exit early for dependabot PRs
-        if: contains(github.ref, 'dependabot/')
-        run: exit 0
       - name: Use Node.js 12.x
+        if: ! contains(github.ref, 'dependabot/')
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
       - name: Get yarn cache
+        if: ! contains(github.ref, 'dependabot/')
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
+        if: ! contains(github.ref, 'dependabot/')
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Cache node modules
+        if: ! contains(github.ref, 'dependabot/')
         uses: actions/cache@v1
         with:
           path: node_modules
@@ -33,8 +34,10 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-node_modules-
       - name: yarn install
+        if: ! contains(github.ref, 'dependabot/')
         run: yarn install
       - uses: chromaui/action@v1
+        if: ! contains(github.ref, 'dependabot/')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           appCode: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -10,6 +10,10 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
+      - name: Echo actor
+        run: echo ${{github.actor}}
+      - name: Echo head_ref
+        run: echo ${{github.head_ref}}
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,8 +4,8 @@ on: [push]
 
 jobs:
   chromatic:
-    runs-on: ubuntu-latest
     if: "!contains(github.ref, 'dependabot/')"
+    runs-on: ubuntu-latest
     env:
       CI: true
     steps:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   chromatic:
-    if: ${{ ! contains(github.ref, 'dependabot/') }}
+    if: ! ${{ contains(github.ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     env:
       CI: true


### PR DESCRIPTION
I'm not sure why the previous check I had for `github.actor != 'dependabot-preview'` wasn't working.  It's possible that the actor is actually something different since `dependabot-preview` is an app not a user.

This solution instead checks the name of the PR and doesn't run the `chromatic` job if the ref for the PR contains `dependabot/`.

It took me a long time to figure out the syntax.  It turns out you have to wrap things in double quotes that have special characters like `!`.  I found the answer on https://github.community/t5/GitHub-Actions/Expression-syntax-for-not-startswith/td-p/39571. 

Test Plan: merge and wait for the next dependabot PR