### PR TITLE
Fix the waiting state

### DIFF
--- a/packages/wonder-blocks-button/components/__tests__/button.test.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.test.js
@@ -196,6 +196,9 @@ describe("Button", () => {
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
+        // We want the button to look exactly the same as if someone had passed
+        // `spinner={true}` as a prop.
+        expect(wrapper.find("ButtonCore")).toHaveProp({spinner: true});
         expect(wrapper.find("CircularSpinner")).toExist();
     });
 

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -52,7 +52,7 @@ export default class ButtonCore extends React.Component<Props> {
             spinner,
             icon,
             id,
-            waiting,
+            waiting: _,
             ...handlers
         } = this.props;
         const {router} = this.context;
@@ -127,7 +127,7 @@ export default class ButtonCore extends React.Component<Props> {
         const contents = (
             <React.Fragment>
                 {label}
-                {(spinner || waiting) && (
+                {spinner && (
                     <CircularSpinner
                         style={sharedStyles.spinner}
                         size={{medium: "small", small: "xsmall"}[size]}

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -218,7 +218,7 @@ export default class Button extends React.Component<Props> {
                     {...state}
                     {...handlers}
                     disabled={disabled}
-                    spinner={spinner}
+                    spinner={spinner || state.waiting}
                     skipClientNav={skipClientNav}
                     href={href}
                 >


### PR DESCRIPTION
## Summary:
We were showing the spinner but not hiding the text or changing
the background color to grey.  This PR fixes that by setting the
'spinner' prop on ButtonCore to 'true' if 'waiting' is 'true'.

Issue: none

## Test plan:
- yarn start
- load localhost:6060
- click on the "Aysnc action, client-side nav" button
- see that the button looks 'spinner={true}' is set

Reviewers: #fe-infra