### PR TITLE
WB-1121: Add chromatic GH action back on dependabot PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -48,4 +48,9 @@ jobs:
     # (else) Run this step on dependabot PRs.
     - name: Skip Chromatic builds
       if: ${{ github.actor == 'dependabot[bot]' }}
-      run: yarn chromatic --skip
+      uses: chromaui/action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+        exitZeroOnChanges: true
+        skip: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -53,4 +53,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
         exitZeroOnChanges: true
+        # This is a flag that allows us to skip the build in the case of a
+        # dependabot PR. We still need to report the build as successful so that
+        # the checks are valid and Dependabot can continue.
         skip: true


### PR DESCRIPTION
## Summary:

There was an issue with the Chromatic action (CLI) that didn't allow
skipping tests using the --skip flag (or `skip` env var in this case).

This now can be added back because the fix was applied on the Chromatic CLI repo.

Issue: WB-1121

## Test plan:

- Merge this PR.
- Comment `@dependabot recreate` on one of the dependabot-generated PRs.
- Verify that the Chromatic tests are skipped and the PR can be landed automatically.