### PR TITLE
[🔥AUDIT🔥] Update dependabot workflow to use Chromatic CLI directly

### DIFF
--- a/.github/workflows/dependabot-approve-and-merge.yml
+++ b/.github/workflows/dependabot-approve-and-merge.yml
@@ -49,11 +49,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Skip Chromatic builds
-        uses: chromaui/action@v1
+        run: yarn chromatic --project-token=$PROJECT_TOKEN --skip
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
-          skip: true
+          PROJECT_TOKEN: ${{ secrets.CHROMATIC_APP_CODE }}
       # Here the PR gets approved.
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

There's a current issue with the Chromatic Github action that doesn't allow to
skip tests for dependabot PRs.

https://github.com/chromaui/chromatic-cli/issues/309

We need to make this change to switch to using the CLI directly until the action
gets fixed.

Issue: XXX-XXXX

## Test plan:

Merge into a dependabot PR and see if it works!