### PR TITLE
fix(clickable) WB-860:  href prop not working with keyboard navigation

### DIFF
--- a/config/jest/log-on-fail-reporter.js
+++ b/config/jest/log-on-fail-reporter.js
@@ -3,7 +3,7 @@
  * From: https://gist.github.com/GeeWee/71db0d9911b4a087e4b2486386168b05
  */
 const chalk = require("chalk");
-const {getConsoleOutput} = require("jest-util");
+const {getConsoleOutput} = require("@jest/console");
 const DefaultReporter = require("@jest/reporters/build/default_reporter")
     .default;
 const getResultHeader = require("@jest/reporters/build/get_result_header")

--- a/packages/wonder-blocks-clickable/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-clickable/__snapshots__/generated-snapshot.test.js.snap
@@ -237,7 +237,7 @@ exports[`wonder-blocks-clickable example 3 1`] = `
   <a
     aria-label=""
     className=""
-    href="https://khanacademy.org"
+    href="https://www.khanacademy.org/about/tos"
     onBlur={[Function]}
     onClick={[Function]}
     onDragStart={[Function]}

--- a/packages/wonder-blocks-clickable/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-clickable/__snapshots__/generated-snapshot.test.js.snap
@@ -213,3 +213,102 @@ exports[`wonder-blocks-clickable example 2 1`] = `
   </a>
 </div>
 `;
+
+exports[`wonder-blocks-clickable example 3 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <a
+    aria-label=""
+    className=""
+    href="https://khanacademy.org"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    style={
+      Object {
+        "MozOsxFontSmoothing": "inherit",
+        "WebkitFontSmoothing": "inherit",
+        "background": "transparent",
+        "border": "none",
+        "boxSizing": "border-box",
+        "color": "inherit",
+        "font": "inherit",
+        "lineHeight": "normal",
+        "margin": 0,
+        "outline": "none",
+        "overflow": "visible",
+        "padding": 0,
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+        "width": "auto",
+      }
+    }
+    tabIndex={0}
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "22px",
+          }
+        }
+      >
+        This text should navigate using the keyboard
+      </span>
+    </div>
+  </a>
+</div>
+`;

--- a/packages/wonder-blocks-clickable/components/clickable.js
+++ b/packages/wonder-blocks-clickable/components/clickable.js
@@ -136,14 +136,15 @@ export default class Clickable extends React.Component<Props> {
     };
 
     render() {
+        const {href, onClick, skipClientNav} = this.props;
         const ClickableBehavior = getClickableBehavior(
-            this.props.href,
-            this.props.skipClientNav,
+            href,
+            skipClientNav,
             this.context.router,
         );
 
         return (
-            <ClickableBehavior onClick={this.props.onClick}>
+            <ClickableBehavior href={href} onClick={onClick}>
                 {(state, handlers) =>
                     this.getCorrectTag(state, {
                         // eslint-disable-next-line react/prop-types

--- a/packages/wonder-blocks-clickable/components/clickable.md
+++ b/packages/wonder-blocks-clickable/components/clickable.md
@@ -88,3 +88,49 @@ const styles = StyleSheet.create({
     </View>
 </MemoryRouter>
 ```
+
+### Navigating with the Keyboard
+
+Clickable adds support to keyboard navigation. This way, your components are
+accessible and emulate better the browser's behavior.
+
+*NOTE:* If you want to navigate to an external URL and/or reload the window, make
+sure to use `href` and `skipClientNav={true}`.
+
+```jsx
+import {StyleSheet} from "aphrodite";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {View} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Body} from "@khanacademy/wonder-blocks-typography";
+
+const styles = StyleSheet.create({
+    hovered: {
+        textDecoration: "underline",
+        backgroundColor: Color.teal,
+    },
+    pressed: {
+        color: Color.blue,
+    },
+    focused: {
+        outline: `solid 4px ${Color.lightBlue}`,
+    },
+});
+
+<View>
+    <Clickable href="https://khanacademy.org" skipClientNav={true}>
+        {
+            ({hovered, focused, pressed}) =>
+            <View style={[
+                hovered && styles.hovered,
+                focused && styles.focused,
+                pressed && styles.pressed,
+            ]}>
+                <Body>
+                    This text should navigate using the keyboard
+                </Body>
+            </View>
+        }
+    </Clickable>
+</View>
+```

--- a/packages/wonder-blocks-clickable/components/clickable.md
+++ b/packages/wonder-blocks-clickable/components/clickable.md
@@ -118,7 +118,7 @@ const styles = StyleSheet.create({
 });
 
 <View>
