### PR TITLE
WB-792 - Fix Modal header subtitle out of sync with spec

### DIFF
--- a/packages/wonder-blocks-modal/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -1235,9 +1235,9 @@ exports[`wonder-blocks-modal example 7 1`] = `
                   "color": "rgba(33,36,44,0.64)",
                   "display": "block",
                   "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
-                  "fontSize": 16,
+                  "fontSize": 14,
                   "fontWeight": 400,
-                  "lineHeight": "20px",
+                  "lineHeight": "18px",
                   "marginTop": 8,
                 }
               }

--- a/packages/wonder-blocks-modal/src/components/modal-header.js
+++ b/packages/wonder-blocks-modal/src/components/modal-header.js
@@ -6,10 +6,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {MediaLayout} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
-import {
-    HeadingMedium,
-    LabelMedium,
-} from "@khanacademy/wonder-blocks-typography";
+import {HeadingMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 type Common = {|
     /**
@@ -149,12 +146,12 @@ export default class ModalHeader extends React.Component<Props> {
                             {title}
                         </HeadingMedium>
                         {subtitle && (
-                            <LabelMedium
+                            <LabelSmall
                                 style={light && styles.subtitle}
                                 testId={testId && `${testId}-subtitle`}
                             >
                                 {subtitle}
-                            </LabelMedium>
+                            </LabelSmall>
                         )}
                     </View>
                 )}


### PR DESCRIPTION
## Summary:
Fix the `ModalHeader`'s subtitle label that had the Typography style of
`LabelMedium` while the [design spec](https://www.figma.com/file/CRryTHqyr1l6aOOltD32KMh5/Modal-v2?node-id=412%3A195) requested `LabelSmall`.

Issue: https://khanacademy.atlassian.net/browse/WB-792

## Test plan:
1. Open Styleguidist on the browser.
2. Go to the Modal section, under "Modals".
3. See the "OnePaneDialog with above container" example.
4. (Optional) You can also inspect-element and view that `LabelSmall` is used

---

##### Using inspect-element demonstrates that `LabelSmall` is now being used:
<img width="1674" alt="modal-test" src="https://user-images.githubusercontent.com/60367213/121599650-fbeb8f00-ca08-11eb-9902-6d73e61e4032.png">
