### PR TITLE
Changed initialFocusedIndex on drop downs to scroll into view (#1175)

### DIFF
--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -285,6 +285,96 @@ describe("DropdownCore", () => {
         expect(handleOpen.mock.calls[0][0]).toBe(true);
     });
 
+    it("selects correct item when starting off at an undefined index", () => {
+        const handleOpen = jest.fn();
+        dropdown.setProps({
+            initialFocusedIndex: undefined,
+            onOpenChanged: (open) => handleOpen(open),
+            open: true,
+        });
+
+        jest.runAllTimers();
+        expect(document.activeElement).toBe(elementAtIndex(dropdown, 0));
+    });
+
+    it("selects correct item when starting off at an undefined index and a searchbox", () => {
+        const handleOpen = jest.fn();
+        const handleSearchTextChanged = jest.fn();
+        dropdown.setProps({
+            initialFocusedIndex: undefined,
+            onOpenChanged: (open) => handleOpen(open),
+            searchText: "",
+            items: [
+                {
+                    component: (
+                        <SearchTextInput
+                            testId="item-0"
+                            key="search-text-input"
+                            onChange={handleSearchTextChanged}
+                            searchText={""}
+                        />
+                    ),
+                    focusable: true,
+                    populatedProps: {},
+                },
+            ],
+            open: true,
+        });
+        jest.runAllTimers();
+        expect(document.activeElement).toBe(elementAtIndex(dropdown, 0));
+    });
+
+    it("selects correct item when starting off at a different index and a searchbox", () => {
+        const handleOpen = jest.fn();
+        const handleSearchTextChanged = jest.fn();
+        dropdown.setProps({
+            initialFocusedIndex: 1,
+            onOpenChanged: (open) => handleOpen(open),
+            searchText: "",
+            items: [
+                {
+                    component: (
+                        <SearchTextInput
+                            testId="search"
+                            key="search-text-input"
+                            onChange={handleSearchTextChanged}
+                            searchText={""}
+                        />
+                    ),
+                    focusable: true,
+                    populatedProps: {},
+                },
+                {
+                    component: (
+                        <OptionItem
+                            testId="item-0"
+                            label="item 1"
+                            value="1"
+                            key="1"
+                        />
+                    ),
+                    focusable: false,
+                    populatedProps: {},
+                },
+                {
+                    component: (
+                        <OptionItem
+                            testId="item-1"
+                            label="item 2"
+                            value="2"
+                            key="2"
+                        />
+                    ),
+                    focusable: true,
+                    populatedProps: {},
+                },
+            ],
+            open: true,
+        });
+        jest.runAllTimers();
+        expect(document.activeElement).toBe(elementAtIndex(dropdown, 1));
+    });
+
     it("selects correct item when starting off at a different index", () => {
         const handleOpen = jest.fn();
         dropdown.setProps({

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
@@ -57,9 +57,12 @@ type State = {|
 |};
 
 /**
- * Maximum visible items inside the dropdown list
+ * Maximum visible items inside the dropdown list.
+ * Based on the defined height that we're using, this is the maximium
+ * number of items that can fit into the visible porition of the
+ * dropdowns list box.
  */
-const MAX_VISIBLE_ITEMS = 10;
+const MAX_VISIBLE_ITEMS = 9;
 
 /**
  * A react-window's List wrapper that instantiates the virtualized list and

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -42,7 +42,7 @@ type DefaultProps = {|
      * An index that represents the index of the focused element when the menu
      * is opened.
      */
-    initialFocusedIndex: number,
+    initialFocusedIndex?: number,
 
     /**
      * Whether this menu should be left-aligned or right-aligned with the
@@ -198,7 +198,6 @@ class DropdownCore extends React.Component<Props, State> {
 
     static defaultProps: DefaultProps = {
         alignment: "left",
-        initialFocusedIndex: 0,
         labels: {
             noResults: defaultLabels.noResults,
         },
@@ -239,7 +238,9 @@ class DropdownCore extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
-        this.focusedIndex = this.props.initialFocusedIndex;
+        // Apply our initial focus index
+        this.resetFocusedIndex();
+
         this.state = {
             prevItems: this.props.items,
             itemRefs: [],
@@ -310,14 +311,42 @@ class DropdownCore extends React.Component<Props, State> {
         this.removeEventListeners();
     }
 
+    hasSearchBox(): boolean {
+        return (
+            !!this.props.onSearchTextChanged &&
+            typeof this.props.searchText === "string"
+        );
+    }
+
+    // Resets our initial focus index to what was passed in
+    // via the props
+    resetFocusedIndex() {
+        const {initialFocusedIndex} = this.props;
+
+        // If we are given an initial focus index, select it.  Otherwise
+        // default to the first item
+        if (initialFocusedIndex) {
+            // If we have a search box visible, then our focus
+            // index is going to be offset by 1, since the orginal
+            // index doesn't account for the search box's
+            // existence.
+            if (this.hasSearchBox()) {
+                this.focusedIndex = initialFocusedIndex + 1;
+            } else {
+                this.focusedIndex = initialFocusedIndex;
+            }
+        } else {
+            this.focusedIndex = 0;
+        }
+    }
+
     // Figure out focus states for the dropdown after it has changed from open
     // to closed or vice versa
     initialFocusItem() {
-        const {initialFocusedIndex, open} = this.props;
+        const {open} = this.props;
 
         if (open) {
-            // Reset focused index
-            this.focusedIndex = initialFocusedIndex;
+            this.resetFocusedIndex();
             this.scheduleToFocusCurrentItem();
         } else if (!open) {
             this.itemsClicked = false;
@@ -363,16 +392,27 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusCurrentItem() {
-        const node = ((ReactDOM.findDOMNode(
-            this.state.itemRefs[this.focusedIndex].ref.current,
-        ): any): HTMLElement);
-        if (node) {
-            node.focus();
-            // Keep track of the original index of the newly focused item.
-            // To be used if the set of focusable items in the menu changes
-            this.focusedOriginalIndex = this.state.itemRefs[
-                this.focusedIndex
-            ].originalIndex;
+        const fousedItemRef = this.state.itemRefs[this.focusedIndex];
+
+        if (fousedItemRef) {
+            // force react-window to scroll to ensure the focused item is visible
+            if (this.listRef.current) {
+                // Our focused index does not include disabled items, but the
+                // react-window index system does include the disabled items
+                // in the count.  So we need to use "originalIndex", which
+                // does account for disabled items.
+                this.listRef.current.scrollToItem(fousedItemRef.originalIndex);
+            }
+
+            const node = ((ReactDOM.findDOMNode(
+                fousedItemRef.ref.current,
+            ): any): HTMLElement);
+            if (node) {
+                node.focus();
+                // Keep track of the original index of the newly focused item.
+                // To be used if the set of focusable items in the menu changes
+                this.focusedOriginalIndex = fousedItemRef.originalIndex;
+            }
         }
     }
 
@@ -383,11 +423,6 @@ class DropdownCore extends React.Component<Props, State> {
             this.focusedIndex -= 1;
         }
 
-        // force react-window to scroll on the correct position
-        if (this.listRef.current) {
-            this.listRef.current.scrollToItem(this.focusedIndex);
-        }
-
         this.scheduleToFocusCurrentItem();
     }
 
@@ -396,11 +431,6 @@ class DropdownCore extends React.Component<Props, State> {
             this.focusedIndex = 0;
         } else {
             this.focusedIndex += 1;
-        }
-
-        // force react-window to scroll on the correct position
-        if (this.listRef.current) {
-            this.listRef.current.scrollToItem(this.focusedIndex);
         }
 
         this.scheduleToFocusCurrentItem();
@@ -417,12 +447,7 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     handleKeyDown: (event: SyntheticKeyboardEvent<>) => void = (event) => {
-        const {
-            onOpenChanged,
-            open,
-            onSearchTextChanged,
-            searchText,
-        } = this.props;
+        const {onOpenChanged, open, searchText} = this.props;
         const keyCode = event.which || event.keyCode;
         // If menu isn't open and user presses down, open the menu
         if (!open) {
@@ -434,8 +459,6 @@ class DropdownCore extends React.Component<Props, State> {
             return;
         }
 
-        const showSearchTextInput =
-            !!onSearchTextChanged && typeof searchText === "string";
         // Handle all other key behavior
         switch (keyCode) {
             case keyCodes.tab:
@@ -444,7 +467,7 @@ class DropdownCore extends React.Component<Props, State> {
                 // is displayed. When user presses tab, we should move focus
                 // to the dismiss button.
                 if (
-                    showSearchTextInput &&
+                    this.hasSearchBox() &&
                     this.focusedIndex === 0 &&
                     searchText
                 ) {
@@ -456,7 +479,7 @@ class DropdownCore extends React.Component<Props, State> {
             case keyCodes.space:
                 // When we display SearchTextInput and the focus is on it,
                 // we should let the user type space.
-                if (showSearchTextInput && this.focusedIndex === 0) {
+                if (this.hasSearchBox() && this.focusedIndex === 0) {
                     return;
                 }
                 // Prevent space from scrolling down the page
@@ -475,20 +498,13 @@ class DropdownCore extends React.Component<Props, State> {
 
     // Some keys should be handled during the keyup event instead.
     handleKeyUp: (event: SyntheticKeyboardEvent<>) => void = (event) => {
-        const {
-            onOpenChanged,
-            open,
-            onSearchTextChanged,
-            searchText,
-        } = this.props;
+        const {onOpenChanged, open} = this.props;
         const keyCode = event.which || event.keyCode;
-        const showSearchTextInput =
-            !!onSearchTextChanged && typeof searchText === "string";
         switch (keyCode) {
             case keyCodes.space:
                 // When we display SearchTextInput and the focus is on it,
                 // we should let the user type space.
-                if (showSearchTextInput && this.focusedIndex === 0) {
+                if (this.hasSearchBox() && this.focusedIndex === 0) {
                     return;
                 }
                 // Prevent space from scrolling down the page

--- a/packages/wonder-blocks-dropdown/src/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.js
@@ -228,12 +228,14 @@ export default class SingleSelect extends React.Component<Props, State> {
             const {disabled, value} = option.props;
             const selected = selectedValue === value;
 
-            if (!disabled) {
-                indexCounter += 1;
-            }
             if (selected) {
                 this.selectedIndex = indexCounter;
             }
+
+            if (!disabled) {
+                indexCounter += 1;
+            }
+
             return {
                 component: option,
                 focusable: !disabled,


### PR DESCRIPTION
## Summary:
Changed the initialFocusedIndex on drop downs so that it will
be in view when you open the dropdown.  This had a few cascade
effects that were touched up in the process.

Issue: WB-1091

## Test plan:
Ensure all unit tests are functioning.

Run on a non-filtered and filtered dropdown:
* Open dropdown
* Select off screen item
* Close dropdown
* Open Dropdown
* Observe the item is visible