### PR TITLE
WB-1088 - Add `autocomplete` and `readonly` Props to TextField and LabeledTextField

### DIFF
--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -402,4 +402,41 @@ describe("LabeledTextField", () => {
         const textField = wrapper.find(`[data-test-id="${testId}-field"]`);
         expect(textField).toExist();
     });
+
+    it("readOnly prop is passed to textfield", async () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                readOnly={true}
+            />,
+        );
+
+        // Assert
+        const textField = wrapper.find("TextFieldInternal");
+        expect(textField).toHaveProp("readOnly", true);
+    });
+
+    it("autoComplete prop is passed to textfield", async () => {
+        // Arrange
+        const autoComplete = "name";
+
+        // Act
+        const wrapper = mount(
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                autoComplete={autoComplete}
+            />,
+        );
+
+        // Assert
+        const textField = wrapper.find("TextFieldInternal");
+        expect(textField).toHaveProp("autoComplete", autoComplete);
+    });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -384,4 +384,41 @@ describe("TextField", () => {
         const input = wrapper.find("input");
         expect(input).toContainMatchingElement(`[aria-label="${ariaLabel}"]`);
     });
+
+    it("readOnly prop is passed to the input element", async () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value={"Text"}
+                onChange={() => {}}
+                readOnly={true}
+            />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toHaveProp("readOnly");
+    });
+
+    it("autoComplete prop is passed to the input element", async () => {
+        // Arrange
+        const autoComplete = "name";
+
+        // Act
+        const wrapper = mount(
+            <TextField
+                id={"tf-1"}
+                value={"Text"}
+                onChange={() => {}}
+                autoComplete={autoComplete}
+            />,
+        );
+
+        // Assert
+        const input = wrapper.find("input");
+        expect(input).toHaveProp("autoComplete", autoComplete);
+    });
 });

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -100,6 +100,16 @@ type Props = {|
      * Optional test ID for e2e testing.
      */
     testId?: string,
+
+    /**
+     * Specifies if the TextField is read-only.
+     */
+    readOnly?: boolean,
+
+    /**
+     * Specifies if the TextField allows autocomplete.
+     */
+    autoComplete?: string,
 |};
 
 type PropsWithForwardRef = {|
@@ -194,6 +204,8 @@ class LabeledTextFieldInternal extends React.Component<
             light,
             style,
             testId,
+            readOnly,
+            autoComplete,
             forwardedRef,
         } = this.props;
 
@@ -223,6 +235,8 @@ class LabeledTextFieldInternal extends React.Component<
                                 onFocus={this.handleFocus}
                                 onBlur={this.handleBlur}
                                 light={light}
