### PR TITLE
Chromatic: Add delay to Tooltip and Popover snapshots

### DIFF
--- a/packages/wonder-blocks-popover/src/components/popover.stories.js
+++ b/packages/wonder-blocks-popover/src/components/popover.stories.js
@@ -13,11 +13,10 @@ import PopoverContent from "./popover-content.js";
 export default {
     title: "Floating/Popover",
     parameters: {
-        // TODO(WB-1170): Re-enable this after investigating more about
-        // Chromatic flakyness.
+        // TODO(WB-1170): Reassess this after investigating more about Chromatic
+        // flakyness.
         chromatic: {
-            // Disables chromatic testing for these stories.
-            disableSnapshot: true,
+            delay: 200,
         },
     },
 };

--- a/packages/wonder-blocks-popover/src/components/popover.stories.js
+++ b/packages/wonder-blocks-popover/src/components/popover.stories.js
@@ -12,6 +12,14 @@ import PopoverContent from "./popover-content.js";
 
 export default {
     title: "Floating/Popover",
+    parameters: {
+        // TODO(WB-1170): Re-enable this after investigating more about
+        // Chromatic flakyness.
+        chromatic: {
+            // Disables chromatic testing for these stories.
+            disableSnapshot: true,
+        },
+    },
 };
 
 const styles = StyleSheet.create({

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.stories.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.stories.js
@@ -11,11 +11,10 @@ import type {StoryComponentType} from "@storybook/react";
 export default {
     title: "Floating/Tooltip",
     parameters: {
-        // TODO(WB-1170): Re-enable this after investigating more about
-        // Chromatic flakyness.
+        // TODO(WB-1170): Reassess this after investigating more about Chromatic
+        // flakyness.
         chromatic: {
-            // Disables chromatic testing for these stories.
-            disableSnapshot: true,
+            delay: 200,
         },
     },
 };

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.stories.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.stories.js
@@ -10,6 +10,14 @@ import type {StoryComponentType} from "@storybook/react";
 
 export default {
     title: "Floating/Tooltip",
+    parameters: {
+        // TODO(WB-1170): Re-enable this after investigating more about
+        // Chromatic flakyness.
+        chromatic: {
+            // Disables chromatic testing for these stories.
+            disableSnapshot: true,
+        },
+    },
 };
 
 const BaseTooltipExample = ({placement}: {|placement: Placement|}) => {


### PR DESCRIPTION
## Summary:

Initial work for investigating on Chromatic about some flaky tests with PopperJS.

This first step is ~just to disable~ add a delay to the Popover and Tooltip
snapshots until we get a better sense of how (and if we can) remove the
flakyness.

Issue: WB-1170

## Test plan:

Verify that the chromatic build doesn't report any changes on the Tooltip and
Popover stories.