### PR TITLE
Add ability to query if there are unfulfilled requests

### DIFF
--- a/packages/wonder-blocks-data/src/components/internal-data.js
+++ b/packages/wonder-blocks-data/src/components/internal-data.js
@@ -209,7 +209,7 @@ export default class InternalData<
         const result = this._resultFromState();
         // We only track data requests when we are server-side and we don't
         // already have a result. The existence of a result is indicated by the
-        // loading flag being true.
+        // loading flag being false.
         if (result.loading && Server.isServerSide()) {
             return this._renderWithTrackingContext(result);
         }

--- a/packages/wonder-blocks-data/src/components/internal-data.js
+++ b/packages/wonder-blocks-data/src/components/internal-data.js
@@ -207,6 +207,9 @@ export default class InternalData<
 
     render(): React.Node {
         const result = this._resultFromState();
+        // We only track data requests when we are server-side and we don't
+        // already have a result. The existence of a result is indicated by the
+        // loading flag being true.
         if (result.loading && Server.isServerSide()) {
             return this._renderWithTrackingContext(result);
         }

--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -1,4 +1,5 @@
 // @flow
+import {Server} from "@khanacademy/wonder-blocks-core";
 import {ResponseCache as ResCache} from "./util/response-cache.js";
 import {RequestTracker} from "./util/request-tracking.js";
 
@@ -21,8 +22,21 @@ export type {
 export const initializeCache = (source: ResponseCache): void =>
     ResCache.Default.initialize(source);
 
-export const fulfillAllDataRequests = (): Promise<ResponseCache> =>
-    RequestTracker.Default.fulfillTrackedRequests();
+export const fulfillAllDataRequests = (): Promise<ResponseCache> => {
+    if (!Server.isServerSide()) {
+        return Promise.reject(
+            new Error("Data requests are not tracked when client-side"),
+        );
+    }
+    return RequestTracker.Default.fulfillTrackedRequests();
+};
+
+export const hasUnfulfilledRequests = (): boolean => {
+    if (!Server.isServerSide()) {
+        throw new Error("Data requests are not tracked when client-side");
+    }
+    return RequestTracker.Default.hasUnfulfilledRequests;
+};
 
 export const removeFromCache = <TOptions, TData: ValidData>(
     handler: IRequestHandler<TOptions, TData>,

--- a/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
@@ -142,6 +142,62 @@ describe("../request-tracking.js", () => {
             });
         });
 
+        describe("#hasUnfulfilledRequests", () => {
+            it("should return false if no requests have been tracked", () => {
+                // Arrange
+                const requestTracker = createRequestTracker();
+
+                // Act
+                const result = requestTracker.hasUnfulfilledRequests;
+
+                // Assert
+                expect(result).toBe(false);
+            });
+
+            it("should return true if there are requests waiting to be fulfilled", () => {
+                // Arrange
+                const requestTracker = createRequestTracker();
+                const fakeHandler: IRequestHandler<any, any> = {
+                    fulfillRequest: jest.fn(),
+                    getKey: jest.fn().mockReturnValue("MY_KEY"),
+                    shouldRefreshCache: () => false,
+                    type: "MY_TYPE",
+                    cache: null,
+                    hydrate: true,
+                };
+                const options = {these: "are options"};
+                requestTracker.trackDataRequest(fakeHandler, options);
+
+                // Act
+                const result = requestTracker.hasUnfulfilledRequests;
+
+                // Assert
+                expect(result).toBe(true);
+            });
+
+            it("should return false if all tracked requests have been fulfilled", () => {
+                // Arrange
+                const requestTracker = createRequestTracker();
+                const fakeHandler: IRequestHandler<any, any> = {
+                    fulfillRequest: jest.fn().mockResolvedValue(5),
+                    getKey: jest.fn().mockReturnValue("MY_KEY"),
+                    shouldRefreshCache: () => false,
+                    type: "MY_TYPE",
+                    cache: null,
+                    hydrate: true,
+                };
+                const options = {these: "are options"};
+                requestTracker.trackDataRequest(fakeHandler, options);
+                requestTracker.fulfillTrackedRequests();
+
+                // Act
+                const result = requestTracker.hasUnfulfilledRequests;
+
+                // Assert
+                expect(result).toBe(false);
+            });
+        });
+
         describe("#fulfillTrackedRequests", () => {
             it("should return an empty cache if no requests tracked", async () => {
                 // Arrange

--- a/packages/wonder-blocks-data/src/util/request-tracking.js
+++ b/packages/wonder-blocks-data/src/util/request-tracking.js
@@ -99,6 +99,13 @@ export class RequestTracker {
     };
 
     /**
+     * Indicates if we have requests waiting to be fulfilled.
+     */
+    get hasUnfulfilledRequests(): boolean {
+        return Object.keys(this._trackedRequests).length > 0;
+    }
+
+    /**
      * Initiate fulfillment of all tracked requests.
      *
      * This loops over the requests that were tracked using TrackData, and asks


### PR DESCRIPTION
## Summary:
Now that WonderBlocks is responsible for cached queries, it is important that we support repeated render loops to get all the data requests. React Apollo's getDataFromTree handled this with its own render loop. Since we already have a
render loop in WebApp, we need to know when to stop looping in order to recreate similar behavior. We already do this for PageSettings by checking if anymore changes got made in the previous render and for loadables by checking for pending loadables. This adds the ability to check if we have pending tracked data requests.

Once this is in webapp, we can update the render loop to incorporate WB Data fulfillment rather that it only occurring once after a single tracking cycle.

Issue: FEI-3701

## Test plan:
`yarn test`

Incorporate into webapp, modify rendering to include WB Data fulfillment and tracking in the render loop, and update snapshots. They should then resemble the snapshots from before the move off React Apollo.