### PR TITLE
Modal: Basic dialog experiment

### DIFF
--- a/packages/wonder-blocks-modal/src/components/basic-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/basic-dialog.js
@@ -1,0 +1,118 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import {MediaLayout} from "@khanacademy/wonder-blocks-layout";
+import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+
+import ModalDialog from "./modal-dialog.js";
+import ModalPanel from "./modal-panel.js";
+
+type Props = {|
+    ...AriaProps,
+
+    /**
+     * The content of the modal.
+     */
+    children: React.Node,
+
+    /**
+     * Called when the close button is clicked.
+     *
+     * If you're using `ModalLauncher`, you probably shouldn't use this prop!
+     * Instead, to listen for when the modal closes, add an `onClose` handler to
+     * the `ModalLauncher`.  Doing so will result in a console.warn().
+     */
+    onClose?: () => mixed,
+
+    /**
+     * When true, the close button is shown; otherwise, the close button is not
+     * shown.
+     */
+    closeButtonVisible?: boolean,
+
+    /**
+     * Optional custom styles.
+     */
+    style?: StyleType,
+
+    /**
+     * Test ID used for e2e testing. This ID will be passed down to the Dialog.
+     */
+    testId?: string,
+
+    /**
+     * An optional id parameter for the element that provides the dialog title.
+     *
+     * NOTE: The best way to generate a unique title id is by using IDProvider
+     * in the parent container.
+     */
+    titleId?: string,
+|};
+
+type DefaultProps = {|
+    closeButtonVisible: $PropertyType<Props, "closeButtonVisible">,
+|};
+
+/**
+ * This is the minimal layout for modal experiences that only require to display
+ * some content (no header or footer included).
+ *
+ * The content of the dialog itself is fully customizable, but the
+ * left/right/top/bottom padding is fixed.
+ */
+export default class BasicDialog extends React.Component<Props> {
+    static defaultProps: DefaultProps = {
+        closeButtonVisible: true,
+    };
+
+    render(): React.Node {
+        const {
+            onClose,
+            children,
+            style,
+            closeButtonVisible,
+            testId,
+            titleId,
+        } = this.props;
+
+        return (
+            <MediaLayout styleSheets={styleSheets}>
+                {({styles}) => (
+                    <ModalDialog
+                        style={[styles.dialog, style]}
+                        testId={testId}
+                        aria-labelledby={titleId}
+                    >
+                        <ModalPanel
+                            onClose={onClose}
+                            content={children}
+                            closeButtonVisible={closeButtonVisible}
+                            testId={testId}
+                        />
+                    </ModalDialog>
+                )}
+            </MediaLayout>
+        );
+    }
+}
+
+const styleSheets = {
+    small: StyleSheet.create({
+        dialog: {
+            width: "100%",
+            height: "100%",
+            overflow: "hidden",
+        },
+    }),
+
+    mdOrLarger: StyleSheet.create({
+        dialog: {
+            width: "auto",
+            minWidth: 420,
+            maxWidth: 576,
+            height: "auto",
+            minHeight: 320,
+            maxHeight: 624,
+        },
+    }),
+};

--- a/packages/wonder-blocks-modal/src/components/basic-dialog.stories.js
+++ b/packages/wonder-blocks-modal/src/components/basic-dialog.stories.js
@@ -1,0 +1,96 @@
+/* eslint-disable no-alert */
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import Button from "@khanacademy/wonder-blocks-button";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {Body, HeadingLarge} from "@khanacademy/wonder-blocks-typography";
+
+import type {StoryComponentType} from "@storybook/react";
+import BasicDialog from "./basic-dialog.js";
+import ModalLauncher from "./modal-launcher.js";
+
+const customViewports = {
+    phone: {
+        name: "phone",
+        styles: {
+            width: "320px",
+            height: "568px",
+        },
+    },
+    tablet: {
+        name: "tablet",
+        styles: {
+            width: "640px",
+            height: "960px",
+        },
+    },
+    desktop: {
+        name: "desktop",
+        styles: {
+            width: "1024px",
+            height: "768px",
+        },
+    },
+};
+
+export default {
+    title: "Modal/BasicDialog",
+    parameters: {
+        viewport: {
+            viewports: customViewports,
+            defaultViewport: "desktop",
+        },
+        chromatic: {
+            viewports: [320, 640, 1024],
+        },
+    },
+};
+
+export const minimal: StoryComponentType = () => {
+    const modal = (
+        <BasicDialog
+            closeButtonVisible={true}
+            style={styles.customDialog}
+            testId="basic-dialog-minimal"
+            titleId="some-unique-id"
+        >
+            <View style={styles.content}>
+                <HeadingLarge id="some-unique-id">Are you sure?</HeadingLarge>
+                <Strut size={Spacing.small_12} />
+                <Body>
+                    This example shows how to use a simple modal that does not
+                    have header and footer. Only allows you to pass a custom
+                    content in it.
+                </Body>
+                <Strut size={Spacing.xLarge_32} />
+                <Button kind="primary">Primary action</Button>
+                <Strut size={Spacing.small_12} />
+                <Button kind="tertiary">Cancel</Button>
+            </View>
+        </BasicDialog>
+    );
+
+    return (
+        <ModalLauncher
+            modal={modal}
+            testId="modal-launcher-default-example"
+            opened={true}
+            onClose={() => alert("This would close the modal.")}
+        />
+    );
+};
+
+const styles = StyleSheet.create({
+    customDialog: {
+        width: 420,
+    },
+    content: {
+        alignItems: "center",
+        justifyContent: "center",
+        flex: 1,
+    },
+});

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.stories.js
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.stories.js
@@ -38,7 +38,7 @@ const customViewports = {
 };
 
 export default {
-    title: "OnePaneDialog",
+    title: "Modal/OnePaneDialog",
     parameters: {
         viewport: {
             viewports: customViewports,


### PR DESCRIPTION
## Summary:

Adds a new Modal variant: BasicDialog.

The intention of this experiment is to be able to use minimal modals that don't
contain a header or footer elements, only content.

Issue: XXX-XXXX

## Test plan:

Navigate to storybook and see the `minimal` example.