### PR TITLE
WB-1032 - Add `light` prop to `Clickable`

### DIFF
--- a/packages/wonder-blocks-clickable/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-clickable/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -110,6 +110,113 @@ exports[`wonder-blocks-clickable example 2 1`] = `
   className=""
   style={
     Object {
+      "alignItems": "stretch",
+      "backgroundColor": "#0a2a66",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "color": "#ffffff",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 12,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <button
+    aria-label=""
+    className=""
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="tab"
+    style={
+      Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
+        "MozOsxFontSmoothing": "inherit",
+        "WebkitFontSmoothing": "inherit",
+        "background": "transparent",
+        "border": "none",
+        "boxSizing": "border-box",
+        "color": "inherit",
+        "cursor": "pointer",
+        "font": "inherit",
+        "lineHeight": "normal",
+        "margin": 0,
+        "outline": "none",
+        "overflow": "visible",
+        "padding": 0,
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+        "width": "auto",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexDirection": "column",
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "lineHeight": "22px",
+          }
+        }
+      >
+        This text is clickable!
+      </span>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`wonder-blocks-clickable example 3 1`] = `
+<div
+  className=""
+  style={
+    Object {
       "alignItems": "center",
       "borderStyle": "solid",
       "borderWidth": 0,
@@ -218,7 +325,7 @@ exports[`wonder-blocks-clickable example 2 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-clickable example 3 1`] = `
+exports[`wonder-blocks-clickable example 4 1`] = `
 <div
   className=""
   style={

--- a/packages/wonder-blocks-clickable/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-clickable/src/__tests__/generated-snapshot.test.js
@@ -59,6 +59,45 @@ describe("wonder-blocks-clickable", () => {
 
     it("example 2", () => {
         const styles = StyleSheet.create({
+            background: {
+                backgroundColor: Color.darkBlue,
+                color: Color.white,
+                padding: Spacing.small_12,
+            },
+            hovered: {
+                textDecoration: "underline",
+                backgroundColor: Color.purple,
+            },
+            pressed: {
+                color: Color.blue,
+            },
+        });
+        const example = (
+            <View style={styles.background}>
+                <Clickable
+                    onClick={() => alert("You clicked some text!")}
+                    role="tab"
+                    light={true}
+                >
+                    {({hovered, focused, pressed}) => (
+                        <View
+                            style={[
+                                hovered && styles.hovered,
+                                pressed && styles.pressed,
+                            ]}
+                        >
+                            <Body>This text is clickable!</Body>
+                        </View>
+                    )}
+                </Clickable>
+            </View>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 3", () => {
+        const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
                 alignItems: "center",
@@ -95,7 +134,7 @@ describe("wonder-blocks-clickable", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 3", () => {
+    it("example 4", () => {
         const styles = StyleSheet.create({
             hovered: {
                 textDecoration: "underline",

--- a/packages/wonder-blocks-clickable/src/components/clickable.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.js
@@ -49,6 +49,13 @@ type CommonProps = {|
     className?: string,
 
     /**
+     * Whether the Clickable is on a dark colored background.
+     * Sets the default focus ring color to white, instead of blue.
+     * Defaults to false.
+     */
+    light: boolean,
+
+    /**
      * Disables or enables the child; defaults to false
      */
     disabled: boolean,
@@ -167,6 +174,7 @@ type ContextTypes = {|
 |};
 
 type DefaultProps = {|
+    light: $PropertyType<Props, "light">,
     disabled: $PropertyType<Props, "disabled">,
     "aria-label": $PropertyType<Props, "aria-label">,
 |};
@@ -203,6 +211,7 @@ export default class Clickable extends React.Component<Props> {
     static contextTypes: ContextTypes = {router: PropTypes.any};
 
     static defaultProps: DefaultProps = {
+        light: false,
         disabled: false,
         "aria-label": "",
     };
@@ -269,6 +278,7 @@ export default class Clickable extends React.Component<Props> {
             onKeyDown,
             onKeyUp,
             hideDefaultFocusRing,
+            light,
             disabled,
             ...restProps
         } = this.props;
@@ -281,7 +291,9 @@ export default class Clickable extends React.Component<Props> {
         const getStyle = (state: ClickableState): StyleType => [
             styles.reset,
             styles.link,
-            !hideDefaultFocusRing && state.focused && styles.focused,
+            !hideDefaultFocusRing &&
+                state.focused &&
+                (light ? styles.focusedLight : styles.focused),
             style,
         ];
 
@@ -369,5 +381,8 @@ const styles = StyleSheet.create({
     },
     focused: {
         outline: `solid 2px ${Color.blue}`,
+    },
+    focusedLight: {
+        outline: `solid 2px ${Color.white}`,
     },
 });

--- a/packages/wonder-blocks-clickable/src/components/clickable.md
+++ b/packages/wonder-blocks-clickable/src/components/clickable.md
@@ -50,6 +50,52 @@ const styles = StyleSheet.create({
 </View>
 ```
 
+Clickable has a `light` prop which changes the default focus ring color to fit a dark background.
+
+```jsx
+import {StyleSheet} from "aphrodite";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {View} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {Body} from "@khanacademy/wonder-blocks-typography";
+
+const styles = StyleSheet.create({
+    background: {
+        backgroundColor: Color.darkBlue,
+        color: Color.white,
+        padding: Spacing.small_12,
+    },
+    hovered: {
+        textDecoration: "underline",
+        backgroundColor: Color.purple,
+    },
+    pressed: {
+        color: Color.blue,
+    },
+});
+
+<View style={styles.background}>
+    <Clickable
+        onClick={() => alert("You clicked some text!")}
+        role="tab"
+        light={true}
+    >
+        {
+            ({hovered, focused, pressed}) =>
+            <View style={[
+                hovered && styles.hovered,
+                pressed && styles.pressed,
+            ]}>
+                <Body>
+                    This text is clickable!
+                </Body>
+            </View>
+        }
+    </Clickable>
+</View>
+```
+
 ### Client-Side routing with Clickable
 
 If your Clickable component is within a React-Router enviroment, your component will automatically default to client-side routing with the `href` prop is set. This behavior can be toggeled by passing the `skipClientNav` prop. In this example we see two Clickable h1 tags, one which employs client-side routing, and the other uses skipClientNav to avoid this default behavior.

--- a/packages/wonder-blocks-clickable/src/components/clickable.stories.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.stories.js
@@ -5,6 +5,8 @@ import {StyleSheet} from "aphrodite";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
@@ -12,6 +14,47 @@ import type {StoryComponentType} from "@storybook/react";
 export default {
     title: "Clickable",
 };
+
+export const basic: StoryComponentType = () => (
+    <View>
+        <View style={styles.centerText}>
+            <Clickable
+                href="https://www.khanacademy.org/about/tos"
+                skipClientNav={true}
+            >
+                {({hovered, focused, pressed}) => (
+                    <View
+                        style={[
+                            hovered && styles.hovered,
+                            pressed && styles.pressed,
+                        ]}
+                    >
+                        <Body>This text is clickable!</Body>
+                    </View>
+                )}
+            </Clickable>
+        </View>
+        <Strut size={Spacing.xLarge_32} />
+        <View style={[styles.centerText, styles.dark]}>
+            <Clickable
+                href="https://www.khanacademy.org/about/tos"
+                skipClientNav={true}
+                light={true}
+            >
+                {({hovered, focused, pressed}) => (
+                    <View
+                        style={[
+                            hovered && styles.hovered,
+                            pressed && styles.pressed,
+                        ]}
+                    >
+                        <Body>This text is clickable!</Body>
+                    </View>
+                )}
+            </Clickable>
+        </View>
+    </View>
+);
 
 export const keyboardNavigation: StoryComponentType = () => (
     <View>
@@ -74,5 +117,13 @@ const styles = StyleSheet.create({
     },
     focused: {
         outline: `solid 4px ${Color.lightBlue}`,
+    },
+    centerText: {
+        textAlign: "center",
+    },
+    dark: {
+        backgroundColor: Color.darkBlue,
+        color: Color.white,
+        padding: Spacing.xSmall_8,
     },
 });


### PR DESCRIPTION
## Summary:
Added the `light` prop to the `Clickable` component in
`wonder-blocks-clickable` which will cause the default focus ring to be
white instead of blue when the `light` prop is set to true.

Issue: https://khanacademy.atlassian.net/browse/WB-1032

## Test plan:
1. Open Styleguidist in browser
2. Go to: http://localhost:6060/#!/Clickable/3
3. Press 'tab' and see that the default focus ring is white when the
   `light` prop is set to true.

![SS1](https://user-images.githubusercontent.com/60367213/118289558-1890b780-b49b-11eb-9297-53330fbe1124.png)

##### When `light` is set to false.
![SS2](https://user-images.githubusercontent.com/60367213/118289582-1d556b80-b49b-11eb-85f7-3e81141f771c.png)
