### PR TITLE
WB-808 - Add right padding to ModalHeader title

### DIFF
--- a/packages/wonder-blocks-modal/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -842,6 +842,7 @@ exports[`wonder-blocks-modal example 6 1`] = `
                   "fontWeight": 700,
                   "marginBottom": 0,
                   "marginTop": 0,
+                  "paddingRight": 16,
                 }
               }
             >
@@ -1220,6 +1221,7 @@ exports[`wonder-blocks-modal example 7 1`] = `
                   "fontWeight": 700,
                   "marginBottom": 0,
                   "marginTop": 0,
+                  "paddingRight": 16,
                 }
               }
             >
@@ -1860,6 +1862,7 @@ exports[`wonder-blocks-modal example 8 1`] = `
                   "fontWeight": 700,
                   "marginBottom": 0,
                   "marginTop": 0,
+                  "paddingRight": 16,
                 }
               }
             >
@@ -2453,6 +2456,7 @@ exports[`wonder-blocks-modal example 9 1`] = `
                   "fontWeight": 700,
                   "marginBottom": 0,
                   "marginTop": 0,
+                  "paddingRight": 16,
                 }
               }
             >

--- a/packages/wonder-blocks-modal/src/components/modal-header.js
+++ b/packages/wonder-blocks-modal/src/components/modal-header.js
@@ -140,6 +140,7 @@ export default class ModalHeader extends React.Component<Props> {
                             </View>
                         )}
                         <HeadingMedium
+                            style={styles.title}
                             id={titleId}
                             testId={testId && `${testId}-title`}
                         >
@@ -182,6 +183,11 @@ const styleSheets = {
             marginBottom: Spacing.xSmall_8,
         },
 
+        title: {
+            // Prevent title from overlapping the close button
+            paddingRight: Spacing.medium_16,
+        },
+
         subtitle: {
             color: Color.offBlack64,
             marginTop: Spacing.xSmall_8,
@@ -192,6 +198,10 @@ const styleSheets = {
         header: {
             paddingLeft: Spacing.medium_16,
             paddingRight: Spacing.medium_16,
+        },
+
+        title: {
+            paddingRight: Spacing.xLarge_32,
         },
     }),
 };


### PR DESCRIPTION
## Summary:
Added right padding to the `title` of `ModalHeader` due to it
overlapping with the close button of the `OnePaneDialog`.

The Jira ticket specifically mentioned that the "Change Email Modal"
would show this issue on a mobile phone. The "Change Email Modal" it was
referring to was involving the `ModalHeader`. The screenshots below show
the before and after with the best attempt at recreating the issue in
Styleguidist.

Issue: https://khanacademy.atlassian.net/browse/WB-808

## Test plan:
1. Open Styleguidist.
2. Go to the "Modal" section and choose any modal with a close button.
3. Edit the example and add a long title.
4. You can play around with the screen size and see how the title now
   wraps before hitting the boundaries of the close button.

---

#### Before the fix (iPhone 6/7/8 relative screen size)
![modal-title-before](https://user-images.githubusercontent.com/60367213/121725518-fb0d3880-caae-11eb-947b-171664f29655.png)

#### After the fix (iPhone 6/7/8 relative screen size)
![modal-title-after-1](https://user-images.githubusercontent.com/60367213/121725566-082a2780-caaf-11eb-913d-6f2c882e81d0.png)

#### After the fix (iPhone 5/SE relative screen size)
![modal-title-after-2](https://user-images.githubusercontent.com/60367213/121725716-3f003d80-caaf-11eb-98aa-168612124c84.png)

---

#### The closest a word from the title gets to the close button before wrapping (small / mobile screen size)
![modal-title-closest-small](https://user-images.githubusercontent.com/60367213/121726063-a7e7b580-caaf-11eb-9310-092d47cc4a1d.png)

#### The closest a word from the title gets to the close button before wrapping (large / desktop screen size)
![modal-title-closest-large](https://user-images.githubusercontent.com/60367213/121726111-b9c95880-caaf-11eb-8fc4-40c745d3033a.png)
