### PR TITLE
Improve navigation callback documentation

### DIFF
--- a/packages/wonder-blocks-button/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -2850,7 +2850,7 @@ exports[`wonder-blocks-button example 9 1`] = `
         }
       }
     >
-      Async action, client-side nav
+      beforeNav, client-side nav
     </span>
   </a>
   <a
@@ -2918,7 +2918,7 @@ exports[`wonder-blocks-button example 9 1`] = `
         }
       }
     >
-      Async action, server-side nav
+      beforeNav, server-side nav
     </span>
   </a>
   <a
@@ -2987,7 +2987,7 @@ exports[`wonder-blocks-button example 9 1`] = `
         }
       }
     >
-      Async action, open URL in new tab
+      beforeNav, open URL in new tab
     </span>
   </a>
 </div>
@@ -3078,13 +3078,242 @@ exports[`wonder-blocks-button example 10 1`] = `
         }
       }
     >
-      This button prevent navigation.
+      safeWithNav, client-side nav
+    </span>
+  </a>
+  <a
+    className=""
+    href="/foo"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    style={
+      Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "marginRight": 10,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "inline-block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      safeWithNav, server-side nav
+    </span>
+  </a>
+  <a
+    className=""
+    href="https://google.com"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    rel="noopener noreferrer"
+    role="button"
+    style={
+      Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "marginRight": 10,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+    target="_blank"
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "inline-block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      safeWithNav, open URL in new tab
     </span>
   </a>
 </div>
 `;
 
 exports[`wonder-blocks-button example 11 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "center",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <a
+    className=""
+    href="/foo"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    style={
+      Object {
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "marginRight": 10,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "inline-block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      This button prevents navigation.
+    </span>
+  </a>
+</div>
+`;
+
+exports[`wonder-blocks-button example 12 1`] = `
 <div
   className=""
   style={
@@ -3718,7 +3947,7 @@ exports[`wonder-blocks-button example 11 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 12 1`] = `
+exports[`wonder-blocks-button example 13 1`] = `
 <div
   className=""
   style={
@@ -3817,7 +4046,7 @@ exports[`wonder-blocks-button example 12 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 13 1`] = `
+exports[`wonder-blocks-button example 14 1`] = `
 <div
   className=""
   style={
@@ -3912,7 +4141,7 @@ exports[`wonder-blocks-button example 13 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 14 1`] = `
+exports[`wonder-blocks-button example 15 1`] = `
 <div
   className=""
   style={
@@ -4139,7 +4368,7 @@ exports[`wonder-blocks-button example 14 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 15 1`] = `
+exports[`wonder-blocks-button example 16 1`] = `
 <div
   className=""
   style={
@@ -4313,7 +4542,7 @@ exports[`wonder-blocks-button example 15 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 16 1`] = `
+exports[`wonder-blocks-button example 17 1`] = `
 <div
   className=""
   style={
@@ -4488,7 +4717,7 @@ exports[`wonder-blocks-button example 16 1`] = `
 </div>
 `;
 
-exports[`wonder-blocks-button example 17 1`] = `
+exports[`wonder-blocks-button example 18 1`] = `
 <div
   className=""
   style={
@@ -4674,102 +4903,6 @@ exports[`wonder-blocks-button example 17 1`] = `
       </span>
     </button>
   </div>
-</div>
-`;
-
-exports[`wonder-blocks-button example 18 1`] = `
-<div
-  className=""
-  style={
-    Object {
-      "alignItems": "stretch",
-      "borderStyle": "solid",
-      "borderWidth": 0,
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flexDirection": "row",
-      "margin": 0,
-      "minHeight": 0,
-      "minWidth": 0,
-      "padding": 0,
-      "position": "relative",
-      "zIndex": 0,
-    }
-  }
->
-  <button
-    aria-label=""
-    className=""
-    disabled={false}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    style={
-      Object {
-        "::MozFocusInner": Object {
-          "border": 0,
-        },
-        ":focus": Object {
-          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-        },
-        "alignItems": "center",
-        "background": "#1865f2",
-        "border": "none",
-        "borderRadius": 4,
-        "boxSizing": "border-box",
-        "color": "#ffffff",
-        "cursor": "pointer",
-        "display": "inline-flex",
-        "height": 40,
-        "justifyContent": "center",
-        "margin": 0,
-        "outline": "none",
-        "paddingBottom": 0,
-        "paddingLeft": 16,
-        "paddingRight": 16,
-        "paddingTop": 0,
-        "position": "relative",
-        "textDecoration": "none",
-        "touchAction": "manipulation",
-        "userSelect": "none",
-      }
-    }
-    tabIndex={0}
-    type="button"
-  >
-    <span
-      className=""
-      style={
-        Object {
-          "MozOsxFontSmoothing": "grayscale",
-          "WebkitFontSmoothing": "antialiased",
-          "alignItems": "center",
-          "display": "inline-block",
-          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
-          "fontSize": 16,
-          "fontWeight": "bold",
-          "lineHeight": "20px",
-          "overflow": "hidden",
-          "pointerEvents": "none",
-          "textOverflow": "ellipsis",
-          "whiteSpace": "nowrap",
-        }
-      }
-    >
-      Click me!
-    </span>
-  </button>
 </div>
 `;
 

--- a/packages/wonder-blocks-button/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-button/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -4772,3 +4772,99 @@ exports[`wonder-blocks-button example 18 1`] = `
   </button>
 </div>
 `;
+
+exports[`wonder-blocks-button example 19 1`] = `
+<div
+  className=""
+  style={
+    Object {
+      "alignItems": "stretch",
+      "borderStyle": "solid",
+      "borderWidth": 0,
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexDirection": "row",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "zIndex": 0,
+    }
+  }
+>
+  <button
+    aria-label=""
+    className=""
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    style={
+      Object {
+        "::MozFocusInner": Object {
+          "border": 0,
+        },
+        ":focus": Object {
+          "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        },
+        "alignItems": "center",
+        "background": "#1865f2",
+        "border": "none",
+        "borderRadius": 4,
+        "boxSizing": "border-box",
+        "color": "#ffffff",
+        "cursor": "pointer",
+        "display": "inline-flex",
+        "height": 40,
+        "justifyContent": "center",
+        "margin": 0,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 0,
+        "position": "relative",
+        "textDecoration": "none",
+        "touchAction": "manipulation",
+        "userSelect": "none",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <span
+      className=""
+      style={
+        Object {
+          "MozOsxFontSmoothing": "grayscale",
+          "WebkitFontSmoothing": "antialiased",
+          "alignItems": "center",
+          "display": "inline-block",
+          "fontFamily": "Lato, \\"Noto Sans\\", sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+          "overflow": "hidden",
+          "pointerEvents": "none",
+          "textOverflow": "ellipsis",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      Click me!
+    </span>
+  </button>
+</div>
+`;

--- a/packages/wonder-blocks-button/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/src/__tests__/generated-snapshot.test.js
@@ -546,7 +546,7 @@ describe("wonder-blocks-button", () => {
                         style={styles.button}
                         onClick={(e) => e.preventDefault()}
                     >
-                        This button prevent navigation.
+                        This button prevents navigation.
                     </Button>
                     <Switch>
                         <Route path="/foo">

--- a/packages/wonder-blocks-button/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-button/src/__tests__/generated-snapshot.test.js
@@ -426,7 +426,7 @@ describe("wonder-blocks-button", () => {
                             })
                         }
                     >
-                        Async action, client-side nav
+                        beforeNav, client-side nav
                     </Button>
                     <Button
                         href="/foo"
@@ -438,7 +438,7 @@ describe("wonder-blocks-button", () => {
                             })
                         }
                     >
-                        Async action, server-side nav
+                        beforeNav, server-side nav
                     </Button>
                     <Button
                         href="https://google.com"
@@ -451,7 +451,7 @@ describe("wonder-blocks-button", () => {
                             })
                         }
                     >
-                        Async action, open URL in new tab
+                        beforeNav, open URL in new tab
                     </Button>
                     <Switch>
                         <Route path="/foo">
@@ -466,6 +466,68 @@ describe("wonder-blocks-button", () => {
     });
 
     it("example 10", () => {
+        const styles = StyleSheet.create({
+            row: {
+                flexDirection: "row",
+                alignItems: "center",
+            },
+            button: {
+                marginRight: 10,
+            },
+        }); // NOTE: In actual code you would use BrowserRouter instead
+
+        const example = (
+            <MemoryRouter>
+                <View style={styles.row}>
+                    <Button
+                        href="/foo"
+                        style={styles.button}
+                        safeWithNav={() =>
+                            new Promise((resolve, reject) => {
+                                setTimeout(resolve, 1000);
+                            })
+                        }
+                    >
+                        safeWithNav, client-side nav
+                    </Button>
+                    <Button
+                        href="/foo"
+                        style={styles.button}
+                        skipClientNav={true}
+                        safeWithNav={() =>
+                            new Promise((resolve, reject) => {
+                                setTimeout(resolve, 1000);
+                            })
+                        }
+                    >
+                        safeWithNav, server-side nav
+                    </Button>
+                    <Button
+                        href="https://google.com"
+                        target="_blank"
+                        style={styles.button}
+                        skipClientNav={true}
+                        safeWithNav={() =>
+                            new Promise((resolve, reject) => {
+                                setTimeout(resolve, 1000);
+                            })
+                        }
+                    >
+                        safeWithNav, open URL in new tab
+                    </Button>
+                    <Switch>
+                        <Route path="/foo">
+                            <View id="foo">Hello, world!</View>
+                        </Route>
+                    </Switch>
+                </View>
+            </MemoryRouter>
+        );
+        const tree = renderer.create(example).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
+    it("example 11", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -498,7 +560,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 11", () => {
+    it("example 12", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -542,7 +604,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 12", () => {
+    it("example 13", () => {
         const example = (
             <View>
                 <form onSubmit={() => alert("the form was submitted")}>
@@ -554,7 +616,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 13", () => {
+    it("example 14", () => {
         const example = (
             <View>
                 <Button>Label</Button>
@@ -564,7 +626,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 14", () => {
+    it("example 15", () => {
         const styles = StyleSheet.create({
             column: {
                 alignItems: "flex-start",
@@ -594,7 +656,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 15", () => {
+    it("example 16", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -621,7 +683,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 16", () => {
+    it("example 17", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -649,7 +711,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 17", () => {
+    it("example 18", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",
@@ -672,7 +734,7 @@ describe("wonder-blocks-button", () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it("example 18", () => {
+    it("example 19", () => {
         const styles = StyleSheet.create({
             row: {
                 flexDirection: "row",

--- a/packages/wonder-blocks-button/src/components/__docs__/button.argtypes.js
+++ b/packages/wonder-blocks-button/src/components/__docs__/button.argtypes.js
@@ -199,12 +199,11 @@ export default {
         },
     },
     beforeNav: {
-        description: `Run async code before navigating. If the promise returned rejects then navigation will not occur.`,
+        description: `Run async code before navigating. If the promise returned rejects then navigation will not occur. If both safeWithNav and beforeNav are provided, beforeNav will be run first and safeWithNav will only be run if beforeNav does not reject.`,
         table: {
             category: "Navigation",
             type: {
                 summary: "() => Promise<mixed>",
-                detail: `If both safeWithNav and beforeNav are provided, beforeNav will be run first and safeWithNav will only be run if beforeNav does not reject.`,
             },
         },
     },

--- a/packages/wonder-blocks-button/src/components/__docs__/navigation-callbacks.stories.mdx
+++ b/packages/wonder-blocks-button/src/components/__docs__/navigation-callbacks.stories.mdx
@@ -1,0 +1,59 @@
+import {Meta, Story, Canvas} from "@storybook/addon-docs";
+import {StyleSheet} from "aphrodite";
+
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+
+<Meta
+    title="Navigation/Button/Navigation Callbacks"
+    component={Button}
+    parameters={{
+        previewTabs: {
+            canvas: {hidden: true},
+        },
+        viewMode: "docs",
+        chromatic: {
+            // Disables chromatic testing for these stories.
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+## Running Callbacks on Navigation
+
+Sometimes you may need to run some code and also navigate when the user
+clicks the button. For example, you might want to send a request to the
+server and also send the user to a different page. You can do this by
+passing in a URL to the `href` prop and also passing in a callback
+function to either the `onClick`, `beforeNav`, or `safeWithNav` prop.
+Which prop you choose depends on your use case.
+
+- `onClick` is guaranteed to run to completion before navigation starts,
+  but it is not async aware, so it should only be used if all of the code
+  in your callback function executes synchronously.
+
+- `beforeNav` is guaranteed to run async operations before navigation
+  starts. You must return a promise from the callback function passed in
+  to this prop, and the navigation will happen after the promise
+  resolves. This prop should be used if it's important that the async code
+  completely finishes before the next URL starts loading.
+
+- `safeWithNav` runs async code concurrently with navigation when safe,
+  but delays navigation until the async code is finished when
+  concurrent execution is not safe. You must return a promise from the
+  callback function passed in to this prop, and Wonder Blocks will run
+  the async code in parallel with client-side navigation or while opening
+  a new tab, but will wait until the async code finishes to start a
+  server-side navigation. This prop should be used when it's okay to load
+  the next URL while the async callback code is running.
+
+This table gives an overview of the options:
+
+| Prop         | Async safe? | Completes before navigation? |
+|--------------|-------------|------------------------------|
+| onClick      | no          | yes                          |
+| beforeNav    | yes         | yes                          |
+| safeWithNav  | yes         | no                           |
+
+
+

--- a/packages/wonder-blocks-button/src/components/__docs__/navigation-callbacks.stories.mdx
+++ b/packages/wonder-blocks-button/src/components/__docs__/navigation-callbacks.stories.mdx
@@ -35,7 +35,8 @@ Which prop you choose depends on your use case.
 - `beforeNav` is guaranteed to run async operations before navigation
   starts. You must return a promise from the callback function passed in
   to this prop, and the navigation will happen after the promise
-  resolves. This prop should be used if it's important that the async code
+  resolves. If the promise rejects, the navigation will not occur.
+  This prop should be used if it's important that the async code
   completely finishes before the next URL starts loading.
 
 - `safeWithNav` runs async code concurrently with navigation when safe,
@@ -44,16 +45,24 @@ Which prop you choose depends on your use case.
   callback function passed in to this prop, and Wonder Blocks will run
   the async code in parallel with client-side navigation or while opening
   a new tab, but will wait until the async code finishes to start a
-  server-side navigation. This prop should be used when it's okay to load
+  server-side navigation. If the promise rejects the navigation will
+  happen anyway. This prop should be used when it's okay to load
   the next URL while the async callback code is running.
 
 This table gives an overview of the options:
 
-| Prop         | Async safe? | Completes before navigation? |
-|--------------|-------------|------------------------------|
-| onClick      | no          | yes                          |
-| beforeNav    | yes         | yes                          |
-| safeWithNav  | yes         | no                           |
+| Prop        | Async safe? | Completes before navigation? |
+|-------------|-------------|------------------------------|
+| onClick     | no          | yes                          |
+| beforeNav   | yes         | yes                          |
+| safeWithNav | yes         | no                           |
 
+It is possible to use more than one of these props on the same element.
+If multiple props are used, they will run in this order: first `onClick`,
+then `beforeNav`, then `safeWithNav`. If both `beforeNav` and `safeWithNav`
+are used, the `safeWithNav` callback will not be called until the
+`beforeNav` promise resolves successfully. If the `beforeNav` promise
+rejects, `safeWithNav` will not be run.
 
-
+If the `onClick` handler calls `preventDefault()`, then `beforeNav`
+and `safeWithNav` will still run, but navigation will not occur.

--- a/packages/wonder-blocks-button/src/components/button.js
+++ b/packages/wonder-blocks-button/src/components/button.js
@@ -139,11 +139,10 @@ export type SharedProps = {|
     /**
      * Function to call when button is clicked.
      *
-     * This callback should be used for things like marking BigBingo
-     * conversions. It should NOT be used to redirect to a different URL or to
-     * prevent navigation via e.preventDefault(). The event passed to this
-     * handler will have its preventDefault() and stopPropagation() methods
-     * stubbed out.
+     * This callback should be used for running synchronous code, like
+     * dispatching a Redux action. For asynchronous code see the
+     * beforeNav and safeWithNav props. It should NOT be used to redirect
+     * to a different URL.
      *
      * Note: onClick is optional if href is present, but must be defined if
      * href is not

--- a/packages/wonder-blocks-button/src/components/button.md
+++ b/packages/wonder-blocks-button/src/components/button.md
@@ -458,7 +458,7 @@ This table gives an overview of the options:
 
 ### Example: beforeNav callbacks
 
-These examples always wait until the async callback code completes before
+These buttons always wait until the async callback code completes before
 starting navigation.
 
 ```jsx
@@ -521,7 +521,7 @@ const styles = StyleSheet.create({
 
 ### Example: safeWithNav callbacks
 
-These examples navigate immediately when doing client-side navigation
+These buttons navigate immediately when doing client-side navigation
 or when opening a new tab, but wait until the async callback code
 completes before starting server-side navigation.
 

--- a/packages/wonder-blocks-button/src/components/button.md
+++ b/packages/wonder-blocks-button/src/components/button.md
@@ -1,4 +1,4 @@
-#### Example: kind
+### Example: kind
 
 There are three `kind`s of buttons: `"primary"` (default), `"secondary"`, and
 `"tertiary"`:
@@ -40,7 +40,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-#### Example: color
+### Example: color
 
 Buttons have a `color` that is either `"default"` (the default, as shown above) or `"destructive"` (as can seen below):
 
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-#### Example: disabled
+### Example: disabled
 
 Buttons can be `disabled`:
 
@@ -139,7 +139,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-#### Example: dark
+### Example: dark
 
 Buttons on a `darkBlue` background should set `light` to `true`.
 ```jsx
@@ -212,7 +212,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-#### Example: size
+### Example: size
 
 Buttons have a `size` that's either `"medium"` (default), `"small"`, or `"xlarge"`.
 ```js
@@ -309,7 +309,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-#### Example: spinner
+### Example: spinner
 
 Buttons can show a `spinner`.  This is useful when indicating to a user that
 their input has been recognized but that the operation will take some time.
@@ -343,7 +343,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-#### Example: Navigation
+### Example: Navigation
 
 ```jsx
 import Button from "@khanacademy/wonder-blocks-button";
@@ -384,7 +384,7 @@ const styles = StyleSheet.create({
 </View>
 ```
 
-#### Example: Navigation with React Router
+### Example: Navigation with React Router
 
 Buttons do client-side navigation by default, if React Router exists:
 ```jsx
@@ -420,12 +420,47 @@ const styles = StyleSheet.create({
     </View>
 </MemoryRouter>
 ```
+### Running callbacks on navigation
 
-#### Example: Navigation with async action
+Sometimes you may need to run some code and also navigate when the user
+clicks the button. For example, you might want to send a request to the
+server and also send the user to a different page. You can do this by
+passing in a URL to the `href` prop and also passing in a callback
+function to either the `onClick`, `beforeNav`, or `safeWithNav` prop.
+Which prop you choose depends on your use case.
 
-Sometimes you may need to perform an async action either before or during
-navigation.  This can be accomplished with `beforeNav` and `safeWithNav`
-respectively.
+- `onClick` is guaranteed to run to completion before navigation starts,
+  but it is not async aware, so it should only be used if all of the code
+  in your callback function executes synchronously.
+
+- `beforeNav` is guaranteed to run async operations before navigation
+  starts. You must return a promise from the callback function passed in
+  to this prop, and the navigation will happen after the promise
+  resolves. This prop should be used if it's important that the async code
+  completely finishes before the next URL starts loading.
+
+- `safeWithNav` runs async code concurrently with navigation when safe,
+  but delays navigation until the async code is finished when
+  concurrent execution is not safe. You must return a promise from the
+  callback function passed in to this prop, and Wonder Blocks will run
+  the async code in parallel with client-side navigation or while opening
+  a new tab, but will wait until the async code finishes to start a
+  server-side navigation. This prop should be used when it's okay to load
+  the next URL while the async callback code is running.
+
+This table gives an overview of the options:
+
+| Prop         | Async safe? | Completes before navigation? |
+|--------------|-------------|------------------------------|
+| onClick      | no          | yes                          |
+| beforeNav    | yes         | yes                          |
+| safeWithNav  | yes         | no                           |
+
+### Example: beforeNav callbacks
+
+These examples always wait until the async callback code completes before
+starting navigation.
+
 ```jsx
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -452,7 +487,7 @@ const styles = StyleSheet.create({
                 setTimeout(resolve, 1000);
             })}
         >
-            Async action, client-side nav
+            beforeNav, client-side nav
         </Button>
         <Button
             href="/foo"
@@ -462,7 +497,7 @@ const styles = StyleSheet.create({
                 setTimeout(resolve, 1000);
             })}
         >
-            Async action, server-side nav
+            beforeNav, server-side nav
         </Button>
         <Button
             href="https://google.com"
@@ -473,7 +508,7 @@ const styles = StyleSheet.create({
                 setTimeout(resolve, 1000);
             })}
         >
-            Async action, open URL in new tab
+            beforeNav, open URL in new tab
         </Button>
         <Switch>
             <Route path="/foo">
@@ -484,7 +519,71 @@ const styles = StyleSheet.create({
 </MemoryRouter>
 ```
 
-#### Example: Prevent navigation by calling e.preventDefault()
+### Example: safeWithNav callbacks
+
+These examples navigate immediately when doing client-side navigation
+or when opening a new tab, but wait until the async callback code
+completes before starting server-side navigation.
+
+```jsx
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {StyleSheet} from "aphrodite";
+import {MemoryRouter, Route, Switch} from "react-router-dom";
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    button: {
+        marginRight: 10,
+    }
+});
+
+// NOTE: In actual code you would use BrowserRouter instead
+<MemoryRouter>
+    <View style={styles.row}>
+        <Button
+            href="/foo"
+            style={styles.button}
+            safeWithNav={() => new Promise((resolve, reject) => {
+                setTimeout(resolve, 1000);
+            })}
+        >
+            safeWithNav, client-side nav
+        </Button>
+        <Button
+            href="/foo"
+            style={styles.button}
+            skipClientNav={true}
+            safeWithNav={() => new Promise((resolve, reject) => {
+                setTimeout(resolve, 1000);
+            })}
+        >
+            safeWithNav, server-side nav
+        </Button>
+        <Button
+            href="https://google.com"
+            target="_blank"
+            style={styles.button}
+            skipClientNav={true}
+            safeWithNav={() => new Promise((resolve, reject) => {
+                setTimeout(resolve, 1000);
+            })}
+        >
+            safeWithNav, open URL in new tab
+        </Button>
+        <Switch>
+            <Route path="/foo">
+                <View id="foo">Hello, world!</View>
+            </Route>
+        </Switch>
+    </View>
+</MemoryRouter>
+```
+
+### Example: Prevent navigation by calling e.preventDefault()
 
 Sometimes you may need to perform an async action either before or during
 navigation.  This can be accomplished with `beforeNav` and `safeWithNav`
@@ -524,7 +623,7 @@ const styles = StyleSheet.create({
 </MemoryRouter>
 ```
 
-#### Example: style
+### Example: style
 
 Buttons can have a `style` props which supports width, position, margin,
 and flex styles.
@@ -582,7 +681,7 @@ const kinds = ["primary", "secondary", "tertiary"];
 </View>
 ```
 
-#### Example: "submit" buttons in forms
+### Example: "submit" buttons in forms
 
 ```jsx
 import Button from "@khanacademy/wonder-blocks-button";

--- a/packages/wonder-blocks-button/src/components/button.stories.js
+++ b/packages/wonder-blocks-button/src/components/button.stories.js
@@ -464,7 +464,7 @@ SafeWithNavCallbacks.storyName = "safeWithNav Callbacks";
 SafeWithNavCallbacks.parameters = {
     docs: {
         storyDescription:
-            "These buttons navigate immediately when doing client-side navigation or when opening a new tab, but wait until the async callback code completes before starting server-side navigation.",
+            "If the `onClick` callback calls `preventDefault()`, then navigation will not occur.",
     },
     chromatic: {
         disableSnapshot: true,
@@ -482,7 +482,7 @@ export const PreventNavigation: StoryComponentType = () => (
                     e.preventDefault();
                 }}
             >
-                This button prevent navigation.
+                This button prevents navigation.
             </Button>
             <Switch>
                 <Route path="/foo">

--- a/packages/wonder-blocks-button/src/components/button.stories.js
+++ b/packages/wonder-blocks-button/src/components/button.stories.js
@@ -353,7 +353,7 @@ ButtonsWithRouter.parameters = {
     },
 };
 
-export const NavigationWithAsyncAction: StoryComponentType = () => (
+export const BeforeNavCallbacks: StoryComponentType = () => (
     <MemoryRouter>
         <View style={styles.row}>
             <Button
@@ -365,7 +365,7 @@ export const NavigationWithAsyncAction: StoryComponentType = () => (
                     })
                 }
             >
-                Async action, client-side nav
+                beforeNav, client-side nav
             </Button>
             <Button
                 href="/foo"
@@ -377,7 +377,7 @@ export const NavigationWithAsyncAction: StoryComponentType = () => (
                     })
                 }
             >
-                Async action, server-side nav
+                beforeNav, server-side nav
             </Button>
             <Button
                 href="https://google.com"
@@ -389,7 +389,7 @@ export const NavigationWithAsyncAction: StoryComponentType = () => (
                     })
                 }
             >
-                Async action, open URL
+                beforeNav, open URL in new tab
             </Button>
             <Switch>
                 <Route path="/foo">
@@ -400,10 +400,71 @@ export const NavigationWithAsyncAction: StoryComponentType = () => (
     </MemoryRouter>
 );
 
-NavigationWithAsyncAction.parameters = {
+BeforeNavCallbacks.storyName = "beforeNav Callbacks";
+
+BeforeNavCallbacks.parameters = {
     docs: {
         storyDescription:
-            "Sometimes you may need to perform an async action either before or during navigation. This can be accomplished with `beforeNav` and `safeWithNav` respectively.",
+            "These buttons always wait until the async callback code completes before starting navigation.",
+    },
+    chromatic: {
+        disableSnapshot: true,
+    },
+};
+
+export const SafeWithNavCallbacks: StoryComponentType = () => (
+    <MemoryRouter>
+        <View style={styles.row}>
+            <Button
+                href="/foo"
+                style={styles.button}
+                safeWithNav={() =>
+                    new Promise((resolve, reject) => {
+                        setTimeout(resolve, 1000);
+                    })
+                }
+            >
+                safeWithNav, client-side nav
+            </Button>
+            <Button
+                href="/foo"
+                style={styles.button}
+                skipClientNav={true}
+                safeWithNav={() =>
+                    new Promise((resolve, reject) => {
+                        setTimeout(resolve, 1000);
+                    })
+                }
+            >
+                safeWithNav, server-side nav
+            </Button>
+            <Button
+                href="https://google.com"
+                style={styles.button}
+                skipClientNav={true}
+                safeWithNav={() =>
+                    new Promise((resolve, reject) => {
+                        setTimeout(resolve, 1000);
+                    })
+                }
+            >
+                safeWithNav, open URL in new tab
+            </Button>
+            <Switch>
+                <Route path="/foo">
+                    <View id="foo">Hello, world!</View>
+                </Route>
+            </Switch>
+        </View>
+    </MemoryRouter>
+);
+
+SafeWithNavCallbacks.storyName = "safeWithNav Callbacks";
+
+SafeWithNavCallbacks.parameters = {
+    docs: {
+        storyDescription:
+            "These buttons navigate immediately when doing client-side navigation or when opening a new tab, but wait until the async callback code completes before starting server-side navigation.",
     },
     chromatic: {
         disableSnapshot: true,

--- a/packages/wonder-blocks-clickable/src/components/clickable.md
+++ b/packages/wonder-blocks-clickable/src/components/clickable.md
@@ -145,6 +145,13 @@ const styles = StyleSheet.create({
 </MemoryRouter>
 ```
 
+### Running callbacks on navigation
+
+When using the `href` prop, the `onClick`, `beforeNav`, and `safeWithNav` props
+can be used to run callbacks when navigating to the new URL. Which prop to use
+depends on the use case. See the [Button](#section-button) documentation for
+details.
+
 ### Navigating with the Keyboard
 
 Clickable adds support to keyboard navigation. This way, your components are

--- a/packages/wonder-blocks-link/src/components/link.md
+++ b/packages/wonder-blocks-link/src/components/link.md
@@ -35,3 +35,9 @@ import Link from "@khanacademy/wonder-blocks-link";
     </Link>
 </View>
 ```
+
+### Running callbacks on navigation
+
+The `onClick`, `beforeNav`, and `safeWithNav` props can be used to run callbacks
+when navigating to the new URL. Which prop to use depends on the use case. See
+the [Button](#section-button) documentation for details.


### PR DESCRIPTION
## Summary:
This commit adds additional documentation describing the `onClick`,
`beforeNav`, and `safeWithNav` props. These props have been available in
Wonder Blocks for a while, but there has been some confusion about when to
use each one. This commit attempts to add enough detail about these
props to make it clear what the use case is for each prop.

Additionally, this commit changes the section headings in button.md from
h4 to h3 elements. This avoids a gap in heading levels and also brings the
section in line with other sections on the page.

Issue: none

## Test plan:
- Load the documentation and read the Button, Clickable, and Link
  sections.

Button
![image](https://user-images.githubusercontent.com/37850/141476819-c92b8044-33d0-4082-a5ab-e139d58fc309.png)

Clickable
![image](https://user-images.githubusercontent.com/37850/141476932-8745c7fe-ab24-44be-bbb2-c12505d3425a.png)

Link
![image](https://user-images.githubusercontent.com/37850/141476980-36f43595-87ff-495b-850b-58083bcd9fa9.png)

Storybook Documentation Page
![image](https://user-images.githubusercontent.com/37850/141509760-02ae2ba6-4820-4e14-8749-a1b82669559a.png)

Storybook Examples
![image](https://user-images.githubusercontent.com/37850/141513340-9ba12dd8-5568-40ca-b1e5-d831a1ca7ced.png)
