### PR TITLE
feat(link) WB-859: Add id to Link

### DIFF
--- a/packages/wonder-blocks-data/generated-snapshot.test.js
+++ b/packages/wonder-blocks-data/generated-snapshot.test.js
@@ -133,7 +133,7 @@ describe("wonder-blocks-data", () => {
 
         const handler = new MyHandler();
 
-        const getEntryInterceptor = function(options) {
+        const getEntryInterceptor = function (options) {
             if (options === "DATA") {
                 return {
                     data: "I'm DATA from the cache",
@@ -211,7 +211,7 @@ describe("wonder-blocks-data", () => {
 
         const handler = new MyHandler();
 
-        const getEntryIntercept = function(options) {
+        const getEntryIntercept = function (options) {
             if (options === "ERROR") {
                 return {
                     error: "I'm an ERROR from the cache interceptor",
@@ -277,7 +277,7 @@ describe("wonder-blocks-data", () => {
 
         const handler = new MyHandler();
 
-        const fulfillRequestInterceptor = function(options) {
+        const fulfillRequestInterceptor = function (options) {
             if (options === "DATA") {
                 return Promise.resolve("INTERCEPTED DATA!");
             }
@@ -314,7 +314,7 @@ describe("wonder-blocks-data", () => {
                 super("INTERCEPT_DATA_HANDLER2");
                 let _counter = 0;
 
-                this.fulfillRequest = function(options) {
+                this.fulfillRequest = function (options) {
                     return Promise.resolve(`DATA ${_counter++}`);
                 };
             }
@@ -326,7 +326,7 @@ describe("wonder-blocks-data", () => {
 
         const handler = new MyHandler();
 
-        const shouldRefreshCacheInterceptor = function(options) {
+        const shouldRefreshCacheInterceptor = function (options) {
             if (options === "DATA") {
                 return true;
             }

--- a/packages/wonder-blocks-dropdown/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/generated-snapshot.test.js
@@ -1397,8 +1397,9 @@ describe("wonder-blocks-dropdown", () => {
                 <OptionItem
                     key={i}
                     value={(i + 1).toString()}
-                    label={`School ${i +
-                        1} in Wizarding World Some more really long labels?`}
+                    label={`School ${
+                        i + 1
+                    } in Wizarding World Some more really long labels?`}
                 />
             ));
 

--- a/packages/wonder-blocks-link/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__snapshots__/generated-snapshot.test.js.snap
@@ -195,6 +195,7 @@ exports[`wonder-blocks-link example 2 1`] = `
   <a
     className=""
     href="#nonexistent-link"
+    id="typography-link"
     onBlur={[Function]}
     onClick={[Function]}
     onDragStart={[Function]}

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -27,6 +27,11 @@ export type SharedProps = {|
     caret: boolean,
 
     /**
+     * An optional id attribute.
+     */
+    id?: string,
+
+    /**
      * Kind of Link. Note: Secondary light Links are not supported.
      */
     kind: "primary" | "secondary",

--- a/packages/wonder-blocks-link/components/link.md
+++ b/packages/wonder-blocks-link/components/link.md
@@ -6,11 +6,11 @@ import {View} from "@khanacademy/wonder-blocks-core";
 
 <View>
     <p>
-    I am a <Link href="#nonexistent-link">Primary Link</Link>. <span
-    style={{color: Color.offBlack64}}>My friend the
-    <Link href="#secondary-nonexistent-link" kind="secondary">Secondary Link
-    </Link> is used here with a lighter text.</span> We also have a
-    <Link href="#" visitable={true}>Visitable Primary Link</Link> friend.
+        I am a <Link href="#nonexistent-link">Primary Link</Link>. <span
+        style={{color: Color.offBlack64}}>My friend the
+        <Link href="#secondary-nonexistent-link" kind="secondary">Secondary Link
+        </Link> is used here with a lighter text.</span> We also have a
+        <Link href="#" visitable={true}>Visitable Primary Link</Link> friend.
     </p>
     <p style={{backgroundColor: Color.darkBlue, color: Color.white64, padding: 10}}>
         I am a <Link href="#dark-link" light={true}>Primary Link</Link> used on
@@ -30,7 +30,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
 
 <View>
-    <Link href="#nonexistent-link">
+    <Link href="#nonexistent-link" id="typography-link">
         <HeadingSmall>Heading inside a Link element</HeadingSmall>
     </Link>
 </View>

--- a/packages/wonder-blocks-link/generated-snapshot.test.js
+++ b/packages/wonder-blocks-link/generated-snapshot.test.js
@@ -62,7 +62,7 @@ describe("wonder-blocks-link", () => {
     it("example 2", () => {
         const example = (
             <View>
-                <Link href="#nonexistent-link">
+                <Link href="#nonexistent-link" id="typography-link">
                     <HeadingSmall>Heading inside a Link element</HeadingSmall>
                 </Link>
             </View>


### PR DESCRIPTION
- Adds the `id` prop to the `<Link />` component.
- Fixes some remaining changes from the `prettier` upgrade.

### Test plan
Check that the `Link` snapshot includes the `id` when set in the example.