### PR TITLE
WB-1066 - Add the first set of Props to LabeledTextField

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -6250,6 +6250,7 @@ exports[`wonder-blocks-form example 19 1`] = `
 >
   <label
     className=""
+    htmlFor="uid-field-40-wb-id-field"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -6361,9 +6362,11 @@ exports[`wonder-blocks-form example 19 1`] = `
     }
   />
   <input
+    aria-describedby="uid-field-40-wb-id-error"
+    aria-invalid="false"
     className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
     disabled={false}
-    id="tf-1"
+    id="uid-field-40-wb-id-field"
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
@@ -6399,6 +6402,7 @@ exports[`wonder-blocks-form example 19 1`] = `
   />
   <span
     className=""
+    id="uid-field-40-wb-id-error"
     role="alert"
     style={
       Object {
@@ -6440,6 +6444,7 @@ exports[`wonder-blocks-form example 20 1`] = `
 >
   <label
     className=""
+    htmlFor="uid-field-41-wb-id-field"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -6551,15 +6556,17 @@ exports[`wonder-blocks-form example 20 1`] = `
     }
   />
   <input
+    aria-describedby="uid-field-41-wb-id-error"
+    aria-invalid="false"
     className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-disabled_1ab5c0p"
     disabled={true}
-    id="tf-1"
+    id="uid-field-41-wb-id-field"
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
     placeholder="Placeholder"
     type="text"
-    value="Value"
+    value=""
   />
   <div
     aria-hidden="true"
@@ -6589,6 +6596,7 @@ exports[`wonder-blocks-form example 20 1`] = `
   />
   <span
     className=""
