### PR TITLE
Update enzyme shim config to better align with webapp

### DIFF
--- a/config/jest/test-setup.js
+++ b/config/jest/test-setup.js
@@ -2,9 +2,15 @@ const {StyleSheetTestUtils} = require("aphrodite");
 const Enzyme = require("enzyme");
 const EnzymeAdapter = require("enzyme-adapter-react-16");
 
+const {unmountAll} = require("../../utils/testing/enzyme-shim.js");
+
 StyleSheetTestUtils.suppressStyleInjection();
 
 // Setup enzyme's react adapter
 Enzyme.configure({adapter: new EnzymeAdapter()});
 
 require("jest-enzyme/lib/index.js");
+
+afterEach(() => {
+    unmountAll();
+});

--- a/config/jest/test.config.js
+++ b/config/jest/test.config.js
@@ -18,6 +18,7 @@ module.exports = {
     moduleNameMapper: {
         "^@khanacademy/wonder-blocks-(.*)$":
             "<rootDir>/packages/wonder-blocks-$1/src/index.js",
+        "^enzyme$": "<rootDir>/utils/testing/enzyme-shim.js",
     },
     collectCoverageFrom: [
         "packages/**/*.js",

--- a/consistency-tests/__tests__/clickables.test.js
+++ b/consistency-tests/__tests__/clickables.test.js
@@ -6,6 +6,7 @@
  * checks that the common behaviors exist on all of these components.
  */
 import * as React from "react";
+import {mount} from "enzyme";
 
 import {ActionItem} from "@khanacademy/wonder-blocks-dropdown";
 import Button from "@khanacademy/wonder-blocks-button";
@@ -13,7 +14,6 @@ import Clickable from "@khanacademy/wonder-blocks-clickable";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 import Link from "@khanacademy/wonder-blocks-link";
-import {mount, unmountAll} from "../../utils/testing/mount.js";
 
 // We create a wrapper around Clickable since it expects a render function for
 // is children while all of the other components do not.
@@ -39,7 +39,6 @@ describe.each`
         // the testing environment.
         window.location.assign = jest.fn();
         window.open = jest.fn();
-        unmountAll();
     });
 
     afterEach(() => {

--- a/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.js
+++ b/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.js
@@ -1,14 +1,10 @@
 // @flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 import Breadcrumbs from "../breadcrumbs.js";
 import BreadcrumbsItem from "../breadcrumbs-item.js";
 
 describe("Breadcrumbs", () => {
-    afterEach(() => {
-        unmountAll();
-    });
-
     it("should set aria-current to the last item", () => {
         // Arrange
         const wrapper = mount(

--- a/packages/wonder-blocks-button/src/components/__tests__/button.test.js
+++ b/packages/wonder-blocks-button/src/components/__tests__/button.test.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from "react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import Button from "../button.js";
 
@@ -19,10 +18,6 @@ const keyCodes = {
 };
 
 describe("Button", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("client-side navigation", () => {
         // Arrange
         const wrapper = mount(

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.js
@@ -2,8 +2,7 @@
 // @flow
 import * as React from "react";
 import {MemoryRouter, Switch, Route} from "react-router-dom";
-import {shallow} from "enzyme";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount, shallow} from "enzyme";
 
 import getClickableBehavior from "../../util/get-clickable-behavior.js";
 import ClickableBehavior from "../clickable-behavior.js";
@@ -26,7 +25,6 @@ describe("ClickableBehavior", () => {
         // the testing environment.
         window.location.assign = jest.fn();
         window.open = jest.fn();
-        unmountAll();
     });
 
     afterEach(() => {

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {mount} from "enzyme";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import Clickable from "../clickable.js";
 
 const wait = (delay: number = 0) =>
@@ -13,10 +13,6 @@ const wait = (delay: number = 0) =>
     });
 
 describe("Clickable", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("client-side navigation", () => {
         // Arrange
         const wrapper = mount(

--- a/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server.js";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import View from "../view.js";
 
@@ -12,10 +11,6 @@ import UniqueIDProvider from "../unique-id-provider.js";
 import WithSSRPlaceholder from "../with-ssr-placeholder.js";
 
 describe("UniqueIDProvider", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     describe("mockOnFirstRender is default (false)", () => {
         test("initial render is nothing on server", () => {
             // Arrange

--- a/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.js
@@ -1,16 +1,11 @@
 // @flow
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server.js";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import WithSSRPlaceholder from "../with-ssr-placeholder.js";
 
 describe("WithSSRPlaceholder", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     describe("client-side rendering", () => {
         test("calls placeholder render first, then the actual content render", async () => {
             // Arrange

--- a/packages/wonder-blocks-core/src/util/__tests__/add-style.test.js
+++ b/packages/wonder-blocks-core/src/util/__tests__/add-style.test.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import addStyle from "../add-style.js";
 
@@ -20,7 +19,6 @@ describe("addStyle", () => {
     beforeEach(() => {
         SNAPSHOT_INLINE_APHRODITE = global.SNAPSHOT_INLINE_APHRODITE;
         global.SNAPSHOT_INLINE_APHRODITE = false;
-        unmountAll();
     });
 
     afterEach(() => {

--- a/packages/wonder-blocks-core/src/util/__tests__/enumerate-scroll-ancestors.test.js
+++ b/packages/wonder-blocks-core/src/util/__tests__/enumerate-scroll-ancestors.test.js
@@ -1,15 +1,11 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import enumerateScrollAncestors from "../enumerate-scroll-ancestors.js";
 
 describe("enumerateScrollAncestors", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("@@iterator() method returns iterator", () => {
         // Arrange
         const enumerator = enumerateScrollAncestors((null: any));

--- a/packages/wonder-blocks-core/src/util/__tests__/get-element-intersection.test.js
+++ b/packages/wonder-blocks-core/src/util/__tests__/get-element-intersection.test.js
@@ -1,7 +1,8 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
+
 import enumerateScrollAncestors from "../enumerate-scroll-ancestors.js";
 import getElementIntersection from "../get-element-intersection.js";
 
@@ -16,7 +17,6 @@ describe("getElementIntersection", () => {
         // Flow doesn't like jest mocks
         // $FlowFixMe[prop-missing]
         enumerateScrollAncestors.mockClear();
-        unmountAll();
     });
 
     test("element is null, returns unspecified intersection", () => {

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -1,12 +1,12 @@
 /* eslint-disable max-lines */
 // @flow
 import * as React from "react";
+import {mount, shallow} from "enzyme";
 
 // eslint-disable-next-line import/extensions
 import * as ReactDOMServer from "react-dom/server";
 import {Server, View} from "@khanacademy/wonder-blocks-core";
-import {shallow} from "enzyme";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+
 import TrackData from "../track-data.js";
 import {RequestFulfillment} from "../../util/request-fulfillment.js";
 import {ResponseCache} from "../../util/response-cache.js";
@@ -32,7 +32,6 @@ describe("Data", () => {
     });
 
     afterEach(() => {
-        unmountAll();
         jest.resetAllMocks();
     });
 

--- a/packages/wonder-blocks-data/src/components/__tests__/intercept-cache.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/intercept-cache.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import InterceptContext from "../intercept-context.js";
 import InterceptData from "../intercept-data.js";
@@ -10,7 +10,6 @@ import type {IRequestHandler} from "../../util/types.js";
 
 describe("InterceptCache", () => {
     afterEach(() => {
-        unmountAll();
         jest.resetAllMocks();
     });
 

--- a/packages/wonder-blocks-data/src/components/__tests__/intercept-data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/intercept-data.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import InterceptContext from "../intercept-context.js";
 import InterceptData from "../intercept-data.js";
@@ -10,7 +10,6 @@ import type {IRequestHandler} from "../../util/types.js";
 
 describe("InterceptData", () => {
     afterEach(() => {
-        unmountAll();
         jest.resetAllMocks();
     });
 

--- a/packages/wonder-blocks-data/src/components/__tests__/internal-data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/internal-data.test.js
@@ -1,12 +1,12 @@
 /* eslint-disable max-lines */
 // @flow
 import * as React from "react";
+import {mount, shallow} from "enzyme";
 
 // eslint-disable-next-line import/extensions
 import * as ReactDOMServer from "react-dom/server";
 import {Server, View} from "@khanacademy/wonder-blocks-core";
-import {shallow} from "enzyme";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+
 import TrackData from "../track-data.js";
 import {RequestFulfillment} from "../../util/request-fulfillment.js";
 import {ResponseCache} from "../../util/response-cache.js";
@@ -30,7 +30,6 @@ describe("InternalData", () => {
     });
 
     afterEach(() => {
-        unmountAll();
         jest.resetAllMocks();
     });
 

--- a/packages/wonder-blocks-data/src/components/__tests__/track-data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/track-data.test.js
@@ -1,15 +1,13 @@
 // @flow
 import * as React from "react";
 import {Server} from "@khanacademy/wonder-blocks-core";
-import {shallow} from "enzyme";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount, shallow} from "enzyme";
 
 import TrackData from "../track-data.js";
 import {RequestTracker, TrackerContext} from "../../util/request-tracking.js";
 
 describe("TrackData", () => {
     afterEach(() => {
-        unmountAll();
         jest.resetAllMocks();
     });
 

--- a/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import {RequestTracker, TrackerContext} from "../request-tracking.js";
 import {ResponseCache} from "../response-cache.js";
@@ -9,10 +9,6 @@ import type {IRequestHandler} from "../types.js";
 
 describe("../request-tracking.js", () => {
     describe("TrackerContext", () => {
-        afterEach(() => {
-            unmountAll();
-        });
-
         it("should default to null", async () => {
             // Arrange
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
@@ -1,6 +1,7 @@
 //@flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
+
 import ActionItem from "../action-item.js";
 import OptionItem from "../option-item.js";
 import SeparatorItem from "../separator-item.js";
@@ -14,10 +15,6 @@ describe("ActionMenu", () => {
     const onClick = jest.fn();
     const onToggle = jest.fn();
     const onChange = jest.fn();
-
-    afterEach(() => {
-        unmountAll();
-    });
 
     it("opens the menu on mouse click", () => {
         // Arrange

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core-virtualized.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core-virtualized.test.js
@@ -1,7 +1,7 @@
 //@flow
 import * as React from "react";
 import {VariableSizeList as List} from "react-window";
-import {mount} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import OptionItem from "../option-item.js";
 import SeparatorItem from "../separator-item.js";

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import OptionItem from "../option-item.js";
 import SearchTextInput from "../search-text-input.js";
@@ -88,7 +88,6 @@ describe("DropdownCore", () => {
     });
 
     afterEach(() => {
-        unmountAll();
         jest.restoreAllMocks();
     });
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
@@ -1,11 +1,11 @@
 /* eslint-disable max-lines */
 //@flow
 import * as React from "react";
+import {mount} from "enzyme";
 
 import {ClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import DropdownOpener from "../dropdown-opener.js";
 import SelectOpener from "../select-opener.js";
 import ActionItem from "../action-item.js";
@@ -68,7 +68,6 @@ describe("MultiSelect", () => {
     });
 
     afterEach(() => {
-        unmountAll();
         jest.restoreAllMocks();
     });
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -1,7 +1,7 @@
 //@flow
 import * as React from "react";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import DropdownOpener from "../dropdown-opener.js";
 import SelectOpener from "../select-opener.js";
@@ -31,7 +31,6 @@ describe("SingleSelect", () => {
 
     afterEach(() => {
         window.scrollTo.mockClear();
-        unmountAll();
     });
 
     it("closes/opens the select on mouse click, space, and enter", () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/checkbox-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/checkbox-group.test.js
@@ -1,6 +1,6 @@
 //@flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import CheckboxGroup from "../checkbox-group.js";
 import Choice from "../choice.js";
@@ -23,10 +23,6 @@ describe("CheckboxGroup", () => {
                 <Choice label="c" value="c" aria-labelledby="test-c" />
             </CheckboxGroup>,
         );
-    });
-
-    afterEach(() => {
-        unmountAll();
     });
 
     it("has the correct items checked", () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
@@ -1,6 +1,6 @@
 //@flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import RadioGroup from "../radio-group.js";
 import Choice from "../choice.js";
@@ -23,10 +23,6 @@ describe("RadioGroup", () => {
                 <Choice label="c" value="c" aria-labelledby="test-c" />
             </RadioGroup>,
         );
-    });
-
-    afterEach(() => {
-        unmountAll();
     });
 
     it("selects only one item at a time", () => {

--- a/packages/wonder-blocks-grid/src/components/__tests__/row.test.js
+++ b/packages/wonder-blocks-grid/src/components/__tests__/row.test.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from "react";
+import {mount} from "enzyme";
 
 import {
     MEDIA_DEFAULT_SPEC,
@@ -8,13 +9,8 @@ import {
 } from "@khanacademy/wonder-blocks-layout";
 import Row from "../row.js";
 import Cell from "../cell.js";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 
 describe("Row", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     describe("large", () => {
         it("should render Cells with largeCols and cols", () => {
             // Arrange

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.js
@@ -1,18 +1,14 @@
 // @flow
 import * as React from "react";
-import {shallow} from "enzyme";
+import {mount, shallow} from "enzyme";
+
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import expectRenderError from "../../../../../utils/testing/expect-render-error.js";
 import IconButton from "../icon-button.js";
 
 describe("IconButton", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("render an icon", (done) => {
         const wrapper = shallow(
             <IconButton

--- a/packages/wonder-blocks-icon/src/components/__tests__/icon.test.js
+++ b/packages/wonder-blocks-icon/src/components/__tests__/icon.test.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from "react";
 import * as Core from "@khanacademy/wonder-blocks-core";
+import {mount} from "enzyme";
+
 import icons from "../../util/icon-assets.js";
 import {getPathForIcon, viewportPixelsForSize} from "../../util/icon-util.js";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 
 // We mock things out so that we're in control of what really gets rendered.
 // Means we can test that we're using addStyle to generate the component
@@ -37,7 +37,6 @@ jest.mock("../../util/icon-util.js", () => ({
 describe("Icon", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        unmountAll();
     });
 
     test("creates a styled svg using addStyle", async () => {

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout-context.test.js
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout-context.test.js
@@ -1,11 +1,11 @@
 // @flow
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {mount} from "enzyme";
 
 import MediaLayout from "../media-layout.js";
 import MediaLayoutContext from "../media-layout-context.js";
 import {resizeWindow, matchMedia} from "../../util/test-util.js";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 
 import {
     MEDIA_DEFAULT_SPEC,
@@ -15,7 +15,6 @@ import {
 
 describe("MediaLayoutContext", () => {
     beforeEach(() => {
-        unmountAll();
         window.matchMedia = matchMedia;
     });
 

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.js
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.js
@@ -2,14 +2,13 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {mount} from "enzyme";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import MediaLayout from "../media-layout.js";
 import {resizeWindow, matchMedia} from "../../util/test-util.js";
 
 describe("MediaLayout", () => {
     beforeEach(() => {
-        unmountAll();
         window.matchMedia = matchMedia;
     });
 

--- a/packages/wonder-blocks-link/src/components/__tests__/link.test.js
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.test.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {mount} from "enzyme";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import Link from "../link.js";
 
 const wait = (delay: number = 0) =>
@@ -16,7 +16,6 @@ describe("Link", () => {
         // Note: window.location.assign needs a mock function in the testing
         // environment.
         window.location.assign = jest.fn();
-        unmountAll();
     });
 
     afterEach(() => {

--- a/packages/wonder-blocks-modal/src/components/__tests__/close-button.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/close-button.test.js
@@ -1,16 +1,12 @@
 // @flow
 import * as React from "react";
+import {mount} from "enzyme";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import expectRenderError from "../../../../../utils/testing/expect-render-error.js";
 import CloseButton from "../close-button.js";
 import ModalContext from "../modal-context.js";
 
 describe("CloseButton", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("ModalContext.Provider and onClose should warn", () => {
         expectRenderError(
             <ModalContext.Provider value={{closeModal: () => {}}}>
@@ -23,9 +19,11 @@ describe("CloseButton", () => {
     test("testId should be set in the Icon element", () => {
         // Arrange
         const wrapper = mount(
-            <ModalContext.Provider value={{closeModal: () => {}}}>
-                <CloseButton testId="modal-example-close" />,
-            </ModalContext.Provider>,
+            <div>
+                <ModalContext.Provider value={{closeModal: () => {}}}>
+                    <CloseButton testId="modal-example-close" />,
+                </ModalContext.Provider>
+            </div>,
         );
 
         // Act

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import ModalBackdrop from "../modal-backdrop.js";
 import OnePaneDialog from "../one-pane-dialog.js";
@@ -31,10 +31,6 @@ const exampleModalWithButtons = (
 );
 
 describe("ModalBackdrop", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("Clicking the backdrop triggers `onCloseModal`", () => {
         const onCloseModal = jest.fn();
 

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-header.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-header.test.js
@@ -1,12 +1,11 @@
 // @flow
 import * as React from "react";
-import {shallow} from "enzyme";
+import {mount, shallow} from "enzyme";
 
 import {
     Breadcrumbs,
     BreadcrumbsItem,
 } from "@khanacademy/wonder-blocks-breadcrumbs";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 
 import ModalHeader from "../modal-header.js";
 
@@ -17,10 +16,6 @@ const exampleBreadcrumbs: React.Element<typeof Breadcrumbs> = (
 );
 
 describe("ModalHeader", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("renders the title by default", () => {
         // Arrange, Act
         const wrapper = shallow(

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from "react";
-import {shallow} from "enzyme";
+import {mount, shallow} from "enzyme";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import ModalLauncher from "../modal-launcher.js";
 import OnePaneDialog from "../one-pane-dialog.js";
 
@@ -18,10 +17,6 @@ const exampleModal = (
 
 describe("ModalLauncher", () => {
     window.scrollTo = jest.fn();
-
-    beforeEach(() => {
-        unmountAll();
-    });
 
     test("Children can launch the modal", () => {
         const wrapper = mount(

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-panel.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-panel.test.js
@@ -1,19 +1,15 @@
 // @flow
 import * as React from "react";
+import {mount} from "enzyme";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
 import expectRenderError from "../../../../../utils/testing/expect-render-error.js";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import ModalPanel from "../modal-panel.js";
 import ModalContext from "../modal-context.js";
 import CloseButton from "../close-button.js";
 
 describe("ModalPanel", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("ModalContext.Provider and onClose should warn", () => {
         expectRenderError(
             <ModalContext.Provider value={{closeModal: () => {}}}>

--- a/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.js
@@ -1,15 +1,10 @@
 // @flow
 import * as React from "react";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import OnePaneDialog from "../one-pane-dialog.js";
 
 describe("OnePaneDialog", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     test("testId should be set in the Dialog element", () => {
         // Arrange
         const wrapper = mount(

--- a/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.js
@@ -1,17 +1,12 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import FocusManager from "../focus-manager.js";
 import {findFocusableNodes} from "../../util/util.js";
 
 describe("FocusManager", () => {
-    afterEach(() => {
-        unmountAll();
-    });
-
     it("should focus on the first focusable element inside the popover", async () => {
         // Arrange
         const ref = await new Promise((resolve) => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/initial-focus.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/initial-focus.test.js
@@ -1,17 +1,12 @@
 // @flow
 import * as React from "react";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import InitialFocus from "../initial-focus.js";
 
 describe("InitialFocus", () => {
     beforeEach(() => {
         jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-        unmountAll();
     });
 
     it("should try to focus on a given element by id", () => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-anchor.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-anchor.test.js
@@ -1,13 +1,10 @@
 // @flow
 import * as React from "react";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
+
 import PopoverAnchor from "../popover-anchor.js";
 
 describe("PopoverAnchor", () => {
-    afterEach(() => {
-        unmountAll();
-    });
-
     it("should set child node as ref", () => {
         // Arrange
         const updateRef = jest.fn();

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from "react";
-
-import {mount} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import PopoverContent from "../popover-content.js";
 import PopoverContext from "../popover-context.js";

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-dialog.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-dialog.test.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
+import {mount} from "enzyme";
 
 import {TooltipTail} from "@khanacademy/wonder-blocks-tooltip";
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 
 import PopoverDialog from "../popover-dialog.js";
 import PopoverContentCore from "../popover-content-core.js";
@@ -10,10 +10,6 @@ import PopoverContentCore from "../popover-content-core.js";
 jest.mock("@khanacademy/wonder-blocks-tooltip");
 
 describe("PopoverDialog", () => {
-    afterEach(() => {
-        unmountAll();
-    });
-
     it("should update the tail color to match the content's color", () => {
         // Arrange
         const onUpdateMock = jest.fn();

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-keypress-listener.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-keypress-listener.test.js
@@ -1,15 +1,10 @@
 // @flow
 import * as React from "react";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import PopoverKeypressListener from "../popover-keypress-listener.js";
 
 describe("PopoverKeypressListener", () => {
-    afterEach(() => {
-        unmountAll();
-    });
-
     it("should call onClose if Escape is pressed", () => {
         // Arrange
         const onCloseMock = jest.fn();

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.js
@@ -1,17 +1,12 @@
 // @flow
 import * as React from "react";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import Popover from "../popover.js";
 import PopoverContent from "../popover-content.js";
 import {PopoverContentCore} from "../../index.js";
 
 describe("Popover", () => {
-    afterEach(() => {
-        unmountAll();
-    });
-
     it("should set the anchor as the popover ref", () => {
         // Arrange
         const wrapper = mount(

--- a/packages/wonder-blocks-timing/src/components/__tests__/action-scheduler-provider.test.js
+++ b/packages/wonder-blocks-timing/src/components/__tests__/action-scheduler-provider.test.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from "react";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import ActionSchedulerProvider from "../action-scheduler-provider.js";
 import ActionScheduler from "../../util/action-scheduler.js";
@@ -9,10 +8,6 @@ import ActionScheduler from "../../util/action-scheduler.js";
 jest.mock("../../util/action-scheduler.js");
 
 describe("ActionSchedulerProvider", () => {
-    afterEach(() => {
-        unmountAll();
-    });
-
     it("should render children with action scheduler instance", () => {
         // Arrange
         const childrenMock = jest.fn().mockReturnValueOnce(null);

--- a/packages/wonder-blocks-timing/src/components/__tests__/with-action-scheduler.test.js
+++ b/packages/wonder-blocks-timing/src/components/__tests__/with-action-scheduler.test.js
@@ -1,17 +1,12 @@
 // @flow
 import * as React from "react";
-
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
+import {mount} from "enzyme";
 
 import withActionScheduler from "../with-action-scheduler.js";
 
 import type {WithActionSchedulerProps} from "../../util/types.js";
 
 describe("withActionScheduler", () => {
-    afterEach(() => {
-        unmountAll();
-    });
-
     it("should provide wrapped component with IScheduleActions instance", () => {
         // Arrange
         const Component = (props) =>

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
@@ -3,8 +3,8 @@
 // @flow
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {mount} from "enzyme";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import TooltipAnchor from "../tooltip-anchor.js";
 import {
     TooltipAppearanceDelay,
@@ -21,7 +21,6 @@ describe("TooltipAnchor", () => {
         if (typeof document.removeEventListener.mockReset === "function") {
             document.removeEventListener.mockRestore();
         }
-        unmountAll();
         jest.clearAllTimers();
         jest.useFakeTimers();
 

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-bubble.test.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import {mount} from "enzyme";
+
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import TooltipBubble from "../tooltip-bubble.js";
 import typeof TooltipContent from "../tooltip-content.js";
 
@@ -18,10 +19,6 @@ describe("TooltipBubble", () => {
             top: 0,
             left: 50,
         },
-    });
-
-    beforeEach(() => {
-        unmountAll();
     });
 
     test("updates reference to bubble container", async () => {

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-popper.test.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import {mount} from "enzyme";
+
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import typeof TooltipBubble from "../tooltip-bubble.js";
 import TooltipPopper from "../tooltip-popper.js";
 
@@ -43,10 +44,6 @@ class TestHarness extends React.Component<any, State> {
 }
 
 describe("TooltipPopper", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     // The TooltipPopper component is just a wrapper around react-popper.
     // PopperJS requires full visual rendering and we don't do that here as
     // we're not in a browser.

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.integration.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.integration.test.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
+import {mount} from "enzyme";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import Tooltip from "../tooltip.js";
 import TooltipBubble from "../tooltip-bubble.js";
 import TooltipAnchor from "../tooltip-anchor.js";
@@ -9,7 +9,6 @@ import {TooltipDisappearanceDelay} from "../../util/constants.js";
 
 describe("tooltip integration tests", () => {
     beforeEach(() => {
-        unmountAll();
         jest.useFakeTimers();
         // jest.clearAllMocks().resetModules();
     });

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.js
@@ -1,11 +1,11 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import {mount} from "enzyme";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import Tooltip from "../tooltip.js";
 import TooltipBubble from "../tooltip-bubble.js";
 import TooltipContent from "../tooltip-content.js";
@@ -26,7 +26,6 @@ jest.mock("@khanacademy/wonder-blocks-core", () => {
 
 describe("Tooltip", () => {
     beforeEach(() => {
-        unmountAll();
         jest.clearAllMocks();
         jest.clearAllTimers();
         jest.useFakeTimers();

--- a/packages/wonder-blocks-tooltip/src/util/__tests__/ref-tracker.test.js
+++ b/packages/wonder-blocks-tooltip/src/util/__tests__/ref-tracker.test.js
@@ -1,19 +1,15 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import {mount} from "enzyme";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import {mount, unmountAll} from "../../../../../utils/testing/mount.js";
 import RefTracker from "../ref-tracker.js";
 
 type CallbackFn = (?HTMLElement) => void;
 
 describe("RefTracker", () => {
-    beforeEach(() => {
-        unmountAll();
-    });
-
     describe("#setCallback", () => {
         test("called with falsy value, no throw", () => {
             // Arrange

--- a/shared-unpackaged/__tests__/is-obscured.test.js
+++ b/shared-unpackaged/__tests__/is-obscured.test.js
@@ -1,10 +1,9 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import {mount} from "enzyme";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-
-import {mount, unmountAll} from "../../utils/testing/mount.js";
 
 import isObscured from "../is-obscured.js";
 
@@ -13,8 +12,6 @@ describe("isObscured", () => {
     beforeEach(() => {
         // Some tests will want to mock this, so let's ensure we can reset it
         ogElementFromPoint = document.elementFromPoint;
-
-        unmountAll();
     });
 
     afterEach(() => {

--- a/utils/testing/enzyme-shim.js
+++ b/utils/testing/enzyme-shim.js
@@ -1,6 +1,12 @@
 // @flow
-import {mount as enzymeMount} from "enzyme";
+/**
+ * Shim to add auto-unmounting to enzyme.
+ */
+import * as React from "react";
 import type {ReactWrapper} from "enzyme";
+import * as enzyme from "enzyme/build";
+
+export * from "enzyme/build";
 
 /**
  * Enzyme doesn't unmount mounted things and all tests share the same DOM
@@ -10,7 +16,7 @@ import type {ReactWrapper} from "enzyme";
  */
 const ACTIVE_WRAPPERS = {};
 
-const unmountAll = () => {
+export const unmountAll = () => {
     const wrappersToUnmount = Object.keys(ACTIVE_WRAPPERS);
     for (const key of wrappersToUnmount) {
         const wrapper = ACTIVE_WRAPPERS[key];
@@ -21,11 +27,11 @@ const unmountAll = () => {
     }
 };
 
-function mount<T>(nodes: React$Element<T>): ReactWrapper<T> {
-    const wrapper = enzymeMount<T>(nodes);
+export function mount<T>(
+    nodes: React.Element<React.AbstractComponent<T>>,
+): ReactWrapper<T> {
+    const wrapper = enzyme.mount<T>(nodes);
     const identity = ACTIVE_WRAPPERS.length;
     ACTIVE_WRAPPERS[identity] = wrapper;
     return wrapper;
 }
-
-export {mount, unmountAll};


### PR DESCRIPTION
## Summary:
This PR moves the call to 'unmountAll()' into an 'afterEach()' block jest-setup.js.  This guarantees that it's being called after each test without developers having to manually add a call to it in each test suite they right.  It was missing in a few them as it is.

This will also make it easier to use package references in the TypeScript experimeents I'm working on.

Issue: none

## Test plan:
- yarn test
- yarn flow