### PR TITLE
Add module.name_mapper entry in .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,3 +5,6 @@
 deprecated-type=error
 deprecated-utility=error
 implicit-inexact-object=error
+
+[options]
+module.name_mapper='@khanacademy/\(wonder-blocks-[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'


### PR DESCRIPTION
## Summary:
Without this people would have build packages first.  Also, the build packages could be out of sync with other local changes which is confusing.  This avoids the issue, but have 'yarn flow' work out of the box (well after running 'yarn install').

Issue: None

## Test plan:
- yarn clean followed by yarn flow