+    id="uid-field-41-wb-id-error"
     role="alert"
     style={
       Object {

--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -6250,7 +6250,7 @@ exports[`wonder-blocks-form example 19 1`] = `
 >
   <label
     className=""
-    htmlFor="uid-field-40-wb-id-field"
+    htmlFor="uid-labeled-text-field-40-wb-id-field"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -6362,11 +6362,11 @@ exports[`wonder-blocks-form example 19 1`] = `
     }
   />
   <input
-    aria-describedby="uid-field-40-wb-id-error"
+    aria-describedby="uid-labeled-text-field-40-wb-id-error"
     aria-invalid="false"
     className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
     disabled={false}
-    id="uid-field-40-wb-id-field"
+    id="uid-labeled-text-field-40-wb-id-field"
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
@@ -6402,7 +6402,7 @@ exports[`wonder-blocks-form example 19 1`] = `
   />
   <span
     className=""
-    id="uid-field-40-wb-id-error"
+    id="uid-labeled-text-field-40-wb-id-error"
     role="alert"
     style={
       Object {
@@ -6444,7 +6444,7 @@ exports[`wonder-blocks-form example 20 1`] = `
 >
   <label
     className=""
-    htmlFor="uid-field-41-wb-id-field"
+    htmlFor="uid-labeled-text-field-41-wb-id-field"
     style={
       Object {
         "MozOsxFontSmoothing": "grayscale",
@@ -6556,11 +6556,11 @@ exports[`wonder-blocks-form example 20 1`] = `
     }
   />
   <input
-    aria-describedby="uid-field-41-wb-id-error"
+    aria-describedby="uid-labeled-text-field-41-wb-id-error"
     aria-invalid="false"
     className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-disabled_1ab5c0p"
     disabled={true}
-    id="uid-field-41-wb-id-field"
+    id="uid-labeled-text-field-41-wb-id-field"
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
@@ -6596,7 +6596,7 @@ exports[`wonder-blocks-form example 20 1`] = `
   />
   <span
     className=""
-    id="uid-field-41-wb-id-error"
+    id="uid-labeled-text-field-41-wb-id-error"
     role="alert"
     style={
       Object {

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -1238,13 +1238,25 @@ describe("wonder-blocks-form", () => {
     });
 
     it("example 19", () => {
-        const example = <LabeledTextField />;
+        const example = (
+            <LabeledTextField
+                label="Label"
+                description="Description"
+                initialValue="Value"
+            />
+        );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     it("example 20", () => {
-        const example = <LabeledTextField disabled={true} />;
+        const example = (
+            <LabeledTextField
+                label="Label"
+                description="Description"
+                disabled={true}
+            />
+        );
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -13,7 +13,7 @@ const wait = (delay: number = 0) =>
 describe("LabeledTextField", () => {
     it("labeledtextfield becomes focused", () => {
         // Arrange
-        const wrapper = mount(<LabeledTextField />);
+        const wrapper = mount(<LabeledTextField label="Label" />);
         const field = wrapper.find("TextField");
 
         // Act
@@ -25,7 +25,7 @@ describe("LabeledTextField", () => {
 
     it("labeledtextfield becomes blurred", async () => {
         // Arrange
-        const wrapper = mount(<LabeledTextField />);
+        const wrapper = mount(<LabeledTextField label="Label" />);
         const field = wrapper.find("TextField");
 
         // Act
@@ -37,11 +37,103 @@ describe("LabeledTextField", () => {
         expect(wrapper).toHaveState("focused", false);
     });
 
-    it("disabled prop disables the input", async () => {
+    it("value state changes when the user types", () => {
+        // Arrange
+        const wrapper = mount(<LabeledTextField label="Label" />);
+        const input = wrapper.find("input");
+
+        // Act
+        const newValue = "New Value";
+        input.simulate("change", {target: {value: newValue}});
+
+        // Assert
+        expect(wrapper).toHaveState("value", newValue);
+    });
+
+    it("id prop is passed to input", () => {
+        // Arrange
+        const id = "exampleid";
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField id={id} label="Label" disabled={true} />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toContainMatchingElement(`[id="${id}-field"]`);
+    });
+
+    it("auto-generated id is passed to input when id prop is not set", () => {
         // Arrange
 
         // Act
-        const wrapper = mount(<LabeledTextField disabled={true} />);
+        const wrapper = mount(<LabeledTextField label="Label" />);
+
+        // Assert
+        // Since the generated id is unique, we cannot know what it will be
+        // so we only test if the id attribute is set.
+        const input = wrapper.find("input");
+        expect(input).toContainMatchingElement("[id]");
+    });
+
+    it("type prop is passed to input", () => {
+        // Arrange
+        const type = "email";
+
+        // Act
+        const wrapper = mount(<LabeledTextField type={type} label="Label" />);
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toContainMatchingElement(`[type="${type}"]`);
+    });
+
+    it("label prop is rendered", () => {
+        // Arrange
+        const label = "Label";
+
+        // Act
+        const wrapper = mount(<LabeledTextField label={label} />);
+
+        // Assert
+        expect(wrapper).toIncludeText(label);
+    });
+
+    it("description prop is rendered", () => {
+        // Arrange
+        const description = "Description";
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField label="Label" description={description} />,
+        );
+
+        // Assert
+        expect(wrapper).toIncludeText(description);
+    });
+
+    it("initialValue prop is set on mount", () => {
+        // Arrange
+        const initialValue = "Value";
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField initialValue={initialValue} label="Label" />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toContainMatchingElement(`[value="${initialValue}"]`);
+    });
+
+    it("disabled prop disables the input", () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField label="Label" disabled={true} />,
+        );
 
         // Assert
         const input = wrapper.find("input");

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -71,10 +71,10 @@ describe("LabeledTextField", () => {
         const wrapper = mount(<LabeledTextField label="Label" />);
 
         // Assert
-        // Since the generated id is unique, we cannot know what it will be
-        // so we only test if the id attribute is set.
+        // Since the generated id is unique, we cannot know what it will be.
+        // We only test if the id attribute starts with "uid-" and ends with "-field".
         const input = wrapper.find("input");
-        expect(input).toContainMatchingElement("[id]");
+        expect(input.props()["id"]).toMatch(/uid-.*-field/);
     });
 
     it("type prop is passed to input", () => {
@@ -124,7 +124,7 @@ describe("LabeledTextField", () => {
 
         // Assert
         const input = wrapper.find("input");
-        expect(input).toContainMatchingElement(`[value="${initialValue}"]`);
+        expect(input).toHaveValue(initialValue);
     });
 
     it("disabled prop disables the input", () => {

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -70,16 +70,12 @@ export default class LabeledTextField extends React.Component<Props, State> {
 
     constructor(props: Props) {
         super(props);
-        if (props.initialValue) {
-            this.state.value = props.initialValue;
-        }
+        this.state = {
+            value: props.initialValue ? props.initialValue : "",
+            error: null,
+            focused: false,
+        };
     }
-
-    state: State = {
-        value: "",
-        error: null,
-        focused: false,
-    };
 
     handleOnFocus: (
         event: SyntheticFocusEvent<HTMLInputElement>,
@@ -107,7 +103,7 @@ export default class LabeledTextField extends React.Component<Props, State> {
         const {id, type, label, description, disabled} = this.props;
 
         return (
-            <IDProvider id={id} scope="field">
+            <IDProvider id={id} scope="labeled-text-field">
                 {(uniqueId) => (
                     <FieldHeading
                         id={uniqueId}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -1,10 +1,39 @@
 // @flow
 import * as React from "react";
 
+import {IDProvider} from "@khanacademy/wonder-blocks-core";
+import {type Typography} from "@khanacademy/wonder-blocks-typography";
+
 import FieldHeading from "./field-heading.js";
-import TextField from "./text-field.js";
+import TextField, {type TextFieldType} from "./text-field.js";
 
 type Props = {|
+    /**
+     * An optional unique identifier for the TextField.
+     * If no id is specified, a unique id will be auto-generated.
+     */
+    id?: string,
+
+    /**
+     * Determines the type of input. Defaults to text.
+     */
+    type: TextFieldType,
+
+    /**
+     * Provide a label for the TextField.
+     */
+    label: string | React.Element<Typography>,
+
+    /**
+     * Provide a description for the TextField.
+     */
+    description?: string | React.Element<Typography>,
+
+    /**
+     * The initial input value.
+     */
+    initialValue?: string,
+
     /**
      * Makes a read-only input field that cannot be focused. Defaults to false.
      */
@@ -12,10 +41,16 @@ type Props = {|
 |};
 
 type DefaultProps = {|
+    type: $PropertyType<Props, "type">,
     disabled: $PropertyType<Props, "disabled">,
 |};
 
 type State = {|
+    /**
+     * The value of the input.
+     */
+    value: string,
+
     /**
      * Displayed when the validation fails.
      */
@@ -29,10 +64,19 @@ type State = {|
 
 export default class LabeledTextField extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
+        type: "text",
         disabled: false,
     };
 
+    constructor(props: Props) {
+        super(props);
+        if (props.initialValue) {
+            this.state.value = props.initialValue;
+        }
+    }
+
     state: State = {
+        value: "",
         error: null,
         focused: false,
     };
@@ -53,25 +97,42 @@ export default class LabeledTextField extends React.Component<Props, State> {
         });
     };
 
+    handleOnChange: (newValue: string) => mixed = (newValue) => {
+        this.setState({
+            value: newValue,
+        });
+    };
+
     render(): React.Node {
-        const {disabled} = this.props;
+        const {id, type, label, description, disabled} = this.props;
+
         return (
-            <FieldHeading
-                field={
-                    <TextField
-                        id="tf-1"
-                        value="Value"
-                        placeholder="Placeholder"
-                        disabled={disabled}
-                        onChange={() => {}}
-                        onFocus={this.handleOnFocus}
-                        onBlur={this.handleOnBlur}
+            <IDProvider id={id} scope="field">
+                {(uniqueId) => (
+                    <FieldHeading
+                        id={uniqueId}
+                        field={
+                            <TextField
+                                id={`${uniqueId}-field`}
+                                aria-describedby={`${uniqueId}-error`}
+                                aria-invalid={
+                                    this.state.error ? "true" : "false"
+                                }
+                                type={type}
+                                value={this.state.value}
+                                placeholder="Placeholder"
+                                disabled={disabled}
+                                onChange={this.handleOnChange}
+                                onFocus={this.handleOnFocus}
+                                onBlur={this.handleOnBlur}
+                            />
+                        }
+                        label={label}
+                        description={description}
+                        error="Error"
                     />
-                }
-                label="Label"
-                description="Description"
-                error="Error"
-            />
+                )}
+            </IDProvider>
         );
     }
 }

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.md
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.md
@@ -3,12 +3,12 @@ LabeledTextField derives from TextField and allows the handling of single lines 
 ```js
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
-<LabeledTextField />;
+<LabeledTextField label="Label" description="Description" initialValue="Value" />;
 ```
 
 The field can be disabled
 ```js
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
-<LabeledTextField disabled={true} />
+<LabeledTextField label="Label" description="Description" disabled={true} />
 ```

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
@@ -9,8 +9,14 @@ export default {
     title: "Form / LabeledTextField",
 };
 
-export const basic: StoryComponentType = () => <LabeledTextField />;
+export const basic: StoryComponentType = () => (
+    <LabeledTextField
+        label="Label"
+        description="Description"
+        initialValue="Value"
+    />
+);
 
 export const disabled: StoryComponentType = () => (
-    <LabeledTextField disabled={true} />
+    <LabeledTextField label="Label" description="Description" disabled={true} />
 );

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -8,7 +8,7 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
-type TextFieldType = "text" | "password" | "email" | "number" | "tel";
+export type TextFieldType = "text" | "password" | "email" | "number" | "tel";
 
 type Props = {|
     ...AriaProps,


### PR DESCRIPTION
## Summary:
Adding the first set of props to `LabeledTextField`.
This includes:
* id
* type
* label
* description
* initialValue

I added unit tests to cover these new props (current Coverage is 100%).

Issue: https://khanacademy.atlassian.net/browse/WB-1066

## Test plan:
1. Open Styleguidist or React Storybook in browser (see generated links).
2. View the new props in action.
Note: I will be adding examples that use different TextField `type`s when I add validation