### PR TITLE
WB-1038 - Add role="tab" to Clickable

### DIFF
--- a/packages/wonder-blocks-clickable/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-clickable/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -37,6 +37,7 @@ exports[`wonder-blocks-clickable example 1 1`] = `
     onTouchCancel={[Function]}
     onTouchEnd={[Function]}
     onTouchStart={[Function]}
+    role="tab"
     style={
       Object {
         "::MozFocusInner": Object {

--- a/packages/wonder-blocks-clickable/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-clickable/src/__tests__/generated-snapshot.test.js
@@ -37,6 +37,7 @@ describe("wonder-blocks-clickable", () => {
                 <Clickable
                     onClick={() => alert("You clicked some text!")}
                     hideDefaultFocusRing={true}
+                    role="tab"
                 >
                     {({hovered, focused, pressed}) => (
                         <View

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
@@ -10,7 +10,8 @@ export type ClickableRole =
     | "listbox"
     | "option"
     | "menuitem"
-    | "menu";
+    | "menu"
+    | "tab";
 
 const getAppropriateTriggersForRole = (role: ?ClickableRole) => {
     switch (role) {

--- a/packages/wonder-blocks-clickable/src/components/clickable.md
+++ b/packages/wonder-blocks-clickable/src/components/clickable.md
@@ -32,6 +32,7 @@ const styles = StyleSheet.create({
     <Clickable
         onClick={() => alert("You clicked some text!")}
         hideDefaultFocusRing={true}
+        role="tab"
     >
         {
             ({hovered, focused, pressed}) =>

--- a/packages/wonder-blocks-clickable/src/components/clickable.stories.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.stories.js
@@ -43,6 +43,27 @@ keyboardNavigation.story = {
     },
 };
 
+export const keyboardNavigationTab: StoryComponentType = () => (
+    <View>
+        <Clickable role="tab" aria-controls="panel-1" id="tab-1">
+            {({hovered, focused, pressed}) => (
+                <View
+                    style={[
+                        hovered && styles.hovered,
+                        focused && styles.focused,
+                        pressed && styles.pressed,
+                    ]}
+                >
+                    <Body>Open School Info</Body>
+                </View>
+            )}
+        </Clickable>
+        <View id="panel-1" role="tabpanel" tabindex="0" aria-labelledby="tab-1">
+            This is the information for the school.
+        </View>
+    </View>
+);
+
 const styles = StyleSheet.create({
     hovered: {
         textDecoration: "underline",


### PR DESCRIPTION
## Summary:
Added the ability for role="tab" on the Clickable component to prevent
Flow errors.

Issue: https://khanacademy.atlassian.net/browse/WB-1038

## Test plan:
1. Open Styleguidist in the browser
2. Go to: http://localhost:6060/#!/Clickable/1
3. See if pressing tab focuses the Clickable element

<img width="1264" alt="voice-over-example" src="https://user-images.githubusercontent.com/60367213/117727323-7e382780-b1ad-11eb-8c17-1c137c538a47.png">
