### PR TITLE
Add onKeyDown/onKeyUp to Link as well

### DIFF
--- a/packages/wonder-blocks-link/components/__tests__/link.test.js
+++ b/packages/wonder-blocks-link/components/__tests__/link.test.js
@@ -320,4 +320,42 @@ describe("Link", () => {
             expect(window.location.assign).not.toHaveBeenCalled();
         });
     });
+
+    describe("raw events", () => {
+        test("onKeyDown", () => {
+            // Arrange
+            const keyMock = jest.fn();
+            const wrapper = mount(
+                <Link href="/" onKeyDown={keyMock}>
+                    Click me!
+                </Link>,
+            );
+
+            // Act
+            wrapper.find(Link).simulate("keydown", {keyCode: 32});
+
+            // Assert
+            expect(keyMock).toHaveBeenCalledWith(
+                expect.objectContaining({keyCode: 32}),
+            );
+        });
+
+        test("onKeyUp", () => {
+            // Arrange
+            const keyMock = jest.fn();
+            const wrapper = mount(
+                <Link href="/" onKeyDown={keyMock}>
+                    Click me!
+                </Link>,
+            );
+
+            // Act
+            wrapper.find(Link).simulate("keydown", {keyCode: 32});
+
+            // Assert
+            expect(keyMock).toHaveBeenCalledWith(
+                expect.objectContaining({keyCode: 32}),
+            );
+        });
+    });
 });

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -135,6 +135,16 @@ export type SharedProps = {|
      * navigation is guaranteed to succeed.
      */
     safeWithNav?: () => Promise<mixed>,
+
+    /**
+     * Respond to raw "keydown" event.
+     */
+    onKeyDown?: (e: SyntheticKeyboardEvent<>) => mixed,
+
+    /**
+     * Respond to raw "keyup" event.
+     */
+    onKeyUp?: (e: SyntheticKeyboardEvent<>) => mixed,
 |};
 
 /**
@@ -171,6 +181,8 @@ export default class Link extends React.Component<SharedProps> {
             skipClientNav,
             children,
             tabIndex,
+            onKeyDown,
+            onKeyUp,
             ...sharedProps
         } = this.props;
 
@@ -188,6 +200,8 @@ export default class Link extends React.Component<SharedProps> {
                 onClick={onClick}
                 beforeNav={beforeNav}
                 safeWithNav={safeWithNav}
+                onKeyDown={onKeyDown}
+                onKeyUp={onKeyUp}
             >
                 {(state, {tabIndex: clickableTabIndex, ...handlers}) => {
                     return (


### PR DESCRIPTION
## Summary:
In #1069 I added these props to Clickable to handle some custom keyboard behavior in webapp's search box/page.  I thought Clickable would be enough, but there are some <a> tags where we want the thing to look like an actual link.

Issue: none

## Test plan:
- yarn test

Reviewers: #fe-infra