### PR TITLE
WB-1012: Open links in a new tab if target="_blank" is set

### DIFF
--- a/consistency-tests/__tests__/clickables.test.js
+++ b/consistency-tests/__tests__/clickables.test.js
@@ -1,0 +1,63 @@
+// @flow
+/**
+ * There are a number of components that share common behaviors due to their
+ * use of ClickableBehavior.  It's not enough to test ClickableBehavior since
+ * each of the components has to connect things correctly.  This set of tests
+ * checks that the common behaviors exist on all of these components.
+ */
+import * as React from "react";
+
+import {ActionItem} from "@khanacademy/wonder-blocks-dropdown";
+import Button from "@khanacademy/wonder-blocks-button";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {icons} from "@khanacademy/wonder-blocks-icon";
+import Link from "@khanacademy/wonder-blocks-link";
+import {mount, unmountAll} from "../../utils/testing/mount.js";
+
+// We create a wrapper around Clickable since it expects a render function for
+// is children while all of the other components do not.
+const ClickableWrapper = (props: any) => {
+    const {children, ...restProps} = props;
+    return <Clickable {...restProps}>{(clickableState) => children}</Clickable>;
+};
+
+describe.each`
+    Component           | name            | extraProps
+    ${ActionItem}       | ${"ActionItem"} | ${{}}
+    ${Button}           | ${"Button"}     | ${{}}
+    ${ClickableWrapper} | ${"Clickable"}  | ${{}}
+    ${IconButton}       | ${"IconButton"} | ${{icon: icons.search}}
+    ${Link}             | ${"Link"}       | ${{}}
+`("$name", ({Component, name, extraProps}) => {
+    beforeEach(() => {
+        // Note: window.location.assign and window.open need mock functions in
+        // the testing environment.
+        window.location.assign = jest.fn();
+        window.open = jest.fn();
+        unmountAll();
+    });
+
+    afterEach(() => {
+        window.location.assign.mockClear();
+        window.open.mockClear();
+    });
+
+    it("opens a new tab when target='_blank'", () => {
+        const wrapper = mount(
+            <Component
+                href="https://www.khanacademy.org"
+                target="_blank"
+                {...extraProps}
+            >
+                Click me
+            </Component>,
+        );
+        wrapper.simulate("click");
+
+        expect(window.open).toHaveBeenCalledWith(
+            "https://www.khanacademy.org",
+            "_blank",
+        );
+    });
+});

--- a/consistency-tests/__tests__/clickables.test.js
+++ b/consistency-tests/__tests__/clickables.test.js
@@ -22,13 +22,17 @@ const ClickableWrapper = (props: any) => {
     return <Clickable {...restProps}>{(clickableState) => children}</Clickable>;
 };
 
