### PR TITLE
Add 'id' prop to Button

### DIFF
--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -51,6 +51,7 @@ export default class ButtonCore extends React.Component<Props> {
             testId,
             spinner,
             icon,
+            id,
             ...handlers
         } = this.props;
         const {router} = this.context;
@@ -87,6 +88,7 @@ export default class ButtonCore extends React.Component<Props> {
 
         const commonProps = {
             "data-test-id": testId,
+            id: id,
             role: "button",
             style: [defaultStyle, style],
             ...handlers,

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -69,6 +69,11 @@ export type SharedProps = {|
     disabled: boolean,
 
     /**
+     * An optional id attribute.
+     */
+    id?: string,
+
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string,

--- a/packages/wonder-blocks-button/components/button.test.js
+++ b/packages/wonder-blocks-button/components/button.test.js
@@ -87,6 +87,7 @@ describe("Button", () => {
     });
 
     test("disallow navigation when href and disabled are both set", () => {
+        // Arrange
         const wrapper = mount(
             <MemoryRouter>
                 <div>
@@ -108,5 +109,27 @@ describe("Button", () => {
 
         // Assert
         expect(wrapper.find("#foo").exists()).toBe(false);
+    });
+
+    it("should set label on the underlying button", () => {
+        // Arrange
+        const wrapper = mount(
+            <Button id="foo" onClick={() => {}}>
+                Click me!
+            </Button>,
+        );
+
+        expect(wrapper.find("button")).toHaveProp({id: "foo"});
+    });
+
+    it("should set label on the underlying link", () => {
+        // Arrange
+        const wrapper = mount(
+            <Button id="foo" href="/bar">
+                Click me!
+            </Button>,
+        );
+
+        expect(wrapper.find("a")).toHaveProp({id: "foo"});
     });
 });


### PR DESCRIPTION
Most of our components support an optional id, but it was missing on Button.  This diff fixes that.

Issue: none

Test plan: yarn test