### PR TITLE
Changed initialFocusedIndex on drop downs to scroll into view

### DIFF
--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -285,6 +285,96 @@ describe("DropdownCore", () => {
         expect(handleOpen.mock.calls[0][0]).toBe(true);
     });
 
+    it("selects correct item when starting off at an undefined index", () => {
+        const handleOpen = jest.fn();
+        dropdown.setProps({
+            initialFocusedIndex: undefined,
+            onOpenChanged: (open) => handleOpen(open),
+            open: true,
+        });
+
+        jest.runAllTimers();
+        expect(document.activeElement).toBe(elementAtIndex(dropdown, 0));
+    });
+
+    it("selects correct item when starting off at an undefined index and a searchbox", () => {
+        const handleOpen = jest.fn();
+        const handleSearchTextChanged = jest.fn();
+        dropdown.setProps({
+            initialFocusedIndex: undefined,
+            onOpenChanged: (open) => handleOpen(open),
+            searchText: "",
+            items: [
+                {
+                    component: (
+                        <SearchTextInput
+                            testId="item-0"
+                            key="search-text-input"
+                            onChange={handleSearchTextChanged}
+                            searchText={""}
+                        />
+                    ),
+                    focusable: true,
+                    populatedProps: {},
+                },
+            ],
+            open: true,
+        });
+        jest.runAllTimers();
+        expect(document.activeElement).toBe(elementAtIndex(dropdown, 0));
+    });
+
+    it("selects correct item when starting off at a different index and a searchbox", () => {
+        const handleOpen = jest.fn();
+        const handleSearchTextChanged = jest.fn();
+        dropdown.setProps({
+            initialFocusedIndex: 1,
+            onOpenChanged: (open) => handleOpen(open),
+            searchText: "",
+            items: [
+                {
+                    component: (
+                        <SearchTextInput
+                            testId="search"
+                            key="search-text-input"
+                            onChange={handleSearchTextChanged}
+                            searchText={""}
+                        />
+                    ),
+                    focusable: true,
+                    populatedProps: {},
+                },
+                {
+                    component: (
+                        <OptionItem
+                            testId="item-0"
+                            label="item 1"
+                            value="1"
+                            key="1"
+                        />
+                    ),
+                    focusable: false,
+                    populatedProps: {},
+                },
+                {
+                    component: (
+                        <OptionItem
+                            testId="item-1"
+                            label="item 2"
+                            value="2"
+                            key="2"
+                        />
+                    ),
+                    focusable: true,
+                    populatedProps: {},
+                },
+            ],
+            open: true,
+        });
+        jest.runAllTimers();
+        expect(document.activeElement).toBe(elementAtIndex(dropdown, 1));
+    });
+
     it("selects correct item when starting off at a different index", () => {
         const handleOpen = jest.fn();
         dropdown.setProps({

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
@@ -57,7 +57,10 @@ type State = {|
 |};
 
 /**
- * Maximum visible items inside the dropdown list
+ * Maximum visible items inside the dropdown list.
+ * Based on the defined height that we're using, this is the maximium
+ * number of items that can fit into the visible porition of the
+ * dropdowns list box.
  */
 const MAX_VISIBLE_ITEMS = 9;
 

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
@@ -59,7 +59,7 @@ type State = {|
 /**
  * Maximum visible items inside the dropdown list
  */
-const MAX_VISIBLE_ITEMS = 10;
+const MAX_VISIBLE_ITEMS = 9;
 
 /**
  * A react-window's List wrapper that instantiates the virtualized list and

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -198,7 +198,6 @@ class DropdownCore extends React.Component<Props, State> {
 
     static defaultProps: DefaultProps = {
         alignment: "left",
-        initialFocusedIndex: undefined,
         labels: {
             noResults: defaultLabels.noResults,
         },
@@ -239,14 +238,8 @@ class DropdownCore extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
-        // If we are given an initial focus index, select it.  Otherwise
-        // default to the first item
-        if (props.initialFocusedIndex) {
-            this.focusedIndex =
-                props.initialFocusedIndex + this.getIndexOffset();
-        } else {
-            this.focusedIndex = 0;
-        }
+        // Apply our initial focus index
+        this.resetFocusedIndex();
 
         this.state = {
             prevItems: this.props.items,
@@ -325,32 +318,35 @@ class DropdownCore extends React.Component<Props, State> {
         );
     }
 
-    // If we have a search box visible, then our focus
-    // index is going to be offset by 1, since the orginal
-    // index doesn't account for the search box's
-    // existence.
-    getIndexOffset(): number {
-        if (this.hasSearchBox()) {
-            return 1;
-        }
+    // Resets our initial focus index to what was passed in
+    // via the props
+    resetFocusedIndex() {
+        const {initialFocusedIndex} = this.props;
 
-        return 0;
+        // If we are given an initial focus index, select it.  Otherwise
+        // default to the first item
+        if (initialFocusedIndex) {
+            // If we have a search box visible, then our focus
+            // index is going to be offset by 1, since the orginal
+            // index doesn't account for the search box's
+            // existence.
+            if (this.hasSearchBox()) {
+                this.focusedIndex = initialFocusedIndex + 1;
+            } else {
+                this.focusedIndex = initialFocusedIndex;
+            }
+        } else {
+            this.focusedIndex = 0;
+        }
     }
 
     // Figure out focus states for the dropdown after it has changed from open
     // to closed or vice versa
     initialFocusItem() {
-        const {initialFocusedIndex, open} = this.props;
+        const {open} = this.props;
 
         if (open) {
-            // Reset focused index
-            // If we are given an initial focus index, select it.  Otherwise
-            // default to the first item
-            if (initialFocusedIndex) {
-                this.focusedIndex = initialFocusedIndex + this.getIndexOffset();
-            } else {
-                this.focusedIndex = 0;
-            }
+            this.resetFocusedIndex();
             this.scheduleToFocusCurrentItem();
         } else if (!open) {
             this.itemsClicked = false;
@@ -396,28 +392,26 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusCurrentItem() {
-        if (this.state.itemRefs[this.focusedIndex]) {
+        const fousedItemRef = this.state.itemRefs[this.focusedIndex];
+
+        if (fousedItemRef) {
             // force react-window to scroll to ensure the focused item is visible
             if (this.listRef.current) {
                 // Our focused index does not include disabled items, but the
                 // react-window index system does include the disabled items
                 // in the count.  So we need to use "originalIndex", which
                 // does account for disabled items.
-                this.listRef.current.scrollToItem(
-                    this.state.itemRefs[this.focusedIndex].originalIndex,
-                );
+                this.listRef.current.scrollToItem(fousedItemRef.originalIndex);
             }
 
             const node = ((ReactDOM.findDOMNode(
-                this.state.itemRefs[this.focusedIndex].ref.current,
+                fousedItemRef.ref.current,
             ): any): HTMLElement);
             if (node) {
                 node.focus();
                 // Keep track of the original index of the newly focused item.
                 // To be used if the set of focusable items in the menu changes
-                this.focusedOriginalIndex = this.state.itemRefs[
-                    this.focusedIndex
-                ].originalIndex;
+                this.focusedOriginalIndex = fousedItemRef.originalIndex;
             }
         }
     }

--- a/packages/wonder-blocks-dropdown/src/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.js
@@ -228,12 +228,14 @@ export default class SingleSelect extends React.Component<Props, State> {
             const {disabled, value} = option.props;
             const selected = selectedValue === value;
 
-            if (!disabled) {
-                indexCounter += 1;
-            }
             if (selected) {
                 this.selectedIndex = indexCounter;
             }
+
+            if (!disabled) {
+                indexCounter += 1;
+            }
+
             return {
                 component: option,
                 focusable: !disabled,


### PR DESCRIPTION
## Summary:
If you have a select list with more than 9 items, they won't
all fit in view.  If you have the 10th or later item selected,
upon open that item should not only be selected, but visible
too.  To accomidate this, I updated the code so that
initialFocusedIndex not only focuses the item, but scrolls
it into view.  This brought to light a few bugs that were
fixed along the way.

Issue: https://khanacademy.atlassian.net/browse/WB-1091
https://khanacademy.atlassian.net/browse/CLASS-7007

## Test plan:
Verify that all unit tests work correctly.
In the Wonder Blocks documentation,
"Single select with search filter and custom styles"
example:
  * Open the drop down
  * Select an item that is initially out of view
  * Re-open drop down
  * Verify that the item visible
Change the example so no filter is available and
rerun the changes.

Open the dropdown
Select the filter
Type values
Enter a space, verifying that it works
Press tab, verifying that it moves you to the X