### PR TITLE
Remove unsafe componentWillMount from ScrollDisabler

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,11 @@
 module.exports = {
     extends: ["@khanacademy"],
     plugins: ["import", "promise", "monorepo"],
+    settings: {
+        react: {
+            version: "detect",
+        },
+    },
     rules: {
         "flowtype/require-exact-type": ["error", "always"],
         "flowtype/no-types-missing-file-annotation": "error",
@@ -45,6 +50,7 @@ module.exports = {
         "react/no-string-refs": "error",
         "react/no-this-in-sfc": "error",
         "react/no-unescaped-entities": "error",
+        "react/no-deprecated": "error",
         "react/react-in-jsx-scope": "error",
         "react/require-render-return": "error",
         "monorepo/no-internal-import": "error",

--- a/packages/wonder-blocks-modal/components/scroll-disabler.js
+++ b/packages/wonder-blocks-modal/components/scroll-disabler.js
@@ -17,14 +17,18 @@ const needsHackyMobileSafariScrollDisabler = (() => {
     return userAgent.indexOf("iPad") > -1 || userAgent.indexOf("iPhone") > -1;
 })();
 
-class ScrollDisabler extends Component<{||}> {
+type Props = {||};
+
+class ScrollDisabler extends Component<Props> {
     static oldOverflow: string;
     static oldPosition: string;
     static oldScrollY: number;
     static oldWidth: string;
     static oldTop: string;
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         if (ScrollDisabler.numModalsOpened === 0) {
             const body = document.body;
             if (!body) {

--- a/packages/wonder-blocks-modal/components/scroll-disabler.js
+++ b/packages/wonder-blocks-modal/components/scroll-disabler.js
@@ -26,9 +26,7 @@ class ScrollDisabler extends Component<Props> {
     static oldWidth: string;
     static oldTop: string;
 
-    constructor(props: Props) {
-        super(props);
-
+    componentDidMount() {
         if (ScrollDisabler.numModalsOpened === 0) {
             const body = document.body;
             if (!body) {


### PR DESCRIPTION
When I was updating webapp to use 16.9, there was a warning about using `componentWillMount` that was causing a number of tests to fail.  This PR moves this logic into the `ScrollDisabler`'s constructor.  I've also added a new lint rule: `no-deprecated` which flags deprecated methods based on the current version of react we're using.

Test Plan: 
- yarn start
- open http://localhost:6060/#section-modal
- click on one of the buttons to open a modal
- try scroll with the modal open, see that the page doesn't scroll
- close the modal, see that the page doesn't jump