### PR TITLE
Prevent nesting of RenderStateRoots

### DIFF
--- a/.changeset/no-nested-render-state-roots.md
+++ b/.changeset/no-nested-render-state-roots.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Nesting of `RenderStateRoot`s inside each other can result in extra renders
+and potentially incorrect behavior.  `RenderStateRoot` now throws if it
+appears as a descendent of another `RenderStateRoot`.

--- a/packages/wonder-blocks-core/src/components/__tests__/render-state-root.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/render-state-root.test.js
@@ -55,4 +55,18 @@ describe("RenderStateRoot", () => {
         // Assert
         expect(values[1]).toEqual(RenderState.Standard);
     });
+
+    it("should not allow nesting of <RenderStateRoot>", () => {
+        // Act
+        const underTest = () =>
+            render(
+                <RenderStateRoot>
+                    <RenderStateRoot>Hello, world!</RenderStateRoot>
+                </RenderStateRoot>,
+            );
+
+        expect(underTest).toThrowErrorMatchingInlineSnapshot(
+            `"There's already a <RenderStateRoot> above this instance in the render tree.  This instance should be removed."`,
+        );
+    });
 });

--- a/packages/wonder-blocks-core/src/components/render-state-root.js
+++ b/packages/wonder-blocks-core/src/components/render-state-root.js
@@ -7,7 +7,7 @@ import * as React from "react";
 // eslint-disable-next-line import/named
 import {RenderState, RenderStateContext} from "./render-state-context.js";
 
-const {useEffect, useState} = React;
+const {useContext, useEffect, useState} = React;
 
 type Props = {|
     children: React.Node,
@@ -15,6 +15,14 @@ type Props = {|
 
 export const RenderStateRoot = ({children}: Props): React.Node => {
     const [firstRender, setFirstRender] = useState<boolean>(true);
+    const contextValue = useContext(RenderStateContext);
+
+    if (contextValue !== RenderState.Root) {
+        throw new Error(
+            "There's already a <RenderStateRoot> above this instance in " +
+                "the render tree.  This instance should be removed.",
+        );
+    }
 
     useEffect(() => {
         setFirstRender(false);

--- a/packages/wonder-blocks-core/src/hooks/use-unique-id.stories.mdx
+++ b/packages/wonder-blocks-core/src/hooks/use-unique-id.stories.mdx
@@ -24,7 +24,7 @@ factory for each subsequent render. The identifier factory is unique to
 each component.
 
 NOTE: All uses of `uniqueUniqueIdWithoutMock` should appear as descendants
-of `<RenderStateRoot>`.  It's customary to place `<RenderStateRoot>` near
+of `<RenderStateRoot>`. It's customary to place `<RenderStateRoot>` near
 the base of the render tree since only one instance is allow in any given
 render tree.
 
@@ -73,7 +73,7 @@ during the initial render, but is not the default, because it is not always safe
 (e.g., we need actual IDs for some SVG constructs).
 
 NOTE: All uses of `uniqueUniqueIdWithMock` should appear as descendants
-of `<RenderStateRoot>`.  It's customary to place `<RenderStateRoot>` near
+of `<RenderStateRoot>`. It's customary to place `<RenderStateRoot>` near
 the base of the render tree since only one instance is allow in any given
 render tree.
 

--- a/packages/wonder-blocks-core/src/hooks/use-unique-id.stories.mdx
+++ b/packages/wonder-blocks-core/src/hooks/use-unique-id.stories.mdx
@@ -23,6 +23,11 @@ It will return `null` on the initial render and then the same identifier
 factory for each subsequent render. The identifier factory is unique to
 each component.
 
+NOTE: All uses of `uniqueUniqueIdWithoutMock` should appear as descendants
+of `<RenderStateRoot>`.  It's customary to place `<RenderStateRoot>` near
+the base of the render tree since only one instance is allow in any given
+render tree.
+
 export const WithoutMockExample = () => {
     const [count, setCount] = React.useState(0);
     const renders = React.useRef([]);
@@ -66,6 +71,11 @@ It will return a mock identifier factory on the initial render that doesn'that
 guarantee identifier uniqueness. Mock mode can help things appear on the screen
 during the initial render, but is not the default, because it is not always safe
 (e.g., we need actual IDs for some SVG constructs).
+
+NOTE: All uses of `uniqueUniqueIdWithMock` should appear as descendants
+of `<RenderStateRoot>`.  It's customary to place `<RenderStateRoot>` near
+the base of the render tree since only one instance is allow in any given
+render tree.
 
 export const WithMockExample = () => {
     const [count, setCount] = React.useState(0);

--- a/packages/wonder-blocks-core/src/hooks/use-unique-id.stories.mdx
+++ b/packages/wonder-blocks-core/src/hooks/use-unique-id.stories.mdx
@@ -23,7 +23,7 @@ It will return `null` on the initial render and then the same identifier
 factory for each subsequent render. The identifier factory is unique to
 each component.
 
-NOTE: All uses of `uniqueUniqueIdWithoutMock` should appear as descendants
+NOTE: All uses of `useUniqueIdWithoutMock` should appear as descendants
 of `<RenderStateRoot>`. It's customary to place `<RenderStateRoot>` near
 the base of the render tree since only one instance is allow in any given
 render tree.
@@ -72,7 +72,7 @@ guarantee identifier uniqueness. Mock mode can help things appear on the screen
 during the initial render, but is not the default, because it is not always safe
 (e.g., we need actual IDs for some SVG constructs).
 
-NOTE: All uses of `uniqueUniqueIdWithMock` should appear as descendants
+NOTE: All uses of `useUniqueIdWithMock` should appear as descendants
 of `<RenderStateRoot>`. It's customary to place `<RenderStateRoot>` near
 the base of the render tree since only one instance is allow in any given
 render tree.


### PR DESCRIPTION
## Summary:
Nesting of RenderStateRoots will result in unnecessary renders at best and incorrect behavior at worst.  This PR updates the component to throw if it detects that its a descendant of another RenderStateRoot.

Issue: none

## Test plan:
- yarn test