### PR TITLE
Add `aria-describedby` to Choice inputs when a description is provided

### DIFF
--- a/packages/wonder-blocks-core/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-core/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -272,13 +272,13 @@ exports[`wonder-blocks-core example 5 1`] = `
   }
 >
   <label
-    htmlFor="uid-field-0-wb-id"
+    htmlFor="uid-field-1-wb-id"
   >
     Label with ID 
-    uid-field-0-wb-id
+    uid-field-1-wb-id
     :
     <input
-      id="uid-field-0-wb-id"
+      id="uid-field-1-wb-id"
       type="text"
     />
   </label>
@@ -705,7 +705,7 @@ exports[`wonder-blocks-core example 10 1`] = `
       Render 
       0
       : 
-      uid--1-my-unique-id
+      uid--2-my-unique-id
     </span>
   </div>
 </div>
@@ -881,7 +881,7 @@ exports[`wonder-blocks-core example 11 1`] = `
       }
     >
       get("an-id"): 
-      uid--2-an-id
+      uid--3-an-id
     </span>
     <span
       className=""
@@ -898,7 +898,7 @@ exports[`wonder-blocks-core example 11 1`] = `
       }
     >
       get("something"): 
-      uid--2-something
+      uid--3-something
     </span>
   </div>
 </div>
@@ -976,7 +976,7 @@ exports[`wonder-blocks-core example 12 1`] = `
       }
     >
       The id returned for "my-identifier": 
-      uid-first-3-my-identifier
+      uid-first-4-my-identifier
     </span>
   </div>
   <h4
@@ -1031,7 +1031,7 @@ exports[`wonder-blocks-core example 12 1`] = `
       }
     >
       The id returned for "my-identifier": 
-      uid-second-4-my-identifier
+      uid-second-5-my-identifier
     </span>
   </div>
 </div>

--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -814,7 +814,7 @@ exports[`wonder-blocks-form example 2 1`] = `
       tabIndex={-1}
     >
       <input
-        aria-describedby="assignment-description"
+        aria-describedby="uid-choice-6-description"
         aria-invalid={false}
         checked={false}
         className=""
@@ -895,7 +895,7 @@ exports[`wonder-blocks-form example 2 1`] = `
     </div>
     <span
       className=""
