### PR TITLE
Add 'large' size variant to Button

### DIFF
--- a/packages/wonder-blocks-button/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -1218,7 +1218,7 @@ exports[`wonder-blocks-button example 5 1`] = `
       "borderWidth": 0,
       "boxSizing": "border-box",
       "display": "flex",
-      "flexDirection": "row",
+      "flexDirection": "column",
       "margin": 0,
       "minHeight": 0,
       "minWidth": 0,
@@ -1228,229 +1228,738 @@ exports[`wonder-blocks-button example 5 1`] = `
     }
   }
 >
-  <button
+  <div
     className=""
-    disabled={false}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
-    role="button"
     style={
       Object {
-        "::MozFocusInner": Object {
-          "border": 0,
-        },
-        ":focus": Object {
-          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-        },
-        "alignItems": "center",
-        "background": "#1865f2",
-        "border": "none",
-        "borderRadius": 4,
-        "boxSizing": "border-box",
-        "color": "#ffffff",
-        "cursor": "pointer",
-        "display": "inline-flex",
-        "height": 32,
-        "justifyContent": "center",
-        "margin": 0,
-        "marginRight": 10,
-        "outline": "none",
-        "paddingBottom": 0,
-        "paddingLeft": 16,
-        "paddingRight": 16,
-        "paddingTop": 0,
-        "position": "relative",
-        "textDecoration": "none",
-        "touchAction": "manipulation",
-        "userSelect": "none",
-      }
-    }
-    tabIndex={0}
-    type="button"
-  >
-    <span
-      className=""
-      style={
-        Object {
-          "MozOsxFontSmoothing": "grayscale",
-          "WebkitFontSmoothing": "antialiased",
-          "alignItems": "center",
-          "display": "inline-block",
-          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
-          "fontSize": 14,
-          "fontWeight": "bold",
-          "lineHeight": "18px",
-          "overflow": "hidden",
-          "pointerEvents": "none",
-          "textOverflow": "ellipsis",
-          "whiteSpace": "nowrap",
-        }
-      }
-    >
-      Label
-    </span>
-  </button>
-  <button
-    className=""
-    disabled={false}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    style={
-      Object {
-        "::MozFocusInner": Object {
-          "border": 0,
-        },
-        ":focus": Object {
-          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-        },
-        "alignItems": "center",
-        "background": "none",
-        "border": "none",
-        "borderColor": "rgba(33,36,44,0.50)",
-        "borderRadius": 4,
+        "alignItems": "stretch",
         "borderStyle": "solid",
-        "borderWidth": 1,
+        "borderWidth": 0,
         "boxSizing": "border-box",
-        "color": "#1865f2",
-        "cursor": "pointer",
-        "display": "inline-flex",
-        "height": 32,
-        "justifyContent": "center",
+        "display": "flex",
+        "flexDirection": "row",
         "margin": 0,
-        "marginRight": 10,
-        "outline": "none",
-        "paddingBottom": 0,
-        "paddingLeft": 16,
-        "paddingRight": 16,
-        "paddingTop": 0,
+        "marginBottom": 8,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
         "position": "relative",
-        "textDecoration": "none",
-        "touchAction": "manipulation",
-        "userSelect": "none",
+        "zIndex": 0,
       }
     }
-    tabIndex={0}
-    type="button"
   >
-    <span
+    <button
       className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
       style={
         Object {
-          "MozOsxFontSmoothing": "grayscale",
-          "WebkitFontSmoothing": "antialiased",
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
-          "display": "inline-block",
-          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
-          "fontSize": 14,
-          "fontWeight": "bold",
-          "lineHeight": "18px",
-          "overflow": "hidden",
-          "pointerEvents": "none",
-          "textOverflow": "ellipsis",
-          "whiteSpace": "nowrap",
+          "background": "#1865f2",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#ffffff",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 32,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
         }
       }
+      tabIndex={0}
+      type="button"
     >
