### PR TITLE
Make the 'style' prop that addStyle adds optional

### DIFF
--- a/packages/wonder-blocks-core/util/add-style.js
+++ b/packages/wonder-blocks-core/util/add-style.js
@@ -12,7 +12,7 @@ export default function addStyle<T: React.AbstractComponent<any> | string>(
     defaultStyle?: StyleType,
 ): React.AbstractComponent<{
     ...React.ElementConfig<T>,
-    style: StyleType,
+    style?: StyleType,
     ...
 }> {
     function StyleComponent(props: {

--- a/packages/wonder-blocks-core/util/add-styles.flowtest.js
+++ b/packages/wonder-blocks-core/util/add-styles.flowtest.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import addStyle from "./add-style.js";
+
+const styles = StyleSheet.create({
+    list: {
+        padding: 8,
+    },
+    customList: {
+        border: "solid 1px blue",
+    },
+});
+
+const StyledList = addStyle("ul", styles.list);
+
+// eslint-disable-next-line no-unused-vars
+const list1 = <StyledList />;
+
+// eslint-disable-next-line no-unused-vars
+const list2 = <StyledList style={styles.customList} />;


### PR DESCRIPTION
## Summary:
If you're doing 'const StyledList = addStyle("ul", styles.list)' and there's
no custom style for an invidual 'StyledList' on the page then you shouldn't
be required to provide a 'style' prop to 'StyledList'.  This usage is more like
how the styled-components library functions.

Issue: none

## Test plan:
- yarn test