### PR TITLE
Add support for className to addStyle

### DIFF
--- a/packages/wonder-blocks-core/util/__tests__/add-style.test.js
+++ b/packages/wonder-blocks-core/util/__tests__/add-style.test.js
@@ -1,0 +1,69 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {mount, unmountAll} from "../../../../utils/testing/mount.js";
+
+import addStyle from "../add-style.js";
+
+const StyledDiv = addStyle<"div">("div");
+
+const styles = StyleSheet.create({
+    foo: {
+        height: "100%",
+    },
+});
+
+describe("addStyle", () => {
+    let SNAPSHOT_INLINE_APHRODITE;
+
+    beforeEach(() => {
+        SNAPSHOT_INLINE_APHRODITE = global.SNAPSHOT_INLINE_APHRODITE;
+        global.SNAPSHOT_INLINE_APHRODITE = false;
+        unmountAll();
+    });
+
+    afterEach(() => {
+        global.SNAPSHOT_INLINE_APHRODITE = SNAPSHOT_INLINE_APHRODITE;
+    });
+
+    it("should set the className if no style is provided", () => {
+        const wrapper = mount(<StyledDiv className="foo" />);
+
+        const div = wrapper.find("div");
+
+        expect(div).toHaveProp("className", "foo");
+    });
+
+    it("should set the className to include foo and inlineStyles", () => {
+        const wrapper = mount(
+            <StyledDiv className="foo" style={{width: "100%"}} />,
+        );
+
+        const div = wrapper.find("div");
+
+        const classNames = div.props().className.split(" ");
+        expect(classNames).toHaveLength(2);
+        expect(classNames[0].startsWith("inlineStyles")).toBeTruthy();
+        expect(classNames[1]).toEqual("foo");
+    });
+
+    it("should set the className if an stylesheet style is provided", () => {
+        const wrapper = mount(<StyledDiv style={styles.foo} />);
+
+        const div = wrapper.find("div");
+
+        expect(div).toHaveProp("className", expect.any(String));
+    });
+
+    it("should set the className if an stylesheet style is provided", () => {
+        const wrapper = mount(<StyledDiv className="foo" style={styles.foo} />);
+
+        const div = wrapper.find("div");
+
+        const classNames = div.props().className.split(" ");
+        expect(classNames).toHaveLength(2);
+        expect(classNames[0]).toEqual(expect.any(String));
+        expect(classNames[1]).toEqual("foo");
+    });
+});

--- a/packages/wonder-blocks-core/util/add-style.js
+++ b/packages/wonder-blocks-core/util/add-style.js
@@ -20,23 +20,24 @@ export default function addStyle<T: React.AbstractComponent<any> | string>(
         style: StyleType,
         ...
     }) {
-        const {style, ...tmpOtherProps} = props;
+        const {className, style, ...tmpOtherProps} = props;
         // NOTE(jeresig): We need to cast the remaining props to be the right
         // value to ensure that they're typed properly.
         const otherProps: React.ElementConfig<T> = (tmpOtherProps: any);
         const reset =
             typeof Component === "string" ? overrides[Component] : null;
 
-        const {className, style: inlineStyles} = processStyleList([
-            reset,
-            defaultStyle,
-            style,
-        ]);
+        const {
+            className: aphroditeClassName,
+            style: inlineStyles,
+        } = processStyleList([reset, defaultStyle, style]);
 
         return (
             <Component
                 {...otherProps}
-                className={className}
+                className={[aphroditeClassName, className]
+                    .filter(Boolean)
+                    .join(" ")}
                 style={inlineStyles}
             />
         );


### PR DESCRIPTION
## Summary:
I'm doing some work on the Google search results component in webapp and we're doing some pretty hacky stuff (replacing Google <a> tags with our <Link> component).  This is so that we can track conversions without having to use /bigbingo_redirect.  In order to do this properly though Link needs to support the "className" prop.  This PR updates 'addStyle' to handle className properly and since the underlying components Link renders are wrapped in 'addStyle' it too will handle className properly.

Issue: none

## Test plan:
- yarn test

Reviewers: #fe-infra