### PR TITLE
WB-1065 - Add States to LabeledTextField

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -6417,3 +6417,193 @@ exports[`wonder-blocks-form example 19 1`] = `
   </span>
 </div>
 `;
+
+exports[`wonder-blocks-form example 20 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <label
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "color": "#21242c",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "20px",
+      }
+    }
+  >
+    Label
+  </label>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 4,
+        "MsFlexPreferredSize": 4,
+        "WebkitFlexBasis": 4,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 4,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 4,
+        "zIndex": 0,
+      }
+    }
+  />
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "color": "rgba(33,36,44,0.64)",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 14,
+        "fontWeight": 400,
+        "lineHeight": "18px",
+      }
+    }
+  >
+    Description
+  </span>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 4,
+        "MsFlexPreferredSize": 4,
+        "WebkitFlexBasis": 4,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 4,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 4,
+        "zIndex": 0,
+      }
+    }
+  />
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 8,
+        "MsFlexPreferredSize": 8,
+        "WebkitFlexBasis": 8,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 8,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 8,
+        "zIndex": 0,
+      }
+    }
+  />
+  <input
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-disabled_1ab5c0p"
+    disabled={true}
+    id="tf-1"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    placeholder="Placeholder"
+    type="text"
+    value="Value"
+  />
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 12,
+        "MsFlexPreferredSize": 12,
+        "WebkitFlexBasis": 12,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 12,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 12,
+        "zIndex": 0,
+      }
+    }
+  />
+  <span
+    className=""
+    role="alert"
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "color": "#d92916",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 14,
+        "fontWeight": 400,
+        "lineHeight": "18px",
+      }
+    }
+  >
+    Error
+  </span>
+</div>
+`;

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -1238,13 +1238,13 @@ describe("wonder-blocks-form", () => {
     });
 
     it("example 19", () => {
-        class LabeledTextFieldExample extends React.Component {
-            render() {
-                return <LabeledTextField />;
-            }
-        }
+        const example = <LabeledTextField />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
 
-        const example = <LabeledTextFieldExample />;
+    it("example 20", () => {
+        const example = <LabeledTextField disabled={true} />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -1,0 +1,50 @@
+//@flow
+import * as React from "react";
+import {mount} from "enzyme";
+
+import LabeledTextField from "../labeled-text-field.js";
+
+const wait = (delay: number = 0) =>
+    new Promise((resolve, reject) => {
+        // eslint-disable-next-line no-restricted-syntax
+        return setTimeout(resolve, delay);
+    });
+
+describe("LabeledTextField", () => {
+    it("labeledtextfield becomes focused", () => {
+        // Arrange
+        const wrapper = mount(<LabeledTextField />);
+        const field = wrapper.find("TextField");
+
+        // Act
+        field.simulate("focus");
+
+        // Assert
+        expect(wrapper).toHaveState("focused", true);
+    });
+
+    it("labeledtextfield becomes blurred", async () => {
+        // Arrange
+        const wrapper = mount(<LabeledTextField />);
+        const field = wrapper.find("TextField");
+
+        // Act
+        field.simulate("focus");
+        await wait(0);
+        field.simulate("blur");
+
+        // Assert
+        expect(wrapper).toHaveState("focused", false);
+    });
+
+    it("disabled prop disables the input", async () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(<LabeledTextField disabled={true} />);
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toBeDisabled();
+    });
+});

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -4,8 +4,57 @@ import * as React from "react";
 import FieldHeading from "./field-heading.js";
 import TextField from "./text-field.js";
 
-export default class LabeledTextField extends React.Component<{||}> {
+type Props = {|
+    /**
+     * Makes a read-only input field that cannot be focused. Defaults to false.
+     */
+    disabled: boolean,
+|};
+
+type DefaultProps = {|
+    disabled: $PropertyType<Props, "disabled">,
+|};
+
+type State = {|
+    /**
+     * Displayed when the validation fails.
+     */
+    error: ?string,
+
+    /**
+     * The user focuses on the textfield.
+     */
+    focused: boolean,
+|};
+
+export default class LabeledTextField extends React.Component<Props, State> {
+    static defaultProps: DefaultProps = {
+        disabled: false,
+    };
+
+    state: State = {
+        error: null,
+        focused: false,
+    };
+
+    handleOnFocus: (
+        event: SyntheticFocusEvent<HTMLInputElement>,
+    ) => mixed = () => {
+        this.setState({
+            focused: true,
+        });
+    };
+
+    handleOnBlur: (
+        event: SyntheticFocusEvent<HTMLInputElement>,
+    ) => mixed = () => {
+        this.setState({
+            focused: false,
+        });
+    };
+
     render(): React.Node {
+        const {disabled} = this.props;
         return (
             <FieldHeading
                 field={
@@ -13,7 +62,10 @@ export default class LabeledTextField extends React.Component<{||}> {
                         id="tf-1"
                         value="Value"
                         placeholder="Placeholder"
+                        disabled={disabled}
                         onChange={() => {}}
+                        onFocus={this.handleOnFocus}
+                        onBlur={this.handleOnBlur}
                     />
                 }
                 label="Label"

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.md
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.md
@@ -3,11 +3,12 @@ LabeledTextField derives from TextField and allows the handling of single lines 
 ```js
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
-class LabeledTextFieldExample extends React.Component {
-    render() {
-        return <LabeledTextField />;
-    }
-}
+<LabeledTextField />;
+```
 
-<LabeledTextFieldExample />
+The field can be disabled
+```js
+import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
+
+<LabeledTextField disabled={true} />
 ```

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
@@ -10,3 +10,7 @@ export default {
 };
 
 export const basic: StoryComponentType = () => <LabeledTextField />;
+
+export const disabled: StoryComponentType = () => (
+    <LabeledTextField disabled={true} />
+);


### PR DESCRIPTION
## Summary:
Added the `error` and `focused` state to the `LabeledTextField`. The `enabled` state was added in the form of a `disabled` prop where it is set to `false` by default.

Included unit tests to cover these new states and prop (except the `error` state because it will be covered once validation is added).

Issue: https://khanacademy.atlassian.net/browse/WB-1065

## Test plan:
1. View the code to see the new states and prop
2. View Styleguidist and / or React Storybook examples under Form / LabeledTextField (see generated links)

---

#### The `disabled` Prop in Action:
![labeled-text-field-disabled](https://user-images.githubusercontent.com/60367213/122073622-2d27de80-cdbe-11eb-867e-e341ac515496.png)
