### PR TITLE
WB-1051 - Add States to TextField

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5900,3 +5900,13 @@ exports[`wonder-blocks-form example 10 1`] = `
   placeholder="Placeholder"
 />
 `;
+
+exports[`wonder-blocks-form example 11 1`] = `
+<input
+  className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-disabled_1ab5c0p"
+  disabled={true}
+  onBlur={[Function]}
+  onFocus={[Function]}
+  placeholder="Placeholder"
+/>
+`;

--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5893,7 +5893,10 @@ exports[`wonder-blocks-form example 9 1`] = `
 
 exports[`wonder-blocks-form example 10 1`] = `
 <input
-  className="input_gfhfc1-o_O-LabelMedium_1rew30o-o_O-default_nqqn0x"
+  className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
+  disabled={false}
+  onBlur={[Function]}
+  onFocus={[Function]}
   placeholder="Placeholder"
 />
 `;

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -606,4 +606,10 @@ describe("wonder-blocks-form", () => {
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
+    it("example 11", () => {
+        const example = <TextField disabled={true} />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -1,0 +1,48 @@
+//@flow
+import * as React from "react";
+import {mount} from "enzyme";
+
+import TextField from "../text-field.js";
+
+const wait = (delay: number = 0) =>
+    new Promise((resolve, reject) => {
+        // eslint-disable-next-line no-restricted-syntax
+        return setTimeout(resolve, delay);
+    });
+
+describe("TextField", () => {
+    it("textfield is focused", () => {
+        // Arrange
+        const wrapper = mount(<TextField />);
+
+        // Act
+        wrapper.simulate("focus");
+
+        // Assert
+        expect(wrapper).toHaveState("focused", true);
+    });
+
+    it("textfield is blurred", async () => {
+        // Arrange
+        const wrapper = mount(<TextField />);
+
+        // Act
+        wrapper.simulate("focus");
+        await wait(0);
+        wrapper.simulate("blur");
+
+        // Assert
+        expect(wrapper).toHaveState("focused", false);
+    });
+
+    it("disabled prop is true", () => {
+        // Arrange
+        const wrapper = mount(<TextField disabled={true} />);
+        const input = wrapper.find("input");
+
+        // Act
+
+        // Assert
+        expect(input).toBeDisabled();
+    });
+});

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -7,46 +7,75 @@ import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
-type State = {|
-    enabled: boolean,
+type Props = {|
+    /**
+     * Makes a read-only input field that cannot be focused.
+     */
     disabled: boolean,
+|};
+
+type DefaultProps = {|
+    disabled: $PropertyType<Props, "disabled">,
+|};
+
+type State = {|
+    /**
+     * Displayed when the validation fails.
+     */
     error: ?string,
+
+    /**
+     * The user focuses on this field.
+     */
     focused: boolean,
 |};
 
-export default class TextField extends React.Component<{||}, State> {
-    state: State = {
-        enabled: true,
+/**
+ * A TextField is an element used to accept a single line of text from the user.
+ */
+export default class TextField extends React.Component<Props, State> {
+    static defaultProps: DefaultProps = {
         disabled: false,
+    };
+
+    state: State = {
         error: null,
         focused: false,
     };
 
-    handleOnFocus: () => void = () => {
+    handleOnFocus: (
+        event: SyntheticFocusEvent<HTMLInputElement>,
+    ) => mixed = () => {
         this.setState({
             focused: true,
         });
     };
 
-    handleOnBlur: () => void = () => {
+    handleOnBlur: (
+        event: SyntheticFocusEvent<HTMLInputElement>,
+    ) => mixed = () => {
         this.setState({
             focused: false,
         });
     };
 
     render(): React.Node {
+        const {disabled} = this.props;
         return (
             <input
                 className={css([
                     styles.input,
                     typographyStyles.LabelMedium,
-                    this.state.enabled && styles.default,
-                    this.state.disabled && styles.disabled,
-                    this.state.error && styles.error,
-                    this.state.focused && styles.focused,
+                    styles.default,
+                    // Prioritizes disabled, then focused, then error (if any)
+                    disabled
+                        ? styles.disabled
+                        : this.state.focused
+                        ? styles.focused
+                        : this.state.error && styles.error,
                 ])}
                 placeholder="Placeholder"
-                disabled={this.state.disabled}
+                disabled={disabled}
                 onFocus={this.handleOnFocus}
                 onBlur={this.handleOnBlur}
             />

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -7,16 +7,48 @@ import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
-export default class TextField extends React.Component<{||}> {
+type State = {|
+    enabled: boolean,
+    disabled: boolean,
+    error: ?string,
+    focused: boolean,
+|};
+
+export default class TextField extends React.Component<{||}, State> {
+    state: State = {
+        enabled: true,
+        disabled: false,
+        error: null,
+        focused: false,
+    };
+
+    handleOnFocus: () => void = () => {
+        this.setState({
+            focused: true,
+        });
+    };
+
+    handleOnBlur: () => void = () => {
+        this.setState({
+            focused: false,
+        });
+    };
+
     render(): React.Node {
         return (
             <input
                 className={css([
                     styles.input,
                     typographyStyles.LabelMedium,
-                    styles.default,
+                    this.state.enabled && styles.default,
+                    this.state.disabled && styles.disabled,
+                    this.state.error && styles.error,
+                    this.state.focused && styles.focused,
                 ])}
                 placeholder="Placeholder"
+                disabled={this.state.disabled}
+                onFocus={this.handleOnFocus}
+                onBlur={this.handleOnBlur}
             />
         );
     }
@@ -32,23 +64,37 @@ const styles = StyleSheet.create({
         margin: 0,
         outline: "none",
         boxShadow: "none",
-        "::placeholder": {
-            color: Color.offBlack64,
-        },
     },
     default: {
         background: Color.white,
         border: `1px solid ${Color.offBlack16}`,
         color: Color.offBlack,
+        "::placeholder": {
+            color: Color.offBlack64,
+        },
     },
     error: {
         background: "rgba(217, 41, 22, 0.06)",
         border: `1px solid ${Color.red}`,
         color: Color.offBlack,
+        "::placeholder": {
+            color: Color.offBlack64,
+        },
     },
     disabled: {
         background: Color.offWhite,
         border: `1px solid ${Color.offBlack16}`,
         color: Color.offBlack64,
+        "::placeholder": {
+            color: Color.offBlack32,
+        },
+    },
+    focused: {
+        background: Color.white,
+        border: `1px solid ${Color.blue}`,
+        color: Color.offBlack,
+        "::placeholder": {
+            color: Color.offBlack64,
+        },
     },
 });

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -1,7 +1,15 @@
-A demonstration of the TextField styles.
+A demonstration of a default TextField.
 
 ```js
 import {TextField} from "@khanacademy/wonder-blocks-form";
 
 <TextField />
+```
+
+A disabled TextField.
+
+```js
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+<TextField disabled={true} />
 ```

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -9,3 +9,5 @@ export default {
 };
 
 export const basic: StoryComponentType = () => <TextField />;
+
+export const disabled: StoryComponentType = () => <TextField disabled={true} />;


### PR DESCRIPTION
## Summary:
Integrated the States that TextField will use. This includes `enabled`,
`disabled`, `error`, and `focused`. Included the `focused` style for
when the user is focused on (editing) the TextField. I attached images
below of this new style.

Issue: https://khanacademy.atlassian.net/browse/WB-1051

## Test plan:
1. View the generated Storybook link. Check the "Form / TextField" section.
2. You can also view Styleguidist under the "Form" section.
###### NOTE: No props have been added yet so the TextField is stuck in the `enabled` state, but it will also show the `focused` state when you click on the TextField.

##### onFocus [no text]
![focus-notext](https://user-images.githubusercontent.com/60367213/119385979-89e71c00-bc8c-11eb-92bd-04f9931cbbd1.png)

##### onFocus [text]
![focus-text](https://user-images.githubusercontent.com/60367213/119386006-93708400-bc8c-11eb-86e1-9d1a5a99081c.png)
