### PR TITLE
Roll back flow-related change and comment why

### DIFF
--- a/packages/wonder-blocks-data/components/data.js
+++ b/packages/wonder-blocks-data/components/data.js
@@ -140,19 +140,20 @@ export default class Data<TOptions, TData: ValidData> extends React.Component<
                     /**
                      * Need to share our types with InternalData so Flow
                      * doesn't need to infer them and find mismatches.
+                     * However, just deriving a new component creates issues
+                     * where InternalData starts rerendering too often.
+                     * Couldn't track down why, so suppressing the error
+                     * instead.
                      */
-                    class TypedInternalData extends InternalData<
-                        TOptions,
-                        TData,
-                    > {}
                     return (
-                        <TypedInternalData
+                        <InternalData
+                            // $FlowIgnore[incompatible-type-arg]
                             handler={handler}
                             options={this.props.options}
                             getEntry={getEntry}
                         >
                             {(result) => this.props.children(result)}
-                        </TypedInternalData>
+                        </InternalData>
                     );
                 }}
             </InterceptContext.Consumer>


### PR DESCRIPTION
## Summary:
Having this wrapper component was causing the children of InternalData to render
more than we wanted. I was unable to easily prevent it from doing so. So, instead
I removed the extra component and addressed the flow error with a suppression.

Issue: FEI-3327

## Test plan:
1. `yarn build:all`
2. copy contents of packages/wonder-blocks-data to webapp's node_modules
3. Exit `javascript/data-access/with-content-data_test.js` in webapp to remove `forceStatic:true`
4. Run `yarn test javascript/data-access/with-content-data_test.js`