-      Label
-    </span>
-  </button>
-  <button
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 14,
+            "fontWeight": "bold",
+            "lineHeight": "18px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderColor": "rgba(33,36,44,0.50)",
+          "borderRadius": 4,
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "boxSizing": "border-box",
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 32,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 14,
+            "fontWeight": "bold",
+            "lineHeight": "18px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 32,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 14,
+            "fontWeight": "bold",
+            "lineHeight": "18px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "position": "relative",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+  </div>
+  <div
     className=""
-    disabled={false}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
-    role="button"
     style={
       Object {
-        "::MozFocusInner": Object {
-          "border": 0,
-        },
-        ":focus": Object {
-          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-        },
-        "alignItems": "center",
-        "background": "none",
-        "border": "none",
-        "borderRadius": 4,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "boxSizing": "border-box",
-        "color": "#1865f2",
-        "cursor": "pointer",
-        "display": "inline-flex",
-        "height": 32,
-        "justifyContent": "center",
+        "display": "flex",
+        "flexDirection": "row",
         "margin": 0,
-        "marginRight": 10,
-        "outline": "none",
-        "paddingBottom": 0,
-        "paddingLeft": 0,
-        "paddingRight": 0,
-        "paddingTop": 0,
+        "marginBottom": 8,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
         "position": "relative",
-        "textDecoration": "none",
-        "touchAction": "manipulation",
-        "userSelect": "none",
+        "zIndex": 0,
       }
     }
-    tabIndex={0}
-    type="button"
   >
-    <span
+    <button
       className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
       style={
         Object {
-          "MozOsxFontSmoothing": "grayscale",
-          "WebkitFontSmoothing": "antialiased",
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
           "alignItems": "center",
-          "display": "inline-block",
-          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
-          "fontSize": 14,
-          "fontWeight": "bold",
-          "lineHeight": "18px",
-          "overflow": "hidden",
-          "pointerEvents": "none",
+          "background": "#1865f2",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#ffffff",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 0,
           "position": "relative",
-          "textOverflow": "ellipsis",
-          "whiteSpace": "nowrap",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
         }
       }
+      tabIndex={0}
+      type="button"
     >
-      Label
-    </span>
-  </button>
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": "bold",
+            "lineHeight": "20px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderColor": "rgba(33,36,44,0.50)",
+          "borderRadius": 4,
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "boxSizing": "border-box",
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": "bold",
+            "lineHeight": "20px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": "bold",
+            "lineHeight": "20px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "position": "relative",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+  </div>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "row",
+        "margin": 0,
+        "marginBottom": 8,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "#1865f2",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#ffffff",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 60,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 32,
+          "paddingRight": 32,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 18,
+            "fontWeight": "bold",
+            "lineHeight": "20px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderColor": "rgba(33,36,44,0.50)",
+          "borderRadius": 4,
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "boxSizing": "border-box",
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 60,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 32,
+          "paddingRight": 32,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 18,
+            "fontWeight": "bold",
+            "lineHeight": "20px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "none",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 60,
+          "justifyContent": "center",
+          "margin": 0,
+          "marginRight": 10,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 18,
+            "fontWeight": "bold",
+            "lineHeight": "20px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "position": "relative",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Label
+      </span>
+    </button>
+  </div>
 </div>
 `;
 
@@ -1474,6 +1983,134 @@ exports[`wonder-blocks-button example 6 1`] = `
     }
   }
 >
+  <button
+    aria-label="loading"
+    className=""
+    disabled={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    style={
+      Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "rgba(33,36,44,0.32)",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "rgba(255,255,255,0.64)",
+        "cursor": "default",
+        "display": "inline-flex",
+        "height": 60,
+        "justifyContent": "center",
+        "margin": 0,
+        "marginRight": 10,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 32,
+        "paddingRight": 32,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={-1}
+    type="button"
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "inline-block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 18,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "visibility": "hidden",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      Click me!
+    </span>
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "absolute",
+          "zIndex": 0,
+        }
+      }
+    >
+      <svg
+        height={48}
+        viewBox="0 0 48 48"
+        width={48}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          className=""
+          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+          fillRule="nonzero"
+          style={
+            Object {
+              "animationDuration": "1.1s",
+              "animationIterationCount": "infinite",
+              "animationName": Object {
+                "0%": Object {
+                  "transform": "rotate(0deg)",
+                },
+                "100%": Object {
+                  "transform": "rotate(360deg)",
+                },
+                "50%": Object {
+                  "transform": "rotate(180deg)",
+                },
+              },
+              "animationTimingFunction": "linear",
+              "fill": "#ffffff",
+              "transformOrigin": "50% 50%",
+            }
+          }
+        />
+      </svg>
+    </div>
+  </button>
   <button
     aria-label="loading"
     className=""
