### PR TITLE
WB-1083 - Make LabeledTextField be a Controlled Component

### DIFF
--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -151,6 +151,23 @@ describe("LabeledTextField", () => {
         expect(input).toHaveValue(value);
     });
 
+    it("value prop change from parent reflects on input value", async () => {
+        // Arrange
+        const handleChange = jest.fn((newValue: string) => {});
+
+        const wrapper = mount(
+            <LabeledTextField label="Label" value="" onChange={handleChange} />,
+        );
+
+        // Act
+        const newValue = "new value";
+        wrapper.setProps({value: newValue});
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toHaveValue(newValue);
+    });
+
     it("disabled prop disables the input", () => {
         // Arrange
 

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -14,7 +14,9 @@ const wait = (delay: number = 0) =>
 describe("LabeledTextField", () => {
     it("labeledtextfield becomes focused", () => {
         // Arrange
-        const wrapper = mount(<LabeledTextField label="Label" />);
+        const wrapper = mount(
+            <LabeledTextField label="Label" value="" onChange={() => {}} />,
+        );
         const field = wrapper.find("TextFieldInternal");
 
         // Act
@@ -29,7 +31,9 @@ describe("LabeledTextField", () => {
 
     it("labeledtextfield becomes blurred", async () => {
         // Arrange
-        const wrapper = mount(<LabeledTextField label="Label" />);
+        const wrapper = mount(
+            <LabeledTextField label="Label" value="" onChange={() => {}} />,
+        );
         const field = wrapper.find("TextFieldInternal");
 
         // Act
@@ -44,29 +48,19 @@ describe("LabeledTextField", () => {
         );
     });
 
-    it("value state changes when the user types", () => {
-        // Arrange
-        const wrapper = mount(<LabeledTextField label="Label" />);
-        const input = wrapper.find("input");
-
-        // Act
-        const newValue = "New Value";
-        input.simulate("change", {target: {value: newValue}});
-
-        // Assert
-        expect(wrapper.find("LabeledTextFieldInternal")).toHaveState(
-            "value",
-            newValue,
-        );
-    });
-
     it("id prop is passed to input", () => {
         // Arrange
         const id = "exampleid";
 
         // Act
         const wrapper = mount(
-            <LabeledTextField id={id} label="Label" disabled={true} />,
+            <LabeledTextField
+                id={id}
+                label="Label"
+                value=""
+                onChange={() => {}}
+                disabled={true}
+            />,
         );
 
         // Assert
@@ -78,7 +72,9 @@ describe("LabeledTextField", () => {
         // Arrange
 
         // Act
-        const wrapper = mount(<LabeledTextField label="Label" />);
+        const wrapper = mount(
+            <LabeledTextField label="Label" value="" onChange={() => {}} />,
+        );
 
         // Assert
         // Since the generated id is unique, we cannot know what it will be.
@@ -92,7 +88,14 @@ describe("LabeledTextField", () => {
         const type = "email";
 
         // Act
-        const wrapper = mount(<LabeledTextField type={type} label="Label" />);
+        const wrapper = mount(
+            <LabeledTextField
+                type={type}
+                label="Label"
+                value=""
+                onChange={() => {}}
+            />,
+        );
 
         // Assert
         const input = wrapper.find("input");
@@ -104,7 +107,9 @@ describe("LabeledTextField", () => {
         const label = "Label";
 
         // Act
-        const wrapper = mount(<LabeledTextField label={label} />);
+        const wrapper = mount(
+            <LabeledTextField label={label} value="" onChange={() => {}} />,
+        );
 
         // Assert
         expect(wrapper).toIncludeText(label);
@@ -116,25 +121,34 @@ describe("LabeledTextField", () => {
 
         // Act
         const wrapper = mount(
-            <LabeledTextField label="Label" description={description} />,
+            <LabeledTextField
+                label="Label"
+                description={description}
+                value=""
+                onChange={() => {}}
+            />,
         );
 
         // Assert
         expect(wrapper).toIncludeText(description);
     });
 
-    it("initialValue prop is set on mount", () => {
+    it("value prop is set on mount", () => {
         // Arrange
-        const initialValue = "Value";
+        const value = "Value";
 
         // Act
         const wrapper = mount(
-            <LabeledTextField initialValue={initialValue} label="Label" />,
+            <LabeledTextField
+                label="Label"
+                value={value}
+                onChange={() => {}}
+            />,
         );
 
         // Assert
         const input = wrapper.find("input");
-        expect(input).toHaveValue(initialValue);
+        expect(input).toHaveValue(value);
     });
 
     it("disabled prop disables the input", () => {
@@ -142,7 +156,12 @@ describe("LabeledTextField", () => {
 
         // Act
         const wrapper = mount(
-            <LabeledTextField label="Label" disabled={true} />,
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                disabled={true}
+            />,
         );
 
         // Assert
@@ -154,7 +173,12 @@ describe("LabeledTextField", () => {
         // Arrange
         const validate = jest.fn((value: string): ?string => {});
         const wrapper = mount(
-            <LabeledTextField label="Label" validate={validate} />,
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                validate={validate}
+            />,
         );
 
         // Act
@@ -180,7 +204,8 @@ describe("LabeledTextField", () => {
         const wrapper = mount(
             <LabeledTextField
                 label="Label"
-                initialValue="LongerThan8Chars"
+                value="LongerThan8Chars"
+                onChange={() => {}}
                 validate={validate}
                 onValidate={handleValidate}
             />,
@@ -199,7 +224,7 @@ describe("LabeledTextField", () => {
         const handleChange = jest.fn((newValue: string) => {});
 
         const wrapper = mount(
-            <LabeledTextField label="Label" onChange={handleChange} />,
+            <LabeledTextField label="Label" value="" onChange={handleChange} />,
         );
 
         // Act
@@ -220,7 +245,12 @@ describe("LabeledTextField", () => {
         );
 
         const wrapper = mount(
-            <LabeledTextField label="Label" onKeyDown={handleKeyDown} />,
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                onKeyDown={handleKeyDown}
+            />,
         );
 
         // Act
@@ -236,7 +266,12 @@ describe("LabeledTextField", () => {
         // Arrange
         const handleFocus = jest.fn(() => {});
         const wrapper = mount(
-            <LabeledTextField label="Label" onFocus={handleFocus} />,
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                onFocus={handleFocus}
+            />,
         );
 
         // Act
@@ -251,7 +286,12 @@ describe("LabeledTextField", () => {
         // Arrange
         const handleBlur = jest.fn(() => {});
         const wrapper = mount(
-            <LabeledTextField label="Label" onBlur={handleBlur} />,
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                onBlur={handleBlur}
+            />,
         );
 
         // Act
@@ -270,7 +310,12 @@ describe("LabeledTextField", () => {
 
         // Act
         const wrapper = mount(
-            <LabeledTextField label="Label" placeholder={placeholder} />,
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                placeholder={placeholder}
+            />,
         );
 
         // Assert
@@ -284,7 +329,14 @@ describe("LabeledTextField", () => {
         // Arrange
 
         // Act
-        const wrapper = mount(<LabeledTextField label="Label" light={true} />);
+        const wrapper = mount(
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                light={true}
+            />,
+        );
 
         // Assert
         const textField = wrapper.find("TextFieldInternal");
@@ -302,7 +354,12 @@ describe("LabeledTextField", () => {
 
         // Act
         const wrapper = mount(
-            <LabeledTextField label="Label" style={styles.style1} />,
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                style={styles.style1}
+            />,
         );
 
         // Assert
@@ -316,7 +373,12 @@ describe("LabeledTextField", () => {
 
         // Act
         const wrapper = mount(
-            <LabeledTextField label="Label" testId={testId} />,
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                testId={testId}
+            />,
         );
 
         // Assert

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -32,9 +32,9 @@ type Props = {|
     description?: string | React.Element<Typography>,
 
     /**
-     * The initial input value.
+     * The input value.
      */
-    initialValue?: string,
+    value: string,
 
     /**
      * Makes a read-only input field that cannot be focused. Defaults to false.
@@ -55,7 +55,7 @@ type Props = {|
     /**
      * Called when the value has changed.
      */
-    onChange?: (newValue: string) => mixed,
+    onChange: (newValue: string) => mixed,
 
     /**
      * Called when a key is pressed.
@@ -106,11 +106,6 @@ type DefaultProps = {|
 
 type State = {|
     /**
-     * The value of the input.
-     */
-    value: string,
-
-    /**
      * Displayed when the validation fails.
      */
     error: ?string,
@@ -139,7 +134,6 @@ class LabeledTextFieldInternal extends React.Component<
     constructor(props: PropsWithForwardRef) {
         super(props);
         this.state = {
-            value: props.initialValue || "",
             error: null,
             focused: false,
         };
@@ -150,15 +144,6 @@ class LabeledTextFieldInternal extends React.Component<
         this.setState({error: errorMessage}, () => {
             if (onValidate) {
                 onValidate(errorMessage);
-            }
-        });
-    };
-
-    handleChange: (newValue: string) => mixed = (newValue) => {
-        const {onChange} = this.props;
-        this.setState({value: newValue}, () => {
-            if (onChange) {
-                onChange(newValue);
             }
         });
     };
@@ -191,8 +176,10 @@ class LabeledTextFieldInternal extends React.Component<
             type,
             label,
             description,
+            value,
             disabled,
             validate,
+            onChange,
             onKeyDown,
             placeholder,
             light,
@@ -216,12 +203,12 @@ class LabeledTextFieldInternal extends React.Component<
                                 }
                                 testId={testId && `${testId}-field`}
                                 type={type}
-                                value={this.state.value}
+                                value={value}
                                 placeholder={placeholder}
                                 disabled={disabled}
                                 validate={validate}
                                 onValidate={this.handleValidate}
-                                onChange={this.handleChange}
+                                onChange={onChange}
                                 onKeyDown={onKeyDown}
                                 onFocus={this.handleFocus}
                                 onBlur={this.handleBlur}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.md
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.md
@@ -6,6 +6,13 @@ Text
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "Khan",
+        };
+    }
+
     handleKeyDown(event) {
         if (event.key === "Enter") {
             event.currentTarget.blur();
@@ -17,7 +24,8 @@ class LabeledTextFieldExample extends React.Component {
             <LabeledTextField
                 label="Name"
                 description="Please enter your name"
-                initialValue="Khan"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
                 placeholder="Name"
                 onKeyDown={this.handleKeyDown}
             />
@@ -34,6 +42,13 @@ Number
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "18",
+        };
+    }
+
     handleKeyDown(event) {
         if (event.key === "Enter") {
             event.currentTarget.blur();
@@ -46,7 +61,8 @@ class LabeledTextFieldExample extends React.Component {
                 label="Age"
                 type="number"
                 description="Please enter your age"
-                initialValue="18"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
                 placeholder="Age"
                 onKeyDown={this.handleKeyDown}
             />
@@ -63,6 +79,13 @@ Password
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "Password123",
+        };
+    }
+
     validate(value) {
         if (value.length < 8) {
             return "Password must be at least 8 characters long";
@@ -84,7 +107,8 @@ class LabeledTextFieldExample extends React.Component {
                 label="Password"
                 type="password"
                 description="Please enter a secure password"
-                initialValue="Password123"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
                 placeholder="Password"
                 validate={this.validate}
                 onKeyDown={this.handleKeyDown}
@@ -102,6 +126,13 @@ Email
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "khan@khan.org",
+        };
+    }
+
     validate(value) {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
@@ -121,7 +152,8 @@ class LabeledTextFieldExample extends React.Component {
                 label="Email"
                 type="email"
                 description="Please provide your personal email"
-                initialValue="khan@khan.org"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
                 placeholder="Email"
                 validate={this.validate}
                 onKeyDown={this.handleKeyDown}
@@ -139,6 +171,13 @@ Telephone
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "123-456-7890",
+        };
+    }
+
     validate(value) {
         const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
         if (!telRegex.test(value)) {
@@ -158,7 +197,8 @@ class LabeledTextFieldExample extends React.Component {
                 label="Telephone"
                 type="tel"
                 description="Please provide your personal phone number"
-                initialValue="123-456-7890"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
                 placeholder="Telephone"
                 validate={this.validate}
                 onKeyDown={this.handleKeyDown}
@@ -176,6 +216,13 @@ The field can have an error
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 
 class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "khan",
+        };
+    }
+
     validate(value) {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
@@ -195,7 +242,8 @@ class LabeledTextFieldExample extends React.Component {
                 label="Email"
                 type="email"
                 description="Please enter your personal email"
-                initialValue="khan"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
                 placeholder="Email"
                 validate={this.validate}
                 onKeyDown={this.handleKeyDown}
@@ -215,6 +263,8 @@ import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 <LabeledTextField
     label="Name"
     description="Please enter your name"
+    value=""
+    onChange={() => {}}
     placeholder="Name"
     disabled={true}
 />
@@ -231,6 +281,13 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {StyleSheet} from "aphrodite";
 
 class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "",
+        };
+    }
+
     handleKeyDown(event) {
         if (event.key === "Enter") {
             event.currentTarget.blur();
@@ -249,6 +306,8 @@ class LabeledTextFieldExample extends React.Component {
                             Please enter your name
                         </LabelSmall>
                     }
+                    value={this.state.value}
+                    onChange={(newValue) => this.setState({value: newValue})}
                     placeholder="Name"
                     light={true}
                     onKeyDown={this.handleKeyDown}
@@ -282,6 +341,13 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 
 class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "Khan",
+        };
+    }
+
     handleKeyDown(event) {
         if (event.key === "Enter") {
             event.currentTarget.blur();
@@ -293,7 +359,8 @@ class LabeledTextFieldExample extends React.Component {
             <LabeledTextField
                 label="Name"
                 description="Please enter your name"
-                initialValue="Khan"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
                 placeholder="Name"
                 style={styles.customField}
                 onKeyDown={this.handleKeyDown}
@@ -330,6 +397,9 @@ import {StyleSheet} from "aphrodite";
 class LabeledTextFieldExample extends React.Component {
     constructor(props) {
         super(props);
+        this.state = {
+            value: "Khan",
+        };
         this.inputRef = React.createRef();
         this.handleSubmit = this.handleSubmit.bind(this);
     }
@@ -352,7 +422,8 @@ class LabeledTextFieldExample extends React.Component {
                 <LabeledTextField
                     label="Name"
                     description="Please enter your name"
-                    initialValue="Khan"
+                    value={this.state.value}
+                    onChange={(newValue) => this.setState({value: newValue})}
                     placeholder="Name"
                     onKeyDown={this.handleKeyDown}
                     ref={this.inputRef}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
@@ -17,6 +17,8 @@ export default {
 };
 
 export const text: StoryComponentType = () => {
+    const [value, setValue] = React.useState("Khan");
+
     const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
         if (event.key === "Enter") {
             event.currentTarget.blur();
@@ -27,7 +29,8 @@ export const text: StoryComponentType = () => {
         <LabeledTextField
             label="Name"
             description="Please enter your name"
-            initialValue="Khan"
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             placeholder="Name"
             onKeyDown={handleKeyDown}
         />
@@ -35,6 +38,8 @@ export const text: StoryComponentType = () => {
 };
 
 export const number: StoryComponentType = () => {
+    const [value, setValue] = React.useState("18");
+
     const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
         if (event.key === "Enter") {
             event.currentTarget.blur();
@@ -46,7 +51,8 @@ export const number: StoryComponentType = () => {
             label="Age"
             type="number"
             description="Please enter your age"
-            initialValue="18"
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             placeholder="Age"
             onKeyDown={handleKeyDown}
         />
@@ -54,6 +60,8 @@ export const number: StoryComponentType = () => {
 };
 
 export const password: StoryComponentType = () => {
+    const [value, setValue] = React.useState("Password123");
+
     const validate = (value: string) => {
         if (value.length < 8) {
             return "Password must be at least 8 characters long";
@@ -74,7 +82,8 @@ export const password: StoryComponentType = () => {
             label="Password"
             type="password"
             description="Please enter a secure password"
-            initialValue="Password123"
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             placeholder="Password"
             validate={validate}
             onKeyDown={handleKeyDown}
@@ -83,6 +92,8 @@ export const password: StoryComponentType = () => {
 };
 
 export const email: StoryComponentType = () => {
+    const [value, setValue] = React.useState("khan@khan.org");
+
     const validate = (value: string) => {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
@@ -100,7 +111,8 @@ export const email: StoryComponentType = () => {
         <LabeledTextField
             label="Email"
             type="email"
-            initialValue="khan@khan.org"
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             description="Please provide your personal email"
             placeholder="Email"
             validate={validate}
@@ -110,6 +122,8 @@ export const email: StoryComponentType = () => {
 };
 
 export const telephone: StoryComponentType = () => {
+    const [value, setValue] = React.useState("123-456-7890");
+
     const validate = (value: string) => {
         const telRegex = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
         if (!telRegex.test(value)) {
@@ -127,7 +141,8 @@ export const telephone: StoryComponentType = () => {
         <LabeledTextField
             label="Telephone"
             type="tel"
-            initialValue="123-456-7890"
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             description="Please provide your personal phone number"
             placeholder="Telephone"
             validate={validate}
@@ -137,6 +152,8 @@ export const telephone: StoryComponentType = () => {
 };
 
 export const error: StoryComponentType = () => {
+    const [value, setValue] = React.useState("khan");
+
     const validate = (value: string) => {
         const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
         if (!emailRegex.test(value)) {
@@ -154,7 +171,8 @@ export const error: StoryComponentType = () => {
         <LabeledTextField
             label="Email"
             type="email"
-            initialValue="khan"
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             description="Please provide your personal email"
             placeholder="Email"
             validate={validate}
@@ -167,12 +185,16 @@ export const disabled: StoryComponentType = () => (
     <LabeledTextField
         label="Name"
         description="Please enter your name"
+        value=""
+        onChange={() => {}}
         placeholder="Name"
         disabled={true}
     />
 );
 
 export const light: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+
     const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
         if (event.key === "Enter") {
             event.currentTarget.blur();
@@ -190,6 +212,8 @@ export const light: StoryComponentType = () => {
                         Please enter your name
                     </LabelSmall>
                 }
+                value={value}
+                onChange={(newValue) => setValue(newValue)}
                 placeholder="Name"
                 light={true}
                 onKeyDown={handleKeyDown}
@@ -199,6 +223,8 @@ export const light: StoryComponentType = () => {
 };
 
 export const customStyle: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+
     const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
         if (event.key === "Enter") {
             event.currentTarget.blur();
@@ -209,6 +235,8 @@ export const customStyle: StoryComponentType = () => {
         <LabeledTextField
             label="Name"
             description="Please enter your name"
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
             placeholder="Name"
             style={styles.customField}
             onKeyDown={handleKeyDown}
@@ -217,6 +245,7 @@ export const customStyle: StoryComponentType = () => {
 };
 
 export const ref: StoryComponentType = () => {
+    const [value, setValue] = React.useState("Khan");
     const inputRef = React.createRef<HTMLInputElement>();
 
     const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
@@ -236,7 +265,8 @@ export const ref: StoryComponentType = () => {
             <LabeledTextField
                 label="Name"
                 description="Please enter your name"
-                initialValue="Khan"
+                value={value}
+                onChange={(newValue) => setValue(newValue)}
                 placeholder="Name"
                 onKeyDown={handleKeyDown}
                 ref={inputRef}


### PR DESCRIPTION
## Summary:
Changed `LabeledTextField` to behave as a controlled component. Now, the `value` and `onChange` props are **required**.
The `LabeledTextField` no longer has its `initialValue` prop, so the `npm` upgrade should be a major change.

**Note:** See issue for details on why `LabeledTextField` was changed to a controlled component.

Issue: https://khanacademy.atlassian.net/browse/WB-1083

## Test plan:
1. View the examples on Styleguidist and React Storybook for `LabeledTextField` under "Form / LabeledTextField"
2. View the code examples to see the new API for the `LabeledTextField`.