### PR TITLE
WB-1049 - Add `id`, `type`, `value`, and `onChange` Props to TextField

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5915,7 +5915,7 @@ exports[`wonder-blocks-form example 11 1`] = `
   onFocus={[Function]}
   placeholder="Placeholder"
   type="number"
-  value=""
+  value="12345"
 />
 `;
 
@@ -5929,7 +5929,7 @@ exports[`wonder-blocks-form example 12 1`] = `
   onFocus={[Function]}
   placeholder="Placeholder"
   type="password"
-  value=""
+  value="Password123"
 />
 `;
 

--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5895,18 +5895,54 @@ exports[`wonder-blocks-form example 10 1`] = `
 <input
   className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
   disabled={false}
+  id="tf-1"
   onBlur={[Function]}
+  onChange={[Function]}
   onFocus={[Function]}
   placeholder="Placeholder"
+  type="text"
+  value=""
 />
 `;
 
 exports[`wonder-blocks-form example 11 1`] = `
 <input
-  className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-disabled_1ab5c0p"
-  disabled={true}
+  className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
+  disabled={false}
+  id="tf-1"
   onBlur={[Function]}
+  onChange={[Function]}
   onFocus={[Function]}
   placeholder="Placeholder"
+  type="number"
+  value=""
+/>
+`;
+
+exports[`wonder-blocks-form example 12 1`] = `
+<input
+  className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
+  disabled={false}
+  id="tf-1"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  placeholder="Placeholder"
+  type="password"
+  value=""
+/>
+`;
+
+exports[`wonder-blocks-form example 13 1`] = `
+<input
+  className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-disabled_1ab5c0p"
+  disabled={true}
+  id="tf-1"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  placeholder="Placeholder"
+  type="text"
+  value=""
 />
 `;

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -602,13 +602,104 @@ describe("wonder-blocks-form", () => {
     });
 
     it("example 10", () => {
-        const example = <TextField />;
+        class TextFieldExample extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: "",
+                };
+            }
+
+            render() {
+                return (
+                    <TextField
+                        id="tf-1"
+                        type="text"
+                        value={this.state.value}
+                        onChange={(newValue) =>
+                            this.setState({
+                                value: newValue,
+                            })
+                        }
+                    />
+                );
+            }
+        }
+
+        const example = <TextFieldExample />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     it("example 11", () => {
-        const example = <TextField disabled={true} />;
+        class TextFieldExample extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: "",
+                };
+            }
+
+            render() {
+                return (
+                    <TextField
+                        id="tf-1"
+                        type="number"
+                        value={this.state.value}
+                        onChange={(newValue) =>
+                            this.setState({
+                                value: newValue,
+                            })
+                        }
+                    />
+                );
+            }
+        }
+
+        const example = <TextFieldExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 12", () => {
+        class TextFieldExample extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: "",
+                };
+            }
+
+            render() {
+                return (
+                    <TextField
+                        id="tf-1"
+                        type="password"
+                        value={this.state.value}
+                        onChange={(newValue) =>
+                            this.setState({
+                                value: newValue,
+                            })
+                        }
+                    />
+                );
+            }
+        }
+
+        const example = <TextFieldExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 13", () => {
+        const example = (
+            <TextField
+                id="tf-1"
+                value=""
+                onChange={() => void 0}
+                disabled={true}
+            />
+        );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -636,7 +636,7 @@ describe("wonder-blocks-form", () => {
             constructor(props) {
                 super(props);
                 this.state = {
-                    value: "",
+                    value: "12345",
                 };
             }
 
@@ -666,7 +666,7 @@ describe("wonder-blocks-form", () => {
             constructor(props) {
                 super(props);
                 this.state = {
-                    value: "",
+                    value: "Password123",
                 };
             }
 
@@ -693,12 +693,7 @@ describe("wonder-blocks-form", () => {
 
     it("example 13", () => {
         const example = (
-            <TextField
-                id="tf-1"
-                value=""
-                onChange={() => void 0}
-                disabled={true}
-            />
+            <TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
         );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -1,4 +1,4 @@
-//@flow
+// @flow
 import * as React from "react";
 import {mount} from "enzyme";
 
@@ -13,7 +13,9 @@ const wait = (delay: number = 0) =>
 describe("TextField", () => {
     it("textfield is focused", () => {
         // Arrange
-        const wrapper = mount(<TextField />);
+        const wrapper = mount(
+            <TextField id="tf-1" value="" onChange={() => void 0} />,
+        );
 
         // Act
         wrapper.simulate("focus");
@@ -24,7 +26,9 @@ describe("TextField", () => {
 
     it("textfield is blurred", async () => {
         // Arrange
-        const wrapper = mount(<TextField />);
+        const wrapper = mount(
+            <TextField id="tf-1" value="" onChange={() => void 0} />,
+        );
 
         // Act
         wrapper.simulate("focus");
@@ -35,14 +39,99 @@ describe("TextField", () => {
         expect(wrapper).toHaveState("focused", false);
     });
 
+    it("id prop is passed to input", () => {
+        // Arrange
+        const id: string = "tf-1";
+
+        // Act
+        const wrapper = mount(
+            <TextField
+                id={id}
+                value=""
+                onChange={() => void 0}
+                disabled={true}
+            />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toHaveProp("id", id);
+    });
+
+    it("type prop is passed to input", () => {
+        // Arrange
+        const type = "number";
+
+        // Act
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                type={type}
+                value=""
+                onChange={() => void 0}
+                disabled={true}
+            />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toHaveProp("type", type);
+    });
+
+    it("value prop is passed to input", () => {
+        // Arrange
+        const value = "Text";
+
+        // Act
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value={value}
+                onChange={() => void 0}
+                disabled={true}
+            />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toHaveValue(value);
+    });
+
     it("disabled prop is true", () => {
         // Arrange
-        const wrapper = mount(<TextField disabled={true} />);
+        const wrapper = mount(
+            <TextField
+                id="tf-1"
+                value=""
+                onChange={() => void 0}
+                disabled={true}
+            />,
+        );
         const input = wrapper.find("input");
 
         // Act
 
         // Assert
         expect(input).toBeDisabled();
+    });
+
+    it("onChange is called when value changes", () => {
+        // Arrange
+        const handleOnChange = jest.fn();
+
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="Text"
+                onChange={handleOnChange}
+                disabled={true}
+            />,
+        );
+
+        // Act
+        wrapper.simulate("change", {target: {value: "Text2"}});
+
+        // Assert
+        expect(handleOnChange).toHaveBeenCalled();
     });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -14,7 +14,7 @@ describe("TextField", () => {
     it("textfield is focused", () => {
         // Arrange
         const wrapper = mount(
-            <TextField id="tf-1" value="" onChange={() => void 0} />,
+            <TextField id="tf-1" value="" onChange={() => {}} />,
         );
 
         // Act
@@ -27,7 +27,7 @@ describe("TextField", () => {
     it("textfield is blurred", async () => {
         // Arrange
         const wrapper = mount(
-            <TextField id="tf-1" value="" onChange={() => void 0} />,
+            <TextField id="tf-1" value="" onChange={() => {}} />,
         );
 
         // Act
@@ -39,26 +39,21 @@ describe("TextField", () => {
         expect(wrapper).toHaveState("focused", false);
     });
 
-    it("id prop is passed to input", () => {
+    it("id prop is passed to the input element", () => {
         // Arrange
         const id: string = "tf-1";
 
         // Act
         const wrapper = mount(
-            <TextField
-                id={id}
-                value=""
-                onChange={() => void 0}
-                disabled={true}
-            />,
+            <TextField id={id} value="" onChange={() => {}} disabled={true} />,
         );
 
         // Assert
         const input = wrapper.find("input");
-        expect(input).toHaveProp("id", id);
+        expect(input).toContainMatchingElement(`[id="${id}"]`);
     });
 
-    it("type prop is passed to input", () => {
+    it("type prop is passed to the input element", () => {
         // Arrange
         const type = "number";
 
@@ -68,17 +63,17 @@ describe("TextField", () => {
                 id={"tf-1"}
                 type={type}
                 value=""
-                onChange={() => void 0}
+                onChange={() => {}}
                 disabled={true}
             />,
         );
 
         // Assert
         const input = wrapper.find("input");
-        expect(input).toHaveProp("type", type);
+        expect(input).toContainMatchingElement(`[type="${type}"]`);
     });
 
-    it("value prop is passed to input", () => {
+    it("value prop is passed to the input element", () => {
         // Arrange
         const value = "Text";
 
@@ -87,23 +82,23 @@ describe("TextField", () => {
             <TextField
                 id={"tf-1"}
                 value={value}
-                onChange={() => void 0}
+                onChange={() => {}}
                 disabled={true}
             />,
         );
 
         // Assert
         const input = wrapper.find("input");
-        expect(input).toHaveValue(value);
+        expect(input).toContainMatchingElement(`[value="${value}"]`);
     });
 
-    it("disabled prop is true", () => {
+    it("disabled prop disables the input element", () => {
         // Arrange
         const wrapper = mount(
             <TextField
                 id="tf-1"
                 value=""
-                onChange={() => void 0}
+                onChange={() => {}}
                 disabled={true}
             />,
         );
@@ -129,9 +124,10 @@ describe("TextField", () => {
         );
 
         // Act
-        wrapper.simulate("change", {target: {value: "Text2"}});
+        const newValue = "Test2";
+        wrapper.simulate("change", {target: {value: newValue}});
 
         // Assert
-        expect(handleOnChange).toHaveBeenCalled();
+        expect(handleOnChange).toHaveBeenCalledWith(newValue);
     });
 });

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -7,14 +7,37 @@ import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
+type TextFieldType = "text" | "password" | "email" | "number" | "tel";
+
 type Props = {|
     /**
-     * Makes a read-only input field that cannot be focused.
+     * The unique identifier for the input.
+     */
+    id: string,
+
+    /**
+     * Determines the type of input. Defaults to text.
+     */
+    type: TextFieldType,
+
+    /**
+     * The input value.
+     */
+    value: string,
+
+    /**
+     * Makes a read-only input field that cannot be focused. Defaults to false.
      */
     disabled: boolean,
+
+    /**
+     * Called when the value has changed.
+     */
+    onChange: (newValue: string) => mixed,
 |};
 
 type DefaultProps = {|
+    type: $PropertyType<Props, "type">,
     disabled: $PropertyType<Props, "disabled">,
 |};
 
@@ -35,12 +58,20 @@ type State = {|
  */
 export default class TextField extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
+        type: "text",
         disabled: false,
     };
 
     state: State = {
         error: null,
         focused: false,
+    };
+
+    handleOnChange: (event: SyntheticInputEvent<HTMLInputElement>) => mixed = (
+        event,
+    ) => {
+        const {onChange} = this.props;
+        onChange(event.target.value);
     };
 
     handleOnFocus: (
@@ -60,7 +91,7 @@ export default class TextField extends React.Component<Props, State> {
     };
 
     render(): React.Node {
-        const {disabled} = this.props;
+        const {id, type, value, disabled} = this.props;
         return (
             <input
                 className={css([
@@ -74,8 +105,12 @@ export default class TextField extends React.Component<Props, State> {
                         ? styles.focused
                         : this.state.error && styles.error,
                 ])}
+                id={id}
+                type={type}
                 placeholder="Placeholder"
+                value={value}
                 disabled={disabled}
+                onChange={this.handleOnChange}
                 onFocus={this.handleOnFocus}
                 onBlur={this.handleOnBlur}
             />

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -1,15 +1,91 @@
-A demonstration of a default TextField.
+Text
 
 ```js
 import {TextField} from "@khanacademy/wonder-blocks-form";
 
-<TextField />
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "",
+        };
+    }
+
+    render() {
+        return (
+            <TextField
+                id="tf-1"
+                type="text"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
+            />
+        );
+    }
+}
+
+<TextFieldExample />
 ```
 
-A disabled TextField.
+Number
 
 ```js
 import {TextField} from "@khanacademy/wonder-blocks-form";
 
-<TextField disabled={true} />
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "",
+        };
+    }
+
+    render() {
+        return (
+            <TextField
+                id="tf-1"
+                type="number"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
+            />
+        );
+    }
+}
+
+<TextFieldExample />
+```
+
+Password
+
+```js
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "",
+        };
+    }
+
+    render() {
+        return (
+            <TextField
+                id="tf-1"
+                type="password"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
+            />
+        );
+    }
+}
+
+<TextFieldExample />
+```
+
+Disabled
+
+```js
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+<TextField id="tf-1" value="" onChange={() => void 0} disabled={true} />
 ```

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -35,7 +35,7 @@ class TextFieldExample extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            value: "",
+            value: "12345",
         };
     }
 
@@ -63,7 +63,7 @@ class TextFieldExample extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            value: "",
+            value: "Password123",
         };
     }
 
@@ -87,5 +87,5 @@ Disabled
 ```js
 import {TextField} from "@khanacademy/wonder-blocks-form";
 
-<TextField id="tf-1" value="" onChange={() => void 0} disabled={true} />
+<TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
 ```

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -26,7 +26,7 @@ export const text: StoryComponentType = () => {
 };
 
 export const number: StoryComponentType = () => {
-    const [value, setValue] = React.useState("");
+    const [value, setValue] = React.useState("12345");
 
     const handleOnChange = (newValue: string) => {
         setValue(newValue);
@@ -43,7 +43,7 @@ export const number: StoryComponentType = () => {
 };
 
 export const password: StoryComponentType = () => {
-    const [value, setValue] = React.useState("");
+    const [value, setValue] = React.useState("Password123");
 
     const handleOnChange = (newValue: string) => {
         setValue(newValue);
@@ -60,5 +60,5 @@ export const password: StoryComponentType = () => {
 };
 
 export const disabled: StoryComponentType = () => (
-    <TextField id="tf-1" value="" onChange={() => void 0} disabled={true} />
+    <TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
 );

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -8,6 +8,57 @@ export default {
     title: "Form / TextField",
 };
 
-export const basic: StoryComponentType = () => <TextField />;
+export const text: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
 
-export const disabled: StoryComponentType = () => <TextField disabled={true} />;
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    return (
+        <TextField
+            id="tf-1"
+            type="text"
+            value={value}
+            onChange={handleOnChange}
+        />
+    );
+};
+
+export const number: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    return (
+        <TextField
+            id="tf-1"
+            type="number"
+            value={value}
+            onChange={handleOnChange}
+        />
+    );
+};
+
+export const password: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    return (
+        <TextField
+            id="tf-1"
+            type="password"
+            value={value}
+            onChange={handleOnChange}
+        />
+    );
+};
+
+export const disabled: StoryComponentType = () => (
+    <TextField id="tf-1" value="" onChange={() => void 0} disabled={true} />
+);


### PR DESCRIPTION
## Summary:
* Added the Props `id`, `type`, `value`, and `onChange` to the TextField.
* Included unit tests for all of these new props (Coverage displays 100% for the TextField component after the new unit tests).
* Added more examples to Styleguidist and React Storybook.

Issue: WB-1049

## Test plan:
1. Open Styleguidist in the browser
2. Check the new examples under Form -> TextField
3. You can also view the new examples on React Storybook under Form -> Textfield

##### These are the new additions I added to Styleguidist and React Storybook

###### Number
<img width="391" alt="tf-number" src="https://user-images.githubusercontent.com/60367213/119705566-84b9d680-be1e-11eb-957d-f21c690464cb.png">

###### Password
<img width="390" alt="tf-password" src="https://user-images.githubusercontent.com/60367213/119705570-86839a00-be1e-11eb-84c9-c170aebbae87.png">

##### NOTE: Will also add `email` and `tel` examples when the `validation` prop is added.