### PR TITLE
Experiment: refactor conditional props

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,5 +79,8 @@ module.exports = {
                 ],
             },
         ],
+
+        // customization of rules
+        "react/prop-types": "off", // we let Flow/TS keep track of valid props
     },
 };

--- a/packages/wonder-blocks-button/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -2937,6 +2937,7 @@ exports[`wonder-blocks-button example 9 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    rel="noopener noreferrer"
     role="button"
     style={
       Object {

--- a/packages/wonder-blocks-button/src/components/__tests__/button.flowtest.js
+++ b/packages/wonder-blocks-button/src/components/__tests__/button.flowtest.js
@@ -36,12 +36,13 @@ import Button from "../button.js";
 // It's also fine to use href by itself
 <Button href="/foo">Hello, world!</Button>;
 
-const getUrl = () => "/foo";
+const getUrl: () => string = () => "/foo";
 
 // This test purposefully uses a function to get a string to pass with href.
 // This can trigger errors if there are ambiguous cases in the disjoint union
 // type being used to describe the props.  It's unclear why this error isn't
 // trigger by passing a string directly as the href.
+// $FlowFixMe[speculation-ambiguous]: this error will go after migrating to TypeScript
 <Button href={getUrl()}>Hello, world!</Button>;
 
 // $FlowExpectedError[incompatible-type]: type="submit" can't be used with href since we render an anchor.

--- a/packages/wonder-blocks-button/src/components/button-core.js
+++ b/packages/wonder-blocks-button/src/components/button-core.js
@@ -27,6 +27,7 @@ type Props = {|
     ...ClickableState,
     href?: string,
     type?: "submit",
+    target?: "_blank",
 |};
 
 type ContextTypes = {|

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
@@ -62,22 +62,6 @@ type CommonProps = {|
     disabled: boolean,
 
     /**
-     * A URL.
-     *
-     * If specified, clicking on the component will navigate to the location
-     * provided.
-     * For keyboard navigation, the default is that both an enter and space
-     * press would also navigate to this location. See the triggerOnEnter and
-     * triggerOnSpace props for more details.
-     */
-    href?: string,
-
-    /**
-     * This should only be used by button.js.
-     */
-    type?: "submit",
-
-    /**
      * Specifies the type of relationship between the current document and the
      * linked document. Should only be used when `href` is specified. This
      * defaults to "noopener noreferrer" when `target="_blank"`, but can be
@@ -91,14 +75,6 @@ type CommonProps = {|
      * A function to be executed `onclick`.
      */
     onClick?: (e: SyntheticEvent<>) => mixed,
-
-    /**
-     * Run async code in the background while client-side navigating. If the
-     * browser does a full page load navigation, the callback promise must be
-     * settled before the navigation will occur. Errors are ignored so that
-     * navigation is guaranteed to succeed.
-     */
-    safeWithNav?: () => Promise<mixed>,
 
     /**
      * Passed in by withRouter HOC.
@@ -157,18 +133,24 @@ export type ClickableState = {|
     waiting: boolean,
 |};
 
-type Props =
+type ConditionaProps =
     | {|
-          ...CommonProps,
+          /**
+           * A URL.
+           *
+           * If specified, clicking on the component will navigate to the location
+           * provided.
+           * For keyboard navigation, the default is that both an enter and space
+           * press would also navigate to this location. See the triggerOnEnter and
+           * triggerOnSpace props for more details.
+           */
+          href: string,
 
           /**
            * A target destination window for a link to open in. Should only be used
            * when `href` is specified.
            */
           target?: "_blank",
-      |}
-    | {|
-          ...CommonProps,
 
           /**
            * Run async code before navigating to the URL passed to `href`. If the
@@ -184,7 +166,33 @@ type Props =
            * navigation.
            */
           beforeNav?: () => Promise<mixed>,
+
+          /**
+           * Run async code in the background while client-side navigating. If the
+           * browser does a full page load navigation, the callback promise must be
+           * settled before the navigation will occur. Errors are ignored so that
+           * navigation is guaranteed to succeed.
+           */
+          safeWithNav?: () => Promise<mixed>,
+
+          type?: empty,
+      |}
+    | {|
+          /**
+           * This should only be used by button.js.
+           */
+          type?: "submit",
+
+          href?: empty,
+          target?: empty,
+          beforeNav?: empty,
+          safeWithNav?: empty,
       |};
+
+type Props = {|
+    ...CommonProps,
+    ...ConditionaProps,
+|};
 
 type DefaultProps = {|
     disabled: $PropertyType<Props, "disabled">,
@@ -351,12 +359,7 @@ export default class ClickableBehavior extends React.Component<
 
     navigateOrReset(shouldNavigate: boolean) {
         if (shouldNavigate) {
-            const {
-                history,
-                href,
-                skipClientNav,
-                target = undefined,
-            } = this.props;
+            const {history, href, skipClientNav, target} = this.props;
             if (href) {
                 if (target === "_blank") {
                     window.open(href, "_blank");

--- a/packages/wonder-blocks-clickable/src/components/clickable.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.js
@@ -32,12 +32,6 @@ type CommonProps = {|
     onClick?: (e: SyntheticEvent<>) => mixed,
 
     /**
-     * Optinal href which Clickable should direct to, uses client-side routing
-     * by default if react-router is present
-     */
-    href?: string,
-
-    /**
      * Styles to apply to the Clickable compoenent
      */
     style?: StyleType,
@@ -56,14 +50,6 @@ type CommonProps = {|
      * An optional id attribute.
      */
     id?: string,
-
-    /**
-     * Specifies the type of relationship between the current document and the
-     * linked document. Should only be used when `href` is specified. This
-     * defaults to "noopener noreferrer" when `target="_blank"`, but can be
-     * overridden by setting this prop to something else.
-     */
-    rel?: string,
 
     /**
      * The role of the component, can be a role of type ClickableRole
@@ -97,19 +83,26 @@ type CommonProps = {|
     hideDefaultFocusRing?: boolean,
 |};
 
-type Props =
+type ConditionalProps =
     | {|
-          ...CommonProps,
+          /**
+           * Optinal href which Clickable should direct to, uses client-side routing
+           * by default if react-router is present
+           */
+          href: string,
 
           /**
            * A target destination window for a link to open in.
            */
           target?: "_blank",
-      |}
-    | {|
-          ...CommonProps,
 
-          href: string,
+          /**
+           * Specifies the type of relationship between the current document and the
+           * linked document. Should only be used when `href` is specified. This
+           * defaults to "noopener noreferrer" when `target="_blank"`, but can be
+           * overridden by setting this prop to something else.
+           */
+          rel?: string,
 
           /**
            * Run async code before navigating. If the promise returned rejects then
@@ -118,12 +111,7 @@ type Props =
            * If both safeWithNav and beforeNav are provided, beforeNav will be run
            * first and safeWithNav will only be run if beforeNav does not reject.
            */
-          beforeNav: () => Promise<mixed>,
-      |}
-    | {|
-          ...CommonProps,
-
-          href: string,
+          beforeNav?: () => Promise<mixed>,
 
           /**
            * Run async code in the background while client-side navigating. If the
@@ -131,35 +119,19 @@ type Props =
            * settled before the navigation will occur. Errors are ignored so that
            * navigation is guaranteed to succeed.
            */
-          safeWithNav: () => Promise<mixed>,
-
-          /**
-           * A target destination window for a link to open in.
-           */
-          target?: "_blank",
+          safeWithNav?: () => Promise<mixed>,
       |}
     | {|
-          ...CommonProps,
-
-          href: string,
-
-          /**
-           * Run async code before navigating. If the promise returned rejects then
-           * navigation will not occur.
-           *
-           * If both safeWithNav and beforeNav are provided, beforeNav will be run
-           * first and safeWithNav will only be run if beforeNav does not reject.
-           */
-          beforeNav: () => Promise<mixed>,
-
-          /**
-           * Run async code in the background while client-side navigating. If the
-           * browser does a full page load navigation, the callback promise must be
-           * settled before the navigation will occur. Errors are ignored so that
-           * navigation is guaranteed to succeed.
-           */
-          safeWithNav: () => Promise<mixed>,
+          href?: empty,
+          target?: empty,
+          beforeNav?: empty,
+          safeWithNav?: empty,
       |};
+
+type Props = {|
+    ...CommonProps,
+    ...ConditionalProps,
+|};
 
 type ContextTypes = {|
     router: $FlowFixMe,
@@ -280,10 +252,12 @@ export default class Clickable extends React.Component<Props> {
             style,
         ];
 
-        if (beforeNav) {
+        if (href) {
             return (
                 <ClickableBehavior
-                    href={href}
+                    // TODO: remove annotation after migrating to TypeScript
+                    href={(href: string)}
+                    target={target}
                     onClick={onClick}
                     beforeNav={beforeNav}
                     safeWithNav={safeWithNav}
@@ -303,12 +277,9 @@ export default class Clickable extends React.Component<Props> {
         } else {
             return (
                 <ClickableBehavior
-                    href={href}
                     onClick={onClick}
-                    safeWithNav={safeWithNav}
                     onKeyDown={onKeyDown}
                     onKeyUp={onKeyUp}
-                    target={target}
                 >
                     {(state, childrenProps) =>
                         this.getCorrectTag(state, {

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -15,7 +15,11 @@ import InterceptCache from "../intercept-cache.js";
 import InterceptData from "../intercept-data.js";
 import Data from "../data.js";
 
-import type {IRequestHandler} from "../../util/types.js";
+import type {
+    IRequestHandler,
+    InterceptFulfillRequestFn,
+    InterceptShouldRefreshCacheFn,
+} from "../../util/types.js";
 
 describe("Data", () => {
     beforeEach(() => {
@@ -851,10 +855,14 @@ describe("Data", () => {
                         cache: null,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
-                    const shouldRefreshCacheFn = jest.fn(() => true);
-                    const fulfillRequestFn = jest.fn(() =>
-                        Promise.resolve("DATA!"),
-                    );
+                    const shouldRefreshCacheFn: InterceptShouldRefreshCacheFn<
+                        string,
+                        string,
+                    > = jest.fn(() => true);
+                    const fulfillRequestFn: InterceptFulfillRequestFn<
+                        string,
+                        string,
+                    > = jest.fn(() => Promise.resolve("DATA!"));
 
                     // Act
                     mount(

--- a/packages/wonder-blocks-data/src/components/__tests__/intercept-cache.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/intercept-cache.test.js
@@ -6,7 +6,11 @@ import InterceptContext from "../intercept-context.js";
 import InterceptData from "../intercept-data.js";
 import InterceptCache from "../intercept-cache.js";
 
-import type {IRequestHandler} from "../../util/types.js";
+import type {
+    IRequestHandler,
+    InterceptFulfillRequestFn,
+    InterceptShouldRefreshCacheFn,
+} from "../../util/types.js";
 
 describe("InterceptCache", () => {
     afterEach(() => {
@@ -88,8 +92,14 @@ describe("InterceptCache", () => {
             type: "MY_HANDLER",
             cache: null,
         };
-        const fulfillRequestFn = jest.fn();
-        const shouldRefreshCacheFn = jest.fn();
+        const fulfillRequestFn: InterceptFulfillRequestFn<
+            string,
+            string,
+        > = jest.fn();
+        const shouldRefreshCacheFn: InterceptShouldRefreshCacheFn<
+            string,
+            string,
+        > = jest.fn();
         const getEntryFn = jest.fn();
         const captureContextFn = jest.fn();
 

--- a/packages/wonder-blocks-data/src/components/__tests__/intercept-data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/intercept-data.test.js
@@ -6,7 +6,11 @@ import InterceptContext from "../intercept-context.js";
 import InterceptData from "../intercept-data.js";
 import InterceptCache from "../intercept-cache.js";
 
-import type {IRequestHandler} from "../../util/types.js";
+import type {
+    IRequestHandler,
+    InterceptFulfillRequestFn,
+    InterceptShouldRefreshCacheFn,
+} from "../../util/types.js";
 
 describe("InterceptData", () => {
     afterEach(() => {
@@ -65,10 +69,22 @@ describe("InterceptData", () => {
             type: "MY_HANDLER",
             cache: null,
         };
-        const fulfillRequest1Fn = jest.fn();
-        const shouldRefreshCache1Fn = jest.fn();
-        const fulfillRequest2Fn = jest.fn();
-        const shouldRefreshCache2Fn = jest.fn();
+        const fulfillRequest1Fn: InterceptFulfillRequestFn<
+            string,
+            string,
+        > = jest.fn();
+        const shouldRefreshCache1Fn: InterceptShouldRefreshCacheFn<
+            string,
+            string,
+        > = jest.fn();
+        const fulfillRequest2Fn: InterceptFulfillRequestFn<
+            string,
+            string,
+        > = jest.fn();
+        const shouldRefreshCache2Fn: InterceptShouldRefreshCacheFn<
+            string,
+            string,
+        > = jest.fn();
         const captureContextFn = jest.fn();
 
         // Act

--- a/packages/wonder-blocks-data/src/components/intercept-data.js
+++ b/packages/wonder-blocks-data/src/components/intercept-data.js
@@ -26,38 +26,42 @@ type BaseProps<TOptions, TData> = {|
     children: React.Node,
 |};
 
-type FulfillRequestProps<TOptions, TData> = {|
-    /**
-     * Called to fulfill a request.
-     * If this returns null, the request will be fulfilled by the
-     * handler of the original request being intercepted.
-     */
-    fulfillRequest: InterceptFulfillRequestFn<TOptions, TData>,
-|};
+// type FulfillRequestProps<TOptions, TData> = {|
+//     /**
+//      * Called to fulfill a request.
+//      * If this returns null, the request will be fulfilled by the
+//      * handler of the original request being intercepted.
+//      */
+//     fulfillRequest: InterceptFulfillRequestFn<TOptions, TData>,
+// |};
 
-type ShouldRefreshCacheProps<TOptions, TData> = {|
-    /**
-     * Called to determine if the cache should be refreshed.
-     * If this returns null, the handler being intercepted will be asked if
-     * the cache should be refreshed.
-     */
-    shouldRefreshCache: InterceptShouldRefreshCacheFn<TOptions, TData>,
-|};
+// type ShouldRefreshCacheProps<TOptions, TData> = {|
+//     /**
+//      * Called to determine if the cache should be refreshed.
+//      * If this returns null, the handler being intercepted will be asked if
+//      * the cache should be refreshed.
+//      */
+//     shouldRefreshCache: InterceptShouldRefreshCacheFn<TOptions, TData>,
+// |};
 
-type Props<TOptions, TData> =
+type ConditionalProps<TOptions, TData> =
     | {|
-          ...BaseProps<TOptions, TData>,
-          ...FulfillRequestProps<TOptions, TData>,
-          ...ShouldRefreshCacheProps<TOptions, TData>,
+          fulfillRequest: InterceptFulfillRequestFn<TOptions, TData>,
+          shouldRefreshCache?: empty,
       |}
     | {|
-          ...BaseProps<TOptions, TData>,
-          ...FulfillRequestProps<TOptions, TData>,
+          fulfillRequest?: empty,
+          shouldRefreshCache: InterceptShouldRefreshCacheFn<TOptions, TData>,
       |}
     | {|
-          ...BaseProps<TOptions, TData>,
-          ...ShouldRefreshCacheProps<TOptions, TData>,
+          fulfillRequest: InterceptFulfillRequestFn<TOptions, TData>,
+          shouldRefreshCache: InterceptShouldRefreshCacheFn<TOptions, TData>,
       |};
+
+type Props<TOptions, TData> = {|
+    ...BaseProps<TOptions, TData>,
+    ...ConditionalProps<TOptions, TData>,
+|};
 
 /**
  * This component provides a mechanism to intercept the data requests for the

--- a/packages/wonder-blocks-data/src/components/intercept-data.js
+++ b/packages/wonder-blocks-data/src/components/intercept-data.js
@@ -26,36 +26,39 @@ type BaseProps<TOptions, TData> = {|
     children: React.Node,
 |};
 
-// type FulfillRequestProps<TOptions, TData> = {|
-//     /**
-//      * Called to fulfill a request.
-//      * If this returns null, the request will be fulfilled by the
-//      * handler of the original request being intercepted.
-//      */
-//     fulfillRequest: InterceptFulfillRequestFn<TOptions, TData>,
-// |};
+type FulfillRequestProps<TOptions, TData> = {|
+    /**
+     * Called to fulfill a request.
+     * If this returns null, the request will be fulfilled by the
+     * handler of the original request being intercepted.
+     */
+    fulfillRequest: InterceptFulfillRequestFn<TOptions, TData>,
+|};
 
-// type ShouldRefreshCacheProps<TOptions, TData> = {|
-//     /**
-//      * Called to determine if the cache should be refreshed.
-//      * If this returns null, the handler being intercepted will be asked if
-//      * the cache should be refreshed.
-//      */
-//     shouldRefreshCache: InterceptShouldRefreshCacheFn<TOptions, TData>,
-// |};
+type ShouldRefreshCacheProps<TOptions, TData> = {|
+    /**
+     * Called to determine if the cache should be refreshed.
+     * If this returns null, the handler being intercepted will be asked if
+     * the cache should be refreshed.
+     */
+    shouldRefreshCache: InterceptShouldRefreshCacheFn<TOptions, TData>,
+|};
 
+// Most other ConditionalProps only have two branches.  This one has three
+// because the condition it enforces is different.  It requires at least one
+// of `fulfillRequest` and `shouldRefreshCache` be used.
 type ConditionalProps<TOptions, TData> =
     | {|
-          fulfillRequest: InterceptFulfillRequestFn<TOptions, TData>,
+          ...FulfillRequestProps<TOptions, TData>,
           shouldRefreshCache?: empty,
       |}
     | {|
           fulfillRequest?: empty,
-          shouldRefreshCache: InterceptShouldRefreshCacheFn<TOptions, TData>,
+          ...ShouldRefreshCacheProps<TOptions, TData>,
       |}
     | {|
-          fulfillRequest: InterceptFulfillRequestFn<TOptions, TData>,
-          shouldRefreshCache: InterceptShouldRefreshCacheFn<TOptions, TData>,
+          ...FulfillRequestProps<TOptions, TData>,
+          ...ShouldRefreshCacheProps<TOptions, TData>,
       |};
 
 type Props<TOptions, TData> = {|

--- a/packages/wonder-blocks-data/src/util/types.js
+++ b/packages/wonder-blocks-data/src/util/types.js
@@ -4,8 +4,8 @@ export type ValidData = string | boolean | number | {...};
 export type Result<TData: ValidData> =
     | {|
           loading: true,
-          data?: void,
-          error?: void,
+          data?: empty,
+          error?: empty,
       |}
     | {|
           loading: false,
@@ -16,11 +16,11 @@ export type Result<TData: ValidData> =
 export type CacheEntry<TData: ValidData> =
     | {|
           error: string,
-          data?: ?void,
+          data?: ?empty,
       |}
     | {|
           data: TData,
-          error?: ?void,
+          error?: ?empty,
       |};
 
 type HandlerSubcache = {

--- a/packages/wonder-blocks-dropdown/src/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.js
@@ -146,74 +146,81 @@ export default class ActionItem extends React.Component<ActionProps> {
             router,
         );
 
-        return (
-            <ClickableBehavior
-                disabled={disabled}
-                onClick={onClick}
-                href={href}
-                role={role}
-                target={target}
-            >
-                {(state, childrenProps) => {
-                    const {pressed, hovered, focused} = state;
+        const children = (state, childrenProps) => {
+            const {pressed, hovered, focused} = state;
 
-                    const defaultStyle = [
-                        styles.shared,
-                        disabled && styles.disabled,
-                        !disabled &&
-                            (pressed
-                                ? styles.active
-                                : (hovered || focused) && styles.focus),
-                        // pass optional styles from react-window (if applies)
-                        style,
-                    ];
+            const defaultStyle = [
+                styles.shared,
+                disabled && styles.disabled,
+                !disabled &&
+                    (pressed
+                        ? styles.active
+                        : (hovered || focused) && styles.focus),
+                // pass optional styles from react-window (if applies)
+                style,
+            ];
 
-                    const props = {
-                        "data-test-id": testId,
-                        disabled,
-                        role,
-                        style: [defaultStyle],
-                        ...childrenProps,
-                    };
+            const props = {
+                "data-test-id": testId,
+                disabled,
+                role,
+                style: [defaultStyle],
+                ...childrenProps,
+            };
 
-                    const children = (
-                        <React.Fragment>
-                            <LabelMedium
-                                style={[indent && styles.indent, styles.label]}
-                            >
-                                {label}
-                            </LabelMedium>
-                        </React.Fragment>
-                    );
+            const children = (
+                <React.Fragment>
+                    <LabelMedium
+                        style={[indent && styles.indent, styles.label]}
+                    >
+                        {label}
+                    </LabelMedium>
+                </React.Fragment>
+            );
 
-                    if (href && !disabled) {
-                        return router && !skipClientNav ? (
-                            <StyledLink {...props} to={href}>
-                                {children}
-                            </StyledLink>
-                        ) : (
-                            <StyledAnchor
-                                {...props}
-                                href={href}
-                                target={target}
-                            >
-                                {children}
-                            </StyledAnchor>
-                        );
-                    } else {
-                        return (
-                            <StyledButton
-                                type="button"
-                                {...props}
-                                disabled={disabled}
-                            >
-                                {children}
-                            </StyledButton>
-                        );
-                    }
-                }}
-            </ClickableBehavior>
-        );
+            if (href && !disabled) {
+                return router && !skipClientNav ? (
+                    <StyledLink {...props} to={href}>
+                        {children}
+                    </StyledLink>
+                ) : (
+                    <StyledAnchor {...props} href={href} target={target}>
+                        {children}
+                    </StyledAnchor>
+                );
+            } else {
+                return (
+                    <StyledButton type="button" {...props} disabled={disabled}>
+                        {children}
+                    </StyledButton>
+                );
+            }
+        };
+
+        if (href) {
+            return (
+                <ClickableBehavior
+                    // TODO: remove annotation after migrating to TypeScript
+                    href={(href: string)}
+                    disabled={disabled}
+                    onClick={onClick}
+                    role={role}
+                    target={target}
+                >
+                    {children}
+                </ClickableBehavior>
+            );
+        } else {
+            return (
+                <ClickableBehavior
+                    disabled={disabled}
+                    onClick={onClick}
+                    role={role}
+                >
+                    {children}
+                </ClickableBehavior>
+            );
+        }
     }
 }
 

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.js
@@ -188,6 +188,7 @@ export default class IconButton extends React.Component<SharedProps> {
             href,
             skipClientNav,
             tabIndex,
+            rel,
             target,
             ...sharedProps
         } = this.props;
@@ -198,31 +199,50 @@ export default class IconButton extends React.Component<SharedProps> {
             this.context.router,
         );
 
-        return (
-            <ClickableBehavior
-                disabled={sharedProps.disabled}
-                href={href}
-                onClick={onClick}
-                role="button"
-                target={target}
-            >
-                {(state, {tabIndex: clickableTabIndex, ...childrenProps}) => {
-                    return (
-                        <IconButtonCore
-                            {...sharedProps}
-                            {...state}
-                            {...childrenProps}
-                            skipClientNav={skipClientNav}
-                            href={href}
-                            target={target}
-                            // If tabIndex is provide to the component we allow
-                            // it to override the tabIndex provide to use by
-                            // ClickableBehavior.
-                            tabIndex={tabIndex || clickableTabIndex}
-                        />
-                    );
-                }}
-            </ClickableBehavior>
-        );
+        const children = (
+            state,
+            {tabIndex: clickableTabIndex, ...childrenProps},
+        ) => {
+            return (
+                <IconButtonCore
+                    {...sharedProps}
+                    {...state}
+                    {...childrenProps}
+                    skipClientNav={skipClientNav}
+                    href={href}
+                    target={target}
+                    // If tabIndex is provide to the component we allow
+                    // it to override the tabIndex provide to use by
+                    // ClickableBehavior.
+                    tabIndex={tabIndex || clickableTabIndex}
+                />
+            );
+        };
+
+        if (href) {
+            return (
+                <ClickableBehavior
+                    // TODO: remove annotation after migrating to TypeScript
+                    href={(href: string)}
+                    role="button"
+                    disabled={sharedProps.disabled}
+                    onClick={onClick}
+                    target={target}
+                    rel={rel}
+                >
+                    {children}
+                </ClickableBehavior>
+            );
+        } else {
+            return (
+                <ClickableBehavior
+                    disabled={sharedProps.disabled}
+                    onClick={onClick}
+                    role="button"
+                >
+                    {children}
+                </ClickableBehavior>
+            );
+        }
     }
 }

--- a/packages/wonder-blocks-link/src/components/link-core.js
+++ b/packages/wonder-blocks-link/src/components/link-core.js
@@ -18,6 +18,7 @@ type Props = {|
     ...ChildrenProps,
     ...ClickableState,
     href: string,
+    target?: "_blank",
 |};
 
 type ContextTypes = {|

--- a/packages/wonder-blocks-link/src/components/link.js
+++ b/packages/wonder-blocks-link/src/components/link.js
@@ -198,7 +198,7 @@ export default class Link extends React.Component<Props> {
     render(): React.Node {
         const {
             onClick,
-            beforeNav = undefined,
+            beforeNav,
             safeWithNav,
             href,
             skipClientNav,
@@ -206,7 +206,7 @@ export default class Link extends React.Component<Props> {
             tabIndex,
             onKeyDown,
             onKeyUp,
-            target = undefined,
+            target,
             ...sharedProps
         } = this.props;
 
@@ -245,6 +245,7 @@ export default class Link extends React.Component<Props> {
                     href={(href: string)}
                     role="link"
                     disabled={false}
+                    target={target}
                     onClick={onClick}
                     beforeNav={beforeNav}
                     safeWithNav={safeWithNav}


### PR DESCRIPTION
## Summary:
This is part of a series of experimental PRs to determine the feasibility of migrating to TypeScript.

This PR in particular is some pre-work to refactor our conditional props into a form that TypeScript knows how to deal with.  This is based on the pattern described in https://www.benmvp.com/blog/conditional-react-props-typescript/.

Note: Flow does not like passing the results of function calls as props that are conditional props.  This is a bug in Flow since Flow is just fine passing a literal or variable that is the same type as the return type of the function.  This is fine because we deploy wonder-blocks to webapp in this state.  We'll convert it to TypeScript and then deploy it webapp.  TypeScript doesn't have this bug.

Issue: none

## Test plan:
- yarn flow