### PR TITLE
FEI-4023: Create useInterval hook

### DIFF
--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-interval.test.js
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-interval.test.js
@@ -1,0 +1,294 @@
+// @flow
+import {renderHook, act} from "@testing-library/react-hooks";
+import {SchedulePolicy, ClearPolicy} from "../../util/policies.js";
+
+import {useInterval} from "../use-interval.js";
+
+describe("useInterval", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("throws if the action is not a function", () => {
+        // Arrange
+
+        // Act
+        const {result} = renderHook(() => useInterval((null: any), 1000));
+
+        // Assert
+        expect(result.error).toEqual(Error("Action must be a function"));
+    });
+
+    it("throws if the period is less than 1", () => {
+        // Arrange
+
+        // Act
+        const {result} = renderHook(() => useInterval(() => {}, 0));
+
+        // Assert
+        expect(result.error).toEqual(Error("Interval period must be >= 1"));
+    });
+
+    it("sets an interval when schedule policy is SchedulePolicy.Immediately", () => {
+        // Arrange
+        const intervalSpy = jest.spyOn(global, "setInterval");
+
+        // Act
+        renderHook(() => useInterval(() => {}, 1000));
+
+        // Assert
+        expect(intervalSpy).toHaveBeenCalledTimes(1);
+    });
+
+    describe("isSet", () => {
+        it("is false when the interval has not been set [SchedulePolicy.OnDemand]", () => {
+            // Arrange
+            const {result} = renderHook(() =>
+                useInterval(() => {}, 1000, {
+                    schedulePolicy: SchedulePolicy.OnDemand,
+                }),
+            );
+
+            // Act
+            const isSet = result.current.isSet;
+
+            // Assert
+            expect(isSet).toBeFalsy();
+        });
+
+        it("is true when the interval is active", () => {
+            // Arrange
+            const {result} = renderHook(() => useInterval(() => {}, 1000));
+            act(() => {
+                result.current.set();
+            });
+
+            // Act
+            const isSet = result.current.isSet;
+
+            // Assert
+            expect(isSet).toBeTruthy();
+        });
+
+        it("is false when the interval is cleared", () => {
+            // Arrange
+            const {result} = renderHook(() => useInterval(() => {}, 1000));
+            act(() => {
+                result.current.set();
+                result.current.clear();
+            });
+
+            // Act
+            const isSet = result.current.isSet;
+
+            // Assert
+            expect(isSet).toBeFalsy();
+        });
+    });
+
+    describe("#set", () => {
+        it("should call setInterval", () => {
+            // Arrange
+            const intervalSpy = jest.spyOn(global, "setInterval");
+            const {result} = renderHook(() =>
+                useInterval(() => {}, 500, {
+                    schedulePolicy: SchedulePolicy.OnDemand,
+                }),
+            );
+
+            // Act
+            act(() => {
+                result.current.set();
+            });
+
+            // Assert
+            expect(intervalSpy).toHaveBeenNthCalledWith(
+                1,
+                expect.any(Function),
+                500,
+            );
+        });
+
+        it("should invoke setInterval to call the given action", () => {
+            // Arrange
+            const intervalSpy = jest.spyOn(global, "setInterval");
+            const action = jest.fn();
+            const {result} = renderHook(() =>
+                useInterval(action, 500, {
+                    schedulePolicy: SchedulePolicy.OnDemand,
+                }),
+            );
+
+            act(() => {
+                result.current.set();
+            });
+            const scheduledAction = intervalSpy.mock.calls[0][0];
+
+            // Act
+            scheduledAction();
+
+            // Assert
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        it("should clear the active interval", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() =>
+                useInterval(action, 500, {
+                    schedulePolicy: SchedulePolicy.OnDemand,
+                }),
+            );
+            act(() => {
+                result.current.set();
+            });
+
+            // Act
+            act(() => {
+                result.current.set();
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        it("should set an interval that stays active while not cleared", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() => useInterval(action, 500));
+            act(() => {
+                result.current.set();
+            });
+
+            // Act
+            act(() => {
+                jest.advanceTimersByTime(1501);
+            });
+
+            // Assert
+            expect(action).toHaveBeenCalledTimes(3);
+        });
+
+        it("should continue to be set after calling it multiple times", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() => useInterval(action, 500));
+            act(() => {
+                result.current.set();
+            });
+
+            // Act
+            act(() => {
+                result.current.set();
+            });
+            act(() => {
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).toHaveBeenCalled();
+        });
+
+        it("should set the timeout after clearing it", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() => useInterval(action, 500));
+            act(() => {
+                result.current.clear();
+            });
+
+            // Act
+            act(() => {
+                result.current.set();
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).toHaveBeenCalled();
+        });
+    });
+
+    describe("#clear", () => {
+        it("should clear an active interval", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() => useInterval(action, 500));
+            act(() => {
+                result.current.set();
+            });
+
+            // Act
+            act(() => {
+                result.current.clear();
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).not.toHaveBeenCalled();
+        });
+
+        it("should invoke the action if clear policy is ClearPolicy.Resolve", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() => useInterval(action, 500));
+            act(() => {
+                result.current.set();
+            });
+
+            // Act
+            act(() => {
+                result.current.clear(ClearPolicy.Resolve);
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        it("should not invoke the action if clear policy is ClearPolicy.Cancel", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() =>
+                useInterval(action, 500, {
+                    schedulePolicy: SchedulePolicy.Immediately,
+                }),
+            );
+            act(() => {
+                result.current.set();
+            });
+
+            // Act
+            act(() => {
+                result.current.clear(ClearPolicy.Cancel);
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).not.toHaveBeenCalled();
+        });
+
+        it("should not invoke the action if interval is inactive and clear policy is ClearPolicy.Resolve", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() =>
+                useInterval(action, 500, {
+                    schedulePolicy: SchedulePolicy.OnDemand,
+                }),
+            );
+
+            // Act
+            act(() => {
+                result.current.clear(ClearPolicy.Resolve);
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/wonder-blocks-timing/src/hooks/use-interval.js
+++ b/packages/wonder-blocks-timing/src/hooks/use-interval.js
@@ -1,0 +1,79 @@
+// @flow
+import {useEffect, useState, useCallback, useRef} from "react";
+
+import {
+    SchedulePolicy as SchedulePolicies,
+    ClearPolicy as ClearPolicies,
+} from "../util/policies.js";
+import type {IInterval, ClearPolicy, Options} from "../util/types.js";
+
+export function useInterval(
+    action: () => mixed,
+    intervalMs: number,
+    options?: Options,
+): IInterval {
+    if (typeof action !== "function") {
+        throw new Error("Action must be a function");
+    }
+
+    if (intervalMs < 1) {
+        throw new Error("Interval period must be >= 1");
+    }
+
+    const schedulePolicy =
+        options?.schedulePolicy ?? SchedulePolicies.Immediately;
+    const [isSet, setIsSet] = useState(
+        schedulePolicy === SchedulePolicies.Immediately,
+    );
+    const actionRef = useRef(action);
+    const mountedRef = useRef(false);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    useEffect(() => {
+        actionRef.current = action;
+    }, [action]);
+
+    const clear = useCallback(
+        (policy?: ClearPolicy) => {
+            if (
+                isSet &&
+                (policy ?? options?.clearPolicy) === ClearPolicies.Resolve
+            ) {
+                actionRef.current();
+            }
+            // This will cause the useEffect below to re-run
+            setIsSet(false);
+        },
+        [isSet, options?.clearPolicy],
+    );
+
+    const set = useCallback(() => {
+        if (!isSet) {
+            // This will cause the useEffect below to re-run
+            setIsSet(true);
+        }
+    }, [isSet]);
+
+    useEffect(() => {
+        if (isSet && mountedRef.current) {
+            const timeout = setInterval(() => {
+                actionRef.current();
+            }, intervalMs);
+
+            return () => {
+                clearInterval(timeout);
+                if (!mountedRef.current) {
+                    clear();
+                }
+            };
+        }
+    }, [clear, isSet, intervalMs]);
+
+    return {isSet, set, clear};
+}

--- a/packages/wonder-blocks-timing/src/hooks/use-interval.stories.mdx
+++ b/packages/wonder-blocks-timing/src/hooks/use-interval.stories.mdx
@@ -1,0 +1,147 @@
+import {Meta, Story, Source, Canvas} from "@storybook/addon-docs";
+
+import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import {View} from "@khanacademy/wonder-blocks-core";
+import Button from "@khanacademy/wonder-blocks-button";
+
+import {ClearPolicy, SchedulePolicy} from "../util/policies.js";
+import {useInterval} from "./use-interval.js";
+
+<Meta
+    title="Timing/useInterval"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# `useInterval`
+
+`useInterval` is a hook that provides a convenient API for setting and clearing
+an interval. It is defined as follows:
+
+```ts
+function useInterval(
+    action: () => mixed,
+    timeoutMs: number,
+    options?: {|
+        schedulePolicy?: "schedule-immediately" | "schedule-on-demand",
+        clearPolicy?: "resolve-on-clear" | "cancel-on-clear",
+    |},
+): ITimeout;
+
+interface ITimeout {
+    get isSet(): boolean;
+    set(): void;
+    clear(policy?: ClearPolicy): void;
+}
+```
+
+By default the interval will be set immediately up creation. The `options` parameter can
+be used to control when when the interval is schedule and whether or not `action` should be
+called when the interval is cleared.
+
+Notes:
+
+-   Because `clear` takes a param, it's import that you don't pass it directly to an event handler,
+    e.g. `<Button onClick={clear} />` will not work as expected.
+-   Calling `set` after the interval has been cleared will restart the interval.
+-   Updating the second paramter, `timeoutMs`, will also restart the interval.
+-   When the component using this hooks is unmounted, the interval will automatically be cleared.
+-   Calling `set` after the interval is already set does nothing.
+
+export const Immediately = () => {
+    const [callCount, setCallCount] = React.useState(0);
+    const callback = React.useCallback(() => {
+        setCallCount((callCount) => callCount + 1);
+    }, []);
+    const {isSet, set, clear} = useInterval(callback, 1000);
+    return (
+        <View>
+            <View>isSet = {isSet.toString()}</View>
+            <View>callCount = {callCount}</View>
+            <View style={{flexDirection: "row"}}>
+                <Button onClick={set}>Set interval</Button>
+                <Button onClick={clear}>Clear interval</Button>
+            </View>
+        </View>
+    );
+};
+
+<Canvas>
+    <Story name="Immediately">
+        <Immediately />
+    </Story>
+</Canvas>
+
+```jsx
+const Immediately = () => {
+    const [callCount, setCallCount] = React.useState(0);
+    const callback = React.useCallback(() => {
+        setCallCount((callCount) => callCount + 1);
+    }, []);
+    const {isSet, set, clear} = useInterval(callback, 1000);
+    return (
+        <View>
+            <View>isSet = {isSet.toString()}</View>
+            <View>callCount = {callCount}</View>
+            <View style={{flexDirection: "row"}}>
+                <Button onClick={() => set()}>Set interval</Button>
+                <Button onClick={() => clear()}>Clear interval</Button>
+            </View>
+        </View>
+    );
+};
+```
+
+export const OnDemandAndResolveOnClear = () => {
+    const [callCount, setCallCount] = React.useState(0);
+    const callback = React.useCallback(() => {
+        console.log("action called");
+        setCallCount((callCount) => callCount + 1);
+    }, []);
+    const {isSet, set, clear} = useInterval(callback, 1000, {
+        clearPolicy: ClearPolicy.Resolve,
+        schedulePolicy: SchedulePolicy.OnDemand,
+    });
+    return (
+        <View>
+            <View>isSet = {isSet.toString()}</View>
+            <View>callCount = {callCount}</View>
+            <View style={{flexDirection: "row"}}>
+                <Button onClick={() => set()}>Set interval</Button>
+                <Button onClick={() => clear()}>Clear interval</Button>
+            </View>
+        </View>
+    );
+};
+
+<Canvas>
+    <Story name="OnDemandAndResolveOnClear">
+        <OnDemandAndResolveOnClear />
+    </Story>
+</Canvas>
+
+```jsx
+const OnDemandAndResolveOnClear = () => {
+    const [callCount, setCallCount] = React.useState(0);
+    const callback = React.useCallback(() => {
+        setCallCount((callCount) => callCount + 1);
+    }, []);
+    const {isSet, set, clear} = useInterval(callback, 1000, {
+        clearPolicy: ClearPolicy.Resolve,
+        schedulePolicy: SchedulePolicy.OnDemand,
+    });
+    return (
+        <View>
+            <View>isSet = {isSet.toString()}</View>
+            <View>callCount = {callCount}</View>
+            <View style={{flexDirection: "row"}}>
+                <Button onClick={() => set()}>Set interval</Button>
+                <Button onClick={() => clear()}>Clear interval</Button>
+            </View>
+        </View>
+    );
+};
+```


### PR DESCRIPTION
## Summary:
This is very similar to the useTimeout hook from #1225.  I ported the tests from timeout.test.js and added a few additional tests.  This should provide a high level of confidence that the hook and withActionScheduler's schedule.interval() method have consistent behavior.

Issue: FEI-4023

## Test plan:
- yarn jest use-interval.test.js
- http://localhost:6061/?path=/docs/timing-useinterval--immediately
- test that the example stories behave as expected