### PR TITLE
Remove unnecessary dev dependencies

### DIFF
--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -19,10 +19,8 @@
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "popper.js": "^1.14.1",
     "prop-types": "^15.6.2",
     "react-dom": "^16.4.1",
-    "react-popper": "^1.0.0",
     "react-router-dom": "^4.2.2",
     "react": "^16.4.1"
   },

--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -21,12 +21,12 @@
     "aphrodite": "^1.2.5",
     "popper.js": "^1.14.1",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1"
-  },
-  "devDependencies": {
     "react-dom": "^16.4.1",
     "react-popper": "^1.0.0",
     "react-router-dom": "^4.2.2",
+    "react": "^16.4.1"
+  },
+  "devDependencies": {
     "wb-dev-build-settings": "^0.0.3"
   }
 }

--- a/packages/wonder-blocks-color/package.json
+++ b/packages/wonder-blocks-color/package.json
@@ -13,8 +13,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "@khanacademy/wonder-blocks-core": "^2.6.1",
-    "@khanacademy/wonder-blocks-typography": "^1.1.14",
     "wb-dev-build-settings": "^0.0.3"
   },
   "author": "",

--- a/packages/wonder-blocks-icon/package.json
+++ b/packages/wonder-blocks-icon/package.json
@@ -18,7 +18,6 @@
     "@khanacademy/wonder-blocks-core": "^2.6.1"
   },
   "devDependencies": {
-    "@khanacademy/wonder-blocks-color": "^1.1.14",
     "wb-dev-build-settings": "^0.0.3"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-layout/package.json
+++ b/packages/wonder-blocks-layout/package.json
@@ -17,7 +17,6 @@
     "@khanacademy/wonder-blocks-spacing": "^2.1.14"
   },
   "devDependencies": {
-    "@khanacademy/wonder-blocks-button": "^2.7.2",
     "wb-dev-build-settings": "^0.0.3"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -31,7 +31,6 @@
     "react-dom": "^16.4.1"
   },
   "devDependencies": {
-    "@khanacademy/wonder-blocks-button": "^2.7.2",
     "wb-dev-build-settings": "^0.0.3"
   }
 }

--- a/packages/wonder-blocks-spacing/package.json
+++ b/packages/wonder-blocks-spacing/package.json
@@ -13,7 +13,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "@khanacademy/wonder-blocks-color": "^1.1.14",
     "wb-dev-build-settings": "^0.0.3"
   },
   "author": "",

--- a/packages/wonder-blocks-typography/package.json
+++ b/packages/wonder-blocks-typography/package.json
@@ -22,7 +22,6 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "@khanacademy/wonder-blocks-color": "^1.1.14",
     "wb-dev-build-settings": "^0.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14434,7 +14434,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.4.1, react-dom@^16.4.3, react-dom@^16.8.3:
+react-dom@^16.4.3, react-dom@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==


### PR DESCRIPTION
## Summary:
lerna looks at changes to local packages that appear in both dependencies and devDependencies when deciding which modules' versions to bump.  Because of how yarn workspaces works and how we've configured jest and flow all of our dev-tooling just works without listing local modules as devDependencies in local packages.  By removing them from devDependencies we avoid unnecessary version bumping from lerna.

Issue: none

## Test plan:
- yarn test
- yarn start
- yarn start:storybook

Reviewers: #fe-infra