### PR TITLE
[🔥AUDIT🔥] [fixescaping] Preserve multiline environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build Slack message
         if: steps.changesets.outputs.published == 'true'
-        run: echo "UPDATED_PACKAGES=$(jq '[group_by(.name) | .[] | " - "+.[].name+"@"+.[].version] | join("\n")' <<< '${{ steps.changesets.outputs.publishedPackages }}')" >> $GITHUB_ENV
+        run: echo "UPDATED_PACKAGES=$(jq -r '[group_by(.name) | .[] | " - "+.[].name+"@"+.[].version] | join("\n")' <<< '${{ steps.changesets.outputs.publishedPackages }}')" >> $GITHUB_ENV
 
       - name: Send a Slack notification if a publish happens
         if: steps.changesets.outputs.published == 'true'
@@ -68,7 +68,7 @@ jobs:
           SLACK_MSG_AUTHOR: ${{ github.event.pull_request.user.login }}
           SLACK_USERNAME: GithubGoose
           SLACK_ICON_EMOJI: ":goose:"
-          SLACK_MESSAGE: "A new version of ${{ github.event.repository.name }} was published! 🎉 \n${{ env.UPDATED_PACKAGES }}\nRelease notes → https://github.com/Khan/${{ github.event.repository.name }}/releases/"
+          SLACK_MESSAGE: "A new version of ${{ github.event.repository.name }} was published! 🎉 \n$UPDATED_PACKAGES\nRelease notes → https://github.com/Khan/${{ github.event.repository.name }}/releases/"
           SLACK_TITLE: "New Wonder Blocks release!"
           SLACK_FOOTER: Wonder Blocks Slack Notification
           MSG_MINIMAL: true


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
It's quite hard to get good answers about how to do this in GitHub Actions with their substitution syntax, but I tried this locally and it works, so hopefully it works there too.

Issue: XXX-XXXX

## Test plan:
Given an environment variable created using the `jq` command that we now know works, I ran this locally...

```
printf "A new version of wb was published! 🎉 \n$UPDATED_PACKAGES\nRelease notes → https://github.com/Khan/wb/releases/"
```

And I was able to see the output:

```
A new version of wb was published! 🎉
 - @khanacademy/wonder-blocks-data@3.1.0
Release notes → https://github.com/Khan/wb/releases/
```