### PR TITLE
[🔥AUDIT🔥] [finallyfixupslackmessageforreleases] Output a valid multiline environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,19 @@ jobs:
 
       - name: Build Slack message
         if: steps.changesets.outputs.published == 'true'
-        run: echo "UPDATED_PACKAGES=$(jq -r '[group_by(.name) | .[] | " - "+.[].name+"@"+.[].version] | join("\n")' <<< '${{ steps.changesets.outputs.publishedPackages }}')" >> $GITHUB_ENV
+        # We have to do this in stages to make sure that the output into the
+        # GITHUB_ENV retains are lines and is valid for updating the env.
+        # This is based of option 2 from
+        # - LIVE: https://trstringer.com/github-actions-multiline-strings/
+        # - ARCHIVE: https://web.archive.org/web/20211017170102/https://trstringer.com/github-actions-multiline-strings/
+        run: |
+          UPDATED_PACKAGES=$(cat << EOF
+              $(jq -r '[group_by(.name) | .[] | " - "+.[].name+"@"+.[].version] | join("\n")' <<< '${{ steps.changesets.outputs.publishedPackages }}')
+              EOF
+          )
+          echo "UPDATED_PACKAGES<<EOF" >> $GITHUB_ENV
+          echo "$UPDATED_PACKAGES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Send a Slack notification if a publish happens
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This utilizes a "here" document to properly construct a multiline environment variable.

This follows the option 2 guidance found here: [LIVE](https://trstringer.com/github-actions-multiline-strings/)|[ARCHIVE](https://web.archive.org/web/20211017170102/https://trstringer.com/github-actions-multiline-strings/)

### Why was it broken?
The reason this broken was that we added the `-r` to `jq` to get a raw output instead of one that quoted the output and escaped control characters.
We want the raw string because otherwise, we'll output the surrounding quotes and such.
However, the raw output means it writes the newlines to the environment file (`$GITHUB_ENV`) and that file is interpreted line by line. So the first line sets a valid env variable, but subsequent lines are an invalid syntax.

Broken $GITHUB_ENV file:
```
UPDATED_PACKAGE = - @khanacademy/wonder-blocks-button@2.11.1
 - @khanacademy/wonder-blocks-cell@1.0.1
 - @khanacademy/wonder-blocks-clickable@2.2.2
 - @khanacademy/wonder-blocks-dropdown@2.6.1
 - @khanacademy/wonder-blocks-form@2.3.2
 - @khanacademy/wonder-blocks-icon-button@3.4.2
 - @khanacademy/wonder-blocks-link@3.8.2
 - @khanacademy/wonder-blocks-modal@2.2.0
 - @khanacademy/wonder-blocks-popover@1.1.6
 - @khanacademy/wonder-blocks-tooltip@1.3.6
```

Without the `-r` we'd get a single line in the $GITHUB_ENV file but then when using that var, we would get surrounding double-quotes in our output.

### Why will it work now?
Using the linked guidance, I used what is referred to as a [here document](https://web.archive.org/web/20211017195622/https://tldp.org/LDP/abs/html/here-docs.html) to construct the environment variable. With this change, we get a different output to the $GITHUB_ENV:

```
UPDATED_PACKAGE<<EOF
 - @khanacademy/wonder-blocks-button@2.11.1
 - @khanacademy/wonder-blocks-cell@1.0.1
 - @khanacademy/wonder-blocks-clickable@2.2.2
 - @khanacademy/wonder-blocks-dropdown@2.6.1
 - @khanacademy/wonder-blocks-form@2.3.2
 - @khanacademy/wonder-blocks-icon-button@3.4.2
 - @khanacademy/wonder-blocks-link@3.8.2
 - @khanacademy/wonder-blocks-modal@2.2.0
 - @khanacademy/wonder-blocks-popover@1.1.6
 - @khanacademy/wonder-blocks-tooltip@1.3.6
EOF
```

This should retain our newlines in the environment variable in the manner we want while also being a valid $GITHUB_ENV syntax that avoids the error we saw in [Nisha's recent release](https://github.com/Khan/wonder-blocks/runs/4957870806?check_suite_focus=true).

Issue: XXX-XXXX

## Test plan:
I ran various bits of this code locally to verify the output (it's how I generated the above examples). It all works. The only bit I cannot test locally is how GitHub will use the output in the $GITHUB_ENV target file. However, based on examples I've read, it should just work. We will find out.