### PR TITLE
Fix issues from #1047

### DIFF
--- a/packages/wonder-blocks-button/components/__tests__/button.flowtest.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.flowtest.js
@@ -1,0 +1,34 @@
+// @flow
+/* eslint-disable flowtype/no-unused-expressions */
+import * as React from "react";
+
+import Button from "../button.js";
+
+// $ExpectError: href must be used with beforeNav
+<Button beforeNav={() => Promise.resolve()}>Hello, world!</Button>;
+
+// $ExpectError: href must be used with safeWithNav
+<Button safeWithNav={() => Promise.resolve()}>Hello, world!</Button>;
+
+// It's okay to use onClick with href
+<Button href="/foo" onClick={() => {}}>
+    Hello, world!
+</Button>;
+
+<Button href="/foo" beforeNav={() => Promise.resolve()}>
+    Hello, world!
+</Button>;
+
+<Button href="/foo" safeWithNav={() => Promise.resolve()}>
+    Hello, world!
+</Button>;
+
+// All three of these props can be used together
+<Button
+    href="/foo"
+    beforeNav={() => Promise.resolve()}
+    safeWithNav={() => Promise.resolve()}
+    onClick={() => {}}
+>
+    Hello, world!
+</Button>;

--- a/packages/wonder-blocks-button/components/__tests__/button.flowtest.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.flowtest.js
@@ -32,3 +32,6 @@ import Button from "../button.js";
 >
     Hello, world!
 </Button>;
+
+// It's also fine to use href by itself
+<Button href="/foo">Hello, world!</Button>;

