### PR TITLE
WB-1120: Remove dependabot check in node-ci.yml

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,7 +8,6 @@ on:
 # Steps: Setup/build > lint > flow > test > coverage > codecov
 jobs:
   lint_and_test:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     env:
       CI: true


### PR DESCRIPTION
## Summary:

Removed dependabot check in node-ci.yml to run tests, linter, etc. on dependabot
Pull Requests.

By doing this change, now dependabot will be able to run lint and test checks so
we avoid introducing any regressions when upgrading third-party dependencies.

Issue: WB-1120

## Test plan:

- Merge this PR.
- Comment `@dependabot recreate` on one of the dependabot-generated PRs.
- Verify that the Node CI worflow is triggered.