### PR TITLE
Handle mailto:, tel:, etc. hrefs in isClientSideUrl

### DIFF
--- a/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {isClientSideUrl} from "../is-client-side-url.js";
 
-describe("isExternalUrl", () => {
+describe("isClientSideUrl", () => {
     test("returns boolean based on the url", () => {
         // external URLs
         expect(
@@ -23,9 +23,13 @@ describe("isExternalUrl", () => {
         expect(isClientSideUrl("javascript:void(0)")).toEqual(false);
         expect(isClientSideUrl("mailto:foo@example.com")).toEqual(false);
         expect(isClientSideUrl("tel:+1234567890")).toEqual(false);
+        expect(isClientSideUrl("tel:+1234567890")).toEqual(false);
+        expect(isClientSideUrl("ms-help://kb12345.htm")).toEqual(false);
+        expect(isClientSideUrl("z39.50s://0.0.0.0")).toEqual(false);
 
-        // fake HREFs
+        // anchor-only HREFs
         expect(isClientSideUrl("#")).toEqual(false);
+        expect(isClientSideUrl("#foo")).toEqual(false);
 
         // internal URLs
         expect(isClientSideUrl("/foo//bar")).toEqual(true);

--- a/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
@@ -3,7 +3,7 @@ import {isClientSideUrl} from "../is-client-side-url.js";
 
 describe("isExternalUrl", () => {
     test("returns boolean based on the url", () => {
-        // external urls
+        // external URLs
         expect(
             isClientSideUrl(
                 "//khanacademy.zendesk.com/hc/en-us/articles/236355907",
@@ -18,12 +18,16 @@ describe("isExternalUrl", () => {
         expect(isClientSideUrl("//www.google.com")).toEqual(false);
         expect(isClientSideUrl("//")).toEqual(false);
 
-        // fake hrefs
-        expect(isClientSideUrl("#")).toEqual(false);
+        // non-http(s) URLs
         expect(isClientSideUrl("javascript:void(0);")).toEqual(false);
         expect(isClientSideUrl("javascript:void(0)")).toEqual(false);
+        expect(isClientSideUrl("mailto:foo@example.com")).toEqual(false);
+        expect(isClientSideUrl("tel:+1234567890")).toEqual(false);
 
-        // internal urls
+        // fake HREFs
+        expect(isClientSideUrl("#")).toEqual(false);
+
+        // internal URLs
         expect(isClientSideUrl("/foo//bar")).toEqual(true);
         expect(isClientSideUrl("/coach/dashboard")).toEqual(true);
         expect(isClientSideUrl("/math/early-math/modal/e/addition_1")).toEqual(

--- a/packages/wonder-blocks-clickable/src/util/is-client-side-url.js
+++ b/packages/wonder-blocks-clickable/src/util/is-client-side-url.js
@@ -6,9 +6,5 @@
  * - true for all other values, e.g. /foo/bar
  */
 export const isClientSideUrl = (href: string): boolean => {
-    return (
-        !/^(https?:)?\/\//i.test(href) &&
-        !/^[a-zA-Z]+:/.test(href) &&
-        href !== "#"
-    );
+    return !/^(https?:)?\/\//i.test(href) && !/^(#[\w-]*|[\w\-.]+:)/.test(href);
 };

--- a/packages/wonder-blocks-clickable/src/util/is-client-side-url.js
+++ b/packages/wonder-blocks-clickable/src/util/is-client-side-url.js
@@ -2,12 +2,13 @@
 /**
  * Returns:
  * - false for hrefs staring with http://, https://, //.
- * - false for '#' and 'javascript:void(0);'
+ * - false for '#', 'javascript:...', 'mailto:...', 'tel:...', etc.
  * - true for all other values, e.g. /foo/bar
  */
 export const isClientSideUrl = (href: string): boolean => {
     return (
         !/^(https?:)?\/\//i.test(href) &&
-        !/^(#|javascript:void\(0\);?)$/.test(href)
+        !/^[a-zA-Z]+:/.test(href) &&
+        href !== "#"
     );
 };


### PR DESCRIPTION
## Summary:
In #1107 I updated the logic to decide when to render a <a> vs a <Link>.  I didn't realize we used mailto: and tel: in webapp.  This PR handles those cases in a more general way which should hopefully be more future proof.

Issue: none

## Test plan:
- yarn jest packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js