### PR TITLE
Get CJS output so that it's best for test use

### DIFF
--- a/build-settings/package.json
+++ b/build-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-dev-build-settings",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.js",
   "license": "MIT",
   "private": true

--- a/build-settings/webpack.config.js
+++ b/build-settings/webpack.config.js
@@ -7,7 +7,12 @@
 const fs = require("fs");
 const path = require("path");
 
-const babelOptions = require("./babel.config.js")({env: () => false});
+/**
+ * We tell babel to build as test output here (targetting node and not as es6)
+ * because we use the output in testing and Jest doesn't yet support es6
+ * modules.
+ */
+const babelOptions = require("./babel.config.js")({env: () => true});
 
 const packages = fs
     .readdirSync(path.join(process.cwd(), "packages"))
@@ -46,6 +51,7 @@ const genWebpackConfig = function (subPkgRoot) {
             ],
         },
         optimization: {
+            concatenateModules: false,
             minimize: false,
         },
         node: {process: false},

--- a/packages/wonder-blocks-breadcrumbs/package.json
+++ b/packages/wonder-blocks-breadcrumbs/package.json
@@ -26,6 +26,6 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -31,6 +31,6 @@
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -26,6 +26,6 @@
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-color/package.json
+++ b/packages/wonder-blocks-color/package.json
@@ -13,7 +13,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -24,7 +24,7 @@
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-data/package.json
+++ b/packages/wonder-blocks-data/package.json
@@ -20,7 +20,7 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -39,6 +39,6 @@
     "react-window": "^1.8.5"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -29,6 +29,6 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-grid/package.json
+++ b/packages/wonder-blocks-grid/package.json
@@ -25,6 +25,6 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -28,6 +28,6 @@
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-icon/package.json
+++ b/packages/wonder-blocks-icon/package.json
@@ -19,7 +19,7 @@
     "@khanacademy/wonder-blocks-core": "^3.1.4"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-layout/package.json
+++ b/packages/wonder-blocks-layout/package.json
@@ -18,7 +18,7 @@
     "@khanacademy/wonder-blocks-spacing": "^3.0.3"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -27,6 +27,6 @@
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -32,6 +32,6 @@
     "react-dom": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -34,6 +34,6 @@
     "react-popper": "^2.0.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-progress-spinner/package.json
+++ b/packages/wonder-blocks-progress-spinner/package.json
@@ -25,6 +25,6 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-spacing/package.json
+++ b/packages/wonder-blocks-spacing/package.json
@@ -13,7 +13,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-timing/package.json
+++ b/packages/wonder-blocks-timing/package.json
@@ -17,7 +17,7 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-toolbar/package.json
+++ b/packages/wonder-blocks-toolbar/package.json
@@ -25,6 +25,6 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -31,6 +31,6 @@
     "react-popper": "^2.0.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }

--- a/packages/wonder-blocks-typography/package.json
+++ b/packages/wonder-blocks-typography/package.json
@@ -23,6 +23,6 @@
     "react": "^16.4.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.1.0"
+    "wb-dev-build-settings": "^0.1.1"
   }
 }


### PR DESCRIPTION
## Summary:
We only use the CommonJS output to support Jest testing.
This update has the babel output for webpack set to target node instead
of esmodules, and also sets webpack to avoid module concatenation. This
second change is necessary to prevent webpack from mangling react
component names (it does this to avoid collisions across the concatenated
modules).

Issue: None

## Test plan:
`yarn build:cjs` and check the output code to see that the component names aren't mangled.

We'll also see what happens when we use this code in webapp tests.