### PR TITLE
Add some tests that test the interaction of RenderStateRoot with other components

### DIFF
--- a/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.js
@@ -9,6 +9,7 @@ import SsrIDFactory from "../../util/ssr-id-factory.js";
 import UniqueIDFactory from "../../util/unique-id-factory.js";
 import UniqueIDProvider from "../unique-id-provider.js";
 import WithSSRPlaceholder from "../with-ssr-placeholder.js";
+import {RenderStateRoot} from "../render-state-root.js";
 
 describe("UniqueIDProvider", () => {
     describe("mockOnFirstRender is default (false)", () => {
@@ -145,6 +146,27 @@ describe("UniqueIDProvider", () => {
                         </UniqueIDProvider>
                     )}
                 </WithSSRPlaceholder>
+            );
+
+            // Act
+            mount(nodes);
+
+            // Assert
+            expect(foo).toHaveBeenCalled();
+            expect(foo.mock.calls[0][0]).toBeTruthy();
+        });
+    });
+
+    describe("inside a RenderStateRoot", () => {
+        test("it should pass an id to its children", () => {
+            // Arrange
+            const foo = jest.fn(() => null);
+            const nodes = (
+                <RenderStateRoot>
+                    <UniqueIDProvider mockOnFirstRender={false}>
+                        {(ids) => foo(ids.get(""))}
+                    </UniqueIDProvider>
+                </RenderStateRoot>
             );
 
             // Act

--- a/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.js
@@ -4,6 +4,7 @@ import * as ReactDOMServer from "react-dom/server.js";
 import {mount} from "enzyme";
 
 import WithSSRPlaceholder from "../with-ssr-placeholder.js";
+import {RenderStateRoot} from "../render-state-root.js";
 
 describe("WithSSRPlaceholder", () => {
     describe("client-side rendering", () => {
@@ -184,6 +185,75 @@ describe("WithSSRPlaceholder", () => {
                 // Assert
                 expect(result).toBe("");
             });
+        });
+    });
+
+    describe("inside a RenderStateRoot", () => {
+        test("calls placeholder render first, then the actual content render", async () => {
+            // Arrange
+            const mockPlaceholder = jest.fn(() => null);
+            await new Promise((resolve) => {
+                const nodes = (
+                    <RenderStateRoot>
+                        <WithSSRPlaceholder placeholder={mockPlaceholder}>
+                            {() => {
+                                resolve();
+                                return null;
+                            }}
+                        </WithSSRPlaceholder>
+                    </RenderStateRoot>
+                );
+
+                // Act
+                mount(nodes);
+            });
+
+            // Assert
+            // Our promise doesn't resolve until the children render, therefore
+            // we don't get here until that and so if the placeholder has been
+            // called, it must have been called first.
+            expect(mockPlaceholder).toHaveBeenCalledTimes(1);
+        });
+
+        test("server-side rendering, calls placeholder render only", () => {
+            // Arrange
+            const mockChildren = jest.fn(() => null);
+            const mockPlaceholder = jest.fn(() => null);
+
+            const nodes = (
+                <RenderStateRoot>
+                    <WithSSRPlaceholder placeholder={mockPlaceholder}>
+                        {mockChildren}
+                    </WithSSRPlaceholder>
+                </RenderStateRoot>
+            );
+
+            // Act
+            ReactDOMServer.renderToStaticMarkup(nodes);
+
+            // Assert
+            expect(mockPlaceholder).toHaveBeenCalledTimes(1);
+            expect(mockChildren).toHaveBeenCalledTimes(0);
+        });
+
+        test("null placeholder returns null", () => {
+            // Arrange
+            const mockChildren = jest.fn(() => null);
+
+            const nodes = (
+                <RenderStateRoot>
+                    <WithSSRPlaceholder placeholder={null}>
+                        {mockChildren}
+                    </WithSSRPlaceholder>
+                </RenderStateRoot>
+            );
+
+            // Act
+            const result = ReactDOMServer.renderToStaticMarkup(nodes);
+
+            // Assert
+            expect(result).toBe("");
+            expect(mockChildren).toHaveBeenCalledTimes(0);
         });
     });
 });


### PR DESCRIPTION
## Summary:
I added a few tests that verify that `WithSSRPlaceholder` and `UniqueIDProvider` can operate as descendants of `RenderStateRoot` without blowing up.

Issue: none

## Test plan:
- yarn jest unique-id-provider.test.js with-ssr-placeholder.test.js