### PR TITLE
Avoid ambiguous cases in Button's prop types

### DIFF
--- a/packages/wonder-blocks-button/components/__tests__/button.flowtest.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.flowtest.js
@@ -35,3 +35,11 @@ import Button from "../button.js";
 
 // It's also fine to use href by itself
 <Button href="/foo">Hello, world!</Button>;
+
+const getUrl = () => "/foo";
+
+// This test purposefully uses a function to get a string to pass with href.
+// This can trigger errors if there are ambiguous cases in the disjoint union
+// type being used to describe the props.  It's unclear why this error isn't
+// trigger by passing a string directly as the href.
+<Button href={getUrl()}>Hello, world!</Button>;

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -139,7 +139,7 @@ export type SharedProps = {|
 // We structure the props in this way to ensure that whenever we're using
 // beforeNav or safeWithNav that we're also using href.  We also need to specify
 // a number of different variations to avoid ambigious situations where flow
-// finds more than one valide object type in the disjoint union.
+// finds more than one valid object type in the disjoint union.
 type Props =
     | {|
           ...SharedProps,

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -136,6 +136,10 @@ export type SharedProps = {|
     onClick?: (e: SyntheticEvent<>) => mixed,
 |};
 
+// We structure the props in this way to ensure that whenever we're using
+// beforeNav or safeWithNav that we're also using href.  We also need to specify
+// a number of different variations to avoid ambigious situations where flow
+// finds more than one valide object type in the disjoint union.
 type Props =
     | {|
           ...SharedProps,
@@ -152,7 +156,12 @@ type Props =
            * If both safeWithNav and beforeNav are provided, beforeNav will be run
            * first and safeWithNav will only be run if beforeNav does not reject.
            */
-          beforeNav?: () => Promise<mixed>,
+          beforeNav: () => Promise<mixed>,
+      |}
+    | {|
+          ...SharedProps,
+
+          href: string,
 
           /**
            * Run async code in the background while client-side navigating. If the
@@ -160,7 +169,29 @@ type Props =
            * settled before the navigation will occur. Errors are ignored so that
            * navigation is guaranteed to succeed.
            */
-          safeWithNav?: () => Promise<mixed>,
+          safeWithNav: () => Promise<mixed>,
+      |}
+    | {|
+          ...SharedProps,
+
+          href: string,
+
+          /**
+           * Run async code before navigating. If the promise returned rejects then
+           * navigation will not occur.
+           *
+           * If both safeWithNav and beforeNav are provided, beforeNav will be run
+           * first and safeWithNav will only be run if beforeNav does not reject.
+           */
+          beforeNav: () => Promise<mixed>,
+
+          /**
+           * Run async code in the background while client-side navigating. If the
+           * browser does a full page load navigation, the callback promise must be
+           * settled before the navigation will occur. Errors are ignored so that
+           * navigation is guaranteed to succeed.
+           */
+          safeWithNav: () => Promise<mixed>,
       |};
 
 /**


### PR DESCRIPTION
## Summary:
After deploying to webapp, a bunch of flow errors were triggered because the flow types for Button's props are ambiguous when only 'href' is being passed.

The error only triggers when passing the result of a function call instead of just passing a string.  I've added a flow test that reproduces the issue.

This PR fixes it by splitting up the possible cases to be more explicit to avoid ambiguous cases.

Issue: none

## Test plan:
- yarn flow

Reviewers: #fe-infra