### PR TITLE
Make all URLs with an anchor non-client-side

### DIFF
--- a/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
@@ -27,9 +27,11 @@ describe("isClientSideUrl", () => {
         expect(isClientSideUrl("ms-help://kb12345.htm")).toEqual(false);
         expect(isClientSideUrl("z39.50s://0.0.0.0")).toEqual(false);
 
-        // anchor-only HREFs
+        // HREFs with anchors
         expect(isClientSideUrl("#")).toEqual(false);
         expect(isClientSideUrl("#foo")).toEqual(false);
+        expect(isClientSideUrl("/foo#bar")).toEqual(false);
+        expect(isClientSideUrl("foo/bar#baz")).toEqual(false);
 
         // internal URLs
         expect(isClientSideUrl("/foo//bar")).toEqual(true);

--- a/packages/wonder-blocks-clickable/src/util/is-client-side-url.js
+++ b/packages/wonder-blocks-clickable/src/util/is-client-side-url.js
@@ -9,5 +9,8 @@ export const isClientSideUrl = (href: string): boolean => {
     if (typeof href !== "string") {
         return false;
     }
-    return !/^(https?:)?\/\//i.test(href) && !/^(#[\w-]*|[\w\-.]+:)/.test(href);
+    return (
+        !/^(https?:)?\/\//i.test(href) &&
+        !/^([^#]*#[\w-]*|[\w\-.]+:)/.test(href)
+    );
 };


### PR DESCRIPTION
## Summary:
React-router's Link component doesn't handle URLs with hashes correctly.  It will navigate to the correct pathname, but it doesn't scroll the page to the anchor with the given hash.  This PR makes all URLs with hashes use <a> tags.  If the URL is the same, it shouldn't trigger a full page reload.  In the future we can explore using react-router-hash-link, but it's not an official react-router component and it does some shenanigans with tabindex and focus which makes me cautious about adopting it because we don't want to introduce any new a11y issues.

Issue: none

## Test plan:
- yarn jest packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js