### PR TITLE
Allow setting a role of alertdialog for ModalDialog and OnePaneDialog

### DIFF
--- a/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.js
@@ -21,4 +21,22 @@ describe("OnePaneDialog", () => {
         // Assert
         expect(dialog.prop("testId")).toBe("one-pane-dialog-example");
     });
+
+    test("role can be overriden to alertdialog", () => {
+        // Arrange
+        const wrapper = mount(
+            <OnePaneDialog
+                title="Dialog with multi-step footer"
+                content="dummy content"
+                testId="one-pane-dialog-example"
+                role="alertdialog"
+            />,
+        );
+
+        // Act
+        const dialog = wrapper.find(`[role="alertdialog"]`).first();
+
+        // Assert
+        expect(dialog).toHaveLength(1);
+    });
 });

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.js
@@ -33,6 +33,13 @@ type Props = {|
     below?: React.Node,
 
     /**
+     * When set, overrides the default role value. Default role is "dialog"
+     * Roles other than dialog and alertdialog aren't appropriate for this
+     * component
+     */
+    role?: "dialog" | "alertdialog",
+
+    /**
      * Custom styles
      */
     style?: StyleType,
@@ -41,6 +48,10 @@ type Props = {|
      * Test ID used for e2e testing.
      */
     testId?: string,
+|};
+
+type DefaultProps = {|
+    role: $PropertyType<Props, "role">,
 |};
 
 /**
@@ -54,10 +65,15 @@ type Props = {|
  * the `aria-labelledby` attribute however this is recommended. It should match the `id` of the dialog title.
  */
 export default class ModalDialog extends React.Component<Props> {
+    static defaultProps: DefaultProps = {
+        role: "dialog",
+    };
+
     render(): React.Node {
         const {
             above,
             below,
+            role,
             style,
             children,
             testId,
@@ -76,7 +92,7 @@ export default class ModalDialog extends React.Component<Props> {
                         <View style={[styles.wrapper, style]}>
                             {below && <View style={styles.below}>{below}</View>}
                             <View
-                                role="dialog"
+                                role={role}
                                 aria-modal="true"
                                 aria-labelledby={ariaLabelledBy}
                                 style={styles.dialog}

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
@@ -63,6 +63,13 @@ type Common = {|
     below?: React.Node,
 
     /**
+     * When set, overrides the default role value. Default role is "dialog"
+     * Roles other than dialog and alertdialog aren't appropriate for this
+     * component
+     */
+    role?: "dialog" | "alertdialog",
+
+    /**
      * Optional custom styles.
      */
     style?: StyleType,
@@ -162,6 +169,7 @@ export default class OnePaneDialog extends React.Component<Props> {
             closeButtonVisible,
             testId,
             titleId,
+            role,
         } = this.props;
 
         return (
@@ -175,6 +183,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                                 below={below}
                                 testId={testId}
                                 aria-labelledby={uniqueId}
+                                role={role}
                             >
                                 <ModalPanel
                                     onClose={onClose}


### PR DESCRIPTION
## Summary:
Alert dialog is similar to dialog, but it cues the screen reader techologoy to announce the alert message when the modal is opened
For more context: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alertdialog_role

Issue: WB-1089

## Test plan:
`yarn test`