### PR TITLE
WB-1227: Storybook - Fix WB aliases on the webpack config file

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,6 @@
+const path = require("path");
+const webpack = require("webpack");
+
 module.exports = {
     stories: ["../packages/**/*.stories.@(js|mdx)"],
     addons: [
@@ -10,5 +13,28 @@ module.exports = {
     ],
     reactOptions: {
         fastRefresh: true,
+    },
+    // Overriding the default webpack config to allow using storybook with our
+    // monorepo.
+    // See https://storybook.js.org/docs/react/configure/webpack
+    webpackFinal: async (config, {configType}) => {
+        const wbRegex = /^@khanacademy\/wonder-blocks(-.*)$/;
+        // Aliases for internal wonder-blocks packages
+        config.plugins.push(
+            new webpack.NormalModuleReplacementPlugin(wbRegex, function (
+                resource,
+            ) {
+                // Replace the module with a direct reference to the
+                // internal folder.
+                // $1 is the unique package name, e.g. cell, birthday-picker
+                resource.request = resource.request.replace(
+                    wbRegex,
+                    path.resolve(__dirname, "../packages/wonder-blocks$1/src"),
+                );
+            }),
+        );
+
+        // Return the altered config
+        return config;
     },
 };


### PR DESCRIPTION
## Summary:

Overriding the Storybook's webpack config so we can work with custom WB aliases
to be able to run Storybook inside our monorepo.

Issue: https://khanacademy.atlassian.net/browse/WB-1227

## Test plan:

```
yarn start:storybook
```

1. Verify that storybook starts locally.
2. Verify that the Storybook chromatic build works fine.