### PR TITLE
WEB-2990.2: Add beforeNav and safeWithNav props to Link

### DIFF
--- a/packages/wonder-blocks-breadcrumbs/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-breadcrumbs/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -52,7 +52,6 @@ exports[`wonder-blocks-breadcrumbs example 1 1`] = `
           }
         }
         tabIndex={0}
-        waiting={false}
       >
         Home
       </a>
@@ -111,7 +110,6 @@ exports[`wonder-blocks-breadcrumbs example 1 1`] = `
           }
         }
         tabIndex={0}
-        waiting={false}
       >
         About
       </a>

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -136,8 +136,8 @@ export type SharedProps = {|
     onClick?: (e: SyntheticEvent<>) => mixed,
 
     /**
-     * Run async code before navigating. If the promise returned rejects then
-     * navigation will not occur.
+     * Run async code before navigating to the URL passed to `href`. If the
+     * promise returned rejects then navigation will not occur.
      *
      * If both safeWithNav and beforeNav are provided, beforeNav will be run
      * first and safeWithNav will only be run if beforeNav does not reject.

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -80,8 +80,8 @@ type Props = {|
     onClick?: (e: SyntheticEvent<>) => mixed,
 
     /**
-     * Run async code before navigating.  If the promise returned rejects then
-     * navigation will not occur.
+     * Run async code before navigating to the URL passed to `href`. If the
+     * promise returned rejects then navigation will not occur.
      *
      * If both safeWithNav and beforeNav are provided, beforeNav will be run
      * first and safeWithNav will only be run if beforeNav does not reject.

--- a/packages/wonder-blocks-link/__tests__/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__tests__/__snapshots__/custom-snapshot.test.js.snap
@@ -26,7 +26,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:false focused 1`] = 
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -58,7 +57,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 1`] = 
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -90,7 +88,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 1`] = 
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -125,7 +122,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:true focused 1`] = `
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -160,7 +156,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 1`] = `
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -195,7 +190,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 1`] = `
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -227,7 +221,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:false focused 1`] = `
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -259,7 +252,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 1`] = `
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -291,7 +283,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 1`] = `
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -323,7 +314,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -355,7 +345,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -387,7 +376,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -422,7 +410,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -457,7 +444,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -492,7 +478,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -524,7 +509,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -556,7 +540,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -588,7 +571,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -620,7 +602,6 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false focused 1`] 
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -652,7 +633,6 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 1`] 
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -684,7 +664,6 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 1`] 
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -716,7 +695,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -748,7 +726,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>
@@ -780,7 +757,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
     }
   }
   tabIndex={0}
-  waiting={false}
 >
   Click me
 </a>

--- a/packages/wonder-blocks-link/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -47,7 +47,6 @@ exports[`wonder-blocks-link example 1 1`] = `
         }
       }
       tabIndex={0}
-      waiting={false}
     >
       Primary Link
     </a>
@@ -86,7 +85,6 @@ exports[`wonder-blocks-link example 1 1`] = `
           }
         }
         tabIndex={0}
-        waiting={false}
       >
         Secondary Link
       </a>
@@ -123,7 +121,6 @@ exports[`wonder-blocks-link example 1 1`] = `
         }
       }
       tabIndex={0}
-      waiting={false}
     >
       Visitable Primary Link
     </a>
@@ -166,7 +163,6 @@ exports[`wonder-blocks-link example 1 1`] = `
         }
       }
       tabIndex={0}
-      waiting={false}
     >
       Primary Link
     </a>
@@ -222,7 +218,6 @@ exports[`wonder-blocks-link example 2 1`] = `
       }
     }
     tabIndex={0}
-    waiting={false}
   >
     <h4
       className=""

--- a/packages/wonder-blocks-link/components/__tests__/link.flowtest.js
+++ b/packages/wonder-blocks-link/components/__tests__/link.flowtest.js
@@ -1,0 +1,37 @@
+// @flow
+/* eslint-disable flowtype/no-unused-expressions */
+import * as React from "react";
+
+import Link from "../link.js";
+
+// $ExpectError: href must be used with beforeNav
+<Link beforeNav={() => Promise.resolve()}>Hello, world!</Link>;
+
+// $ExpectError: href must be used with safeWithNav
+<Link safeWithNav={() => Promise.resolve()}>Hello, world!</Link>;
+
+// It's okay to use onClick with href
+<Link href="/foo" onClick={() => {}}>
+    Hello, world!
+</Link>;
+
+<Link href="/foo" beforeNav={() => Promise.resolve()}>
+    Hello, world!
+</Link>;
+
+<Link href="/foo" safeWithNav={() => Promise.resolve()}>
+    Hello, world!
+</Link>;
+
+// All three of these props can be used together
+<Link
+    href="/foo"
+    beforeNav={() => Promise.resolve()}
+    safeWithNav={() => Promise.resolve()}
+    onClick={() => {}}
+>
+    Hello, world!
+</Link>;
+
+// It's also fine to use href by itself
+<Link href="/foo">Hello, world!</Link>;

--- a/packages/wonder-blocks-link/components/__tests__/link.test.js
+++ b/packages/wonder-blocks-link/components/__tests__/link.test.js
@@ -240,7 +240,7 @@ describe("Link", () => {
         });
     });
 
