### PR TITLE
Add optional `required` prop to `Checkbox` and `Radio` components

### DIFF
--- a/packages/wonder-blocks-form/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/__snapshots__/custom-snapshot.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CheckboxCore type:default state:default checked:false 1`] = `
+exports[`CheckboxCore type:default state:default checked:false required:false 1`] = `
 <input
   aria-invalid={false}
   checked={false}
@@ -30,7 +30,37 @@ exports[`CheckboxCore type:default state:default checked:false 1`] = `
 />
 `;
 
-exports[`CheckboxCore type:default state:default checked:true 1`] = `
+exports[`CheckboxCore type:default state:default checked:false required:true 1`] = `
+<input
+  aria-invalid={false}
+  checked={false}
+  className=""
+  disabled={false}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#ffffff",
+      "borderColor": "rgba(33,36,44,0.50)",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "border-box",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:default state:default checked:true required:false 1`] = `
 Array [
   <input
     aria-invalid={false}
@@ -82,7 +112,59 @@ Array [
 ]
 `;
 
-exports[`CheckboxCore type:default state:hovered checked:false 1`] = `
+exports[`CheckboxCore type:default state:default checked:true required:true 1`] = `
+Array [
+  <input
+    aria-invalid={false}
+    checked={true}
+    className=""
+    disabled={false}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "backgroundColor": "#1865f2",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="#ffffff"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:default state:hovered checked:false required:false 1`] = `
 <input
   aria-invalid={false}
   checked={false}
@@ -112,7 +194,37 @@ exports[`CheckboxCore type:default state:hovered checked:false 1`] = `
 />
 `;
 
-exports[`CheckboxCore type:default state:hovered checked:true 1`] = `
+exports[`CheckboxCore type:default state:hovered checked:false required:true 1`] = `
+<input
+  aria-invalid={false}
+  checked={false}
+  className=""
+  disabled={false}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#ffffff",
+      "borderColor": "#1865f2",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:default state:hovered checked:true required:false 1`] = `
 Array [
   <input
     aria-invalid={false}
@@ -165,7 +277,60 @@ Array [
 ]
 `;
 
-exports[`CheckboxCore type:default state:pressed checked:false 1`] = `
+exports[`CheckboxCore type:default state:hovered checked:true required:true 1`] = `
+Array [
+  <input
+    aria-invalid={false}
+    checked={true}
+    className=""
+    disabled={false}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "backgroundColor": "#1865f2",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxShadow": "0 0 0 1px #ffffff, 0 0 0 3px #1865f2",
+        "boxSizing": "border-box",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="#ffffff"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:default state:pressed checked:false required:false 1`] = `
 <input
   aria-invalid={false}
   checked={false}
@@ -195,7 +360,37 @@ exports[`CheckboxCore type:default state:pressed checked:false 1`] = `
 />
 `;
 
-exports[`CheckboxCore type:default state:pressed checked:true 1`] = `
+exports[`CheckboxCore type:default state:pressed checked:false required:true 1`] = `
+<input
+  aria-invalid={false}
+  checked={false}
+  className=""
+  disabled={false}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#dae6fd",
+      "borderColor": "#1865f2",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:default state:pressed checked:true required:false 1`] = `
 Array [
   <input
     aria-invalid={false}
@@ -249,7 +444,61 @@ Array [
 ]
 `;
 
