### PR TITLE
Add missing props to a few components

### DIFF
--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -85,7 +85,27 @@ export type SharedProps = {|
     href?: string,
 
     /**
-     * A target destination window for a link to open in.
+     * Specifies the type of relationship between the current document and the
+     * linked document. Should only be used when `href` is specified.
+     */
+    rel?:
+        | "alternate"
+        | "author"
+        | "bookmark"
+        | "external"
+        | "help"
+        | "license"
+        | "next"
+        | "nofollow"
+        | "noreferrer"
+        | "noopener"
+        | "prev"
+        | "search"
+        | "tag",
+
+    /**
+     * A target destination window for a link to open in. Should only be used
+     * when `href` is specified.
      */
     target?: string,
 

--- a/packages/wonder-blocks-clickable/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-clickable/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -126,6 +126,7 @@ exports[`wonder-blocks-clickable example 2 1`] = `
   <a
     aria-label=""
     className=""
+    disabled={false}
     href="/foo"
     onBlur={[Function]}
     onClick={[Function]}
@@ -170,6 +171,7 @@ exports[`wonder-blocks-clickable example 2 1`] = `
   <a
     aria-label=""
     className=""
+    disabled={false}
     href="/foo"
     onBlur={[Function]}
     onClick={[Function]}
@@ -237,6 +239,7 @@ exports[`wonder-blocks-clickable example 3 1`] = `
   <a
     aria-label=""
     className=""
+    disabled={false}
     href="https://www.khanacademy.org/about/tos"
     onBlur={[Function]}
     onClick={[Function]}

--- a/packages/wonder-blocks-clickable/components/clickable.js
+++ b/packages/wonder-blocks-clickable/components/clickable.js
@@ -4,6 +4,7 @@ import {StyleSheet} from "aphrodite";
 import PropTypes from "prop-types";
 import {Link} from "react-router-dom";
 import type {
+    AriaProps,
     StyleType,
     ClickableRole,
     ClickableState,
@@ -11,6 +12,13 @@ import type {
 import {addStyle, getClickableBehavior} from "@khanacademy/wonder-blocks-core";
 
 type CommonProps = {|
+    /**
+     * aria-label should be used when `spinner={true}` to let people using screen
+     * readers that the action taken by clicking the button will take some
+     * time to complete.
+     */
+    ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,
+
     /**
      * The child of Clickable must be a function which returns the component
      * which should be made Clickable.  The function is passed an object with
@@ -40,6 +48,35 @@ type CommonProps = {|
     disabled: boolean,
 
     /**
+     * An optional id attribute.
+     */
+    id?: string,
+
+    /**
+     * A target destination window for a link to open in.
+     */
+    target?: string,
+
+    /**
+     * Specifies the type of relationship between the current document and the
+     * linked document. Should only be used when `href` is specified.
+     */
+    rel?:
+        | "alternate"
+        | "author"
+        | "bookmark"
+        | "external"
+        | "help"
+        | "license"
+        | "next"
+        | "nofollow"
+        | "noreferrer"
+        | "noopener"
+        | "prev"
+        | "search"
+        | "tag",
+
+    /**
      * The role of the component, can be a role of type ClickableRole
      */
     role?: ClickableRole,
@@ -48,11 +85,6 @@ type CommonProps = {|
      * Avoids client-side routing in the presence of the href prop
      */
     skipClientNav?: boolean,
-
-    /**
-     * Use to label the component
-     */
-    "aria-label": string,
 
     /**
      * Test ID used for e2e testing.
@@ -201,6 +233,9 @@ export default class Clickable extends React.Component<Props> {
             skipClientNav,
             beforeNav = undefined,
             safeWithNav = undefined,
+            style,
+            testId,
+            ...restProps
         } = this.props;
         const ClickableBehavior = getClickableBehavior(
             href,
@@ -217,10 +252,9 @@ export default class Clickable extends React.Component<Props> {
             >
                 {(state, handlers) =>
                     this.getCorrectTag(state, {
-                        // eslint-disable-next-line react/prop-types
-                        "aria-label": this.props["aria-label"],
-                        "data-test-id": this.props.testId,
-                        style: [styles.reset, this.props.style],
+                        ...restProps,
+                        "data-test-id": testId,
+                        style: [styles.reset, style],
                         ...handlers,
                     })
                 }

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -53,6 +53,25 @@ export type SharedProps = {|
     target?: string,
 
     /**
+     * Specifies the type of relationship between the current document and the
+     * linked document. Should only be used when `href` is specified.
+     */
+    rel?:
+        | "alternate"
+        | "author"
+        | "bookmark"
+        | "external"
+        | "help"
+        | "license"
+        | "next"
+        | "nofollow"
+        | "noreferrer"
+        | "noopener"
+        | "prev"
+        | "search"
+        | "tag",
+
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string,


### PR DESCRIPTION
## Summary:
In some places we pass "rel" to links in webapp.  I've added this optional prop
to Button, Link, and Clickable as those are most likely to need that prop.  I've
also added "target", and all of our ARIA props to Clickable.

Issue: none

## Test plan:
- yarn test

Reivewers: #fe-infra