### PR TITLE
WB-1048 - Add TextField and the basic styles.

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5882,3 +5882,36 @@ exports[`wonder-blocks-form example 9 1`] = `
   </fieldset>
 </div>
 `;
+
+exports[`wonder-blocks-form example 10 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "background": "#ffffff",
+      "border": "1px solid rgba(33,36,44,0.16)",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "color": "#21242c",
+      "display": "flex",
+      "flexDirection": "column",
+      "height": 40,
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": "10px 10px 10px 16px",
+      "position": "relative",
+      "width": 288,
+      "zIndex": 0,
+    }
+  }
+>
+  <input
+    className="input_8lp9zk-o_O-LabelMedium_1rew30o"
+    placeholder="Placeholder"
+  />
+</div>
+`;

--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5884,34 +5884,8 @@ exports[`wonder-blocks-form example 9 1`] = `
 `;
 
 exports[`wonder-blocks-form example 10 1`] = `
-<div
-  className=""
-  style={
-    Object {
-      "alignItems": "stretch",
-      "background": "#ffffff",
-      "border": "1px solid rgba(33,36,44,0.16)",
-      "borderRadius": 4,
-      "borderStyle": "solid",
-      "borderWidth": 0,
-      "boxSizing": "border-box",
-      "color": "#21242c",
-      "display": "flex",
-      "flexDirection": "column",
-      "height": 40,
-      "margin": 0,
-      "minHeight": 0,
-      "minWidth": 0,
-      "padding": "10px 10px 10px 16px",
-      "position": "relative",
-      "width": 288,
-      "zIndex": 0,
-    }
-  }
->
-  <input
-    className="input_8lp9zk-o_O-LabelMedium_1rew30o"
-    placeholder="Placeholder"
-  />
-</div>
+<input
+  className="input_gfhfc1-o_O-LabelMedium_1rew30o-o_O-default_nqqn0x"
+  placeholder="Placeholder"
+/>
 `;

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -15,6 +15,7 @@ import {
     CheckboxGroup,
     Choice,
     RadioGroup,
+    TextField,
 } from "@khanacademy/wonder-blocks-form";
 import {StyleSheet} from "aphrodite";
 import {
@@ -596,6 +597,12 @@ describe("wonder-blocks-form", () => {
                 <ClassSelectorExample />
             </View>
         );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 10", () => {
+        const example = <TextField />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-form/src/__tests__/index.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/index.test.js
@@ -16,6 +16,7 @@ describe("@khanacademy/wonder-blocks-form", () => {
                 "Choice",
                 "Radio",
                 "RadioGroup",
+                "TextField",
             ].sort(),
         );
     });

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -3,33 +3,38 @@
 import * as React from "react";
 import {StyleSheet, css} from "aphrodite";
 
-import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
 export default class TextField extends React.Component<{||}> {
     render(): React.Node {
         return (
-            <View style={[styles.container, styles.default]}>
-                <input
-                    className={css([
-                        styles.input,
-                        typographyStyles.LabelMedium,
-                    ])}
-                    placeholder="Placeholder"
-                />
-            </View>
+            <input
+                className={css([
+                    styles.input,
+                    typographyStyles.LabelMedium,
+                    styles.default,
+                ])}
+                placeholder="Placeholder"
+            />
         );
     }
 }
 
 const styles = StyleSheet.create({
-    container: {
-        width: 288,
+    input: {
+        width: "100%",
         height: 40,
         borderRadius: 4,
         boxSizing: "border-box",
-        padding: "10px 10px 10px 16px",
+        paddingLeft: Spacing.medium_16,
+        margin: 0,
+        outline: "none",
+        boxShadow: "none",
+        "::placeholder": {
+            color: Color.offBlack64,
+        },
     },
     default: {
         background: Color.white,
@@ -37,7 +42,7 @@ const styles = StyleSheet.create({
         color: Color.offBlack,
     },
     error: {
-        background: `linear-gradient(0deg, rgba(217, 41, 22, 0.06), rgba(217, 41, 22, 0.06)), ${Color.white}`,
+        background: "rgba(217, 41, 22, 0.06)",
         border: `1px solid ${Color.red}`,
         color: Color.offBlack,
     },
@@ -45,21 +50,5 @@ const styles = StyleSheet.create({
         background: Color.offWhite,
         border: `1px solid ${Color.offBlack16}`,
         color: Color.offBlack64,
-    },
-    input: {
-        flex: 1,
-        display: "flex",
-        alignItems: "center",
-        width: "100%",
-        background: "none",
-        color: "inherit",
-        border: "none",
-        outline: "none",
-        boxShadow: "none",
-        padding: 0,
-        margin: 0,
-        "::placeholder": {
-            color: Color.offBlack64,
-        },
     },
 });

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -1,0 +1,65 @@
+// @flow
+
+import * as React from "react";
+import {StyleSheet, css} from "aphrodite";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
+
+export default class TextField extends React.Component<{||}> {
+    render(): React.Node {
+        return (
+            <View style={[styles.container, styles.default]}>
+                <input
+                    className={css([
+                        styles.input,
+                        typographyStyles.LabelMedium,
+                    ])}
+                    placeholder="Placeholder"
+                />
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    container: {
+        width: 288,
+        height: 40,
+        borderRadius: 4,
+        boxSizing: "border-box",
+        padding: "10px 10px 10px 16px",
+    },
+    default: {
+        background: Color.white,
+        border: `1px solid ${Color.offBlack16}`,
+        color: Color.offBlack,
+    },
+    error: {
+        background: `linear-gradient(0deg, rgba(217, 41, 22, 0.06), rgba(217, 41, 22, 0.06)), ${Color.white}`,
+        border: `1px solid ${Color.red}`,
+        color: Color.offBlack,
+    },
+    disabled: {
+        background: Color.offWhite,
+        border: `1px solid ${Color.offBlack16}`,
+        color: Color.offBlack64,
+    },
+    input: {
+        flex: 1,
+        display: "flex",
+        alignItems: "center",
+        width: "100%",
+        background: "none",
+        color: "inherit",
+        border: "none",
+        outline: "none",
+        boxShadow: "none",
+        padding: 0,
+        margin: 0,
+        "::placeholder": {
+            color: Color.offBlack64,
+        },
+    },
+});

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -1,0 +1,7 @@
+A demonstration of the TextField styles.
+
+```js
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+<TextField />
+```

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -1,0 +1,11 @@
+// @flow
+import * as React from "react";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+import type {StoryComponentType} from "@storybook/react";
+
+export default {
+    title: "Form / TextField",
+};
+
+export const basic: StoryComponentType = () => <TextField />;

--- a/packages/wonder-blocks-form/src/index.js
+++ b/packages/wonder-blocks-form/src/index.js
@@ -4,5 +4,6 @@ import Radio from "./components/radio.js";
 import Choice from "./components/choice.js";
 import CheckboxGroup from "./components/checkbox-group.js";
 import RadioGroup from "./components/radio-group.js";
+import TextField from "./components/text-field.js";
 
-export {Checkbox, Radio, Choice, CheckboxGroup, RadioGroup};
+export {Checkbox, Radio, Choice, CheckboxGroup, RadioGroup, TextField};

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -95,6 +95,7 @@ module.exports = {
                 "packages/wonder-blocks-form/src/components/choice.js",
                 "packages/wonder-blocks-form/src/components/checkbox-group.js",
                 "packages/wonder-blocks-form/src/components/radio-group.js",
+                "packages/wonder-blocks-form/src/components/text-field.js",
             ],
             sections: [
                 {


### PR DESCRIPTION
## Summary:
Adding TextField to `wonder-blocks-form`. Implemented the basic look and
styles of the TextField from the [Figma](https://www.figma.com/file/VbVu3h2BpBhH80niq101MHHE/Wonder-Blocks-(Web)?node-id=495%3A2) concept. No props or any other
abilities have been implemented. Only its styles.

###### Figma Default
![figma-default](https://user-images.githubusercontent.com/60367213/119182020-059c5b00-ba38-11eb-9e7a-7709869290bd.png)
###### WB Default
![default-text](https://user-images.githubusercontent.com/60367213/119181964-f1585e00-ba37-11eb-8bd3-511b98ed90e7.png)
![default-placeholder](https://user-images.githubusercontent.com/60367213/119181974-f4ebe500-ba37-11eb-9a8a-0f7ba583693e.png)

###### Figma Disabled
![figma-disabled](https://user-images.githubusercontent.com/60367213/119182103-21076600-ba38-11eb-9b61-b1d3c75700d5.png)
###### WB Disabled
![disabled-text](https://user-images.githubusercontent.com/60367213/119182132-2795dd80-ba38-11eb-8c87-ed2c1d75cf4e.png)
![disabled-placeholder](https://user-images.githubusercontent.com/60367213/119182142-295fa100-ba38-11eb-9d36-3e676718c4d3.png)


###### Figma Error
![figma-error](https://user-images.githubusercontent.com/60367213/119182167-311f4580-ba38-11eb-9f18-c9f00c311df1.png)
###### WB Error
![error-text](https://user-images.githubusercontent.com/60367213/119182204-3bd9da80-ba38-11eb-90d0-38e61dd1de3e.png)
![error-placeholder](https://user-images.githubusercontent.com/60367213/119182211-3d0b0780-ba38-11eb-8f45-5be741edba1c.png)

Issue: https://khanacademy.atlassian.net/browse/WB-1048

## Test plan:
1. You can view the `TextField` section on Styleguidist, but since no error
and disabled props have been implemented yet, it is stuck on its default state.
2. I attached screenshots of the different styles above. Those screenshots are
the result of directly changing the style of the TextField using the 'default', 'disabled', and 'error' style.