### PR TITLE
FEI-3316: Make dispatched 'submit' events cancelable

### DIFF
--- a/packages/wonder-blocks-button/components/button.stories.js
+++ b/packages/wonder-blocks-button/components/button.stories.js
@@ -247,3 +247,29 @@ export const buttonWithSpinner: React.ComponentType<Empty> = () => (
         </Button>
     </View>
 );
+
+export const submitButtonInForm: React.ComponentType<Empty> = () => (
+    <form
+        onSubmit={(e) => {
+            e.preventDefault();
+            window.alert("form submitted"); // eslint-disable-line no-alert
+        }}
+    >
+        <View>
+            Foo: <input id="foo" value="bar" />
+            <Button type="submit">Submit</Button>
+        </View>
+    </form>
+);
+
+submitButtonInForm.story = {
+    parameters: {
+        options: {
+            showAddonPanel: true,
+        },
+        chromatic: {
+            // We already have screenshots of other stories that cover more of the button states
+            disable: true,
+        },
+    },
+};

--- a/packages/wonder-blocks-clickable/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/components/clickable-behavior.js
@@ -445,7 +445,13 @@ export default class ClickableBehavior extends React.Component<
             let target = e.currentTarget;
             while (target) {
                 if (target instanceof window.HTMLFormElement) {
-                    const event = new window.Event("submit");
+                    // This event must be marked as cancelable otherwise calling
+                    // e.preventDefault() on it won't do anything in Firefox.
+                    // Chrome and Safari allow calling e.preventDefault() on
+                    // non-cancelable events, but really they shouldn't.
+                    const event = new window.Event("submit", {
+                        cancelable: true,
+                    });
                     target.dispatchEvent(event);
                     break;
                 }


### PR DESCRIPTION
## Summary:
This was causing login forms to redirect to the LOHP without logging users in when using Firefox.  This issue arose because of a recent change in webapp to use forms properly.

In wonder-blocks we do a bunch of custom handling of events which involves calling 'preventDefault' on the user generated events.  Normally the browser would generate 'submit' events for us, but we have to do it ourselves in wonder-blocks because of this custom handling.

In webapp we need to call 'preventDefault' on the generate 'submit' event as part of the login flow.  Firefox does not support calling 'preventDefault' on non-cancelable events (which is what we were generating).  Safari and Chrome allow this but this may change in the future.

This PR fixes the issue by making the 'submit' event we generate cancelable.

Issue: FEI-3316

## Test plan:
- yarn clean
- yarn start-storybook
- open the "Submit Button in Form" story in Firefox
- submit the form by pressing "enter" when the cursor is in the textfield, see that the story doesn't reload
- submit the form by pressing "spacebar" when the cursor is on the button, see that the story doesn't reload
- submit the form by clicking the "submit" button, see that the story doesn't reload