### PR TITLE
Remove keyboard tracking from dropdown-core so that menus can be accessed with a screen reader

### DIFF
--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -76,7 +76,6 @@ describe("DropdownCore", () => {
                     },
                 ]}
                 role="listbox"
-                keyboard={true}
                 light={false}
                 open={false}
                 // mock the opener elements
@@ -95,7 +94,6 @@ describe("DropdownCore", () => {
         const handleOpen = jest.fn();
         dropdown.setProps({
             initialFocusedIndex: 0,
-            keyboard: true,
             onOpenChanged: (open) => handleOpen(open),
             open: true,
         });
@@ -232,7 +230,6 @@ describe("DropdownCore", () => {
                         },
                     ]}
                     role="listbox"
-                    keyboard={true}
                     light={false}
                     open={true}
                     // mock the opener elements
@@ -292,7 +289,6 @@ describe("DropdownCore", () => {
         const handleOpen = jest.fn();
         dropdown.setProps({
             initialFocusedIndex: 2,
-            keyboard: true,
             onOpenChanged: (open) => handleOpen(open),
             open: true,
         });
@@ -307,43 +303,10 @@ describe("DropdownCore", () => {
         expect(document.activeElement).toBe(elementAtIndex(dropdown, 0));
     });
 
-    it("focuses correct item when opened with click, then switching to keyboard", () => {
-        dropdown.setProps({
-            initialFocusedIndex: 1,
-            keyboard: false,
-            open: true,
-        });
-
-        dropdown.simulate("keydown", {keyCode: keyCodes.down});
-        dropdown.simulate("keyup", {keyCode: keyCodes.down});
-        jest.runAllTimers();
-        expect(document.activeElement).toBe(elementAtIndex(dropdown, 1));
-    });
-
-    it("focuses correct item after clicking on option, then switching to keyboard", () => {
-        dropdown.setProps({
-            initialFocusedIndex: 0,
-            keyboard: false,
-            open: true,
-        });
-
-        const option1 = dropdown.find("OptionItem").at(1);
-
-        // Click on item at index 1
-        option1.simulate("click");
-
-        // When starting to use keyboard behavior, should move to next item
-        dropdown.simulate("keydown", {keyCode: keyCodes.down});
-        dropdown.simulate("keyup", {keyCode: keyCodes.down});
-        jest.runAllTimers();
-        expect(document.activeElement).toBe(elementAtIndex(dropdown, 2));
-    });
-
     it("focuses correct item with clicking/pressing with initial focused of not 0", () => {
         // Same as the previous test, expect initialFocusedIndex is 2 now
         dropdown.setProps({
             initialFocusedIndex: 2,
-            keyboard: false,
             open: true,
         });
 
@@ -400,7 +363,6 @@ describe("DropdownCore", () => {
                     populatedProps: {},
                 },
             ],
-            keyboard: true,
             open: true,
         });
 
@@ -423,7 +385,6 @@ describe("DropdownCore", () => {
     it("focuses correct item after different items become focusable", () => {
         dropdown.setProps({
             initialFocusedIndex: 0,
-            keyboard: true,
             open: true,
         });
 
@@ -639,7 +600,7 @@ describe("DropdownCore", () => {
                 },
             ],
         });
-        // SearchTextInput should be focused (since keyboard is true)
+        // SearchTextInput should be focused
         const searchInput = dropdown.find(SearchTextInput);
         jest.runAllTimers();
 
@@ -677,7 +638,7 @@ describe("DropdownCore", () => {
             ],
             open: true,
         });
-        // SearchTextInput should be focused (since keyboard is true)
+        // SearchTextInput should be focused
         const searchInput = dropdown.find(SearchTextInput).find("input");
         jest.runAllTimers();
         expect(document.activeElement).toBe(elementAtIndex(dropdown, 0));

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -315,7 +315,7 @@ describe("DropdownCore", () => {
         // Click on item at index 1
         option1.simulate("click");
 
-        // When starting to use keyboard behavior, should move to next item
+        // should move to next item
         dropdown.simulate("keydown", {keyCode: keyCodes.down});
         dropdown.simulate("keyup", {keyCode: keyCodes.down});
         jest.runAllTimers();

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
@@ -379,9 +379,6 @@ describe("MultiSelect", () => {
             .find(OptionItem)
             .at(2)
             .find(ClickableBehavior);
-        // The focus is on opener. Press up (or down) should focus the input
-        select.simulate("keydown", {keyCode: keyCodes.up});
-        select.simulate("keyup", {keyCode: keyCodes.up});
         jest.runAllTimers();
         expect(searchInput.state("focused")).toBe(true);
 
@@ -400,9 +397,6 @@ describe("MultiSelect", () => {
         select.setState({open: true});
         const searchInput = select.find(SearchTextInput);
         const selectAll = select.find(ActionItem).at(0).find(ClickableBehavior);
-        // The focus is on opener. Press up (or down) should focus the input
-        select.simulate("keydown", {keyCode: keyCodes.down});
-        select.simulate("keyup", {keyCode: keyCodes.down});
         jest.runAllTimers();
         expect(searchInput.state("focused")).toBe(true);
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -55,7 +55,7 @@ describe("SingleSelect", () => {
                 expect(screen.queryByRole("listbox")).toBeInTheDocument();
             });
 
-            it("the opener should keep the focus after opening", () => {
+            it("should focus the first item in the dropdown", () => {
                 // Arrange
                 render(uncontrolledSingleSelect);
                 const opener = screen.getByText("Choose");
@@ -63,7 +63,9 @@ describe("SingleSelect", () => {
                 // Act
                 userEvent.click(opener);
 
-                expect(screen.getByRole("button")).toHaveFocus();
+                // Assert
+                const options = screen.getAllByRole("option");
+                expect(options[0]).toHaveFocus();
             });
 
             it("should close when clicking on the default opener a second time", () => {

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.js
@@ -94,10 +94,6 @@ type State = {|
      * Whether or not the dropdown is open.
      */
     opened: boolean,
-    /**
-     * Whether or not last open state change was triggered by a keyboard click.
-     */
-    keyboard?: boolean,
 |};
 
 type DefaultProps = {|
@@ -117,7 +113,6 @@ export default class ActionMenu extends React.Component<Props, State> {
     };
 
     state: State = {
-        keyboard: false,
         opened: false,
     };
 
@@ -145,13 +140,9 @@ export default class ActionMenu extends React.Component<Props, State> {
         }
     };
 
-    handleOpenChanged: (opened: boolean, keyboard?: boolean) => void = (
-        opened,
-        keyboard,
-    ) => {
+    handleOpenChanged: (opened: boolean) => void = (opened) => {
         this.setState({
             opened,
-            keyboard,
         });
 
         if (this.props.onToggle) {
@@ -231,7 +222,7 @@ export default class ActionMenu extends React.Component<Props, State> {
     };
 
     handleClick: (e: SyntheticEvent<>) => void = (e) => {
-        this.handleOpenChanged(!this.state.opened, e.type === "keyup");
+        this.handleOpenChanged(!this.state.opened);
     };
 
     renderOpener(numItems: number): React.Element<typeof DropdownOpener> {
@@ -283,7 +274,6 @@ export default class ActionMenu extends React.Component<Props, State> {
                 alignment={alignment}
                 open={this.state.opened}
                 items={items}
-                keyboard={this.state.keyboard}
                 openerElement={this.openerElement}
                 onOpenChanged={this.handleOpenChanged}
                 dropdownStyle={[styles.menuTopSpace, dropdownStyle]}

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.js
@@ -180,11 +180,6 @@ type State = {|
     open: boolean,
 
     /**
-     * Whether or not last open state change was triggered by a keyboard click.
-     */
-    keyboard?: boolean,
-
-    /**
      * The text input to filter the items by their label. Defaults to an empty
      * string.
      */
@@ -265,13 +260,9 @@ export default class MultiSelect extends React.Component<Props, State> {
         }
     }
 
-    handleOpenChanged: (opened: boolean, keyboard?: boolean) => void = (
-        opened,
-        keyboard,
-    ) => {
+    handleOpenChanged: (opened: boolean) => void = (opened) => {
         this.setState({
             open: opened,
-            keyboard,
             searchText: "",
             lastSelectedValues: this.props.selectedValues,
         });
@@ -489,7 +480,7 @@ export default class MultiSelect extends React.Component<Props, State> {
     };
 
     handleClick: (e: SyntheticEvent<>) => void = (e: SyntheticEvent<>) => {
-        this.handleOpenChanged(!this.state.open, e.type === "keyup");
+        this.handleOpenChanged(!this.state.open);
     };
 
     renderOpener(
@@ -586,7 +577,6 @@ export default class MultiSelect extends React.Component<Props, State> {
                     ...this.getShortcuts(numOptions),
                     ...filteredItems,
                 ]}
-                keyboard={this.state.keyboard}
                 light={light}
                 onOpenChanged={this.handleOpenChanged}
                 open={open}

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.js
@@ -69,7 +69,7 @@ type SelectOpenerProps = {|
     /**
      * Callback for when the SelectOpener is pressed.
      */
-    onOpenChanged: (open: boolean, keyboard: boolean) => mixed,
+    onOpenChanged: (open: boolean) => mixed,
 
     /**
      * Whether the dropdown is open.
@@ -100,7 +100,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
 
     handleClick: (e: SyntheticEvent<>) => void = (e) => {
         const {open} = this.props;
-        this.props.onOpenChanged(!open, e.type === "keyup");
+        this.props.onOpenChanged(!open);
     };
 
     render(): React.Node {

--- a/packages/wonder-blocks-dropdown/src/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.js
@@ -117,10 +117,6 @@ type State = {|
      * Whether or not the dropdown is open.
      */
     open: boolean,
-    /**
-     * Whether or not last opened state change was triggered by a keyboard click.
-     */
-    keyboard?: boolean,
 
     /**
      * The text input to filter the items by their label. Defaults to an empty
@@ -188,13 +184,9 @@ export default class SingleSelect extends React.Component<Props, State> {
         };
     }
 
-    handleOpenChanged: (opened: boolean, keyboard?: boolean) => void = (
-        opened,
-        keyboard,
-    ) => {
+    handleOpenChanged: (opened: boolean) => void = (opened) => {
         this.setState({
             open: opened,
-            keyboard,
             searchText: "",
         });
 
@@ -313,7 +305,7 @@ export default class SingleSelect extends React.Component<Props, State> {
     };
 
     handleClick: (e: SyntheticEvent<>) => void = (e) => {
-        this.handleOpenChanged(!this.state.open, e.type === "keyup");
+        this.handleOpenChanged(!this.state.open);
     };
 
     renderOpener(
@@ -409,7 +401,6 @@ export default class SingleSelect extends React.Component<Props, State> {
                 ]}
                 initialFocusedIndex={this.selectedIndex}
                 items={items}
-                keyboard={this.state.keyboard}
                 light={light}
                 onOpenChanged={this.handleOpenChanged}
                 open={this.state.open}


### PR DESCRIPTION
## Summary:
The focus events that we have for keyboard users are also important for screen readers - but screen readers generate click events that cannot be differentiated from regular click events. For that reason I removed all of the keyboard specific code and merged the click interface with the keyboard interface to the bet of my ability.

This is so that mobile screen readers can access the dropdowns. Without this change, focus is not shifted into the menu when it is opened with a screen reader, and screen reader users cannot interact with the menu.
It also greatly improves screen reader access on web. Currently dropdowns can be only accessed if the user knows to switch to the keyboard controls (enter/arrow) instead of using the screen reader controls (ie VO + enter / VO + arrow keys) which isn't a reasonable assumption to make of our users.

Issue: LP-10008

## Test plan:
yarn jest

Open a dropdown menu with a mobile screen reader (VoiceOver/Safari/iOS or TalkBack/Chrome/Android). Note that your focus jumps into the menu