+                                readOnly={readOnly}
+                                autoComplete={autoComplete}
                                 ref={forwardedRef}
                             />
                         }

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.md
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.md
@@ -459,3 +459,77 @@ const styles = StyleSheet.create({
 
 <LabeledTextFieldExample />
 ```
+
+The field can be read-only
+
+```js
+import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
+
+class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "Khan",
+        };
+    }
+
+    handleKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    render() {
+        return (
+            <LabeledTextField
+                label="Name"
+                description="Please enter your name"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
+                placeholder="Name"
+                onKeyDown={this.handleKeyDown}
+                readOnly={true}
+            />
+        );
+    }
+}
+
+<LabeledTextFieldExample />
+```
+
+The field can have specific autocomplete
+
+```js
+import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
+
+class LabeledTextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "",
+        };
+    }
+
+    handleKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    render() {
+        return (
+            <LabeledTextField
+                label="Name"
+                description="Please enter your name"
+                value={this.state.value}
+                onChange={(newValue) => this.setState({value: newValue})}
+                placeholder="Name"
+                onKeyDown={this.handleKeyDown}
+                autoComplete="name"
+            />
+        );
+    }
+}
+
+<LabeledTextFieldExample />
+```

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.stories.js
@@ -292,6 +292,50 @@ export const ref: StoryComponentType = () => {
     );
 };
 
+export const readOnly: StoryComponentType = () => {
+    const [value, setValue] = React.useState("Khan");
+
+    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <LabeledTextField
+            label="Read Only"
+            description="This is a read-only field."
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
+            placeholder="Name"
+            onKeyDown={handleKeyDown}
+            readOnly={true}
+        />
+    );
+};
+
+export const autoComplete: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+
+    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <LabeledTextField
+            label="Name"
+            description="Please enter your name."
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
+            placeholder="Name"
+            onKeyDown={handleKeyDown}
+            autoComplete="name"
+        />
+    );
+};
+
 const styles = StyleSheet.create({
     darkBackground: {
         background: Color.darkBlue,

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -90,6 +90,16 @@ type Props = {|
      * Optional test ID for e2e testing.
      */
     testId?: string,
+
+    /**
+     * Specifies if the input field is read-only.
+     */
+    readOnly?: boolean,
+
+    /**
+     * Specifies if the input field allows autocomplete.
+     */
+    autoComplete?: string,
 |};
 
 type PropsWithForwardRef = {|
@@ -198,6 +208,8 @@ class TextFieldInternal extends React.Component<PropsWithForwardRef, State> {
             light,
             style,
             testId,
+            readOnly,
+            autoComplete,
             forwardedRef,
             // The following props are being included here to avoid
             // passing them down to the otherProps spread
@@ -239,6 +251,8 @@ class TextFieldInternal extends React.Component<PropsWithForwardRef, State> {
                 onBlur={this.handleBlur}
                 required={required}
                 data-test-id={testId}
+                readOnly={readOnly}
+                autoComplete={autoComplete}
                 ref={forwardedRef}
                 {...otherProps}
             />

--- a/packages/wonder-blocks-form/src/components/text-field.md
+++ b/packages/wonder-blocks-form/src/components/text-field.md
@@ -682,3 +682,89 @@ const styles = StyleSheet.create({
 
 <TextFieldExample />
 ```
+
+Read Only
+
+```js
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "Khan",
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+    }
+
+    handleChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    render() {
+        return (
+            <TextField
+                id="tf-1"
+                type="text"
+                value={this.state.value}
+                placeholder="Text"
+                onChange={this.handleChange}
+                onKeyDown={this.handleKeyDown}
+                readOnly={true}
+            />
+        );
+    }
+}
+
+<TextFieldExample />
+```
+
+Autocomplete
+
+```js
+import {TextField} from "@khanacademy/wonder-blocks-form";
+
+class TextFieldExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: "",
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+    }
+
+    handleChange(newValue) {
+        this.setState({value: newValue});
+    }
+
+    handleKeyDown(event) {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    }
+
+    render() {
+        return (
+            <TextField
+                id="tf-1"
+                type="text"
+                value={this.state.value}
+                placeholder="Text"
+                onChange={this.handleChange}
+                onKeyDown={this.handleKeyDown}
+                autoComplete="name"
+            />
+        );
+    }
+}
+
+<TextFieldExample />
+```

--- a/packages/wonder-blocks-form/src/components/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/text-field.stories.js
@@ -433,6 +433,58 @@ export const ref: StoryComponentType = () => {
     );
 };
 
+export const readOnly: StoryComponentType = () => {
+    const [value, setValue] = React.useState("Khan");
+
+    const handleChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <TextField
+            id="tf-1"
+            type="text"
+            value={value}
+            placeholder="Text"
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            readOnly={true}
+        />
+    );
+};
+
+export const autoComplete: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+
+    const handleChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    return (
+        <TextField
+            id="tf-1"
+            type="text"
+            value={value}
+            placeholder="Name"
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            autoComplete="name"
+        />
+    );
+};
+
 const styles = StyleSheet.create({
     errorMessage: {
         color: Color.red,


### PR DESCRIPTION
## Summary:
Adding `autoComplete` and `readOnly` props to the `TextField` and
`LabeledTextField` components. These two props appear to be useful in
new scenarios that we are running into in Webapp in the `TextField` and
`LabeledTextField` migration.

Issue: https://khanacademy.atlassian.net/browse/WB-1088

## Test plan:
- Added unit tests to ensure the new props are in `<input/>`.
- Added examples to React Storybook and Styleguidist.