### PR TITLE
Don't set boolean attributes that don't exist on HTML elements

### DIFF
--- a/packages/wonder-blocks-core/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -134,7 +134,6 @@ exports[`wonder-blocks-core example 3 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <div
         aria-hidden="true"

--- a/packages/wonder-blocks-dropdown/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -89,7 +89,6 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <div
         className=""
@@ -292,7 +291,6 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <div
         className=""
@@ -474,7 +472,6 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <div
         className=""
@@ -656,7 +653,6 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       }
       tabIndex={-1}
       type="button"
-      waiting={false}
     >
       <div
         className=""
@@ -839,7 +835,6 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <div
         className=""
@@ -1021,7 +1016,6 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <div
         className=""

--- a/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu-opener-core.js
@@ -56,6 +56,7 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
             focused,
             hovered,
             pressed,
+            waiting: _,
             testId,
             opened,
             "aria-label": ariaLabel,

--- a/packages/wonder-blocks-form/__tests__/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/__tests__/__snapshots__/custom-snapshot.test.js.snap
@@ -27,7 +27,6 @@ exports[`CheckboxCore type:default state:default checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -58,7 +57,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -111,7 +109,6 @@ exports[`CheckboxCore type:default state:hovered checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -143,7 +140,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -196,7 +192,6 @@ exports[`CheckboxCore type:default state:pressed checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -229,7 +224,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -283,7 +277,6 @@ exports[`CheckboxCore type:disabled state:default checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -316,7 +309,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -370,7 +362,6 @@ exports[`CheckboxCore type:disabled state:hovered checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -403,7 +394,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -457,7 +447,6 @@ exports[`CheckboxCore type:disabled state:pressed checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -490,7 +479,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -543,7 +531,6 @@ exports[`CheckboxCore type:error state:default checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -574,7 +561,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -627,7 +613,6 @@ exports[`CheckboxCore type:error state:hovered checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -659,7 +644,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -712,7 +696,6 @@ exports[`CheckboxCore type:error state:pressed checked:false 1`] = `
     }
   }
   type="checkbox"
-  waiting={false}
 />
 `;
 
@@ -745,7 +728,6 @@ Array [
       }
     }
     type="checkbox"
-    waiting={false}
   />,
   <svg
     className=""
@@ -798,7 +780,6 @@ exports[`RadioCore type:default state:default checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -829,7 +810,6 @@ exports[`RadioCore type:default state:default checked:true 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -860,7 +840,6 @@ exports[`RadioCore type:default state:hovered checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -892,7 +871,6 @@ exports[`RadioCore type:default state:hovered checked:true 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -923,7 +901,6 @@ exports[`RadioCore type:default state:pressed checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -955,7 +932,6 @@ exports[`RadioCore type:default state:pressed checked:true 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -987,7 +963,6 @@ exports[`RadioCore type:disabled state:default checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -1020,7 +995,6 @@ Array [
       }
     }
     type="radio"
-    waiting={false}
   />,
   <span
     style={
@@ -1066,7 +1040,6 @@ exports[`RadioCore type:disabled state:hovered checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -1099,7 +1072,6 @@ Array [
       }
     }
     type="radio"
-    waiting={false}
   />,
   <span
     style={
@@ -1145,7 +1117,6 @@ exports[`RadioCore type:disabled state:pressed checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -1178,7 +1149,6 @@ Array [
       }
     }
     type="radio"
-    waiting={false}
   />,
   <span
     style={
@@ -1223,7 +1193,6 @@ exports[`RadioCore type:error state:default checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -1254,7 +1223,6 @@ exports[`RadioCore type:error state:default checked:true 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -1285,7 +1253,6 @@ exports[`RadioCore type:error state:hovered checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -1317,7 +1284,6 @@ exports[`RadioCore type:error state:hovered checked:true 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -1348,7 +1314,6 @@ exports[`RadioCore type:error state:pressed checked:false 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;
 
@@ -1380,6 +1345,5 @@ exports[`RadioCore type:error state:pressed checked:true 1`] = `
     }
   }
   type="radio"
-  waiting={false}
 />
 `;

--- a/packages/wonder-blocks-form/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -100,7 +100,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -209,7 +208,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <svg
         className=""
@@ -340,7 +338,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -449,7 +446,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <svg
         className=""
@@ -581,7 +577,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -692,7 +687,6 @@ exports[`wonder-blocks-form example 1 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <svg
         className=""
@@ -847,7 +841,6 @@ exports[`wonder-blocks-form example 2 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -1083,7 +1076,6 @@ exports[`wonder-blocks-form example 3 1`] = `
           }
         }
         type="checkbox"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -1216,7 +1208,6 @@ exports[`wonder-blocks-form example 4 1`] = `
           }
         }
         type="radio"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -1326,7 +1317,6 @@ exports[`wonder-blocks-form example 4 1`] = `
           }
         }
         type="radio"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -1436,7 +1426,6 @@ exports[`wonder-blocks-form example 4 1`] = `
           }
         }
         type="radio"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -1546,7 +1535,6 @@ exports[`wonder-blocks-form example 4 1`] = `
           }
         }
         type="radio"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -1657,7 +1645,6 @@ exports[`wonder-blocks-form example 4 1`] = `
           }
         }
         type="radio"
-        waiting={false}
       />
       <div
         aria-hidden="true"
@@ -1768,7 +1755,6 @@ exports[`wonder-blocks-form example 4 1`] = `
           }
         }
         type="radio"
-        waiting={false}
       />
       <span
         style={
@@ -2014,7 +2000,6 @@ exports[`wonder-blocks-form example 5 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -2149,7 +2134,6 @@ exports[`wonder-blocks-form example 5 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -2303,7 +2287,6 @@ exports[`wonder-blocks-form example 5 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -2438,7 +2421,6 @@ exports[`wonder-blocks-form example 5 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -2573,7 +2555,6 @@ exports[`wonder-blocks-form example 5 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -2707,7 +2688,6 @@ exports[`wonder-blocks-form example 5 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <svg
             className=""
@@ -2957,7 +2937,6 @@ exports[`wonder-blocks-form example 6 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -3093,7 +3072,6 @@ exports[`wonder-blocks-form example 6 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -3229,7 +3207,6 @@ exports[`wonder-blocks-form example 6 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -3365,7 +3342,6 @@ exports[`wonder-blocks-form example 6 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -3501,7 +3477,6 @@ exports[`wonder-blocks-form example 6 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -3637,7 +3612,6 @@ exports[`wonder-blocks-form example 6 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -3848,7 +3822,6 @@ exports[`wonder-blocks-form example 7 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -3989,7 +3962,6 @@ exports[`wonder-blocks-form example 7 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -4130,7 +4102,6 @@ exports[`wonder-blocks-form example 7 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -4271,7 +4242,6 @@ exports[`wonder-blocks-form example 7 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -4412,7 +4382,6 @@ exports[`wonder-blocks-form example 7 1`] = `
               }
             }
             type="checkbox"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -4670,7 +4639,6 @@ exports[`wonder-blocks-form example 8 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -4806,7 +4774,6 @@ exports[`wonder-blocks-form example 8 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -4961,7 +4928,6 @@ exports[`wonder-blocks-form example 8 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -5096,7 +5062,6 @@ exports[`wonder-blocks-form example 8 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -5231,7 +5196,6 @@ exports[`wonder-blocks-form example 8 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -5442,7 +5406,6 @@ exports[`wonder-blocks-form example 9 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -5583,7 +5546,6 @@ exports[`wonder-blocks-form example 9 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -5724,7 +5686,6 @@ exports[`wonder-blocks-form example 9 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"
@@ -5865,7 +5826,6 @@ exports[`wonder-blocks-form example 9 1`] = `
               }
             }
             type="radio"
-            waiting={false}
           />
           <div
             aria-hidden="true"

--- a/packages/wonder-blocks-form/components/checkbox-core.js
+++ b/packages/wonder-blocks-form/components/checkbox-core.js
@@ -48,6 +48,7 @@ export default class CheckboxCore extends React.Component<Props> {
             hovered,
             focused,
             pressed,
+            waiting: _,
             ...sharedProps
         } = this.props;
 

--- a/packages/wonder-blocks-form/components/radio-core.js
+++ b/packages/wonder-blocks-form/components/radio-core.js
@@ -39,6 +39,7 @@ const StyledInput = addStyle("input");
             hovered,
             focused,
             pressed,
+            waiting: _,
             ...sharedProps
         } = this.props;
         const stateStyles = _generateStyles(checked, error);

--- a/packages/wonder-blocks-icon-button/__tests__/__snapshots__/custom-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__tests__/__snapshots__/custom-snapshot.test.js.snap
@@ -46,7 +46,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false disa
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -120,7 +119,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false focu
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -194,7 +192,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false hove
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -268,7 +265,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -338,7 +334,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true disab
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -412,7 +407,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true focus
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -486,7 +480,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true hover
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -560,7 +553,6 @@ exports[`IconButtonCore kind:primary color:default size:default light:true press
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -630,7 +622,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -704,7 +695,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -778,7 +768,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -852,7 +841,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -922,7 +910,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -996,7 +983,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1070,7 +1056,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1144,7 +1129,6 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1214,7 +1198,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1288,7 +1271,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1362,7 +1344,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1436,7 +1417,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1506,7 +1486,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true d
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1580,7 +1559,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true f
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1654,7 +1632,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true h
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1728,7 +1705,6 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true p
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1798,7 +1774,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1872,7 +1847,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -1946,7 +1920,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2020,7 +1993,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2090,7 +2062,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2164,7 +2135,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2238,7 +2208,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2312,7 +2281,6 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2382,7 +2350,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false di
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2456,7 +2423,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false fo
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2530,7 +2496,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false ho
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2604,7 +2569,6 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false pr
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2674,7 +2638,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2748,7 +2711,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2822,7 +2784,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2896,7 +2857,6 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -2966,7 +2926,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3040,7 +2999,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3114,7 +3072,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3188,7 +3145,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3258,7 +3214,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3332,7 +3287,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3406,7 +3360,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3480,7 +3433,6 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3550,7 +3502,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false dis
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3624,7 +3575,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false foc
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3698,7 +3648,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false hov
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3772,7 +3721,6 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false pre
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3842,7 +3790,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3916,7 +3863,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -3990,7 +3936,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4064,7 +4009,6 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4134,7 +4078,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4208,7 +4151,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4282,7 +4224,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4356,7 +4297,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4426,7 +4366,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
   }
   tabIndex={-1}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4500,7 +4439,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4574,7 +4512,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""
@@ -4648,7 +4585,6 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
   }
   tabIndex={0}
   type="button"
-  waiting={false}
 >
   <svg
     className=""

--- a/packages/wonder-blocks-icon-button/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-icon-button/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -65,7 +65,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     }
     tabIndex={0}
     type="button"
-    waiting={false}
   >
     <svg
       className=""
@@ -158,7 +157,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     }
     tabIndex={0}
     type="button"
-    waiting={false}
   >
     <svg
       className=""
@@ -247,7 +245,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
       }
     }
     tabIndex={0}
-    waiting={false}
   >
     <svg
       className=""
@@ -340,7 +337,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     }
     tabIndex={-1}
     type="button"
-    waiting={false}
   >
     <svg
       className=""
@@ -433,7 +429,6 @@ exports[`wonder-blocks-icon-button example 1 1`] = `
     }
     tabIndex={-1}
     type="button"
-    waiting={false}
   >
     <svg
       className=""
@@ -524,7 +519,6 @@ exports[`wonder-blocks-icon-button example 2 1`] = `
     }
     tabIndex={0}
     type="button"
-    waiting={false}
   >
     <svg
       className=""

--- a/packages/wonder-blocks-icon-button/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button-core.js
@@ -52,6 +52,7 @@ export default class IconButtonCore extends React.Component<Props> {
             pressed,
             style,
             testId,
+            waiting: _,
             ...handlers
         } = this.props;
         const {router} = this.context;

--- a/packages/wonder-blocks-modal/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -277,7 +277,6 @@ exports[`wonder-blocks-modal example 3 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <div
         className=""
@@ -781,7 +780,6 @@ exports[`wonder-blocks-modal example 6 1`] = `
             }
             tabIndex={0}
             type="button"
-            waiting={false}
           >
             <svg
               className=""
@@ -1158,7 +1156,6 @@ exports[`wonder-blocks-modal example 7 1`] = `
             }
             tabIndex={0}
             type="button"
-            waiting={false}
           >
             <svg
               className=""
@@ -1686,7 +1683,6 @@ exports[`wonder-blocks-modal example 8 1`] = `
             }
             tabIndex={0}
             type="button"
-            waiting={false}
           >
             <svg
               className=""
@@ -2395,7 +2391,6 @@ exports[`wonder-blocks-modal example 9 1`] = `
             }
             tabIndex={0}
             type="button"
-            waiting={false}
           >
             <svg
               className=""
@@ -3174,7 +3169,6 @@ exports[`wonder-blocks-modal example 10 1`] = `
               }
               tabIndex={0}
               type="button"
-              waiting={false}
             >
               <svg
                 className=""

--- a/packages/wonder-blocks-popover/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-popover/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -706,7 +706,6 @@ exports[`wonder-blocks-popover example 6 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <svg
         className=""
@@ -1398,7 +1397,6 @@ exports[`wonder-blocks-popover example 9 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <svg
         className=""
@@ -1628,7 +1626,6 @@ exports[`wonder-blocks-popover example 10 1`] = `
       }
       tabIndex={0}
       type="button"
-      waiting={false}
     >
       <svg
         className=""

--- a/packages/wonder-blocks-toolbar/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-toolbar/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -396,7 +396,6 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
         }
         tabIndex={0}
         type="button"
-        waiting={false}
       >
         <svg
           className=""
@@ -488,7 +487,6 @@ exports[`wonder-blocks-toolbar example 2 1`] = `
         }
         tabIndex={0}
         type="button"
-        waiting={false}
       >
         <svg
           className=""
@@ -740,7 +738,6 @@ exports[`wonder-blocks-toolbar example 3 1`] = `
         }
         tabIndex={0}
         type="button"
-        waiting={false}
       >
         <svg
           className=""
@@ -991,7 +988,6 @@ exports[`wonder-blocks-toolbar example 4 1`] = `
         }
         tabIndex={0}
         type="button"
-        waiting={false}
       >
         <svg
           className=""
@@ -1233,7 +1229,6 @@ exports[`wonder-blocks-toolbar example 5 1`] = `
         }
         tabIndex={0}
         type="button"
-        waiting={false}
       >
         <svg
           className=""
@@ -1877,7 +1872,6 @@ exports[`wonder-blocks-toolbar example 7 1`] = `
         }
         tabIndex={0}
         type="button"
-        waiting={false}
       >
         <svg
           className=""

--- a/packages/wonder-blocks-tooltip/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -543,7 +543,6 @@ exports[`wonder-blocks-tooltip example 6 1`] = `
     }
     tabIndex={0}
     type="button"
-    waiting={false}
   >
     <svg
       className=""


### PR DESCRIPTION
## Summary:
React (dev-only build I believe) complains about setting boolean
attributes that don't exist on HTML elements.  This PR fixes the
issue.  While this should be an issue in prod, it will lead to
noisy console logs during dev so we should fix it.

Issue: none

## Test plan:
- yarn start
- load localhost:6060
- see that there are no React errors complaining about non-existent boolean attributes

Reviewers: #fe-infra