### PR TITLE
WB-1181: Allow birthday component to be disabled

### DIFF
--- a/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.argtypes.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.argtypes.js
@@ -2,37 +2,13 @@
 import {defaultLabels} from "../birthday-picker.js";
 
 export default {
-    defaultValue: {
-        control: {type: "text"},
-        description:
-            "The default value to populate the birthdate with. Should be in the format: `YYYY-MM-DD` (e.g. 2021-05-26). It's only used to populate the initial value as this is an uncontrolled component.",
-        table: {
-            type: {
-                summary: "string",
-            },
-        },
-    },
     labels: {
-        control: {type: "object"},
-        description:
-            "The object containing the custom labels used inside this component.",
         defaultValue: defaultLabels,
-        table: {
-            type: {
-                summary: "Labels",
-                detail: "{month?: string, year?: string, day?: string, errorMessage?: string}",
-            },
-        },
     },
     onChange: {
         action: "onChanged",
-        description:
-            "Listen for changes to the birthdate. Could be a string in the `YYYY-MM-DD` format or `null`.",
         table: {
             category: "Events",
-            type: {
-                summary: "(date: ?string) => mixed",
-            },
         },
     },
 };

--- a/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.stories.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.stories.js
@@ -64,6 +64,10 @@ BirthdayPickerWithDefaultValue.parameters = {
     chromatic: {
         disableSnapshot: true,
     },
+    docs: {
+        storyDescription:
+            "This component is empty by default, but we can pass in a defined birthday by using the `defaultValue` prop.",
+    },
 };
 
 export const InvalidBirthdayPicker: StoryComponentType = Template.bind({});
@@ -71,6 +75,13 @@ export const InvalidBirthdayPicker: StoryComponentType = Template.bind({});
 InvalidBirthdayPicker.args = {
     onChange: () => {},
     defaultValue: "2030-07-19",
+};
+
+InvalidBirthdayPicker.parameters = {
+    docs: {
+        storyDescription:
+            "In case the birthday is invalid, we display an error message indicating this problem.",
+    },
 };
 
 export const BirthdayPickerWithCustomLabels: StoryComponentType = Template.bind(
@@ -85,5 +96,26 @@ BirthdayPickerWithCustomLabels.args = {
         month: "Mes",
         year: "Año",
         errorMessage: "Por favor seleccione una fecha válida.",
+    },
+};
+
+BirthdayPickerWithCustomLabels.parameters = {
+    docs: {
+        storyDescription:
+            "We can pass custom labels to the component. This can be helpful when we need to pass in translated strings. The default labels are: `Day`, `Month`, `Year` used as placeholders and 'Please select a valid birthdate.' to indicate an `errorMessage` when the validation fails. For more info about how to use this, refer to the `labels` prop in the Props table documentation above.",
+    },
+};
+
+export const DisabledBirthdayPicker: StoryComponentType = Template.bind({});
+
+DisabledBirthdayPicker.args = {
+    onChange: () => {},
+    disabled: true,
+};
+
+DisabledBirthdayPicker.parameters = {
+    docs: {
+        storyDescription:
+            "A BirthdayPicker can be disabled by passing the `disabled` prop. This will disable all the dropdown controls and prevent them from being interacted with.",
     },
 };

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
@@ -122,6 +122,22 @@ describe("BirthdayPicker", () => {
             expect(yearPicker).toHaveTextContent("Year");
         });
 
+        it("renders correctly the disabled state", () => {
+            // Arrange
+
+            // Act
+            render(<BirthdayPicker disabled={true} onChange={() => {}} />);
+
+            const monthPicker = screen.getByTestId("birthday-picker-month");
+            const dayPicker = screen.getByTestId("birthday-picker-day");
+            const yearPicker = screen.getByTestId("birthday-picker-year");
+
+            // Assert
+            expect(monthPicker).toBeDisabled();
+            expect(dayPicker).toBeDisabled();
+            expect(yearPicker).toBeDisabled();
+        });
+
         it("renders an error with an invalid default value", async () => {
             // Arrange
             const defaultValue = "2021-02-31";

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.js
@@ -40,6 +40,11 @@ type Props = {|
     defaultValue?: string,
 
     /**
+     * Whether the birthdate fields are disabled.
+     */
+    disabled?: boolean,
+
+    /**
      * The object containing the custom labels used inside this component.
      */
     labels?: Labels,
@@ -248,12 +253,14 @@ export default class BirthdayPicker extends React.Component<Props, State> {
     }
 
     render(): React.Element<any> {
+        const {disabled} = this.props;
         const {month, day, year} = this.state;
 
         return (
             <>
                 <View testId="birthday-picker" style={{flexDirection: "row"}}>
                     <SingleSelect
+                        disabled={disabled}
                         placeholder={this.labels.month}
                         onChange={this.handleMonthChange}
                         selectedValue={month}
@@ -270,6 +277,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                     </SingleSelect>
                     <Strut size={Spacing.xSmall_8} />
                     <SingleSelect
+                        disabled={disabled}
                         placeholder={this.labels.day}
                         onChange={this.handleDayChange}
                         selectedValue={day}
@@ -286,6 +294,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                     </SingleSelect>
                     <Strut size={Spacing.xSmall_8} />
                     <SingleSelect
+                        disabled={disabled}
                         placeholder={this.labels.year}
                         onChange={this.handleYearChange}
                         selectedValue={year}


### PR DESCRIPTION
## Summary:

- Added the `disabled` prop.
- Added docs and tests covering this case.
- Added documentation to the existing stories.
- Removed some Storybook `argTypes` not needed anymore. SB is taking correctly the info from the `Props` type.

Issue: WB-1181

## Test plan:

```
yarn jest packages/wonder-blocks-birthday-picker/
yarn start:storybook
```

Navigate to http://localhost:6061/?path=/story/birthdaypicker--disabled-birthday-picker
<img width="337" alt="Screen Shot 2022-02-01 at 5 23 56 PM" src="https://user-images.githubusercontent.com/843075/152061655-4168839b-356e-4d41-95c4-21ee4005907c.png">

Verify that the birthday picker is disabled and cannot be interacted with.

https://user-images.githubusercontent.com/843075/152061785-6f30f361-1b06-40dd-b9f4-87af39d27fe0.mov


