### PR TITLE
Stop modals from closing when user releases click in the backdrop

### DIFF
--- a/.changeset/good-months-tickle.md
+++ b/.changeset/good-months-tickle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": minor
+---
+
+Modals will no longer close when a user presses in the panel, drags, and releases the mouse in backdrop and vice versa.

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js
@@ -3,6 +3,7 @@ import * as React from "react";
 import {mount} from "enzyme";
 import "jest-enzyme";
 import {render, screen, fireEvent} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import ModalBackdrop from "../modal-backdrop.js";
 import OnePaneDialog from "../one-pane-dialog.js";
@@ -64,16 +65,7 @@ describe("ModalBackdrop", () => {
         const backdrop = screen.getByTestId("modal-backdrop-test-id");
 
         //Act
-
-        // Simulate click
-        //
-        // The component looks for mouseup and mousedown instead of just click
-        // on the backdrop to make sure the user didn't drag into or out from
-        // the modal panel.
-        // eslint-disable-next-line testing-library/prefer-user-event
-        fireEvent.mouseDown(backdrop);
-        // eslint-disable-next-line testing-library/prefer-user-event
-        fireEvent.mouseUp(backdrop);
+        userEvent.click(backdrop);
 
         // Assert
         expect(onCloseModal).toHaveBeenCalled();

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import {mount} from "enzyme";
 import "jest-enzyme";
+import {render, screen, fireEvent} from "@testing-library/react";
 
 import ModalBackdrop from "../modal-backdrop.js";
 import OnePaneDialog from "../one-pane-dialog.js";
@@ -17,6 +18,7 @@ const exampleModal = (
         content={<div data-modal-content />}
         title="Title"
         footer={<div data-modal-footer />}
+        testId="example-modal-test-id"
     />
 );
 
@@ -47,19 +49,33 @@ describe("ModalBackdrop", () => {
     });
 
     test("Clicking the backdrop triggers `onCloseModal`", () => {
+        // Arrange
         const onCloseModal = jest.fn();
 
-        // We use `mount` instead of `shallow` here, because the component's
-        // click handler expects actual DOM events.
-        const wrapper = mount(
-            <ModalBackdrop onCloseModal={onCloseModal}>
+        render(
+            <ModalBackdrop
+                onCloseModal={onCloseModal}
+                testId="modal-backdrop-test-id"
+            >
                 {exampleModal}
             </ModalBackdrop>,
         );
 
-        expect(onCloseModal).not.toHaveBeenCalled();
+        const backdrop = screen.getByTestId("modal-backdrop-test-id");
 
-        wrapper.simulate("click");
+        //Act
+
+        // Simulate click
+        //
+        // The component looks for mouseup and mousedown instead of just click
+        // on the backdrop to make sure the user didn't drag into or out from
+        // the modal panel.
+        // eslint-disable-next-line testing-library/prefer-user-event
+        fireEvent.mouseDown(backdrop);
+        // eslint-disable-next-line testing-library/prefer-user-event
+        fireEvent.mouseUp(backdrop);
+
+        // Assert
         expect(onCloseModal).toHaveBeenCalled();
     });
 
@@ -75,6 +91,62 @@ describe("ModalBackdrop", () => {
         );
 
         wrapper.find("[data-modal-content]").simulate("click");
+        expect(onCloseModal).not.toHaveBeenCalled();
+    });
+
+    test("Clicking and dragging into the backdrop does not close modal", () => {
+        // Arrange
+        const onCloseModal = jest.fn();
+
+        render(
+            <ModalBackdrop
+                onCloseModal={onCloseModal}
+                testId="modal-backdrop-test-id"
+            >
+                {exampleModal}
+            </ModalBackdrop>,
+        );
+
+        const panel = screen.getByTestId("example-modal-test-id");
+        const backdrop = screen.getByTestId("modal-backdrop-test-id");
+
+        // Act
+
+        // Dragging the mouse
+        // eslint-disable-next-line testing-library/prefer-user-event
+        fireEvent.mouseDown(panel);
+        // eslint-disable-next-line testing-library/prefer-user-event
+        fireEvent.mouseUp(backdrop);
+
+        // Assert
+        expect(onCloseModal).not.toHaveBeenCalled();
+    });
+
+    test("Clicking and dragging in from the backdrop does not close modal", () => {
+        // Arrange
+        const onCloseModal = jest.fn();
+
+        render(
+            <ModalBackdrop
+                onCloseModal={onCloseModal}
+                testId="modal-backdrop-test-id"
+            >
+                {exampleModal}
+            </ModalBackdrop>,
+        );
+
+        const panel = screen.getByTestId("example-modal-test-id");
+        const backdrop = screen.getByTestId("modal-backdrop-test-id");
+
+        // Act
+
+        // Dragging the mouse
+        // eslint-disable-next-line testing-library/prefer-user-event
+        fireEvent.mouseDown(backdrop);
+        // eslint-disable-next-line testing-library/prefer-user-event
+        fireEvent.mouseUp(panel);
+
+        // Assert
         expect(onCloseModal).not.toHaveBeenCalled();
     });
 
@@ -97,6 +169,7 @@ describe("ModalBackdrop", () => {
         // Arrange
         // We need the elements in the DOM document, it seems, for this test
         // to work. Changing to testing-library will likely fix this.
+        // Then we can remove the lint suppression.
         const attachElement = getElementAttachedToDocument("container");
         const initialFocusId = "initial-focus";
 
@@ -126,7 +199,9 @@ describe("ModalBackdrop", () => {
         // Assert
         // first we verify the element exists in the DOM
         expect(initialFocusElement).toHaveLength(1);
+
         // verify the focus is set on the correct element
+        // eslint-disable-next-line testing-library/no-node-access
         expect(document.activeElement).toBe(initialFocusElement.getDOMNode());
     });
 
@@ -134,6 +209,7 @@ describe("ModalBackdrop", () => {
         // Arrange
         // We need the elements in the DOM document, it seems, for this test
         // to work. Changing to testing-library will likely fix this.
+        // Then we can remove the lint suppression.
         const attachElement = getElementAttachedToDocument("container");
         const initialFocusId = "initial-focus";
         const firstFocusableElement = "[data-first-button]";
@@ -156,6 +232,7 @@ describe("ModalBackdrop", () => {
         // first we verify the element doesn't exist in the DOM
         expect(initialFocusElement).toHaveLength(0);
         // verify the focus is set on the first focusable element instead
+        // eslint-disable-next-line testing-library/no-node-access
         expect(document.activeElement).toBe(
             wrapper.find(firstFocusableElement).getDOMNode(),
         );
@@ -165,6 +242,7 @@ describe("ModalBackdrop", () => {
         // Arrange
         // We need the elements in the DOM document, it seems, for this test
         // to work. Changing to testing-library will likely fix this.
+        // Then we can remove the lint suppression.
         const attachElement = getElementAttachedToDocument("container");
         const wrapper = mount(
             <ModalBackdrop onCloseModal={() => {}}>
@@ -180,6 +258,7 @@ describe("ModalBackdrop", () => {
             .getDOMNode();
 
         // Assert
+        // eslint-disable-next-line testing-library/no-node-access
         expect(document.activeElement).toBe(focusableElement);
     });
 
@@ -187,6 +266,7 @@ describe("ModalBackdrop", () => {
         // Arrange
         // We need the elements in the DOM document, it seems, for this test
         // to work. Changing to testing-library will likely fix this.
+        // Then we can remove the lint suppression.
         const attachElement = getElementAttachedToDocument("container");
         const wrapper = mount(
             <ModalBackdrop onCloseModal={() => {}}>
@@ -202,6 +282,7 @@ describe("ModalBackdrop", () => {
             .getDOMNode();
 
         // Assert
+        // eslint-disable-next-line testing-library/no-node-access
         expect(document.activeElement).toBe(focusableElement);
     });
 });

--- a/packages/wonder-blocks-modal/src/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/src/components/modal-backdrop.js
@@ -26,6 +26,10 @@ type Props = {|
     testId?: string,
 |};
 
+type State = {|
+    mousePressedOutside: boolean,
+|};
+
 /**
  * A private component used by ModalLauncher. This is the fixed-position
  * container element that gets mounted outside the DOM. It overlays the modal
@@ -36,7 +40,7 @@ type Props = {|
  * and adding an `onClose` prop that will call `onCloseModal`. If an
  * `onClose` prop is already provided, the two are merged.
  */
-export default class ModalBackdrop extends React.Component<Props> {
+export default class ModalBackdrop extends React.Component<Props, State> {
     componentDidMount() {
         const node: HTMLElement = (ReactDOM.findDOMNode(this): any);
         if (!node) {
@@ -56,6 +60,8 @@ export default class ModalBackdrop extends React.Component<Props> {
             firstFocusableElement.focus();
         }, 0);
     }
+
+    _mousePressedOutside: boolean = false;
 
     /**
      * Returns an element specified by the user
@@ -107,12 +113,18 @@ export default class ModalBackdrop extends React.Component<Props> {
      * _directly_ from the positioner, not bubbled up from its children), close
      * the modal.
      */
-    handleClick: (e: SyntheticEvent<>) => void = (e: SyntheticEvent<>) => {
-        // Was the lowest-level click target (`e.target`) the positioner element
-        // (`e.currentTarget`)?
-        if (e.target === e.currentTarget) {
+    handleMouseDown: (e: SyntheticEvent<>) => void = (e: SyntheticEvent<>) => {
+        // Confirm that it is the backdrop that is being clicked, not the child
+        this._mousePressedOutside = e.target === e.currentTarget;
+    };
+
+    handleMouseUp: (e: SyntheticEvent<>) => void = (e: SyntheticEvent<>) => {
+        // Confirm that it is the backdrop that is being clicked, not the child
+        // and that the mouse was pressed in the backdrop first.
+        if (e.target === e.currentTarget && this._mousePressedOutside) {
             this.props.onCloseModal();
         }
+        this._mousePressedOutside = false;
     };
 
     render(): React.Node {
@@ -124,7 +136,8 @@ export default class ModalBackdrop extends React.Component<Props> {
         return (
             <View
                 style={styles.modalPositioner}
-                onClick={this.handleClick}
+                onMouseDown={this.handleMouseDown}
+                onMouseUp={this.handleMouseUp}
                 testId={testId}
                 {...backdropProps}
             >

--- a/packages/wonder-blocks-modal/src/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/src/components/modal-backdrop.js
@@ -26,10 +26,6 @@ type Props = {|
     testId?: string,
 |};
 
-type State = {|
-    mousePressedOutside: boolean,
-|};
-
 /**
  * A private component used by ModalLauncher. This is the fixed-position
  * container element that gets mounted outside the DOM. It overlays the modal
@@ -40,7 +36,7 @@ type State = {|
  * and adding an `onClose` prop that will call `onCloseModal`. If an
  * `onClose` prop is already provided, the two are merged.
  */
-export default class ModalBackdrop extends React.Component<Props, State> {
+export default class ModalBackdrop extends React.Component<Props> {
     componentDidMount() {
         const node: HTMLElement = (ReactDOM.findDOMNode(this): any);
         if (!node) {


### PR DESCRIPTION
## Summary:
Right now, if you click in the modal backround and release in the panel, the modal closes even though it should not.
Also in Chrome, if you click in a modal panel and release in the backdrop, the modal closes even though it should not.

- Instead of handling `click`, handle `mouseup` and `mouedown` and keep track of whether both happened in the backdrop.
  Only close if the user pressed AND released in the backdrop.

Issue: https://khanacademy.atlassian.net/browse/WB-602

Not sure how to show where my presses and releases are, but this video contains a variety of presses
and releases on Google Chrome.

https://user-images.githubusercontent.com/13231763/150456137-778f6880-bbb1-473a-9310-d34c8b475eac.mov



## Test plan:
`yarn test packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js`

Manual testing - USE MULTIPLE BROWSERS.
- Open the Netlify wonder blocks app (localhost:6060)
- Click on a modal launcher (ex. the "Open flexible modal" button)
- Press inside the panel, drag out, and release in the backdrop. The modal should not close.
- Press outside the panel, drag out, and release in the panel.
- Try different combinations of pressing and releasing inside and outside the panel.
- Click in the panel. The modal should not close.
- Click in the backdrop. The modal should close.