### PR TITLE
WB-1070 - Fix ModalHeader not setting testId properly (OnePanelDialog)

### DIFF
--- a/packages/wonder-blocks-modal/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -1179,7 +1179,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
           </button>
           <div
             className=""
-            data-test-id="one-pane-dialog-above-ModalHeader"
+            data-test-id="one-pane-dialog-above-header"
             style={
               Object {
                 "alignItems": "stretch",
@@ -1201,7 +1201,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
           >
             <h3
               className=""
-              data-test-id="one-pane-dialog-above-ModalHeader-title"
+              data-test-id="one-pane-dialog-above-header-title"
               id="uid-modal-1-wb-id"
               style={
                 Object {
@@ -1227,7 +1227,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
             </h3>
             <span
               className=""
-              data-test-id="one-pane-dialog-above-ModalHeader-subtitle"
+              data-test-id="one-pane-dialog-above-header-subtitle"
               style={
                 Object {
                   "MozOsxFontSmoothing": "grayscale",

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
@@ -128,7 +128,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                     title={title}
                     breadcrumbs={(breadcrumbs: React.Element<Breadcrumbs>)}
                     titleId={uniqueId}
-                    testId={testId && `${testId}-ModalHeader`}
+                    testId={testId && `${testId}-header`}
                 />
             );
         } else if (subtitle) {
@@ -137,7 +137,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                     title={title}
                     subtitle={(subtitle: string)}
                     titleId={uniqueId}
-                    testId={testId && `${testId}-ModalHeader`}
+                    testId={testId && `${testId}-header`}
                 />
             );
         } else {
@@ -145,7 +145,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                 <ModalHeader
                     title={title}
                     titleId={uniqueId}
-                    testId={testId && `${testId}-ModalHeader`}
+                    testId={testId && `${testId}-header`}
                 />
             );
         }

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
@@ -128,6 +128,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                     title={title}
                     breadcrumbs={(breadcrumbs: React.Element<Breadcrumbs>)}
                     titleId={uniqueId}
+                    testId={testId && `${testId}-ModalHeader`}
                 />
             );
         } else if (subtitle) {
@@ -140,7 +141,13 @@ export default class OnePaneDialog extends React.Component<Props> {
                 />
             );
         } else {
-            return <ModalHeader title={title} titleId={uniqueId} />;
+            return (
+                <ModalHeader
+                    title={title}
+                    titleId={uniqueId}
+                    testId={testId && `${testId}-ModalHeader`}
+                />
+            );
         }
     }
 


### PR DESCRIPTION
## Summary:
Fixed `ModalHeader` not being passed a testId when used inside
`OnePaneDialog`. It was previously working in the case that `ModalHeader`
had a subtitle, but not in other cases. That was fixed.

Issue: https://khanacademy.atlassian.net/browse/WB-1070

## Test plan:
1. You can view the code and see that testId is now being passed in all cases.
2. You can also open Styleguidist and check that testId is being passed
   on all cases of `ModalHeader` when used in a `OnePaneDialog`. This
   can be see through "inspect element".

---

#### Inspect Element Check
##### * I passed a "testId" to the Styleguidist examples that used `ModalHeader` and `OnePaneDialog`.
##### * You can see that the "testId" is indeed passed on the `ModalHeader` (even when there is no subtitle).

<img width="1678" alt="modal-test-id" src="https://user-images.githubusercontent.com/60367213/121605788-98665f00-ca12-11eb-862a-f08cb6b046fc.png">