-    describe("server-side navigation", () => {
+    describe("full page load navigation", () => {
         test("doesn't redirect if safeWithNav hasn't resolved yet when skipClientNav=true", () => {
             // Arrange
             jest.spyOn(window.location, "assign").mockImplementation(() => {});

--- a/packages/wonder-blocks-link/components/__tests__/link.test.js
+++ b/packages/wonder-blocks-link/components/__tests__/link.test.js
@@ -5,83 +5,310 @@ import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {mount, unmountAll} from "../../../../utils/testing/mount.js";
 import Link from "../link.js";
 
+const wait = (delay: number = 0) =>
+    new Promise((resolve, reject) => {
+        // eslint-disable-next-line no-restricted-syntax
+        return setTimeout(resolve, delay);
+    });
+
 describe("Link", () => {
     beforeEach(() => {
         unmountAll();
     });
 
-    test("client-side navigation", () => {
-        // Arrange
-        const wrapper = mount(
-            <MemoryRouter>
-                <div>
-                    <Link testId="link" href="/foo">
-                        Click me!
-                    </Link>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
-            </MemoryRouter>,
-        );
+    describe("client-side navigation", () => {
+        test("works for known URLs", () => {
+            // Arrange
+            const wrapper = mount(
+                <MemoryRouter>
+                    <div>
+                        <Link testId="link" href="/foo">
+                            Click me!
+                        </Link>
+                        <Switch>
+                            <Route path="/foo">
+                                <div id="foo">Hello, world!</div>
+                            </Route>
+                        </Switch>
+                    </div>
+                </MemoryRouter>,
+            );
 
-        // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-        buttonWrapper.simulate("click", {button: 0});
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {button: 0});
 
-        // Assert
-        expect(wrapper.find("#foo").exists()).toBe(true);
+            // Assert
+            expect(wrapper.find("#foo").exists()).toBe(true);
+        });
+
+        test("navigation with unknown URL fails", () => {
+            // Arrange
+            const wrapper = mount(
+                <MemoryRouter>
+                    <div>
+                        <Link testId="link" href="/unknown">
+                            Click me!
+                        </Link>
+                        <Switch>
+                            <Route path="/foo">
+                                <div id="foo">Hello, world!</div>
+                            </Route>
+                        </Switch>
+                    </div>
+                </MemoryRouter>,
+            );
+
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {button: 0});
+
+            // Assert
+            expect(wrapper.find("#foo").exists()).toBe(false);
+        });
+
+        test("waits until beforeNav resolves before navigating", async () => {
+            // Arrange
+            const wrapper = mount(
+                <MemoryRouter>
+                    <div>
+                        <Link
+                            testId="link"
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                        >
+                            Click me!
+                        </Link>
+                        <Switch>
+                            <Route path="/foo">
+                                <div id="foo">Hello, world!</div>
+                            </Route>
+                        </Switch>
+                    </div>
+                </MemoryRouter>,
+            );
+
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {
+                button: 0,
+            });
+            await wait(0);
+            wrapper.update();
+
+            // Assert
+            expect(wrapper.find("#foo")).toExist();
+        });
+
+        test("doesn't navigate before beforeNav resolves", async () => {
+            // Arrange
+            const wrapper = mount(
+                <MemoryRouter>
+                    <div>
+                        <Link
+                            testId="link"
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                        >
+                            Click me!
+                        </Link>
+                        <Switch>
+                            <Route path="/foo">
+                                <div id="foo">Hello, world!</div>
+                            </Route>
+                        </Switch>
+                    </div>
+                </MemoryRouter>,
+            );
+
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {
+                button: 0,
+            });
+
+            // Assert
+            expect(wrapper.find("#foo")).not.toExist();
+        });
+
+        test("does not navigate if beforeNav rejects", async () => {
+            // Arrange
+            const wrapper = mount(
+                <MemoryRouter>
+                    <div>
+                        <Link
+                            testId="link"
+                            href="/foo"
+                            beforeNav={() => Promise.reject()}
+                        >
+                            Click me!
+                        </Link>
+                        <Switch>
+                            <Route path="/foo">
+                                <div id="foo">Hello, world!</div>
+                            </Route>
+                        </Switch>
+                    </div>
+                </MemoryRouter>,
+            );
+
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {
+                button: 0,
+            });
+            await wait(0);
+            wrapper.update();
+
+            // Assert
+            expect(wrapper.find("#foo")).not.toExist();
+        });
+
+        test("runs safeWithNav if set", async () => {
+            // Arrange
+            const safeWithNavMock = jest.fn();
+            const wrapper = mount(
+                <MemoryRouter>
+                    <div>
+                        <Link
+                            testId="link"
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                            safeWithNav={safeWithNavMock}
+                        >
+                            Click me!
+                        </Link>
+                        <Switch>
+                            <Route path="/foo">
+                                <div id="foo">Hello, world!</div>
+                            </Route>
+                        </Switch>
+                    </div>
+                </MemoryRouter>,
+            );
+
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {
+                button: 0,
+            });
+            await wait(0);
+            wrapper.update();
+
+            // Assert
+            expect(safeWithNavMock).toHaveBeenCalled();
+        });
+
+        test("doesn't run safeWithNav until beforeNav resolves", () => {
+            // Arrange
+            const safeWithNavMock = jest.fn();
+            const wrapper = mount(
+                <MemoryRouter>
+                    <div>
+                        <Link
+                            testId="link"
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                            safeWithNav={safeWithNavMock}
+                        >
+                            Click me!
+                        </Link>
+                        <Switch>
+                            <Route path="/foo">
+                                <div id="foo">Hello, world!</div>
+                            </Route>
+                        </Switch>
+                    </div>
+                </MemoryRouter>,
+            );
+
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {
+                button: 0,
+            });
+
+            // Assert
+            expect(safeWithNavMock).not.toHaveBeenCalled();
+        });
     });
 
-    test("client-side navigation with unknown URL fails", () => {
-        // Arrange
-        const wrapper = mount(
-            <MemoryRouter>
-                <div>
-                    <Link testId="link" href="/unknown">
-                        Click me!
-                    </Link>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
-            </MemoryRouter>,
-        );
+    describe("server-side navigation", () => {
+        test("doesn't redirect if safeWithNav hasn't resolved yet when skipClientNav=true", () => {
+            // Arrange
+            jest.spyOn(window.location, "assign").mockImplementation(() => {});
+            const wrapper = mount(
+                <Link
+                    testId="link"
+                    href="/foo"
+                    safeWithNav={() => Promise.resolve()}
+                    skipClientNav={true}
+                >
+                    Click me!
+                </Link>,
+            );
 
-        // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-        buttonWrapper.simulate("click", {button: 0});
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {
+                button: 0,
+            });
 
-        // Assert
-        expect(wrapper.find("#foo").exists()).toBe(false);
-    });
+            // Assert
+            expect(window.location.assign).not.toHaveBeenCalled();
+        });
 
-    test("client-side navigation with `skipClientNav` set to `true` fails", () => {
-        // Arrange
-        const wrapper = mount(
-            <MemoryRouter>
-                <div>
-                    <Link testId="link" href="/foo" skipClientNav>
-                        Click me!
-                    </Link>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
-            </MemoryRouter>,
-        );
+        test("redirects after safeWithNav resolves when skipClientNav=true", async () => {
+            // Arrange
+            jest.spyOn(window.location, "assign").mockImplementation(() => {});
+            const wrapper = mount(
+                <Link
+                    testId="link"
+                    href="/foo"
+                    safeWithNav={() => Promise.resolve()}
+                    skipClientNav={true}
+                >
+                    Click me!
+                </Link>,
+            );
 
-        // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-        buttonWrapper.simulate("click", {button: 0});
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {
+                button: 0,
+            });
+            await wait(0);
+            wrapper.update();
 
-        // Assert
-        expect(wrapper.find("#foo").exists()).toBe(false);
+            // Assert
+            expect(window.location.assign).toHaveBeenCalledWith("/foo");
+        });
+
+        test("redirects after beforeNav and safeWithNav resolve when skipClientNav=true", async () => {
+            // Arrange
+            jest.spyOn(window.location, "assign").mockImplementation(() => {});
+            const wrapper = mount(
+                <Link
+                    testId="link"
+                    href="/foo"
+                    beforeNav={() => Promise.resolve()}
+                    safeWithNav={() => Promise.resolve()}
+                    skipClientNav={true}
+                >
+                    Click me!
+                </Link>,
+            );
+
+            // Act
+            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
+            buttonWrapper.simulate("click", {
+                button: 0,
+            });
+            await wait(0);
+            wrapper.update();
+
+            // Assert
+            expect(window.location.assign).toHaveBeenCalledWith("/foo");
+        });
     });
 });

--- a/packages/wonder-blocks-link/components/link-core.js
+++ b/packages/wonder-blocks-link/components/link-core.js
@@ -40,6 +40,7 @@ export default class LinkCore extends React.Component<Props> {
             pressed,
             style,
             testId,
+            waiting: _,
             ...handlers
         } = this.props;
         const {router} = this.context;

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -112,9 +112,9 @@ export type SharedProps = {|
 
     /**
      * Run async code in the background while client-side navigating. If the
-     * navigation is server-side, the callback must be settled before the
-     * navigation will occur. Errors are ignored so that navigation is
-     * guaranteed to succeed.
+     * browser does a full page load navigation, the callback promise must be
+     * settled before the navigation will occur. Errors are ignored so that
+     * navigation is guaranteed to succeed.
      */
     safeWithNav?: () => Promise<mixed>,
 |};

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -100,6 +100,23 @@ export type SharedProps = {|
      * stubbed out.
      */
     onClick?: (e: SyntheticEvent<>) => mixed,
+
+    /**
+     * Run async code before navigating. If the promise returned rejects then
+     * navigation will not occur.
+     *
+     * If both safeWithNav and beforeNav are provided, beforeNav will be run
+     * first and safeWithNav will only be run if beforeNav does not reject.
+     */
+    beforeNav?: () => Promise<mixed>,
+
+    /**
+     * Run async code in the background while client-side navigating. If the
+     * navigation is server-side, the callback must be settled before the
+     * navigation will occur. Errors are ignored so that navigation is
+     * guaranteed to succeed.
+     */
+    safeWithNav?: () => Promise<mixed>,
 |};
 
 /**
@@ -131,6 +148,8 @@ export default class Link extends React.Component<SharedProps> {
     render() {
         const {
             onClick,
+            beforeNav,
+            safeWithNav,
             href,
             skipClientNav,
             children,
@@ -146,9 +165,11 @@ export default class Link extends React.Component<SharedProps> {
         return (
             <ClickableBehavior
                 disabled={false}
-                onClick={onClick}
                 href={href}
                 role="link"
+                onClick={onClick}
+                beforeNav={beforeNav}
+                safeWithNav={safeWithNav}
             >
                 {(state, handlers) => {
                     return (

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -102,8 +102,8 @@ export type SharedProps = {|
     onClick?: (e: SyntheticEvent<>) => mixed,
 
     /**
-     * Run async code before navigating. If the promise returned rejects then
-     * navigation will not occur.
+     * Run async code before navigating to the URL passed to `href`. If the
+     * promise returned rejects then navigation will not occur.
      *
      * If both safeWithNav and beforeNav are provided, beforeNav will be run
      * first and safeWithNav will only be run if beforeNav does not reject.

--- a/packages/wonder-blocks-toolbar/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -2046,7 +2046,6 @@ exports[`wonder-blocks-toolbar example 7 1`] = `
           }
         }
         tabIndex={0}
-        waiting={false}
       >
         <span
           className=""


### PR DESCRIPTION
## Summary:
This builds on the initial work from #1047 to add the same props to Link.  I didn't both creating navigation examples like I did for Button since the docs for Button are quite a bit more extensive than they are for Link.  The props show up in the docs and that should be sufficient.

Issue: WEB-2990

## Test plan:
- yarn test