### PR TITLE
WEB-2990.?: Use promises instead of async/await

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,11 +1,9 @@
 /* eslint-disable import/no-commonjs */
-const path = require("path");
 const {createConfig, babel, postcss} = require("webpack-blocks");
 
 const babelConfig = require("./build-settings/babel.config.js");
 
 module.exports = {
-    require: [path.resolve(__dirname, "styleguide.setup.js")],
     webpackConfig: createConfig([babel(babelConfig), postcss()]),
     styleguideDir: "docs",
     assetsDir: "static",

--- a/styleguide.setup.js
+++ b/styleguide.setup.js
@@ -1,7 +1,0 @@
-/**
- * Styleguidist doesn't include regeneratorRuntime by default so in order for
- * code using async functions to work we need to tell styleguidist to import
- * the babel polyfill before any other code.
- */
-// eslint-disable-next-line import/no-unassigned-import
-import "@babel/polyfill";


### PR DESCRIPTION
## Summary:
Even though we're using async/await in some places in webapp, the code we generator
here doesn't see webapp's version of regeneratorRuntime.  This PR changes the use
of async/await in clickable-behavior.js to Promises instead.

This PR also removes the changes I made to the styleguidist config to drop the import
of @babel/polyfill which was providing regeneratorRuntime locally.

Issue: WEB-2990

## Test plan:
- yarn start
- load localhost:6060 and see that it loads fine without regeneratorRuntime errors
- yarn test

Reviewers: #fe-infra