### PR TITLE
[🔥AUDIT🔥] Disable Tooltip and Popover snapshots

### DIFF
--- a/packages/wonder-blocks-popover/src/components/popover.stories.js
+++ b/packages/wonder-blocks-popover/src/components/popover.stories.js
@@ -16,7 +16,7 @@ export default {
         // TODO(WB-1170): Reassess this after investigating more about Chromatic
         // flakyness.
         chromatic: {
-            delay: 400,
+            disableSnapshot: true,
         },
     },
 };

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.stories.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.stories.js
@@ -17,7 +17,7 @@ export default {
         // TODO(WB-1170): Reassess this after investigating more about Chromatic
         // flakyness.
         chromatic: {
-            delay: 400,
+            disableSnapshot: true,
         },
     },
 };


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Temporary fix that disables these snapshots so Chromatic stops reporting flaky
visual regressions.

Issue: WB-1170

## Test plan:

Verify in Chromatic that these stories are no longer reported.