### PR TITLE
[WB-498] Fix obscurity check for when popper can obscure the anchor

### DIFF
--- a/config/jest/test.config.js
+++ b/config/jest/test.config.js
@@ -22,6 +22,7 @@ module.exports = {
     },
     collectCoverageFrom: [
         "packages/**/*.js",
+        "shared-unpackaged/**/*.js",
         "!packages/**/*.stories.js",
         "!packages/**/*.flowtest.js",
         "!packages/**/dist/**/*.js",

--- a/flow-typed/popper.js
+++ b/flow-typed/popper.js
@@ -1,0 +1,169 @@
+// @flow
+
+declare module "popper.js" {
+    declare type Position = "top" | "right" | "bottom" | "left";
+
+    declare type Placement =
+        | "auto-start"
+        | "auto"
+        | "auto-end"
+        | "top-start"
+        | "top"
+        | "top-end"
+        | "right-start"
+        | "right"
+        | "right-end"
+        | "bottom-end"
+        | "bottom"
+        | "bottom-start"
+        | "left-end"
+        | "left"
+        | "left-start";
+
+    declare type Boundary = "scrollParent" | "viewport" | "window";
+
+    declare type Behavior = "flip" | "clockwise" | "counterclockwise";
+
+    declare type ModifierFn = (data: Data, options: Object) => Data;
+
+    declare type Attributes = {|
+        "x-out-of-boundaries": "" | false,
+        "x-placement": Placement,
+    |};
+
+    declare type Padding = {|
+        top?: number,
+        bottom?: number,
+        left?: number,
+        right?: number,
+    |};
+
+    declare type BaseModifier = {|
+        order?: number,
+        enabled?: boolean,
+        fn?: ModifierFn,
+    |};
+
+    declare type Modifiers = {
+        shift?: BaseModifier,
+        offset?: {|
+            ...BaseModifier,
+            offset?: number | string,
+        |},
+        preventOverflow?: {|
+            ...BaseModifier,
+            priority?: Position[],
+            padding?: number | Padding,
+            boundariesElement?: Boundary | Element,
+            escapeWithReference?: boolean,
+        |},
+        keepTogether?: BaseModifier,
+        arrow?: {|
+            ...BaseModifier,
+            element?: string | Element,
+        |},
+        flip?: {|
+            ...BaseModifier,
+            behavior?: Behavior | Position[],
+            padding?: number | Padding,
+            boundariesElement?: Boundary | Element,
+            flipVariations?: boolean,
+            flipVariationsByContent?: boolean,
+        |},
+        inner?: BaseModifier,
+        hide?: BaseModifier,
+        applyStyle?: {|
+            ...BaseModifier,
+            onLoad?: Function,
+            gpuAcceleration?: boolean,
+        |},
+        computeStyle?: {|
+            ...BaseModifier,
+            gpuAcceleration?: boolean,
+            x?: "bottom" | "top",
+            y?: "left" | "right",
+        |},
+
+        [name: string]: ?{
+            ...BaseModifier,
+            [key: string]: any,
+            ...
+        },
+        ...
+    };
+
+    declare type Offset = {|
+        top: number,
+        left: number,
+        width: number,
+        height: number,
+    |};
+
+    declare type Data = {|
+        instance: Popper,
+        placement: Placement,
+        originalPlacement: Placement,
+        flipped: boolean,
+        hide: boolean,
+        arrowElement: Element,
+        styles: CSSStyleDeclaration,
+        arrowStyles: CSSStyleDeclaration,
+        attributes: Attributes,
+        boundaries: Object,
+        offsets: {|
+            popper: Offset,
+            reference: Offset,
+            arrow: {|
+                top: number,
+                left: number,
+            |},
+        |},
+    |};
+
+    declare type PopperOptions = {|
+        placement?: Placement,
+        positionFixed?: boolean,
+        eventsEnabled?: boolean,
+        modifiers?: Modifiers,
+        removeOnDestroy?: boolean,
+
+        onCreate?: (data: Data) => void,
+
+        onUpdate?: (data: Data) => void,
+    |};
+
+    declare interface ReferenceObject {
+        clientHeight: number;
+        clientWidth: number;
+
+        getBoundingClientRect(): ClientRect;
+    }
+
+    declare class Popper {
+        static modifiers: {...BaseModifier, name: string, ...}[];
+        static placements: Placement[];
+        static Defaults: PopperOptions;
+
+        options: PopperOptions;
+        popper: Element;
+        reference: Element | ReferenceObject;
+
+        constructor(
+            reference: Element | ReferenceObject,
+            popper: Element,
+            options?: PopperOptions,
+        ): Popper;
+
+        destroy(): void;
+
+        update(): void;
+
+        scheduleUpdate(): void;
+
+        enableEventListeners(): void;
+
+        disableEventListeners(): void;
+    }
+
+    declare module.exports: typeof Popper;
+}

--- a/flow-typed/popper.js
+++ b/flow-typed/popper.js
@@ -1,4 +1,5 @@
 // @flow
+// This hand-crafted file is based on the TypeScript types.
 
 declare module "popper.js" {
     declare type Position = "top" | "right" | "bottom" | "left";

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-popper.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-popper.js
@@ -44,7 +44,10 @@ export default class TooltipPopper extends React.Component<Props> {
 
         // We'll hide some complexity from the children here and ensure
         // that our placement always has a value.
-        const placement = popperProps.placement || this.props.placement;
+        const placement: Placement =
+            // We know that popperProps.placement will only be one of our
+            // supported values, so just cast it.
+            (popperProps.placement: any) || this.props.placement;
 
         // Just in case the callbacks have changed, let's update our reference
         // trackers.
@@ -54,7 +57,7 @@ export default class TooltipPopper extends React.Component<Props> {
         // Here we translate from the react-popper's PropperChildrenProps
         // to our own TooltipBubbleProps.
         const bubbleProps = {
-            placement: placement,
+            placement,
             style: {
                 // NOTE(jeresig): We can't just use `popperProps.style` here
                 // as the Flow type doesn't match Aphrodite's CSS flow props

--- a/shared-unpackaged/__tests__/is-obscured.test.js
+++ b/shared-unpackaged/__tests__/is-obscured.test.js
@@ -5,6 +5,8 @@ import {mount} from "enzyme";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
+import type {ReferenceObject} from "popper.js";
+import * as GetIntersection from "../get-intersection.js";
 import isObscured from "../is-obscured.js";
 
 describe("isObscured", () => {
@@ -27,7 +29,9 @@ describe("isObscured", () => {
     test("element is null, throws", () => {
         // Arrange
         const element: Element = (null: any);
-        const popperElement: any = "FAKE_ELEMENT";
+        const popperElement: any = {
+            contains: () => false,
+        };
 
         // Act
         const underTest = () => isObscured(element, popperElement);
@@ -38,7 +42,9 @@ describe("isObscured", () => {
 
     test("element is not obscured by anything, returns false", async () => {
         // Arrange
-        const popperElement: any = "FAKE_ELEMENT";
+        const popperElement: any = {
+            contains: () => false,
+        };
         const ref = await new Promise((resolve) => {
             const nodes = (
                 <View>
@@ -50,7 +56,7 @@ describe("isObscured", () => {
 
         const element = ((ReactDOM.findDOMNode(ref): any): Element);
 
-        // When not obscurred, elementFromPoint should return the element.
+        // When not obscured, elementFromPoint should return the element.
         // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
         document.elementFromPoint = jest.fn().mockReturnValue(element);
 
@@ -63,7 +69,9 @@ describe("isObscured", () => {
 
     test("element is partially obscured, returns false", async () => {
         // Arrange
-        const popperElement: any = "FAKE_ELEMENT";
+        const popperElement: any = {
+            contains: () => false,
+        };
         const {ref, otherRef} = await new Promise((resolve) => {
             let ref;
             let otherRef;
@@ -87,11 +95,12 @@ describe("isObscured", () => {
         });
         const element = ((ReactDOM.findDOMNode(ref): any): Element);
         const otherElement = ((ReactDOM.findDOMNode(otherRef): any): Element);
-        // When not obscurred, elementFromPoint should return the element.
-        // So let's return the element for one corner but not the other.
+        // When not obscured, elementFromPoint should return the element.
+        // So let's return the element for one point but not the others.
         // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
         document.elementFromPoint = jest
             .fn()
+            .mockImplementationOnce(() => otherElement)
             .mockImplementationOnce(() => element)
             .mockImplementationOnce(() => otherElement);
 
@@ -104,7 +113,9 @@ describe("isObscured", () => {
 
     test("element is obscured, returns true", async () => {
         // Arrange
-        const popperElement: any = "FAKE_ELEMENT";
+        const popperElement: any = {
+            contains: () => false,
+        };
         const {ref, otherRef} = await new Promise((resolve) => {
             let ref;
             let otherRef;
@@ -128,7 +139,8 @@ describe("isObscured", () => {
         });
         const element = ((ReactDOM.findDOMNode(ref): any): Element);
         const otherElement = ((ReactDOM.findDOMNode(otherRef): any): Element);
-        // When not obscurred, elementFromPoint should return the element.
+        // When not obscured, elementFromPoint should return the element.
+        // We want to show it obscured, so we don't return the element.
         // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
         document.elementFromPoint = jest.fn().mockReturnValue(otherElement);
 
@@ -141,7 +153,9 @@ describe("isObscured", () => {
 
     test("element is not obscured, but elementFromPoint returns parent or child, returns false", async () => {
         // Arrange
-        const popperElement: any = "FAKE_ELEMENT";
+        const popperElement: any = {
+            contains: () => false,
+        };
         const {parentRef, elementRef, childRef} = await new Promise(
             (resolve) => {
                 let parentRef;
@@ -180,11 +194,12 @@ describe("isObscured", () => {
         const childElement = ((ReactDOM.findDOMNode(childRef): any): Element);
         expect(childElement).toBeTruthy();
 
-        // When not obscurred, elementFromPoint should return the element.
-        // So let's return the element for one corner but not the other.
+        // When not obscured, elementFromPoint should return the element
+        // or a child. Here we just return child and parent.
         // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
         document.elementFromPoint = jest
             .fn()
+            .mockImplementationOnce(() => parentElement)
             .mockImplementationOnce(() => parentElement)
             .mockImplementationOnce(() => childElement);
 
@@ -193,5 +208,484 @@ describe("isObscured", () => {
 
         // Assert
         expect(result).toBeFalsy();
+    });
+
+    describe("popper element is returned by elementFromPoint", () => {
+        test("popper element pointer-events style set to none", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                let anchorRef;
+                let popperRef;
+                const tryResolve = (ar, pr) => {
+                    anchorRef = anchorRef || ar;
+                    popperRef = popperRef || pr;
+                    if (anchorRef && popperRef) {
+                        resolve({anchorRef, popperRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r)}>Anchor</View>
+                        <View ref={(r) => tryResolve(null, r)}>
+                            Popper (obscuring anchor)
+                        </View>
+                    </View>
+                );
+                mount(nodes);
+            });
+
+            const {anchorRef, popperRef} = await ref;
+
+            const anchorEl = ((ReactDOM.findDOMNode(anchorRef): any): Element);
+            expect(anchorEl).toBeTruthy();
+            const popperEl = ((ReactDOM.findDOMNode(popperRef): any): Element);
+            expect(popperEl).toBeTruthy();
+
+            const pointerEventsSpy = jest.spyOn(
+                (popperEl: any).style,
+                "pointerEvents",
+                "set",
+            );
+
+            // We return the popperRef here so that it is then modified.
+            // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+            document.elementFromPoint = jest
+                .fn()
+                .mockReturnValueOnce(popperEl)
+                .mockReturnValue(anchorEl);
+
+            // Act
+            isObscured(anchorEl, popperEl);
+
+            // Assert
+            expect(pointerEventsSpy).toHaveBeenCalledWith("none");
+        });
+
+        test("visibility is rechecked", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                let anchorRef;
+                let popperRef;
+                const tryResolve = (ar, pr) => {
+                    anchorRef = anchorRef || ar;
+                    popperRef = popperRef || pr;
+                    if (anchorRef && popperRef) {
+                        resolve({anchorRef, popperRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r)}>Anchor</View>
+                        <View ref={(r) => tryResolve(null, r)}>
+                            Popper (obscuring anchor)
+                        </View>
+                    </View>
+                );
+                mount(nodes);
+            });
+
+            const {anchorRef, popperRef} = await ref;
+
+            const anchorEl = ((ReactDOM.findDOMNode(anchorRef): any): Element);
+            expect(anchorEl).toBeTruthy();
+            const popperEl = ((ReactDOM.findDOMNode(popperRef): any): Element);
+            expect(popperEl).toBeTruthy();
+
+            // We return the popperRef here so that it is then modified.
+            // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+            document.elementFromPoint = jest
+                .fn()
+                .mockReturnValueOnce(popperEl)
+                .mockReturnValue(anchorEl);
+
+            // Act
+            isObscured(anchorEl, popperEl);
+
+            // Assert
+            expect(document.elementFromPoint).toHaveBeenCalledTimes(2);
+        });
+
+        test("on success, popper element pointer-events reset", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                let anchorRef;
+                let popperRef;
+                const tryResolve = (ar, pr) => {
+                    anchorRef = anchorRef || ar;
+                    popperRef = popperRef || pr;
+                    if (anchorRef && popperRef) {
+                        resolve({anchorRef, popperRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r)}>Anchor</View>
+                        <View ref={(r) => tryResolve(null, r)}>
+                            Popper (obscuring anchor)
+                        </View>
+                    </View>
+                );
+                mount(nodes);
+            });
+
+            const {anchorRef, popperRef} = await ref;
+
+            const anchorEl = ((ReactDOM.findDOMNode(anchorRef): any): Element);
+            expect(anchorEl).toBeTruthy();
+            const popperEl = ((ReactDOM.findDOMNode(popperRef): any): Element);
+            expect(popperEl).toBeTruthy();
+
+            (popperEl: any).style.pointerEvents = "BEFORE_VALUE";
+            const pointerEventsSpy = jest.spyOn(
+                (popperEl: any).style,
+                "pointerEvents",
+                "set",
+            );
+
+            // We return the popperRef here so that it is then modified.
+            // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+            document.elementFromPoint = jest
+                .fn()
+                .mockReturnValueOnce(popperEl)
+                .mockReturnValue(anchorEl);
+
+            // Act
+            isObscured(anchorEl, popperEl);
+
+            // Assert
+            expect(pointerEventsSpy).toHaveBeenCalledWith("BEFORE_VALUE");
+        });
+
+        test("on error, popper element pointer-events reset", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                let anchorRef;
+                let popperRef;
+                const tryResolve = (ar, pr) => {
+                    anchorRef = anchorRef || ar;
+                    popperRef = popperRef || pr;
+                    if (anchorRef && popperRef) {
+                        resolve({anchorRef, popperRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r)}>Anchor</View>
+                        <View ref={(r) => tryResolve(null, r)}>
+                            Popper (obscuring anchor)
+                        </View>
+                    </View>
+                );
+                mount(nodes);
+            });
+
+            const {anchorRef, popperRef} = await ref;
+
+            const anchorEl = ((ReactDOM.findDOMNode(anchorRef): any): Element);
+            expect(anchorEl).toBeTruthy();
+            const popperEl = ((ReactDOM.findDOMNode(popperRef): any): Element);
+            expect(popperEl).toBeTruthy();
+
+            (popperEl: any).style.pointerEvents = "BEFORE_VALUE";
+            const pointerEventsSpy = jest.spyOn(
+                (popperEl: any).style,
+                "pointerEvents",
+                "set",
+            );
+
+            // We return the popperRef here so that it is then modified.
+            // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+            document.elementFromPoint = jest
+                .fn()
+                .mockReturnValueOnce(popperEl)
+                .mockImplementation(() => {
+                    throw new Error("Oh noes!");
+                });
+
+            // Act
+            try {
+                isObscured(anchorEl, popperEl);
+            } catch (e) {
+                // We know it will throw. That's part of the test.
+            }
+
+            // Assert
+            expect(pointerEventsSpy).toHaveBeenCalledWith("BEFORE_VALUE");
+        });
+    });
+
+    describe("child of popper element is returned by elementFromPoint", () => {
+        test("child of popper element pointer-events style set to none", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                let anchorRef;
+                let popperRef;
+                let popperChildRef;
+                const tryResolve = (ar, pr, pcr) => {
+                    anchorRef = anchorRef || ar;
+                    popperRef = popperRef || pr;
+                    popperChildRef = popperChildRef || pcr;
+                    if (anchorRef && popperRef && popperChildRef) {
+                        resolve({anchorRef, popperRef, popperChildRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r)}>Anchor</View>
+                        <View ref={(r) => tryResolve(null, r)}>
+                            <View ref={(r) => tryResolve(null, null, r)}>
+                                Popper (obscuring anchor)
+                            </View>
+                        </View>
+                    </View>
+                );
+                mount(nodes);
+            });
+
+            const {anchorRef, popperRef, popperChildRef} = await ref;
+
+            const anchorEl = ((ReactDOM.findDOMNode(anchorRef): any): Element);
+            expect(anchorEl).toBeTruthy();
+            const popperEl = ((ReactDOM.findDOMNode(popperRef): any): Element);
+            expect(popperEl).toBeTruthy();
+            const popperChildEl = ((ReactDOM.findDOMNode(
+                popperChildRef,
+            ): any): Element);
+            expect(popperChildEl).toBeTruthy();
+
+            const pointerEventsSpy = jest.spyOn(
+                (popperChildEl: any).style,
+                "pointerEvents",
+                "set",
+            );
+
+            // We return the popperRef here so that it is then modified.
+            // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+            document.elementFromPoint = jest
+                .fn()
+                .mockReturnValueOnce(popperChildEl)
+                .mockReturnValue(anchorEl);
+
+            // Act
+            isObscured(anchorEl, popperEl);
+
+            // Assert
+            expect(pointerEventsSpy).toHaveBeenCalledWith("none");
+        });
+
+        test("visibility is rechecked", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                let anchorRef;
+                let popperRef;
+                let popperChildRef;
+                const tryResolve = (ar, pr, pcr) => {
+                    anchorRef = anchorRef || ar;
+                    popperRef = popperRef || pr;
+                    popperChildRef = popperChildRef || pcr;
+                    if (anchorRef && popperRef && popperChildRef) {
+                        resolve({anchorRef, popperRef, popperChildRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r)}>Anchor</View>
+                        <View ref={(r) => tryResolve(null, r)}>
+                            <View ref={(r) => tryResolve(null, null, r)}>
+                                Popper (obscuring anchor)
+                            </View>
+                        </View>
+                    </View>
+                );
+                mount(nodes);
+            });
+
+            const {anchorRef, popperRef, popperChildRef} = await ref;
+
+            const anchorEl = ((ReactDOM.findDOMNode(anchorRef): any): Element);
+            expect(anchorEl).toBeTruthy();
+            const popperEl = ((ReactDOM.findDOMNode(popperRef): any): Element);
+            expect(popperEl).toBeTruthy();
+            const popperChildEl = ((ReactDOM.findDOMNode(
+                popperChildRef,
+            ): any): Element);
+            expect(popperChildEl).toBeTruthy();
+
+            // We return the popperRef here so that it is then modified.
+            // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+            document.elementFromPoint = jest
+                .fn()
+                .mockReturnValueOnce(popperChildEl)
+                .mockReturnValue(anchorEl);
+
+            // Act
+            isObscured(anchorEl, popperEl);
+
+            // Assert
+            expect(document.elementFromPoint).toHaveBeenCalledTimes(2);
+        });
+
+        test("on success, child of popper element pointer-events reset", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                let anchorRef;
+                let popperRef;
+                let popperChildRef;
+                const tryResolve = (ar, pr, pcr) => {
+                    anchorRef = anchorRef || ar;
+                    popperRef = popperRef || pr;
+                    popperChildRef = popperChildRef || pcr;
+                    if (anchorRef && popperRef && popperChildRef) {
+                        resolve({anchorRef, popperRef, popperChildRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r)}>Anchor</View>
+                        <View ref={(r) => tryResolve(null, r)}>
+                            <View ref={(r) => tryResolve(null, null, r)}>
+                                Popper (obscuring anchor)
+                            </View>
+                        </View>
+                    </View>
+                );
+                mount(nodes);
+            });
+
+            const {anchorRef, popperRef, popperChildRef} = await ref;
+
+            const anchorEl = ((ReactDOM.findDOMNode(anchorRef): any): Element);
+            expect(anchorEl).toBeTruthy();
+            const popperEl = ((ReactDOM.findDOMNode(popperRef): any): Element);
+            expect(popperEl).toBeTruthy();
+            const popperChildEl = ((ReactDOM.findDOMNode(
+                popperChildRef,
+            ): any): Element);
+            expect(popperChildEl).toBeTruthy();
+
+            (popperChildEl: any).style.pointerEvents = "BEFORE_VALUE";
+            const pointerEventsSpy = jest.spyOn(
+                (popperChildEl: any).style,
+                "pointerEvents",
+                "set",
+            );
+
+            // We return the popperRef here so that it is then modified.
+            // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+            document.elementFromPoint = jest
+                .fn()
+                .mockReturnValueOnce(popperChildEl)
+                .mockReturnValue(anchorEl);
+
+            // Act
+            isObscured(anchorEl, popperEl);
+
+            // Assert
+            expect(pointerEventsSpy).toHaveBeenCalledWith("BEFORE_VALUE");
+        });
+
+        test("on error, popper element pointer-events reset", async () => {
+            // Arrange
+            const ref = await new Promise((resolve) => {
+                let anchorRef;
+                let popperRef;
+                let popperChildRef;
+                const tryResolve = (ar, pr, pcr) => {
+                    anchorRef = anchorRef || ar;
+                    popperRef = popperRef || pr;
+                    popperChildRef = popperChildRef || pcr;
+                    if (anchorRef && popperRef && popperChildRef) {
+                        resolve({anchorRef, popperRef, popperChildRef});
+                    }
+                };
+
+                const nodes = (
+                    <View>
+                        <View ref={(r) => tryResolve(r)}>Anchor</View>
+                        <View ref={(r) => tryResolve(null, r)}>
+                            <View ref={(r) => tryResolve(null, null, r)}>
+                                Popper (obscuring anchor)
+                            </View>
+                        </View>
+                    </View>
+                );
+                mount(nodes);
+            });
+
+            const {anchorRef, popperRef, popperChildRef} = await ref;
+
+            const anchorEl = ((ReactDOM.findDOMNode(anchorRef): any): Element);
+            expect(anchorEl).toBeTruthy();
+            const popperEl = ((ReactDOM.findDOMNode(popperRef): any): Element);
+            expect(popperEl).toBeTruthy();
+            const popperChildEl = ((ReactDOM.findDOMNode(
+                popperChildRef,
+            ): any): Element);
+            expect(popperChildEl).toBeTruthy();
+
+            (popperChildEl: any).style.pointerEvents = "BEFORE_VALUE";
+            const pointerEventsSpy = jest.spyOn(
+                (popperChildEl: any).style,
+                "pointerEvents",
+                "set",
+            );
+
+            // We return the popperRef here so that it is then modified.
+            // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+            document.elementFromPoint = jest
+                .fn()
+                .mockReturnValueOnce(popperChildEl)
+                .mockImplementation(() => {
+                    throw new Error("Oh noes!");
+                });
+
+            // Act
+            try {
+                isObscured(anchorEl, popperEl);
+            } catch (e) {
+                // We know it will throw. That's part of the test.
+            }
+
+            // Assert
+            expect(pointerEventsSpy).toHaveBeenCalledWith("BEFORE_VALUE");
+        });
+    });
+
+    test("fallsback to intersection check if anchor is a reference instead of an element", () => {
+        // Arrange
+        const getIntersectionSpy = jest.spyOn(GetIntersection, "default");
+        const popperElement: any = {
+            contains: () => false,
+        };
+        const element: ReferenceObject = {
+            clientHeight: 100,
+            clientWidth: 100,
+            getBoundingClientRect: () =>
+                ({
+                    bottom: 100,
+                    top: 0,
+                    left: 0,
+                    right: 100,
+                    height: 100,
+                    width: 100,
+                }: any),
+        };
+
+        // When not obscured, elementFromPoint should return the element.
+        // $FlowFixMe[cannot-write] Flow doesn't like us doing this to the document
+        document.elementFromPoint = jest.fn().mockReturnValue(element);
+
+        // Act
+        isObscured(element, popperElement);
+
+        // Assert
+        expect(getIntersectionSpy).toHaveBeenCalled();
     });
 });

--- a/shared-unpackaged/__tests__/is-obscured.test.js
+++ b/shared-unpackaged/__tests__/is-obscured.test.js
@@ -26,18 +26,20 @@ describe("isObscured", () => {
 
     test("element is null, throws", () => {
         // Arrange
-        const element = ((null: any): Element);
+        const element: Element = (null: any);
+        const popperElement: any = "FAKE_ELEMENT";
 
         // Act
-        const underTest = () => isObscured(element);
+        const underTest = () => isObscured(element, popperElement);
 
         // Assert
         expect(underTest).toThrowError();
     });
 
     test("element is not obscured by anything, returns false", async () => {
+        // Arrange
+        const popperElement: any = "FAKE_ELEMENT";
         const ref = await new Promise((resolve) => {
-            // Arrange
             const nodes = (
                 <View>
                     <View ref={resolve}>Unobscured</View>
@@ -53,7 +55,7 @@ describe("isObscured", () => {
         document.elementFromPoint = jest.fn().mockReturnValue(element);
 
         // Act
-        const result = isObscured(element);
+        const result = isObscured(element, popperElement);
 
         // Assert
         expect(result).toBeFalsy();
@@ -61,6 +63,7 @@ describe("isObscured", () => {
 
     test("element is partially obscured, returns false", async () => {
         // Arrange
+        const popperElement: any = "FAKE_ELEMENT";
         const {ref, otherRef} = await new Promise((resolve) => {
             let ref;
             let otherRef;
@@ -93,7 +96,7 @@ describe("isObscured", () => {
             .mockImplementationOnce(() => otherElement);
 
         // Act
-        const result = isObscured(element);
+        const result = isObscured(element, popperElement);
 
         // Assert
         expect(result).toBeFalsy();
@@ -101,6 +104,7 @@ describe("isObscured", () => {
 
     test("element is obscured, returns true", async () => {
         // Arrange
+        const popperElement: any = "FAKE_ELEMENT";
         const {ref, otherRef} = await new Promise((resolve) => {
             let ref;
             let otherRef;
@@ -129,7 +133,7 @@ describe("isObscured", () => {
         document.elementFromPoint = jest.fn().mockReturnValue(otherElement);
 
         // Act
-        const result = isObscured(element);
+        const result = isObscured(element, popperElement);
 
         // Assert
         expect(result).toBeTruthy();
@@ -137,6 +141,7 @@ describe("isObscured", () => {
 
     test("element is not obscured, but elementFromPoint returns parent or child, returns false", async () => {
         // Arrange
+        const popperElement: any = "FAKE_ELEMENT";
         const {parentRef, elementRef, childRef} = await new Promise(
             (resolve) => {
                 let parentRef;
@@ -184,7 +189,7 @@ describe("isObscured", () => {
             .mockImplementationOnce(() => childElement);
 
         // Act
-        const result = isObscured(element);
+        const result = isObscured(element, popperElement);
 
         // Assert
         expect(result).toBeFalsy();

--- a/shared-unpackaged/__tests__/visibility-modifier.test.js
+++ b/shared-unpackaged/__tests__/visibility-modifier.test.js
@@ -25,7 +25,7 @@ describe("Visibility PopperJS Modifier", () => {
         expect(result).toMatchObject({
             enabled: true,
             fn: expect.any(Function),
-            order: Popper.Defaults.modifiers.hide.order + 1,
+            order: (Popper.Defaults.modifiers?.hide?.order || 0) + 1,
         });
     });
 
@@ -37,7 +37,7 @@ describe("Visibility PopperJS Modifier", () => {
             test("obscured horizontally only, is not visible", () => {
                 // Arrange
                 const psuedoAnchorElement = {};
-                const data = {
+                const data: any = {
                     instance: {reference: psuedoAnchorElement},
                     attributes: {},
                     hide: false,
@@ -59,7 +59,7 @@ describe("Visibility PopperJS Modifier", () => {
             test("obscured vertically only, is not visible", () => {
                 // Arrange
                 const psuedoAnchorElement = {};
-                const data = {
+                const data: any = {
                     instance: {reference: psuedoAnchorElement},
                     attributes: {
                         "x-out-of-boundaries": "",
@@ -83,7 +83,7 @@ describe("Visibility PopperJS Modifier", () => {
             test("obscured totally, is not visible", () => {
                 // Arrange
                 const psuedoAnchorElement = {};
-                const data = {
+                const data: any = {
                     instance: {reference: psuedoAnchorElement},
                     attributes: {},
                     hide: false,
@@ -106,7 +106,7 @@ describe("Visibility PopperJS Modifier", () => {
         test("obscured by fixed or absolute components, is not visible", () => {
             // Arrange
             const psuedoAnchorElement = {};
-            const data = {
+            const data: any = {
                 instance: {reference: psuedoAnchorElement},
                 attributes: {},
                 hide: false,
@@ -137,7 +137,7 @@ describe("Visibility PopperJS Modifier", () => {
         test("not obscured by parent nor fixed/absolute positioning", () => {
             // Arrange
             const psuedoAnchorElement = {};
-            const data = {
+            const data: any = {
                 instance: {reference: psuedoAnchorElement},
                 attributes: {
                     "x-out-of-boundaries": "",

--- a/shared-unpackaged/get-axis-intersection.js
+++ b/shared-unpackaged/get-axis-intersection.js
@@ -1,0 +1,19 @@
+// @flow
+import type {AxisIntersection, Bounds} from "./types.js";
+
+export default function getAxisIntersection(
+    intersectingRect: Bounds,
+    boundsRect: Bounds,
+    axis: "vertical" | "horizontal",
+): AxisIntersection {
+    const start = (rect) => (axis === "horizontal" ? rect.left : rect.top);
+    const end = (rect) => (axis === "horizontal" ? rect.right : rect.bottom);
+
+    if (end(intersectingRect) <= start(boundsRect)) {
+        return "before";
+    } else if (start(intersectingRect) >= end(boundsRect)) {
+        return "after";
+    }
+
+    return "within";
+}

--- a/shared-unpackaged/get-bounds.js
+++ b/shared-unpackaged/get-bounds.js
@@ -5,7 +5,7 @@ import getEdges from "./get-edges.js";
 
 export default function getBounds(
     element: Element | ReferenceObject,
-    withoutEdges: boolean = true,
+    withoutEdges: boolean = false,
 ): Bounds {
     const elementRect = element.getBoundingClientRect();
     const edges = getEdges(element, withoutEdges);

--- a/shared-unpackaged/get-bounds.js
+++ b/shared-unpackaged/get-bounds.js
@@ -1,0 +1,35 @@
+// @flow
+import type {ReferenceObject} from "popper.js";
+import type {Bounds} from "./types.js";
+import getEdges from "./get-edges.js";
+
+export default function getBounds(
+    element: Element | ReferenceObject,
+    withoutEdges: boolean = true,
+): Bounds {
+    const elementRect = element.getBoundingClientRect();
+    const edges = getEdges(element, withoutEdges);
+
+    return {
+        left:
+            elementRect.left +
+            edges.margin.left +
+            edges.padding.left +
+            edges.border.left,
+        top:
+            elementRect.top +
+            edges.margin.top +
+            edges.padding.top +
+            edges.border.top,
+        right:
+            elementRect.right -
+            edges.margin.right -
+            edges.padding.right -
+            edges.border.right,
+        bottom:
+            elementRect.bottom -
+            edges.margin.bottom -
+            edges.padding.bottom -
+            edges.border.bottom,
+    };
+}

--- a/shared-unpackaged/get-edges.js
+++ b/shared-unpackaged/get-edges.js
@@ -1,0 +1,63 @@
+// @flow
+import type {ReferenceObject} from "popper.js";
+
+type Sizes = {|
+    top: number,
+    left: number,
+    bottom: number,
+    right: number,
+|};
+
+type Edges = {|
+    margin: Sizes,
+    border: Sizes,
+    padding: Sizes,
+|};
+
+const EmptySizes: Sizes = Object.freeze({
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+});
+
+/**
+ * Get the margin, padding, and border edges for a given element.
+ */
+export default function getEdges(
+    element: Element | ReferenceObject,
+    withoutEdges: boolean,
+): Edges {
+    if (!withoutEdges && element instanceof Element) {
+        const style =
+            ((element: any).currentStyle: ?CSSStyleDeclaration) ||
+            window.getComputedStyle(element);
+
+        return {
+            margin: {
+                left: parseFloat(style.marginLeft),
+                top: parseFloat(style.marginTop),
+                right: parseFloat(style.marginRight),
+                bottom: parseFloat(style.marginBottom),
+            },
+            padding: {
+                left: parseFloat(style.paddingLeft),
+                top: parseFloat(style.paddingTop),
+                right: parseFloat(style.paddingRight),
+                bottom: parseFloat(style.paddingBottom),
+            },
+            border: {
+                left: parseFloat(style.borderLeftWidth),
+                top: parseFloat(style.borderTopWidth),
+                right: parseFloat(style.borderRightWidth),
+                bottom: parseFloat(style.borderBottomWidth),
+            },
+        };
+    }
+
+    return {
+        margin: EmptySizes,
+        padding: EmptySizes,
+        border: EmptySizes,
+    };
+}

--- a/shared-unpackaged/get-edges.js
+++ b/shared-unpackaged/get-edges.js
@@ -32,7 +32,6 @@ export default function getEdges(
         const style =
             ((element: any).currentStyle: ?CSSStyleDeclaration) ||
             window.getComputedStyle(element);
-
         return {
             margin: {
                 left: parseFloat(style.marginLeft),

--- a/shared-unpackaged/get-intersection.js
+++ b/shared-unpackaged/get-intersection.js
@@ -1,0 +1,27 @@
+// @flow
+import type {Bounds, Intersection} from "./types.js";
+import getAxisIntersection from "./get-axis-intersection.js";
+
+/**
+ * Determine how one rectangle intersects another.
+ *
+ * The intersection should be interpreted as whether the first rectangle is
+ * within the second.
+ */
+export default function getIntersection(
+    intersectingRect: Bounds,
+    boundsRect: Bounds,
+): Intersection {
+    const horizontal = getAxisIntersection(
+        intersectingRect,
+        boundsRect,
+        "horizontal",
+    );
+    const vertical = getAxisIntersection(
+        intersectingRect,
+        boundsRect,
+        "vertical",
+    );
+
+    return {horizontal, vertical};
+}

--- a/shared-unpackaged/is-obscured.js
+++ b/shared-unpackaged/is-obscured.js
@@ -1,4 +1,8 @@
 // @flow
+import type {ReferenceObject} from "popper.js";
+import getBounds from "./get-bounds.js";
+import getIntersection from "./get-intersection.js";
+
 /**
  * Determine if an element is obscured by other elements.
  *
@@ -6,7 +10,10 @@
  * overdrawn by another element. Note that this won't work if the given element
  * has `pointer-events: none`.
  */
-export default function isObscured(element: Element): boolean {
+export default function isObscured(
+    anchorElement: Element | ReferenceObject,
+    popperElement: Element,
+): boolean {
     // TODO(somewhatabstract): We should be smarter in this algorithm and
     // actually look at the intersection of the elements doing the obscuring
     // just as we already do with our scroll parent intersections. That way we
@@ -15,8 +22,9 @@ export default function isObscured(element: Element): boolean {
     // point is not visible.
 
     // Before we assume we're visible let's check to see if something else
-    // is obscuring us.  Here we make the assumption that if our topleft and
-    // bottomright corners are covered by something, we're not visible.
+    // is obscuring us. Here we check a variety of points of the element
+    // like topleft, bottomright, and center to see if they are covered by
+    // something, and if so, assume we're not visible.
     // There are ways that this can still not work, such as different
     // elements only covering those points and the remainder being visible,
     // or if some covering element has none for pointer-events style, but
@@ -26,55 +34,68 @@ export default function isObscured(element: Element): boolean {
     // going to end up hiding, so, you know, probably don't do that.
     // We're not explicitly checking for that CSS since it's a corner-case and
     // would impact perf of the regular cases if we were always checking it.
-    // TODO(somewhatabstract): Consider how we might mitigate the pointer-events
-    // issue and make this call more robust.
-    const anchorRect = element.getBoundingClientRect();
-    const style =
-        ((element: any).currentStyle: ?CSSStyleDeclaration) ||
-        window.getComputedStyle(element);
-    const anchorLeft =
-        anchorRect.left +
-        parseFloat(style.marginLeft) +
-        parseFloat(style.paddingLeft) +
-        parseFloat(style.borderLeftWidth);
-    const anchorTop =
-        anchorRect.top +
-        parseFloat(style.marginTop) +
-        parseFloat(style.paddingTop) +
-        parseFloat(style.borderTopWidth);
-    const topLeftElement = document.elementFromPoint(anchorLeft, anchorTop);
-    // The bottom right corner is one less than the bounds, otherwise we
-    // can end up getting the parent of the anchor, rather than the anchor
-    // itself.
-    const anchorRight =
-        anchorRect.right -
-        parseFloat(style.marginRight) -
-        parseFloat(style.paddingRight) -
-        parseFloat(style.borderRightWidth);
-    const anchorBottom =
-        anchorRect.bottom -
-        parseFloat(style.marginBottom) -
-        parseFloat(style.paddingBottom) -
-        parseFloat(style.borderBottomWidth);
-    const bottomRightElement = document.elementFromPoint(
-        anchorRight,
-        anchorBottom,
-    );
-    // TODO(somewhatabstract): Need to cater to the case where the viewport is
-    // zoomed such that both corners are off screen but the rest isn't as in
-    // some browsers, elementFromPoint then doesn't return the element (see
-    // WB-300).
 
-    // To cope with us hitting a child of our anchor or a parent due to
-    // borders and things, we do some descendancy checks. We're ok with
-    // saying that we're visible if we hit a parent because we already
-    // checked them for visibility earlier.
-    const topLeftVisible =
-        topLeftElement &&
-        (element.contains(topLeftElement) || topLeftElement.contains(element));
-    const bottomRightVisible =
-        bottomRightElement &&
-        (element.contains(bottomRightElement) ||
-            bottomRightElement.contains(element));
-    return !topLeftVisible && !bottomRightVisible;
+    // TODO(somewhatabstract, WB-300): Need to cater to the case where the
+    // viewport is zoomed such that both corners are off screen but the rest
+    // isn't. In this case some browsers don't return the element from
+    // `elementFromPoint` then doesn't return the element.
+    // Also, consider how we might mitigate the pointer-events issue and make
+    // this call more robust.
+
+    const bounds = getBounds(anchorElement, true);
+
+    // This method does the main work, taking some coordinates and determining
+    // if our element is visible at that point or not.
+    const isVisible = (x: number, y: number): boolean => {
+        const elAtPoint = document.elementFromPoint(x, y);
+        if (elAtPoint != null && elAtPoint === popperElement) {
+            // Oh no, we're being obscured by our own popper.
+            // We need to look behind it. Shenanigans time.
+            const displayStyle = elAtPoint?.style.display;
+            // Remove pointer events so that we can look through it.
+            elAtPoint.style.pointerEvents = "none";
+            try {
+                const visible = isVisible(x, y);
+                return visible;
+            } finally {
+                // Make sure we put things back the way we found them. :)
+                elAtPoint.style.pointerEvents = displayStyle;
+            }
+        }
+        if (anchorElement instanceof Element) {
+            // If we are working with an element, then we can do some decendency checks
+            // to ensure we're not just hitting a child. We're ok with saying that
+            // we're visible if we hit a parent because we check them for visibility
+            // elsewhere.
+            return (
+                elAtPoint != null &&
+                (anchorElement.contains(elAtPoint) ||
+                    elAtPoint.contains(anchorElement))
+            );
+        }
+
+        // If element is a reference object, all we have to work with is
+        // intersection for checking obscurity. Since this doesn't cover
+        // parent/child relationships in the DOM, it's not really effective
+        // on its own and is possibly about as good as just returning `true`.
+        const intersection = () =>
+            elAtPoint && getIntersection(bounds, getBounds(elAtPoint, true));
+        return (
+            intersection?.horizontal !== "within" ||
+            intersection?.vertical !== "within"
+        );
+    };
+
+    // NOTE: We are using functions here so that we only do as much work
+    // as we need to, short-circuiting as soon as we have a definitive
+    // answer.
+    const isTopLeftVisible = () => isVisible(bounds.left, bounds.top);
+    const isBottomRightVisible = () => isVisible(bounds.right, bounds.bottom);
+    const isCenterVisible = () =>
+        isVisible(
+            bounds.left + (bounds.right - bounds.left) / 2,
+            bounds.top + (bounds.bottom - bounds.top) / 2,
+        );
+
+    return !isTopLeftVisible() && !isBottomRightVisible() && !isCenterVisible();
 }

--- a/shared-unpackaged/types.js
+++ b/shared-unpackaged/types.js
@@ -1,0 +1,34 @@
+// @flow
+/**
+ * Indicates the intersection state of an item on a single axis.
+ */
+export type AxisIntersection =
+    // The item is partly or fully within the bounds.
+    | "within"
+
+    // The item is outside the starting bounds.
+    | "before"
+
+    // The item is outside the ending bounds.
+    | "after";
+
+/**
+ * Indicates the visibility of an item on the horizontal and vertical axes.
+ */
+export type Intersection = {|
+    // The intersection on the horizontal axis.
+    horizontal: ?AxisIntersection,
+
+    // The intersection on the vertical axis.
+    vertical: ?AxisIntersection,
+|};
+
+/**
+ * Describes the bounds of a rectangle.
+ */
+export type Bounds = {|
+    left: number,
+    top: number,
+    right: number,
+    bottom: number,
+|};

--- a/shared-unpackaged/visibility-modifier.js
+++ b/shared-unpackaged/visibility-modifier.js
@@ -9,20 +9,16 @@
  * details on popper.js modifiers.
  */
 import PopperJS from "popper.js";
+import type {Data} from "popper.js";
 
 import {getElementIntersection} from "@khanacademy/wonder-blocks-core";
 
 import isObscured from "./is-obscured.js";
 
-type ModifierData = {
-    [key: string]: any,
-    ...
-};
-
 /**
  * The function that implements the modifier.
  */
-function visibilityModifierFn(data: any): ModifierData {
+function visibilityModifierFn(data: Data): Data {
     const anchorElement = data.instance.reference;
 
     // First, we see how the element intersects with its scroll parents.
@@ -33,7 +29,7 @@ function visibilityModifierFn(data: any): ModifierData {
     const hide =
         horizontal !== "within" ||
         vertical !== "within" ||
-        isObscured(anchorElement);
+        isObscured(anchorElement, data.instance.popper);
 
     // If we're hidden, we mimic what the built-in hide method does,
     // and set the hide flag and the OOB attribute with appropriate
@@ -75,6 +71,6 @@ function visibilityModifierFn(data: any): ModifierData {
 export default {
     enabled: true,
     // We want this to run after the "hide" modifier, by default.
-    order: (PopperJS.Defaults.modifiers["hide"].order + 1: number),
+    order: ((PopperJS.Defaults.modifiers?.hide?.order || 0) + 1: number),
     fn: visibilityModifierFn,
 };


### PR DESCRIPTION
## Summary:
Firstly, this adds flow types to popper.js. From that, I fixed an edge case
where the anchor element passed to `isObscured` could be just a reference
object - I don't know under what circumstances that occurs, though I had seen
an error along those lines in the past, so that should be fixed if it happens
anywhere.

Finally, and most importantly, I have fixed the issue that would cause the
popper (whether a tooltip, menu, dropdown, or popover) to flicker or not appear
when being scrolled near the top of the screen. It turns out this was because
the popper portion was coming back as something covering the anchor element.
To work around this, the popper (or child of a popper, as was the case with
the action menu) is set to not receive pointer events while the obscurity check
is completed.

Issue: WB-498

## Test plan:
With the test site, you can compare with "prod".
In this video, you can see the behavior in production that clearly illustrates
the problem being fixed.

https://user-images.githubusercontent.com/1266297/120145758-a9f56e80-c1a9-11eb-9879-131406e755a6.mov

Using the test site, one can see that this no longer occurs.

https://user-images.githubusercontent.com/1266297/120146006-09ec1500-c1aa-11eb-853f-922662992445.mov

