### PR TITLE
WB-1063 - Implement FieldHeading Component

### DIFF
--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
@@ -9,14 +9,14 @@ describe("FieldHeading", () => {
     it("fieldheading renders the label text", () => {
         // Arrange
         const label = "Label";
+
+        // Act
         const wrapper = mount(
             <FieldHeading
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
                 label={label}
             />,
         );
-
-        // Act
 
         // Assert
         expect(wrapper).toIncludeText(label);
@@ -25,6 +25,8 @@ describe("FieldHeading", () => {
     it("fieldheading renders the description text", () => {
         // Arrange
         const description = "Description";
+
+        // Act
         const wrapper = mount(
             <FieldHeading
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
@@ -33,8 +35,6 @@ describe("FieldHeading", () => {
             />,
         );
 
-        // Act
-
         // Assert
         expect(wrapper).toIncludeText(description);
     });
@@ -42,6 +42,8 @@ describe("FieldHeading", () => {
     it("fieldheading renders the error text", () => {
         // Arrange
         const error = "Error";
+
+        // Act
         const wrapper = mount(
             <FieldHeading
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
@@ -50,9 +52,106 @@ describe("FieldHeading", () => {
             />,
         );
 
-        // Act
-
         // Assert
         expect(wrapper).toIncludeText(error);
+    });
+
+    it("fieldheading adds testId to label", () => {
+        // Arrange
+        const testId = "testid";
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                testId={testId}
+            />,
+        );
+
+        // Assert
+        const label = wrapper.find(`[data-test-id="${testId}-label"]`);
+        expect(label).toExist();
+    });
+
+    it("fieldheading adds testId to description", () => {
+        // Arrange
+        const testId = "testid";
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                description="Description"
+                testId={testId}
+            />,
+        );
+
+        // Assert
+        const description = wrapper.find(
+            `[data-test-id="${testId}-description"]`,
+        );
+        expect(description).toExist();
+    });
+
+    it("fieldheading adds testId to error", () => {
+        // Arrange
+        const testId = "testid";
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                error="Error"
+                testId={testId}
+            />,
+        );
+
+        // Assert
+        const error = wrapper.find(`[data-test-id="${testId}-error"]`);
+        expect(error).toExist();
+    });
+
+    it("fieldheading adds the correctly formatted id to label's htmlFor", () => {
+        // Arrange
+        const id = "exampleid";
+        const testId = "testid";
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                id={id}
+                testId={testId}
+            />,
+        );
+
+        // Assert
+        const label = wrapper.find(`[data-test-id="${testId}-label"]`);
+        expect(label).toContainMatchingElement(`[htmlFor="${id}-field"]`);
+    });
+
+    it("fieldheading adds the correctly formatted id to error's id", () => {
+        // Arrange
+        const id = "exampleid";
+        const testId = "testid";
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                error="Error"
+                id={id}
+                testId={testId}
+            />,
+        );
+
+        // Assert
+        const error = wrapper.find(`[data-test-id="${testId}-error"]`);
+        expect(error).toContainMatchingElement(`[id="${id}-error"]`);
     });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
@@ -1,0 +1,58 @@
+// @flow
+import * as React from "react";
+import {mount} from "enzyme";
+
+import FieldHeading from "../field-heading.js";
+import TextField from "../text-field.js";
+
+describe("FieldHeading", () => {
+    it("fieldheading renders the label text", () => {
+        // Arrange
+        const label = "Label";
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label={label}
+            />,
+        );
+
+        // Act
+
+        // Assert
+        expect(wrapper).toIncludeText(label);
+    });
+
+    it("fieldheading renders the description text", () => {
+        // Arrange
+        const description = "Description";
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                description={description}
+            />,
+        );
+
+        // Act
+
+        // Assert
+        expect(wrapper).toIncludeText(description);
+    });
+
+    it("fieldheading renders the error text", () => {
+        // Arrange
+        const error = "Error";
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                error={error}
+            />,
+        );
+
+        // Act
+
+        // Assert
+        expect(wrapper).toIncludeText(error);
+    });
+});

--- a/packages/wonder-blocks-form/src/components/field-heading.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.js
@@ -32,46 +32,104 @@ type Props = {|
      * The message for the error element.
      */
     error?: string | React.Element<Typography>,
+
+    /**
+     * A unique id to link the label (and optional error) to the field.
+     *
+     * The label will assume that the field will have its id formatted as `${id}-field`.
+     * The field can assume that the error will have its id formatted as `${id}-error`.
+     */
+    id?: string,
+
+    /**
+     * Optional test ID for e2e testing.
+     */
+    testId?: string,
 |};
 
 export default class FieldHeading extends React.Component<Props> {
-    isString: (item: string | React.Element<Typography>) => boolean = (
-        item,
-    ) => {
-        // Helps check if a prop is of type "string" to either render the default
-        // label or a custom Typography label passed by the user.
-        return typeof item === "string";
-    };
+    renderLabel(): React.Node {
+        const {label, id, testId} = this.props;
 
-    render(): React.Node {
-        const {field, label, description, error} = this.props;
         return (
-            <View>
-                {label && this.isString(label) ? (
-                    <LabelMedium style={[styles.label]}>{label}</LabelMedium>
+            <React.Fragment>
+                {typeof label === "string" ? (
+                    <LabelMedium
+                        style={styles.label}
+                        tag="label"
+                        htmlFor={id && `${id}-field`}
+                        testId={testId && `${testId}-label`}
+                    >
+                        {label}
+                    </LabelMedium>
                 ) : (
                     label
                 )}
-                {<Strut size={Spacing.xxxSmall_4} />}
+                <Strut size={Spacing.xxxSmall_4} />
+            </React.Fragment>
+        );
+    }
 
-                {description && this.isString(description) ? (
-                    <LabelSmall style={[styles.description]}>
+    maybeRenderDescription(): ?React.Node {
+        const {description, testId} = this.props;
+
+        if (!description) {
+            return null;
+        }
+
+        return (
+            <React.Fragment>
+                {typeof description === "string" ? (
+                    <LabelSmall
+                        style={styles.description}
+                        testId={testId && `${testId}-description`}
+                    >
                         {description}
                     </LabelSmall>
                 ) : (
                     description
                 )}
-                {description && <Strut size={Spacing.xxxSmall_4} />}
+                <Strut size={Spacing.xxxSmall_4} />
+            </React.Fragment>
+        );
+    }
 
-                <Strut size={Spacing.xSmall_8} />
-                {field}
+    maybeRenderError(): ?React.Node {
+        const {error, id, testId} = this.props;
 
-                {error && <Strut size={Spacing.small_12} />}
-                {error && this.isString(error) ? (
-                    <LabelSmall style={[styles.error]}>{error}</LabelSmall>
+        if (!error) {
+            return null;
+        }
+
+        return (
+            <React.Fragment>
+                <Strut size={Spacing.small_12} />
+                {typeof error === "string" ? (
+                    <LabelSmall
+                        style={styles.error}
+                        role="alert"
+                        id={id && `${id}-error`}
+                        testId={testId && `${testId}-error`}
+                    >
+                        {error}
+                    </LabelSmall>
                 ) : (
                     error
                 )}
+            </React.Fragment>
+        );
+    }
+
+    render(): React.Node {
+        const {field} = this.props;
+
+        return (
+            <View>
+                {this.renderLabel()}
+                {this.maybeRenderDescription()}
+                <Strut size={Spacing.xSmall_8} />
+                {field}
+                {this.maybeRenderError()}
             </View>
         );
     }

--- a/packages/wonder-blocks-form/src/components/field-heading.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.js
@@ -1,0 +1,90 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {
+    type Typography,
+    LabelMedium,
+    LabelSmall,
+} from "@khanacademy/wonder-blocks-typography";
+
+type Props = {|
+    /**
+     * The form field component.
+     */
+    field: React.Node,
+
+    /**
+     * The title for the label element.
+     */
+    label: string | React.Element<Typography>,
+
+    /**
+     * The text for the description element.
+     */
+    description?: string | React.Element<Typography>,
+
+    /**
+     * The message for the error element.
+     */
+    error?: string | React.Element<Typography>,
+|};
+
+export default class FieldHeading extends React.Component<Props> {
+    isString: (item: string | React.Element<Typography>) => boolean = (
+        item,
+    ) => {
+        // Helps check if a prop is of type "string" to either render the default
+        // label or a custom Typography label passed by the user.
+        return typeof item === "string";
+    };
+
+    render(): React.Node {
+        const {field, label, description, error} = this.props;
+        return (
+            <View>
+                {label && this.isString(label) ? (
+                    <LabelMedium style={[styles.label]}>{label}</LabelMedium>
+                ) : (
+                    label
+                )}
+                {<Strut size={Spacing.xxxSmall_4} />}
+
+                {description && this.isString(description) ? (
+                    <LabelSmall style={[styles.description]}>
+                        {description}
+                    </LabelSmall>
+                ) : (
+                    description
+                )}
+                {description && <Strut size={Spacing.xxxSmall_4} />}
+
+                <Strut size={Spacing.xSmall_8} />
+                {field}
+
+                {error && <Strut size={Spacing.small_12} />}
+                {error && this.isString(error) ? (
+                    <LabelSmall style={[styles.error]}>{error}</LabelSmall>
+                ) : (
+                    error
+                )}
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    label: {
+        color: Color.offBlack,
+    },
+    description: {
+        color: Color.offBlack64,
+    },
+    error: {
+        color: Color.red,
+    },
+});

--- a/packages/wonder-blocks-form/src/components/field-heading.stories.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.stories.js
@@ -1,0 +1,104 @@
+// @flow
+import * as React from "react";
+
+import {TextField} from "@khanacademy/wonder-blocks-form";
+import {LabelLarge, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+
+import type {StoryComponentType} from "@storybook/react";
+import FieldHeading from "./field-heading.js";
+
+export default {
+    title: "Form / FieldHeading",
+};
+
+export const basic: StoryComponentType = () => {
+    const [value, setValue] = React.useState("khan");
+    const [errorMessage, setErrorMessage] = React.useState();
+    const [focused, setFocused] = React.useState(false);
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const validation = (value: string) => {
+        const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+        if (!emailRegex.test(value)) {
+            return "Please enter a valid email";
+        }
+    };
+
+    const handleOnValidation = (errorMessage: ?string) => {
+        setErrorMessage(errorMessage);
+    };
+
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    const handleOnFocus = () => {
+        setFocused(true);
+    };
+
+    const handleOnBlur = () => {
+        setFocused(false);
+    };
+
+    return (
+        <FieldHeading
+            field={
+                <TextField
+                    id="tf-1"
+                    type="email"
+                    value={value}
+                    placeholder="Email"
+                    validation={validation}
+                    onValidation={handleOnValidation}
+                    onChange={handleOnChange}
+                    onKeyDown={handleOnKeyDown}
+                    onFocus={handleOnFocus}
+                    onBlur={handleOnBlur}
+                />
+            }
+            label="Email"
+            description="Please enter your personal email."
+            error={!focused && errorMessage ? errorMessage : undefined}
+        />
+    );
+};
+
+export const withTypography: StoryComponentType = () => {
+    const [value, setValue] = React.useState("Khan");
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const handleOnKeyDown = (
+        event: SyntheticKeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <FieldHeading
+            field={
+                <TextField
+                    id="tf-1"
+                    type="text"
+                    value={value}
+                    placeholder="Name"
+                    onChange={handleOnChange}
+                    onKeyDown={handleOnKeyDown}
+                />
+            }
+            label={<LabelLarge>Your Name</LabelLarge>}
+            description={<LabelSmall>Please enter your full name.</LabelSmall>}
+        />
+    );
+};

--- a/packages/wonder-blocks-form/src/components/field-heading.stories.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.stories.js
@@ -15,6 +15,7 @@ export const basic: StoryComponentType = () => {
     const [value, setValue] = React.useState("khan");
     const [errorMessage, setErrorMessage] = React.useState();
     const [focused, setFocused] = React.useState(false);
+    const uniqueId = "uniqueid123";
 
     const handleOnChange = (newValue: string) => {
         setValue(newValue);
@@ -51,7 +52,9 @@ export const basic: StoryComponentType = () => {
         <FieldHeading
             field={
                 <TextField
-                    id="tf-1"
+                    id={`${uniqueId}-field`}
+                    aria-describedby={`${uniqueId}-error`}
+                    aria-invalid={errorMessage ? "true" : "false"}
                     type="email"
                     value={value}
                     placeholder="Email"
@@ -66,12 +69,14 @@ export const basic: StoryComponentType = () => {
             label="Email"
             description="Please enter your personal email."
             error={!focused && errorMessage ? errorMessage : undefined}
+            id={uniqueId}
         />
     );
 };
 
 export const withTypography: StoryComponentType = () => {
     const [value, setValue] = React.useState("Khan");
+    const uniqueId = "uniqueid123";
 
     const handleOnChange = (newValue: string) => {
         setValue(newValue);
@@ -89,7 +94,7 @@ export const withTypography: StoryComponentType = () => {
         <FieldHeading
             field={
                 <TextField
-                    id="tf-1"
+                    id={`${uniqueId}-field`}
                     type="text"
                     value={value}
                     placeholder="Name"
@@ -97,8 +102,13 @@ export const withTypography: StoryComponentType = () => {
                     onKeyDown={handleOnKeyDown}
                 />
             }
-            label={<LabelLarge>Your Name</LabelLarge>}
+            label={
+                <LabelLarge tag="label" htmlFor={`${uniqueId}-field`}>
+                    Your Name
+                </LabelLarge>
+            }
             description={<LabelSmall>Please enter your full name.</LabelSmall>}
+            id={uniqueId}
         />
     );
 };


### PR DESCRIPTION
## Summary:
Added the `FieldHeading` private component under `wonder-blocks-form`.
This component is intended to provide a reusable handy label, description, and error element.

In the current situation, it is mainly intended to be used for `LabeledTextField`,
but later it may be easily used by other form fields.

Issue: https://khanacademy.atlassian.net/browse/WB-1063

## Test plan:
I added a temporary example to React Storybook (see generated link below).
You can view it under Form / FieldHeading.

#### NOTE: I will remove the `FieldHeading` example from React Storybook on the next PR.

---

##### Example 1: Showing Label and Description
<img width="419" alt="basic-1" src="https://user-images.githubusercontent.com/60367213/121592318-22f19300-ca00-11eb-811a-445ead29704d.png">

##### Example 2: Showing Error
<img width="420" alt="basic-error-1" src="https://user-images.githubusercontent.com/60367213/121592365-34d33600-ca00-11eb-85b7-ca12208147f7.png">

##### Example 3: Passing Custom Typography Labels
<img width="420" alt="basic-custom" src="https://user-images.githubusercontent.com/60367213/121592403-40bef800-ca00-11eb-885b-78c18d9938e5.png">
