### PR TITLE
WB-1004: Update Button to work with <form>s

### DIFF
--- a/packages/wonder-blocks-button/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -3669,6 +3669,105 @@ exports[`wonder-blocks-button example 12 1`] = `
     }
   }
 >
+  <form
+    onSubmit={[Function]}
+  >
+    <button
+      className=""
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      style={
+        Object {
+          "::MozFocusInner": Object {
+            "border": 0,
+          },
+          ":focus": Object {
+            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+          },
+          "alignItems": "center",
+          "background": "#1865f2",
+          "border": "none",
+          "borderRadius": 4,
+          "boxSizing": "border-box",
+          "color": "#ffffff",
+          "cursor": "pointer",
+          "display": "inline-flex",
+          "height": 40,
+          "justifyContent": "center",
+          "margin": 0,
+          "outline": "none",
+          "paddingBottom": 0,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 0,
+          "position": "relative",
+          "textDecoration": "none",
+          "touchAction": "manipulation",
+          "userSelect": "none",
+        }
+      }
+      tabIndex={0}
+      type="submit"
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "alignItems": "center",
+            "display": "inline-block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": "bold",
+            "lineHeight": "20px",
+            "overflow": "hidden",
+            "pointerEvents": "none",
+            "textOverflow": "ellipsis",
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Submit
+      </span>
+    </button>
+  </form>
+</div>
+`;
+
+exports[`wonder-blocks-button example 13 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
   <button
     className=""
     disabled={false}
@@ -3744,7 +3843,7 @@ exports[`wonder-blocks-button example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 13 1`] = `
+exports[`wonder-blocks-button example 14 1`] = `
 <div
   className=""
   style={
@@ -3971,7 +4070,7 @@ exports[`wonder-blocks-button example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 14 1`] = `
+exports[`wonder-blocks-button example 15 1`] = `
 <div
   className=""
   style={
@@ -4145,7 +4244,7 @@ exports[`wonder-blocks-button example 14 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 15 1`] = `
+exports[`wonder-blocks-button example 16 1`] = `
 <div
   className=""
   style={
@@ -4320,7 +4419,7 @@ exports[`wonder-blocks-button example 15 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 16 1`] = `
+exports[`wonder-blocks-button example 17 1`] = `
 <div
   className=""
   style={
@@ -4509,7 +4608,7 @@ exports[`wonder-blocks-button example 16 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 17 1`] = `
+exports[`wonder-blocks-button example 18 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-button/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/__tests__/generated-snapshot.test.js
@@ -532,7 +532,9 @@ describe("wonder-blocks-button", () => {
     it("example 12", () => {
         const example = (
             <View>
-                <Button>Label</Button>
+                <form onSubmit={() => alert("the form was submitted")}>
+                    <Button type="submit">Submit</Button>
+                </form>
             </View>
         );
         const tree = renderer.create(example).toJSON();
@@ -540,6 +542,16 @@ describe("wonder-blocks-button", () => {
     });
 
     it("example 13", () => {
+        const example = (
+            <View>
+                <Button>Label</Button>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 14", () => {
         const styles = StyleSheet.create({
             column: {
                 alignItems: "flex-start",
@@ -569,7 +581,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 14", () => {
+    it("example 15", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -596,7 +608,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 15", () => {
+    it("example 16", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -624,7 +636,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 16", () => {
+    it("example 17", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -647,7 +659,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 17", () => {
+    it("example 18", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",

--- a/packages/wonder-blocks-button/components/__tests__/button.flowtest.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.flowtest.js
@@ -43,3 +43,11 @@ const getUrl = () => "/foo";
 // type being used to describe the props.  It's unclear why this error isn't
 // trigger by passing a string directly as the href.
 <Button href={getUrl()}>Hello, world!</Button>;
+
+// $ExpectError: type="submit" can't be used with href since we render an anchor.
+<Button href="/foo" type="submit">
+    Hello, world!
+</Button>;
+
+// type="submit" on its own is fine.
+<Button type="submit">Hello, world!</Button>;

--- a/packages/wonder-blocks-button/components/__tests__/button.test.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.test.js
@@ -778,4 +778,40 @@ describe("Button", () => {
             expect(window.location.assign).toHaveBeenCalledWith("/foo");
         });
     });
+
+    describe("type='submit'", () => {
+        test("submit button within form", () => {
+            // Arrange
+            const submitFnMock = jest.fn();
+            const wrapper = mount(
+                <form onSubmit={submitFnMock}>
+                    <Button type="submit">Click me!</Button>
+                </form>,
+            );
+
+            // Act
+            // NOTE: This isn't a very good test since we'd rather simulate a
+            // click.  We can't though since enzyme's 'simulate' method doesn't
+            // actually simulate events.  Instead it calls the matching event
+            // handler on the component instance itself.
+            wrapper.find("button").simulate("submit");
+
+            // Assert
+            expect(submitFnMock).toHaveBeenCalled();
+        });
+
+        test("clicking a submit button doesn't prevent default", () => {
+            // Arrange
+            const preventDefaultMock = jest.fn();
+            const wrapper = mount(<Button type="submit">Click me!</Button>);
+
+            // Act
+            wrapper
+                .find("button")
+                .simulate("click", {preventDefault: preventDefaultMock});
+
+            // Assert
+            expect(preventDefaultMock).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/wonder-blocks-button/components/__tests__/button.test.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.test.js
@@ -12,6 +12,12 @@ const wait = (delay: number = 0) =>
         return setTimeout(resolve, delay);
     });
 
+const keyCodes = {
+    tab: 9,
+    enter: 13,
+    space: 32,
+};
+
 describe("Button", () => {
     beforeEach(() => {
         unmountAll();
@@ -538,12 +544,6 @@ describe("Button", () => {
     });
 
     describe("client-side navigation with keyboard", () => {
-        const keyCodes = {
-            tab: 9,
-            enter: 13,
-            space: 32,
-        };
-
         it("should navigate on pressing the space key", () => {
             // Arrange
             const wrapper = mount(
@@ -780,7 +780,7 @@ describe("Button", () => {
     });
 
     describe("type='submit'", () => {
-        test("submit button within form", () => {
+        test("submit button within form via click", () => {
             // Arrange
             const submitFnMock = jest.fn();
             const wrapper = mount(
@@ -790,28 +790,31 @@ describe("Button", () => {
             );
 
             // Act
-            // NOTE: This isn't a very good test since we'd rather simulate a
-            // click.  We can't though since enzyme's 'simulate' method doesn't
-            // actually simulate events.  Instead it calls the matching event
-            // handler on the component instance itself.
-            wrapper.find("button").simulate("submit");
+            wrapper.find("button").simulate("click");
 
             // Assert
             expect(submitFnMock).toHaveBeenCalled();
         });
 
-        test("clicking a submit button doesn't prevent default", () => {
+        test("submit button within form via keyboard", () => {
             // Arrange
-            const preventDefaultMock = jest.fn();
-            const wrapper = mount(<Button type="submit">Click me!</Button>);
+            const submitFnMock = jest.fn();
+            const wrapper = mount(
+                <form onSubmit={submitFnMock}>
+                    <Button type="submit">Click me!</Button>
+                </form>,
+            );
 
             // Act
-            wrapper
-                .find("button")
-                .simulate("click", {preventDefault: preventDefaultMock});
+            wrapper.find("button").simulate("keydown", {
+                keyCode: keyCodes.enter,
+            });
+            wrapper.find("button").simulate("keyup", {
+                keyCode: keyCodes.enter,
+            });
 
             // Assert
-            expect(preventDefaultMock).not.toHaveBeenCalled();
+            expect(submitFnMock).toHaveBeenCalled();
         });
     });
 });

--- a/packages/wonder-blocks-button/components/__tests__/button.test.js
+++ b/packages/wonder-blocks-button/components/__tests__/button.test.js
@@ -816,5 +816,16 @@ describe("Button", () => {
             // Assert
             expect(submitFnMock).toHaveBeenCalled();
         });
+
+        test("submit button doesn't break if it's not in a form", () => {
+            // Arrange
+            const wrapper = mount(<Button type="submit">Click me!</Button>);
+
+            // Act
+            expect(() => {
+                // Assert
+                wrapper.find("button").simulate("click");
+            }).not.toThrow();
+        });
     });
 });

--- a/packages/wonder-blocks-button/components/button-core.js
+++ b/packages/wonder-blocks-button/components/button-core.js
@@ -25,6 +25,8 @@ type Props = {|
     ...SharedProps,
     ...ClickableHandlers,
     ...ClickableState,
+    href?: string,
+    type?: "submit",
 |};
 
 const StyledAnchor = addStyle<"a">("a");
@@ -42,13 +44,14 @@ export default class ButtonCore extends React.Component<Props> {
             disabled: disabledProp,
             focused,
             hovered,
-            href,
+            href = undefined,
             kind,
             light,
             pressed,
             size,
             style,
             testId,
+            type = undefined,
             spinner,
             icon,
             id,
@@ -159,7 +162,7 @@ export default class ButtonCore extends React.Component<Props> {
         } else {
             return (
                 <StyledButton
-                    type="button"
+                    type={type || "button"}
                     {...commonProps}
                     disabled={disabled}
                 >

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -312,6 +312,7 @@ export default class Button extends React.Component<Props> {
                 disabled={spinner || disabled}
                 href={href}
                 role="button"
+                type={type}
                 onClick={onClick}
                 beforeNav={beforeNav}
                 safeWithNav={safeWithNav}

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -80,11 +80,6 @@ export type SharedProps = {|
     testId?: string,
 
     /**
-     * URL to navigate to.
-     */
-    href?: string,
-
-    /**
      * Specifies the type of relationship between the current document and the
      * linked document. Should only be used when `href` is specified.
      */
@@ -174,6 +169,19 @@ export type SharedProps = {|
 type Props =
     | {|
           ...SharedProps,
+
+          /**
+           * URL to navigate to.
+           */
+          href?: string,
+      |}
+    | {|
+          ...SharedProps,
+
+          /**
+           * Used for buttons within <form>s.
+           */
+          type: "submit",
       |}
     | {|
           ...SharedProps,
@@ -256,7 +264,8 @@ export default class Button extends React.Component<Props> {
 
     render() {
         const {
-            href,
+            href = undefined,
+            type = undefined,
             children,
             skipClientNav,
             spinner,
@@ -287,6 +296,7 @@ export default class Button extends React.Component<Props> {
                     spinner={spinner || state.waiting}
                     skipClientNav={skipClientNav}
                     href={href}
+                    type={type}
                     // If tabIndex is provide to the component we allow
                     // it to override the tabIndex provide to use by
                     // ClickableBehavior.

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -571,6 +571,19 @@ const kinds = ["primary", "secondary", "tertiary"];
 </View>
 ```
 
+#### Example: "submit" buttons in forms
+
+```jsx
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+
+<View>
+    <form onSubmit={() => alert("the form was submitted")}>
+        <Button type="submit">Submit</Button>
+    </form>
+</View>
+```
+
 ### Best Practices
 
 In vertical layouts, buttons will stretch horizontally to fill the available

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -372,6 +372,7 @@ export default class ClickableBehavior extends React.Component<
             onClick = undefined,
             beforeNav = undefined,
             safeWithNav = undefined,
+            href,
         } = this.props;
         let shouldNavigate = true;
 
@@ -385,8 +386,11 @@ export default class ClickableBehavior extends React.Component<
             shouldNavigate = false;
         }
 
