### PR TITLE
fix(dropdown) WB-858: Fix dropdown container width

### DIFF
--- a/packages/wonder-blocks-dropdown/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -2630,7 +2630,6 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      placeholder="Color palette"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -2679,7 +2678,7 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
           }
         }
       >
-        0 items
+        Color palette
       </span>
       <svg
         aria-hidden="true"
@@ -2744,7 +2743,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
         "minWidth": 170,
         "padding": 0,
         "position": "relative",
-        "width": "fit-content",
+        "width": "100%",
         "zIndex": 0,
       }
     }
@@ -2767,7 +2766,6 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      placeholder="Solar system"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -2816,7 +2814,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
           }
         }
       >
-        0 items
+        Solar system
       </span>
       <svg
         aria-hidden="true"
@@ -3135,7 +3133,6 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      placeholder="empty"
       style={
         Object {
           "::MozFocusInner": Object {
@@ -3185,7 +3182,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
           }
         }
       >
-        0 items
+        empty
       </span>
       <svg
         aria-hidden="true"
@@ -3293,7 +3290,6 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
       onTouchCancel={[Function]}
       onTouchEnd={[Function]}
       onTouchStart={[Function]}
-      placeholder="Accessible MultiSelect"
       style={
         Object {
           "::MozFocusInner": Object {

--- a/packages/wonder-blocks-dropdown/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/__tests__/generated-snapshot.test.js
@@ -947,11 +947,11 @@ describe("wonder-blocks-dropdown", () => {
                 return (
                     <MultiSelect
                         onChange={this.handleChange}
-                        placeholder="Color palette"
                         selectedValues={this.state.selectedValues}
                         style={styles.setWidth}
                         testId="palette"
                         labels={{
+                            noneSelected: "Color palette",
                             someSelected: (numSelectedValues) =>
                                 `${numSelectedValues} colors`,
                         }}
@@ -994,8 +994,9 @@ describe("wonder-blocks-dropdown", () => {
             },
             setWidth: {
                 minWidth: 170,
+                width: "100%",
             },
-            dropdownHeight: {
+            customDropdown: {
                 maxHeight: 200,
             },
         });
@@ -1021,11 +1022,11 @@ describe("wonder-blocks-dropdown", () => {
                 return (
                     <MultiSelect
                         onChange={this.handleChange}
-                        placeholder="Solar system"
                         selectedValues={this.state.selectedValues}
                         style={styles.setWidth}
-                        dropdownStyle={styles.dropdownHeight}
+                        dropdownStyle={styles.customDropdown}
                         labels={{
+                            noneSelected: "Solar system",
                             someSelected: (numSelectedValues) =>
                                 `${numSelectedValues} planets`,
                         }}
@@ -1228,7 +1229,11 @@ describe("wonder-blocks-dropdown", () => {
         });
         const example = (
             <View style={styles.row}>
-                <MultiSelect placeholder="empty" />
+                <MultiSelect
+                    labels={{
+                        noneSelected: "empty",
+                    }}
+                />
             </View>
         );
         const tree = renderer.create(example).toJSON();
@@ -1248,7 +1253,11 @@ describe("wonder-blocks-dropdown", () => {
                 <MultiSelect
                     aria-labelledby="label-for-multi-select"
                     id="unique-multi-select"
-                    placeholder="Accessible MultiSelect"
+                    labels={{
+                        noneSelected: "Accessible MultiSelect",
+                        someSelected: (numSelectedValues) =>
+                            `${numSelectedValues} planets`,
+                    }}
                     selectedValues={["one"]}
                 >
                     <OptionItem

--- a/packages/wonder-blocks-dropdown/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core-virtualized.js
@@ -60,11 +60,6 @@ type State = {|
 const MAX_VISIBLE_ITEMS = 10;
 
 /**
- * Maximum horizontal size allowed for the container
- */
-const MAX_ALLOWED_WIDTH = 512;
-
-/**
  * A react-window's List wrapper that instantiates the virtualized list and
  * dynamically calculates the item height depending on the type
  */
@@ -108,11 +103,7 @@ class DropdownCoreVirtualized extends React.Component<Props, State> {
         // after the non-virtualized items are rendered, we get the container
         //  width to pass it to react-window's List
         if (rootNode) {
-            const clientWidth = rootNode.getBoundingClientRect().width;
-            const width =
-                clientWidth < MAX_ALLOWED_WIDTH
-                    ? clientWidth
-                    : MAX_ALLOWED_WIDTH;
+            const width = rootNode.getBoundingClientRect().width;
 
             this.setState({
                 width,

--- a/packages/wonder-blocks-dropdown/components/multi-select.md
+++ b/packages/wonder-blocks-dropdown/components/multi-select.md
@@ -37,11 +37,11 @@ class ExampleNoneSelected extends React.Component {
     render() {
         return <MultiSelect
             onChange={this.handleChange}
-            placeholder="Color palette"
             selectedValues={this.state.selectedValues}
             style={styles.setWidth}
             testId="palette"
             labels={{
+                noneSelected: "Color palette",
                 someSelected: (numSelectedValues) => `${numSelectedValues} colors`,
             }}
         >
@@ -77,8 +77,9 @@ const styles = StyleSheet.create({
     },
     setWidth: {
         minWidth: 170,
+        width: "100%",
     },
-    dropdownHeight: {
+    customDropdown: {
         maxHeight: 200,
     },
 });
@@ -103,11 +104,11 @@ class ExampleScrolling extends React.Component {
     render() {
         return <MultiSelect
             onChange={this.handleChange}
-            placeholder="Solar system"
             selectedValues={this.state.selectedValues}
             style={styles.setWidth}
-            dropdownStyle={styles.dropdownHeight}
+            dropdownStyle={styles.customDropdown}
             labels={{
+                noneSelected: "Solar system",
                 someSelected: (numSelectedValues) => `${numSelectedValues} planets`,
             }}
         >
@@ -297,7 +298,7 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
-    <MultiSelect placeholder="empty" />
+    <MultiSelect labels={{noneSelected: "empty"}} />
 </View>
 ```
 
@@ -329,7 +330,10 @@ import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
     <MultiSelect
         aria-labelledby="label-for-multi-select"
         id="unique-multi-select"
-        placeholder="Accessible MultiSelect"
+        labels={{
+            noneSelected: "Accessible MultiSelect",
+            someSelected: (numSelectedValues) => `${numSelectedValues} planets`,
+        }}
         selectedValues={["one"]}
     >
         <OptionItem label="First element" aria-label="First element, selected" value="one" />

--- a/packages/wonder-blocks-dropdown/components/multi-select.stories.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.stories.js
@@ -1,0 +1,67 @@
+// @flow
+import React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+
+export default {
+    title: "MultiSelect",
+};
+
+class MultiSelectWithCustomStyles extends React.Component {
+    state = {
+        selectedValues: [],
+    };
+
+    handleChange = (update) => {
+        this.setState({
+            selectedValues: update,
+        });
+    };
+
+    render() {
+        return (
+            <MultiSelect
+                onChange={this.handleChange}
+                selectedValues={this.state.selectedValues}
+                style={styles.setWidth}
+                dropdownStyle={styles.customDropdown}
+                labels={{
+                    noneSelected: "Solar system",
+                    someSelected: (numSelectedValues) =>
+                        `${numSelectedValues} planets`,
+                }}
+            >
+                <OptionItem label="Mercury" value="1" />
+                <OptionItem label="Venus" value="2" />
+                <OptionItem label="Earth" value="3" disabled />
+                <OptionItem label="Mars" value="4" />
+                <OptionItem label="Jupiter" value="5" />
+                <OptionItem label="Saturn" value="6" />
+                <OptionItem label="Neptune" value="7" />
+                <OptionItem label="Uranus" value="8" />
+            </MultiSelect>
+        );
+    }
+}
+
+export const customStyles = () => <MultiSelectWithCustomStyles />;
+
+customStyles.story = {
+    parameters: {
+        chromatic: {
+            // we don't need screenshots because this story only tests behavior.
+            disable: true,
+        },
+    },
+};
+
+const styles = StyleSheet.create({
+    setWidth: {
+        minWidth: 170,
+        width: "100%",
+    },
+    customDropdown: {
+        maxHeight: 200,
+    },
+});

--- a/packages/wonder-blocks-dropdown/components/multi-select.stories.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.stories.js
@@ -4,16 +4,28 @@ import {StyleSheet} from "aphrodite";
 
 import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 
+import type {Labels} from "@khanacademy/wonder-blocks-dropdown";
+
 export default {
     title: "MultiSelect",
 };
 
-class MultiSelectWithCustomStyles extends React.Component {
+// Custom MultiSelect labels
+const dropdownLabels: $Shape<Labels> = {
+    noneSelected: "Solar system",
+    someSelected: (numSelectedValues) => `${numSelectedValues} planets`,
+};
+
+type State = {|
+    selectedValues: Array<string>,
+|};
+
+class MultiSelectWithCustomStyles extends React.Component<{||}, State> {
     state = {
         selectedValues: [],
     };
 
-    handleChange = (update) => {
+    handleChange = (update: Array<string>) => {
         this.setState({
             selectedValues: update,
         });
@@ -26,11 +38,7 @@ class MultiSelectWithCustomStyles extends React.Component {
                 selectedValues={this.state.selectedValues}
                 style={styles.setWidth}
                 dropdownStyle={styles.customDropdown}
-                labels={{
-                    noneSelected: "Solar system",
-                    someSelected: (numSelectedValues) =>
-                        `${numSelectedValues} planets`,
-                }}
+                labels={dropdownLabels}
             >
                 <OptionItem label="Mercury" value="1" />
                 <OptionItem label="Venus" value="2" />


### PR DESCRIPTION
## Summary

Fixes an issue introduced in `DropdownVirtualizedCore`. We have removed the maximum container width, allowing the dropdown container to take the width from its parent container.

### Test plan

1. Open https://5e1bf4b385e3fb0020b7073c-eneopdgtcf.chromatic.com/?path=/story/multiselect--custom-styles
2. Verify that when the dropdown is opened, the options container takes the parent's width.

#### BEFORE
<img width="965" alt="dropdown-width-before" src="https://user-images.githubusercontent.com/843075/82372029-368f1d80-99e9-11ea-9e6f-754c00bd1900.png">

#### AFTER
<img width="948" alt="dropdown-width-after" src="https://user-images.githubusercontent.com/843075/82372019-31ca6980-99e9-11ea-8466-30a25326551b.png">
