### PR TITLE
LabeledTextField: Allow passing `aria-describedby` as a prop.

### DIFF
--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -1,6 +1,7 @@
 //@flow
 import * as React from "react";
 import {mount} from "enzyme";
+import {render, screen} from "@testing-library/react";
 
 import {StyleSheet} from "aphrodite";
 import LabeledTextField from "../labeled-text-field.js";
@@ -184,6 +185,49 @@ describe("LabeledTextField", () => {
         // Assert
         const input = wrapper.find("input");
         expect(input).toBeDisabled();
+    });
+
+    it("ariaDescribedby prop sets aria-describedby", () => {
+        // Arrange
+        const ariaDescription = "aria description";
+
+        // Act
+        render(
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                ariaDescribedby={ariaDescription}
+            />,
+        );
+
+        // Assert
+        const input = screen.getByRole("textbox");
+        expect(input.getAttribute("aria-describedby")).toEqual(ariaDescription);
+    });
+
+    it("auto-generates a unique error when ariaDescribedby is not passed in", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LabeledTextField
+                label="Label"
+                value=""
+                onChange={() => {}}
+                // ariaDescribedby is not passed in
+            />,
+        );
+
+        // Assert
+        // Since the generated aria-describedby is unique,
+        // we cannot know what it will be.
+        // We only test if the aria-describedby attribute starts with
+        // "uid-" and ends with "-error".
+        const input = screen.getByRole("textbox");
+        expect(input.getAttribute("aria-describedby")).toMatch(
+            /^uid-.*-error$/,
+        );
     });
 
     it("validate prop is called when input changes", () => {

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -1,11 +1,7 @@
 // @flow
 import * as React from "react";
 
-import {
-    IDProvider,
-    type AriaProps,
-    type StyleType,
-} from "@khanacademy/wonder-blocks-core";
+import {IDProvider, type StyleType} from "@khanacademy/wonder-blocks-core";
 import {type Typography} from "@khanacademy/wonder-blocks-typography";
 
 import FieldHeading from "./field-heading.js";
@@ -14,8 +10,6 @@ import TextField, {type TextFieldType} from "./text-field.js";
 type WithForwardRef = {|forwardedRef: React.Ref<"input">|};
 
 type Props = {|
-    ...AriaProps,
-
     /**
      * An optional unique identifier for the TextField.
      * If no id is specified, a unique id will be auto-generated.
@@ -46,6 +40,11 @@ type Props = {|
      * Makes a read-only input field that cannot be focused. Defaults to false.
      */
     disabled: boolean,
+
+    /**
+     * Identifies the element or elements that describes this text field.
+     */
+    ariaDescribedby?: string | Array<string>,
 
     /**
      * Provide a validation for the input value.
@@ -213,7 +212,7 @@ class LabeledTextFieldInternal extends React.Component<
             readOnly,
             autoComplete,
             forwardedRef,
-            "aria-describedby": ariaDescribedby,
+            ariaDescribedby,
         } = this.props;
 
         return (

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -1,7 +1,11 @@
 // @flow
 import * as React from "react";
 
-import {IDProvider, type StyleType} from "@khanacademy/wonder-blocks-core";
+import {
+    IDProvider,
+    type AriaProps,
+    type StyleType,
+} from "@khanacademy/wonder-blocks-core";
 import {type Typography} from "@khanacademy/wonder-blocks-typography";
 
 import FieldHeading from "./field-heading.js";
@@ -10,6 +14,8 @@ import TextField, {type TextFieldType} from "./text-field.js";
 type WithForwardRef = {|forwardedRef: React.Ref<"input">|};
 
 type Props = {|
+    ...AriaProps,
+
     /**
      * An optional unique identifier for the TextField.
      * If no id is specified, a unique id will be auto-generated.
@@ -207,6 +213,7 @@ class LabeledTextFieldInternal extends React.Component<
             readOnly,
             autoComplete,
             forwardedRef,
+            "aria-describedby": ariaDescribedby,
         } = this.props;
 
         return (
@@ -219,7 +226,11 @@ class LabeledTextFieldInternal extends React.Component<
                         field={
                             <TextField
                                 id={`${uniqueId}-field`}
-                                aria-describedby={`${uniqueId}-error`}
+                                aria-describedby={
+                                    ariaDescribedby
+                                        ? ariaDescribedby
+                                        : `${uniqueId}-error`
+                                }
                                 aria-invalid={
                                     this.state.error ? "true" : "false"
                                 }


### PR DESCRIPTION
## Summary:
Here, we allow the user to pass in aria-describedby as a prop,
but default to the UniqueIdProvider error otherwise.

Issue: https://khanacademy.atlassian.net/browse/WB-1115

## Test plan:
`yarn flow`
`yarn jest packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js`