### PR TITLE
Implement 'caret' prop for Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,10 +117,6 @@
     }
   },
   "lint-staged": {
-    "*.md": [
-      "yarn gen-snapshot-tests",
-      "git add packages/*/__tests__/generated-snapshot.test.js"
-    ],
     "*.js": [
       "eslint --config .eslintrc.js",
       "yarn jest --findRelatedTests",

--- a/packages/wonder-blocks-link/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-link/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -240,3 +240,152 @@ exports[`wonder-blocks-link example 2 1`] = `
   </a>
 </div>
 `;
+
+exports[`wonder-blocks-link example 3 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <h4
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 20,
+        "fontWeight": 700,
+        "lineHeight": "24px",
+        "marginBottom": 0,
+        "marginTop": 0,
+      }
+    }
+  >
+    Heading.
+    <a
+      className=""
+      href="#nonexistent-link"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "outline": "none",
+          "textDecoration": "none",
+        }
+      }
+      tabIndex={0}
+    >
+      Cta link!
+      <svg
+        className=""
+        height="1em"
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="1 0 14 16"
+      >
+        <path
+          d="M8.586 8L5.293 4.707a1 1 0 0 1 1.414-1.414l4 4a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414-1.414L8.586 8z"
+          fill="currentColor"
+        />
+      </svg>
+    </a>
+  </h4>
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "22px",
+      }
+    }
+  >
+    Regular copy.
+    <a
+      className=""
+      href="#nonexistent-link"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "color": "#1865f2",
+          "cursor": "pointer",
+          "outline": "none",
+          "textDecoration": "none",
+        }
+      }
+      tabIndex={0}
+    >
+      Cta link!
+      <svg
+        className=""
+        height="1em"
+        style={
+          Object {
+            "display": "inline-block",
+            "flexGrow": 0,
+            "flexShrink": 0,
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="1 0 14 16"
+      >
+        <path
+          d="M8.586 8L5.293 4.707a1 1 0 0 1 1.414-1.414l4 4a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414-1.414L8.586 8z"
+          fill="currentColor"
+        />
+      </svg>
+    </a>
+  </span>
+</div>
+`;

--- a/packages/wonder-blocks-link/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-link/__tests__/generated-snapshot.test.js
@@ -10,7 +10,7 @@ import renderer from "react-test-renderer";
 jest.mock("react-dom");
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import {HeadingSmall, Body} from "@khanacademy/wonder-blocks-typography";
 import Link from "@khanacademy/wonder-blocks-link";
 
 describe("wonder-blocks-link", () => {
@@ -65,6 +65,27 @@ describe("wonder-blocks-link", () => {
                 <Link href="#nonexistent-link" id="typography-link">
                     <HeadingSmall>Heading inside a Link element</HeadingSmall>
                 </Link>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 3", () => {
+        const example = (
+            <View>
+                <HeadingSmall>
+                    Heading.
+                    <Link href="#nonexistent-link" caret={true}>
+                        Cta link!
+                    </Link>
+                </HeadingSmall>
+                <Body>
+                    Regular copy.
+                    <Link href="#nonexistent-link" caret={true}>
+                        Cta link!
+                    </Link>
+                </Body>
             </View>
         );
         const tree = renderer.create(example).toJSON();

--- a/packages/wonder-blocks-link/components/link-core.js
+++ b/packages/wonder-blocks-link/components/link-core.js
@@ -10,6 +10,8 @@ import type {
     ClickableHandlers,
     ClickableState,
 } from "@khanacademy/wonder-blocks-core";
+import {icons} from "@khanacademy/wonder-blocks-icon";
+
 import type {StyleDeclaration} from "aphrodite";
 import type {SharedProps} from "./link.js";
 
@@ -22,13 +24,14 @@ type Props = {|
 
 const StyledAnchor = addStyle<"a">("a");
 const StyledLink = addStyle<typeof Link>(Link);
+const StyledSvg = addStyle<"svg">("svg");
 
 export default class LinkCore extends React.Component<Props> {
     static contextTypes = {router: PropTypes.any};
 
     render() {
         const {
-            caret, // eslint-disable-line no-unused-vars
+            caret,
             children,
             skipClientNav,
             focused,
@@ -61,13 +64,25 @@ export default class LinkCore extends React.Component<Props> {
             ...handlers,
         };
 
+        const caretIcon = (
+            <StyledSvg
+                height="1em" // set the height to match the current font size
+                viewBox="1 0 14 16" // tweak the icon to be 1px closer to the link text
+                style={sharedStyles.caret}
+            >
+                <path fill="currentColor" d={icons.caretRight.small} />
+            </StyledSvg>
+        );
+
         return router && !skipClientNav ? (
             <StyledLink {...commonProps} to={href}>
                 {children}
+                {caret && caretIcon}
             </StyledLink>
         ) : (
             <StyledAnchor {...commonProps} href={href}>
                 {children}
+                {caret && caretIcon}
             </StyledAnchor>
         );
     }
@@ -80,6 +95,12 @@ const sharedStyles = StyleSheet.create({
         cursor: "pointer",
         textDecoration: "none",
         outline: "none",
+    },
+    caret: {
+        display: "inline-block",
+        verticalAlign: "text-bottom",
+        flexShrink: 0,
+        flexGrow: 0,
     },
 });
 

--- a/packages/wonder-blocks-link/components/link.md
+++ b/packages/wonder-blocks-link/components/link.md
@@ -35,3 +35,22 @@ import Link from "@khanacademy/wonder-blocks-link";
     </Link>
 </View>
 ```
+
+### Example: Link with caret
+
+```js
+import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import {View} from "@khanacademy/wonder-blocks-core";
+import Link from "@khanacademy/wonder-blocks-link";
+
+<View>
+    <HeadingSmall>
+        Heading.
+        <Link href="#nonexistent-link" caret={true}>Cta link!</Link>
+    </HeadingSmall>
+    <Body>
+        Regular copy.
+        <Link href="#nonexistent-link" caret={true}>Cta link!</Link>
+    </Body>
+</View>
+```

--- a/packages/wonder-blocks-link/link.stories.js
+++ b/packages/wonder-blocks-link/link.stories.js
@@ -1,0 +1,54 @@
+// @flow
+import React from "react";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Body} from "@khanacademy/wonder-blocks-typography";
+
+import Link from "./components/link.js";
+
+export default {
+    title: "Link",
+};
+
+export const basicLinks = () => (
+    <View>
+        <Body>
+            <Link href="#nonexistent-link">Primary link</Link>
+            <Link href="#nonexistent-link" kind="secondary">
+                Secondary link
+            </Link>
+        </Body>
+    </View>
+);
+
+export const darkLink = () => (
+    <View style={{backgroundColor: Color.darkBlue}}>
+        <Body>
+            <Link href="#nonexistent-link" light={true}>
+                Primary link
+            </Link>
+        </Body>
+    </View>
+);
+
+darkLink.story = {
+    parameters: {
+        backgrounds: [{name: "darkBlue", value: Color.darkBlue, default: true}],
+    },
+};
+
+export const linksWithCarets = () => (
+    <View>
+        <Body>
+            <Link href="#nonexistent-link" caret={true}>
+                Link with caret.
+            </Link>
+            <View style={{fontSize: 30}}>
+                <Link href="#nonexistent-link" caret={true}>
+                    Large link with caret.
+                </Link>
+            </View>
+        </Body>
+    </View>
+);

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -16,7 +16,8 @@
   "license": "MIT",
   "dependencies": {
     "@khanacademy/wonder-blocks-color": "^1.1.14",
-    "@khanacademy/wonder-blocks-core": "^2.6.1"
+    "@khanacademy/wonder-blocks-core": "^2.6.1",
+    "@khanacademy/wonder-blocks-icon": "^1.2.10"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",


### PR DESCRIPTION
## Summary:
This was work we never got to.  I'm doing this now because I want to replace a ClientLink in webapp with a wonder-blocks-link Link but it has a one-off caret and I want to do it the right way.  This will also make updating other links with carets in webapp easier in the future.

As part of this PR I had to stop processing .md files with lint-staged becuase it was writing to test files at the same time jest was trying to write them and this resulted in test failures.

Issue: none

## Test plan:
- yarn test
- look at the examples in styleguidist and storybook

Reviewers: #fe-infra