### PR TITLE
[FEI-3597].wb Add support for bypassing hydration

### DIFF
--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -59,6 +59,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -84,6 +85,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -112,6 +114,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -147,6 +150,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -182,6 +186,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -216,6 +221,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const consoleSpy = jest
@@ -259,6 +265,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "TYPE1",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeHandler2: IRequestHandler<string, string> = {
                     fulfillRequest: () => new Promise(() => {}),
@@ -266,6 +273,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "TYPE2",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = mount(
@@ -304,6 +312,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = mount(
@@ -336,6 +345,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => null);
@@ -367,6 +377,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => null);
@@ -397,6 +408,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => ({
@@ -433,6 +445,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fulfillRequestFn = jest.fn(() =>
@@ -465,6 +478,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fulfillRequestFn = jest.fn(() => null);
@@ -508,6 +522,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -530,6 +545,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => true,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -555,6 +571,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -580,6 +597,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "TYPE1",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeHandler2: IRequestHandler<string, string> = {
                     fulfillRequest: () => new Promise(() => {}),
@@ -587,6 +605,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "TYPE2",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = mount(
@@ -621,6 +640,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = mount(
@@ -655,6 +675,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => null);
@@ -685,6 +706,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => null);
@@ -716,6 +738,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => ({
@@ -751,6 +774,7 @@ describe("Data", () => {
                         shouldRefreshCache: jest.fn(() => false),
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const shouldRefreshCacheFn = jest.fn(() => true);
@@ -785,6 +809,7 @@ describe("Data", () => {
                         shouldRefreshCache: jest.fn(() => false),
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const shouldRefreshCacheFn = jest.fn(() => null);
@@ -816,6 +841,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => true,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fulfillRequestFn = jest.fn(() =>
@@ -848,6 +874,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const shouldRefreshCacheFn = jest.fn(() => true);
@@ -901,6 +928,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -923,6 +951,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -953,6 +982,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -978,6 +1008,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => null);
@@ -1009,6 +1040,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => ({
@@ -1047,6 +1079,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => ({
@@ -1081,6 +1114,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fulfillRequestFn = jest.fn(() =>
@@ -1116,6 +1150,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const shouldRefreshCacheFn = jest.fn(() => true);
@@ -1156,6 +1191,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const shouldRefreshCacheFn = jest.fn(() => true);
@@ -1207,6 +1243,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -1229,6 +1266,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -1259,6 +1297,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -1290,6 +1329,7 @@ describe("Data", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -1318,6 +1358,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => null);
@@ -1348,6 +1389,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => null);
@@ -1379,6 +1421,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => ({
@@ -1416,6 +1459,7 @@ describe("Data", () => {
                         shouldRefreshCache: () => false,
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fakeGetEntryFn = jest.fn(() => ({
@@ -1450,6 +1494,7 @@ describe("Data", () => {
                         shouldRefreshCache: jest.fn(() => true),
                         type: "MY_HANDLER",
                         cache: null,
+                        hydrate: true,
                     };
                     const fakeChildrenFn = jest.fn(() => null);
                     const fulfillRequestFn = jest.fn(() =>

--- a/packages/wonder-blocks-data/src/components/__tests__/intercept-cache.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/intercept-cache.test.js
@@ -21,6 +21,7 @@ describe("InterceptCache", () => {
             shouldRefreshCache: () => false,
             type: "MY_HANDLER",
             cache: null,
+            hydrate: true,
         };
         const getEntryFn = jest.fn();
         const captureContextFn = jest.fn();
@@ -52,6 +53,7 @@ describe("InterceptCache", () => {
             shouldRefreshCache: () => false,
             type: "MY_HANDLER",
             cache: null,
+            hydrate: true,
         };
         const getEntry1Fn = jest.fn();
         const getEntry2Fn = jest.fn();
@@ -86,6 +88,7 @@ describe("InterceptCache", () => {
             shouldRefreshCache: () => false,
             type: "MY_HANDLER",
             cache: null,
+            hydrate: true,
         };
         const fulfillRequestFn = jest.fn();
         const shouldRefreshCacheFn = jest.fn();

--- a/packages/wonder-blocks-data/src/components/__tests__/intercept-data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/intercept-data.test.js
@@ -31,6 +31,7 @@ describe("InterceptData", () => {
             shouldRefreshCache: () => false,
             type: "MY_HANDLER",
             cache: null,
+            hydrate: true,
         };
         props.handler = fakeHandler;
         const captureContextFn = jest.fn();
@@ -63,6 +64,7 @@ describe("InterceptData", () => {
             shouldRefreshCache: () => false,
             type: "MY_HANDLER",
             cache: null,
+            hydrate: true,
         };
         const fulfillRequest1Fn = jest.fn();
         const shouldRefreshCache1Fn = jest.fn();
@@ -108,6 +110,7 @@ describe("InterceptData", () => {
             shouldRefreshCache: () => false,
             type: "MY_HANDLER",
             cache: null,
+            hydrate: true,
         };
         const fulfillRequestFn = jest.fn();
         const getEntryFn = jest.fn();

--- a/packages/wonder-blocks-data/src/components/__tests__/internal-data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/internal-data.test.js
@@ -47,6 +47,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -75,6 +76,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -104,6 +106,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -136,6 +139,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -179,6 +183,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -218,6 +223,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -256,6 +262,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -294,6 +301,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -333,6 +341,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -372,6 +381,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -412,6 +422,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "TYPE1",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeHandler2: IRequestHandler<string, string> = {
                     fulfillRequest: () => new Promise(() => {}),
@@ -419,6 +430,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "TYPE2",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = mount(
@@ -461,6 +473,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = mount(
@@ -498,6 +511,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -529,6 +543,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -558,6 +573,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => true,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -590,6 +606,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -622,6 +639,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -654,6 +672,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({}: any));
@@ -684,6 +703,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "TYPE1",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeHandler2: IRequestHandler<string, string> = {
                     fulfillRequest: () => new Promise(() => {}),
@@ -691,6 +711,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "TYPE2",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -732,6 +753,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -780,6 +802,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -806,6 +829,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -840,6 +864,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -870,6 +895,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -899,6 +925,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -933,6 +960,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({
@@ -971,6 +999,7 @@ describe("InternalData", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeChildrenFn = jest.fn(() => null);
                 const getEntryFn = jest.fn(() => ({

--- a/packages/wonder-blocks-data/src/components/data.js
+++ b/packages/wonder-blocks-data/src/components/data.js
@@ -95,6 +95,7 @@ export default class Data<TOptions, TData: ValidData> extends React.Component<
             getKey: handler.getKey,
             type: handler.type,
             cache: handler.cache,
+            hydrate: handler.hydrate,
         };
     }
 

--- a/packages/wonder-blocks-data/src/util/__tests__/memory-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/memory-cache.test.js
@@ -50,6 +50,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -73,6 +74,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -96,6 +98,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -119,6 +122,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -141,6 +145,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -163,6 +168,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -183,6 +189,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -203,6 +210,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -225,6 +233,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -247,6 +256,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -276,6 +286,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -314,6 +325,7 @@ describe("MemoryCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act

--- a/packages/wonder-blocks-data/src/util/__tests__/no-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/no-cache.test.js
@@ -14,6 +14,7 @@ describe("NoCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -37,6 +38,7 @@ describe("NoCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -57,6 +59,7 @@ describe("NoCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -77,6 +80,7 @@ describe("NoCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -95,6 +99,7 @@ describe("NoCache", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act

--- a/packages/wonder-blocks-data/src/util/__tests__/request-fulfillment.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-fulfillment.test.js
@@ -29,6 +29,7 @@ describe("RequestFulfillment", () => {
                 shouldRefreshCache: () => false,
                 type: "MY_TYPE",
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -55,6 +56,7 @@ describe("RequestFulfillment", () => {
                 shouldRefreshCache: () => false,
                 type: "BAD_REQUEST",
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -80,6 +82,7 @@ describe("RequestFulfillment", () => {
                 shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -105,6 +108,7 @@ describe("RequestFulfillment", () => {
                 shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -129,6 +133,7 @@ describe("RequestFulfillment", () => {
                 shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -155,6 +160,7 @@ describe("RequestFulfillment", () => {
                 shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
                 cache: null,
+                hydrate: true,
             };
 
             // Act

--- a/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
@@ -44,6 +44,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                     cache: null,
+                    hydrate: true,
                 };
                 const options = {these: "are options"};
 
@@ -63,6 +64,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                     cache: null,
+                    hydrate: true,
                 };
                 const options = {these: "are options"};
 
@@ -86,6 +88,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                     cache: null,
+                    hydrate: true,
                 };
                 const options1 = {these: "are options"};
                 const options2 = {these: "are options"};
@@ -112,6 +115,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: handlerType,
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeHandler2: IRequestHandler<any, any> = {
                     fulfillRequest: jest.fn(),
@@ -119,6 +123,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: handlerType,
                     cache: null,
+                    hydrate: true,
                 };
                 const options1 = {these: "are options"};
                 const options2 = {these: "are also options"};
@@ -163,6 +168,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                     cache: null,
+                    hydrate: true,
                 };
                 requestTracker.trackDataRequest(fakeBadHandler, "OPTIONS");
 
@@ -189,6 +195,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "BAD_REQUEST",
                     cache: null,
+                    hydrate: true,
                 };
                 requestTracker.trackDataRequest(
                     fakeBadRequestHandler,
@@ -223,6 +230,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "BAD_REQUEST",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeBadHandler: IRequestHandler<string, any> = {
                     fulfillRequest: () => {
@@ -232,6 +240,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "BAD_HANDLER",
                     cache: null,
+                    hydrate: true,
                 };
                 const fakeValidHandler: IRequestHandler<string, any> = {
                     fulfillRequest: (() => {
@@ -245,6 +254,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "VALID",
                     cache: null,
+                    hydrate: true,
                 };
                 requestTracker.trackDataRequest(
                     fakeBadRequestHandler,
@@ -293,6 +303,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "VALID",
                     cache: null,
+                    hydrate: true,
                 };
                 requestTracker.trackDataRequest(fakeValidHandler, "OPTIONS1");
 
@@ -313,6 +324,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "STATIC",
                     cache: null,
+                    hydrate: true,
                 };
                 requestTracker.trackDataRequest(fakeStaticHandler, "1");
                 requestTracker.trackDataRequest(fakeStaticHandler, "2");
@@ -338,6 +350,7 @@ describe("../request-tracking.js", () => {
                     shouldRefreshCache: () => false,
                     type: "MY_TYPE",
                     cache: null,
+                    hydrate: true,
                 };
                 requestTracker.trackDataRequest(fakeHandler, "OPTIONS");
 

--- a/packages/wonder-blocks-data/src/util/__tests__/response-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/response-cache.test.js
@@ -2,6 +2,7 @@
 import {Server} from "@khanacademy/wonder-blocks-core";
 import {ResponseCache} from "../response-cache.js";
 import MemoryCache from "../memory-cache.js";
+import NoCache from "../no-cache.js";
 
 import type {IRequestHandler} from "../types.js";
 
@@ -28,6 +29,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
 
             // Act
@@ -91,6 +93,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
             const sourceData = {
                 MY_HANDLER: {
@@ -122,6 +125,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: null,
+                    hydrate: true,
                 };
 
                 // Act
@@ -155,6 +159,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: customCache,
+                    hydrate: true,
                 };
 
                 // Act
@@ -187,6 +192,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: customCache,
+                    hydrate: true,
                 };
 
                 // Act
@@ -198,6 +204,56 @@ describe("../response-cache.js", () => {
                     "options",
                     {data: "data"},
                 );
+                expect(internalCache.store).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("no hydrate", () => {
+            it("should store the entry in the NoCache cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const internalCache = new MemoryCache();
+                const noCacheStoreSpy = jest.spyOn(NoCache.Default, "store");
+                const cache = new ResponseCache(internalCache);
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                    hydrate: false,
+                };
+
+                // Act
+                cache.cacheData(fakeHandler, "options", "data");
+
+                // Assert
+                expect(noCacheStoreSpy).toHaveBeenCalledWith(
+                    fakeHandler,
+                    "options",
+                    {data: "data"},
+                );
+            });
+
+            it("should not store the entry in the framework cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const internalCache = new MemoryCache();
+                jest.spyOn(internalCache, "store");
+                const cache = new ResponseCache(internalCache);
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                    hydrate: false,
+                };
+
+                // Act
+                cache.cacheData(fakeHandler, "options", "data");
+
+                // Assert
                 expect(internalCache.store).not.toHaveBeenCalled();
             });
         });
@@ -216,6 +272,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: null,
+                    hydrate: true,
                 };
 
                 // Act
@@ -249,6 +306,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: customCache,
+                    hydrate: true,
                 };
 
                 // Act
@@ -281,6 +339,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: customCache,
+                    hydrate: true,
                 };
 
                 // Act
@@ -292,6 +351,56 @@ describe("../response-cache.js", () => {
                     "options",
                     {error: "Ooops!"},
                 );
+                expect(internalCache.store).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("no hydrate", () => {
+            it("should store the entry in the NoCache cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const internalCache = new MemoryCache();
+                const noCacheStoreSpy = jest.spyOn(NoCache.Default, "store");
+                const cache = new ResponseCache(internalCache);
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                    hydrate: false,
+                };
+
+                // Act
+                cache.cacheError(fakeHandler, "options", new Error("Ooops!"));
+
+                // Assert
+                expect(noCacheStoreSpy).toHaveBeenCalledWith(
+                    fakeHandler,
+                    "options",
+                    {error: "Ooops!"},
+                );
+            });
+
+            it("should not store the entry in the framework cache", () => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const internalCache = new MemoryCache();
+                jest.spyOn(internalCache, "store");
+                const cache = new ResponseCache(internalCache);
+                const fakeHandler: IRequestHandler<string, string> = {
+                    getKey: () => "MY_KEY",
+                    type: "MY_HANDLER",
+                    shouldRefreshCache: () => false,
+                    fulfillRequest: jest.fn(),
+                    cache: null,
+                    hydrate: false,
+                };
+
+                // Act
+                cache.cacheError(fakeHandler, "options", new Error("Ooops!"));
+
+                // Assert
                 expect(internalCache.store).not.toHaveBeenCalled();
             });
         });
@@ -310,6 +419,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: null,
+                    hydrate: true,
                 };
 
                 // Act
@@ -332,6 +442,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: null,
+                    hydrate: true,
                 };
 
                 // Act
@@ -361,6 +472,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: customCache,
+                    hydrate: true,
                 };
 
                 // Act
@@ -392,6 +504,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: customCache,
+                    hydrate: true,
                 };
 
                 // Act
@@ -425,6 +538,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: customCache,
+                    hydrate: true,
                 };
 
                 // Act
@@ -460,6 +574,7 @@ describe("../response-cache.js", () => {
                     shouldRefreshCache: () => false,
                     fulfillRequest: jest.fn(),
                     cache: customCache,
+                    hydrate: true,
                 };
 
                 // Act
@@ -492,6 +607,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: customCache,
+                hydrate: true,
             };
 
             // Act
@@ -518,6 +634,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: customCache,
+                hydrate: true,
             };
 
             // Act
@@ -553,6 +670,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: customCache,
+                hydrate: true,
             };
 
             // Act
@@ -580,6 +698,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: customCache,
+                hydrate: true,
             };
 
             // Act
@@ -611,6 +730,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: customCache,
+                hydrate: true,
             };
             const predicate = () => false;
 
@@ -645,6 +765,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: customCache,
+                hydrate: true,
             };
 
             // Act
@@ -672,6 +793,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: customCache,
+                hydrate: true,
             };
 
             // Act
@@ -698,6 +820,7 @@ describe("../response-cache.js", () => {
                 shouldRefreshCache: () => false,
                 fulfillRequest: jest.fn(),
                 cache: null,
+                hydrate: true,
             };
             // Let's add to the initialized state to check that everything
             // is cloning as we expect.

--- a/packages/wonder-blocks-data/src/util/no-cache.js
+++ b/packages/wonder-blocks-data/src/util/no-cache.js
@@ -1,6 +1,7 @@
 // @flow
 import type {ValidData, ICache, CacheEntry, IRequestHandler} from "./types.js";
 
+let defaultInstance: ?ICache<any, any> = null;
 /**
  * This is a cache implementation to use when no caching is wanted.
  *
@@ -14,6 +15,13 @@ import type {ValidData, ICache, CacheEntry, IRequestHandler} from "./types.js";
  */
 export default class NoCache<TOptions, TData: ValidData>
     implements ICache<TOptions, TData> {
+    static get Default(): ICache<TOptions, TData> {
+        if (defaultInstance == null) {
+            defaultInstance = new NoCache<TOptions, TData>();
+        }
+        return defaultInstance;
+    }
+
     store: <TOptions, TData: ValidData>(
         handler: IRequestHandler<TOptions, TData>,
         options: TOptions,

--- a/packages/wonder-blocks-data/src/util/request-handler.js
+++ b/packages/wonder-blocks-data/src/util/request-handler.js
@@ -11,10 +11,16 @@ export default class RequestHandler<TOptions, TData: ValidData>
     implements IRequestHandler<TOptions, TData> {
     _type: string;
     _cache: ?ICache<TOptions, TData>;
+    _hydrate: boolean;
 
-    constructor(type: string, cache?: ICache<TOptions, TData>) {
+    constructor(
+        type: string,
+        cache?: ICache<TOptions, TData>,
+        hydrate?: boolean = true,
+    ) {
         this._type = type;
         this._cache = cache || null;
+        this._hydrate = !!hydrate;
     }
 
     get type(): string {
@@ -23,6 +29,10 @@ export default class RequestHandler<TOptions, TData: ValidData>
 
     get cache(): ?ICache<TOptions, TData> {
         return this._cache;
+    }
+
+    get hydrate(): boolean {
+        return this._hydrate;
     }
 
     shouldRefreshCache(

--- a/packages/wonder-blocks-data/src/util/types.js
+++ b/packages/wonder-blocks-data/src/util/types.js
@@ -127,6 +127,15 @@ export interface IRequestHandler<TOptions, TData: ValidData> {
     get cache(): ?ICache<TOptions, TData>;
 
     /**
+     * When true, server-side results are cached and hydrated in the client.
+     * When false, the server-side cache is not used and results are not
+     * hydrated.
+     * This should only be set to false if something is ensuring that the
+     * hydrated client result will match the server result.
+     */
+    get hydrate(): boolean;
+
+    /**
      * Determine if the cached data should be refreshed.
      *
      * If this returns true, the framework will fulfill a new request by


### PR DESCRIPTION
## Summary:
This adds an advanced feature allowing a request handler to opt out of data
hydration. This is useful when some other system is handling that,
such our Apollo Client cache integration.

Issue: FEI-3597

## Test plan:
`yarn test`