### PR TITLE
Fix netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = ./netlify_check.sh
+  ignore = "./netlify_check.sh"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = git log -1 --pretty=%B | grep dependabot
+  ignore = ./netlify_check.sh

--- a/netlify_check.sh
+++ b/netlify_check.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Decided whether we should do a netlify build or not
+
+AUTHOR=`git log -1 --pretty=%an`
+
+if [ "$AUTHOR" == "dependabot-preview[bot]" ]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
The `ignore` directive in netlify.toml files only needs the exit code.  If any text is returned it causes the github check to fail.  We'd like it not to build but the github check should still succeed.  Hopefully this will fix it.  

Netlify docs: https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds.

I tested this by changing the author name to my own and checking the exit code and then switch it back to dependabot and say that is was `1` when the author matched the author of the most recent commit and `0` when it did not.