-exports[`CheckboxCore type:disabled state:default checked:false 1`] = `
+exports[`CheckboxCore type:default state:pressed checked:true required:true 1`] = `
+Array [
+  <input
+    aria-invalid={false}
+    checked={true}
+    className=""
+    disabled={false}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "background": "#1b50b3",
+        "backgroundColor": "#1865f2",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxShadow": "0 0 0 1px #ffffff, 0 0 0 3px #1b50b3",
+        "boxSizing": "border-box",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="#ffffff"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:disabled state:default checked:false required:false 1`] = `
 <input
   aria-invalid={false}
   checked={false}
@@ -280,7 +529,38 @@ exports[`CheckboxCore type:disabled state:default checked:false 1`] = `
 />
 `;
 
-exports[`CheckboxCore type:disabled state:default checked:true 1`] = `
+exports[`CheckboxCore type:disabled state:default checked:false required:true 1`] = `
+<input
+  aria-invalid={false}
+  checked={false}
+  className=""
+  disabled={true}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#f7f8fa",
+      "borderColor": "rgba(33,36,44,0.16)",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "border-box",
+      "cursor": "auto",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:disabled state:default checked:true required:false 1`] = `
 Array [
   <input
     aria-invalid={false}
@@ -334,38 +614,7 @@ Array [
 ]
 `;
 
-exports[`CheckboxCore type:disabled state:hovered checked:false 1`] = `
-<input
-  aria-invalid={false}
-  checked={false}
-  className=""
-  disabled={true}
-  onChange={[Function]}
-  style={
-    Object {
-      "MozAppearance": "none",
-      "WebkitAppearance": "none",
-      "appearance": "none",
-      "backgroundColor": "#f7f8fa",
-      "borderColor": "rgba(33,36,44,0.16)",
-      "borderRadius": 3,
-      "borderStyle": "solid",
-      "borderWidth": 1,
-      "boxSizing": "border-box",
-      "cursor": "auto",
-      "height": 16,
-      "margin": 0,
-      "minHeight": 16,
-      "minWidth": 16,
-      "outline": "none",
-      "width": 16,
-    }
-  }
-  type="checkbox"
-/>
-`;
-
-exports[`CheckboxCore type:disabled state:hovered checked:true 1`] = `
+exports[`CheckboxCore type:disabled state:default checked:true required:true 1`] = `
 Array [
   <input
     aria-invalid={false}
@@ -419,7 +668,7 @@ Array [
 ]
 `;
 
-exports[`CheckboxCore type:disabled state:pressed checked:false 1`] = `
+exports[`CheckboxCore type:disabled state:hovered checked:false required:false 1`] = `
 <input
   aria-invalid={false}
   checked={false}
@@ -450,7 +699,38 @@ exports[`CheckboxCore type:disabled state:pressed checked:false 1`] = `
 />
 `;
 
-exports[`CheckboxCore type:disabled state:pressed checked:true 1`] = `
+exports[`CheckboxCore type:disabled state:hovered checked:false required:true 1`] = `
+<input
+  aria-invalid={false}
+  checked={false}
+  className=""
+  disabled={true}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#f7f8fa",
+      "borderColor": "rgba(33,36,44,0.16)",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "border-box",
+      "cursor": "auto",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:disabled state:hovered checked:true required:false 1`] = `
 Array [
   <input
     aria-invalid={false}
@@ -504,7 +784,231 @@ Array [
 ]
 `;
 
-exports[`CheckboxCore type:error state:default checked:false 1`] = `
+exports[`CheckboxCore type:disabled state:hovered checked:true required:true 1`] = `
+Array [
+  <input
+    aria-invalid={false}
+    checked={true}
+    className=""
+    disabled={true}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "backgroundColor": "#f7f8fa",
+        "borderColor": "rgba(33,36,44,0.16)",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 1,
+        "boxSizing": "border-box",
+        "cursor": "auto",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="rgba(33,36,44,0.32)"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:disabled state:pressed checked:false required:false 1`] = `
+<input
+  aria-invalid={false}
+  checked={false}
+  className=""
+  disabled={true}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#f7f8fa",
+      "borderColor": "rgba(33,36,44,0.16)",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "border-box",
+      "cursor": "auto",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:disabled state:pressed checked:false required:true 1`] = `
+<input
+  aria-invalid={false}
+  checked={false}
+  className=""
+  disabled={true}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#f7f8fa",
+      "borderColor": "rgba(33,36,44,0.16)",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "border-box",
+      "cursor": "auto",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:disabled state:pressed checked:true required:false 1`] = `
+Array [
+  <input
+    aria-invalid={false}
+    checked={true}
+    className=""
+    disabled={true}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "backgroundColor": "#f7f8fa",
+        "borderColor": "rgba(33,36,44,0.16)",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 1,
+        "boxSizing": "border-box",
+        "cursor": "auto",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="rgba(33,36,44,0.32)"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:disabled state:pressed checked:true required:true 1`] = `
+Array [
+  <input
+    aria-invalid={false}
+    checked={true}
+    className=""
+    disabled={true}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "backgroundColor": "#f7f8fa",
+        "borderColor": "rgba(33,36,44,0.16)",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 1,
+        "boxSizing": "border-box",
+        "cursor": "auto",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="rgba(33,36,44,0.32)"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:error state:default checked:false required:false 1`] = `
 <input
   aria-invalid={true}
   checked={false}
@@ -534,7 +1038,37 @@ exports[`CheckboxCore type:error state:default checked:false 1`] = `
 />
 `;
 
-exports[`CheckboxCore type:error state:default checked:true 1`] = `
+exports[`CheckboxCore type:error state:default checked:false required:true 1`] = `
+<input
+  aria-invalid={true}
+  checked={false}
+  className=""
+  disabled={false}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#fceeec",
+      "borderColor": "#d92916",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "border-box",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:error state:default checked:true required:false 1`] = `
 Array [
   <input
     aria-invalid={true}
@@ -586,7 +1120,59 @@ Array [
 ]
 `;
 