--- a/packages/wonder-blocks-button/components/__tests__/button.test.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.test.js
@@ -260,7 +260,7 @@ describe("Button", () => {
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
-        expect(wrapper.find("CircularSpinner")).not.toExist();
+        expect(wrapper.find("CircularSpinner")).toExist();
     });
 
     test("beforeNav resolution and safeWithNav with skipClientNav=true waits for promise resolution", async () => {

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -134,24 +134,34 @@ export type SharedProps = {|
      * href is not
      */
     onClick?: (e: SyntheticEvent<>) => mixed,
-
-    /**
-     * Run async code before navigating. If the promise returned rejects then
-     * navigation will not occur.
-     *
-     * If both safeWithNav and beforeNav are provided, beforeNav will be run
-     * first and safeWithNav will only be run if beforeNav does not reject.
-     */
-    beforeNav?: () => Promise<mixed>,
-
-    /**
-     * Run async code in the background while client-side navigating. If the
-     * navigation is server-side, the callback must be settled before the
-     * navigation will occur. Errors are ignored so that navigation is
-     * guaranteed to succeed.
-     */
-    safeWithNav?: () => Promise<mixed>,
 |};
+
+type Props =
+    | {|
+          ...SharedProps,
+      |}
+    | {|
+          ...SharedProps,
+
+          href: string,
+
+          /**
+           * Run async code before navigating. If the promise returned rejects then
+           * navigation will not occur.
+           *
+           * If both safeWithNav and beforeNav are provided, beforeNav will be run
+           * first and safeWithNav will only be run if beforeNav does not reject.
+           */
+          beforeNav?: () => Promise<mixed>,
+
+          /**
+           * Run async code in the background while client-side navigating. If the
+           * navigation is server-side, the callback must be settled before the
+           * navigation will occur. Errors are ignored so that navigation is
+           * guaranteed to succeed.
+           */
+          safeWithNav?: () => Promise<mixed>,
+      |};
 
 /**
  * Reusable button component.
@@ -170,7 +180,7 @@ export type SharedProps = {|
  * </Button>
  * ```
  */
-export default class Button extends React.Component<SharedProps> {
+export default class Button extends React.Component<Props> {
     static contextTypes = {router: PropTypes.any};
 
     static defaultProps = {
@@ -190,8 +200,8 @@ export default class Button extends React.Component<SharedProps> {
             spinner,
             disabled,
             onClick,
-            beforeNav,
-            safeWithNav,
+            beforeNav = undefined,
+            safeWithNav = undefined,
             ...sharedButtonCoreProps
         } = this.props;
 

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -156,9 +156,9 @@ type Props =
 
           /**
            * Run async code in the background while client-side navigating. If the
-           * navigation is server-side, the callback must be settled before the
-           * navigation will occur. Errors are ignored so that navigation is
-           * guaranteed to succeed.
+           * browser does a full page load navigation, the callback promise must be
+           * settled before the navigation will occur. Errors are ignored so that
+           * navigation is guaranteed to succeed.
            */
           safeWithNav?: () => Promise<mixed>,
       |};

--- a/packages/wonder-blocks-core/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/__tests__/clickable-behavior.test.js
@@ -418,7 +418,7 @@ describe("ClickableBehavior", () => {
         expect(button.state("focused")).toEqual(false);
     });
 
-    describe("server-side navigation", () => {
+    describe("full page load navigation", () => {
         it("both navigates and calls onClick for an anchor link", () => {
             const onClick = jest.fn();
             // Use mount instead of a shallow render to trigger event defaults

--- a/packages/wonder-blocks-core/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/__tests__/clickable-behavior.test.js
@@ -498,7 +498,7 @@ describe("ClickableBehavior", () => {
             expect(window.location.assign).toHaveBeenCalledTimes(1);
         });
 
-        it("should not show waiting UI before safeWithNav resolves", async () => {
+        it("should show waiting UI before safeWithNav resolves", async () => {
             // Arrange
             const link = mount(
                 <ClickableBehavior
@@ -523,7 +523,7 @@ describe("ClickableBehavior", () => {
             link.simulate("click", {preventDefault: jest.fn()});
 
             // Assert
-            expect(link).not.toIncludeText("waiting");
+            expect(link).toIncludeText("waiting");
         });
 
         it("If onClick calls e.preventDefault() then we won't navigate", () => {

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -90,9 +90,9 @@ type Props = {|
 
     /**
      * Run async code in the background while client-side navigating. If the
-     * navigation is server-side, the callback must be settled before the
-     * navigation will occur. Errors are ignored so that navigation is
-     * guaranteed to succeed.
+     * browser does a full page load navigation, the callback promise must be
+     * settled before the navigation will occur. Errors are ignored so that
+     * navigation is guaranteed to succeed.
      */
     safeWithNav?: () => Promise<mixed>,
 
@@ -137,8 +137,8 @@ export type ClickableState = {|
      * When we're waiting for beforeNav or safeWithNav to complete an async
      * action, this will be true.
      *
-     * NOTE: We only wait for safeWithNav to complete when doing server-side
-     * navigation.
+     * NOTE: We only wait for safeWithNav to complete when doing a full page
+     * load navigation.
      */
     waiting: boolean,
 |};

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -335,7 +335,7 @@ export default class ClickableBehavior extends React.Component<
                     try {
                         if (!this.state.waiting) {
                             // We only show the spinner for safeWithNav when doing
-                            // a server-side navigation since since the spinner is
+                            // a full page load navigation since since the spinner is
                             // indicating that we're waiting for navigation to occur.
                             this.setState({waiting: true});
                         }
@@ -479,8 +479,8 @@ export default class ClickableBehavior extends React.Component<
                 this.setState({waiting: false});
             } else {
                 window.location.assign(href);
-                // We don't bother clearing the waiting state, the server-side
-                // navigation will do that for us by loading a new page.
+                // We don't bother clearing the waiting state, the full page
+                // load navigation will do that for us by loading a new page.
             }
         }
     };

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -329,15 +329,16 @@ export default class ClickableBehavior extends React.Component<
 
             if (safeWithNav) {
                 if (history && !skipClientNav) {
-                    if (!this.state.waiting) {
-                        // We only show the spinner for safeWithNav when doing
-                        // a server-side navigation since since the spinner is
-                        // indicating that we're waiting for navigation to occur.
-                        this.setState({waiting: true});
-                    }
+                    // client-side nav
                     safeWithNav();
                 } else {
                     try {
+                        if (!this.state.waiting) {
+                            // We only show the spinner for safeWithNav when doing
+                            // a server-side navigation since since the spinner is
+                            // indicating that we're waiting for navigation to occur.
+                            this.setState({waiting: true});
+                        }
                         await safeWithNav();
                     } catch (error) {
                         // We ignore the error here so that we always


### PR DESCRIPTION
## Summary:
I didn't put the 'waiting' logic for the server-side nav case in the right location.  This PR fixes that.

One of the things from the ADR was wanted to make sure people are using 'beforeNav' and 'safeWithNav' only when 'href' is set.  This PR also fixes that by changing the Button props to be a disjoint union.

Issue: WEB-2990

## Test plan:
- yarn jest