### PR TITLE
Fix flow errors that only manifest in webapp

### DIFF
--- a/packages/wonder-blocks-clickable/util/get-clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/util/get-clickable-behavior.js
@@ -34,6 +34,8 @@ export default function getClickableBehavior(
     if (router && skipClientNav !== true && href && !isExternalUrl(href)) {
         // We cast to `any` here since the type of ClickableBehaviorWithRouter
         // is slightly different from the return type of this function.
+        // TODO(WB-1037): Always return the wrapped version once all routes have
+        // been ported to the app-shell in webapp.
         return (ClickableBehaviorWithRouter: any);
     }
 

--- a/packages/wonder-blocks-clickable/util/get-clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/util/get-clickable-behavior.js
@@ -32,7 +32,9 @@ export default function getClickableBehavior(
     router?: any,
 ): React.ComponentType<React.ElementConfig<typeof ClickableBehavior>> {
     if (router && skipClientNav !== true && href && !isExternalUrl(href)) {
-        return ClickableBehaviorWithRouter;
+        // We cast to `any` here since the type of ClickableBehaviorWithRouter
+        // is slightly different from the return type of this function.
+        return (ClickableBehaviorWithRouter: any);
     }
 
     return ClickableBehavior;

--- a/packages/wonder-blocks-dropdown/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/components/dropdown-core.js
@@ -813,7 +813,9 @@ const styles = StyleSheet.create({
     },
 });
 
-type ExportProps = WithoutActionScheduler<React.ElementConfig<DropdownCore>>;
+type ExportProps = WithoutActionScheduler<
+    React.ElementConfig<typeof DropdownCore>,
+>;
 
 export default (withActionScheduler(
     DropdownCore,


### PR DESCRIPTION
## Summary:
There were a couple of flow errors that appear in webapp in the node_modules after upgrading the wonder-blocks deps there.  I made the changes in this PR directly within node_modules are restarted to flow to make sure things were working as expected before backporting them here.

Issue: none

## Test plan:
- yarn flow