-      id="assignment-description"
+      id="uid-choice-6-description"
       style={
         Object {
           "MozOsxFontSmoothing": "grayscale",
@@ -2109,7 +2109,7 @@ exports[`wonder-blocks-form example 5 1`] = `
           tabIndex={-1}
         >
           <input
-            aria-describedby="Toppings-sausage-description"
+            aria-describedby="uid-choice-15-description"
             aria-invalid={false}
             checked={false}
             className=""
@@ -2190,7 +2190,7 @@ exports[`wonder-blocks-form example 5 1`] = `
         </div>
         <span
           className=""
-          id="Toppings-sausage-description"
+          id="uid-choice-15-description"
           style={
             Object {
               "MozOsxFontSmoothing": "grayscale",
@@ -2666,7 +2666,7 @@ exports[`wonder-blocks-form example 5 1`] = `
           tabIndex={-1}
         >
           <input
-            aria-describedby="Toppings-pineapple-description"
+            aria-describedby="uid-choice-19-description"
             aria-invalid={false}
             checked={true}
             className=""
@@ -2767,7 +2767,7 @@ exports[`wonder-blocks-form example 5 1`] = `
         </div>
         <span
           className=""
-          id="Toppings-pineapple-description"
+          id="uid-choice-19-description"
           style={
             Object {
               "MozOsxFontSmoothing": "grayscale",
@@ -4752,7 +4752,7 @@ exports[`wonder-blocks-form example 8 1`] = `
           tabIndex={-1}
         >
           <input
-            aria-describedby="Pokemon-char-description"
+            aria-describedby="uid-choice-32-description"
             aria-invalid={false}
             checked={false}
             className=""
@@ -4835,7 +4835,7 @@ exports[`wonder-blocks-form example 8 1`] = `
         </div>
         <span
           className=""
-          id="Pokemon-char-description"
+          id="uid-choice-32-description"
           style={
             Object {
               "MozOsxFontSmoothing": "grayscale",

--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -814,6 +814,7 @@ exports[`wonder-blocks-form example 2 1`] = `
       tabIndex={-1}
     >
       <input
+        aria-describedby="assignment-description"
         aria-invalid={false}
         checked={false}
         className=""
@@ -894,6 +895,7 @@ exports[`wonder-blocks-form example 2 1`] = `
     </div>
     <span
       className=""
+      id="assignment-description"
       style={
         Object {
           "MozOsxFontSmoothing": "grayscale",
@@ -2107,6 +2109,7 @@ exports[`wonder-blocks-form example 5 1`] = `
           tabIndex={-1}
         >
           <input
+            aria-describedby="Toppings-sausage-description"
             aria-invalid={false}
             checked={false}
             className=""
@@ -2187,6 +2190,7 @@ exports[`wonder-blocks-form example 5 1`] = `
         </div>
         <span
           className=""
+          id="Toppings-sausage-description"
           style={
             Object {
               "MozOsxFontSmoothing": "grayscale",
@@ -2662,6 +2666,7 @@ exports[`wonder-blocks-form example 5 1`] = `
           tabIndex={-1}
         >
           <input
+            aria-describedby="Toppings-pineapple-description"
             aria-invalid={false}
             checked={true}
             className=""
@@ -2762,6 +2767,7 @@ exports[`wonder-blocks-form example 5 1`] = `
         </div>
         <span
           className=""
+          id="Toppings-pineapple-description"
           style={
             Object {
               "MozOsxFontSmoothing": "grayscale",
@@ -4746,6 +4752,7 @@ exports[`wonder-blocks-form example 8 1`] = `
           tabIndex={-1}
         >
           <input
+            aria-describedby="Pokemon-char-description"
             aria-invalid={false}
             checked={false}
             className=""
@@ -4828,6 +4835,7 @@ exports[`wonder-blocks-form example 8 1`] = `
         </div>
         <span
           className=""
+          id="Pokemon-char-description"
           style={
             Object {
               "MozOsxFontSmoothing": "grayscale",

--- a/packages/wonder-blocks-form/src/components/choice-internal.js
+++ b/packages/wonder-blocks-form/src/components/choice-internal.js
@@ -118,10 +118,16 @@ type DefaultProps = {|
             </LabelMedium>
         );
     }
+    getDescriptionId(): ?string {
+        const {description, id} = this.props;
+        return description && id && `${id}-description`;
+    }
     getDescription(): React.Node {
         const {description} = this.props;
         return (
-            <LabelSmall style={styles.description}>{description}</LabelSmall>
+            <LabelSmall style={styles.description} id={this.getDescriptionId()}>
+                {description}
+            </LabelSmall>
         );
     }
     render(): React.Node {
@@ -154,7 +160,11 @@ type DefaultProps = {|
                                 // focus on basis of it being an input element.
                                 tabIndex={-1}
                             >
-                                <ChoiceCore {...coreProps} {...state} />
+                                <ChoiceCore
+                                    {...coreProps}
+                                    {...state}
+                                    aria-describedby={this.getDescriptionId()}
+                                />
                                 <Strut size={Spacing.xSmall_8} />
                                 {label && this.getLabel()}
                             </View>

--- a/packages/wonder-blocks-form/src/components/choice-internal.js
+++ b/packages/wonder-blocks-form/src/components/choice-internal.js
@@ -118,7 +118,7 @@ type DefaultProps = {|
             </LabelMedium>
         );
     }
-    getDescriptionId(): ?string {
+    getDescriptionId(): string | void {
         const {description, id} = this.props;
         return description && id && `${id}-description`;
     }

--- a/packages/wonder-blocks-form/src/components/choice-internal.js
+++ b/packages/wonder-blocks-form/src/components/choice-internal.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, UniqueIDProvider} from "@khanacademy/wonder-blocks-core";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
@@ -118,14 +118,10 @@ type DefaultProps = {|
             </LabelMedium>
         );
     }
-    getDescriptionId(): string | void {
-        const {description, id} = this.props;
-        return description && id && `${id}-description`;
-    }
-    getDescription(): React.Node {
+    getDescription(id: string | void): React.Node {
         const {description} = this.props;
         return (
-            <LabelSmall style={styles.description} id={this.getDescriptionId()}>
+            <LabelSmall style={styles.description} id={id}>
                 {description}
             </LabelSmall>
         );
@@ -144,35 +140,43 @@ type DefaultProps = {|
         const ChoiceCore = this.getChoiceCoreComponent();
         const ClickableBehavior = getClickableBehavior();
         return (
-            <View style={style} className={className}>
-                <ClickableBehavior
-                    disabled={coreProps.disabled}
-                    onClick={this.handleClick}
-                    role={variant}
-                >
-                    {(state, childrenProps) => {
-                        return (
-                            <View
-                                style={styles.wrapper}
-                                {...childrenProps}
-                                // We are resetting the tabIndex=0 from handlers
-                                // because the ChoiceCore component will receive
-                                // focus on basis of it being an input element.
-                                tabIndex={-1}
+            <UniqueIDProvider mockOnFirstRender={true} scope="choice">
+                {(ids) => {
+                    const descriptionId = description && ids.get("description");
+
+                    return (
+                        <View style={style} className={className}>
+                            <ClickableBehavior
+                                disabled={coreProps.disabled}
+                                onClick={this.handleClick}
+                                role={variant}
                             >
-                                <ChoiceCore
-                                    {...coreProps}
-                                    {...state}
-                                    aria-describedby={this.getDescriptionId()}
-                                />
-                                <Strut size={Spacing.xSmall_8} />
-                                {label && this.getLabel()}
-                            </View>
-                        );
-                    }}
-                </ClickableBehavior>
-                {description && this.getDescription()}
-            </View>
+                                {(state, childrenProps) => {
+                                    return (
+                                        <View
+                                            style={styles.wrapper}
+                                            {...childrenProps}
+                                            // We are resetting the tabIndex=0 from handlers
+                                            // because the ChoiceCore component will receive
+                                            // focus on basis of it being an input element.
+                                            tabIndex={-1}
+                                        >
+                                            <ChoiceCore
+                                                {...coreProps}
+                                                {...state}
+                                                aria-describedby={descriptionId}
+                                            />
+                                            <Strut size={Spacing.xSmall_8} />
+                                            {label && this.getLabel()}
+                                        </View>
+                                    );
+                                }}
+                            </ClickableBehavior>
+                            {description && this.getDescription(descriptionId)}
+                        </View>
+                    );
+                }}
+            </UniqueIDProvider>
         );
     }
 }


### PR DESCRIPTION
The Choice component already takes an optional `description` prop. When
provided, this renders as some smaller additional text below the main
label for the Choice. However, when using tab navigation and a screen
reader, only the main label was being read; the description was being
ignored.

This change wires up the inner `input` and the `description` elements so
that when a `description` is provided, the wrapping element gets an
auto-generated `id`, and the neighboring `input` gets
`aria-describedby=${descriptionId}`.

The result is something like this (in VoiceOver):

"Selected. Squirtle. Radio button (3 of 5). This is the description. You
are currently on a radio button..."

Whereas before this change, it would only read:

"Selected. Squirtle. Radio button (3 of 5). You are currently on a radio
button..."

When no `description` is provided, the result is the same as it was
before.

I tested this manually in Chrome using VoiceOver.