### PR TITLE
Add updated package versions to slack output for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Build Slack message
+        if: steps.changesets.outputs.published == 'true'
+        run: echo "UPDATED_PACKAGES=$(${{ steps.changesets.output.publishedPackages }} | jq -r '[group_by(.name) | .[] | \" - \"+.[].name+\"@\"+.[].version] | join(\"\n\")')" >> $GITHUB_ENV
+
       - name: Send a Slack notification if a publish happens
         if: steps.changesets.outputs.published == 'true'
         uses: rtCamp/action-slack-notify@v2
@@ -64,7 +68,7 @@ jobs:
           SLACK_MSG_AUTHOR: ${{ github.event.pull_request.user.login }}
           SLACK_USERNAME: GithubGoose
           SLACK_ICON_EMOJI: ":goose:"
-          SLACK_MESSAGE: "A new version of ${github.event.repository.name} was published! 🎉 Release notes → https://github.com/Khan/${github.event.repository.name}/releases/"
+          SLACK_MESSAGE: "A new version of ${{ github.event.repository.name }} was published! 🎉 \n${{ UPDATED_PACKAGES }}\nRelease notes → https://github.com/Khan/${{ github.event.repository.name }}/releases/"
           SLACK_TITLE: "New Wonder Blocks release!"
           SLACK_FOOTER: Wonder Blocks Slack Notification
           MSG_MINIMAL: true


### PR DESCRIPTION
## Summary:
This tweaks our release Slack messaging to include the updated packages and fix other things.

Output of the jq filter is as follows:
- given input like changesets.publishedPackages,
   ```
   [
      {
        "name": "foo-package",
        "version": 1.0.0,
      },
      {
        "name": "bar-package",
        "version": 1.0.0,
      },
      {
        "name": "baz-package",
        "version": 1.0.0,
      }
   ]
  ```
- the `jq -r '[group_by(.name) | .[] | " - "+.[].name+"@"+.[].version] | join("\n")'` command will give:
  ```
  - bar-package@1.0.0
  - baz-package@1.0.0
  - foo-package@1.0.0
  ```
- which we should then combine into the Slack message to get something like...

> A new version of wonder-blocks was published! 🎉
> \- bar-package@1.0.0
> \- baz-package@1.0.0
> \- foo-package@1.0.0
>
> Release notes → https://github.com/Khan/wonder-blocks/releases/

Issue: XXX-XXXX

## Test plan:
We will need to do a release to verify the escaping is correct and such. I did test the jq filter locally.