@@ -2457,7 +3094,7 @@ exports[`wonder-blocks-button example 11 1`] = `
           "marginRight": 10,
           "outline": "none",
           "paddingBottom": 0,
-          "paddingLeft": 12,
+          "paddingLeft": 16,
           "paddingRight": 16,
           "paddingTop": 0,
           "position": "relative",
@@ -2761,7 +3398,7 @@ exports[`wonder-blocks-button example 11 1`] = `
           "marginRight": 10,
           "outline": "none",
           "paddingBottom": 0,
-          "paddingLeft": 12,
+          "paddingLeft": 16,
           "paddingRight": 16,
           "paddingTop": 0,
           "position": "relative",

--- a/packages/wonder-blocks-button/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/__tests__/generated-snapshot.test.js
@@ -205,36 +205,89 @@ describe("wonder-blocks-button", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
+                marginBottom: 8,
             },
             button: {
                 marginRight: 10,
             },
         });
         const example = (
-            <View style={styles.row}>
-                <Button
-                    style={styles.button}
-                    onClick={(e) => window.alert("Hello, world!")}
-                    size="small"
-                >
-                    Label
-                </Button>
-                <Button
-                    style={styles.button}
-                    onClick={(e) => window.alert("Hello, world!")}
-                    kind="secondary"
-                    size="small"
-                >
-                    Label
-                </Button>
-                <Button
-                    style={styles.button}
-                    onClick={(e) => window.alert("Hello, world!")}
-                    kind="tertiary"
-                    size="small"
-                >
-                    Label
-                </Button>
+            <View>
+                <View style={styles.row}>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        size="small"
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        kind="secondary"
+                        size="small"
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        kind="tertiary"
+                        size="small"
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={styles.row}>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        size="medium"
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        kind="secondary"
+                        size="medium"
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        kind="tertiary"
+                        size="medium"
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={styles.row}>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        size="large"
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        kind="secondary"
+                        size="large"
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        style={styles.button}
+                        onClick={(e) => window.alert("Hello, world!")}
+                        kind="tertiary"
+                        size="large"
+                    >
+                        Label
+                    </Button>
+                </View>
             </View>
         );
         const tree = renderer.create(example).toJSON();
