### PR TITLE
WB-975: Propagate testId to CloseButton within PopoverContentCore

### DIFF
--- a/packages/wonder-blocks-popover/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-popover/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -660,6 +660,7 @@ exports[`wonder-blocks-popover example 6 1`] = `
     <button
       aria-label="Close Popover"
       className=""
+      data-test-id="popover-close-btn"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -1350,6 +1351,7 @@ exports[`wonder-blocks-popover example 9 1`] = `
     <button
       aria-label="Close Popover"
       className=""
+      data-test-id="popover-close-btn"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -1575,6 +1577,76 @@ exports[`wonder-blocks-popover example 10 1`] = `
       }
     }
   >
+    <button
+      aria-label="Close Popover"
+      className=""
+      data-test-id="example-popover-close-btn"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "boxSizing": "border-box",
+          "color": "#ffffff",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": -8,
+          "outline": "none",
+          "padding": 0,
+          "position": "absolute",
+          "right": 8,
+          "textDecoration": "none",
+          "top": 8,
+          "touchAction": "manipulation",
+          "width": 40,
+          "zIndex": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <svg
+        className=""
+        height={24}
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 24 24"
+        width={24}
+      >
+        <path
+          d="M12 10.586L7.706 6.293a1 1 0 1 0-1.413 1.413L10.586 12l-4.293 4.294a1 1 0 0 0 1.413 1.413L12 13.414l4.294 4.293a1 1 0 0 0 1.413-1.413L13.414 12l4.293-4.294a1 1 0 1 0-1.413-1.413L12 10.586z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
     <div
       className=""
       style={

--- a/packages/wonder-blocks-popover/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-popover/__tests__/generated-snapshot.test.js
@@ -439,7 +439,9 @@ describe("wonder-blocks-popover", () => {
                 <PopoverContentCore
                     color="darkBlue"
                     style={styles.customPopover}
+                    closeButtonVisible={true}
                     onClose={() => alert("close popover!")}
+                    testId="example-popover"
                 >
                     <View>
                         <HeadingSmall>Custom popover title</HeadingSmall>

--- a/packages/wonder-blocks-popover/components/close-button.js
+++ b/packages/wonder-blocks-popover/components/close-button.js
@@ -20,6 +20,11 @@ type Props = {|
      * Custom styles applied to the IconButton
      */
     style?: StyleType,
+
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string,
 |};
 
 /**
@@ -34,7 +39,7 @@ export default class CloseButton extends React.Component<Props> {
     };
 
     render() {
-        const {light, "aria-label": ariaLabel, style} = this.props;
+        const {light, "aria-label": ariaLabel, style, testId} = this.props;
         return (
             <PopoverContext.Consumer>
                 {({close}) => {
@@ -46,6 +51,7 @@ export default class CloseButton extends React.Component<Props> {
                             kind={light ? "primary" : "tertiary"}
                             light={light}
                             style={style}
+                            testId={testId}
                         />
                     );
                 }}

--- a/packages/wonder-blocks-popover/components/popover-content-core.js
+++ b/packages/wonder-blocks-popover/components/popover-content-core.js
@@ -85,6 +85,7 @@ export default class PopoverContentCore extends React.Component<Props> {
                         aria-label={closeButtonLabel}
                         light={closeButtonLight || color !== "white"}
                         style={styles.closeButton}
+                        testId={`${testId || "popover"}-close-btn`}
                     />
                 )}
                 {children}

--- a/packages/wonder-blocks-popover/components/popover-content-core.md
+++ b/packages/wonder-blocks-popover/components/popover-content-core.md
@@ -38,7 +38,9 @@ const styles = StyleSheet.create({
     <PopoverContentCore
         color="darkBlue"
         style={styles.customPopover}
+        closeButtonVisible={true}
         onClose={() => alert("close popover!")}
+        testId="example-popover"
     >
         <View>
             <HeadingSmall>Custom popover title</HeadingSmall>


### PR DESCRIPTION
## Summary

The close button within the `PopoverContentCore` component accepts a `testId` property but did not propagate this to the close button for the popover. This fixes that and makes writing e2e tests easier where the popover needs to be dismissed and cannot click the action item available.

In scenarios where the `testId` is not provided, we can simply set the testId of the closeButton to "popover-close-btn" as a default value.

Issue: https://khanacademy.atlassian.net/browse/WB-975

## Test Plan

- Add a testId to the `PopoverContentCore` component and ensure the `closeButtonVisible` prop is set to true.
- Inspect the close button and ensure that the `data-test-id` attribute of the close button is the provided id appended with "-close-btn".