### PR TITLE
Add onKeyDown/onKeyUp to Clickable

### DIFF
--- a/packages/wonder-blocks-button/components/__tests__/button.test.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.test.js
@@ -22,9 +22,7 @@ describe("Button", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button testId="button" href="/foo">
-                        Click me!
-                    </Button>
+                    <Button href="/foo">Click me!</Button>
                     <Switch>
                         <Route path="/foo">
                             <div id="foo">Hello, world!</div>
@@ -35,7 +33,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -47,11 +45,7 @@ describe("Button", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button
-                        testId="button"
-                        href="/foo"
-                        beforeNav={(e) => Promise.reject()}
-                    >
+                    <Button href="/foo" beforeNav={(e) => Promise.reject()}>
                         Click me!
                     </Button>
                     <Switch>
@@ -64,7 +58,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
         await wait(0);
         buttonWrapper.update();
@@ -80,7 +74,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         beforeNav={(e) => Promise.reject()}
                         safeWithNav={safeWithNavMock}
@@ -97,7 +90,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
         await wait(0);
         buttonWrapper.update();
@@ -111,11 +104,7 @@ describe("Button", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button
-                        testId="button"
-                        href="/foo"
-                        beforeNav={(e) => Promise.resolve()}
-                    >
+                    <Button href="/foo" beforeNav={(e) => Promise.resolve()}>
                         Click me!
                     </Button>
                     <Switch>
@@ -128,7 +117,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
         await wait(0);
         buttonWrapper.update();
@@ -144,7 +133,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         beforeNav={(e) => Promise.resolve()}
                         safeWithNav={safeWithNavMock}
@@ -161,7 +149,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
         await wait(0);
         buttonWrapper.update();
@@ -175,11 +163,7 @@ describe("Button", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button
-                        testId="button"
-                        href="/foo"
-                        beforeNav={(e) => Promise.resolve()}
-                    >
+                    <Button href="/foo" beforeNav={(e) => Promise.resolve()}>
                         Click me!
                     </Button>
                     <Switch>
@@ -192,7 +176,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -209,7 +193,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         safeWithNav={(e) => Promise.resolve()}
                         skipClientNav={true}
@@ -226,7 +209,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
         await wait(0);
         buttonWrapper.update();
@@ -242,7 +225,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         safeWithNav={(e) => Promise.resolve()}
                         skipClientNav={true}
@@ -259,7 +241,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -273,7 +255,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         beforeNav={(e) => Promise.resolve()}
                         safeWithNav={(e) => Promise.resolve()}
@@ -291,7 +272,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
         await wait(0);
         buttonWrapper.update();
@@ -309,7 +290,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         safeWithNav={(e) => Promise.reject()}
                         skipClientNav={true}
@@ -326,7 +306,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
         await wait(0);
         buttonWrapper.update();
@@ -343,7 +323,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         safeWithNav={safeWithNavMock}
                         skipClientNav={false}
@@ -360,7 +339,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -376,7 +355,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         beforeNav={() => Promise.resolve()}
                         safeWithNav={safeWithNavMock}
@@ -394,7 +372,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
         await wait(0);
         buttonWrapper.update();
@@ -409,9 +387,7 @@ describe("Button", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button testId="button" href="/unknown">
-                        Click me!
-                    </Button>
+                    <Button href="/unknown">Click me!</Button>
                     <Switch>
                         <Route path="/foo">
                             <div id="foo">Hello, world!</div>
@@ -422,7 +398,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -434,7 +410,7 @@ describe("Button", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button testId="button" href="/foo" skipClientNav>
+                    <Button href="/foo" skipClientNav>
                         Click me!
                     </Button>
                     <Switch>
@@ -447,7 +423,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -459,7 +435,7 @@ describe("Button", () => {
         const wrapper = mount(
             <MemoryRouter>
                 <div>
-                    <Button testId="button" href="/foo" disabled={true}>
+                    <Button href="/foo" disabled={true}>
                         Click me!
                     </Button>
                     <Switch>
@@ -472,7 +448,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -486,7 +462,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         disabled={true}
                         beforeNav={beforeNavMock}
@@ -503,7 +478,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -517,7 +492,6 @@ describe("Button", () => {
             <MemoryRouter>
                 <div>
                     <Button
-                        testId="button"
                         href="/foo"
                         disabled={true}
                         safeWithNav={safeWithNavMock}
@@ -534,7 +508,7 @@ describe("Button", () => {
         );
 
         // Act
-        const buttonWrapper = wrapper.find(`[data-test-id="button"]`).first();
+        const buttonWrapper = wrapper.find("Button");
         buttonWrapper.simulate("click", {button: 0});
 
         // Assert
@@ -575,9 +549,7 @@ describe("Button", () => {
             const wrapper = mount(
                 <MemoryRouter>
                     <div>
-                        <Button testId="button" href="/foo">
-                            Click me!
-                        </Button>
+                        <Button href="/foo">Click me!</Button>
                         <Switch>
                             <Route path="/foo">
                                 <div id="foo">Hello, world!</div>
@@ -588,9 +560,7 @@ describe("Button", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper
-                .find(`[data-test-id="button"]`)
-                .first();
+            const buttonWrapper = wrapper.find("Button");
             buttonWrapper.simulate("keydown", {
                 keyCode: keyCodes.space,
             });
@@ -607,9 +577,7 @@ describe("Button", () => {
             const wrapper = mount(
                 <MemoryRouter>
                     <div>
-                        <Button testId="button" href="/foo">
-                            Click me!
-                        </Button>
+                        <Button href="/foo">Click me!</Button>
                         <Switch>
                             <Route path="/foo">
                                 <div id="foo">Hello, world!</div>
@@ -620,9 +588,7 @@ describe("Button", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper
-                .find(`[data-test-id="button"]`)
-                .first();
+            const buttonWrapper = wrapper.find("Button");
             buttonWrapper.simulate("keydown", {
                 keyCode: keyCodes.enter,
             });
@@ -639,11 +605,7 @@ describe("Button", () => {
             const wrapper = mount(
                 <MemoryRouter>
                     <div>
-                        <Button
-                            testId="button"
-                            href="/foo"
-                            beforeNav={(e) => Promise.reject()}
-                        >
+                        <Button href="/foo" beforeNav={(e) => Promise.reject()}>
                             Click me!
                         </Button>
                         <Switch>
@@ -656,9 +618,7 @@ describe("Button", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper
-                .find(`[data-test-id="button"]`)
-                .first();
+            const buttonWrapper = wrapper.find("Button");
             buttonWrapper.simulate("keydown", {
                 keyCode: keyCodes.enter,
             });
@@ -678,7 +638,6 @@ describe("Button", () => {
                 <MemoryRouter>
                     <div>
                         <Button
-                            testId="button"
                             href="/foo"
                             beforeNav={(e) => Promise.resolve()}
                         >
@@ -694,9 +653,7 @@ describe("Button", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper
-                .find(`[data-test-id="button"]`)
-                .first();
+            const buttonWrapper = wrapper.find("Button");
             buttonWrapper.simulate("keydown", {
                 keyCode: keyCodes.enter,
             });
@@ -717,7 +674,6 @@ describe("Button", () => {
                 <MemoryRouter>
                     <div>
                         <Button
-                            testId="button"
                             href="/foo"
                             safeWithNav={(e) => Promise.resolve()}
                             skipClientNav={true}
@@ -734,9 +690,7 @@ describe("Button", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper
-                .find(`[data-test-id="button"]`)
-                .first();
+            const buttonWrapper = wrapper.find("Button");
             buttonWrapper.simulate("keydown", {
                 keyCode: keyCodes.enter,
             });
@@ -757,7 +711,6 @@ describe("Button", () => {
                 <MemoryRouter>
                     <div>
                         <Button
-                            testId="button"
                             href="/foo"
                             safeWithNav={(e) => Promise.reject()}
                             skipClientNav={true}
@@ -774,9 +727,7 @@ describe("Button", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper
-                .find(`[data-test-id="button"]`)
-                .first();
+            const buttonWrapper = wrapper.find("Button");
             buttonWrapper.simulate("keydown", {
                 keyCode: keyCodes.enter,
             });
@@ -798,7 +749,6 @@ describe("Button", () => {
                 <MemoryRouter>
                     <div>
                         <Button
-                            testId="button"
                             href="/foo"
                             safeWithNav={safeWithNavMock}
                             skipClientNav={false}
@@ -815,9 +765,7 @@ describe("Button", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper
-                .find(`[data-test-id="button"]`)
-                .first();
+            const buttonWrapper = wrapper.find("Button");
             buttonWrapper.simulate("keydown", {
                 keyCode: keyCodes.enter,
             });

--- a/packages/wonder-blocks-clickable/components/__tests__/clickable.test.js
+++ b/packages/wonder-blocks-clickable/components/__tests__/clickable.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -447,5 +447,58 @@ describe("Clickable", () => {
         // Assert
         expect(safeWithNavMock).toHaveBeenCalled();
         expect(window.location.assign).toHaveBeenCalledWith("/foo");
+    });
+
+    describe("raw events", () => {
+        /**
+         * Clickable expect a function as children so we create a simple wrapper to
+         * allow a React.Node to be passed instead.
+         */
+        const ClickableWrapper = ({
+            children,
+            ...restProps
+        }: {|
+            children: React.Node,
+            onKeyDown?: (e: SyntheticKeyboardEvent<>) => mixed,
+            onKeyUp?: (e: SyntheticKeyboardEvent<>) => mixed,
+        |}) => {
+            return <Clickable {...restProps}>{() => children}</Clickable>;
+        };
+
+        test("onKeyDown", () => {
+            // Arrange
+            const keyMock = jest.fn();
+            const wrapper = mount(
+                <ClickableWrapper onKeyDown={keyMock}>
+                    Click me!
+                </ClickableWrapper>,
+            );
+
+            // Act
+            wrapper.find("Clickable").simulate("keydown", {keyCode: 32});
+
+            // Assert
+            expect(keyMock).toHaveBeenCalledWith(
+                expect.objectContaining({keyCode: 32}),
+            );
+        });
+
+        test("onKeyUp", () => {
+            // Arrange
+            const keyMock = jest.fn();
+            const wrapper = mount(
+                <ClickableWrapper onKeyDown={keyMock}>
+                    Click me!
+                </ClickableWrapper>,
+            );
+
+            // Act
+            wrapper.find("Clickable").simulate("keydown", {keyCode: 32});
+
+            // Assert
+            expect(keyMock).toHaveBeenCalledWith(
+                expect.objectContaining({keyCode: 32}),
+            );
+        });
     });
 });

--- a/packages/wonder-blocks-clickable/components/clickable.js
+++ b/packages/wonder-blocks-clickable/components/clickable.js
@@ -90,6 +90,16 @@ type CommonProps = {|
      * Test ID used for e2e testing.
      */
     testId?: string,
+
+    /**
+     * Respond to raw "keydown" event.
+     */
+    onKeyDown?: (e: SyntheticKeyboardEvent<>) => mixed,
+
+    /**
+     * Respond to raw "keyup" event.
+     */
+    onKeyUp?: (e: SyntheticKeyboardEvent<>) => mixed,
 |};
 
 type Props =
@@ -235,6 +245,8 @@ export default class Clickable extends React.Component<Props> {
             safeWithNav = undefined,
             style,
             testId,
+            onKeyDown,
+            onKeyUp,
             ...restProps
         } = this.props;
         const ClickableBehavior = getClickableBehavior(
@@ -249,6 +261,8 @@ export default class Clickable extends React.Component<Props> {
                 onClick={onClick}
                 beforeNav={beforeNav}
                 safeWithNav={safeWithNav}
+                onKeyDown={onKeyDown}
+                onKeyUp={onKeyUp}
             >
                 {(state, handlers) =>
                     this.getCorrectTag(state, {

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -109,6 +109,16 @@ type Props = {|
      * enter and space keys.
      */
     role?: ClickableRole,
+
+    /**
+     * Respond to raw "keydown" event.
+     */
+    onKeyDown?: (e: SyntheticKeyboardEvent<>) => mixed,
+
+    /**
+     * Respond to raw "keyup" event.
+     */
+    onKeyUp?: (e: SyntheticKeyboardEvent<>) => mixed,
 |};
 
 export type ClickableState = {|
@@ -466,9 +476,14 @@ export default class ClickableBehavior extends React.Component<
     };
 
     handleKeyDown = (e: SyntheticKeyboardEvent<>) => {
+        const {onKeyDown, role} = this.props;
+        if (onKeyDown) {
+            onKeyDown(e);
+        }
+
         const keyCode = e.which || e.keyCode;
         const {triggerOnEnter, triggerOnSpace} = getAppropriateTriggersForRole(
-            this.props.role,
+            role,
         );
         if (
             (triggerOnEnter && keyCode === keyCodes.enter) ||
@@ -488,9 +503,14 @@ export default class ClickableBehavior extends React.Component<
     };
 
     handleKeyUp = (e: SyntheticKeyboardEvent<>) => {
+        const {onKeyUp, role} = this.props;
+        if (onKeyUp) {
+            onKeyUp(e);
+        }
+
         const keyCode = e.which || e.keyCode;
         const {triggerOnEnter, triggerOnSpace} = getAppropriateTriggersForRole(
-            this.props.role,
+            role,
         );
         if (
             (triggerOnEnter && keyCode === keyCodes.enter) ||

--- a/packages/wonder-blocks-link/components/__tests__/link.test.js
+++ b/packages/wonder-blocks-link/components/__tests__/link.test.js
@@ -29,9 +29,7 @@ describe("Link", () => {
             const wrapper = mount(
                 <MemoryRouter>
                     <div>
-                        <Link testId="link" href="/foo">
-                            Click me!
-                        </Link>
+                        <Link href="/foo">Click me!</Link>
                         <Switch>
                             <Route path="/foo">
                                 <div id="foo">Hello, world!</div>
@@ -42,8 +40,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {button: 0});
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {button: 0});
 
             // Assert
             expect(wrapper.find("#foo").exists()).toBe(true);
@@ -54,9 +52,7 @@ describe("Link", () => {
             const wrapper = mount(
                 <MemoryRouter>
                     <div>
-                        <Link testId="link" href="/unknown">
-                            Click me!
-                        </Link>
+                        <Link href="/unknown">Click me!</Link>
                         <Switch>
                             <Route path="/foo">
                                 <div id="foo">Hello, world!</div>
@@ -67,8 +63,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {button: 0});
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {button: 0});
 
             // Assert
             expect(wrapper.find("#foo").exists()).toBe(false);
@@ -79,11 +75,7 @@ describe("Link", () => {
             const wrapper = mount(
                 <MemoryRouter>
                     <div>
-                        <Link
-                            testId="link"
-                            href="/foo"
-                            beforeNav={() => Promise.resolve()}
-                        >
+                        <Link href="/foo" beforeNav={() => Promise.resolve()}>
                             Click me!
                         </Link>
                         <Switch>
@@ -96,8 +88,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
             await wait(0);
@@ -112,11 +104,7 @@ describe("Link", () => {
             const wrapper = mount(
                 <MemoryRouter>
                     <div>
-                        <Link
-                            testId="link"
-                            href="/foo"
-                            beforeNav={() => Promise.resolve()}
-                        >
+                        <Link href="/foo" beforeNav={() => Promise.resolve()}>
                             Click me!
                         </Link>
                         <Switch>
@@ -129,8 +117,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
 
@@ -143,11 +131,7 @@ describe("Link", () => {
             const wrapper = mount(
                 <MemoryRouter>
                     <div>
-                        <Link
-                            testId="link"
-                            href="/foo"
-                            beforeNav={() => Promise.reject()}
-                        >
+                        <Link href="/foo" beforeNav={() => Promise.reject()}>
                             Click me!
                         </Link>
                         <Switch>
@@ -160,8 +144,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
             await wait(0);
@@ -178,7 +162,6 @@ describe("Link", () => {
                 <MemoryRouter>
                     <div>
                         <Link
-                            testId="link"
                             href="/foo"
                             beforeNav={() => Promise.resolve()}
                             safeWithNav={safeWithNavMock}
@@ -195,8 +178,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
             await wait(0);
@@ -213,7 +196,6 @@ describe("Link", () => {
                 <MemoryRouter>
                     <div>
                         <Link
-                            testId="link"
                             href="/foo"
                             beforeNav={() => Promise.resolve()}
                             safeWithNav={safeWithNavMock}
@@ -230,8 +212,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
 
@@ -246,7 +228,6 @@ describe("Link", () => {
             jest.spyOn(window.location, "assign").mockImplementation(() => {});
             const wrapper = mount(
                 <Link
-                    testId="link"
                     href="/foo"
                     safeWithNav={() => Promise.resolve()}
                     skipClientNav={true}
@@ -256,8 +237,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
 
@@ -270,7 +251,6 @@ describe("Link", () => {
             jest.spyOn(window.location, "assign").mockImplementation(() => {});
             const wrapper = mount(
                 <Link
-                    testId="link"
                     href="/foo"
                     safeWithNav={() => Promise.resolve()}
                     skipClientNav={true}
@@ -280,8 +260,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
             await wait(0);
@@ -296,7 +276,6 @@ describe("Link", () => {
             jest.spyOn(window.location, "assign").mockImplementation(() => {});
             const wrapper = mount(
                 <Link
-                    testId="link"
                     href="/foo"
                     beforeNav={() => Promise.resolve()}
                     safeWithNav={() => Promise.resolve()}
@@ -307,8 +286,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
             await wait(0);
@@ -323,7 +302,6 @@ describe("Link", () => {
             jest.spyOn(window.location, "assign").mockImplementation(() => {});
             const wrapper = mount(
                 <Link
-                    testId="link"
                     href="/foo"
                     beforeNav={() => Promise.resolve()}
                     skipClientNav={true}
@@ -333,8 +311,8 @@ describe("Link", () => {
             );
 
             // Act
-            const buttonWrapper = wrapper.find(`[data-test-id="link"]`).first();
-            buttonWrapper.simulate("click", {
+            const linkWrapper = wrapper.find("Link").first();
+            linkWrapper.simulate("click", {
                 button: 0,
             });
 

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,9 +1,10 @@
+/* eslint-disable import/no-commonjs */
 const babelConfig = require("./build-settings/babel.config.js");
 
-module.exports = function(wallaby) {
+module.exports = function (wallaby) {
     const tests = [
-        "packages/wonder-blocks-*/**/*.test.js",
-        "shared-unpackaged/**/*.test.js",
+        "./packages/**/__tests__/*.test.js",
+        "./shared-unpackaged/**/*.test.js",
     ];
 
     return {
@@ -12,13 +13,12 @@ module.exports = function(wallaby) {
         // Wallaby needs to know about all files that may be loaded because
         // of running a test.
         files: [
-            "packages/wonder-blocks-*/**/*.js",
+            "./packages/**/*.js",
             "shared-unpackaged/**/*.js",
             "utils/**/*.js",
             {pattern: "config/jest/*.js", instrument: false},
 
             // These paths are excluded.
-            "!shared-unpackaged/**/*.test.js",
             ...tests.map((test) => `!${test}`),
         ],
 
@@ -32,9 +32,7 @@ module.exports = function(wallaby) {
         // advanced logging features.  Wallaby can't parse the flow and
         // JSX in our source files so need to provide a babel configuration.
         compilers: {
-            "packages/wonder-blocks-*/**/*.js": wallaby.compilers.babel(
-                babelConfig,
-            ),
+            "packages/**/*.js": wallaby.compilers.babel(babelConfig),
             "shared-unpackaged/**/*.js": wallaby.compilers.babel(babelConfig),
             "utils/**/*.js": wallaby.compilers.babel(babelConfig),
         },
@@ -46,7 +44,7 @@ module.exports = function(wallaby) {
 
         testFramework: "jest",
 
-        setup: function(wallaby) {
+        setup: function (wallaby) {
             // We require "path" here because this setup function is run
             // in a different context and does not have access to variables
             // from its closure.


### PR DESCRIPTION
## Summary:
SearchBox in webapp uses onKeyDown to customize keyboard navigation of that component.  In order to switch from <a> to <Clickable> we need to handle these events.  In particular `handleKeyDown` is passed down to `SearchResultsPopup` which passes it down to other components which eventually pass it to `<a>`'s `onKeyDown` prop.

This PR also simplifies some of our existing tests for Link and Button.

Issue: none

## Test plan:
- yarn test

Reviewers: #fe-infra