### PR TITLE
WB-1056 - Add `placeholder`, `required`, `light`, and `style` Props to TextField

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -6047,7 +6047,7 @@ exports[`wonder-blocks-form example 15 1`] = `
   }
 >
   <input
-    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-error_b4h83j"
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-error_1n1oc37"
     disabled={false}
     id="tf-1"
     onBlur={[Function]}

--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -5900,7 +5900,7 @@ exports[`wonder-blocks-form example 10 1`] = `
   onChange={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
-  placeholder="Placeholder"
+  placeholder="Text"
   type="text"
   value=""
 />
@@ -5915,7 +5915,7 @@ exports[`wonder-blocks-form example 11 1`] = `
   onChange={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
-  placeholder="Placeholder"
+  placeholder="Number"
   type="number"
   value="12345"
 />
@@ -5949,7 +5949,7 @@ exports[`wonder-blocks-form example 12 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Password"
     type="password"
     value="Password123"
   />
@@ -5984,7 +5984,7 @@ exports[`wonder-blocks-form example 13 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Email"
     type="email"
     value="khan@khanacademy.org"
   />
@@ -6019,7 +6019,7 @@ exports[`wonder-blocks-form example 14 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Telephone"
     type="email"
     value="123-456-7890"
   />
@@ -6047,14 +6047,14 @@ exports[`wonder-blocks-form example 15 1`] = `
   }
 >
   <input
-    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-error_1vc4qn7"
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-error_b4h83j"
     disabled={false}
     id="tf-1"
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Email"
     type="email"
     value="khan"
   />
@@ -6128,7 +6128,58 @@ exports[`wonder-blocks-form example 16 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
-  placeholder="Placeholder"
+  placeholder="This field is disabled."
+  type="text"
+  value=""
+/>
+`;
+
+exports[`wonder-blocks-form example 17 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "backgroundColor": "#0a2a66",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 16,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <input
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
+    disabled={false}
+    id="tf-1"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    placeholder="Email"
+    type="email"
+    value="khan@khanacademy.org"
+  />
+</div>
+`;
+
+exports[`wonder-blocks-form example 18 1`] = `
+<input
+  className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-customField_subna9"
+  disabled={false}
+  id="tf-1"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  placeholder="Text"
   type="text"
   value=""
 />

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -632,6 +632,7 @@ describe("wonder-blocks-form", () => {
                         id="tf-1"
                         type="text"
                         value={this.state.value}
+                        placeholder="Text"
                         onChange={this.handleOnChange}
                         onKeyDown={this.handleOnKeyDown}
                     />
@@ -673,6 +674,7 @@ describe("wonder-blocks-form", () => {
                         id="tf-1"
                         type="number"
                         value={this.state.value}
+                        placeholder="Number"
                         onChange={this.handleOnChange}
                         onKeyDown={this.handleOnKeyDown}
                     />
@@ -749,6 +751,7 @@ describe("wonder-blocks-form", () => {
                             id="tf-1"
                             type="password"
                             value={this.state.value}
+                            placeholder="Password"
                             validation={this.validation}
                             onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
@@ -842,6 +845,7 @@ describe("wonder-blocks-form", () => {
                             id="tf-1"
                             type="email"
                             value={this.state.value}
+                            placeholder="Email"
                             validation={this.validation}
                             onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
@@ -935,6 +939,7 @@ describe("wonder-blocks-form", () => {
                             id="tf-1"
                             type="email"
                             value={this.state.value}
+                            placeholder="Telephone"
                             validation={this.validation}
                             onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
@@ -1028,6 +1033,7 @@ describe("wonder-blocks-form", () => {
                             id="tf-1"
                             type="email"
                             value={this.state.value}
+                            placeholder="Email"
                             validation={this.validation}
                             onValidation={this.handleOnValidation}
                             onChange={this.handleOnChange}
@@ -1061,8 +1067,167 @@ describe("wonder-blocks-form", () => {
 
     it("example 16", () => {
         const example = (
-            <TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
+            <TextField
+                id="tf-1"
+                value=""
+                placeholder="This field is disabled."
+                onChange={() => {}}
+                disabled={true}
+            />
         );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 17", () => {
+        class TextFieldExample extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: "khan@khanacademy.org",
+                    errorMessage: null,
+                    focused: false,
+                };
+                this.validation = this.validation.bind(this);
+                this.handleOnValidation = this.handleOnValidation.bind(this);
+                this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+                this.handleOnFocus = this.handleOnFocus.bind(this);
+                this.handleOnBlur = this.handleOnBlur.bind(this);
+            }
+
+            validation(value) {
+                const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+
+                if (!emailRegex.test(value)) {
+                    return "Please enter a valid email";
+                }
+            }
+
+            handleOnValidation(errorMessage) {
+                this.setState({
+                    errorMessage: errorMessage,
+                });
+            }
+
+            handleOnChange(newValue) {
+                this.setState({
+                    value: newValue,
+                });
+            }
+
+            handleOnKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
+            }
+
+            handleOnFocus() {
+                this.setState({
+                    focused: true,
+                });
+            }
+
+            handleOnBlur() {
+                this.setState({
+                    focused: false,
+                });
+            }
+
+            render() {
+                return (
+                    <View style={styles.darkBackground}>
+                        <TextField
+                            id="tf-1"
+                            type="email"
+                            value={this.state.value}
+                            light={true}
+                            placeholder="Email"
+                            validation={this.validation}
+                            onValidation={this.handleOnValidation}
+                            onChange={this.handleOnChange}
+                            onKeyDown={this.handleOnKeyDown}
+                            onFocus={this.handleOnFocus}
+                            onBlur={this.handleOnBlur}
+                        />
+                        {!this.state.focused && this.state.errorMessage && (
+                            <View>
+                                <Strut size={Spacing.xSmall_8} />
+                                <Text style={styles.errorMessage}>
+                                    {this.state.errorMessage}
+                                </Text>
+                            </View>
+                        )}
+                    </View>
+                );
+            }
+        }
+
+        const styles = StyleSheet.create({
+            errorMessage: {
+                color: Color.white,
+                paddingLeft: Spacing.xxxSmall_4,
+            },
+            darkBackground: {
+                backgroundColor: Color.darkBlue,
+                padding: Spacing.medium_16,
+            },
+        });
+        const example = <TextFieldExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 18", () => {
+        class TextFieldExample extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: "",
+                };
+                this.handleOnChange = this.handleOnChange.bind(this);
+                this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+            }
+
+            handleOnChange(newValue) {
+                this.setState({
+                    value: newValue,
+                });
+            }
+
+            handleOnKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
+            }
+
+            render() {
+                return (
+                    <TextField
+                        id="tf-1"
+                        style={styles.customField}
+                        type="text"
+                        value={this.state.value}
+                        placeholder="Text"
+                        onChange={this.handleOnChange}
+                        onKeyDown={this.handleOnKeyDown}
+                    />
+                );
+            }
+        }
+
+        const styles = StyleSheet.create({
+            customField: {
+                backgroundColor: Color.darkBlue,
+                color: Color.white,
+                border: "none",
+                maxWidth: 250,
+                "::placeholder": {
+                    color: Color.white64,
+                },
+            },
+        });
+        const example = <TextFieldExample />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -307,4 +307,43 @@ describe("TextField", () => {
         // Assert
         expect(handleOnKeyDown).toHaveReturnedWith(key);
     });
+
+    it("placeholder prop is passed to the input element", () => {
+        // Arrange
+        const placeholder = "Placeholder";
+
+        // Act
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="Text"
+                placeholder={placeholder}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toContainMatchingElement(
+            `[placeholder="${placeholder}"]`,
+        );
+    });
+
+    it("required prop is passed to the input element", () => {
+        // Arrange
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value="Text"
+                onChange={() => {}}
+                required={true}
+            />,
+        );
+
+        // Act
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toContainMatchingElement("[required=true]");
+    });
 });

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -6,6 +6,7 @@ import {StyleSheet, css} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type TextFieldType = "text" | "password" | "email" | "number" | "tel";
 
@@ -60,11 +61,32 @@ type Props = {|
      * Called when the element has been blurred.
      */
     onBlur?: (event: SyntheticFocusEvent<HTMLInputElement>) => mixed,
+
+    /**
+     * Provide hints or examples of what to enter.
+     */
+    placeholder?: string,
+
+    /**
+     * Whether this component is required.
+     */
+    required?: boolean,
+
+    /**
+     * Change the default focus ring color to fit a dark background.
+     */
+    light: boolean,
+
+    /**
+     * Custom styles for the input.
+     */
+    style?: StyleType,
 |};
 
 type DefaultProps = {|
     type: $PropertyType<Props, "type">,
     disabled: $PropertyType<Props, "disabled">,
+    light: $PropertyType<Props, "light">,
 |};
 
 type State = {|
@@ -86,6 +108,7 @@ export default class TextField extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
         type: "text",
         disabled: false,
+        light: false,
     };
 
     constructor(props: Props) {
@@ -150,7 +173,17 @@ export default class TextField extends React.Component<Props, State> {
     };
 
     render(): React.Node {
-        const {id, type, value, disabled, onKeyDown} = this.props;
+        const {
+            id,
+            type,
+            value,
+            disabled,
+            onKeyDown,
+            placeholder,
+            required,
+            light,
+            style,
+        } = this.props;
         return (
             <input
                 className={css([
@@ -161,18 +194,23 @@ export default class TextField extends React.Component<Props, State> {
                     disabled
                         ? styles.disabled
                         : this.state.focused
-                        ? styles.focused
-                        : this.state.error && styles.error,
+                        ? [styles.focused, light && styles.defaultLight]
+                        : this.state.error && [
+                              styles.error,
+                              light && styles.errorLight,
+                          ],
+                    style && style,
                 ])}
                 id={id}
                 type={type}
-                placeholder="Placeholder"
+                placeholder={placeholder}
                 value={value}
                 disabled={disabled}
                 onChange={this.handleOnChange}
                 onKeyDown={onKeyDown}
                 onFocus={this.handleOnFocus}
                 onBlur={this.handleOnBlur}
+                required={required}
             />
         );
     }
@@ -198,7 +236,7 @@ const styles = StyleSheet.create({
         },
     },
     error: {
-        background: "rgba(217, 41, 22, 0.06)",
+        background: `linear-gradient(0deg, rgba(217, 41, 22, 0.06), rgba(217, 41, 22, 0.06)), ${Color.white}`,
         border: `1px solid ${Color.red}`,
         color: Color.offBlack,
         "::placeholder": {
@@ -220,5 +258,11 @@ const styles = StyleSheet.create({
         "::placeholder": {
             color: Color.offBlack64,
         },
+    },
+    defaultLight: {
+        boxShadow: `0px 0px 0px 1px ${Color.blue}, 0px 0px 0px 2px ${Color.white}`,
+    },
+    errorLight: {
+        boxShadow: `0px 0px 0px 1px ${Color.red}, 0px 0px 0px 2px ${Color.white}`,
     },
 });

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 import {StyleSheet, css} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
+import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
@@ -236,7 +236,7 @@ const styles = StyleSheet.create({
         },
     },
     error: {
-        background: `linear-gradient(0deg, rgba(217, 41, 22, 0.06), rgba(217, 41, 22, 0.06)), ${Color.white}`,
+        background: `${mix(fade(Color.red, 0.06), Color.white)}`,
         border: `1px solid ${Color.red}`,
         color: Color.offBlack,
         "::placeholder": {

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -29,6 +29,7 @@ class TextFieldExample extends React.Component {
                 id="tf-1"
                 type="text"
                 value={this.state.value}
+                placeholder="Text"
                 onChange={this.handleOnChange}
                 onKeyDown={this.handleOnKeyDown}
             />
@@ -70,6 +71,7 @@ class TextFieldExample extends React.Component {
                 id="tf-1"
                 type="number"
                 value={this.state.value}
+                placeholder="Number"
                 onChange={this.handleOnChange}
                 onKeyDown={this.handleOnKeyDown}
             />
@@ -144,6 +146,7 @@ class TextFieldExample extends React.Component {
                     id="tf-1"
                     type="password"
                     value={this.state.value}
+                    placeholder="Password"
                     validation={this.validation}
                     onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
@@ -234,6 +237,7 @@ class TextFieldExample extends React.Component {
                     id="tf-1"
                     type="email"
                     value={this.state.value}
+                    placeholder="Email"
                     validation={this.validation}
                     onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
@@ -324,6 +328,7 @@ class TextFieldExample extends React.Component {
                     id="tf-1"
                     type="email"
                     value={this.state.value}
+                    placeholder="Telephone"
                     validation={this.validation}
                     onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
@@ -414,6 +419,7 @@ class TextFieldExample extends React.Component {
                     id="tf-1"
                     type="email"
                     value={this.state.value}
+                    placeholder="Email"
                     validation={this.validation}
                     onValidation={this.handleOnValidation}
                     onChange={this.handleOnChange}
@@ -447,5 +453,164 @@ Disabled
 ```js
 import {TextField} from "@khanacademy/wonder-blocks-form";
 
-<TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
+<TextField
+    id="tf-1" value=""
+    placeholder="This field is disabled."
+    onChange={() => {}}
+    disabled={true}
+/>
+```
+
+Light (default focus ring fits a dark background)
+
+```js
+import {StyleSheet} from "aphrodite";
+import {View, Text} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "khan@khanacademy.org",
+            errorMessage: null,
+            focused: false,
+        };
+        this.validation = this.validation.bind(this);
+        this.handleOnValidation = this.handleOnValidation.bind(this);
+        this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+        this.handleOnFocus = this.handleOnFocus.bind(this);
+        this.handleOnBlur = this.handleOnBlur.bind(this);
+    }
+
+    validation(value) {
+        const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+        if (!emailRegex.test(value)) {
+            return "Please enter a valid email";
+        }
+    }
+
+    handleOnValidation(errorMessage) {
+        this.setState({errorMessage: errorMessage});
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleOnKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    handleOnFocus() {
+        this.setState({focused: true});
+    }
+
+    handleOnBlur() {
+        this.setState({focused: false});
+    }
+
+    render() {
+        return (
+            <View style={styles.darkBackground}>
+                <TextField
+                    id="tf-1"
+                    type="email"
+                    value={this.state.value}
+                    light={true}
+                    placeholder="Email"
+                    validation={this.validation}
+                    onValidation={this.handleOnValidation}
+                    onChange={this.handleOnChange}
+                    onKeyDown={this.handleOnKeyDown}
+                    onFocus={this.handleOnFocus}
+                    onBlur={this.handleOnBlur}
+                />
+                {!this.state.focused && this.state.errorMessage && (
+                    <View>
+                        <Strut size={Spacing.xSmall_8} />
+                        <Text style={styles.errorMessage}>{this.state.errorMessage}</Text>
+                    </View>
+                )}
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    errorMessage: {
+        color: Color.white,
+        paddingLeft: Spacing.xxxSmall_4,
+    },
+    darkBackground: {
+        backgroundColor: Color.darkBlue,
+        padding: Spacing.medium_16,
+    },
+});
+
+<TextFieldExample />
+```
+
+Custom Style
+
+```js
+import {StyleSheet} from "aphrodite";
+import Color from "@khanacademy/wonder-blocks-color";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "",
+        };
+        this.handleOnChange = this.handleOnChange.bind(this);
+        this.handleOnKeyDown = this.handleOnKeyDown.bind(this);
+    }
+
+    handleOnChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleOnKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    render() {
+        return (
+            <TextField
+                id="tf-1"
+                style={styles.customField}
+                type="text"
+                value={this.state.value}
+                placeholder="Text"
+                onChange={this.handleOnChange}
+                onKeyDown={this.handleOnKeyDown}
+            />
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    customField: {
+        backgroundColor: Color.darkBlue,
+        color: Color.white,
+        border: "none",
+        maxWidth: 250,
+        "::placeholder": {
+            color: Color.white64,
+        },
+    },
+});
+
+<TextFieldExample />
 ```

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -34,6 +34,7 @@ export const text: StoryComponentType = () => {
             id="tf-1"
             type="text"
             value={value}
+            placeholder="Text"
             onChange={handleOnChange}
             onKeyDown={handleOnKeyDown}
         />
@@ -60,6 +61,7 @@ export const number: StoryComponentType = () => {
             id="tf-1"
             type="number"
             value={value}
+            placeholder="Number"
             onChange={handleOnChange}
             onKeyDown={handleOnKeyDown}
         />
@@ -110,6 +112,7 @@ export const password: StoryComponentType = () => {
                 id="tf-1"
                 type="password"
                 value={value}
+                placeholder="Password"
                 validation={validation}
                 onValidation={handleOnValidation}
                 onChange={handleOnChange}
@@ -169,6 +172,7 @@ export const email: StoryComponentType = () => {
                 id="tf-1"
                 type="email"
                 value={value}
+                placeholder="Email"
                 validation={validation}
                 onValidation={handleOnValidation}
                 onChange={handleOnChange}
@@ -228,6 +232,7 @@ export const telephone: StoryComponentType = () => {
                 id="tf-1"
                 type="tel"
                 value={value}
+                placeholder="Telephone"
                 validation={validation}
                 onValidation={handleOnValidation}
                 onChange={handleOnChange}
@@ -287,6 +292,7 @@ export const error: StoryComponentType = () => {
                 id="tf-1"
                 type="email"
                 value={value}
+                placeholder="Email"
                 validation={validation}
                 onValidation={handleOnValidation}
                 onChange={handleOnChange}
@@ -305,12 +311,124 @@ export const error: StoryComponentType = () => {
 };
 
 export const disabled: StoryComponentType = () => (
-    <TextField id="tf-1" value="" onChange={() => {}} disabled={true} />
+    <TextField
+        id="tf-1"
+        value=""
+        placeholder="This field is disabled."
+        onChange={() => {}}
+        disabled={true}
+    />
 );
+
+export const light: StoryComponentType = () => {
+    const [value, setValue] = React.useState("khan@khanacademy.org");
+    const [errorMessage, setErrorMessage] = React.useState();
+    const [focused, setFocused] = React.useState(false);
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const validation = (value: string) => {
+        const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+        if (!emailRegex.test(value)) {
+            return "Please enter a valid email";
+        }
+    };
+
+    const handleOnValidation = (errorMessage: ?string) => {
+        setErrorMessage(errorMessage);
+    };
+
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    const handleOnFocus = () => {
+        setFocused(true);
+    };
+
+    const handleOnBlur = () => {
+        setFocused(false);
+    };
+
+    return (
+        <View style={styles.darkBackground}>
+            <TextField
+                id="tf-1"
+                type="email"
+                value={value}
+                placeholder="Email"
+                light={true}
+                validation={validation}
+                onValidation={handleOnValidation}
+                onChange={handleOnChange}
+                onKeyDown={handleOnKeyDown}
+                onFocus={handleOnFocus}
+                onBlur={handleOnBlur}
+            />
+            {!focused && errorMessage && (
+                <View>
+                    <Strut size={Spacing.xSmall_8} />
+                    <Text style={styles.errorMessageLight}>{errorMessage}</Text>
+                </View>
+            )}
+        </View>
+    );
+};
+
+export const customStyle: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <TextField
+            id="tf-1"
+            style={styles.customField}
+            type="text"
+            value={value}
+            placeholder="Text"
+            onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
+        />
+    );
+};
 
 const styles = StyleSheet.create({
     errorMessage: {
         color: Color.red,
         paddingLeft: Spacing.xxxSmall_4,
+    },
+    errorMessageLight: {
+        color: Color.white,
+        paddingLeft: Spacing.xxxSmall_4,
+    },
+    darkBackground: {
+        backgroundColor: Color.darkBlue,
+        padding: Spacing.medium_16,
+    },
+    customField: {
+        backgroundColor: Color.darkBlue,
+        color: Color.white,
+        border: "none",
+        maxWidth: 250,
+        "::placeholder": {
+            color: Color.white64,
+        },
     },
 });


### PR DESCRIPTION
## Summary:
Adding the `placeholder`, `required`, `light`, and `style` props to TextField.

When it comes to the `light` prop, I referenced off of the TextFields in Khan Academy's ["Donate"](https://www.khanacademy.org/donate) page (see images below). This was because the Figma did not specify any specific look for the `light` version of the TextField. Please let me know if there is another `light` style that is preferred.

Issue: https://khanacademy.atlassian.net/browse/WB-1056

## Test plan:
1. Open Styleguidist (or React Storybook)
2. View TextField under Form -> TextField
3. See how all example TextFields have a unique placeholder text.
4. See the "Light" TextField example and how the "default" and "error" states fit the dark background.
5. See the "Custom Style" TextField and view the ease of passing custom styles.

---

#### TextField with `light="true"` (Focus)
<img width="368" alt="tf-light-focus" src="https://user-images.githubusercontent.com/60367213/120539250-0bd1f600-c3ad-11eb-8dca-60fc3ec6672c.png">

#### TextField with `light="true"` (Error)
<img width="368" alt="tf-light-error" src="https://user-images.githubusercontent.com/60367213/120539315-15f3f480-c3ad-11eb-97ad-7de22d7731d6.png">

#### ["Donate"](https://www.khanacademy.org/donate) Page TextField (used as reference for the `light` style)
<img width="630" alt="tf-donate" src="https://user-images.githubusercontent.com/60367213/120539817-987cb400-c3ad-11eb-8afa-39be51fe359d.png">

