### PR TITLE
WB-1222: DetailCell style tweaks

### DIFF
--- a/.changeset/dull-rules-enjoy.md
+++ b/.changeset/dull-rules-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+DetailCell: Style tweaks (changing title from bold to regular, changing vertical padding to 16px)

--- a/packages/wonder-blocks-cell/src/components/detail-cell.js
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.js
@@ -5,9 +5,10 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
-import {LabelSmall, LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {LabelSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import CellCore from "./internal/cell-core.js";
+import {CellMeasurements} from "./internal/common.js";
 
 import type {CellProps, TypographyText} from "../util/types.js";
 
@@ -56,7 +57,10 @@ type DetailCellProps = {|
 
 /**
  * This is a variant of CompactCell that allows adding subtitles, before and
- * after the cell title.
+ * after the cell title. They typically represent an item that can be
+ * clicked/tapped to view more complex details. They vary in height depending on
+ * the presence or absence of subtitles, and they allow for a wide range of
+ * functionality depending on which accessories are active.
  *
  * ### Usage
  *
@@ -76,11 +80,11 @@ function DetailCell(props: DetailCellProps): React.Node {
     const {title, subtitle1, subtitle2, ...coreProps} = props;
 
     return (
-        <CellCore {...coreProps}>
+        <CellCore {...coreProps} innerStyle={styles.innerWrapper}>
             <Subtitle subtitle={subtitle1} disabled={coreProps.disabled} />
             {subtitle1 && <Strut size={Spacing.xxxxSmall_2} />}
             {typeof title === "string" ? (
-                <LabelLarge>{title}</LabelLarge>
+                <LabelMedium>{title}</LabelMedium>
             ) : (
                 title
             )}
@@ -94,6 +98,11 @@ function DetailCell(props: DetailCellProps): React.Node {
 const styles = StyleSheet.create({
     subtitle: {
         color: Color.offBlack64,
+    },
+
+    // This is to override the default padding of the CellCore innerWrapper.
+    innerWrapper: {
+        padding: `${CellMeasurements.detailCellPadding.paddingVertical}px ${CellMeasurements.detailCellPadding.paddingHorizontal}px`,
     },
 });
 

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.js
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.js
@@ -2,6 +2,8 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color, {fade} from "@khanacademy/wonder-blocks-color";
@@ -94,6 +96,14 @@ type CellCoreProps = {|
      * The content of the cell.
      */
     children: React.Node,
+
+    /**
+     * The optional styles applied to the inner wrapper.
+     *
+     * Note: This is not intended to be used externally, only used directly
+     * within the package scope.
+     */
+    innerStyle?: StyleType,
 |};
 
 /**
@@ -118,6 +128,7 @@ const CellCore = (props: CellCoreProps): React.Node => {
         style,
         testId,
         "aria-label": ariaLabel,
+        innerStyle,
     } = props;
 
     const renderCell = (eventState?: ClickableState): React.Node => {
@@ -130,14 +141,15 @@ const CellCore = (props: CellCoreProps): React.Node => {
                     // focused applied to the main wrapper to make the border
                     // outline part of the wrapper
                     eventState?.focused && styles.focused,
-                    // custom styles
-                    style,
                 ]}
                 aria-current={active ? "true" : undefined}
             >
                 <View
                     style={[
                         styles.innerWrapper,
+                        innerStyle,
+                        // custom styles
+                        style,
                         horizontalRuleStyles,
                         disabled && styles.disabled,
                         active && styles.active,

--- a/packages/wonder-blocks-cell/src/components/internal/common.js
+++ b/packages/wonder-blocks-cell/src/components/internal/common.js
@@ -19,6 +19,14 @@ export const CellMeasurements = {
     },
 
     /**
+     * The DetailCell wrapper's gap.
+     */
+    detailCellPadding: {
+        paddingVertical: Spacing.small_12,
+        paddingHorizontal: Spacing.medium_16,
+    },
+
+    /**
      * The extra vertical spacing added to the title/content wrapper.
      */
     contentVerticalSpacing: Spacing.xxxSmall_4,


### PR DESCRIPTION
## Summary:

Applying some changes on the `DetailCell` to match the latest design specs:

- Changed `title` from `bold` to `regular`.
- Changed the vertical padding from `12px` to `16px` (Note: `CompactCell` will remain using `12px`).
- Moved the `style` prop to the `innerWrapper` to be able to display the horizontal rule correctly in case there are layout changes (e.g. overriding padding).

Issue: WB-1222

## Test plan:

Navigate to http://localhost:6061/?path=/story/cell-detailcell--default-detail-cell

Verify that the styles match the design specs:

Figma: https://www.figma.com/file/VbVu3h2BpBhH80niq101MHHE/branch/pQxVhYukfdxJSAXIaSjZvg/Main-Components?node-id=4337%3A2033


BEFORE:
<img width="436" alt="Screen Shot 2022-02-02 at 1 04 47 PM" src="https://user-images.githubusercontent.com/843075/152211783-905d75ee-3e47-433c-8eff-7e5436fbeb08.png">

AFTER:
<img width="449" alt="Screen Shot 2022-02-02 at 1 04 54 PM" src="https://user-images.githubusercontent.com/843075/152211812-c1f0f57f-1558-4382-8b6b-6432f50cffef.png">

