### PR TITLE
Fix SSR bug that would clear hydration cache incorrectly

### DIFF
--- a/packages/wonder-blocks-data/src/util/response-cache.js
+++ b/packages/wonder-blocks-data/src/util/response-cache.js
@@ -158,9 +158,14 @@ export class ResponseCache {
             handler,
         ).retrieve(handler, options);
 
-        // If we hydrated something that the custom cache didn't have,
-        // we need to make sure the custom cache contains that value.
-        if (handler.cache != null && internalEntry != null) {
+        // If we are not server-side and we hydrated something that the custom
+        // cache didn't have, we need to make sure the custom cache contains
+        // that value.
+        if (
+            this._ssrOnlyCache == null &&
+            handler.cache != null &&
+            internalEntry != null
+        ) {
             // Yes, if this throws, we will have a problem. We want that.
             // Bad cache implementations should be overt.
             handler.cache.store(handler, options, internalEntry);


### PR DESCRIPTION
## Summary:
Before this change, rendering data repeatedly in SSR with WB Data and a handler with a custom client-side cache would cause data to be erased from the hydration cache. This was not what we wanted. This simple bug fix addresses that bug.

Issue: FEI-3701

## Test plan:
`yarn test`

I'll be putting this into webapp and it will be clear real quick from content and test prep pages if this is working or not.