@@ -253,6 +306,14 @@ describe("wonder-blocks-button", () => {
         });
         const example = (
             <View style={styles.row}>
+                <Button
+                    spinner={true}
+                    aria-label="loading"
+                    size="large"
+                    style={styles.button}
+                >
+                    Click me!
+                </Button>
                 <Button
                     spinner={true}
                     aria-label="loading"

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -68,6 +68,7 @@ export default class ButtonCore extends React.Component<Props> {
             kind,
             light,
             iconWidth,
+            size,
         );
 
         const disabled = spinner || disabledProp;
@@ -85,6 +86,7 @@ export default class ButtonCore extends React.Component<Props> {
                     ? buttonStyles.active
                     : (hovered || focused) && buttonStyles.focus),
             size === "small" && sharedStyles.small,
+            size === "large" && sharedStyles.large,
         ];
 
         const commonProps = {
@@ -101,6 +103,7 @@ export default class ButtonCore extends React.Component<Props> {
             <Label
                 style={[
                     sharedStyles.text,
+                    size === "large" && sharedStyles.largeText,
                     icon && sharedStyles.textWithIcon,
                     spinner && sharedStyles.hiddenText,
                     kind === "tertiary" && sharedStyles.textWithFocus,
@@ -130,7 +133,11 @@ export default class ButtonCore extends React.Component<Props> {
                 {spinner && (
                     <CircularSpinner
                         style={sharedStyles.spinner}
-                        size={{medium: "small", small: "xsmall"}[size]}
+                        size={
+                            {medium: "small", small: "xsmall", large: "medium"}[
+                                size
+                            ]
+                        }
                         light={kind === "primary"}
                     />
                 )}
@@ -197,6 +204,9 @@ const sharedStyles = StyleSheet.create({
     small: {
         height: 32,
     },
+    large: {
+        height: 60,
+    },
     text: {
         alignItems: "center",
         fontWeight: "bold",
@@ -205,6 +215,10 @@ const sharedStyles = StyleSheet.create({
         textOverflow: "ellipsis",
         display: "inline-block", // allows the button text to truncate
         pointerEvents: "none", // fix Safari bug where the browser was eating mouse events
+    },
+    largeText: {
+        fontSize: 18,
+        lineHeight: "20px",
     },
     textWithIcon: {
         display: "flex", // allows the text and icon to sit nicely together
@@ -225,8 +239,9 @@ const sharedStyles = StyleSheet.create({
 
 const styles = {};
 
-const _generateStyles = (color, kind, light, iconWidth) => {
-    const buttonType = color + kind + light.toString() + iconWidth.toString();
+const _generateStyles = (color, kind, light, iconWidth, size) => {
+    const buttonType =
+        color + kind + light.toString() + iconWidth.toString() + size;
     if (styles[buttonType]) {
         return styles[buttonType];
     }
@@ -234,6 +249,7 @@ const _generateStyles = (color, kind, light, iconWidth) => {
     const {white, white50, white64, offBlack32, offBlack50, darkBlue} = Color;
     const fadedColor = mix(fade(color, 0.32), white);
     const activeColor = mix(offBlack32, color);
+    const padding = size === "large" ? 32 : 16;
 
     let newStyles = {};
     if (kind === "primary") {
@@ -241,6 +257,8 @@ const _generateStyles = (color, kind, light, iconWidth) => {
             default: {
                 background: light ? white : color,
                 color: light ? color : white,
+                paddingLeft: padding,
+                paddingRight: padding,
             },
             focus: {
                 // This assumes a background of white for the regular button and
@@ -272,6 +290,8 @@ const _generateStyles = (color, kind, light, iconWidth) => {
                 borderColor: light ? white50 : offBlack50,
                 borderStyle: "solid",
                 borderWidth: 1,
+                paddingLeft: iconWidth ? padding - 4 : padding,
+                paddingRight: padding,
             },
             focus: {
                 background: light ? "transparent" : white,
@@ -279,8 +299,8 @@ const _generateStyles = (color, kind, light, iconWidth) => {
                 borderWidth: 2,
                 // The left padding for the button with icon should have 4px
                 // less padding
-                paddingLeft: iconWidth ? 11 : 15,
-                paddingRight: 15,
+                paddingLeft: iconWidth ? padding - 5 : padding - 1,
+                paddingRight: padding - 1,
             },
             active: {
                 background: light ? activeColor : fadedColor,
@@ -289,8 +309,8 @@ const _generateStyles = (color, kind, light, iconWidth) => {
                 borderWidth: 2,
                 // The left padding for the button with icon should have 4px
                 // less padding
-                paddingLeft: iconWidth ? 11 : 15,
-                paddingRight: 15,
+                paddingLeft: iconWidth ? padding - 5 : padding - 1,
+                paddingRight: padding - 1,
             },
             disabled: {
                 color: light ? white50 : offBlack32,

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -61,7 +61,7 @@ export type SharedProps = {|
     /**
      * The size of the button. "medium" = height: 40; "small" = height: 32
      */
-    size: "medium" | "small",
+    size: "medium" | "small" | "large",
 
     /**
      * Whether the button is disabled.

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -214,7 +214,7 @@ const styles = StyleSheet.create({
 
 #### Example: size
 
-Buttons have a `size` that's either `"medium"` (default) or `"small"`.
+Buttons have a `size` that's either `"medium"` (default), `"small"`, or `"large"`.
 ```js
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -223,36 +223,89 @@ import {StyleSheet} from "aphrodite";
 const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
+        marginBottom: 8,
     },
     button: {
         marginRight: 10,
     }
 });
 
-<View style={styles.row}>
-    <Button
-        style={styles.button}
-        onClick={(e) => window.alert("Hello, world!")}
-        size="small"
-    >
-        Label
-    </Button>
-    <Button
-        style={styles.button}
-        onClick={(e) => window.alert("Hello, world!")}
-        kind="secondary"
-        size="small"
-    >
-        Label
-    </Button>
-    <Button
-        style={styles.button}
-        onClick={(e) => window.alert("Hello, world!")}
-        kind="tertiary"
-        size="small"
-    >
-        Label
-    </Button>
+<View>
+    <View style={styles.row}>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            size="small"
+        >
+            Label
+        </Button>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            kind="secondary"
+            size="small"
+        >
+            Label
+        </Button>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            kind="tertiary"
+            size="small"
+        >
+            Label
+        </Button>
+    </View>
+    <View style={styles.row}>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            size="medium"
+        >
+            Label
+        </Button>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            kind="secondary"
+            size="medium"
+        >
+            Label
+        </Button>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            kind="tertiary"
+            size="medium"
+        >
+            Label
+        </Button>
+    </View>
+    <View style={styles.row}>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            size="large"
+        >
+            Label
+        </Button>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            kind="secondary"
+            size="large"
+        >
+            Label
+        </Button>
+        <Button
+            style={styles.button}
+            onClick={(e) => window.alert("Hello, world!")}
+            kind="tertiary"
+            size="large"
+        >
+            Label
+        </Button>
+    </View>
 </View>
 ```
 
@@ -278,6 +331,9 @@ const styles = StyleSheet.create({
 });
 
 <View style={styles.row}>
+    <Button spinner={true} aria-label="loading" size="large" style={styles.button}>
+        Click me!
+    </Button>
     <Button spinner={true} aria-label="loading" style={styles.button} href="/foo">
         Click me!
     </Button>

--- a/packages/wonder-blocks-button/components/button.stories.js
+++ b/packages/wonder-blocks-button/components/button.stories.js
@@ -34,7 +34,7 @@ export const buttonsWithKnobs = () => {
     );
     const size = radios(
         "size",
-        {"medium (default)": "medium", small: "small"},
+        {large: "large", "medium (default)": "medium", small: "small"},
         "medium",
     );
     const light = boolean("light", false);
@@ -200,6 +200,22 @@ export const smallButtons = () => (
     </View>
 );
 
+export const largeButtons = () => (
+    <View style={{flexDirection: "row"}}>
+        <Button onClick={() => {}} size="large">
+            Hello, world!
+        </Button>
+        <Strut size={16} />
+        <Button onClick={() => {}} size="large" kind="secondary">
+            Hello, world!
+        </Button>
+        <Strut size={16} />
+        <Button onClick={() => {}} size="large" kind="tertiary">
+            Hello, world!
+        </Button>
+    </View>
+);
+
 export const longLabelsAreEllipsized = () => (
     <Button onClick={() => {}} style={{maxWidth: 200}}>
         label too long for the parent container
@@ -207,7 +223,27 @@ export const longLabelsAreEllipsized = () => (
 );
 
 export const buttonWithSpinner = () => (
-    <Button onClick={() => {}} spinner={true} aria-label={"waiting"}>
-        Hello, world
-    </Button>
+    <View style={{flexDirection: "row"}}>
+        <Button
+            onClick={() => {}}
+            spinner={true}
+            size="large"
+            aria-label={"waiting"}
+        >
+            Hello, world
+        </Button>
+        <Strut size={16} />
+        <Button onClick={() => {}} spinner={true} aria-label={"waiting"}>
+            Hello, world
+        </Button>
+        <Strut size={16} />
+        <Button
+            onClick={() => {}}
+            spinner={true}
+            size="small"
+            aria-label={"waiting"}
+        >
+            Hello, world
+        </Button>
+    </View>
 );


### PR DESCRIPTION
The reason for adding this variant is that it's currently impossible to create type-safe wrappers around button with the current version of flow that we're using in webapp.  Until we can update flow to a version that fixes this issue we'll have to make do with a "large" size variant in wonder-blocks itself.

Test Plan:
- look at the buttons on the netlify preview page see that they look decent
- hover over all button sizes with and without icons to see that the width doesn't change
