### PR TITLE
WB-1053 - Add `onKeyDown`, `onFocus`, and `onBlur` Props to TextField

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5899,6 +5899,7 @@ exports[`wonder-blocks-form example 10 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   placeholder="Placeholder"
   type="text"
   value=""
@@ -5913,6 +5914,7 @@ exports[`wonder-blocks-form example 11 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   placeholder="Placeholder"
   type="number"
   value="12345"
@@ -5946,6 +5948,7 @@ exports[`wonder-blocks-form example 12 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
     placeholder="Placeholder"
     type="password"
     value="Password123"
@@ -5980,6 +5983,7 @@ exports[`wonder-blocks-form example 13 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
     placeholder="Placeholder"
     type="email"
     value="khan@khanacademy.org"
@@ -6014,6 +6018,7 @@ exports[`wonder-blocks-form example 14 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
+    onKeyDown={[Function]}
     placeholder="Placeholder"
     type="email"
     value="123-456-7890"
@@ -6022,6 +6027,100 @@ exports[`wonder-blocks-form example 14 1`] = `
 `;
 
 exports[`wonder-blocks-form example 15 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <input
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-error_1vc4qn7"
+    disabled={false}
+    id="tf-1"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    placeholder="Placeholder"
+    type="email"
+    value="khan"
+  />
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      aria-hidden="true"
+      className=""
+      style={
+        Object {
+          "MsFlexBasis": 8,
+          "MsFlexPreferredSize": 8,
+          "WebkitFlexBasis": 8,
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexBasis": 8,
+          "flexDirection": "column",
+          "flexShrink": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "width": 8,
+          "zIndex": 0,
+        }
+      }
+    />
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "color": "#d92916",
+          "paddingLeft": 4,
+        }
+      }
+    >
+      Please enter a valid email
+    </span>
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-form example 16 1`] = `
 <input
   className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-disabled_1ab5c0p"
   disabled={true}

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -610,6 +610,20 @@ describe("wonder-blocks-form", () => {
                 this.state = {
                     value: "",
                 };
+                this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+            }
+
+            handleOnChange(newValue) {
+                this.setState({
+                    value: newValue,
+                });
+            }
+
+            handleOnKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
             }
 
             render() {
@@ -618,11 +632,8 @@ describe("wonder-blocks-form", () => {
                         id="tf-1"
                         type="text"
                         value={this.state.value}
-                        onChange={(newValue) =>
-                            this.setState({
-                                value: newValue,
-                            })
-                        }
+                        onChange={this.handleOnChange}
+                        onKeyDown={this.handleOnKeyDown}
                     />
                 );
             }
@@ -640,6 +651,20 @@ describe("wonder-blocks-form", () => {
                 this.state = {
                     value: "12345",
                 };
+                this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+            }
+
+            handleOnChange(newValue) {
+                this.setState({
+                    value: newValue,
+                });
+            }
+
+            handleOnKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
             }
 
             render() {
@@ -648,11 +673,8 @@ describe("wonder-blocks-form", () => {
                         id="tf-1"
                         type="number"
                         value={this.state.value}
-                        onChange={(newValue) =>
-                            this.setState({
-                                value: newValue,
-                            })
-                        }
+                        onChange={this.handleOnChange}
+                        onKeyDown={this.handleOnKeyDown}
                     />
                 );
             }
@@ -670,14 +692,18 @@ describe("wonder-blocks-form", () => {
                 this.state = {
                     value: "Password123",
                     errorMessage: null,
+                    focused: false,
                 };
                 this.validation = this.validation.bind(this);
                 this.handleOnValidation = this.handleOnValidation.bind(this);
                 this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+                this.handleOnFocus = this.handleOnFocus.bind(this);
+                this.handleOnBlur = this.handleOnBlur.bind(this);
             }
 
             validation(value) {
-                if (value.length <= 8) {
+                if (value.length < 8) {
                     return "Password must be at least 8 characters long";
                 }
 
@@ -698,6 +724,24 @@ describe("wonder-blocks-form", () => {
                 });
             }
 
+            handleOnKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
+            }
+
+            handleOnFocus() {
+                this.setState({
+                    focused: true,
+                });
+            }
+
+            handleOnBlur() {
+                this.setState({
+                    focused: false,
+                });
+            }
+
             render() {
                 return (
                     <View>
@@ -708,8 +752,11 @@ describe("wonder-blocks-form", () => {
                             validation={this.validation}
                             onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
+                            onKeyDown={this.handleOnKeyDown}
+                            onFocus={this.handleOnFocus}
+                            onBlur={this.handleOnBlur}
                         />
-                        {this.state.errorMessage && (
+                        {!this.state.focused && this.state.errorMessage && (
                             <View>
                                 <Strut size={Spacing.xSmall_8} />
                                 <Text style={styles.errorMessage}>
@@ -740,10 +787,14 @@ describe("wonder-blocks-form", () => {
                 this.state = {
                     value: "khan@khanacademy.org",
                     errorMessage: null,
+                    focused: false,
                 };
                 this.validation = this.validation.bind(this);
                 this.handleOnValidation = this.handleOnValidation.bind(this);
                 this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+                this.handleOnFocus = this.handleOnFocus.bind(this);
+                this.handleOnBlur = this.handleOnBlur.bind(this);
             }
 
             validation(value) {
@@ -766,6 +817,24 @@ describe("wonder-blocks-form", () => {
                 });
             }
 
+            handleOnKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
+            }
+
+            handleOnFocus() {
+                this.setState({
+                    focused: true,
+                });
+            }
+
+            handleOnBlur() {
+                this.setState({
+                    focused: false,
+                });
+            }
+
             render() {
                 return (
                     <View>
@@ -776,8 +845,11 @@ describe("wonder-blocks-form", () => {
                             validation={this.validation}
                             onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
+                            onKeyDown={this.handleOnKeyDown}
+                            onFocus={this.handleOnFocus}
+                            onBlur={this.handleOnBlur}
                         />
-                        {this.state.errorMessage && (
+                        {!this.state.focused && this.state.errorMessage && (
                             <View>
                                 <Strut size={Spacing.xSmall_8} />
                                 <Text style={styles.errorMessage}>
@@ -808,10 +880,14 @@ describe("wonder-blocks-form", () => {
                 this.state = {
                     value: "123-456-7890",
                     errorMessage: null,
+                    focused: false,
                 };
                 this.validation = this.validation.bind(this);
                 this.handleOnValidation = this.handleOnValidation.bind(this);
                 this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+                this.handleOnFocus = this.handleOnFocus.bind(this);
+                this.handleOnBlur = this.handleOnBlur.bind(this);
             }
 
             validation(value) {
@@ -834,6 +910,24 @@ describe("wonder-blocks-form", () => {
                 });
             }
 
+            handleOnKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
+            }
+
+            handleOnFocus() {
+                this.setState({
+                    focused: true,
+                });
+            }
+
+            handleOnBlur() {
+                this.setState({
+                    focused: false,
+                });
+            }
+
             render() {
                 return (
                     <View>
@@ -844,8 +938,11 @@ describe("wonder-blocks-form", () => {
                             validation={this.validation}
                             onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
+                            onKeyDown={this.handleOnKeyDown}
+                            onFocus={this.handleOnFocus}
+                            onBlur={this.handleOnBlur}
                         />
-                        {this.state.errorMessage && (
+                        {!this.state.focused && this.state.errorMessage && (
                             <View>
                                 <Strut size={Spacing.xSmall_8} />
                                 <Text style={styles.errorMessage}>
@@ -870,6 +967,99 @@ describe("wonder-blocks-form", () => {
     });
 
     it("example 15", () => {
+        class TextFieldExample extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: "khan",
+                    errorMessage: null,
+                    focused: false,
+                };
+                this.validation = this.validation.bind(this);
+                this.handleOnValidation = this.handleOnValidation.bind(this);
+                this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+                this.handleOnFocus = this.handleOnFocus.bind(this);
+                this.handleOnBlur = this.handleOnBlur.bind(this);
+            }
+
+            validation(value) {
+                const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+
+                if (!emailRegex.test(value)) {
+                    return "Please enter a valid email";
+                }
+            }
+
+            handleOnValidation(errorMessage) {
+                this.setState({
+                    errorMessage: errorMessage,
+                });
+            }
+
+            handleOnChange(newValue) {
+                this.setState({
+                    value: newValue,
+                });
+            }
+
+            handleOnKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
+            }
+
+            handleOnFocus() {
+                this.setState({
+                    focused: true,
+                });
+            }
+
+            handleOnBlur() {
+                this.setState({
+                    focused: false,
+                });
+            }
+
+            render() {
+                return (
+                    <View>
+                        <TextField
+                            id="tf-1"
+                            type="email"
+                            value={this.state.value}
+                            validation={this.validation}
+                            onValidation={this.handleOnValidation}
+                            onChange={this.handleOnChange}
+                            onKeyDown={this.handleOnKeyDown}
+                            onFocus={this.handleOnFocus}
+                            onBlur={this.handleOnBlur}
+                        />
+                        {!this.state.focused && this.state.errorMessage && (
+                            <View>
+                                <Strut size={Spacing.xSmall_8} />
+                                <Text style={styles.errorMessage}>
+                                    {this.state.errorMessage}
+                                </Text>
+                            </View>
+                        )}
+                    </View>
+                );
+            }
+        }
+
+        const styles = StyleSheet.create({
+            errorMessage: {
+                color: Color.red,
+                paddingLeft: Spacing.xxxSmall_4,
+            },
+        });
+        const example = <TextFieldExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 16", () => {
         const example = (
             <TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
         );

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -24,6 +24,26 @@ describe("TextField", () => {
         expect(wrapper).toHaveState("focused", true);
     });
 
+    it("onFocus is called after textfield is focused", () => {
+        // Arrange
+        const handleOnFocus = jest.fn(() => {});
+
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="TextIsLongerThan8"
+                onChange={() => {}}
+                onFocus={handleOnFocus}
+            />,
+        );
+
+        // Act
+        wrapper.simulate("focus");
+
+        // Assert
+        expect(handleOnFocus).toHaveBeenCalled();
+    });
+
     it("textfield is blurred", async () => {
         // Arrange
         const wrapper = mount(
@@ -39,13 +59,35 @@ describe("TextField", () => {
         expect(wrapper).toHaveState("focused", false);
     });
 
+    it("onBlur is called after textfield is blurred", async () => {
+        // Arrange
+        const handleOnBlur = jest.fn(() => {});
+
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="TextIsLongerThan8"
+                onChange={() => {}}
+                onBlur={handleOnBlur}
+            />,
+        );
+
+        // Act
+        wrapper.simulate("focus");
+        await wait(0);
+        wrapper.simulate("blur");
+
+        // Assert
+        expect(handleOnBlur).toHaveBeenCalled();
+    });
+
     it("id prop is passed to the input element", () => {
         // Arrange
         const id: string = "tf-1";
 
         // Act
         const wrapper = mount(
-            <TextField id={id} value="" onChange={() => {}} disabled={true} />,
+            <TextField id={id} value="" onChange={() => {}} />,
         );
 
         // Assert
@@ -59,13 +101,7 @@ describe("TextField", () => {
 
         // Act
         const wrapper = mount(
-            <TextField
-                id={"tf-1"}
-                type={type}
-                value=""
-                onChange={() => {}}
-                disabled={true}
-            />,
+            <TextField id={"tf-1"} type={type} value="" onChange={() => {}} />,
         );
 
         // Assert
@@ -79,12 +115,7 @@ describe("TextField", () => {
 
         // Act
         const wrapper = mount(
-            <TextField
-                id={"tf-1"}
-                value={value}
-                onChange={() => {}}
-                disabled={true}
-            />,
+            <TextField id={"tf-1"} value={value} onChange={() => {}} />,
         );
 
         // Assert
@@ -115,12 +146,7 @@ describe("TextField", () => {
         const handleOnChange = jest.fn();
 
         const wrapper = mount(
-            <TextField
-                id={"tf-1"}
-                value="Text"
-                onChange={handleOnChange}
-                disabled={true}
-            />,
+            <TextField id={"tf-1"} value="Text" onChange={handleOnChange} />,
         );
 
         // Act
@@ -141,7 +167,6 @@ describe("TextField", () => {
                 value="Text"
                 validation={handleValidation}
                 onChange={() => {}}
-                disabled={true}
             />,
         );
 
@@ -167,7 +192,6 @@ describe("TextField", () => {
                 value="TextIsLong"
                 validation={handleValidation}
                 onChange={() => {}}
-                disabled={true}
             />,
         );
 
@@ -194,7 +218,6 @@ describe("TextField", () => {
                 value="TextIsLongerThan8"
                 validation={handleValidation}
                 onChange={() => {}}
-                disabled={true}
             />,
         );
 
@@ -223,7 +246,6 @@ describe("TextField", () => {
                 validation={validation}
                 onValidation={handleOnValidation}
                 onChange={() => {}}
-                disabled={true}
             />,
         );
 
@@ -233,5 +255,56 @@ describe("TextField", () => {
 
         // Assert
         expect(handleOnValidation).toHaveBeenCalledWith(errorMessage);
+    });
+
+    it("onValidation is called on input's initial value", () => {
+        // Arrange
+        const errorMessage = "Value is too short";
+        const handleOnValidation = jest.fn((errorMessage: ?string) => {});
+        const validation = jest.fn((value: string): ?string => {
+            if (value.length < 8) {
+                return errorMessage;
+            }
+        });
+
+        // Act
+        mount(
+            <TextField
+                id={"tf-1"}
+                value="Short"
+                validation={validation}
+                onValidation={handleOnValidation}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(handleOnValidation).toHaveBeenCalledWith(errorMessage);
+    });
+
+    it("onKeyDown is called after keyboard key press", () => {
+        // Arrange
+        const handleOnKeyDown = jest.fn(
+            (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+                return event.key;
+            },
+        );
+
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="TextIsLongerThan8"
+                onChange={() => {}}
+                onKeyDown={handleOnKeyDown}
+            />,
+        );
+
+        // Act
+        const key = "Enter";
+        const input = wrapper.find("input");
+        input.simulate("keyDown", {key: key});
+
+        // Assert
+        expect(handleOnKeyDown).toHaveReturnedWith(key);
     });
 });

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -54,12 +54,12 @@ type Props = {|
     /**
      * Called when the element has been focused.
      */
-    onFocus?: () => mixed,
+    onFocus?: (event: SyntheticFocusEvent<HTMLInputElement>) => mixed,
 
     /**
      * Called when the element has been blurred.
      */
-    onBlur?: () => mixed,
+    onBlur?: (event: SyntheticFocusEvent<HTMLInputElement>) => mixed,
 |};
 
 type DefaultProps = {|
@@ -125,27 +125,27 @@ export default class TextField extends React.Component<Props, State> {
         onChange(newValue);
     };
 
-    handleOnFocus: (
-        event: SyntheticFocusEvent<HTMLInputElement>,
-    ) => mixed = () => {
+    handleOnFocus: (event: SyntheticFocusEvent<HTMLInputElement>) => mixed = (
+        event,
+    ) => {
         const {onFocus} = this.props;
         this.setState({
             focused: true,
         });
         if (onFocus) {
-            onFocus();
+            onFocus(event);
         }
     };
 
-    handleOnBlur: (
-        event: SyntheticFocusEvent<HTMLInputElement>,
-    ) => mixed = () => {
+    handleOnBlur: (event: SyntheticFocusEvent<HTMLInputElement>) => mixed = (
+        event,
+    ) => {
         const {onBlur} = this.props;
         this.setState({
             focused: false,
         });
         if (onBlur) {
-            onBlur();
+            onBlur(event);
         }
     };
 

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -45,6 +45,21 @@ type Props = {|
      * Called when the value has changed.
      */
     onChange: (newValue: string) => mixed,
+
+    /**
+     * Called when a key is pressed.
+     */
+    onKeyDown?: (event: SyntheticKeyboardEvent<HTMLInputElement>) => mixed,
+
+    /**
+     * Called when the element has been focused.
+     */
+    onFocus?: () => mixed,
+
+    /**
+     * Called when the element has been blurred.
+     */
+    onBlur?: () => mixed,
 |};
 
 type DefaultProps = {|
@@ -78,11 +93,12 @@ export default class TextField extends React.Component<Props, State> {
         focused: false,
     };
 
-    handleOnChange: (event: SyntheticInputEvent<HTMLInputElement>) => mixed = (
-        event,
-    ) => {
-        const {validation, onValidation, onChange} = this.props;
-        const newValue = event.target.value;
+    componentDidMount() {
+        this.maybeValidate(this.props.value);
+    }
+
+    maybeValidate: (newValue: string) => void = (newValue) => {
+        const {validation, onValidation} = this.props;
         if (validation) {
             const maybeError = validation(newValue);
             this.setState({error: maybeError});
@@ -90,27 +106,43 @@ export default class TextField extends React.Component<Props, State> {
                 onValidation(maybeError);
             }
         }
+    };
+
+    handleOnChange: (event: SyntheticInputEvent<HTMLInputElement>) => mixed = (
+        event,
+    ) => {
+        const {onChange} = this.props;
+        const newValue = event.target.value;
+        this.maybeValidate(newValue);
         onChange(newValue);
     };
 
     handleOnFocus: (
         event: SyntheticFocusEvent<HTMLInputElement>,
     ) => mixed = () => {
+        const {onFocus} = this.props;
         this.setState({
             focused: true,
         });
+        if (onFocus) {
+            onFocus();
+        }
     };
 
     handleOnBlur: (
         event: SyntheticFocusEvent<HTMLInputElement>,
     ) => mixed = () => {
+        const {onBlur} = this.props;
         this.setState({
             focused: false,
         });
+        if (onBlur) {
+            onBlur();
+        }
     };
 
     render(): React.Node {
-        const {id, type, value, disabled} = this.props;
+        const {id, type, value, disabled, onKeyDown} = this.props;
         return (
             <input
                 className={css([
@@ -130,6 +162,7 @@ export default class TextField extends React.Component<Props, State> {
                 value={value}
                 disabled={disabled}
                 onChange={this.handleOnChange}
+                onKeyDown={onKeyDown}
                 onFocus={this.handleOnFocus}
                 onBlur={this.handleOnBlur}
             />

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -88,6 +88,14 @@ export default class TextField extends React.Component<Props, State> {
         disabled: false,
     };
 
+    constructor(props: Props) {
+        super(props);
+        if (props.validation) {
+            // Ensures error is updated on unmounted server-side renders
+            this.state.error = props.validation(props.value) || null;
+        }
+    }
+
     state: State = {
         error: null,
         focused: false,
@@ -100,7 +108,7 @@ export default class TextField extends React.Component<Props, State> {
     maybeValidate: (newValue: string) => void = (newValue) => {
         const {validation, onValidation} = this.props;
         if (validation) {
-            const maybeError = validation(newValue);
+            const maybeError = validation(newValue) || null;
             this.setState({error: maybeError});
             if (onValidation) {
                 onValidation(maybeError);

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -9,6 +9,18 @@ class TextFieldExample extends React.Component {
         this.state = {
             value: "",
         };
+        this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleOnKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
     }
 
     render() {
@@ -17,7 +29,8 @@ class TextFieldExample extends React.Component {
                 id="tf-1"
                 type="text"
                 value={this.state.value}
-                onChange={(newValue) => this.setState({value: newValue})}
+                onChange={this.handleOnChange}
+                onKeyDown={this.handleOnKeyDown}
             />
         );
     }
@@ -37,6 +50,18 @@ class TextFieldExample extends React.Component {
         this.state = {
             value: "12345",
         };
+        this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleOnKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
     }
 
     render() {
@@ -45,7 +70,8 @@ class TextFieldExample extends React.Component {
                 id="tf-1"
                 type="number"
                 value={this.state.value}
-                onChange={(newValue) => this.setState({value: newValue})}
+                onChange={this.handleOnChange}
+                onKeyDown={this.handleOnKeyDown}
             />
         );
     }
@@ -70,14 +96,18 @@ class TextFieldExample extends React.Component {
         this.state = {
             value: "Password123",
             errorMessage: null,
+            focused: false,
         };
         this.validation = this.validation.bind(this);
         this.handleOnValidation = this.handleOnValidation.bind(this);
         this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+        this.handleOnFocus = this.handleOnFocus.bind(this);
+        this.handleOnBlur = this.handleOnBlur.bind(this);
     }
 
     validation(value) {
-        if (value.length <= 8) {
+        if (value.length < 8) {
             return "Password must be at least 8 characters long";
         }
         if (!/\d/.test(value)) {
@@ -93,6 +123,20 @@ class TextFieldExample extends React.Component {
         this.setState({value: newValue});
     }
 
+    handleOnKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    handleOnFocus() {
+        this.setState({focused: true});
+    }
+
+    handleOnBlur() {
+        this.setState({focused: false});
+    }
+
     render() {
         return (
             <View>
@@ -103,8 +147,11 @@ class TextFieldExample extends React.Component {
                     validation={this.validation}
                     onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
+                    onKeyDown={this.handleOnKeyDown}
+                    onFocus={this.handleOnFocus}
+                    onBlur={this.handleOnBlur}
                 />
-                {this.state.errorMessage && (
+                {!this.state.focused && this.state.errorMessage && (
                     <View>
                         <Strut size={Spacing.xSmall_8} />
                         <Text style={styles.errorMessage}>{this.state.errorMessage}</Text>
@@ -141,10 +188,14 @@ class TextFieldExample extends React.Component {
         this.state = {
             value: "khan@khanacademy.org",
             errorMessage: null,
+            focused: false,
         };
         this.validation = this.validation.bind(this);
         this.handleOnValidation = this.handleOnValidation.bind(this);
         this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+        this.handleOnFocus = this.handleOnFocus.bind(this);
+        this.handleOnBlur = this.handleOnBlur.bind(this);
     }
 
     validation(value) {
@@ -162,6 +213,20 @@ class TextFieldExample extends React.Component {
         this.setState({value: newValue});
     }
 
+    handleOnKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    handleOnFocus() {
+        this.setState({focused: true});
+    }
+
+    handleOnBlur() {
+        this.setState({focused: false});
+    }
+
     render() {
         return (
             <View>
@@ -172,8 +237,11 @@ class TextFieldExample extends React.Component {
                     validation={this.validation}
                     onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
+                    onKeyDown={this.handleOnKeyDown}
+                    onFocus={this.handleOnFocus}
+                    onBlur={this.handleOnBlur}
                 />
-                {this.state.errorMessage && (
+                {!this.state.focused && this.state.errorMessage && (
                     <View>
                         <Strut size={Spacing.xSmall_8} />
                         <Text style={styles.errorMessage}>{this.state.errorMessage}</Text>
@@ -210,10 +278,14 @@ class TextFieldExample extends React.Component {
         this.state = {
             value: "123-456-7890",
             errorMessage: null,
+            focused: false,
         };
         this.validation = this.validation.bind(this);
         this.handleOnValidation = this.handleOnValidation.bind(this);
         this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+        this.handleOnFocus = this.handleOnFocus.bind(this);
+        this.handleOnBlur = this.handleOnBlur.bind(this);
     }
 
     validation(value) {
@@ -231,6 +303,20 @@ class TextFieldExample extends React.Component {
         this.setState({value: newValue});
     }
 
+    handleOnKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    handleOnFocus() {
+        this.setState({focused: true});
+    }
+
+    handleOnBlur() {
+        this.setState({focused: false});
+    }
+
     render() {
         return (
             <View>
@@ -241,8 +327,101 @@ class TextFieldExample extends React.Component {
                     validation={this.validation}
                     onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
+                    onKeyDown={this.handleOnKeyDown}
+                    onFocus={this.handleOnFocus}
+                    onBlur={this.handleOnBlur}
                 />
-                {this.state.errorMessage && (
+                {!this.state.focused && this.state.errorMessage && (
+                    <View>
+                        <Strut size={Spacing.xSmall_8} />
+                        <Text style={styles.errorMessage}>{this.state.errorMessage}</Text>
+                    </View>
+                )}
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    errorMessage: {
+        color: Color.red,
+        paddingLeft: Spacing.xxxSmall_4,
+    },
+});
+
+<TextFieldExample />
+```
+
+Error
+
+```js
+import {StyleSheet} from "aphrodite";
+import {View, Text} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "khan",
+            errorMessage: null,
+            focused: false,
+        };
+        this.validation = this.validation.bind(this);
+        this.handleOnValidation = this.handleOnValidation.bind(this);
+        this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+        this.handleOnFocus = this.handleOnFocus.bind(this);
+        this.handleOnBlur = this.handleOnBlur.bind(this);
+    }
+
+    validation(value) {
+        const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+        if (!emailRegex.test(value)) {
+            return "Please enter a valid email";
+        }
+    }
+
+    handleOnValidation(errorMessage) {
+        this.setState({errorMessage: errorMessage});
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleOnKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    handleOnFocus() {
+        this.setState({focused: true});
+    }
+
+    handleOnBlur() {
+        this.setState({focused: false});
+    }
+
+    render() {
+        return (
+            <View>
+                <TextField
+                    id="tf-1"
+                    type="email"
+                    value={this.state.value}
+                    validation={this.validation}
+                    onValidation={this.handleOnValidation}
+                    onChange={this.handleOnChange}
+                    onKeyDown={this.handleOnKeyDown}
+                    onFocus={this.handleOnFocus}
+                    onBlur={this.handleOnBlur}
+                />
+                {!this.state.focused && this.state.errorMessage && (
                     <View>
                         <Strut size={Spacing.xSmall_8} />
                         <Text style={styles.errorMessage}>{this.state.errorMessage}</Text>

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -21,12 +21,21 @@ export const text: StoryComponentType = () => {
         setValue(newValue);
     };
 
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
     return (
         <TextField
             id="tf-1"
             type="text"
             value={value}
             onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
         />
     );
 };
@@ -38,12 +47,21 @@ export const number: StoryComponentType = () => {
         setValue(newValue);
     };
 
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
     return (
         <TextField
             id="tf-1"
             type="number"
             value={value}
             onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
         />
     );
 };
@@ -51,13 +69,14 @@ export const number: StoryComponentType = () => {
 export const password: StoryComponentType = () => {
     const [value, setValue] = React.useState("Password123");
     const [errorMessage, setErrorMessage] = React.useState();
+    const [focused, setFocused] = React.useState(false);
 
     const handleOnChange = (newValue: string) => {
         setValue(newValue);
     };
 
     const validation = (value: string) => {
-        if (value.length <= 8) {
+        if (value.length < 8) {
             return "Password must be at least 8 characters long";
         }
         if (!/\d/.test(value)) {
@@ -69,6 +88,22 @@ export const password: StoryComponentType = () => {
         setErrorMessage(errorMessage);
     };
 
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    const handleOnFocus = () => {
+        setFocused(true);
+    };
+
+    const handleOnBlur = () => {
+        setFocused(false);
+    };
+
     return (
         <View>
             <TextField
@@ -78,8 +113,11 @@ export const password: StoryComponentType = () => {
                 validation={validation}
                 onValidation={handleOnValidation}
                 onChange={handleOnChange}
+                onKeyDown={handleOnKeyDown}
+                onFocus={handleOnFocus}
+                onBlur={handleOnBlur}
             />
-            {errorMessage && (
+            {!focused && errorMessage && (
                 <View>
                     <Strut size={Spacing.xSmall_8} />
                     <Text style={styles.errorMessage}>{errorMessage}</Text>
@@ -92,6 +130,7 @@ export const password: StoryComponentType = () => {
 export const email: StoryComponentType = () => {
     const [value, setValue] = React.useState("khan@khanacademy.org");
     const [errorMessage, setErrorMessage] = React.useState();
+    const [focused, setFocused] = React.useState(false);
 
     const handleOnChange = (newValue: string) => {
         setValue(newValue);
@@ -108,6 +147,22 @@ export const email: StoryComponentType = () => {
         setErrorMessage(errorMessage);
     };
 
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    const handleOnFocus = () => {
+        setFocused(true);
+    };
+
+    const handleOnBlur = () => {
+        setFocused(false);
+    };
+
     return (
         <View>
             <TextField
@@ -117,8 +172,11 @@ export const email: StoryComponentType = () => {
                 validation={validation}
                 onValidation={handleOnValidation}
                 onChange={handleOnChange}
+                onKeyDown={handleOnKeyDown}
+                onFocus={handleOnFocus}
+                onBlur={handleOnBlur}
             />
-            {errorMessage && (
+            {!focused && errorMessage && (
                 <View>
                     <Strut size={Spacing.xSmall_8} />
                     <Text style={styles.errorMessage}>{errorMessage}</Text>
@@ -131,6 +189,7 @@ export const email: StoryComponentType = () => {
 export const telephone: StoryComponentType = () => {
     const [value, setValue] = React.useState("123-456-7890");
     const [errorMessage, setErrorMessage] = React.useState();
+    const [focused, setFocused] = React.useState(false);
 
     const handleOnChange = (newValue: string) => {
         setValue(newValue);
@@ -147,6 +206,22 @@ export const telephone: StoryComponentType = () => {
         setErrorMessage(errorMessage);
     };
 
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    const handleOnFocus = () => {
+        setFocused(true);
+    };
+
+    const handleOnBlur = () => {
+        setFocused(false);
+    };
+
     return (
         <View>
             <TextField
@@ -156,8 +231,70 @@ export const telephone: StoryComponentType = () => {
                 validation={validation}
                 onValidation={handleOnValidation}
                 onChange={handleOnChange}
+                onKeyDown={handleOnKeyDown}
+                onFocus={handleOnFocus}
+                onBlur={handleOnBlur}
             />
-            {errorMessage && (
+            {!focused && errorMessage && (
+                <View>
+                    <Strut size={Spacing.xSmall_8} />
+                    <Text style={styles.errorMessage}>{errorMessage}</Text>
+                </View>
+            )}
+        </View>
+    );
+};
+
+export const error: StoryComponentType = () => {
+    const [value, setValue] = React.useState("khan");
+    const [errorMessage, setErrorMessage] = React.useState();
+    const [focused, setFocused] = React.useState(false);
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const validation = (value: string) => {
+        const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+        if (!emailRegex.test(value)) {
+            return "Please enter a valid email";
+        }
+    };
+
+    const handleOnValidation = (errorMessage: ?string) => {
+        setErrorMessage(errorMessage);
+    };
+
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    const handleOnFocus = () => {
+        setFocused(true);
+    };
+
+    const handleOnBlur = () => {
+        setFocused(false);
+    };
+
+    return (
+        <View>
+            <TextField
+                id="tf-1"
+                type="email"
+                value={value}
+                validation={validation}
+                onValidation={handleOnValidation}
+                onChange={handleOnChange}
+                onKeyDown={handleOnKeyDown}
+                onFocus={handleOnFocus}
+                onBlur={handleOnBlur}
+            />
+            {!focused && errorMessage && (
                 <View>
                     <Strut size={Spacing.xSmall_8} />
                     <Text style={styles.errorMessage}>{errorMessage}</Text>


### PR DESCRIPTION
## Summary:
Adding `onKeyDown`, `onFocus`, and `onBlur` props to TextField. Also
adding the ability to validate the initial value of TextField on
component mount and call `onValidation` as necessary.

Issue: https://khanacademy.atlassian.net/browse/WB-1053

## Test plan:
1. Open Styleguidist (or React Storybook).
2. Go to the TextField under Form -> TextField.
3. Notice how pressing "Enter" while the TextField is focused will blur the TextField.
4. Also notice how the error message (on invalid input) will only show when the TextField is not focused (aka blurred).

---

##### Error message only showing when TextField is blurred (1)
![tf-password](https://user-images.githubusercontent.com/60367213/120378440-0b215d00-c2e4-11eb-8c48-d125c0961565.gif)


##### Error message only showing when TextField is blurred (2)
![tf-email](https://user-images.githubusercontent.com/60367213/120378455-11173e00-c2e4-11eb-930b-3fc3bc7b02d6.gif)


##### Error message shows on component mount if initial value is invalid
<img width="381" alt="tf-email-initial" src="https://user-images.githubusercontent.com/60367213/120364142-7feb9b80-c2d2-11eb-8b84-9cc5be3c6f71.png">
