### PR TITLE
WB-1086 - Make LabeledTextField's `style` prop Apply to FieldHeading

### DIFF
--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from "react";
 import {mount} from "enzyme";
+import {StyleSheet} from "aphrodite";
 
 import FieldHeading from "../field-heading.js";
 import TextField from "../text-field.js";
@@ -153,5 +154,29 @@ describe("FieldHeading", () => {
         // Assert
         const error = wrapper.find(`[data-test-id="${testId}-error"]`);
         expect(error).toContainMatchingElement(`[id="${id}-error"]`);
+    });
+
+    it("stype prop applies to the fieldheading container", () => {
+        // Arrange
+        const styles = StyleSheet.create({
+            style1: {
+                flexGrow: 1,
+                background: "blue",
+            },
+        });
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                error="Error"
+                style={styles.style1}
+            />,
+        );
+
+        // Assert
+        const container = wrapper.find("View").at(0);
+        expect(container).toHaveStyle(styles.style1);
     });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -360,7 +360,7 @@ describe("LabeledTextField", () => {
         expect(textField).toHaveProp("light", true);
     });
 
-    it("style prop is passed to textfield", async () => {
+    it("style prop is passed to fieldheading", async () => {
         // Arrange
         const styles = StyleSheet.create({
             style1: {
@@ -380,8 +380,8 @@ describe("LabeledTextField", () => {
         );
 
         // Assert
-        const textField = wrapper.find("TextFieldInternal");
-        expect(textField).toHaveStyle(styles.style1);
+        const fieldHeading = wrapper.find("FieldHeading");
+        expect(fieldHeading).toHaveStyle(styles.style1);
     });
 
     it("testId prop is passed to textfield", async () => {

--- a/packages/wonder-blocks-form/src/components/field-heading.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, type StyleType} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
@@ -32,6 +32,11 @@ type Props = {|
      * The message for the error element.
      */
     error?: string | React.Element<Typography>,
+
+    /**
+     * Custom styles for the field heading container.
+     */
+    style?: StyleType,
 
     /**
      * A unique id to link the label (and optional error) to the field.
@@ -125,10 +130,10 @@ export default class FieldHeading extends React.Component<Props> {
     }
 
     render(): React.Node {
-        const {field} = this.props;
+        const {field, style} = this.props;
 
         return (
-            <View>
+            <View style={style}>
                 {this.renderLabel()}
                 {this.maybeRenderDescription()}
                 <Strut size={Spacing.xSmall_8} />

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -84,6 +84,15 @@ type Props = {|
 
     /**
      * Custom styles for the container.
+     *
+     * Note: This style is passed to the field heading container
+     * due to scenarios where we would like to set a specific
+     * width for the text field. If we apply the style directly
+     * to the text field, the container would not be affected.
+     * For example, setting text field to "width: 50%" would not
+     * affect the container since text field is a child of the container.
+     * In this case, the container would maintain its width ocuppying
+     * unnecessary space when the text field is smaller.
      */
     style?: StyleType,
 

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -83,7 +83,7 @@ type Props = {|
     light: boolean,
 
     /**
-     * Custom styles for the TextField component.
+     * Custom styles for the container.
      */
     style?: StyleType,
 
@@ -194,6 +194,7 @@ class LabeledTextFieldInternal extends React.Component<
                     <FieldHeading
                         id={uniqueId}
                         testId={testId}
+                        style={style}
                         field={
                             <TextField
                                 id={`${uniqueId}-field`}
@@ -213,7 +214,6 @@ class LabeledTextFieldInternal extends React.Component<
                                 onFocus={this.handleFocus}
                                 onBlur={this.handleBlur}
                                 light={light}
-                                style={style}
                                 ref={forwardedRef}
                             />
                         }

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.md
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.md
@@ -333,6 +333,71 @@ const styles = StyleSheet.create({
 <LabeledTextFieldExample />
 ```
 
+The field container can have a style
+
+```js
+import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {StyleSheet} from "aphrodite";
+
+class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            firstName: "",
+            lastName: "",
+        };
+    }
+
+    handleKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    render() {
+        return (
+            <View style={styles.row}>
+                <LabeledTextField
+                    label="First name"
+                    description="Please enter your first name"
+                    placeholder="Khan"
+                    value={this.state.firstName}
+                    onChange={(newValue) => this.setState({firstName: newValue})}
+                    placeholder="Khan"
+                    style={styles.grow}
+                    onKeyDown={this.handleKeyDown}
+                />
+                <Strut size={Spacing.xLarge_32} />
+                <LabeledTextField
+                    label="Last name"
+                    description="Please enter your last name"
+                    placeholder="Academy"
+                    value={this.state.lastName}
+                    onChange={(newValue) => this.setState({lastName: newValue})}
+                    placeholder="Academy"
+                    style={styles.grow}
+                    onKeyDown={this.handleKeyDown}
+                />
+            </View>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+    },
+    grow: {
+        flexGrow: 1,
+    },
+});
+
+<LabeledTextFieldExample />
+```
+
 The field forwards its ref to the input
 
 ```js

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.md
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.md
@@ -333,57 +333,6 @@ const styles = StyleSheet.create({
 <LabeledTextFieldExample />
 ```
 
-The field can have custom styles
-
-```js
-import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
-import {StyleSheet} from "aphrodite";
-import Color from "@khanacademy/wonder-blocks-color";
-
-class LabeledTextFieldExample extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            value: "Khan",
-        };
-    }
-
-    handleKeyDown(event) {
-        if (event.key === "Enter") {
-            event.currentTarget.blur();
-        }
-    }
-
-    render() {
-        return (
-            <LabeledTextField
-                label="Name"
-                description="Please enter your name"
-                value={this.state.value}
-                onChange={(newValue) => this.setState({value: newValue})}
-                placeholder="Name"
-                style={styles.customField}
-                onKeyDown={this.handleKeyDown}
-            />
-        );
-    }
-}
-
-const styles = StyleSheet.create({
-    customField: {
-        backgroundColor: Color.darkBlue,
-        color: Color.white,
-        border: "none",
-        maxWidth: 250,
-        "::placeholder": {
-            color: Color.white64,
-        },
-    },
-});
-
-<LabeledTextFieldExample />
-```
-
 The field forwards its ref to the input
 
 ```js

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
@@ -222,28 +222,6 @@ export const light: StoryComponentType = () => {
     );
 };
 
-export const customStyle: StoryComponentType = () => {
-    const [value, setValue] = React.useState("");
-
-    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
-        if (event.key === "Enter") {
-            event.currentTarget.blur();
-        }
-    };
-
-    return (
-        <LabeledTextField
-            label="Name"
-            description="Please enter your name"
-            value={value}
-            onChange={(newValue) => setValue(newValue)}
-            placeholder="Name"
-            style={styles.customField}
-            onKeyDown={handleKeyDown}
-        />
-    );
-};
-
 export const ref: StoryComponentType = () => {
     const [value, setValue] = React.useState("Khan");
     const inputRef = React.createRef<HTMLInputElement>();
@@ -289,15 +267,6 @@ const styles = StyleSheet.create({
     },
     offWhiteColor: {
         color: Color.white64,
-    },
-    customField: {
-        backgroundColor: Color.darkBlue,
-        color: Color.white,
-        border: "none",
-        maxWidth: 250,
-        "::placeholder": {
-            color: Color.white64,
-        },
     },
     button: {
         maxWidth: 150,

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
@@ -222,6 +222,41 @@ export const light: StoryComponentType = () => {
     );
 };
 
+export const customStyle: StoryComponentType = () => {
+    const [firstName, setFirstName] = React.useState("");
+    const [lastName, setLastName] = React.useState("");
+
+    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <View style={styles.row}>
+            <LabeledTextField
+                label="First name"
+                description="Please enter your first name"
+                value={firstName}
+                onChange={(newValue) => setFirstName(newValue)}
+                placeholder="Khan"
+                style={styles.grow}
+                onKeyDown={handleKeyDown}
+            />
+            <Strut size={Spacing.xLarge_32} />
+            <LabeledTextField
+                label="Last name"
+                description="Please enter your last name"
+                value={lastName}
+                onChange={(newValue) => setLastName(newValue)}
+                placeholder="Academy"
+                style={styles.grow}
+                onKeyDown={handleKeyDown}
+            />
+        </View>
+    );
+};
+
 export const ref: StoryComponentType = () => {
     const [value, setValue] = React.useState("Khan");
     const inputRef = React.createRef<HTMLInputElement>();
@@ -270,5 +305,11 @@ const styles = StyleSheet.create({
     },
     button: {
         maxWidth: 150,
+    },
+    row: {
+        flexDirection: "row",
+    },
+    grow: {
+        flexGrow: 1,
     },
 });


### PR DESCRIPTION
## Summary:
Currently, the style prop on `LabeledTextField` applies to the internal `TextField` element.
Due to problems with trying to set width, margin, padding, etc., to the entire `FieldHeading` container,
we would like to instead have the style prop apply to the FieldHeading container.

Issue: https://khanacademy.atlassian.net/browse/WB-1086

## Test plan:
- Added unit tests to ensure `LabeledTextField`'s style is passed to FieldHeading
- Tested examples where setting flexGrow applies to the entire FieldHeading container