### PR TITLE
WB-1052 - Add `validation` and `onError` Props to TextField

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5920,20 +5920,108 @@ exports[`wonder-blocks-form example 11 1`] = `
 `;
 
 exports[`wonder-blocks-form example 12 1`] = `
-<input
-  className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
-  disabled={false}
-  id="tf-1"
-  onBlur={[Function]}
-  onChange={[Function]}
-  onFocus={[Function]}
-  placeholder="Placeholder"
-  type="password"
-  value="Password123"
-/>
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <input
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
+    disabled={false}
+    id="tf-1"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    placeholder="Placeholder"
+    type="password"
+    value="Password123"
+  />
+</div>
 `;
 
 exports[`wonder-blocks-form example 13 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <input
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
+    disabled={false}
+    id="tf-1"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    placeholder="Placeholder"
+    type="email"
+    value="khan@khanacademy.org"
+  />
+</div>
+`;
+
+exports[`wonder-blocks-form example 14 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <input
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
+    disabled={false}
+    id="tf-1"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    placeholder="Placeholder"
+    type="email"
+    value="123-456-7890"
+  />
+</div>
+`;
+
+exports[`wonder-blocks-form example 15 1`] = `
 <input
   className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-disabled_1ab5c0p"
   disabled={true}

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -671,18 +671,12 @@ describe("wonder-blocks-form", () => {
                     value: "Password123",
                     errorMessage: null,
                 };
+                this.validation = this.validation.bind(this);
+                this.handleOnValidation = this.handleOnValidation.bind(this);
                 this.handleOnChange = this.handleOnChange.bind(this);
-                this.handleValidation = this.handleValidation.bind(this);
-                this.handleOnError = this.handleOnError.bind(this);
             }
 
-            handleOnChange(newValue) {
-                this.setState({
-                    value: newValue,
-                });
-            }
-
-            handleValidation(value) {
+            validation(value) {
                 if (value.length <= 8) {
                     return "Password must be at least 8 characters long";
                 }
@@ -690,15 +684,17 @@ describe("wonder-blocks-form", () => {
                 if (!/\d/.test(value)) {
                     return "Password must contain a numeric value";
                 }
+            }
 
+            handleOnValidation(errorMessage) {
                 this.setState({
-                    errorMessage: null,
+                    errorMessage: errorMessage,
                 });
             }
 
-            handleOnError(errorMessage) {
+            handleOnChange(newValue) {
                 this.setState({
-                    errorMessage: errorMessage,
+                    value: newValue,
                 });
             }
 
@@ -709,9 +705,9 @@ describe("wonder-blocks-form", () => {
                             id="tf-1"
                             type="password"
                             value={this.state.value}
-                            validation={this.handleValidation}
+                            validation={this.validation}
+                            onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
-                            onError={this.handleOnError}
                         />
                         {this.state.errorMessage && (
                             <View>
@@ -745,32 +741,28 @@ describe("wonder-blocks-form", () => {
                     value: "khan@khanacademy.org",
                     errorMessage: null,
                 };
+                this.validation = this.validation.bind(this);
+                this.handleOnValidation = this.handleOnValidation.bind(this);
                 this.handleOnChange = this.handleOnChange.bind(this);
-                this.handleValidation = this.handleValidation.bind(this);
-                this.handleOnError = this.handleOnError.bind(this);
             }
 
-            handleOnChange(newValue) {
-                this.setState({
-                    value: newValue,
-                });
-            }
-
-            handleValidation(value) {
+            validation(value) {
                 const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
 
                 if (!emailRegex.test(value)) {
                     return "Please enter a valid email";
                 }
+            }
 
+            handleOnValidation(errorMessage) {
                 this.setState({
-                    errorMessage: null,
+                    errorMessage: errorMessage,
                 });
             }
 
-            handleOnError(errorMessage) {
+            handleOnChange(newValue) {
                 this.setState({
-                    errorMessage: errorMessage,
+                    value: newValue,
                 });
             }
 
@@ -781,9 +773,9 @@ describe("wonder-blocks-form", () => {
                             id="tf-1"
                             type="email"
                             value={this.state.value}
-                            validation={this.handleValidation}
+                            validation={this.validation}
+                            onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
-                            onError={this.handleOnError}
                         />
                         {this.state.errorMessage && (
                             <View>
@@ -817,32 +809,28 @@ describe("wonder-blocks-form", () => {
                     value: "123-456-7890",
                     errorMessage: null,
                 };
+                this.validation = this.validation.bind(this);
+                this.handleOnValidation = this.handleOnValidation.bind(this);
                 this.handleOnChange = this.handleOnChange.bind(this);
-                this.handleValidation = this.handleValidation.bind(this);
-                this.handleOnError = this.handleOnError.bind(this);
             }
 
-            handleOnChange(newValue) {
-                this.setState({
-                    value: newValue,
-                });
-            }
-
-            handleValidation(value) {
+            validation(value) {
                 const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
 
                 if (!telRegex.test(value)) {
                     return "Invalid US telephone number";
                 }
+            }
 
+            handleOnValidation(errorMessage) {
                 this.setState({
-                    errorMessage: null,
+                    errorMessage: errorMessage,
                 });
             }
 
-            handleOnError(errorMessage) {
+            handleOnChange(newValue) {
                 this.setState({
-                    errorMessage: errorMessage,
+                    value: newValue,
                 });
             }
 
@@ -853,9 +841,9 @@ describe("wonder-blocks-form", () => {
                             id="tf-1"
                             type="email"
                             value={this.state.value}
-                            validation={this.handleValidation}
+                            validation={this.validation}
+                            onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
-                            onError={this.handleOnError}
                         />
                         {this.state.errorMessage && (
                             <View>

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -8,7 +8,7 @@ import renderer from "react-test-renderer";
 
 // Mock react-dom as jest doesn't like findDOMNode.
 jest.mock("react-dom");
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, Text} from "@khanacademy/wonder-blocks-core";
 import {
     Checkbox,
     Radio,
@@ -24,6 +24,8 @@ import {
     LabelLarge,
 } from "@khanacademy/wonder-blocks-typography";
 import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import CheckboxCore from "./../components/checkbox-core.js";
 import RadioCore from "./../components/radio-core.js";
@@ -667,31 +669,219 @@ describe("wonder-blocks-form", () => {
                 super(props);
                 this.state = {
                     value: "Password123",
+                    errorMessage: null,
                 };
+                this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleValidation = this.handleValidation.bind(this);
+                this.handleOnError = this.handleOnError.bind(this);
+            }
+
+            handleOnChange(newValue) {
+                this.setState({
+                    value: newValue,
+                });
+            }
+
+            handleValidation(value) {
+                if (value.length <= 8) {
+                    return "Password must be at least 8 characters long";
+                }
+
+                if (!/\d/.test(value)) {
+                    return "Password must contain a numeric value";
+                }
+
+                this.setState({
+                    errorMessage: null,
+                });
+            }
+
+            handleOnError(errorMessage) {
+                this.setState({
+                    errorMessage: errorMessage,
+                });
             }
 
             render() {
                 return (
-                    <TextField
-                        id="tf-1"
-                        type="password"
-                        value={this.state.value}
-                        onChange={(newValue) =>
-                            this.setState({
-                                value: newValue,
-                            })
-                        }
-                    />
+                    <View>
+                        <TextField
+                            id="tf-1"
+                            type="password"
+                            value={this.state.value}
+                            validation={this.handleValidation}
+                            onChange={this.handleOnChange}
+                            onError={this.handleOnError}
+                        />
+                        {this.state.errorMessage && (
+                            <View>
+                                <Strut size={Spacing.xSmall_8} />
+                                <Text style={styles.errorMessage}>
+                                    {this.state.errorMessage}
+                                </Text>
+                            </View>
+                        )}
+                    </View>
                 );
             }
         }
 
+        const styles = StyleSheet.create({
+            errorMessage: {
+                color: Color.red,
+                paddingLeft: Spacing.xxxSmall_4,
+            },
+        });
         const example = <TextFieldExample />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     it("example 13", () => {
+        class TextFieldExample extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: "khan@khanacademy.org",
+                    errorMessage: null,
+                };
+                this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleValidation = this.handleValidation.bind(this);
+                this.handleOnError = this.handleOnError.bind(this);
+            }
+
+            handleOnChange(newValue) {
+                this.setState({
+                    value: newValue,
+                });
+            }
+
+            handleValidation(value) {
+                const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+
+                if (!emailRegex.test(value)) {
+                    return "Please enter a valid email";
+                }
+
+                this.setState({
+                    errorMessage: null,
+                });
+            }
+
+            handleOnError(errorMessage) {
+                this.setState({
+                    errorMessage: errorMessage,
+                });
+            }
+
+            render() {
+                return (
+                    <View>
+                        <TextField
+                            id="tf-1"
+                            type="email"
+                            value={this.state.value}
+                            validation={this.handleValidation}
+                            onChange={this.handleOnChange}
+                            onError={this.handleOnError}
+                        />
+                        {this.state.errorMessage && (
+                            <View>
+                                <Strut size={Spacing.xSmall_8} />
+                                <Text style={styles.errorMessage}>
+                                    {this.state.errorMessage}
+                                </Text>
+                            </View>
+                        )}
+                    </View>
+                );
+            }
+        }
+
+        const styles = StyleSheet.create({
+            errorMessage: {
+                color: Color.red,
+                paddingLeft: Spacing.xxxSmall_4,
+            },
+        });
+        const example = <TextFieldExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 14", () => {
+        class TextFieldExample extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: "123-456-7890",
+                    errorMessage: null,
+                };
+                this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleValidation = this.handleValidation.bind(this);
+                this.handleOnError = this.handleOnError.bind(this);
+            }
+
+            handleOnChange(newValue) {
+                this.setState({
+                    value: newValue,
+                });
+            }
+
+            handleValidation(value) {
+                const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
+
+                if (!telRegex.test(value)) {
+                    return "Invalid US telephone number";
+                }
+
+                this.setState({
+                    errorMessage: null,
+                });
+            }
+
+            handleOnError(errorMessage) {
+                this.setState({
+                    errorMessage: errorMessage,
+                });
+            }
+
+            render() {
+                return (
+                    <View>
+                        <TextField
+                            id="tf-1"
+                            type="email"
+                            value={this.state.value}
+                            validation={this.handleValidation}
+                            onChange={this.handleOnChange}
+                            onError={this.handleOnError}
+                        />
+                        {this.state.errorMessage && (
+                            <View>
+                                <Strut size={Spacing.xSmall_8} />
+                                <Text style={styles.errorMessage}>
+                                    {this.state.errorMessage}
+                                </Text>
+                            </View>
+                        )}
+                    </View>
+                );
+            }
+        }
+
+        const styles = StyleSheet.create({
+            errorMessage: {
+                color: Color.red,
+                paddingLeft: Spacing.xxxSmall_4,
+            },
+        });
+        const example = <TextFieldExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 15", () => {
         const example = (
             <TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
         );

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -176,7 +176,7 @@ describe("TextField", () => {
         wrapper.simulate("change", {target: {value: newValue}});
 
         // Assert
-        expect(handleValidation.mock.results[0].value).toEqual(undefined);
+        expect(handleValidation).toHaveReturnedWith(undefined);
     });
 
     it("validation is given an invalid input", () => {
@@ -203,7 +203,7 @@ describe("TextField", () => {
         wrapper.simulate("change", {target: {value: newValue}});
 
         // Assert
-        expect(handleValidation.mock.results[0].value).toEqual(errorMessage);
+        expect(handleValidation).toHaveReturnedWith(errorMessage);
     });
 
     it("onValidation is called after input validation", () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -130,4 +130,108 @@ describe("TextField", () => {
         // Assert
         expect(handleOnChange).toHaveBeenCalledWith(newValue);
     });
+
+    it("validation is called when value changes", () => {
+        // Arrange
+        const handleValidation = jest.fn((value: string): ?string => {});
+
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="Text"
+                validation={handleValidation}
+                onChange={() => {}}
+                disabled={true}
+            />,
+        );
+
+        // Act
+        const newValue = "Text2";
+        wrapper.simulate("change", {target: {value: newValue}});
+
+        // Assert
+        expect(handleValidation).toHaveBeenCalledWith(newValue);
+    });
+
+    it("validation is given a valid input", () => {
+        // Arrange
+        const handleValidation = jest.fn((value: string): ?string => {
+            if (value.length < 8) {
+                return "Value is too short";
+            }
+        });
+
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="TextIsLong"
+                validation={handleValidation}
+                onChange={() => {}}
+                disabled={true}
+            />,
+        );
+
+        // Act
+        const newValue = "TextIsLongerThan8";
+        wrapper.simulate("change", {target: {value: newValue}});
+
+        // Assert
+        expect(handleValidation.mock.results[0].value).toEqual(undefined);
+    });
+
+    it("validation is given an invalid input", () => {
+        // Arrange
+        const errorMessage = "Value is too short";
+        const handleValidation = jest.fn((value: string): ?string => {
+            if (value.length < 8) {
+                return errorMessage;
+            }
+        });
+
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="TextIsLongerThan8"
+                validation={handleValidation}
+                onChange={() => {}}
+                disabled={true}
+            />,
+        );
+
+        // Act
+        const newValue = "Text";
+        wrapper.simulate("change", {target: {value: newValue}});
+
+        // Assert
+        expect(handleValidation.mock.results[0].value).toEqual(errorMessage);
+    });
+
+    it("onError is called on invalid validation", () => {
+        // Arrange
+        const errorMessage = "Value is too short";
+        const handleOnError = jest.fn((errorMessage: string) => {});
+        const handleValidation = jest.fn((value: string): ?string => {
+            if (value.length < 8) {
+                return errorMessage;
+            }
+        });
+
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="TextIsLongerThan8"
+                validation={handleValidation}
+                onChange={() => {}}
+                onError={handleOnError}
+                disabled={true}
+            />,
+        );
+
+        // Act
+        const newValue = "Text";
+        wrapper.simulate("change", {target: {value: newValue}});
+
+        // Assert
+        expect(handleOnError).toHaveBeenCalledWith(errorMessage);
+    });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -206,11 +206,11 @@ describe("TextField", () => {
         expect(handleValidation.mock.results[0].value).toEqual(errorMessage);
     });
 
-    it("onError is called on invalid validation", () => {
+    it("onValidation is called after input validation", () => {
         // Arrange
         const errorMessage = "Value is too short";
-        const handleOnError = jest.fn((errorMessage: string) => {});
-        const handleValidation = jest.fn((value: string): ?string => {
+        const handleOnValidation = jest.fn((errorMessage: ?string) => {});
+        const validation = jest.fn((value: string): ?string => {
             if (value.length < 8) {
                 return errorMessage;
             }
@@ -220,9 +220,9 @@ describe("TextField", () => {
             <TextField
                 id={"tf-1"}
                 value="TextIsLongerThan8"
-                validation={handleValidation}
+                validation={validation}
+                onValidation={handleOnValidation}
                 onChange={() => {}}
-                onError={handleOnError}
                 disabled={true}
             />,
         );
@@ -232,6 +232,6 @@ describe("TextField", () => {
         wrapper.simulate("change", {target: {value: newValue}});
 
         // Assert
-        expect(handleOnError).toHaveBeenCalledWith(errorMessage);
+        expect(handleOnValidation).toHaveBeenCalledWith(errorMessage);
     });
 });

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -31,9 +31,20 @@ type Props = {|
     disabled: boolean,
 
     /**
+     * Provide a validation for the input value.
+     * Return a string error message or null | void for a valid input.
+     */
+    validation?: (value: string) => ?string,
+
+    /**
      * Called when the value has changed.
      */
     onChange: (newValue: string) => mixed,
+
+    /**
+     * Called when the TextField validation has failed.
+     */
+    onError?: (errorMessage: string) => mixed,
 |};
 
 type DefaultProps = {|
@@ -70,8 +81,16 @@ export default class TextField extends React.Component<Props, State> {
     handleOnChange: (event: SyntheticInputEvent<HTMLInputElement>) => mixed = (
         event,
     ) => {
-        const {onChange} = this.props;
-        onChange(event.target.value);
+        const {validation, onChange, onError} = this.props;
+        const newValue = event.target.value;
+        if (validation) {
+            const isError = validation(newValue);
+            this.setState({error: isError});
+            if (isError && onError) {
+                onError(isError);
+            }
+        }
+        onChange(newValue);
     };
 
     handleOnFocus: (

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -37,14 +37,14 @@ type Props = {|
     validation?: (value: string) => ?string,
 
     /**
+     * Called right after the TextField input is validated.
+     */
+    onValidation?: (errorMessage: ?string) => mixed,
+
+    /**
      * Called when the value has changed.
      */
     onChange: (newValue: string) => mixed,
-
-    /**
-     * Called when the TextField validation has failed.
-     */
-    onError?: (errorMessage: string) => mixed,
 |};
 
 type DefaultProps = {|
@@ -81,13 +81,13 @@ export default class TextField extends React.Component<Props, State> {
     handleOnChange: (event: SyntheticInputEvent<HTMLInputElement>) => mixed = (
         event,
     ) => {
-        const {validation, onChange, onError} = this.props;
+        const {validation, onValidation, onChange} = this.props;
         const newValue = event.target.value;
         if (validation) {
-            const isError = validation(newValue);
-            this.setState({error: isError});
-            if (isError && onError) {
-                onError(isError);
+            const maybeError = validation(newValue);
+            this.setState({error: maybeError});
+            if (onValidation) {
+                onValidation(maybeError);
             }
         }
         onChange(newValue);

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -71,27 +71,26 @@ class TextFieldExample extends React.Component {
             value: "Password123",
             errorMessage: null,
         };
+        this.validation = this.validation.bind(this);
+        this.handleOnValidation = this.handleOnValidation.bind(this);
         this.handleOnChange = this.handleOnChange.bind(this);
-        this.handleValidation = this.handleValidation.bind(this);
-        this.handleOnError = this.handleOnError.bind(this);
     }
 
-    handleOnChange(newValue) {
-        this.setState({value: newValue});
-    }
-
-    handleValidation(value) {
+    validation(value) {
         if (value.length <= 8) {
             return "Password must be at least 8 characters long";
         }
         if (!/\d/.test(value)) {
             return "Password must contain a numeric value";
         }
-        this.setState({errorMessage: null})
     }
 
-    handleOnError(errorMessage) {
+    handleOnValidation(errorMessage) {
         this.setState({errorMessage: errorMessage});
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
     }
 
     render() {
@@ -101,9 +100,9 @@ class TextFieldExample extends React.Component {
                     id="tf-1"
                     type="password"
                     value={this.state.value}
-                    validation={this.handleValidation}
+                    validation={this.validation}
+                    onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
-                    onError={this.handleOnError}
                 />
                 {this.state.errorMessage && (
                     <View>
@@ -143,25 +142,24 @@ class TextFieldExample extends React.Component {
             value: "khan@khanacademy.org",
             errorMessage: null,
         };
+        this.validation = this.validation.bind(this);
+        this.handleOnValidation = this.handleOnValidation.bind(this);
         this.handleOnChange = this.handleOnChange.bind(this);
-        this.handleValidation = this.handleValidation.bind(this);
-        this.handleOnError = this.handleOnError.bind(this);
     }
 
-    handleOnChange(newValue) {
-        this.setState({value: newValue});
-    }
-
-    handleValidation(value) {
+    validation(value) {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
             return "Please enter a valid email";
         }
-        this.setState({errorMessage: null})
     }
 
-    handleOnError(errorMessage) {
+    handleOnValidation(errorMessage) {
         this.setState({errorMessage: errorMessage});
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
     }
 
     render() {
@@ -171,9 +169,9 @@ class TextFieldExample extends React.Component {
                     id="tf-1"
                     type="email"
                     value={this.state.value}
-                    validation={this.handleValidation}
+                    validation={this.validation}
+                    onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
-                    onError={this.handleOnError}
                 />
                 {this.state.errorMessage && (
                     <View>
@@ -213,25 +211,24 @@ class TextFieldExample extends React.Component {
             value: "123-456-7890",
             errorMessage: null,
         };
+        this.validation = this.validation.bind(this);
+        this.handleOnValidation = this.handleOnValidation.bind(this);
         this.handleOnChange = this.handleOnChange.bind(this);
-        this.handleValidation = this.handleValidation.bind(this);
-        this.handleOnError = this.handleOnError.bind(this);
     }
 
-    handleOnChange(newValue) {
-        this.setState({value: newValue});
-    }
-
-    handleValidation(value) {
+    validation(value) {
         const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
         if (!telRegex.test(value)) {
             return "Invalid US telephone number";
         }
-        this.setState({errorMessage: null})
     }
 
-    handleOnError(errorMessage) {
+    handleOnValidation(errorMessage) {
         this.setState({errorMessage: errorMessage});
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
     }
 
     render() {
@@ -241,9 +238,9 @@ class TextFieldExample extends React.Component {
                     id="tf-1"
                     type="email"
                     value={this.state.value}
-                    validation={this.handleValidation}
+                    validation={this.validation}
+                    onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
-                    onError={this.handleOnError}
                 />
                 {this.state.errorMessage && (
                     <View>

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -54,9 +54,14 @@ class TextFieldExample extends React.Component {
 <TextFieldExample />
 ```
 
-Password
+Password (with Validation)
 
 ```js
+import {StyleSheet} from "aphrodite";
+import {View, Text} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 
 class TextFieldExample extends React.Component {
@@ -64,20 +69,199 @@ class TextFieldExample extends React.Component {
         super(props);
         this.state = {
             value: "Password123",
+            errorMessage: null,
         };
+        this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleValidation = this.handleValidation.bind(this);
+        this.handleOnError = this.handleOnError.bind(this);
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleValidation(value) {
+        if (value.length <= 8) {
+            return "Password must be at least 8 characters long";
+        }
+        if (!/\d/.test(value)) {
+            return "Password must contain a numeric value";
+        }
+        this.setState({errorMessage: null})
+    }
+
+    handleOnError(errorMessage) {
+        this.setState({errorMessage: errorMessage});
     }
 
     render() {
         return (
-            <TextField
-                id="tf-1"
-                type="password"
-                value={this.state.value}
-                onChange={(newValue) => this.setState({value: newValue})}
-            />
+            <View>
+                <TextField
+                    id="tf-1"
+                    type="password"
+                    value={this.state.value}
+                    validation={this.handleValidation}
+                    onChange={this.handleOnChange}
+                    onError={this.handleOnError}
+                />
+                {this.state.errorMessage && (
+                    <View>
+                        <Strut size={Spacing.xSmall_8} />
+                        <Text style={styles.errorMessage}>{this.state.errorMessage}</Text>
+                    </View>
+                )}
+            </View>
         );
     }
 }
+
+const styles = StyleSheet.create({
+    errorMessage: {
+        color: Color.red,
+        paddingLeft: Spacing.xxxSmall_4,
+    },
+});
+
+<TextFieldExample />
+```
+
+Email (with Validation)
+
+```js
+import {StyleSheet} from "aphrodite";
+import {View, Text} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "khan@khanacademy.org",
+            errorMessage: null,
+        };
+        this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleValidation = this.handleValidation.bind(this);
+        this.handleOnError = this.handleOnError.bind(this);
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleValidation(value) {
+        const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+        if (!emailRegex.test(value)) {
+            return "Please enter a valid email";
+        }
+        this.setState({errorMessage: null})
+    }
+
+    handleOnError(errorMessage) {
+        this.setState({errorMessage: errorMessage});
+    }
+
+    render() {
+        return (
+            <View>
+                <TextField
+                    id="tf-1"
+                    type="email"
+                    value={this.state.value}
+                    validation={this.handleValidation}
+                    onChange={this.handleOnChange}
+                    onError={this.handleOnError}
+                />
+                {this.state.errorMessage && (
+                    <View>
+                        <Strut size={Spacing.xSmall_8} />
+                        <Text style={styles.errorMessage}>{this.state.errorMessage}</Text>
+                    </View>
+                )}
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    errorMessage: {
+        color: Color.red,
+        paddingLeft: Spacing.xxxSmall_4,
+    },
+});
+
+<TextFieldExample />
+```
+
+Telephone (with Validation)
+
+```js
+import {StyleSheet} from "aphrodite";
+import {View, Text} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "123-456-7890",
+            errorMessage: null,
+        };
+        this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleValidation = this.handleValidation.bind(this);
+        this.handleOnError = this.handleOnError.bind(this);
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleValidation(value) {
+        const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
+        if (!telRegex.test(value)) {
+            return "Invalid US telephone number";
+        }
+        this.setState({errorMessage: null})
+    }
+
+    handleOnError(errorMessage) {
+        this.setState({errorMessage: errorMessage});
+    }
+
+    render() {
+        return (
+            <View>
+                <TextField
+                    id="tf-1"
+                    type="email"
+                    value={this.state.value}
+                    validation={this.handleValidation}
+                    onChange={this.handleOnChange}
+                    onError={this.handleOnError}
+                />
+                {this.state.errorMessage && (
+                    <View>
+                        <Strut size={Spacing.xSmall_8} />
+                        <Text style={styles.errorMessage}>{this.state.errorMessage}</Text>
+                    </View>
+                )}
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    errorMessage: {
+        color: Color.red,
+        paddingLeft: Spacing.xxxSmall_4,
+    },
+});
 
 <TextFieldExample />
 ```

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -56,17 +56,16 @@ export const password: StoryComponentType = () => {
         setValue(newValue);
     };
 
-    const handleValidation = (value: string) => {
+    const validation = (value: string) => {
         if (value.length <= 8) {
             return "Password must be at least 8 characters long";
         }
         if (!/\d/.test(value)) {
             return "Password must contain a numeric value";
         }
-        setErrorMessage();
     };
 
-    const handleOnError = (errorMessage: string) => {
+    const handleOnValidation = (errorMessage: ?string) => {
         setErrorMessage(errorMessage);
     };
 
@@ -76,9 +75,9 @@ export const password: StoryComponentType = () => {
                 id="tf-1"
                 type="password"
                 value={value}
-                validation={handleValidation}
+                validation={validation}
+                onValidation={handleOnValidation}
                 onChange={handleOnChange}
-                onError={handleOnError}
             />
             {errorMessage && (
                 <View>
@@ -98,15 +97,14 @@ export const email: StoryComponentType = () => {
         setValue(newValue);
     };
 
-    const handleValidation = (value: string) => {
+    const validation = (value: string) => {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
             return "Please enter a valid email";
         }
-        setErrorMessage();
     };
 
-    const handleOnError = (errorMessage: string) => {
+    const handleOnValidation = (errorMessage: ?string) => {
         setErrorMessage(errorMessage);
     };
 
@@ -116,9 +114,9 @@ export const email: StoryComponentType = () => {
                 id="tf-1"
                 type="email"
                 value={value}
-                validation={handleValidation}
+                validation={validation}
+                onValidation={handleOnValidation}
                 onChange={handleOnChange}
-                onError={handleOnError}
             />
             {errorMessage && (
                 <View>
@@ -138,15 +136,14 @@ export const telephone: StoryComponentType = () => {
         setValue(newValue);
     };
 
-    const handleValidation = (value: string) => {
+    const validation = (value: string) => {
         const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
         if (!telRegex.test(value)) {
             return "Invalid US telephone number";
         }
-        setErrorMessage();
     };
 
-    const handleOnError = (errorMessage: string) => {
+    const handleOnValidation = (errorMessage: ?string) => {
         setErrorMessage(errorMessage);
     };
 
@@ -156,9 +153,9 @@ export const telephone: StoryComponentType = () => {
                 id="tf-1"
                 type="tel"
                 value={value}
-                validation={handleValidation}
+                validation={validation}
+                onValidation={handleOnValidation}
                 onChange={handleOnChange}
-                onError={handleOnError}
             />
             {errorMessage && (
                 <View>

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -1,5 +1,11 @@
 // @flow
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {View, Text} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 
 import type {StoryComponentType} from "@storybook/react";
@@ -44,21 +50,133 @@ export const number: StoryComponentType = () => {
 
 export const password: StoryComponentType = () => {
     const [value, setValue] = React.useState("Password123");
+    const [errorMessage, setErrorMessage] = React.useState();
 
     const handleOnChange = (newValue: string) => {
         setValue(newValue);
     };
 
+    const handleValidation = (value: string) => {
+        if (value.length <= 8) {
+            return "Password must be at least 8 characters long";
+        }
+        if (!/\d/.test(value)) {
+            return "Password must contain a numeric value";
+        }
+        setErrorMessage();
+    };
+
+    const handleOnError = (errorMessage: string) => {
+        setErrorMessage(errorMessage);
+    };
+
     return (
-        <TextField
-            id="tf-1"
-            type="password"
-            value={value}
-            onChange={handleOnChange}
-        />
+        <View>
+            <TextField
+                id="tf-1"
+                type="password"
+                value={value}
+                validation={handleValidation}
+                onChange={handleOnChange}
+                onError={handleOnError}
+            />
+            {errorMessage && (
+                <View>
+                    <Strut size={Spacing.xSmall_8} />
+                    <Text style={styles.errorMessage}>{errorMessage}</Text>
+                </View>
+            )}
+        </View>
+    );
+};
+
+export const email: StoryComponentType = () => {
+    const [value, setValue] = React.useState("khan@khanacademy.org");
+    const [errorMessage, setErrorMessage] = React.useState();
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const handleValidation = (value: string) => {
+        const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+        if (!emailRegex.test(value)) {
+            return "Please enter a valid email";
+        }
+        setErrorMessage();
+    };
+
+    const handleOnError = (errorMessage: string) => {
+        setErrorMessage(errorMessage);
+    };
+
+    return (
+        <View>
+            <TextField
+                id="tf-1"
+                type="email"
+                value={value}
+                validation={handleValidation}
+                onChange={handleOnChange}
+                onError={handleOnError}
+            />
+            {errorMessage && (
+                <View>
+                    <Strut size={Spacing.xSmall_8} />
+                    <Text style={styles.errorMessage}>{errorMessage}</Text>
+                </View>
+            )}
+        </View>
+    );
+};
+
+export const telephone: StoryComponentType = () => {
+    const [value, setValue] = React.useState("123-456-7890");
+    const [errorMessage, setErrorMessage] = React.useState();
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const handleValidation = (value: string) => {
+        const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
+        if (!telRegex.test(value)) {
+            return "Invalid US telephone number";
+        }
+        setErrorMessage();
+    };
+
+    const handleOnError = (errorMessage: string) => {
+        setErrorMessage(errorMessage);
+    };
+
+    return (
+        <View>
+            <TextField
+                id="tf-1"
+                type="tel"
+                value={value}
+                validation={handleValidation}
+                onChange={handleOnChange}
+                onError={handleOnError}
+            />
+            {errorMessage && (
+                <View>
+                    <Strut size={Spacing.xSmall_8} />
+                    <Text style={styles.errorMessage}>{errorMessage}</Text>
+                </View>
+            )}
+        </View>
     );
 };
 
 export const disabled: StoryComponentType = () => (
     <TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
 );
+
+const styles = StyleSheet.create({
+    errorMessage: {
+        color: Color.red,
+        paddingLeft: Spacing.xxxSmall_4,
+    },
+});


### PR DESCRIPTION
## Summary:
Adding the `validation` and `onError` Props to TextField.
The `validation` prop will be called after every value change.
The `onError` prop will be called after every failed `validation`.

Added unit tests to test both new props.

Included examples on Styleguidist and React Storybook of `validation`
and `onError` working with the `password`, `email`, and `telephone`
type TextFields.

Issue: https://khanacademy.atlassian.net/browse/WB-1052

## Test plan:
1. Open Styleguidist (or React Storybook)
2. Go to the TextField (under Form -> TextField)
3. See the given examples, specially the `password`, `email`, and
   `telephone` TextField examples where `validation` and `onError` are at work.

---

#### Below are examples of validations with error messages:

##### Failed validation on `password` TextField
![tf-password](https://user-images.githubusercontent.com/60367213/120011633-23bc0b00-bfa4-11eb-9579-e637dfd0e69c.png)

##### Failed validation on `email` TextField
![tf-email](https://user-images.githubusercontent.com/60367213/120011778-477f5100-bfa4-11eb-903b-4e5687480bce.png)

#### Failed validation on `telephone` TextField
![tf-telephone](https://user-images.githubusercontent.com/60367213/120011811-5403a980-bfa4-11eb-9d44-c1bc8b43425f.png)
