### PR TITLE
Fix netlify_check.sh to do the right thing.

### DIFF
--- a/netlify_check.sh
+++ b/netlify_check.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Decided whether we should do a netlify build or not
+# See https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds
 
 AUTHOR=`git log -1 --pretty=%an`
 
 if [ "$AUTHOR" == "dependabot-preview[bot]" ]; then
-    exit 1
+    exit 0 # don't build
 else
-    exit 0
+    exit 1 # build as usual
 fi


### PR DESCRIPTION
From the docs:
> An exit-code of 1 indicates the contents have changed, so if your command returns that code the build process will continue per usual. An exit-code of 0 indicates that the build should return early.
