### PR TITLE
Don't render react-router Link if href is not a string

### DIFF
--- a/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
@@ -39,7 +39,7 @@ describe("isClientSideUrl", () => {
         );
     });
 
-    test("handles edge cases", () => {
+    test("invalid values for 'href' should return false", () => {
         // $FlowIgnore: testing invalid input
         expect(isClientSideUrl(null)).toEqual(false);
         // $FlowIgnore: testing invalid input

--- a/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
@@ -38,4 +38,11 @@ describe("isClientSideUrl", () => {
             true,
         );
     });
+
+    test("handles edge cases", () => {
+        // $FlowIgnore: testing invalid input
+        expect(isClientSideUrl(null)).toEqual(false);
+        // $FlowIgnore: testing invalid input
+        expect(isClientSideUrl(undefined)).toEqual(false);
+    });
 });

--- a/packages/wonder-blocks-clickable/src/util/is-client-side-url.js
+++ b/packages/wonder-blocks-clickable/src/util/is-client-side-url.js
@@ -6,5 +6,8 @@
  * - true for all other values, e.g. /foo/bar
  */
 export const isClientSideUrl = (href: string): boolean => {
+    if (typeof href !== "string") {
+        return false;
+    }
     return !/^(https?:)?\/\//i.test(href) && !/^(#[\w-]*|[\w\-.]+:)/.test(href);
 };


### PR DESCRIPTION
## Summary:
It's hard to guarantee that we're always passing an 'href' to 'Link' since Perseus is consuming Link in webapp in a way that isn't type safe.  Link will throw if it doesn't get a value for its 'to' property.  This diff avoids the situation by rendering an 'a' tag if 'href' is 'undefined' or 'null'.

Issue: none

## Test plan:
- yarn jest packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js