-    <Clickable href="https://khanacademy.org" skipClientNav={true}>
+    <Clickable href="https://www.khanacademy.org/about/tos" skipClientNav={true}>
         {
             ({hovered, focused, pressed}) =>
             <View style={[

--- a/packages/wonder-blocks-clickable/components/clickable.stories.js
+++ b/packages/wonder-blocks-clickable/components/clickable.stories.js
@@ -13,7 +13,10 @@ export default {
 
 export const keyboardNavigation = () => (
     <View>
-        <Clickable href="https://khanacademy.org" skipClientNav={true}>
+        <Clickable
+            href="https://www.khanacademy.org/about/tos"
+            skipClientNav={true}
+        >
             {({hovered, focused, pressed}) => (
                 <View
                     style={[
@@ -28,6 +31,15 @@ export const keyboardNavigation = () => (
         </Clickable>
     </View>
 );
+
+keyboardNavigation.story = {
+    parameters: {
+        chromatic: {
+            // we don't need screenshots because this story only tests behavior.
+            disable: true,
+        },
+    },
+};
 
 const styles = StyleSheet.create({
     hovered: {

--- a/packages/wonder-blocks-clickable/components/clickable.stories.js
+++ b/packages/wonder-blocks-clickable/components/clickable.stories.js
@@ -1,0 +1,43 @@
+// @flow
+import React from "react";
+
+import {StyleSheet} from "aphrodite";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {View} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Body} from "@khanacademy/wonder-blocks-typography";
+
+export default {
+    title: "Clickable",
+};
+
+export const keyboardNavigation = () => (
+    <View>
+        <Clickable href="https://khanacademy.org" skipClientNav={true}>
+            {({hovered, focused, pressed}) => (
+                <View
+                    style={[
+                        hovered && styles.hovered,
+                        focused && styles.focused,
+                        pressed && styles.pressed,
+                    ]}
+                >
+                    <Body>This text should navigate using the keyboard</Body>
+                </View>
+            )}
+        </Clickable>
+    </View>
+);
+
+const styles = StyleSheet.create({
+    hovered: {
+        textDecoration: "underline",
+        backgroundColor: Color.teal,
+    },
+    pressed: {
+        color: Color.blue,
+    },
+    focused: {
+        outline: `solid 4px ${Color.lightBlue}`,
+    },
+});

--- a/packages/wonder-blocks-clickable/components/clickable.test.js
+++ b/packages/wonder-blocks-clickable/components/clickable.test.js
@@ -112,4 +112,35 @@ describe("Clickable", () => {
         // Assert
         expect(wrapper.find("#foo").exists()).toBe(false);
     });
+
+    test("should verify if href is passed to Clickablebehavior", () => {
+        // Arrange, Act
+        const wrapper = mount(
+            <Clickable testId="button" href="/foo" skipClientNav={true}>
+                {(eventState) => <h1>Click Me!</h1>}
+            </Clickable>,
+        );
+
+        // Assert
+        expect(wrapper.find("ClickableBehavior")).toHaveProp({href: "/foo"});
+    });
+
+    test("should navigate to a specific link using the keyboard", () => {
+        // Arrange
+        window.location.assign = jest.fn();
+
+        const wrapper = mount(
+            <Clickable testId="button" href="/foo" skipClientNav={true}>
+                {(eventState) => <h1>Click Me!</h1>}
+            </Clickable>,
+        );
+
+        // Act
+        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        // simulate Enter
+        buttonWrapper.simulate("keyup", {keyCode: 13});
+
+        // Assert
+        expect(window.location.assign).toHaveBeenCalledWith("/foo");
+    });
 });

--- a/packages/wonder-blocks-clickable/generated-snapshot.test.js
+++ b/packages/wonder-blocks-clickable/generated-snapshot.test.js
@@ -104,7 +104,10 @@ describe("wonder-blocks-clickable", () => {
         });
         const example = (
             <View>
-                <Clickable href="https://khanacademy.org" skipClientNav={true}>
+                <Clickable
+                    href="https://www.khanacademy.org/about/tos"
+                    skipClientNav={true}
+                >
                     {({hovered, focused, pressed}) => (
                         <View
                             style={[

--- a/packages/wonder-blocks-clickable/generated-snapshot.test.js
+++ b/packages/wonder-blocks-clickable/generated-snapshot.test.js
@@ -88,4 +88,40 @@ describe("wonder-blocks-clickable", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
+    it("example 3", () => {
+        const styles = StyleSheet.create({
+            hovered: {
+                textDecoration: "underline",
+                backgroundColor: Color.teal,
+            },
+            pressed: {
+                color: Color.blue,
+            },
+            focused: {
+                outline: `solid 4px ${Color.lightBlue}`,
+            },
+        });
+        const example = (
+            <View>
+                <Clickable href="https://khanacademy.org" skipClientNav={true}>
+                    {({hovered, focused, pressed}) => (
+                        <View
+                            style={[
+                                hovered && styles.hovered,
+                                focused && styles.focused,
+                                pressed && styles.pressed,
+                            ]}
+                        >
+                            <Body>
+                                This text should navigate using the keyboard
+                            </Body>
+                        </View>
+                    )}
+                </Clickable>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
Fixed an issue that prevented `Clickable` to work with keyboard navigation.

The specific case happens when we set `href` and `skipClientNav` and try to open a link using the keyboard. The issue was that `href` wasn't passed down to `ClickableBehavior` and this caused the component to avoid navigating because `href` was undefined for that case.

To fix this, we are adding `href` to the internal `ClickableBehavior` instance.

### Test plan

1. Open https://5e1bf4b385e3fb0020b7073c-cwqfgsekob.chromatic.com/?path=/story/clickable--keyboard-navigation
2. Using the keyboard, hover on the clickable link, then press `Enter` and verify the browser opens the URL set in `href` (https://khanacademy.org in this case).