+const IconButtonWrapper = (props: any) => (
+    <IconButton {...props} icon={icons.search} />
+);
+
 describe.each`
-    Component           | name            | extraProps
-    ${ActionItem}       | ${"ActionItem"} | ${{}}
-    ${Button}           | ${"Button"}     | ${{}}
-    ${ClickableWrapper} | ${"Clickable"}  | ${{}}
-    ${IconButton}       | ${"IconButton"} | ${{icon: icons.search}}
-    ${Link}             | ${"Link"}       | ${{}}
+    Component            | name
+    ${ActionItem}        | ${"ActionItem"}
+    ${Button}            | ${"Button"}
+    ${ClickableWrapper}  | ${"Clickable"}
+    ${IconButtonWrapper} | ${"IconButton"}
+    ${Link}              | ${"Link"}
 `("$name", ({Component, name, extraProps}) => {
     beforeEach(() => {
         // Note: window.location.assign and window.open need mock functions in

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -274,6 +274,7 @@ export default class Button extends React.Component<Props> {
             beforeNav = undefined,
             safeWithNav = undefined,
             tabIndex,
+            target,
             ...sharedButtonCoreProps
         } = this.props;
 
@@ -316,6 +317,7 @@ export default class Button extends React.Component<Props> {
                 onClick={onClick}
                 beforeNav={beforeNav}
                 safeWithNav={safeWithNav}
+                target={target}
             >
                 {renderProp}
             </ClickableBehavior>

--- a/packages/wonder-blocks-clickable/components/clickable.js
+++ b/packages/wonder-blocks-clickable/components/clickable.js
@@ -249,6 +249,7 @@ export default class Clickable extends React.Component<Props> {
             beforeNav = undefined,
             safeWithNav = undefined,
             style,
+            target,
             testId,
             onKeyDown,
             onKeyUp,
@@ -266,6 +267,7 @@ export default class Clickable extends React.Component<Props> {
                 onClick={onClick}
                 beforeNav={beforeNav}
                 safeWithNav={safeWithNav}
+                target={target}
                 onKeyDown={onKeyDown}
                 onKeyUp={onKeyUp}
             >

--- a/packages/wonder-blocks-core/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-core/components/__tests__/clickable-behavior.test.js
@@ -22,14 +22,16 @@ const wait = (delay: number = 0) =>
 
 describe("ClickableBehavior", () => {
     beforeEach(() => {
-        // Note: window.location.assign needs a mock function in the testing
-        // environment.
+        // Note: window.location.assign and window.open need mock functions in
+        // the testing environment.
         window.location.assign = jest.fn();
+        window.open = jest.fn();
         unmountAll();
     });
 
     afterEach(() => {
         window.location.assign.mockClear();
+        window.open.mockClear();
     });
 
     it("renders a label", () => {
@@ -1032,5 +1034,30 @@ describe("ClickableBehavior", () => {
             // Assert
             expect(wrapper).not.toIncludeText("Hello, world!");
         });
+    });
+
+    it("opens a new tab when target='_blank'", () => {
+        const link = mount(
+            <ClickableBehavior
+                disabled={false}
+                href="https://www.khanacademy.org"
+                role="link"
+                target="_blank"
+            >
+                {(state, handlers) => {
+                    return (
+                        <a href="https://www.khanacademy.org" {...handlers}>
+                            Label
+                        </a>
+                    );
+                }}
+            </ClickableBehavior>,
+        );
+        link.simulate("click");
+
+        expect(window.open).toHaveBeenCalledWith(
+            "https://www.khanacademy.org",
+            "_blank",
+        );
     });
 });

--- a/packages/wonder-blocks-core/components/clickable-behavior.js
+++ b/packages/wonder-blocks-core/components/clickable-behavior.js
@@ -73,6 +73,12 @@ type Props = {|
     href?: string,
 
     /**
+     * A target destination window for a link to open in. Should only be used
+     * when `href` is specified.
+     */
+    target?: string,
+
+    /**
      * This should only be used by button.js.
      */
     type?: "submit",
@@ -315,13 +321,17 @@ export default class ClickableBehavior extends React.Component<
 
     navigateOrReset(shouldNavigate: boolean) {
         if (shouldNavigate) {
-            const {history, href, skipClientNav} = this.props;
+            const {history, href, skipClientNav, target} = this.props;
             if (href) {
                 if (history && !skipClientNav) {
                     history.push(href);
                     this.setState({waiting: false});
                 } else {
-                    window.location.assign(href);
+                    if (target === "_blank") {
+                        window.open(href, "_blank");
+                    } else {
+                        window.location.assign(href);
+                    }
                     // We don't bother clearing the waiting state, the full page
                     // load navigation will do that for us by loading a new page.
                 }

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -141,6 +141,7 @@ export default class ActionItem extends React.Component<ActionProps> {
                 onClick={onClick}
                 href={href}
                 role={role}
+                target={target}
             >
                 {(state, handlers) => {
                     const {pressed, hovered, focused} = state;

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -188,6 +188,7 @@ export default class IconButton extends React.Component<SharedProps> {
             href,
             skipClientNav,
             tabIndex,
+            target,
             ...sharedProps
         } = this.props;
 
@@ -203,6 +204,7 @@ export default class IconButton extends React.Component<SharedProps> {
                 href={href}
                 onClick={onClick}
                 role="button"
+                target={target}
             >
                 {(state, {tabIndex: clickableTabIndex, ...handlers}) => {
                     return (

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -188,6 +188,7 @@ export default class Link extends React.Component<SharedProps> {
             tabIndex,
             onKeyDown,
             onKeyUp,
+            target,
             ...sharedProps
         } = this.props;
 
@@ -205,6 +206,7 @@ export default class Link extends React.Component<SharedProps> {
                 onClick={onClick}
                 beforeNav={beforeNav}
                 safeWithNav={safeWithNav}
+                target={target}
                 onKeyDown={onKeyDown}
                 onKeyUp={onKeyUp}
             >

--- a/wallaby.js
+++ b/wallaby.js
@@ -3,8 +3,9 @@ const babelConfig = require("./build-settings/babel.config.js");
 
 module.exports = function (wallaby) {
     const tests = [
-        "./packages/**/__tests__/*.test.js",
-        "./shared-unpackaged/**/*.test.js",
+        "packages/**/__tests__/*.test.js",
+        "shared-unpackaged/**/*.test.js",
+        "consistency-tests/__tests__/*.test.js",
     ];
 
     return {
@@ -13,8 +14,9 @@ module.exports = function (wallaby) {
         // Wallaby needs to know about all files that may be loaded because
         // of running a test.
         files: [
-            "./packages/**/*.js",
+            "packages/**/*.js",
             "shared-unpackaged/**/*.js",
+            "consistency-tests/**/*.js",
             "utils/**/*.js",
             {pattern: "config/jest/*.js", instrument: false},
 
@@ -34,6 +36,9 @@ module.exports = function (wallaby) {
         compilers: {
             "packages/**/*.js": wallaby.compilers.babel(babelConfig),
             "shared-unpackaged/**/*.js": wallaby.compilers.babel(babelConfig),
+            "consistency-tests/**/*.test.js": wallaby.compilers.babel(
+                babelConfig,
+            ),
             "utils/**/*.js": wallaby.compilers.babel(babelConfig),
         },
 


### PR DESCRIPTION
## Summary:
clickable-behavior.js does a lot of custom handling when a user activates a link.  When implementing this custom handling we forgot to re-implement the default browser behavior of opening links with target="_blank" in a new tab.  This PR re-implements that browser behavior.

Issue: WB-1012

## Test plan:
- yarn test
- edit one of the button examples in styleguidist to use target="_blank"
- click on it, see the link open in a new tab

Reviewers: #fe-infra