### PR TITLE
WB-1043 - Fix Dropdown list scrollbar padding

### DIFF
--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
@@ -101,11 +101,12 @@ class DropdownCoreVirtualized extends React.Component<Props, State> {
      */
     setWidth() {
         const rootNode = ((ReactDOM.findDOMNode(this): any): ?HTMLElement);
+        const parentNode = rootNode?.parentElement;
 
         // after the non-virtualized items are rendered, we get the container
         //  width to pass it to react-window's List
-        if (rootNode) {
-            const width = rootNode.getBoundingClientRect().width;
+        if (parentNode) {
+            const width = parentNode.getBoundingClientRect().width;
 
             this.setState({
                 width,

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
@@ -212,6 +212,7 @@ class DropdownCoreVirtualized extends React.Component<Props, State> {
                 itemCount={data.length}
                 itemSize={this.getItemSize}
                 itemData={data}
+                style={{overflowX: "hidden"}}
                 // react-window doesn't accept maybe numbers. It wants numbers
                 // or strings.
                 // $FlowFixMe

--- a/packages/wonder-blocks-dropdown/src/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.js
@@ -236,11 +236,11 @@ export default class SingleSelect extends React.Component<Props, State> {
             const {disabled, value} = option.props;
             const selected = selectedValue === value;
 
-            if (selected) {
-                this.selectedIndex = indexCounter;
-            }
             if (!disabled) {
                 indexCounter += 1;
+            }
+            if (selected) {
+                this.selectedIndex = indexCounter;
             }
             return {
                 component: option,


### PR DESCRIPTION
## Summary:
Fixed a wrong width calculation with the `wonder-blocks-dropdown` list
which was causing a padding issue with the scrollbar (when the list was
large enough for the scrollbar to show).

Also fixed an issue with the single-select dropdown highlighting the incorrect
selected item when the dropdown was re-opened.

Issue: https://khanacademy.atlassian.net/browse/WB-1043

## Test plan:
1. Open Styleguidist in browser (or React Storybook)
2. Go to: http://localhost:6060/#!/SingleSelect/17 (Storybook: http://localhost:59197/?path=/story/dropdown-multiselect--custom-styles-opened)
3. See that the dropdown scrollbar is perfectly aligned to the right edge (and also the selected item is correctly highlighted when dropdown is re-opened)

#### Screenshots of the scrollbar aligning correctly on different widths
![dd-ss1](https://user-images.githubusercontent.com/60367213/118155226-9db59700-b3dd-11eb-887a-d004e81cfe58.png)
![dd-ss2](https://user-images.githubusercontent.com/60367213/118155236-9f7f5a80-b3dd-11eb-8782-68e6dd89bea3.png)
![dd-ss3](https://user-images.githubusercontent.com/60367213/118155245-a1491e00-b3dd-11eb-8ccf-ae1cc941967a.png)
