### PR TITLE
In Clickable add event source information

### DIFF
--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -113,6 +113,11 @@ export type ClickableState = {|
      * See component documentation for more details.
      */
     pressed: boolean,
+
+    /**
+     * Where the input originated
+     */
+    inputType: null | "touch" | "mouse" | "keyboard",
 |};
 
 export type ClickableHandlers = {|
@@ -158,6 +163,7 @@ const startState = {
     hovered: false,
     focused: false,
     pressed: false,
+    inputType: null,
 };
 
 /**
@@ -282,21 +288,26 @@ export default class ClickableBehavior extends React.Component<
         // When the left button is pressed already, we want it to be pressed
         if (e.buttons === 1) {
             this.dragging = true;
-            this.setState({pressed: true});
+            this.setState({pressed: true, inputType: "mouse"});
         } else if (!this.waitingForClick) {
-            this.setState({hovered: true});
+            this.setState({hovered: true, inputType: "mouse"});
         }
     };
 
     handleMouseLeave = () => {
         if (!this.waitingForClick) {
             this.dragging = false;
-            this.setState({hovered: false, pressed: false, focused: false});
+            this.setState({
+                hovered: false,
+                pressed: false,
+                focused: false,
+                inputType: "mouse",
+            });
         }
     };
 
     handleMouseDown = () => {
-        this.setState({pressed: true});
+        this.setState({pressed: true, inputType: "mouse"});
     };
 
     handleMouseUp = (e: SyntheticMouseEvent<>) => {
@@ -304,7 +315,7 @@ export default class ClickableBehavior extends React.Component<
             this.dragging = false;
             this.handleClick(e);
         }
-        this.setState({pressed: false, focused: false});
+        this.setState({pressed: false, focused: false, inputType: "mouse"});
     };
 
     handleDragStart = (e: SyntheticMouseEvent<>) => {
@@ -313,16 +324,16 @@ export default class ClickableBehavior extends React.Component<
     };
 
     handleTouchStart = () => {
-        this.setState({pressed: true});
+        this.setState({pressed: true, inputType: "touch"});
     };
 
     handleTouchEnd = () => {
-        this.setState({pressed: false});
+        this.setState({pressed: false, inputType: "touch"});
         this.waitingForClick = true;
     };
 
     handleTouchCancel = () => {
-        this.setState({pressed: false});
+        this.setState({pressed: false, inputType: "touch"});
         this.waitingForClick = true;
     };
 
@@ -340,7 +351,7 @@ export default class ClickableBehavior extends React.Component<
             // call the supplied onClick and handle potential navigation in
             // handleKeyUp instead.
             e.preventDefault();
-            this.setState({pressed: true});
+            this.setState({pressed: true, inputType: "keyboard"});
         } else if (!triggerOnEnter && keyCode === keyCodes.enter) {
             // If the component isn't supposed to trigger on enter, we have to
             // keep track of the enter keydown to negate the onClick callback
@@ -375,11 +386,11 @@ export default class ClickableBehavior extends React.Component<
     };
 
     handleFocus = (e: SyntheticFocusEvent<>) => {
-        this.setState({focused: true});
+        this.setState({focused: true, inputType: "keyboard"});
     };
 
     handleBlur = (e: SyntheticFocusEvent<>) => {
-        this.setState({focused: false, pressed: false});
+        this.setState({focused: false, pressed: false, inputType: "keyboard"});
     };
 
     maybeNavigate = () => {

--- a/packages/wonder-blocks-core/components/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.test.js
@@ -51,8 +51,10 @@ describe("ClickableBehavior", () => {
             buttons: 0,
         });
         expect(button.state("hovered")).toEqual(true);
+        expect(button.state("inputType")).toEqual("mouse");
         button.simulate("mouseleave");
         expect(button.state("hovered")).toEqual(false);
+        expect(button.state("inputType")).toEqual("mouse");
     });
 
     it("changes only pressed state on mouse enter/leave while dragging", () => {
@@ -69,14 +71,17 @@ describe("ClickableBehavior", () => {
         button.simulate("mousedown");
         button.simulate("dragstart", {preventDefault: jest.fn()});
         expect(button.state("pressed")).toEqual(true);
+        expect(button.state("inputType")).toEqual("mouse");
 
         button.simulate("mouseleave");
         expect(button.state("pressed")).toEqual(false);
+        expect(button.state("inputType")).toEqual("mouse");
 
         button.simulate("mouseenter", {
             buttons: 1,
         });
         expect(button.state("pressed")).toEqual(true);
+        expect(button.state("inputType")).toEqual("mouse");
     });
 
     it("changes pressed state on mouse down/up", () => {
@@ -91,8 +96,10 @@ describe("ClickableBehavior", () => {
         expect(button.state("pressed")).toEqual(false);
         button.simulate("mousedown");
         expect(button.state("pressed")).toEqual(true);
+        expect(button.state("inputType")).toEqual("mouse");
         button.simulate("mouseup");
         expect(button.state("pressed")).toEqual(false);
+        expect(button.state("inputType")).toEqual("mouse");
     });
 
     it("changes pressed state on touch start/end/cancel", () => {
@@ -107,14 +114,19 @@ describe("ClickableBehavior", () => {
         expect(button.state("pressed")).toEqual(false);
         button.simulate("touchstart");
         expect(button.state("pressed")).toEqual(true);
+        expect(button.state("inputType")).toEqual("touch");
         button.simulate("touchend");
         expect(button.state("pressed")).toEqual(false);
+        expect(button.state("inputType")).toEqual("touch");
 
         expect(button.state("pressed")).toEqual(false);
+        expect(button.state("inputType")).toEqual("touch");
         button.simulate("touchstart");
         expect(button.state("pressed")).toEqual(true);
+        expect(button.state("inputType")).toEqual("touch");
         button.simulate("touchcancel");
         expect(button.state("pressed")).toEqual(false);
+        expect(button.state("inputType")).toEqual("touch");
     });
 
     it("enters focused state on key press after click", () => {
@@ -137,6 +149,7 @@ describe("ClickableBehavior", () => {
         });
         button.simulate("click");
         expect(button.state("focused")).toEqual(true);
+        expect(button.state("inputType")).toEqual("keyboard");
     });
 
     it("exits focused state on click after key press", () => {
@@ -194,6 +207,7 @@ describe("ClickableBehavior", () => {
         expect(button.state("pressed")).toEqual(true);
         button.simulate("keyup", {keyCode: keyCodes.enter});
         expect(button.state("pressed")).toEqual(false);
+        expect(button.state("inputType")).toEqual("keyboard");
     });
 
     it("changes pressed state on only enter key down/up for a link", () => {


### PR DESCRIPTION
Adds event source information in the Clickable component to differentiate between a keyboard, a touch device, and a mouse. This is needed for the math-input which has different states for touch down vs. mouse down.

NOTE:
- Snapshot tests aren't passing and I'm not sure how to update them, @kevinbarabash 