### PR TITLE
Properly support SSR request fulfillment without hydration support

### DIFF
--- a/packages/wonder-blocks-data/src/util/__tests__/request-fulfillment.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-fulfillment.test.js
@@ -36,7 +36,7 @@ describe("RequestFulfillment", () => {
             await requestFulfillment.fulfill(fakeBadHandler, "OPTIONS");
 
             // Assert
-            expect(responseCache.cloneCachedData()).toStrictEqual({
+            expect(responseCache.cloneHydratableData()).toStrictEqual({
                 MY_TYPE: {
                     MY_KEY: {
                         error: "OH NO!",
@@ -63,7 +63,7 @@ describe("RequestFulfillment", () => {
             await requestFulfillment.fulfill(fakeBadRequestHandler, "OPTIONS");
 
             // Assert
-            expect(responseCache.cloneCachedData()).toStrictEqual({
+            expect(responseCache.cloneHydratableData()).toStrictEqual({
                 BAD_REQUEST: {
                     OPTIONS: {
                         error: "OH NO!",
@@ -87,9 +87,10 @@ describe("RequestFulfillment", () => {
 
             // Act
             await requestFulfillment.fulfill(fakeRequestHandler, "OPTIONS");
+            const result = responseCache.cloneHydratableData();
 
             // Assert
-            expect(responseCache.cloneCachedData()).toStrictEqual({
+            expect(result).toStrictEqual({
                 VALID_REQUEST: {
                     OPTIONS: {
                         data: "DATA!",
@@ -160,7 +161,7 @@ describe("RequestFulfillment", () => {
                 shouldRefreshCache: () => false,
                 type: "VALID_REQUEST",
                 cache: null,
-                hydrate: true,
+                hydrate: false,
             };
 
             // Act

--- a/packages/wonder-blocks-data/src/util/__tests__/response-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/response-cache.test.js
@@ -354,7 +354,7 @@ describe("../response-cache.js", () => {
         });
 
         describe("no hydrate", () => {
-            it("should store the entry in the NoCache cache", () => {
+            it("should store the entry in the ssr-only cache", () => {
                 // Arrange
                 jest.spyOn(Server, "isServerSide").mockReturnValue(true);
                 const ssrOnlyCache = new MemoryCache();

--- a/packages/wonder-blocks-data/src/util/__tests__/response-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/response-cache.test.js
@@ -2,7 +2,6 @@
 import {Server} from "@khanacademy/wonder-blocks-core";
 import {ResponseCache} from "../response-cache.js";
 import MemoryCache from "../memory-cache.js";
-import NoCache from "../no-cache.js";
 
 import type {IRequestHandler} from "../types.js";
 
@@ -209,12 +208,13 @@ describe("../response-cache.js", () => {
         });
 
         describe("no hydrate", () => {
-            it("should store the entry in the NoCache cache", () => {
+            it("should store the entry in the ssr-only cache", () => {
                 // Arrange
                 jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const ssrOnlyCache = new MemoryCache();
                 const internalCache = new MemoryCache();
-                const noCacheStoreSpy = jest.spyOn(NoCache.Default, "store");
-                const cache = new ResponseCache(internalCache);
+                const storeSpy = jest.spyOn(ssrOnlyCache, "store");
+                const cache = new ResponseCache(internalCache, ssrOnlyCache);
                 const fakeHandler: IRequestHandler<string, string> = {
                     getKey: () => "MY_KEY",
                     type: "MY_HANDLER",
@@ -228,11 +228,9 @@ describe("../response-cache.js", () => {
                 cache.cacheData(fakeHandler, "options", "data");
 
                 // Assert
-                expect(noCacheStoreSpy).toHaveBeenCalledWith(
-                    fakeHandler,
-                    "options",
-                    {data: "data"},
-                );
+                expect(storeSpy).toHaveBeenCalledWith(fakeHandler, "options", {
+                    data: "data",
+                });
             });
 
             it("should not store the entry in the framework cache", () => {
@@ -359,9 +357,10 @@ describe("../response-cache.js", () => {
             it("should store the entry in the NoCache cache", () => {
                 // Arrange
                 jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                const ssrOnlyCache = new MemoryCache();
                 const internalCache = new MemoryCache();
-                const noCacheStoreSpy = jest.spyOn(NoCache.Default, "store");
-                const cache = new ResponseCache(internalCache);
+                const storeSpy = jest.spyOn(ssrOnlyCache, "store");
+                const cache = new ResponseCache(internalCache, ssrOnlyCache);
                 const fakeHandler: IRequestHandler<string, string> = {
                     getKey: () => "MY_KEY",
                     type: "MY_HANDLER",
@@ -375,11 +374,9 @@ describe("../response-cache.js", () => {
                 cache.cacheError(fakeHandler, "options", new Error("Ooops!"));
 
                 // Assert
-                expect(noCacheStoreSpy).toHaveBeenCalledWith(
-                    fakeHandler,
-                    "options",
-                    {error: "Ooops!"},
-                );
+                expect(storeSpy).toHaveBeenCalledWith(fakeHandler, "options", {
+                    error: "Ooops!",
+                });
             });
 
             it("should not store the entry in the framework cache", () => {
@@ -808,8 +805,8 @@ describe("../response-cache.js", () => {
         });
     });
 
-    describe("#cloneCachedData", () => {
-        it("should clone the internal cache", () => {
+    describe("#cloneHydratableData", () => {
+        it("should clone the internal hydration cache", () => {
             // Arrange
             const internalCache = new MemoryCache();
             jest.spyOn(internalCache, "cloneData").mockReturnValue("CLONE!");
@@ -828,7 +825,7 @@ describe("../response-cache.js", () => {
             cache.cacheError(fakeHandler, "OPTIONS2", new Error("OH NO!"));
 
             // Act
-            const result = cache.cloneCachedData();
+            const result = cache.cloneHydratableData();
 
             // Assert
             expect(internalCache.cloneData).toHaveBeenCalled();
@@ -843,7 +840,7 @@ describe("../response-cache.js", () => {
             });
 
             // Act
-            const underTest = () => cache.cloneCachedData();
+            const underTest = () => cache.cloneHydratableData();
 
             // Assert
             expect(underTest).toThrowErrorMatchingInlineSnapshot(

--- a/packages/wonder-blocks-data/src/util/request-handler.md
+++ b/packages/wonder-blocks-data/src/util/request-handler.md
@@ -21,6 +21,15 @@ interface IRequestHandler<TOptions, TData> {
     get cache(): ?ICache<TOptions, TData>;
 
     /**
+     * When true, server-side results are cached and hydrated in the client.
+     * When false, the server-side cache is not used and results are not
+     * hydrated.
+     * This should only be set to false if something is ensuring that the
+     * hydrated client result will match the server result.
+     */
+    get hydrate(): boolean;
+
+    /**
      * Determine if the cached data should be refreshed.
      *
      * If this returns true, the framework will use the currently cached value
@@ -56,6 +65,14 @@ called. Subclasses will need to implement this method.
 A default implementation of `getKey` is provided that serializes the options of
 a request to a string and uses that as the cache key. You may want to override
 this behavior to simplify the key or to omit some values from the key.
+
+The `hydrate` property indicates if the data that is fulfilled for the handler
+during SSR should be provided for hydration. This should be `true` in most
+cases. When `false`, React hydration will fail unless some other aspect of your
+SSR process is tracking the data for hydration. An example of setting this to
+false might be when you are using Apollo Client. In that scenario, you may use
+Apollo Cache to store and hydrate the data, while using Wonder Blocks Data to
+track and fulfill any query requests made via Apollo Client.
 
 Finally, the `shouldRefreshCache` method is provided for cases where a handler
 may want control over cache freshness. By default, this will return `true` for

--- a/packages/wonder-blocks-data/src/util/request-tracking.js
+++ b/packages/wonder-blocks-data/src/util/request-tracking.js
@@ -153,7 +153,7 @@ export class RequestTracker {
          * Let's wait for everything to fulfill, and then clone the cached data.
          */
         return Promise.all(promises).then(() =>
-            this._responseCache.cloneCachedData(),
+            this._responseCache.cloneHydratableData(),
         );
     };
 }

--- a/packages/wonder-blocks-data/src/util/types.js
+++ b/packages/wonder-blocks-data/src/util/types.js
@@ -15,12 +15,12 @@ export type Result<TData: ValidData> =
 
 export type CacheEntry<TData: ValidData> =
     | {|
-          error: string,
-          data?: ?void,
+          +error: string,
+          +data?: ?void,
       |}
     | {|
-          data: TData,
-          error?: ?void,
+          +data: TData,
+          +error?: ?void,
       |};
 
 type HandlerSubcache = {


### PR DESCRIPTION
## Summary:
This fixes our SSR support for non-hydrateable handlers to still support
request fulfillment during SSR.

Issue: FEI-3597

## Test plan:
`yarn test`

I'll also be incorporating this version of WB Data into webapp to verify it
all works with the intended use-case; the new GqlQuery component.