### PR TITLE
Update action-menu to pass down the opened state of the menu to the opener

### DIFF
--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
@@ -8,6 +8,7 @@ import SeparatorItem from "../separator-item.js";
 import ActionMenu from "../action-menu.js";
 import DropdownOpener from "../dropdown-opener.js";
 import {keyCodes} from "../../util/constants.js";
+import ActionMenuOpenerCore from "../action-menu-opener-core.js";
 
 jest.mock("../dropdown-core-virtualized.js");
 
@@ -141,6 +142,38 @@ describe("ActionMenu", () => {
 
         // Assert
         expect(menu.state("opened")).toBe(false);
+    });
+
+    it("updates the aria-expanded value when opening and closing", () => {
+        // Arrange
+        const menu = mount(
+            <ActionMenu
+                menuText={"Action menu!"}
+                testId="openTest"
+                onChange={onChange}
+                selectedValues={[]}
+            >
+                <ActionItem label="Action" onClick={onClick} />
+                <SeparatorItem />
+                <OptionItem label="Toggle" value="toggle" onClick={onToggle} />
+            </ActionMenu>,
+        );
+
+        let opener = menu.find(DropdownOpener);
+        let openerCore = menu.find(ActionMenuOpenerCore);
+        expect(openerCore.prop("opened")).toBe(false);
+        expect(opener.find("[aria-expanded='false']")).toExist();
+
+        // Act
+        opener.simulate("keydown", {keyCode: keyCodes.enter});
+        opener.simulate("keyup", {keyCode: keyCodes.enter});
+        menu.update();
+        openerCore = menu.find(ActionMenuOpenerCore);
+        opener = menu.find(DropdownOpener);
+
+        // Assert
+        expect(openerCore.prop("opened")).toBe(true);
+        expect(opener.find("[aria-expanded='true']")).toExist();
     });
 
     it("triggers actions", () => {

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.js
@@ -226,7 +226,8 @@ export default class ActionMenu extends React.Component<Props, State> {
     };
 
     renderOpener(numItems: number): React.Element<typeof DropdownOpener> {
-        const {disabled, menuText, opened, opener, testId} = this.props;
+        const {disabled, menuText, opener, testId} = this.props;
+        const {opened} = this.state;
 
         return (
             <DropdownOpener


### PR DESCRIPTION
## Summary:
When the opener isn't updated to be opened it causes the aria-expanded prop to remain false, which hints to screen readers that the menu is not opened. This fixes that by passing the value of the state instead of the value of the opened prop.

Issue: LP-9477

## Test plan:
yarn jest