### PR TITLE
Add target to ActionItem

### DIFF
--- a/packages/wonder-blocks-dropdown/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/__tests__/generated-snapshot.test.js
@@ -43,6 +43,7 @@ describe("wonder-blocks-dropdown", () => {
                     <ActionItem
                         label="Profile"
                         href="http://khanacademy.org/profile"
+                        target="_blank"
                         testId="profile"
                     />
                     <ActionItem

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -35,6 +35,11 @@ type ActionProps = {|
     href?: string,
 
     /**
+     * A target destination window for a link to open in.
+     */
+    target?: string,
+
+    /**
      * Whether to avoid using client-side navigation.
      *
      * If the URL passed to href is local to the client-side, e.g.
@@ -114,6 +119,7 @@ export default class ActionItem extends React.Component<ActionProps> {
             skipClientNav,
             disabled,
             href,
+            target,
             indent,
             label,
             onClick,
@@ -174,7 +180,11 @@ export default class ActionItem extends React.Component<ActionProps> {
                                 {children}
                             </StyledLink>
                         ) : (
-                            <StyledAnchor {...props} href={href}>
+                            <StyledAnchor
+                                {...props}
+                                href={href}
+                                target={target}
+                            >
                                 {children}
                             </StyledAnchor>
                         );

--- a/packages/wonder-blocks-dropdown/components/action-menu.md
+++ b/packages/wonder-blocks-dropdown/components/action-menu.md
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
         menuText="Betsy Appleseed"
         testId="teacher-menu"
     >
-        <ActionItem label="Profile" href="http://khanacademy.org/profile" testId="profile" />
+        <ActionItem label="Profile" href="http://khanacademy.org/profile" target="_blank" testId="profile" />
         <ActionItem label="Teacher dashboard" href="http://khanacademy.org/coach/dashboard" testId="dashboard" />
         <ActionItem label="Settings (onClick)" onClick={() => console.log("user clicked on settings")} testId="settings" />
         <ActionItem label="Help" disabled={true} onClick={() => console.log("this item is disabled...")} testId="help" />


### PR DESCRIPTION
Unlike Button and Link it has href but not a target prop.

Adding target prop enables to open links in a separate tab.

Issue: https://khanacademy.atlassian.net/browse/WB-861

Test Plan:
 - Run `yarn test`