### PR TITLE
Add changeset file for wonder blocks form

### DIFF
--- a/.changeset/early-cobras-care.md
+++ b/.changeset/early-cobras-care.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+LabeledTextField component now has a `required` prop that will mark is as required with an asterisk and provide validation


### PR DESCRIPTION
## Summary:
I forgot to add the changeset after adding the `required` prop  in https://github.com/Khan/wonder-blocks/pull/1295

I included the changeset here

Issue: none

## Test plan:
N/A I think