### PR TITLE
Configure netlify to ignore dependabot PRs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = git log -1 --pretty=%B | grep dependabot


### PR DESCRIPTION
I found this recipe on https://community.netlify.com/t/common-issue-how-can-i-optimize-my-netlify-build-time/3907/10.

After this is landed we'll have to re-enable builds on PRs to check that it's working as expected.