### PR TITLE
WB-1031: don't defer opening of a URL in a new tab

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     extends: ["@khanacademy"],
-    plugins: ["import", "promise", "monorepo"],
+    plugins: ["import", "jest", "promise", "monorepo"],
     settings: {
         react: {
             version: "detect",
@@ -37,6 +37,7 @@ module.exports = {
                 ignorePackages: true,
             },
         ],
+        "jest/no-focused-tests": "error",
         "promise/always-return": "error",
         "promise/no-return-wrap": "error",
         "promise/param-names": "error",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-import": "^2.20.0",
+    "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-monorepo": "^0.2.1",
     "eslint-plugin-prettier": "^3.1.3",

--- a/packages/wonder-blocks-button/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -2921,6 +2921,76 @@ exports[`wonder-blocks-button example 9 1`] = `
       Async action, server-side nav
     </span>
   </a>
+  <a
+    className=""
+    href="https://google.com"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    rel="noopener noreferrer"
+    role="button"
+    style={
+      Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "marginRight": 10,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+    target="_blank"
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "inline-block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      Async action, open URL in new tab
+    </span>
+  </a>
 </div>
 `;
 

--- a/packages/wonder-blocks-button/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/__tests__/generated-snapshot.test.js
@@ -440,6 +440,20 @@ describe("wonder-blocks-button", () => {
                     >
                         Async action, server-side nav
                     </Button>
+                    <Button
+                        href="https://google.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={styles.button}
+                        skipClientNav={true}
+                        beforeNav={() =>
+                            new Promise((resolve, reject) => {
+                                setTimeout(resolve, 1000);
+                            })
+                        }
+                    >
+                        Async action, open URL in new tab
+                    </Button>
                     <Switch>
                         <Route path="/foo">
                             <View id="foo">Hello, world!</View>

--- a/packages/wonder-blocks-button/components/button.js
+++ b/packages/wonder-blocks-button/components/button.js
@@ -102,7 +102,7 @@ export type SharedProps = {|
      * A target destination window for a link to open in. Should only be used
      * when `href` is specified.
      */
-    target?: string,
+    target?: "_blank",
 
     /**
      * Set the tabindex attribute on the rendered element.
@@ -309,19 +309,34 @@ export default class Button extends React.Component<Props> {
             );
         };
 
-        return (
-            <ClickableBehavior
-                disabled={spinner || disabled}
-                href={href}
-                role="button"
-                type={type}
-                onClick={onClick}
-                beforeNav={beforeNav}
-                safeWithNav={safeWithNav}
-                target={target}
-            >
-                {renderProp}
-            </ClickableBehavior>
-        );
+        if (beforeNav) {
+            return (
+                <ClickableBehavior
+                    disabled={spinner || disabled}
+                    href={href}
+                    role="button"
+                    type={type}
+                    onClick={onClick}
+                    beforeNav={beforeNav}
+                    safeWithNav={safeWithNav}
+                >
+                    {renderProp}
+                </ClickableBehavior>
+            );
+        } else {
+            return (
+                <ClickableBehavior
+                    disabled={spinner || disabled}
+                    href={href}
+                    role="button"
+                    type={type}
+                    onClick={onClick}
+                    safeWithNav={safeWithNav}
+                    target={target}
+                >
+                    {renderProp}
+                </ClickableBehavior>
+            );
+        }
     }
 }

--- a/packages/wonder-blocks-button/components/button.md
+++ b/packages/wonder-blocks-button/components/button.md
@@ -464,6 +464,18 @@ const styles = StyleSheet.create({
         >
             Async action, server-side nav
         </Button>
+        <Button
+            href="https://google.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={styles.button}
+            skipClientNav={true}
+            beforeNav={() => new Promise((resolve, reject) => {
+                setTimeout(resolve, 1000);
+            })}
+        >
+            Async action, open URL in new tab
+        </Button>
         <Switch>
             <Route path="/foo">
                 <View id="foo">Hello, world!</View>

--- a/packages/wonder-blocks-clickable/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-clickable/components/__tests__/clickable-behavior.test.js
@@ -1038,6 +1038,7 @@ describe("ClickableBehavior", () => {
 
     describe("target='_blank'", () => {
         it("opens a new tab", () => {
+            // Arrange
             const link = mount(
                 <ClickableBehavior
                     disabled={false}
@@ -1054,8 +1055,11 @@ describe("ClickableBehavior", () => {
                     }}
                 </ClickableBehavior>,
             );
+
+            // Act
             link.simulate("click");
 
+            // Assert
             expect(window.open).toHaveBeenCalledWith(
                 "https://www.khanacademy.org",
                 "_blank",
@@ -1063,13 +1067,15 @@ describe("ClickableBehavior", () => {
         });
 
         it("opens a new tab when using 'safeWithNav'", () => {
+            // Arrange
+            const safeWithNavMock = jest.fn().mockResolvedValue();
             const link = mount(
                 <ClickableBehavior
                     disabled={false}
                     href="https://www.khanacademy.org"
                     role="link"
                     target="_blank"
-                    safeWithNav={() => Promise.resolve()}
+                    safeWithNav={safeWithNavMock}
                 >
                     {(state, handlers) => {
                         return (
@@ -1080,15 +1086,47 @@ describe("ClickableBehavior", () => {
                     }}
                 </ClickableBehavior>,
             );
+
+            // Act
             link.simulate("click");
 
+            // Assert
             expect(window.open).toHaveBeenCalledWith(
                 "https://www.khanacademy.org",
                 "_blank",
             );
         });
 
+        it("calls 'safeWithNav'", () => {
+            // Arrange
+            const safeWithNavMock = jest.fn().mockResolvedValue();
+            const link = mount(
+                <ClickableBehavior
+                    disabled={false}
+                    href="https://www.khanacademy.org"
+                    role="link"
+                    target="_blank"
+                    safeWithNav={safeWithNavMock}
+                >
+                    {(state, handlers) => {
+                        return (
+                            <a href="https://www.khanacademy.org" {...handlers}>
+                                Label
+                            </a>
+                        );
+                    }}
+                </ClickableBehavior>,
+            );
+
+            // Act
+            link.simulate("click");
+
+            // Assert
+            expect(safeWithNavMock).toHaveBeenCalled();
+        });
+
         it("opens a new tab when inside a router", () => {
+            // Arrange
             const link = mount(
                 <MemoryRouter initialEntries={["/"]}>
                     <ClickableBehavior
@@ -1110,8 +1148,11 @@ describe("ClickableBehavior", () => {
                     </ClickableBehavior>
                 </MemoryRouter>,
             );
+
+            // Act
             link.simulate("click");
 
+            // Assert
             expect(window.open).toHaveBeenCalledWith(
                 "https://www.khanacademy.org",
                 "_blank",
@@ -1119,6 +1160,8 @@ describe("ClickableBehavior", () => {
         });
 
         it("opens a new tab when using 'safeWithNav' inside a router", () => {
+            // Arrange
+            const safeWithNavMock = jest.fn().mockResolvedValue();
             const link = mount(
                 <MemoryRouter initialEntries={["/"]}>
                     <ClickableBehavior
@@ -1126,7 +1169,7 @@ describe("ClickableBehavior", () => {
                         href="https://www.khanacademy.org"
                         role="link"
                         target="_blank"
-                        safeWithNav={() => Promise.resolve()}
+                        safeWithNav={safeWithNavMock}
                     >
                         {(state, handlers) => {
                             return (
@@ -1141,12 +1184,48 @@ describe("ClickableBehavior", () => {
                     </ClickableBehavior>
                 </MemoryRouter>,
             );
+
+            // Act
             link.simulate("click");
 
+            // Assert
             expect(window.open).toHaveBeenCalledWith(
                 "https://www.khanacademy.org",
                 "_blank",
             );
+        });
+
+        it("calls 'safeWithNav' inside a router", () => {
+            // Arrange
+            const safeWithNavMock = jest.fn().mockResolvedValue();
+            const link = mount(
+                <MemoryRouter initialEntries={["/"]}>
+                    <ClickableBehavior
+                        disabled={false}
+                        href="https://www.khanacademy.org"
+                        role="link"
+                        target="_blank"
+                        safeWithNav={safeWithNavMock}
+                    >
+                        {(state, handlers) => {
+                            return (
+                                <a
+                                    href="https://www.khanacademy.org"
+                                    {...handlers}
+                                >
+                                    Label
+                                </a>
+                            );
+                        }}
+                    </ClickableBehavior>
+                </MemoryRouter>,
+            );
+
+            // Act
+            link.simulate("click");
+
+            // Assert
+            expect(safeWithNavMock).toHaveBeenCalled();
         });
     });
 });

--- a/packages/wonder-blocks-clickable/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-clickable/components/__tests__/clickable-behavior.test.js
@@ -20,7 +20,7 @@ const wait = (delay: number = 0) =>
         return setTimeout(resolve, delay);
     });
 
-describe.only("ClickableBehavior", () => {
+describe("ClickableBehavior", () => {
     beforeEach(() => {
         // Note: window.location.assign and window.open need mock functions in
         // the testing environment.

--- a/packages/wonder-blocks-clickable/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-clickable/components/__tests__/clickable-behavior.test.js
@@ -20,7 +20,7 @@ const wait = (delay: number = 0) =>
         return setTimeout(resolve, delay);
     });
 
-describe("ClickableBehavior", () => {
+describe.only("ClickableBehavior", () => {
     beforeEach(() => {
         // Note: window.location.assign and window.open need mock functions in
         // the testing environment.
@@ -1036,28 +1036,117 @@ describe("ClickableBehavior", () => {
         });
     });
 
-    it("opens a new tab when target='_blank'", () => {
-        const link = mount(
-            <ClickableBehavior
-                disabled={false}
-                href="https://www.khanacademy.org"
-                role="link"
-                target="_blank"
-            >
-                {(state, handlers) => {
-                    return (
-                        <a href="https://www.khanacademy.org" {...handlers}>
-                            Label
-                        </a>
-                    );
-                }}
-            </ClickableBehavior>,
-        );
-        link.simulate("click");
+    describe("target='_blank'", () => {
+        it("opens a new tab", () => {
+            const link = mount(
+                <ClickableBehavior
+                    disabled={false}
+                    href="https://www.khanacademy.org"
+                    role="link"
+                    target="_blank"
+                >
+                    {(state, handlers) => {
+                        return (
+                            <a href="https://www.khanacademy.org" {...handlers}>
+                                Label
+                            </a>
+                        );
+                    }}
+                </ClickableBehavior>,
+            );
+            link.simulate("click");
 
-        expect(window.open).toHaveBeenCalledWith(
-            "https://www.khanacademy.org",
-            "_blank",
-        );
+            expect(window.open).toHaveBeenCalledWith(
+                "https://www.khanacademy.org",
+                "_blank",
+            );
+        });
+
+        it("opens a new tab when using 'safeWithNav'", () => {
+            const link = mount(
+                <ClickableBehavior
+                    disabled={false}
+                    href="https://www.khanacademy.org"
+                    role="link"
+                    target="_blank"
+                    safeWithNav={() => Promise.resolve()}
+                >
+                    {(state, handlers) => {
+                        return (
+                            <a href="https://www.khanacademy.org" {...handlers}>
+                                Label
+                            </a>
+                        );
+                    }}
+                </ClickableBehavior>,
+            );
+            link.simulate("click");
+
+            expect(window.open).toHaveBeenCalledWith(
+                "https://www.khanacademy.org",
+                "_blank",
+            );
+        });
+
+        it("opens a new tab when inside a router", () => {
+            const link = mount(
+                <MemoryRouter initialEntries={["/"]}>
+                    <ClickableBehavior
+                        disabled={false}
+                        href="https://www.khanacademy.org"
+                        role="link"
+                        target="_blank"
+                    >
+                        {(state, handlers) => {
+                            return (
+                                <a
+                                    href="https://www.khanacademy.org"
+                                    {...handlers}
+                                >
+                                    Label
+                                </a>
+                            );
+                        }}
+                    </ClickableBehavior>
+                </MemoryRouter>,
+            );
+            link.simulate("click");
+
+            expect(window.open).toHaveBeenCalledWith(
+                "https://www.khanacademy.org",
+                "_blank",
+            );
+        });
+
+        it("opens a new tab when using 'safeWithNav' inside a router", () => {
+            const link = mount(
+                <MemoryRouter initialEntries={["/"]}>
+                    <ClickableBehavior
+                        disabled={false}
+                        href="https://www.khanacademy.org"
+                        role="link"
+                        target="_blank"
+                        safeWithNav={() => Promise.resolve()}
+                    >
+                        {(state, handlers) => {
+                            return (
+                                <a
+                                    href="https://www.khanacademy.org"
+                                    {...handlers}
+                                >
+                                    Label
+                                </a>
+                            );
+                        }}
+                    </ClickableBehavior>
+                </MemoryRouter>,
+            );
+            link.simulate("click");
+
+            expect(window.open).toHaveBeenCalledWith(
+                "https://www.khanacademy.org",
+                "_blank",
+            );
+        });
     });
 });

--- a/packages/wonder-blocks-clickable/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/components/clickable-behavior.js
@@ -349,7 +349,7 @@ export default class ClickableBehavior extends React.Component<
     ) {
         const {skipClientNav, history} = this.props;
 
-        if (history && !skipClientNav) {
+        if ((history && !skipClientNav) || this.props.target === "_blank") {
             // client-side nav
             safeWithNav();
 
@@ -362,11 +362,6 @@ export default class ClickableBehavior extends React.Component<
                 // a full page load navigation since since the spinner is
                 // indicating that we're waiting for navigation to occur.
                 this.setState({waiting: true});
-            }
-
-            if (this.props.target === "_blank") {
-                this.navigateOrReset(shouldNavigate);
-                return;
             }
 
             return safeWithNav()

--- a/packages/wonder-blocks-clickable/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/components/clickable-behavior.js
@@ -96,6 +96,9 @@ type Props = {|
      *
      * If both safeWithNav and beforeNav are provided, beforeNav will be run
      * first and safeWithNav will only be run if beforeNav does not reject.
+     *
+     * WARNING: Using this with `target="_blank"` will trigger built-in popup
+     * blockers in Firefox and Safari.
      */
     beforeNav?: () => Promise<mixed>,
 

--- a/packages/wonder-blocks-clickable/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/components/clickable-behavior.js
@@ -323,15 +323,14 @@ export default class ClickableBehavior extends React.Component<
         if (shouldNavigate) {
             const {history, href, skipClientNav, target} = this.props;
             if (href) {
-                if (history && !skipClientNav) {
+                if (target === "_blank") {
+                    window.open(href, "_blank");
+                    this.setState({waiting: false});
+                } else if (history && !skipClientNav) {
                     history.push(href);
                     this.setState({waiting: false});
                 } else {
-                    if (target === "_blank") {
-                        window.open(href, "_blank");
-                    } else {
-                        window.location.assign(href);
-                    }
+                    window.location.assign(href);
                     // We don't bother clearing the waiting state, the full page
                     // load navigation will do that for us by loading a new page.
                 }
@@ -361,6 +360,12 @@ export default class ClickableBehavior extends React.Component<
                 // indicating that we're waiting for navigation to occur.
                 this.setState({waiting: true});
             }
+
+            if (this.props.target === "_blank") {
+                this.navigateOrReset(shouldNavigate);
+                return;
+            }
+
             return safeWithNav()
                 .then(() => {
                     if (!this.state.waiting) {

--- a/packages/wonder-blocks-clickable/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/components/clickable-behavior.js
@@ -170,7 +170,10 @@ type Props =
            * first and safeWithNav will only be run if beforeNav does not reject.
            *
            * WARNING: Using this with `target="_blank"` will trigger built-in popup
-           * blockers in Firefox and Safari.
+           * blockers in Firefox and Safari.  This is becuase we do navigation
+           * programmatically and `beforeNav` causes a delay which means that the
+           * browser can't make a directly link between a user action and the
+           * navigation.
            */
           beforeNav?: () => Promise<mixed>,
       |};

--- a/packages/wonder-blocks-clickable/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/components/clickable-behavior.js
@@ -170,7 +170,7 @@ type Props =
            * first and safeWithNav will only be run if beforeNav does not reject.
            *
            * WARNING: Using this with `target="_blank"` will trigger built-in popup
-           * blockers in Firefox and Safari.  This is becuase we do navigation
+           * blockers in Firefox and Safari.  This is because we do navigation
            * programmatically and `beforeNav` causes a delay which means that the
            * browser can't make a directly link between a user action and the
            * navigation.

--- a/packages/wonder-blocks-clickable/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/components/clickable-behavior.js
@@ -41,7 +41,7 @@ const getAppropriateTriggersForRole = (role: ?ClickableRole) => {
     }
 };
 
-type Props = {|
+type CommonProps = {|
     /**
      * A function that returns the a React `Element`.
      *
@@ -73,12 +73,6 @@ type Props = {|
     href?: string,
 
     /**
-     * A target destination window for a link to open in. Should only be used
-     * when `href` is specified.
-     */
-    target?: string,
-
-    /**
      * This should only be used by button.js.
      */
     type?: "submit",
@@ -89,18 +83,6 @@ type Props = {|
      * A function to be executed `onclick`.
      */
     onClick?: (e: SyntheticEvent<>) => mixed,
-
-    /**
-     * Run async code before navigating to the URL passed to `href`. If the
-     * promise returned rejects then navigation will not occur.
-     *
-     * If both safeWithNav and beforeNav are provided, beforeNav will be run
-     * first and safeWithNav will only be run if beforeNav does not reject.
-     *
-     * WARNING: Using this with `target="_blank"` will trigger built-in popup
-     * blockers in Firefox and Safari.
-     */
-    beforeNav?: () => Promise<mixed>,
 
     /**
      * Run async code in the background while client-side navigating. If the
@@ -166,6 +148,32 @@ export type ClickableState = {|
      */
     waiting: boolean,
 |};
+
+type Props =
+    | {|
+          ...CommonProps,
+
+          /**
+           * A target destination window for a link to open in. Should only be used
+           * when `href` is specified.
+           */
+          target?: "_blank",
+      |}
+    | {|
+          ...CommonProps,
+
+          /**
+           * Run async code before navigating to the URL passed to `href`. If the
+           * promise returned rejects then navigation will not occur.
+           *
+           * If both safeWithNav and beforeNav are provided, beforeNav will be run
+           * first and safeWithNav will only be run if beforeNav does not reject.
+           *
+           * WARNING: Using this with `target="_blank"` will trigger built-in popup
+           * blockers in Firefox and Safari.
+           */
+          beforeNav?: () => Promise<mixed>,
+      |};
 
 export type ClickableHandlers = {|
     onClick: (e: SyntheticMouseEvent<>) => mixed,
@@ -324,7 +332,12 @@ export default class ClickableBehavior extends React.Component<
 
     navigateOrReset(shouldNavigate: boolean) {
         if (shouldNavigate) {
-            const {history, href, skipClientNav, target} = this.props;
+            const {
+                history,
+                href,
+                skipClientNav,
+                target = undefined,
+            } = this.props;
             if (href) {
                 if (target === "_blank") {
                     window.open(href, "_blank");

--- a/packages/wonder-blocks-clickable/components/clickable.js
+++ b/packages/wonder-blocks-clickable/components/clickable.js
@@ -55,11 +55,6 @@ type CommonProps = {|
     id?: string,
 
     /**
-     * A target destination window for a link to open in.
-     */
-    target?: string,
-
-    /**
      * Specifies the type of relationship between the current document and the
      * linked document. Should only be used when `href` is specified.
      */
@@ -107,6 +102,11 @@ type CommonProps = {|
 type Props =
     | {|
           ...CommonProps,
+
+          /**
+           * A target destination window for a link to open in.
+           */
+          target?: "_blank",
       |}
     | {|
           ...CommonProps,
@@ -134,6 +134,11 @@ type Props =
            * navigation is guaranteed to succeed.
            */
           safeWithNav: () => Promise<mixed>,
+
+          /**
+           * A target destination window for a link to open in.
+           */
+          target?: "_blank",
       |}
     | {|
           ...CommonProps,
@@ -209,7 +214,7 @@ export default class Clickable extends React.Component<Props> {
                     {...commonProps}
                     to={this.props.href}
                     role={this.props.role}
-                    target={this.props.target}
+                    target={this.props.target || undefined}
                     aria-disabled={this.props.disabled ? "true" : undefined}
                 >
                     {this.props.children(clickableState)}
@@ -221,7 +226,7 @@ export default class Clickable extends React.Component<Props> {
                     {...commonProps}
                     href={this.props.href}
                     role={this.props.role}
-                    target={this.props.target}
+                    target={this.props.target || undefined}
                     aria-disabled={this.props.disabled ? "true" : undefined}
                 >
                     {this.props.children(clickableState)}
@@ -248,7 +253,7 @@ export default class Clickable extends React.Component<Props> {
             beforeNav = undefined,
             safeWithNav = undefined,
             style,
-            target,
+            target = undefined,
             testId,
             onKeyDown,
             onKeyUp,
@@ -260,26 +265,47 @@ export default class Clickable extends React.Component<Props> {
             this.context.router,
         );
 
-        return (
-            <ClickableBehavior
-                href={href}
-                onClick={onClick}
-                beforeNav={beforeNav}
-                safeWithNav={safeWithNav}
-                target={target}
-                onKeyDown={onKeyDown}
-                onKeyUp={onKeyUp}
-            >
-                {(state, handlers) =>
-                    this.getCorrectTag(state, {
-                        ...restProps,
-                        "data-test-id": testId,
-                        style: [styles.reset, style],
-                        ...handlers,
-                    })
-                }
-            </ClickableBehavior>
-        );
+        if (beforeNav) {
+            return (
+                <ClickableBehavior
+                    href={href}
+                    onClick={onClick}
+                    beforeNav={beforeNav}
+                    safeWithNav={safeWithNav}
+                    onKeyDown={onKeyDown}
+                    onKeyUp={onKeyUp}
+                >
+                    {(state, handlers) =>
+                        this.getCorrectTag(state, {
+                            ...restProps,
+                            "data-test-id": testId,
+                            style: [styles.reset, style],
+                            ...handlers,
+                        })
+                    }
+                </ClickableBehavior>
+            );
+        } else {
+            return (
+                <ClickableBehavior
+                    href={href}
+                    onClick={onClick}
+                    safeWithNav={safeWithNav}
+                    onKeyDown={onKeyDown}
+                    onKeyUp={onKeyUp}
+                    target={target}
+                >
+                    {(state, handlers) =>
+                        this.getCorrectTag(state, {
+                            ...restProps,
+                            "data-test-id": testId,
+                            style: [styles.reset, style],
+                            ...handlers,
+                        })
+                    }
+                </ClickableBehavior>
+            );
+        }
     }
 }
 

--- a/packages/wonder-blocks-dropdown/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/components/action-item.js
@@ -38,7 +38,7 @@ type ActionProps = {|
     /**
      * A target destination window for a link to open in.
      */
-    target?: string,
+    target?: "_blank",
 
     /**
      * Whether to avoid using client-side navigation.

--- a/packages/wonder-blocks-icon-button/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/components/icon-button.js
@@ -82,7 +82,7 @@ export type SharedProps = {|
     /**
      * A target destination window for a link to open in.
      */
-    target?: string,
+    target?: "_blank",
 
     /**
      * Specifies the type of relationship between the current document and the

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -130,6 +130,9 @@ export type SharedProps = {|
      *
      * If both safeWithNav and beforeNav are provided, beforeNav will be run
      * first and safeWithNav will only be run if beforeNav does not reject.
+     *
+     * WARNING: Using this with `target="_blank"` will trigger built-in popup
+     * blockers in Firefox and Safari.
      */
     beforeNav?: () => Promise<mixed>,
 

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -159,7 +159,7 @@ export type SharedProps =
            * first and safeWithNav will only be run if beforeNav does not reject.
            *
            * WARNING: Using this with `target="_blank"` will trigger built-in popup
-           * blockers in Firefox and Safari.  This is becuase we do navigation
+           * blockers in Firefox and Safari.  This is because we do navigation
            * programmatically and `beforeNav` causes a delay which means that the
            * browser can't make a directly link between a user action and the
            * navigation.

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -159,7 +159,10 @@ export type SharedProps =
            * first and safeWithNav will only be run if beforeNav does not reject.
            *
            * WARNING: Using this with `target="_blank"` will trigger built-in popup
-           * blockers in Firefox and Safari.
+           * blockers in Firefox and Safari.  This is becuase we do navigation
+           * programmatically and `beforeNav` causes a delay which means that the
+           * browser can't make a directly link between a user action and the
+           * navigation.
            */
           beforeNav?: () => Promise<mixed>,
       |};

--- a/packages/wonder-blocks-link/components/link.js
+++ b/packages/wonder-blocks-link/components/link.js
@@ -7,7 +7,7 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 import LinkCore from "./link-core.js";
 
-export type SharedProps = {|
+type CommonProps = {|
     ...AriaProps,
 
     /**
@@ -40,11 +40,6 @@ export type SharedProps = {|
      * secondary or primary (light) links are not allowed to be visitable.
      */
     visitable: boolean,
-
-    /**
-     * A target destination window for a link to open in.
-     */
-    target?: string,
 
     /**
      * Specifies the type of relationship between the current document and the
@@ -125,18 +120,6 @@ export type SharedProps = {|
     onClick?: (e: SyntheticEvent<>) => mixed,
 
     /**
-     * Run async code before navigating to the URL passed to `href`. If the
-     * promise returned rejects then navigation will not occur.
-     *
-     * If both safeWithNav and beforeNav are provided, beforeNav will be run
-     * first and safeWithNav will only be run if beforeNav does not reject.
-     *
-     * WARNING: Using this with `target="_blank"` will trigger built-in popup
-     * blockers in Firefox and Safari.
-     */
-    beforeNav?: () => Promise<mixed>,
-
-    /**
      * Run async code in the background while client-side navigating. If the
      * browser does a full page load navigation, the callback promise must be
      * settled before the navigation will occur. Errors are ignored so that
@@ -154,6 +137,32 @@ export type SharedProps = {|
      */
     onKeyUp?: (e: SyntheticKeyboardEvent<>) => mixed,
 |};
+
+export type SharedProps =
+    | {|
+          ...CommonProps,
+
+          /**
+           * A target destination window for a link to open in.  We only support
+           * "_blank" which opens the URL in a new tab.
+           */
+          target?: "_blank",
+      |}
+    | {|
+          ...CommonProps,
+
+          /**
+           * Run async code before navigating to the URL passed to `href`. If the
+           * promise returned rejects then navigation will not occur.
+           *
+           * If both safeWithNav and beforeNav are provided, beforeNav will be run
+           * first and safeWithNav will only be run if beforeNav does not reject.
+           *
+           * WARNING: Using this with `target="_blank"` will trigger built-in popup
+           * blockers in Firefox and Safari.
+           */
+          beforeNav?: () => Promise<mixed>,
+      |};
 
 /**
  * Reusable link component.
@@ -183,7 +192,7 @@ export default class Link extends React.Component<SharedProps> {
     render() {
         const {
             onClick,
-            beforeNav,
+            beforeNav = undefined,
             safeWithNav,
             href,
             skipClientNav,
@@ -191,7 +200,7 @@ export default class Link extends React.Component<SharedProps> {
             tabIndex,
             onKeyDown,
             onKeyUp,
-            target,
+            target = undefined,
             ...sharedProps
         } = this.props;
 
@@ -201,37 +210,70 @@ export default class Link extends React.Component<SharedProps> {
             this.context.router,
         );
 
-        return (
-            <ClickableBehavior
-                disabled={false}
-                href={href}
-                role="link"
-                onClick={onClick}
-                beforeNav={beforeNav}
-                safeWithNav={safeWithNav}
-                target={target}
-                onKeyDown={onKeyDown}
-                onKeyUp={onKeyUp}
-            >
-                {(state, {tabIndex: clickableTabIndex, ...handlers}) => {
-                    return (
-                        <LinkCore
-                            {...sharedProps}
-                            {...state}
-                            {...handlers}
-                            skipClientNav={skipClientNav}
-                            href={href}
-                            target={target}
-                            // If tabIndex is provide to the component we allow
-                            // it to override the tabIndex provide to use by
-                            // ClickableBehavior.
-                            tabIndex={tabIndex || clickableTabIndex}
-                        >
-                            {children}
-                        </LinkCore>
-                    );
-                }}
-            </ClickableBehavior>
-        );
+        if (beforeNav) {
+            return (
+                <ClickableBehavior
+                    disabled={false}
+                    href={href}
+                    role="link"
+                    onClick={onClick}
+                    beforeNav={beforeNav}
+                    safeWithNav={safeWithNav}
+                    onKeyDown={onKeyDown}
+                    onKeyUp={onKeyUp}
+                >
+                    {(state, {tabIndex: clickableTabIndex, ...handlers}) => {
+                        return (
+                            <LinkCore
+                                {...sharedProps}
+                                {...state}
+                                {...handlers}
+                                skipClientNav={skipClientNav}
+                                href={href}
+                                target={target}
+                                // If tabIndex is provide to the component we allow
+                                // it to override the tabIndex provide to use by
+                                // ClickableBehavior.
+                                tabIndex={tabIndex || clickableTabIndex}
+                            >
+                                {children}
+                            </LinkCore>
+                        );
+                    }}
+                </ClickableBehavior>
+            );
+        } else {
+            return (
+                <ClickableBehavior
+                    disabled={false}
+                    href={href}
+                    role="link"
+                    onClick={onClick}
+                    safeWithNav={safeWithNav}
+                    target={target}
+                    onKeyDown={onKeyDown}
+                    onKeyUp={onKeyUp}
+                >
+                    {(state, {tabIndex: clickableTabIndex, ...handlers}) => {
+                        return (
+                            <LinkCore
+                                {...sharedProps}
+                                {...state}
+                                {...handlers}
+                                skipClientNav={skipClientNav}
+                                href={href}
+                                target={target}
+                                // If tabIndex is provide to the component we allow
+                                // it to override the tabIndex provide to use by
+                                // ClickableBehavior.
+                                tabIndex={tabIndex || clickableTabIndex}
+                            >
+                                {children}
+                            </LinkCore>
+                        );
+                    }}
+                </ClickableBehavior>
+            );
+        }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2654,6 +2654,19 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nodelib/fs.scandir@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
+  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.4"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
+  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+
 "@nodelib/fs.stat@^1.0.1":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
@@ -2662,6 +2675,14 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
+  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.4"
+    fastq "^1.6.0"
 
 "@octokit/endpoint@^5.1.0":
   version "5.4.0"
@@ -3352,6 +3373,11 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@^7.0.3":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -3504,6 +3530,53 @@
   integrity sha512-sYlwNU7zYi6eZbMzFvG6eHD7VsEvFdoDtlD7eI1JTg7YNnuguzmiGsc6MPSq5l8n+h21AsNof0je+9sgOe4+dg==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.2.tgz#9df35049d1d36b6cbaba534d703648b9e1f05cbb"
+  integrity sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.14.2"
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/typescript-estree" "4.14.2"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/scope-manager@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.2.tgz#64cbc9ca64b60069aae0c060b2bf81163243b266"
+  integrity sha512-cuV9wMrzKm6yIuV48aTPfIeqErt5xceTheAgk70N1V4/2Ecj+fhl34iro/vIssJlb7XtzcaD07hWk7Jk0nKghg==
+  dependencies:
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/visitor-keys" "4.14.2"
+
+"@typescript-eslint/types@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.2.tgz#d96da62be22dc9dc6a06647f3633815350fb3174"
+  integrity sha512-LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==
+
+"@typescript-eslint/typescript-estree@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.2.tgz#9c5ebd8cae4d7b014f890acd81e8e17f309c9df9"
+  integrity sha512-ESiFl8afXxt1dNj8ENEZT12p+jl9PqRur+Y19m0Z/SPikGL6rqq4e7Me60SU9a2M28uz48/8yct97VQYaGl0Vg==
+  dependencies:
+    "@typescript-eslint/types" "4.14.2"
+    "@typescript-eslint/visitor-keys" "4.14.2"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.2.tgz#997cbe2cb0690e1f384a833f64794e98727c70c6"
+  integrity sha512-KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==
+  dependencies:
+    "@typescript-eslint/types" "4.14.2"
+    eslint-visitor-keys "^2.0.0"
 
 "@vxna/mini-html-webpack-template@^1.0.0":
   version "1.0.0"
@@ -6900,6 +6973,13 @@ dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
@@ -7559,6 +7639,13 @@ eslint-plugin-import@^2.20.0:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
+eslint-plugin-jest@^24.1.3:
+  version "24.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz#fa3db864f06c5623ff43485ca6c0e8fc5fe8ba0c"
+  integrity sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^4.0.1"
+
 eslint-plugin-jsx-a11y@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz#b872a09d5de51af70a97db1eea7dc933043708aa"
@@ -7644,10 +7731,22 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint-watch@^6.0.1:
   version "6.0.1"
@@ -8072,6 +8171,18 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
+fast-glob@^3.1.1:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-parse@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
@@ -8089,6 +8200,13 @@ fast-safe-stringify@^1.0.8, fast-safe-stringify@^1.2.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz#9fe22c37fb2f7f86f06b8f004377dbf8f1ee7bc1"
   integrity sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw==
+
+fastq@^1.6.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.10.1.tgz#8b8f2ac8bf3632d67afcd65dac248d5fdc45385e"
+  integrity sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==
+  dependencies:
+    reusify "^1.0.4"
 
 fault@^1.0.0, fault@^1.0.1, fault@^1.0.2:
   version "1.0.3"
@@ -8783,6 +8901,13 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -8893,6 +9018,18 @@ globby@8.0.2:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+globby@^11.0.1:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
+  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
 globby@^6.1.0:
   version "6.1.0"
@@ -11844,6 +11981,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -12127,6 +12271,11 @@ merge2@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -15497,6 +15646,11 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2, rimraf@^2.2.8, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -15574,6 +15728,11 @@ run-async@^2.2.0, run-async@^2.4.0:
   integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
   dependencies:
     is-promise "^2.1.0"
+
+run-parallel@^1.1.9:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
+  integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -15754,6 +15913,13 @@ semver@^7.1.3:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.2:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -17238,6 +17404,11 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.5.tgz#840e0739c89fce5f3abd9037bb091dbff16d9dec"
   integrity sha512-ti7OGMOUOzo66wLF3liskw6YQIaSsBgc4GOAlWRnIEj8htCxJUxskanMUoJOD6MDCRAXo36goXJZch+nOS0VMA==
 
+tslib@^1.8.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.9.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
@@ -17246,6 +17417,13 @@ tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.17.1:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.20.0.tgz#ea03ea45462e146b53d70ce0893de453ff24f698"
+  integrity sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
## Summary:
We were deferring the opening of a new URL in a new tab and this was trigger the action to be block by popup blockers built into some browsers (Safari and Firefox).  Deferring navigation is necessary if the navigation is happening in the same tab, but in this case it isn't.  The originating tab is staying around so it can do whatever it needs to do in 'safeWithNav' **while** the other tab opens.

NOTE: using "target='_blank'" with 'beforeNav' won't work and should be disallowed.

Issue: WB-1031

## Test plan:
- run unit tests
- yarn start, open localhost:6060 in Safari or Firefox
- click on the new "Async action, open URL in new tab" button, see that it opens Google in a new tab