-exports[`CheckboxCore type:error state:hovered checked:false 1`] = `
+exports[`CheckboxCore type:error state:default checked:true required:true 1`] = `
+Array [
+  <input
+    aria-invalid={true}
+    checked={true}
+    className=""
+    disabled={false}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "backgroundColor": "#d92916",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="#ffffff"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:error state:hovered checked:false required:false 1`] = `
 <input
   aria-invalid={true}
   checked={false}
@@ -616,7 +1202,37 @@ exports[`CheckboxCore type:error state:hovered checked:false 1`] = `
 />
 `;
 
-exports[`CheckboxCore type:error state:hovered checked:true 1`] = `
+exports[`CheckboxCore type:error state:hovered checked:false required:true 1`] = `
+<input
+  aria-invalid={true}
+  checked={false}
+  className=""
+  disabled={false}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#fceeec",
+      "borderColor": "#d92916",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:error state:hovered checked:true required:false 1`] = `
 Array [
   <input
     aria-invalid={true}
@@ -669,7 +1285,60 @@ Array [
 ]
 `;
 
-exports[`CheckboxCore type:error state:pressed checked:false 1`] = `
+exports[`CheckboxCore type:error state:hovered checked:true required:true 1`] = `
+Array [
+  <input
+    aria-invalid={true}
+    checked={true}
+    className=""
+    disabled={false}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "backgroundColor": "#d92916",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxShadow": "0 0 0 1px #ffffff, 0 0 0 3px #d92916",
+        "boxSizing": "border-box",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="#ffffff"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:error state:pressed checked:false required:false 1`] = `
 <input
   aria-invalid={true}
   checked={false}
@@ -699,7 +1368,91 @@ exports[`CheckboxCore type:error state:pressed checked:false 1`] = `
 />
 `;
 
-exports[`CheckboxCore type:error state:pressed checked:true 1`] = `
+exports[`CheckboxCore type:error state:pressed checked:false required:true 1`] = `
+<input
+  aria-invalid={true}
+  checked={false}
+  className=""
+  disabled={false}
+  onChange={[Function]}
+  style={
+    Object {
+      "MozAppearance": "none",
+      "WebkitAppearance": "none",
+      "appearance": "none",
+      "backgroundColor": "#fceeec",
+      "borderColor": "#9e271d",
+      "borderRadius": 3,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "height": 16,
+      "margin": 0,
+      "minHeight": 16,
+      "minWidth": 16,
+      "outline": "none",
+      "width": 16,
+    }
+  }
+  type="checkbox"
+/>
+`;
+
+exports[`CheckboxCore type:error state:pressed checked:true required:false 1`] = `
+Array [
+  <input
+    aria-invalid={true}
+    checked={true}
+    className=""
+    disabled={false}
+    onChange={[Function]}
+    style={
+      Object {
+        "MozAppearance": "none",
+        "WebkitAppearance": "none",
+        "appearance": "none",
+        "background": "#9e271d",
+        "backgroundColor": "#d92916",
+        "borderRadius": 3,
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxShadow": "0 0 0 1px #ffffff, 0 0 0 3px #9e271d",
+        "boxSizing": "border-box",
+        "height": 16,
+        "margin": 0,
+        "minHeight": 16,
+        "minWidth": 16,
+        "outline": "none",
+        "width": 16,
+      }
+    }
+    type="checkbox"
+  />,
+  <svg
+    className=""
+    height={16}
+    style={
+      Object {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z"
+      fill="#ffffff"
+    />
+  </svg>,
+]
+`;
+
+exports[`CheckboxCore type:error state:pressed checked:true required:true 1`] = `
 Array [
   <input
     aria-invalid={true}

--- a/packages/wonder-blocks-form/custom-snapshot.test.js
+++ b/packages/wonder-blocks-form/custom-snapshot.test.js
@@ -8,28 +8,31 @@ import RadioCore from "./components/radio-core.js";
 const states = ["default", "error", "disabled"];
 const clickableStates = ["default", "hovered", "pressed"];
 const checkedStates = [false, true];
+const requiredStates = [false, true];
 
 describe("CheckboxCore", () => {
     states.forEach((state) => {
         clickableStates.forEach((clickableState) => {
             checkedStates.forEach((checked) => {
-                test(`type:${state} state:${clickableState} checked:${String(
-                    checked,
-                )}`, () => {
-                    const disabled = state === "disabled";
-                    const tree = renderer
-                        .create(
-                            <CheckboxCore
-                                checked={checked}
-                                disabled={disabled}
-                                error={state === "error"}
-                                hovered={clickableState === "hovered"}
-                                pressed={clickableState === "pressed"}
-                                focused={clickableState === "focused"}
-                            />,
-                        )
-                        .toJSON();
-                    expect(tree).toMatchSnapshot();
+                requiredStates.forEach((required) => {
+                    test(`type:${state} state:${clickableState} checked:${String(
+                        checked,
+                    )} required:${String(required)}`, () => {
+                        const disabled = state === "disabled";
+                        const tree = renderer
+                            .create(
+                                <CheckboxCore
+                                    checked={checked}
+                                    disabled={disabled}
+                                    error={state === "error"}
+                                    hovered={clickableState === "hovered"}
+                                    pressed={clickableState === "pressed"}
+                                    focused={clickableState === "focused"}
+                                />,
+                            )
+                            .toJSON();
+                        expect(tree).toMatchSnapshot();
+                    });
                 });
             });
         });

--- a/packages/wonder-blocks-form/util/types.js
+++ b/packages/wonder-blocks-form/util/types.js
@@ -22,6 +22,8 @@ export type ChoiceCoreProps = {|
      * guarantee that the ID is unique within everything rendered on a page.
      * Used to match <label> with <input> elements for screenreaders. */
     id?: string,
+    /** Optionally state that filling in or checking the input is required */
+    required?: boolean,
     /** Optional test ID for e2e testing */
     testId?: string,
 |};


### PR DESCRIPTION
# SUMMARY
Form inputs, like checkboxes, should be able to handle a prop called `required`, which helps screen readers communicate to users that the form element needs to be filled, checked, or selected in order for the user to continue. We don't currently have that prop listed for the Wonder Blocks `Checkbox` and `Radio` components, so it causes a `flow` error if you pass it in. (It does get applied to the HTML element correctly, but you have to suppress the flow error.) We currently have one place where this prop is already being used and its flow error is being suppressed: https://github.com/Khan/webapp/blob/d31d0a873f0d31a4733ade4b5fb6ad04a031602a/javascript/notifications-package/accept-tos-notification.jsx#L205
# TEST PLAN
Run `yarn test` and verify all the tests pass.