### PR TITLE
Add 'className' prop type to commonly used components

### DIFF
--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -142,6 +142,11 @@ export type SharedProps = {|
     }>>,
     */
 
+    /**
+     * Adds CSS classes to the Button.
+     */
+    className?: string,
+
     // NOTE(jeresig): Currently React Docgen (used by Styleguidist) doesn't
     // support ... inside of an exact object type. Thus we had to move the
     // following propers into this SharedProps, even though they should be

--- a/packages/wonder-blocks-clickable/components/clickable.js
+++ b/packages/wonder-blocks-clickable/components/clickable.js
@@ -43,6 +43,11 @@ type CommonProps = {|
     style?: StyleType,
 
     /**
+     * Adds CSS classes to the Clickable.
+     */
+    className?: string,
+
+    /**
      * Disables or enables the child; defaults to false
      */
     disabled: boolean,

--- a/packages/wonder-blocks-dropdown/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/components/action-menu.js
@@ -77,6 +77,11 @@ type Props = {|
     style?: StyleType,
 
     /**
+     * Optional CSS classes for the entire dropdown component.
+     */
+    className?: string,
+
+    /**
      * The child function that returns the anchor the ActionMenu will be
      * activated by. This function takes eventState, which allows the opener
      * element to access pointer event state.
@@ -253,7 +258,7 @@ export default class ActionMenu extends React.Component<Props, State> {
     }
 
     render() {
-        const {alignment, dropdownStyle, style} = this.props;
+        const {alignment, dropdownStyle, style, className} = this.props;
 
         const items = this.getMenuItems();
         const dropdownOpener = this.renderOpener(items.length);
@@ -262,6 +267,7 @@ export default class ActionMenu extends React.Component<Props, State> {
             <DropdownCore
                 role="menu"
                 style={style}
+                className={className}
                 opener={dropdownOpener}
                 alignment={alignment}
                 open={this.state.opened}

--- a/packages/wonder-blocks-dropdown/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core.js
@@ -120,6 +120,11 @@ type Props = {|
     style?: StyleType,
 
     /**
+     * Optional CSS classes for the entire dropdown component.
+     */
+    className?: string,
+
+    /**
      * The aria "role" applied to the dropdown container.
      */
     role: "listbox" | "menu",
@@ -749,13 +754,14 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     render() {
-        const {open, opener, style} = this.props;
+        const {open, opener, style, className} = this.props;
 
         return (
             <View
                 onKeyDown={this.handleKeyDown}
                 onKeyUp={this.handleKeyUp}
                 style={[styles.menuWrapper, style]}
+                className={className}
             >
                 {opener}
                 {open && this.renderDropdown()}

--- a/packages/wonder-blocks-dropdown/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/components/multi-select.js
@@ -163,6 +163,11 @@ type Props = {|
     style?: StyleType,
 
     /**
+     * Adds CSS classes to the opener component wrapper.
+     */
+    className?: string,
+
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string,
@@ -500,6 +505,7 @@ export default class MultiSelect extends React.Component<Props, State> {
             selectedValues,
             shortcuts,
             style,
+            className,
             /* eslint-enable no-unused-vars */
             ...sharedProps
         } = this.props;
@@ -541,6 +547,7 @@ export default class MultiSelect extends React.Component<Props, State> {
             alignment,
             light,
             style,
+            className,
             dropdownStyle,
             children,
             isFilterable,
@@ -574,6 +581,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 opener={opener}
                 openerElement={this.state.openerElement}
                 style={style}
+                className={className}
                 onSearchTextChanged={
                     isFilterable ? this.handleSearchTextChanged : null
                 }

--- a/packages/wonder-blocks-dropdown/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/components/single-select.js
@@ -84,6 +84,11 @@ type Props = {|
     style?: StyleType,
 
     /**
+     * Adds CSS classes to the opener component wrapper.
+     */
+    className?: string,
+
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string,
@@ -319,6 +324,7 @@ export default class SingleSelect extends React.Component<Props, State> {
             onToggle,
             opened,
             style,
+            className,
             /* eslint-enable no-unused-vars */
             ...sharedProps
         } = this.props;
@@ -365,6 +371,7 @@ export default class SingleSelect extends React.Component<Props, State> {
             isFilterable,
             light,
             style,
+            className,
         } = this.props;
         const {searchText} = this.state;
         const allChildren = React.Children.toArray(children).filter(Boolean);
@@ -393,6 +400,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                 opener={opener}
                 openerElement={this.state.openerElement}
                 style={style}
+                className={className}
                 onSearchTextChanged={
                     isFilterable ? this.handleSearchTextChanged : null
                 }

--- a/packages/wonder-blocks-form/components/checkbox.js
+++ b/packages/wonder-blocks-form/components/checkbox.js
@@ -53,6 +53,11 @@ type ChoiceComponentProps = {|
     style?: StyleType,
 
     /**
+     * Adds CSS classes to the Checkbox.
+     */
+    className?: string,
+
+    /**
      * Optional test ID for e2e testing
      */
     testId?: string,

--- a/packages/wonder-blocks-form/components/choice-internal.js
+++ b/packages/wonder-blocks-form/components/choice-internal.js
@@ -33,13 +33,24 @@ type Props = {|
      */
     id?: string,
 
-    /** Optional additional styling. */
+    /**
+     * Optional additional styling.
+     */
     style?: StyleType,
 
-    /** Optional id for testing purposes. */
+    /**
+     * Adds CSS classes to the Button.
+     */
+    className?: string,
+
+    /**
+     * Optional id for testing purposes.
+     */
     testId?: string,
 
-    /** Label for the field. */
+    /**
+     * Label for the field.
+     */
     label?: string,
 
     /** Optional description for the field. */
@@ -113,13 +124,14 @@ type Props = {|
             // eslint-disable-next-line no-unused-vars
             onChange,
             style,
+            className,
             variant,
             ...coreProps
         } = this.props;
         const ChoiceCore = this.getChoiceCoreComponent();
         const ClickableBehavior = getClickableBehavior();
         return (
-            <View style={style}>
+            <View style={style} className={className}>
                 <ClickableBehavior
                     disabled={coreProps.disabled}
                     onClick={this.handleClick}

--- a/packages/wonder-blocks-form/components/radio.js
+++ b/packages/wonder-blocks-form/components/radio.js
@@ -53,6 +53,11 @@ type ChoiceComponentProps = {|
     style?: StyleType,
 
     /**
+     * Adds CSS classes to the Checkbox.
+     */
+    className?: string,
+
+    /**
      * Optional test ID for e2e testing
      */
     testId?: string,

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -62,6 +62,11 @@ export type SharedProps = {|
     }>>,
     */
 
+    /**
+     * Adds CSS classes to the IconButton.
+     */
+    className?: string,
+
     // NOTE(jeresig): Currently React Docgen (used by Styleguidist) doesn't
     // support ... inside of an exact object type. Thus we had to move the
     // following propers into this SharedProps, even though they should be

--- a/packages/wonder-blocks-icon/components/icon.js
+++ b/packages/wonder-blocks-icon/components/icon.js
@@ -10,25 +10,35 @@ import type {IconAsset, IconSize} from "../util/icon-assets.js";
 
 type Props = {|
     ...AriaProps,
+
     /**
      * The color of the icon. Will default to `currentColor`, which means that
      * it will take on the CSS `color` value from the parent element.
      */
     color?: string,
+
     /**
      * One of our named icons from icon-assets.js
      */
     icon: IconAsset,
+
     /**
      * One of `small` (16px), `medium` (24px), `large` (48px),
      * or `xlarge` (96px).
      */
     size: IconSize,
+
     /**
      * Styles that can be processed by `addStyle` — bare style objects,
      * Aphrodite style objects, or arrays thereof.
      */
     style?: StyleType,
+
+    /**
+     * Adds CSS classes to the Icon.
+     */
+    className?: string,
+
     /**
      * Test ID used for e2e testing.
      */

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -103,6 +103,11 @@ export type SharedProps = {|
     }>>,
     */
 
+    /**
+     * Adds CSS classes to the Link.
+     */
+    className?: string,
+
     // NOTE(jeresig): Currently React Docgen (used by Styleguidist) doesn't
     // support ... inside of an exact object type. Thus we had to move the
     // following propers into this SharedProps, even though they should be


### PR DESCRIPTION
## Summary:
In #1072 I added support for 'className' to 'addStyle', but in order to use 'className' on components without flow complaining we also have to add it to the prop types.  For some of the components, the new prop needed to be piped through manually to a child component.  This PR doesn't add 'className' to all components though.  I've filed a followup task to complete this work: https://khanacademy.atlassian.net/browse/WB-1002.

Issue: none

## Test plan:
- yarn start
- in one of the examples for Link, give one of the Links a className, see that it shows up in the inspector
- yarn flow

<img width="1392" alt="Screen Shot 2020-10-20 at 2 25 52 PM" src="https://user-images.githubusercontent.com/1044413/96628419-353b8700-12e0-11eb-8630-745250432d99.png">


Reviewers: #fe-infra