### PR TITLE
[onlybuildactualpackages] Only build actual packages

### DIFF
--- a/.changeset/spotty-birds-collect.md
+++ b/.changeset/spotty-birds-collect.md
@@ -1,0 +1,5 @@
+---
+"wb-dev-build-settings": minor
+---
+
+Builds only include actual packages, not remnant directories from a branch switch

--- a/build-settings/rollup.config.js
+++ b/build-settings/rollup.config.js
@@ -1,27 +1,35 @@
 /* eslint-disable import/no-commonjs */
 import fs from "fs";
+import path from "path";
 import autoExternal from "rollup-plugin-auto-external";
 import babel from "rollup-plugin-babel";
 
 const {presets, plugins} = require("./babel.config.js")({env: () => false});
 
-const createConfig = (pkgName) => ({
-    output: {
-        file: `packages/${pkgName}/dist/es/index.js`,
-        format: "esm",
-    },
-    input: `packages/${pkgName}/src/index.js`,
-    plugins: [
-        babel({
-            presets,
-            plugins,
-            exclude: "node_modules/**",
-            runtimeHelpers: true,
-        }),
-        autoExternal({
-            packagePath: `packages/${pkgName}/package.json`,
-        }),
-    ],
-});
+const createConfig = (pkgName) => {
+    const packageJsonPath = path.join("packages", pkgName, "package.json");
+    if (!fs.existsSync(packageJsonPath)) {
+        return null;
+    }
 
-export default fs.readdirSync("packages").map(createConfig);
+    return {
+        output: {
+            file: `packages/${pkgName}/dist/es/index.js`,
+            format: "esm",
+        },
+        input: `packages/${pkgName}/src/index.js`,
+        plugins: [
+            babel({
+                presets,
+                plugins,
+                exclude: "node_modules/**",
+                runtimeHelpers: true,
+            }),
+            autoExternal({
+                packagePath: `packages/${pkgName}/package.json`,
+            }),
+        ],
+    };
+};
+
+export default fs.readdirSync("packages").map(createConfig).filter(Boolean);

--- a/build-settings/webpack.config.js
+++ b/build-settings/webpack.config.js
@@ -16,7 +16,8 @@ const babelOptions = require("./babel.config.js")({env: () => true});
 
 const packages = fs
     .readdirSync(path.join(process.cwd(), "packages"))
-    .map((dir) => path.join(process.cwd(), "packages", dir));
+    .map((dir) => path.join(process.cwd(), "packages", dir))
+    .filter((dir) => fs.existsSync(path.join(dir, "package.json")));
 
 const genWebpackConfig = function (subPkgRoot) {
     const pkgJsonPath = path.join(subPkgRoot, "package.json");


### PR DESCRIPTION
## Summary:
When things are modified between checkouts, package folders aren't deleted, so we can't use them as an indicator of a package to be built. Instead, check that there is a package.json.

This should fix [things like this](https://github.com/Khan/wonder-blocks/runs/4969439614?check_suite_focus=true) that occur when adding a new package.

The linked failure happens because the build first builds the current code with the new package, then it switches to the base branch and builds that, but the switch doesn't delete the new package folder, and so it tries to build that and fails.

With my change, it should ignore that new package folder in the second case because it will no longer have a package.json file.

Issue: XXX-XXXX

## Test plan:
`yarn build:all`