### PR TITLE
Use namesapce imports for 'prop-types'

### DIFF
--- a/packages/wonder-blocks-button/src/components/button-core.js
+++ b/packages/wonder-blocks-button/src/components/button-core.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import {LabelLarge, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Color, {

--- a/packages/wonder-blocks-button/src/components/button.js
+++ b/packages/wonder-blocks-button/src/components/button.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";

--- a/packages/wonder-blocks-clickable/src/components/clickable.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 import {Link} from "react-router-dom";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";

--- a/packages/wonder-blocks-dropdown/src/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import Color, {SemanticColor, mix} from "@khanacademy/wonder-blocks-color";

--- a/packages/wonder-blocks-dropdown/src/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.js
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.js
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import Color, {
     SemanticColor,

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";

--- a/packages/wonder-blocks-link/src/components/link-core.js
+++ b/packages/wonder-blocks-link/src/components/link-core.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";

--- a/packages/wonder-blocks-link/src/components/link.js
+++ b/packages/wonder-blocks-link/src/components/link.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";


### PR DESCRIPTION
## Summary:
'prop-types' doesn't actually have a default export even though we're doing a default import.  webpack/babel make this work at run time.  TypeScript complains about this.  We could use TS' "allowSyntheticDefaultImports" setting to have it paper of this as well, but changing it a namespace import is easy and better reflect the true nature of this module.

Issue: none

## Test plan:
- yarn flow
- yarn test