### PR TITLE
WB-1069 - Add the Final Set of Props to LabeledTextField

### DIFF
--- a/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-form/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -6371,7 +6371,7 @@ exports[`wonder-blocks-form example 19 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Name"
     type="text"
     value="Khan"
   />
@@ -6521,7 +6521,7 @@ exports[`wonder-blocks-form example 20 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Age"
     type="number"
     value="18"
   />
@@ -6671,7 +6671,7 @@ exports[`wonder-blocks-form example 21 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Password"
     type="password"
     value="Password123"
   />
@@ -6821,7 +6821,7 @@ exports[`wonder-blocks-form example 22 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Email"
     type="email"
     value="khan@khan.org"
   />
@@ -6971,7 +6971,7 @@ exports[`wonder-blocks-form example 23 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Telephone"
     type="tel"
     value="123-456-7890"
   />
@@ -7121,7 +7121,7 @@ exports[`wonder-blocks-form example 24 1`] = `
     onChange={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    placeholder="Placeholder"
+    placeholder="Email"
     type="email"
     value="khan"
   />
@@ -7315,9 +7315,329 @@ exports[`wonder-blocks-form example 25 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="Placeholder"
+    placeholder="Name"
     type="text"
     value=""
+  />
+</div>
+`;
+
+exports[`wonder-blocks-form example 26 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "background": "#0a2a66",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": "16px",
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <div
+    className=""
+    style={
+      Object {
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexDirection": "column",
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "color": "#ffffff",
+          "display": "block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": 400,
+          "lineHeight": "20px",
+        }
+      }
+    >
+      Name
+    </span>
+    <div
+      aria-hidden="true"
+      className=""
+      style={
+        Object {
+          "MsFlexBasis": 4,
+          "MsFlexPreferredSize": 4,
+          "WebkitFlexBasis": 4,
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexBasis": 4,
+          "flexDirection": "column",
+          "flexShrink": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "width": 4,
+          "zIndex": 0,
+        }
+      }
+    />
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "color": "rgba(255,255,255,0.64)",
+          "display": "block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 14,
+          "fontWeight": 400,
+          "lineHeight": "18px",
+        }
+      }
+    >
+      Please enter your name
+    </span>
+    <div
+      aria-hidden="true"
+      className=""
+      style={
+        Object {
+          "MsFlexBasis": 4,
+          "MsFlexPreferredSize": 4,
+          "WebkitFlexBasis": 4,
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexBasis": 4,
+          "flexDirection": "column",
+          "flexShrink": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "width": 4,
+          "zIndex": 0,
+        }
+      }
+    />
+    <div
+      aria-hidden="true"
+      className=""
+      style={
+        Object {
+          "MsFlexBasis": 8,
+          "MsFlexPreferredSize": 8,
+          "WebkitFlexBasis": 8,
+          "alignItems": "stretch",
+          "borderStyle": "solid",
+          "borderWidth": 0,
+          "boxSizing": "border-box",
+          "display": "flex",
+          "flexBasis": 8,
+          "flexDirection": "column",
+          "flexShrink": 0,
+          "margin": 0,
+          "minHeight": 0,
+          "minWidth": 0,
+          "padding": 0,
+          "position": "relative",
+          "width": 8,
+          "zIndex": 0,
+        }
+      }
+    />
+    <input
+      aria-describedby="uid-labeled-text-field-47-wb-id-error"
+      aria-invalid="false"
+      className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3"
+      disabled={false}
+      id="uid-labeled-text-field-47-wb-id-field"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      placeholder="Name"
+      type="text"
+      value=""
+    />
+  </div>
+</div>
+`;
+
+exports[`wonder-blocks-form example 27 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "column",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <label
+    className=""
+    htmlFor="uid-labeled-text-field-48-wb-id-field"
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "color": "#21242c",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 16,
+        "fontWeight": 400,
+        "lineHeight": "20px",
+      }
+    }
+  >
+    Name
+  </label>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 4,
+        "MsFlexPreferredSize": 4,
+        "WebkitFlexBasis": 4,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 4,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 4,
+        "zIndex": 0,
+      }
+    }
+  />
+  <span
+    className=""
+    style={
+      Object {
+        "MozOsxFontSmoothing": "grayscale",
+        "WebkitFontSmoothing": "antialiased",
+        "color": "rgba(33,36,44,0.64)",
+        "display": "block",
+        "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+        "fontSize": 14,
+        "fontWeight": 400,
+        "lineHeight": "18px",
+      }
+    }
+  >
+    Please enter your name
+  </span>
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 4,
+        "MsFlexPreferredSize": 4,
+        "WebkitFlexBasis": 4,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 4,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 4,
+        "zIndex": 0,
+      }
+    }
+  />
+  <div
+    aria-hidden="true"
+    className=""
+    style={
+      Object {
+        "MsFlexBasis": 8,
+        "MsFlexPreferredSize": 8,
+        "WebkitFlexBasis": 8,
+        "alignItems": "stretch",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "boxSizing": "border-box",
+        "display": "flex",
+        "flexBasis": 8,
+        "flexDirection": "column",
+        "flexShrink": 0,
+        "margin": 0,
+        "minHeight": 0,
+        "minWidth": 0,
+        "padding": 0,
+        "position": "relative",
+        "width": 8,
+        "zIndex": 0,
+      }
+    }
+  />
+  <input
+    aria-describedby="uid-labeled-text-field-48-wb-id-error"
+    aria-invalid="false"
+    className="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-customField_subna9"
+    disabled={false}
+    id="uid-labeled-text-field-48-wb-id-field"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    placeholder="Name"
+    type="text"
+    value="Khan"
   />
 </div>
 `;

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -1292,7 +1292,7 @@ describe("wonder-blocks-form", () => {
 
     it("example 21", () => {
         class LabeledTextFieldExample extends React.Component {
-            validation(value) {
+            validate(value) {
                 if (value.length < 8) {
                     return "Password must be at least 8 characters long";
                 }
@@ -1316,7 +1316,7 @@ describe("wonder-blocks-form", () => {
                         description="Please enter a secure password"
                         initialValue="Password123"
                         placeholder="Password"
-                        validation={this.validation}
+                        validate={this.validate}
                         onKeyDown={this.handleKeyDown}
                     />
                 );
@@ -1330,7 +1330,7 @@ describe("wonder-blocks-form", () => {
 
     it("example 22", () => {
         class LabeledTextFieldExample extends React.Component {
-            validation(value) {
+            validate(value) {
                 const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
 
                 if (!emailRegex.test(value)) {
@@ -1352,7 +1352,7 @@ describe("wonder-blocks-form", () => {
                         description="Please provide your personal email"
                         initialValue="khan@khan.org"
                         placeholder="Email"
-                        validation={this.validation}
+                        validate={this.validate}
                         onKeyDown={this.handleKeyDown}
                     />
                 );
@@ -1366,7 +1366,7 @@ describe("wonder-blocks-form", () => {
 
     it("example 23", () => {
         class LabeledTextFieldExample extends React.Component {
-            validation(value) {
+            validate(value) {
                 const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
 
                 if (!telRegex.test(value)) {
@@ -1388,7 +1388,7 @@ describe("wonder-blocks-form", () => {
                         description="Please provide your personal phone number"
                         initialValue="123-456-7890"
                         placeholder="Telephone"
-                        validation={this.validation}
+                        validate={this.validate}
                         onKeyDown={this.handleKeyDown}
                     />
                 );
@@ -1402,7 +1402,7 @@ describe("wonder-blocks-form", () => {
 
     it("example 24", () => {
         class LabeledTextFieldExample extends React.Component {
-            validation(value) {
+            validate(value) {
                 const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
 
                 if (!emailRegex.test(value)) {
@@ -1424,7 +1424,7 @@ describe("wonder-blocks-form", () => {
                         description="Please enter your personal email"
                         initialValue="khan"
                         placeholder="Email"
-                        validation={this.validation}
+                        validate={this.validate}
                         onKeyDown={this.handleKeyDown}
                     />
                 );

--- a/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/generated-snapshot.test.js
@@ -1251,6 +1251,7 @@ describe("wonder-blocks-form", () => {
                         label="Name"
                         description="Please enter your name"
                         initialValue="Khan"
+                        placeholder="Name"
                         onKeyDown={this.handleKeyDown}
                     />
                 );
@@ -1277,6 +1278,7 @@ describe("wonder-blocks-form", () => {
                         type="number"
                         description="Please enter your age"
                         initialValue="18"
+                        placeholder="Age"
                         onKeyDown={this.handleKeyDown}
                     />
                 );
@@ -1313,6 +1315,7 @@ describe("wonder-blocks-form", () => {
                         type="password"
                         description="Please enter a secure password"
                         initialValue="Password123"
+                        placeholder="Password"
                         validation={this.validation}
                         onKeyDown={this.handleKeyDown}
                     />
@@ -1348,6 +1351,7 @@ describe("wonder-blocks-form", () => {
                         type="email"
                         description="Please provide your personal email"
                         initialValue="khan@khan.org"
+                        placeholder="Email"
                         validation={this.validation}
                         onKeyDown={this.handleKeyDown}
                     />
@@ -1383,6 +1387,7 @@ describe("wonder-blocks-form", () => {
                         type="tel"
                         description="Please provide your personal phone number"
                         initialValue="123-456-7890"
+                        placeholder="Telephone"
                         validation={this.validation}
                         onKeyDown={this.handleKeyDown}
                     />
@@ -1418,6 +1423,7 @@ describe("wonder-blocks-form", () => {
                         type="email"
                         description="Please enter your personal email"
                         initialValue="khan"
+                        placeholder="Email"
                         validation={this.validation}
                         onKeyDown={this.handleKeyDown}
                     />
@@ -1435,9 +1441,96 @@ describe("wonder-blocks-form", () => {
             <LabeledTextField
                 label="Name"
                 description="Please enter your name"
+                placeholder="Name"
                 disabled={true}
             />
         );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 26", () => {
+        class LabeledTextFieldExample extends React.Component {
+            handleKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
+            }
+
+            render() {
+                return (
+                    <View style={styles.darkBackground}>
+                        <LabeledTextField
+                            label={
+                                <LabelMedium style={styles.whiteColor}>
+                                    Name
+                                </LabelMedium>
+                            }
+                            description={
+                                <LabelSmall style={styles.offWhiteColor}>
+                                    Please enter your name
+                                </LabelSmall>
+                            }
+                            placeholder="Name"
+                            light={true}
+                            onKeyDown={this.handleKeyDown}
+                        />
+                    </View>
+                );
+            }
+        }
+
+        const styles = StyleSheet.create({
+            darkBackground: {
+                background: Color.darkBlue,
+                padding: `${Spacing.medium_16}px`,
+            },
+            whiteColor: {
+                color: Color.white,
+            },
+            offWhiteColor: {
+                color: Color.white64,
+            },
+        });
+        const example = <LabeledTextFieldExample />;
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 27", () => {
+        class LabeledTextFieldExample extends React.Component {
+            handleKeyDown(event) {
+                if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                }
+            }
+
+            render() {
+                return (
+                    <LabeledTextField
+                        label="Name"
+                        description="Please enter your name"
+                        initialValue="Khan"
+                        placeholder="Name"
+                        style={styles.customField}
+                        onKeyDown={this.handleKeyDown}
+                    />
+                );
+            }
+        }
+
+        const styles = StyleSheet.create({
+            customField: {
+                backgroundColor: Color.darkBlue,
+                color: Color.white,
+                border: "none",
+                maxWidth: 250,
+                "::placeholder": {
+                    color: Color.white64,
+                },
+            },
+        });
+        const example = <LabeledTextFieldExample />;
         const tree = renderer.create(example).toJSON();
         expect(tree).toMatchSnapshot();
     });

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import {mount} from "enzyme";
 
+import {StyleSheet} from "aphrodite";
 import LabeledTextField from "../labeled-text-field.js";
 
 const wait = (delay: number = 0) =>
@@ -252,5 +253,65 @@ describe("LabeledTextField", () => {
 
         // Assert
         expect(handleBlur).toHaveBeenCalled();
+    });
+
+    it("placeholder prop is passed to input", async () => {
+        // Arrange
+        const placeholder = "Placeholder";
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField label="Label" placeholder={placeholder} />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toContainMatchingElement(
+            `[placeholder="${placeholder}"]`,
+        );
+    });
+
+    it("light prop is passed to textfield", async () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(<LabeledTextField label="Label" light={true} />);
+
+        // Assert
+        const textField = wrapper.find("TextField");
+        expect(textField).toHaveProp("light", true);
+    });
+
+    it("style prop is passed to textfield", async () => {
+        // Arrange
+        const styles = StyleSheet.create({
+            style1: {
+                minWidth: 250,
+                background: "blue",
+            },
+        });
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField label="Label" style={styles.style1} />,
+        );
+
+        // Assert
+        const textField = wrapper.find("TextField");
+        expect(textField).toHaveStyle(styles.style1);
+    });
+
+    it("testId prop is passed to textfield", async () => {
+        // Arrange
+        const testId = "example-testid";
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField label="Label" testId={testId} />,
+        );
+
+        // Assert
+        const textField = wrapper.find(`[data-test-id="${testId}-field"]`);
+        expect(textField).toExist();
     });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -141,11 +141,11 @@ describe("LabeledTextField", () => {
         expect(input).toBeDisabled();
     });
 
-    it("validation prop is called when input changes", () => {
+    it("validate prop is called when input changes", () => {
         // Arrange
-        const validation = jest.fn((value: string): ?string => {});
+        const validate = jest.fn((value: string): ?string => {});
         const wrapper = mount(
-            <LabeledTextField label="Label" validation={validation} />,
+            <LabeledTextField label="Label" validate={validate} />,
         );
 
         // Act
@@ -154,15 +154,15 @@ describe("LabeledTextField", () => {
         input.simulate("change", {target: {value: newValue}});
 
         // Assert
-        expect(validation).toHaveBeenCalledWith(newValue);
+        expect(validate).toHaveBeenCalledWith(newValue);
     });
 
-    it("onValidation prop is called on new validated input", () => {
+    it("onValidate prop is called on new validated input", () => {
         // Arrange
-        const handleValidation = jest.fn((errorMessage: ?string) => {});
+        const handleValidate = jest.fn((errorMessage: ?string) => {});
         const errorMessage = "Password must be at least 8 characters long";
 
-        const validation = (value: string): ?string => {
+        const validate = (value: string): ?string => {
             if (value.length < 8) {
                 return errorMessage;
             }
@@ -172,8 +172,8 @@ describe("LabeledTextField", () => {
             <LabeledTextField
                 label="Label"
                 initialValue="LongerThan8Chars"
-                validation={validation}
-                onValidation={handleValidation}
+                validate={validate}
+                onValidate={handleValidate}
             />,
         );
 
@@ -182,7 +182,7 @@ describe("LabeledTextField", () => {
         input.simulate("change", {target: {value: "Short"}});
 
         // Assert
-        expect(handleValidation).toHaveBeenCalledWith(errorMessage);
+        expect(handleValidate).toHaveBeenCalledWith(errorMessage);
     });
 
     it("onChange prop is called on input change", () => {

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import {IDProvider} from "@khanacademy/wonder-blocks-core";
+import {IDProvider, type StyleType} from "@khanacademy/wonder-blocks-core";
 import {type Typography} from "@khanacademy/wonder-blocks-typography";
 
 import FieldHeading from "./field-heading.js";
@@ -69,11 +69,32 @@ type Props = {|
      * Called when the element has been blurred.
      */
     onBlur?: (event: SyntheticFocusEvent<HTMLInputElement>) => mixed,
+
+    /**
+     * Provide hints or examples of what to enter.
+     */
+    placeholder?: string,
+
+    /**
+     * Change the field’s sub-components to fit a dark background.
+     */
+    light: boolean,
+
+    /**
+     * Custom styles for the TextField component.
+     */
+    style?: StyleType,
+
+    /**
+     * Optional test ID for e2e testing.
+     */
+    testId?: string,
 |};
 
 type DefaultProps = {|
     type: $PropertyType<Props, "type">,
     disabled: $PropertyType<Props, "disabled">,
+    light: $PropertyType<Props, "light">,
 |};
 
 type State = {|
@@ -97,6 +118,7 @@ export default class LabeledTextField extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
         type: "text",
         disabled: false,
+        light: false,
     };
 
     constructor(props: Props) {
@@ -110,44 +132,42 @@ export default class LabeledTextField extends React.Component<Props, State> {
 
     handleValidation: (errorMessage: ?string) => mixed = (errorMessage) => {
         const {onValidation} = this.props;
-        this.setState({error: errorMessage});
-        if (onValidation) {
-            onValidation(errorMessage);
-        }
+        this.setState({error: errorMessage}, () => {
+            if (onValidation) {
+                onValidation(errorMessage);
+            }
+        });
     };
 
     handleChange: (newValue: string) => mixed = (newValue) => {
         const {onChange} = this.props;
-        this.setState({
-            value: newValue,
+        this.setState({value: newValue}, () => {
+            if (onChange) {
+                onChange(newValue);
+            }
         });
-        if (onChange) {
-            onChange(newValue);
-        }
     };
 
     handleFocus: (event: SyntheticFocusEvent<HTMLInputElement>) => mixed = (
         event,
     ) => {
         const {onFocus} = this.props;
-        this.setState({
-            focused: true,
+        this.setState({focused: true}, () => {
+            if (onFocus) {
+                onFocus(event);
+            }
         });
-        if (onFocus) {
-            onFocus(event);
-        }
     };
 
     handleBlur: (event: SyntheticFocusEvent<HTMLInputElement>) => mixed = (
         event,
     ) => {
         const {onBlur} = this.props;
-        this.setState({
-            focused: false,
+        this.setState({focused: false}, () => {
+            if (onBlur) {
+                onBlur(event);
+            }
         });
-        if (onBlur) {
-            onBlur(event);
-        }
     };
 
     render(): React.Node {
@@ -159,6 +179,10 @@ export default class LabeledTextField extends React.Component<Props, State> {
             disabled,
             validation,
             onKeyDown,
+            placeholder,
+            light,
+            style,
+            testId,
         } = this.props;
 
         return (
@@ -166,6 +190,7 @@ export default class LabeledTextField extends React.Component<Props, State> {
                 {(uniqueId) => (
                     <FieldHeading
                         id={uniqueId}
+                        testId={testId}
                         field={
                             <TextField
                                 id={`${uniqueId}-field`}
@@ -173,9 +198,10 @@ export default class LabeledTextField extends React.Component<Props, State> {
                                 aria-invalid={
                                     this.state.error ? "true" : "false"
                                 }
+                                testId={testId && `${testId}-field`}
                                 type={type}
                                 value={this.state.value}
-                                placeholder="Placeholder"
+                                placeholder={placeholder}
                                 disabled={disabled}
                                 validation={validation}
                                 onValidation={this.handleValidation}
@@ -183,6 +209,8 @@ export default class LabeledTextField extends React.Component<Props, State> {
                                 onKeyDown={onKeyDown}
                                 onFocus={this.handleFocus}
                                 onBlur={this.handleBlur}
+                                light={light}
+                                style={style}
                             />
                         }
                         label={label}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -43,12 +43,12 @@ type Props = {|
      * Provide a validation for the input value.
      * Return a string error message or null | void for a valid input.
      */
-    validation?: (value: string) => ?string,
+    validate?: (value: string) => ?string,
 
     /**
      * Called when the TextField input is validated.
      */
-    onValidation?: (errorMessage: ?string) => mixed,
+    onValidate?: (errorMessage: ?string) => mixed,
 
     /**
      * Called when the value has changed.
@@ -130,11 +130,11 @@ export default class LabeledTextField extends React.Component<Props, State> {
         };
     }
 
-    handleValidation: (errorMessage: ?string) => mixed = (errorMessage) => {
-        const {onValidation} = this.props;
+    handleValidate: (errorMessage: ?string) => mixed = (errorMessage) => {
+        const {onValidate} = this.props;
         this.setState({error: errorMessage}, () => {
-            if (onValidation) {
-                onValidation(errorMessage);
+            if (onValidate) {
+                onValidate(errorMessage);
             }
         });
     };
@@ -177,7 +177,7 @@ export default class LabeledTextField extends React.Component<Props, State> {
             label,
             description,
             disabled,
-            validation,
+            validate,
             onKeyDown,
             placeholder,
             light,
@@ -203,8 +203,8 @@ export default class LabeledTextField extends React.Component<Props, State> {
                                 value={this.state.value}
                                 placeholder={placeholder}
                                 disabled={disabled}
-                                validation={validation}
-                                onValidation={this.handleValidation}
+                                validation={validate}
+                                onValidation={this.handleValidate}
                                 onChange={this.handleChange}
                                 onKeyDown={onKeyDown}
                                 onFocus={this.handleFocus}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.md
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.md
@@ -63,7 +63,7 @@ Password
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
-    validation(value) {
+    validate(value) {
         if (value.length < 8) {
             return "Password must be at least 8 characters long";
         }
@@ -86,7 +86,7 @@ class LabeledTextFieldExample extends React.Component {
                 description="Please enter a secure password"
                 initialValue="Password123"
                 placeholder="Password"
-                validation={this.validation}
+                validate={this.validate}
                 onKeyDown={this.handleKeyDown}
             />
         );
@@ -102,7 +102,7 @@ Email
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
-    validation(value) {
+    validate(value) {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
             return "Please enter a valid email";
@@ -123,7 +123,7 @@ class LabeledTextFieldExample extends React.Component {
                 description="Please provide your personal email"
                 initialValue="khan@khan.org"
                 placeholder="Email"
-                validation={this.validation}
+                validate={this.validate}
                 onKeyDown={this.handleKeyDown}
             />
         );
@@ -139,7 +139,7 @@ Telephone
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
-    validation(value) {
+    validate(value) {
         const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
         if (!telRegex.test(value)) {
             return "Invalid US telephone number";
@@ -160,7 +160,7 @@ class LabeledTextFieldExample extends React.Component {
                 description="Please provide your personal phone number"
                 initialValue="123-456-7890"
                 placeholder="Telephone"
-                validation={this.validation}
+                validate={this.validate}
                 onKeyDown={this.handleKeyDown}
             />
         );
@@ -176,7 +176,7 @@ The field can have an error
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
-    validation(value) {
+    validate(value) {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
             return "Please enter a valid email";
@@ -197,7 +197,7 @@ class LabeledTextFieldExample extends React.Component {
                 description="Please enter your personal email"
                 initialValue="khan"
                 placeholder="Email"
-                validation={this.validation}
+                validate={this.validate}
                 onKeyDown={this.handleKeyDown}
             />
         );

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.md
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.md
@@ -18,6 +18,7 @@ class LabeledTextFieldExample extends React.Component {
                 label="Name"
                 description="Please enter your name"
                 initialValue="Khan"
+                placeholder="Name"
                 onKeyDown={this.handleKeyDown}
             />
         );
@@ -46,6 +47,7 @@ class LabeledTextFieldExample extends React.Component {
                 type="number"
                 description="Please enter your age"
                 initialValue="18"
+                placeholder="Age"
                 onKeyDown={this.handleKeyDown}
             />
         );
@@ -83,6 +85,7 @@ class LabeledTextFieldExample extends React.Component {
                 type="password"
                 description="Please enter a secure password"
                 initialValue="Password123"
+                placeholder="Password"
                 validation={this.validation}
                 onKeyDown={this.handleKeyDown}
             />
@@ -119,6 +122,7 @@ class LabeledTextFieldExample extends React.Component {
                 type="email"
                 description="Please provide your personal email"
                 initialValue="khan@khan.org"
+                placeholder="Email"
                 validation={this.validation}
                 onKeyDown={this.handleKeyDown}
             />
@@ -155,6 +159,7 @@ class LabeledTextFieldExample extends React.Component {
                 type="tel"
                 description="Please provide your personal phone number"
                 initialValue="123-456-7890"
+                placeholder="Telephone"
                 validation={this.validation}
                 onKeyDown={this.handleKeyDown}
             />
@@ -191,6 +196,7 @@ class LabeledTextFieldExample extends React.Component {
                 type="email"
                 description="Please enter your personal email"
                 initialValue="khan"
+                placeholder="Email"
                 validation={this.validation}
                 onKeyDown={this.handleKeyDown}
             />
@@ -209,6 +215,104 @@ import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 <LabeledTextField
     label="Name"
     description="Please enter your name"
+    placeholder="Name"
     disabled={true}
 />
+```
+
+The field can be in light mode to fit a dark background
+
+```js
+import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import Color from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {StyleSheet} from "aphrodite";
+
+class LabeledTextFieldExample extends React.Component {
+    handleKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    render() {
+        return (
+            <View style={styles.darkBackground}>
+                <LabeledTextField
+                    label={
+                        <LabelMedium style={styles.whiteColor}>Name</LabelMedium>
+                    }
+                    description={
+                        <LabelSmall style={styles.offWhiteColor}>
+                            Please enter your name
+                        </LabelSmall>
+                    }
+                    placeholder="Name"
+                    light={true}
+                    onKeyDown={this.handleKeyDown}
+                />
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    darkBackground: {
+        background: Color.darkBlue,
+        padding: `${Spacing.medium_16}px`,
+    },
+    whiteColor: {
+        color: Color.white,
+    },
+    offWhiteColor: {
+        color: Color.white64,
+    },
+});
+
+<LabeledTextFieldExample />
+```
+
+The field can have custom styles
+
+```js
+import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
+import {StyleSheet} from "aphrodite";
+import Color from "@khanacademy/wonder-blocks-color";
+
+class LabeledTextFieldExample extends React.Component {
+    handleKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    render() {
+        return (
+            <LabeledTextField
+                label="Name"
+                description="Please enter your name"
+                initialValue="Khan"
+                placeholder="Name"
+                style={styles.customField}
+                onKeyDown={this.handleKeyDown}
+            />
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    customField: {
+        backgroundColor: Color.darkBlue,
+        color: Color.white,
+        border: "none",
+        maxWidth: 250,
+        "::placeholder": {
+            color: Color.white64,
+        },
+    },
+});
+
+<LabeledTextFieldExample />
 ```

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
@@ -52,7 +52,7 @@ export const number: StoryComponentType = () => {
 };
 
 export const password: StoryComponentType = () => {
-    const validation = (value: string) => {
+    const validate = (value: string) => {
         if (value.length < 8) {
             return "Password must be at least 8 characters long";
         }
@@ -74,14 +74,14 @@ export const password: StoryComponentType = () => {
             description="Please enter a secure password"
             initialValue="Password123"
             placeholder="Password"
-            validation={validation}
+            validate={validate}
             onKeyDown={handleKeyDown}
         />
     );
 };
 
 export const email: StoryComponentType = () => {
-    const validation = (value: string) => {
+    const validate = (value: string) => {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
             return "Please enter a valid email";
@@ -101,14 +101,14 @@ export const email: StoryComponentType = () => {
             initialValue="khan@khan.org"
             description="Please provide your personal email"
             placeholder="Email"
-            validation={validation}
+            validate={validate}
             onKeyDown={handleKeyDown}
         />
     );
 };
 
 export const telephone: StoryComponentType = () => {
-    const validation = (value: string) => {
+    const validate = (value: string) => {
         const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
         if (!telRegex.test(value)) {
             return "Invalid US telephone number";
@@ -128,14 +128,14 @@ export const telephone: StoryComponentType = () => {
             initialValue="123-456-7890"
             description="Please provide your personal phone number"
             placeholder="Telephone"
-            validation={validation}
+            validate={validate}
             onKeyDown={handleKeyDown}
         />
     );
 };
 
 export const error: StoryComponentType = () => {
-    const validation = (value: string) => {
+    const validate = (value: string) => {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
             return "Please enter a valid email";
@@ -155,7 +155,7 @@ export const error: StoryComponentType = () => {
             initialValue="khan"
             description="Please provide your personal email"
             placeholder="Email"
-            validation={validation}
+            validate={validate}
             onKeyDown={handleKeyDown}
         />
     );

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
@@ -2,6 +2,11 @@
 import * as React from "react";
 
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import Color from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {StyleSheet} from "aphrodite";
 
 import type {StoryComponentType} from "@storybook/react";
 
@@ -21,6 +26,7 @@ export const text: StoryComponentType = () => {
             label="Name"
             description="Please enter your name"
             initialValue="Khan"
+            placeholder="Name"
             onKeyDown={handleKeyDown}
         />
     );
@@ -39,6 +45,7 @@ export const number: StoryComponentType = () => {
             type="number"
             description="Please enter your age"
             initialValue="18"
+            placeholder="Age"
             onKeyDown={handleKeyDown}
         />
     );
@@ -66,6 +73,7 @@ export const password: StoryComponentType = () => {
             type="password"
             description="Please enter a secure password"
             initialValue="Password123"
+            placeholder="Password"
             validation={validation}
             onKeyDown={handleKeyDown}
         />
@@ -92,6 +100,7 @@ export const email: StoryComponentType = () => {
             type="email"
             initialValue="khan@khan.org"
             description="Please provide your personal email"
+            placeholder="Email"
             validation={validation}
             onKeyDown={handleKeyDown}
         />
@@ -118,6 +127,7 @@ export const telephone: StoryComponentType = () => {
             type="tel"
             initialValue="123-456-7890"
             description="Please provide your personal phone number"
+            placeholder="Telephone"
             validation={validation}
             onKeyDown={handleKeyDown}
         />
@@ -144,6 +154,7 @@ export const error: StoryComponentType = () => {
             type="email"
             initialValue="khan"
             description="Please provide your personal email"
+            placeholder="Email"
             validation={validation}
             onKeyDown={handleKeyDown}
         />
@@ -154,6 +165,73 @@ export const disabled: StoryComponentType = () => (
     <LabeledTextField
         label="Name"
         description="Please enter your name"
+        placeholder="Name"
         disabled={true}
     />
 );
+
+export const light: StoryComponentType = () => {
+    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <View style={styles.darkBackground}>
+            <LabeledTextField
+                label={
+                    <LabelMedium style={styles.whiteColor}>Name</LabelMedium>
+                }
+                description={
+                    <LabelSmall style={styles.offWhiteColor}>
+                        Please enter your name
+                    </LabelSmall>
+                }
+                placeholder="Name"
+                light={true}
+                onKeyDown={handleKeyDown}
+            />
+        </View>
+    );
+};
+
+export const customStyle: StoryComponentType = () => {
+    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <LabeledTextField
+            label="Name"
+            description="Please enter your name"
+            placeholder="Name"
+            style={styles.customField}
+            onKeyDown={handleKeyDown}
+        />
+    );
+};
+
+const styles = StyleSheet.create({
+    darkBackground: {
+        background: Color.darkBlue,
+        padding: `${Spacing.medium_16}px`,
+    },
+    whiteColor: {
+        color: Color.white,
+    },
+    offWhiteColor: {
+        color: Color.white64,
+    },
+    customField: {
+        backgroundColor: Color.darkBlue,
+        color: Color.white,
+        border: "none",
+        maxWidth: 250,
+        "::placeholder": {
+            color: Color.white64,
+        },
+    },
+});


### PR DESCRIPTION
## Summary:
Adding the final set of props to `LabeledTextField`.

This includes:
* placeholder
* light
* style
* testId

Included unit tests to verify these props work as expected (Coverage is 100%).

Issue: https://khanacademy.atlassian.net/browse/WB-1069

## Test plan:
1. Open Styleguidist or React Storybook (See generated links).
2. View the new examples under Form / LabeledTextField.

---

### Light Prop Example
<img width="365" alt="labeled-text-field-light-example" src="https://user-images.githubusercontent.com/60367213/122789039-84c1c080-d27c-11eb-9a6e-30f6aca118a9.png">

### Style Prop Example
<img width="290" alt="labeled-text-field-style-example" src="https://user-images.githubusercontent.com/60367213/122789079-8d19fb80-d27c-11eb-9caa-e82d59b02962.png">
