### PR TITLE
[fei4261.useFastlyQuery.tweaks.1] Tweak GQL types

### DIFF
--- a/.changeset/fuzzy-spies-doubt.md
+++ b/.changeset/fuzzy-spies-doubt.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Simplify GQL types

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,8 @@ jobs:
         # - ARCHIVE: https://web.archive.org/web/20211017170102/https://trstringer.com/github-actions-multiline-strings/
         run: |
           UPDATED_PACKAGES=$(cat << EOF
-              $(jq -r '[group_by(.name) | .[] | " - "+.[].name+"@"+.[].version] | join("\n")' <<< '${{ steps.changesets.outputs.publishedPackages }}')
-              EOF
+          $(jq -r '[group_by(.name) | .[] | " - "+.[].name+"@"+.[].version] | join("\n")' <<< '${{ steps.changesets.outputs.publishedPackages }}')
+          EOF
           )
           echo "UPDATED_PACKAGES<<EOF" >> $GITHUB_ENV
           echo "$UPDATED_PACKAGES" >> $GITHUB_ENV

--- a/packages/wonder-blocks-data/src/components/gql-router.js
+++ b/packages/wonder-blocks-data/src/components/gql-router.js
@@ -18,7 +18,7 @@ type Props<TContext: GqlContext> = {|
     /**
      * The function to use when fetching requests.
      */
-    fetch: GqlFetchFn<any, any, any, TContext>,
+    fetch: GqlFetchFn<any, any, TContext>,
 
     /**
      * The children to be rendered inside the router.

--- a/packages/wonder-blocks-data/src/hooks/use-gql.js
+++ b/packages/wonder-blocks-data/src/hooks/use-gql.js
@@ -24,7 +24,7 @@ export const useGql = (): (<
     TVariables: {...},
     TContext: GqlContext,
 >(
-    operation: GqlOperation<TType, TData, TVariables>,
+    operation: GqlOperation<TData, TVariables>,
     options?: GqlFetchOptions<TVariables, TContext>,
 ) => Promise<?TData>) => {
     // This hook only works if the `GqlRouter` has been used to setup context.
@@ -41,13 +41,8 @@ export const useGql = (): (<
     // in hooks deps without fear of it triggering extra renders.
     const gqlFetch = useMemo(
         () =>
-            <
-                TType: GqlOperationType,
-                TData,
-                TVariables: {...},
-                TContext: GqlContext,
-            >(
-                operation: GqlOperation<TType, TData, TVariables>,
+            <TData, TVariables: {...}, TContext: GqlContext>(
+                operation: GqlOperation<TData, TVariables>,
                 options: GqlFetchOptions<TVariables, TContext> = Object.freeze(
                     {},
                 ),

--- a/packages/wonder-blocks-data/src/util/gql-types.js
+++ b/packages/wonder-blocks-data/src/util/gql-types.js
@@ -8,7 +8,6 @@ export type GqlOperationType = "mutation" | "query";
  * A GraphQL operation.
  */
 export type GqlOperation<
-    TType: GqlOperationType,
     // TData is not used to define a field on this type, but it is used
     // to ensure that calls using this operation will properly return the
     // correct data type.
@@ -20,7 +19,7 @@ export type GqlOperation<
     // eslint-disable-next-line no-unused-vars
     TVariables: {...} = Empty,
 > = {
-    type: TType,
+    type: GqlOperationType,
     id: string,
     // We allow other things here to be passed along to the fetch function.
     // For example, we might want to pass the full query/mutation definition
@@ -37,13 +36,8 @@ export type GqlContext = {|
 /**
  * Functions that make fetches of GQL operations.
  */
-export type GqlFetchFn<
-    TType,
-    TData,
-    TVariables: {...},
-    TContext: GqlContext,
-> = (
-    operation: GqlOperation<TType, TData, TVariables>,
+export type GqlFetchFn<TData, TVariables: {...}, TContext: GqlContext> = (
+    operation: GqlOperation<TData, TVariables>,
     variables: ?TVariables,
     context: TContext,
 ) => Promise<Response>;
@@ -52,7 +46,7 @@ export type GqlFetchFn<
  * The configuration stored in the GqlRouterContext context.
  */
 export type GqlRouterConfiguration<TContext: GqlContext> = {|
-    fetch: GqlFetchFn<any, any, any, any>,
+    fetch: GqlFetchFn<any, any, any>,
     defaultContext: TContext,
 |};
 

--- a/packages/wonder-blocks-data/src/util/gql-types.js
+++ b/packages/wonder-blocks-data/src/util/gql-types.js
@@ -26,6 +26,7 @@ export type GqlOperation<
     // as a string here to allow that to be sent to an Apollo server that
     // expects it. This is a courtesy to calling code; these additional
     // values are ignored by WB Data, and passed through as-is.
+    [key: string]: mixed,
     ...
 };
 

--- a/packages/wonder-blocks-testing/src/gql/gql-request-matches-mock.js
+++ b/packages/wonder-blocks-testing/src/gql/gql-request-matches-mock.js
@@ -36,8 +36,8 @@ const areObjectsEqual = (a: any, b: any): boolean => {
 };
 
 export const gqlRequestMatchesMock = (
-    mock: GqlMockOperation<any, any, any, any>,
-    operation: GqlOperation<any, any, any>,
+    mock: GqlMockOperation<any, any, any>,
+    operation: GqlOperation<any, any>,
     variables: ?{...},
     context: GqlContext,
 ): boolean => {

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
@@ -52,13 +52,8 @@ export const mockGqlFetch = (): GqlFetchMockFn => {
         );
     };
 
-    const addMockedOperation = <
-        TType,
-        TData,
-        TVariables: {...},
-        TContext: GqlContext,
-    >(
-        operation: GqlMockOperation<TType, TData, TVariables, TContext>,
+    const addMockedOperation = <TData, TVariables: {...}, TContext: GqlContext>(
+        operation: GqlMockOperation<TData, TVariables, TContext>,
         response: GqlMockResponse<TData>,
         onceOnly: boolean,
     ): GqlFetchMockFn => {
@@ -73,22 +68,20 @@ export const mockGqlFetch = (): GqlFetchMockFn => {
     };
 
     gqlFetchMock.mockOperation = <
-        TType,
         TData,
         TVariables: {...},
         TContext: GqlContext,
     >(
-        operation: GqlMockOperation<TType, TData, TVariables, TContext>,
+        operation: GqlMockOperation<TData, TVariables, TContext>,
         response: GqlMockResponse<TData>,
     ): GqlFetchMockFn => addMockedOperation(operation, response, false);
 
     gqlFetchMock.mockOperationOnce = <
-        TType,
         TData,
         TVariables: {...},
         TContext: GqlContext,
     >(
-        operation: GqlMockOperation<TType, TData, TVariables, TContext>,
+        operation: GqlMockOperation<TData, TVariables, TContext>,
         response: GqlMockResponse<TData>,
     ): GqlFetchMockFn => addMockedOperation(operation, response, true);
 

--- a/packages/wonder-blocks-testing/src/gql/types.js
+++ b/packages/wonder-blocks-testing/src/gql/types.js
@@ -3,29 +3,23 @@ import type {GqlOperation, GqlContext} from "@khanacademy/wonder-blocks-data";
 import type {GqlMockResponse} from "./make-gql-mock-response.js";
 
 export type GqlMockOperation<
-    TType,
     TData,
     TVariables: {...},
     TContext: GqlContext,
 > = {|
-    operation: GqlOperation<TType, TData, TVariables>,
+    operation: GqlOperation<TData, TVariables>,
     variables?: TVariables,
     context?: TContext,
 |};
 
-type GqlMockOperationFn = <
-    TType,
-    TData,
-    TVariables: {...},
-    TContext: GqlContext,
->(
-    operation: GqlMockOperation<TType, TData, TVariables, TContext>,
+type GqlMockOperationFn = <TData, TVariables: {...}, TContext: GqlContext>(
+    operation: GqlMockOperation<TData, TVariables, TContext>,
     response: GqlMockResponse<TData>,
 ) => GqlFetchMockFn;
 
 export type GqlFetchMockFn = {|
     (
-        operation: GqlOperation<any, any, any>,
+        operation: GqlOperation<any, any>,
         variables: ?{...},
         context: GqlContext,
     ): Promise<Response>,
@@ -34,7 +28,7 @@ export type GqlFetchMockFn = {|
 |};
 
 export type GqlMock = {|
-    operation: GqlMockOperation<any, any, any, any>,
+    operation: GqlMockOperation<any, any, any>,
     onceOnly: boolean,
     used: boolean,
     response: () => Promise<Response>,


### PR DESCRIPTION
## Summary:
[fei4261.useFastlyQuery.tweaks.1] Simplify GQL types
[fei4261.useFastlyQuery.tweaks.1] Trying to fix slack message format
[fei4261.useFastlyQuery.tweaks.1] Fix the inexactness of the GqlOperation type

This does some types tweaking and also tries once more to fix the slack message format - if this doesn't work, I think I have one last possibility.

Issue: FEI-4261

## Test plan:
`yarn test`
`yarn flow`