### PR TITLE
WB-472 - Add more flexibility to CheckboxGroup's label and description

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -3695,23 +3695,6 @@ exports[`wonder-blocks-form example 7 1`] = `
     }
   }
 >
-  <span
-    className=""
-    style={
-      Object {
-        "MozOsxFontSmoothing": "grayscale",
-        "WebkitFontSmoothing": "antialiased",
-        "display": "block",
-        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
-        "fontSize": 16,
-        "fontWeight": 700,
-        "lineHeight": "20px",
-        "marginBottom": 16,
-      }
-    }
-  >
-    Select all prime numbers
-  </span>
   <fieldset
     className=""
     style={
@@ -3741,6 +3724,66 @@ exports[`wonder-blocks-form example 7 1`] = `
         }
       }
     >
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "display": "block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 16,
+            "fontWeight": 700,
+            "lineHeight": "20px",
+          }
+        }
+      >
+        Select all prime numbers
+      </span>
+      <span
+        className=""
+        style={
+          Object {
+            "MozOsxFontSmoothing": "grayscale",
+            "WebkitFontSmoothing": "antialiased",
+            "color": "rgba(33,36,44,0.64)",
+            "display": "block",
+            "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+            "fontSize": 12,
+            "fontWeight": 400,
+            "lineHeight": "16px",
+            "marginTop": 5,
+          }
+        }
+      >
+        Hint: There is at least one prime number
+      </span>
+      <div
+        aria-hidden="true"
+        className=""
+        style={
+          Object {
+            "MsFlexBasis": 12,
+            "MsFlexPreferredSize": 12,
+            "WebkitFlexBasis": 12,
+            "alignItems": "stretch",
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "boxSizing": "border-box",
+            "display": "flex",
+            "flexBasis": 12,
+            "flexDirection": "column",
+            "flexShrink": 0,
+            "margin": 0,
+            "minHeight": 0,
+            "minWidth": 0,
+            "padding": 0,
+            "position": "relative",
+            "width": 12,
+            "zIndex": 0,
+          }
+        }
+      />
       <div
         className=""
         style={

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -22,6 +22,7 @@ import {
     LabelMedium,
     LabelSmall,
     LabelLarge,
+    LabelXSmall,
 } from "@khanacademy/wonder-blocks-typography";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
@@ -413,9 +414,6 @@ describe("wonder-blocks-form", () => {
 
     it("example 7", () => {
         const styles = StyleSheet.create({
-            wrapper: {
-                width: 650,
-            },
             choice: {
                 margin: 0,
                 height: 48,
@@ -425,8 +423,9 @@ describe("wonder-blocks-form", () => {
                     borderBottom: "solid 1px #CCC",
                 },
             },
-            prompt: {
-                marginBottom: 16,
+            description: {
+                marginTop: 5,
+                color: Color.offBlack64,
             },
         });
 
@@ -449,6 +448,14 @@ describe("wonder-blocks-form", () => {
             render() {
                 return (
                     <CheckboxGroup
+                        label={
+                            <LabelLarge>Select all prime numbers</LabelLarge>
+                        }
+                        description={
+                            <LabelXSmall style={styles.description}>
+                                Hint: There is at least one prime number
+                            </LabelXSmall>
+                        }
                         groupName="science-classes"
                         onChange={this.handleChange}
                         selectedValues={this.state.selectedValues}
@@ -465,9 +472,6 @@ describe("wonder-blocks-form", () => {
 
         const example = (
             <View>
-                <LabelLarge style={styles.prompt}>
-                    Select all prime numbers
-                </LabelLarge>
                 <ClassSelectorExample />
             </View>
         );

--- a/packages/wonder-blocks-form/src/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.js
@@ -5,7 +5,11 @@ import * as React from "react";
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
-import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {
+    type Typography,
+    LabelMedium,
+    LabelSmall,
+} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import styles from "./group-styles.js";
@@ -28,12 +32,12 @@ type CheckboxGroupProps = {|
      * Optional label for the group. This label is optional to allow for
      * greater flexibility in implementing checkbox and radio groups.
      */
-    label?: string,
+    label?: string | React.Element<Typography>,
 
     /**
      * Optional description for the group.
      */
-    description?: string,
+    description?: string | React.Element<Typography>,
 
     /**
      * Optional error message. If supplied, the group will be displayed in an
@@ -105,15 +109,19 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps> {
             <StyledFieldset data-test-id={testId} style={styles.fieldset}>
                 {/* We have a View here because fieldset cannot be used with flexbox*/}
                 <View style={style}>
-                    {label && (
+                    {typeof label === "string" ? (
                         <StyledLegend style={styles.legend}>
                             <LabelMedium>{label}</LabelMedium>
                         </StyledLegend>
+                    ) : (
+                        label && label
                     )}
-                    {description && (
+                    {typeof description === "string" ? (
                         <LabelSmall style={styles.description}>
                             {description}
                         </LabelSmall>
+                    ) : (
+                        description && description
                     )}
                     {errorMessage && (
                         <LabelSmall style={styles.error}>

--- a/packages/wonder-blocks-form/src/components/checkbox-group.md
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.md
@@ -131,19 +131,17 @@ class ClassSelectorExample extends React.Component {
 ```
 
 This example shows how to use custom styling to change the appearance of the
-checkbox group to look more like a multiple choice question.
+checkbox group to look more like a multiple choice question. You may also provide
+custom typography to the label and description.
 
 ```js
 import {CheckboxGroup, Choice} from "@khanacademy/wonder-blocks-form";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {LabelLarge, LabelXSmall} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 
 const styles = StyleSheet.create({
-    wrapper: {
-        width: 650,
-    },
     choice: {
         margin: 0,
         height: 48,
@@ -153,8 +151,9 @@ const styles = StyleSheet.create({
             borderBottom: "solid 1px #CCC",
         },
     },
-    prompt: {
-        marginBottom: 16,
+    description: {
+        marginTop: 5,
+        color: Color.offBlack64,
     },
 });
 
@@ -176,6 +175,12 @@ class ClassSelectorExample extends React.Component {
 
     render() {
         return <CheckboxGroup
+            label={<LabelLarge>Select all prime numbers</LabelLarge>}
+            description={
+                <LabelXSmall style={styles.description}>
+                    Hint: There is at least one prime number
+                </LabelXSmall>
+            }
             groupName="science-classes"
             onChange={this.handleChange}
             selectedValues={this.state.selectedValues}
@@ -190,9 +195,6 @@ class ClassSelectorExample extends React.Component {
 }
 
 <View>
-    <LabelLarge style={styles.prompt}>
-        Select all prime numbers
-    </LabelLarge>
     <ClassSelectorExample />
 </View>
 ```


### PR DESCRIPTION
## Summary:
Added the type `React.Element<Typography>` to `CheckboxGroup`'s `label` and
`description` props. This gives the user the option to pass in custom typography
components over a simple string.

Issue: https://khanacademy.atlassian.net/browse/WB-472

## Test plan:
1. Open Styleguidist in Browser (view generated link)
2. Go to Form / CheckboxGroup
3. View the "Select all prime numbers" example. I added custom typography to the `label` and `description` props.

---

### Example in Styleguidist:
**\* The `label` and `description` are using custom typography elements**
\
<img width="953" alt="checkbox-group-example-1" src="https://user-images.githubusercontent.com/60367213/121948567-01a0e780-cd1d-11eb-9961-96e745aff6bc.png">