-        // Prevent navigation.
-        e.preventDefault();
+        // Prevent navigation, but only if `href` if set.  This is so that forms
+        // containing a Button with `type="submit"` will still work.
+        if (href) {
+            e.preventDefault();
+        }
 
         if (beforeNav) {
             this.setState({waiting: true});

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -72,6 +72,11 @@ type Props = {|
      */
     href?: string,
 
+    /**
+     * This should only be used by button.js.
+     */
+    type?: "submit",
+
     skipClientNav?: boolean,
 
     /**
@@ -373,8 +378,10 @@ export default class ClickableBehavior extends React.Component<
             beforeNav = undefined,
             safeWithNav = undefined,
             href,
+            type,
         } = this.props;
         let shouldNavigate = true;
+        let canSubmit = true;
 
         if (onClick) {
             onClick(e);
@@ -384,12 +391,24 @@ export default class ClickableBehavior extends React.Component<
         // navigate.
         if (e.defaultPrevented) {
             shouldNavigate = false;
+            canSubmit = false;
         }
 
-        // Prevent navigation, but only if `href` if set.  This is so that forms
-        // containing a Button with `type="submit"` will still work.
-        if (href) {
-            e.preventDefault();
+        e.preventDefault();
+
+        if (!href && type === "submit" && canSubmit) {
+            let target = e.currentTarget;
+            while (target) {
+                if (target instanceof window.HTMLFormElement) {
+                    const event = new window.Event("submit");
+                    target.dispatchEvent(event);
+                    break;
+                }
+                // All events should be typed as SyntheticEvent<HTMLElement>.
+                // Updating all of the places will take some time so I'll do
+                // this later - $FlowFixMe.
+                target = target.parentElement;
+            }
         }
 
         if (beforeNav) {


### PR DESCRIPTION
## Summary:
In the process of adding beforeNav and safeWithNav props, I added a call to e.preventDefault() in response to click, keyboard, and touch events. This unfortunately cause forms with submit buttons to stop working.

To fix the issue, if we're handling an event from a `Button` with `type="submit"` we'll look for ancestor element that's a `<form>` and if we find one we'll dispatch a `submit` event to it.

Issue: WB-1004

## Test plan:
- yarn test
- in styleguidist scroll to the "submit" button example
- click on "submit", see the alert message
- use the keyboard to nav to the "submit" button and press "enter", see the alert message, press "spacebar" and see the alert message

Reviewers: #fe-infra