### PR TITLE
FEI-4212.1: rename timing hooks based on API design spec

### DIFF
--- a/.changeset/fei-4212.1.md
+++ b/.changeset/fei-4212.1.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-timing": minor
+---
+
+Rename `useInterval` and `useTimeout` to `useScheduledInterval`
+and `useScheduledTimeout` respectively.

--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-scheduled-interval.test.js
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-scheduled-interval.test.js
@@ -2,9 +2,9 @@
 import {renderHook, act} from "@testing-library/react-hooks";
 import {SchedulePolicy, ClearPolicy} from "../../util/policies.js";
 
-import {useInterval} from "../use-interval.js";
+import {useScheduledInterval} from "../use-scheduled-interval.js";
 
-describe("useInterval", () => {
+describe("useScheduledInterval", () => {
     beforeEach(() => {
         jest.useFakeTimers();
     });
@@ -17,7 +17,9 @@ describe("useInterval", () => {
         // Arrange
 
         // Act
-        const {result} = renderHook(() => useInterval((null: any), 1000));
+        const {result} = renderHook(() =>
+            useScheduledInterval((null: any), 1000),
+        );
 
         // Assert
         expect(result.error).toEqual(Error("Action must be a function"));
@@ -27,7 +29,7 @@ describe("useInterval", () => {
         // Arrange
 
         // Act
-        const {result} = renderHook(() => useInterval(() => {}, 0));
+        const {result} = renderHook(() => useScheduledInterval(() => {}, 0));
 
         // Assert
         expect(result.error).toEqual(Error("Interval period must be >= 1"));
@@ -38,7 +40,7 @@ describe("useInterval", () => {
         const intervalSpy = jest.spyOn(global, "setInterval");
 
         // Act
-        renderHook(() => useInterval(() => {}, 1000));
+        renderHook(() => useScheduledInterval(() => {}, 1000));
 
         // Assert
         expect(intervalSpy).toHaveBeenCalledTimes(1);
@@ -47,7 +49,9 @@ describe("useInterval", () => {
     it("should call the action before unmounting", () => {
         const action = jest.fn();
         const {unmount} = renderHook(() =>
-            useInterval(action, 1000, {clearPolicy: ClearPolicy.Resolve}),
+            useScheduledInterval(action, 1000, {
+                clearPolicy: ClearPolicy.Resolve,
+            }),
         );
 
         act(() => {
@@ -61,9 +65,12 @@ describe("useInterval", () => {
         // Arrange
         const action1 = jest.fn();
         const action2 = jest.fn();
-        const {rerender} = renderHook(({action}) => useInterval(action, 500), {
-            initialProps: {action: action1},
-        });
+        const {rerender} = renderHook(
+            ({action}) => useScheduledInterval(action, 500),
+            {
+                initialProps: {action: action1},
+            },
+        );
 
         // Act
         rerender({action: action2});
@@ -73,14 +80,17 @@ describe("useInterval", () => {
         expect(action2).toHaveBeenCalledTimes(1);
     });
 
-    it("should only call useInterval once even if action changes", () => {
+    it("should only call useScheduledInterval once even if action changes", () => {
         // Arrange
         const intervalSpy = jest.spyOn(global, "setInterval");
         const action1 = jest.fn();
         const action2 = jest.fn();
-        const {rerender} = renderHook(({action}) => useInterval(action, 500), {
-            initialProps: {action: action1},
-        });
+        const {rerender} = renderHook(
+            ({action}) => useScheduledInterval(action, 500),
+            {
+                initialProps: {action: action1},
+            },
+        );
 
         // Act
         rerender({action: action2});
@@ -93,7 +103,7 @@ describe("useInterval", () => {
         // Arrange
         const action = jest.fn();
         const {rerender} = renderHook(
-            ({intervalMs}) => useInterval(action, intervalMs),
+            ({intervalMs}) => useScheduledInterval(action, intervalMs),
             {
                 initialProps: {intervalMs: 500},
             },
@@ -111,7 +121,7 @@ describe("useInterval", () => {
         // Arrange
         const intervalSpy = jest.spyOn(global, "setInterval");
         const {rerender} = renderHook(
-            ({intervalMs}) => useInterval(() => {}, intervalMs),
+            ({intervalMs}) => useScheduledInterval(() => {}, intervalMs),
             {
                 initialProps: {intervalMs: 500},
             },
@@ -128,7 +138,7 @@ describe("useInterval", () => {
         it("is false when the interval has not been set [SchedulePolicy.OnDemand]", () => {
             // Arrange
             const {result} = renderHook(() =>
-                useInterval(() => {}, 1000, {
+                useScheduledInterval(() => {}, 1000, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -142,7 +152,9 @@ describe("useInterval", () => {
 
         it("is true when the interval is active", () => {
             // Arrange
-            const {result} = renderHook(() => useInterval(() => {}, 1000));
+            const {result} = renderHook(() =>
+                useScheduledInterval(() => {}, 1000),
+            );
             act(() => {
                 result.current.set();
             });
@@ -156,7 +168,9 @@ describe("useInterval", () => {
 
         it("is false when the interval is cleared", () => {
             // Arrange
-            const {result} = renderHook(() => useInterval(() => {}, 1000));
+            const {result} = renderHook(() =>
+                useScheduledInterval(() => {}, 1000),
+            );
             act(() => {
                 result.current.set();
                 result.current.clear();
@@ -175,7 +189,7 @@ describe("useInterval", () => {
             // Arrange
             const intervalSpy = jest.spyOn(global, "setInterval");
             const {result} = renderHook(() =>
-                useInterval(() => {}, 500, {
+                useScheduledInterval(() => {}, 500, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -198,7 +212,7 @@ describe("useInterval", () => {
             const intervalSpy = jest.spyOn(global, "setInterval");
             const action = jest.fn();
             const {result} = renderHook(() =>
-                useInterval(action, 500, {
+                useScheduledInterval(action, 500, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -219,7 +233,7 @@ describe("useInterval", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
-                useInterval(action, 500, {
+                useScheduledInterval(action, 500, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -240,7 +254,9 @@ describe("useInterval", () => {
         it("should set an interval that stays active while not cleared", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useInterval(action, 500));
+            const {result} = renderHook(() =>
+                useScheduledInterval(action, 500),
+            );
             act(() => {
                 result.current.set();
             });
@@ -257,7 +273,9 @@ describe("useInterval", () => {
         it("should continue to be set after calling it multiple times", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useInterval(action, 500));
+            const {result} = renderHook(() =>
+                useScheduledInterval(action, 500),
+            );
             act(() => {
                 result.current.set();
             });
@@ -277,7 +295,9 @@ describe("useInterval", () => {
         it("should set the timeout after clearing it", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useInterval(action, 500));
+            const {result} = renderHook(() =>
+                useScheduledInterval(action, 500),
+            );
             act(() => {
                 result.current.clear();
             });
@@ -295,7 +315,7 @@ describe("useInterval", () => {
         it("shouldn't throw an error if called after the component unmounted", () => {
             const action = jest.fn();
             const {result, unmount} = renderHook(() =>
-                useInterval(action, 500),
+                useScheduledInterval(action, 500),
             );
             act(() => {
                 unmount();
@@ -313,7 +333,9 @@ describe("useInterval", () => {
         it("should clear an active interval", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useInterval(action, 500));
+            const {result} = renderHook(() =>
+                useScheduledInterval(action, 500),
+            );
             act(() => {
                 result.current.set();
             });
@@ -331,7 +353,9 @@ describe("useInterval", () => {
         it("should invoke the action if clear policy is ClearPolicy.Resolve", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useInterval(action, 500));
+            const {result} = renderHook(() =>
+                useScheduledInterval(action, 500),
+            );
             act(() => {
                 result.current.set();
             });
@@ -350,7 +374,7 @@ describe("useInterval", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
-                useInterval(action, 500, {
+                useScheduledInterval(action, 500, {
                     schedulePolicy: SchedulePolicy.Immediately,
                 }),
             );
@@ -372,7 +396,7 @@ describe("useInterval", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
-                useInterval(action, 500, {
+                useScheduledInterval(action, 500, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -391,7 +415,9 @@ describe("useInterval", () => {
             // Arrange
             const action = jest.fn();
             const {result, unmount} = renderHook(() =>
-                useInterval(action, 500, {clearPolicy: ClearPolicy.Resolve}),
+                useScheduledInterval(action, 500, {
+                    clearPolicy: ClearPolicy.Resolve,
+                }),
             );
 
             // Act
@@ -410,7 +436,7 @@ describe("useInterval", () => {
             // Arrange
             const action = jest.fn();
             const {result, unmount} = renderHook(() =>
-                useInterval(action, 500),
+                useScheduledInterval(action, 500),
             );
             act(() => {
                 unmount();

--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-scheduled-timeout.test.js
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-scheduled-timeout.test.js
@@ -2,16 +2,16 @@
 import {renderHook, act} from "@testing-library/react-hooks";
 import {SchedulePolicy, ClearPolicy} from "../../util/policies.js";
 
-import {useTimeout} from "../use-timeout.js";
+import {useScheduledTimeout} from "../use-scheduled-timeout.js";
 
-describe("useTimeout", () => {
+describe("useScheduledTimeout", () => {
     beforeEach(() => {
         jest.useFakeTimers();
     });
 
     it("should return an ITimeout", () => {
         // Arrange
-        const {result} = renderHook(() => useTimeout(() => {}, 1000));
+        const {result} = renderHook(() => useScheduledTimeout(() => {}, 1000));
 
         // Act
 
@@ -27,7 +27,7 @@ describe("useTimeout", () => {
 
     it("should default to being immediately set", () => {
         // Arrange
-        const {result} = renderHook(() => useTimeout(() => {}, 1000));
+        const {result} = renderHook(() => useScheduledTimeout(() => {}, 1000));
 
         // Act
 
@@ -39,7 +39,7 @@ describe("useTimeout", () => {
         it("should call the action after the timeout expires", () => {
             // Arrange
             const action = jest.fn();
-            renderHook(() => useTimeout(action, 1000));
+            renderHook(() => useScheduledTimeout(action, 1000));
 
             // Act
             act(() => {
@@ -53,7 +53,9 @@ describe("useTimeout", () => {
         it("should update isSet to false after the timeout expires", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useTimeout(action, 1000));
+            const {result} = renderHook(() =>
+                useScheduledTimeout(action, 1000),
+            );
 
             // Act
             act(() => {
@@ -67,7 +69,9 @@ describe("useTimeout", () => {
         it("should call the action again if 'set' is called after the action was called", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useTimeout(action, 1000));
+            const {result} = renderHook(() =>
+                useScheduledTimeout(action, 1000),
+            );
 
             // Act
             act(() => {
@@ -84,7 +88,7 @@ describe("useTimeout", () => {
             // Arrange
             const action = jest.fn();
             const {rerender} = renderHook(
-                ({timeoutMs}) => useTimeout(action, timeoutMs),
+                ({timeoutMs}) => useScheduledTimeout(action, timeoutMs),
                 {
                     initialProps: {timeoutMs: 1000},
                 },
@@ -109,7 +113,7 @@ describe("useTimeout", () => {
             // Arrange
             const action = jest.fn();
             const {rerender} = renderHook(
-                ({timeoutMs}) => useTimeout(action, timeoutMs),
+                ({timeoutMs}) => useScheduledTimeout(action, timeoutMs),
                 {
                     initialProps: {timeoutMs: 1000},
                 },
@@ -130,7 +134,7 @@ describe("useTimeout", () => {
             const action1 = jest.fn();
             const action2 = jest.fn();
             const {rerender} = renderHook(
-                ({action}) => useTimeout(action, 1000),
+                ({action}) => useScheduledTimeout(action, 1000),
                 {
                     initialProps: {action: action1},
                 },
@@ -151,7 +155,7 @@ describe("useTimeout", () => {
             const action1 = jest.fn();
             const action2 = jest.fn();
             const {rerender} = renderHook(
-                ({action}) => useTimeout(action, 1000),
+                ({action}) => useScheduledTimeout(action, 1000),
                 {
                     initialProps: {action: action1},
                 },
@@ -170,7 +174,9 @@ describe("useTimeout", () => {
         it("should not call the action if the timeout is cleared", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useTimeout(action, 1000));
+            const {result} = renderHook(() =>
+                useScheduledTimeout(action, 1000),
+            );
 
             // Act
             act(() => {
@@ -185,7 +191,9 @@ describe("useTimeout", () => {
         it("should call the action when the timeout is cleared when passing ClearPolicies.Resolve to clear()", () => {
             // Arrange
             const action = jest.fn();
-            const {result} = renderHook(() => useTimeout(action, 1000));
+            const {result} = renderHook(() =>
+                useScheduledTimeout(action, 1000),
+            );
 
             // Act
             act(() => {
@@ -200,7 +208,9 @@ describe("useTimeout", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
-                useTimeout(action, 1000, {clearPolicy: ClearPolicy.Resolve}),
+                useScheduledTimeout(action, 1000, {
+                    clearPolicy: ClearPolicy.Resolve,
+                }),
             );
 
             // Act
@@ -216,7 +226,9 @@ describe("useTimeout", () => {
             // Arrange
             const action = jest.fn();
             const {unmount} = renderHook(() =>
-                useTimeout(action, 1000, {clearPolicy: ClearPolicy.Resolve}),
+                useScheduledTimeout(action, 1000, {
+                    clearPolicy: ClearPolicy.Resolve,
+                }),
             );
 
             // Act
@@ -229,7 +241,9 @@ describe("useTimeout", () => {
         it("should not call the action on unmount when using the default options", () => {
             // Arrange
             const action = jest.fn();
-            const {unmount} = renderHook(() => useTimeout(action, 1000));
+            const {unmount} = renderHook(() =>
+                useScheduledTimeout(action, 1000),
+            );
 
             // Act
             unmount();
@@ -243,7 +257,7 @@ describe("useTimeout", () => {
         it("should not set the timer on creation", () => {
             // Arrange
             const {result} = renderHook(() =>
-                useTimeout(() => {}, 1000, {
+                useScheduledTimeout(() => {}, 1000, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -258,7 +272,7 @@ describe("useTimeout", () => {
             // Arrange
             const action = jest.fn();
             renderHook(() =>
-                useTimeout(action, 1000, {
+                useScheduledTimeout(action, 1000, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -276,7 +290,7 @@ describe("useTimeout", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
-                useTimeout(action, 1000, {
+                useScheduledTimeout(action, 1000, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -295,7 +309,7 @@ describe("useTimeout", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
-                useTimeout(action, 1000, {
+                useScheduledTimeout(action, 1000, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );
@@ -316,7 +330,7 @@ describe("useTimeout", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
-                useTimeout(action, 1000, {
+                useScheduledTimeout(action, 1000, {
                     schedulePolicy: SchedulePolicy.OnDemand,
                 }),
             );

--- a/packages/wonder-blocks-timing/src/hooks/internal/use-interval.js
+++ b/packages/wonder-blocks-timing/src/hooks/internal/use-interval.js
@@ -10,7 +10,7 @@ import {useUpdatingRef} from "./use-updating-ref.js";
  * @param intervalMs the duration between calls to `action`
  * @param active whether or not the interval is active
  */
-export function useSimpleInterval(
+export function useInterval(
     action: () => mixed,
     intervalMs: number,
     active: boolean,

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.js
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.js
@@ -8,9 +8,9 @@ import {
 import type {IInterval, ClearPolicy, Options} from "../util/types.js";
 
 import {useUpdatingRef} from "./internal/use-updating-ref.js";
-import {useSimpleInterval} from "./internal/use-simple-interval.js";
+import {useInterval} from "./internal/use-interval.js";
 
-export function useInterval(
+export function useScheduledInterval(
     action: () => mixed,
     intervalMs: number,
     options?: Options,
@@ -67,7 +67,7 @@ export function useInterval(
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    useSimpleInterval(action, intervalMs, isSet);
+    useInterval(action, intervalMs, isSet);
 
     return {isSet, set, clear};
 }

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.stories.mdx
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.stories.mdx
@@ -5,7 +5,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 
 import {ClearPolicy, SchedulePolicy} from "../util/policies.js";
-import {useScheduledInterval} from "./use-interval.js";
+import {useScheduledInterval} from "./use-scheduled-interval.js";
 
 <Meta
     title="Timing/useScheduledInterval"

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.stories.mdx
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.stories.mdx
@@ -5,10 +5,10 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 
 import {ClearPolicy, SchedulePolicy} from "../util/policies.js";
-import {useInterval} from "./use-interval.js";
+import {useScheduledInterval} from "./use-interval.js";
 
 <Meta
-    title="Timing/useInterval"
+    title="Timing/useScheduledInterval"
     parameters={{
         chromatic: {
             disableSnapshot: true,
@@ -16,13 +16,13 @@ import {useInterval} from "./use-interval.js";
     }}
 />
 
-# `useInterval`
+# `useScheduledInterval`
 
-`useInterval` is a hook that provides a convenient API for setting and clearing
+`useScheduledInterval` is a hook that provides a convenient API for setting and clearing
 an interval. It is defined as follows:
 
 ```ts
-function useInterval(
+function useScheduledInterval(
     action: () => mixed,
     timeoutMs: number,
     options?: {|
@@ -56,7 +56,7 @@ export const Immediately = () => {
     const callback = React.useCallback(() => {
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const interval = useInterval(callback, 1000);
+    const interval = useScheduledInterval(callback, 1000);
     return (
         <View>
             <View>isSet = {isSet.toString()}</View>
@@ -81,7 +81,7 @@ const Immediately = () => {
     const callback = React.useCallback(() => {
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const interval = useInterval(callback, 1000);
+    const interval = useScheduledInterval(callback, 1000);
     return (
         <View>
             <View>isSet = {isSet.toString()}</View>
@@ -101,7 +101,7 @@ export const OnDemandAndResolveOnClear = () => {
         console.log("action called");
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const interval = useInterval(callback, 1000, {
+    const interval = useScheduledInterval(callback, 1000, {
         clearPolicy: ClearPolicy.Resolve,
         schedulePolicy: SchedulePolicy.OnDemand,
     });
@@ -129,7 +129,7 @@ const OnDemandAndResolveOnClear = () => {
     const callback = React.useCallback(() => {
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const interval = useInterval(callback, 1000, {
+    const interval = useScheduledInterval(callback, 1000, {
         clearPolicy: ClearPolicy.Resolve,
         schedulePolicy: SchedulePolicy.OnDemand,
     });

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.js
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.js
@@ -7,7 +7,7 @@ import {
 } from "../util/policies.js";
 import type {ITimeout, ClearPolicy, Options} from "../util/types.js";
 
-export function useTimeout(
+export function useScheduledTimeout(
     action: () => mixed,
     timeoutMs: number,
     options?: Options,

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.stories.mdx
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.stories.mdx
@@ -5,10 +5,10 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 
 import {ClearPolicy, SchedulePolicy} from "../util/policies.js";
-import {useTimeout} from "./use-timeout.js";
+import {useScheduledTimeout} from "./use-timeout.js";
 
 <Meta
-    title="Timing/useTimeout"
+    title="Timing/useScheduledTimeout"
     parameters={{
         chromatic: {
             disableSnapshot: true,
@@ -16,13 +16,13 @@ import {useTimeout} from "./use-timeout.js";
     }}
 />
 
-# `useTimeout`
+# `useScheduledTimeout`
 
-`useTimeout` is a hook that provides a convenient API for setting and clearing
+`useScheduledTimeout` is a hook that provides a convenient API for setting and clearing
 a timeout. It is defined as follows:
 
 ```ts
-function useTimeout(
+function useScheduledTimeout(
     action: () => mixed,
     timeoutMs: number,
     options?: {|
@@ -57,7 +57,7 @@ export const Immediately = () => {
     const callback = React.useCallback(() => {
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const {isSet, set, clear} = useTimeout(callback, 1000);
+    const {isSet, set, clear} = useScheduledTimeout(callback, 1000);
     return (
         <View>
             <View>isSet = {isSet.toString()}</View>
@@ -82,7 +82,7 @@ const Immediately = () => {
     const callback = React.useCallback(() => {
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const {isSet, set, clear} = useTimeout(callback, 1000);
+    const {isSet, set, clear} = useScheduledTimeout(callback, 1000);
     return (
         <View>
             <View>isSet = {isSet.toString()}</View>
@@ -102,7 +102,7 @@ export const OnDemandAndResolveOnClear = () => {
         console.log("action called");
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const {isSet, set, clear} = useTimeout(callback, 1000, {
+    const {isSet, set, clear} = useScheduledTimeout(callback, 1000, {
         clearPolicy: ClearPolicy.Resolve,
         schedulePolicy: SchedulePolicy.OnDemand,
     });
@@ -130,7 +130,7 @@ const OnDemandAndResolveOnClear = () => {
     const callback = React.useCallback(() => {
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const {isSet, set, clear} = useTimeout(callback, 1000, {
+    const {isSet, set, clear} = useScheduledTimeout(callback, 1000, {
         clearPolicy: ClearPolicy.Resolve,
         schedulePolicy: SchedulePolicy.OnDemand,
     });

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.stories.mdx
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.stories.mdx
@@ -5,7 +5,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 
 import {ClearPolicy, SchedulePolicy} from "../util/policies.js";
-import {useScheduledTimeout} from "./use-timeout.js";
+import {useScheduledTimeout} from "./use-scheduled-timeout.js";
 
 <Meta
     title="Timing/useScheduledTimeout"

--- a/packages/wonder-blocks-timing/src/index.js
+++ b/packages/wonder-blocks-timing/src/index.js
@@ -21,4 +21,5 @@ export type {
 
 export {SchedulePolicy, ClearPolicy} from "./util/policies.js";
 export {default as withActionScheduler} from "./components/with-action-scheduler.js";
-export {useTimeout} from "./hooks/use-timeout.js";
+export {useScheduledInterval} from "./hooks/use-scheduled-interval.js";
+export {useScheduledTimeout} from "./hooks/use-scheduled-timeout.js";


### PR DESCRIPTION
## Summary:
I thought initial that the more complicated hooks might be the default but after auditing our current use of 'withActionScheduler', it turned out that the majority of existing use cases can be met with the simpler API so that will become the default.  In the next PR, I'll export add a 'useTimeout' that mimics the current 'useInterval'.

Issue: FEI-4212

## Test plan:
- yarn jest