### PR TITLE
[fei4261.contextmerge] Only merge properties with non-undefined values

### DIFF
--- a/.changeset/thick-cobras-deny.md
+++ b/.changeset/thick-cobras-deny.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": minor
+---
+
+useGql method now merges defaultContext and partial context by ignoring values explicitly set to undefined in the partial context. This ensures that that existing default context values are not overridden unless explicitly given a value other than undefined.

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-gql.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-gql.test.js
@@ -80,6 +80,7 @@ describe("#useGql", () => {
                 id: "MyQuery",
             };
             const gqlOpContext = {
+                a: undefined, // This should not get included.
                 b: "overrideB",
             };
             const gqlOpVariables = {

--- a/packages/wonder-blocks-data/src/hooks/use-gql.js
+++ b/packages/wonder-blocks-data/src/hooks/use-gql.js
@@ -9,7 +9,6 @@ import type {
     GqlContext,
     GqlOperation,
     GqlFetchOptions,
-    GqlOperationType,
 } from "../util/gql-types.js";
 
 /**
@@ -17,13 +16,12 @@ import type {
  *
  * The fetch function will resolve null if the request was aborted, otherwise
  * it will resolve the data returned by the GraphQL server.
+ *
+ * Context is merged with the default context provided to the GqlRouter.
+ * Values in the partial context given to the returned fetch function will
+ * only be included if they have a value other than undefined.
  */
-export const useGql = (): (<
-    TType: GqlOperationType,
-    TData,
-    TVariables: {...},
-    TContext: GqlContext,
->(
+export const useGql = (): (<TData, TVariables: {...}, TContext: GqlContext>(
     operation: GqlOperation<TData, TVariables>,
     options?: GqlFetchOptions<TVariables, TContext>,
 ) => Promise<?TData>) => {
@@ -47,24 +45,39 @@ export const useGql = (): (<
                     {},
                 ),
             ) => {
-                const {variables, context} = options;
+                const {variables, context = {}} = options;
+
+                // Let's merge the partial context of the fetch with the
+                // default context. We deliberately don't spread because
+                // spreading would overwrite default context values with
+                // undefined if the partial context includes a value explicitly
+                // set to undefined. Instead, we use a map/reduce of keys.
+                const mergedContext = Object.keys(context).reduce(
+                    (acc, key) => {
+                        if (context[key] !== undefined) {
+                            acc[key] = context[key];
+                        }
+                        return acc;
+                    },
+                    {...defaultContext},
+                );
 
                 // Invoke the fetch and extract the data.
-                return fetch(operation, variables, {
-                    ...defaultContext,
-                    ...context,
-                }).then(getGqlDataFromResponse, (error) => {
-                    // Return null if the request was aborted.
-                    // The only way to detect this reliably, it seems, is to
-                    // check the error name and see if it's "AbortError" (this
-                    // is also what Apollo does).
-                    // Even then, it's reliant on the fetch supporting aborts.
-                    if (error.name === "AbortError") {
-                        return null;
-                    }
-                    // Need to make sure we pass other errors along.
-                    throw error;
-                });
+                return fetch(operation, variables, mergedContext).then(
+                    getGqlDataFromResponse,
+                    (error) => {
+                        // Return null if the request was aborted.
+                        // The only way to detect this reliably, it seems, is to
+                        // check the error name and see if it's "AbortError" (this
+                        // is also what Apollo does).
+                        // Even then, it's reliant on the fetch supporting aborts.
+                        if (error.name === "AbortError") {
+                            return null;
+                        }
+                        // Need to make sure we pass other errors along.
+                        throw error;
+                    },
+                );
             },
         [fetch, defaultContext],
     );


### PR DESCRIPTION
## Summary:
I was using the API and found it frustrating that `undefined` values explicitly included would override the defaults. I don't think this is what folks would expect and it certainly makes things harder in our case since we have to do some wrappers around the Wonder Blocks API in webapp.

So, this merges with an algorithm that ignores values explicitly set to undefined.

Also tidied up some typing.

Issue: FEI-4261

## Test plan:
`yarn test`
`yarn flow`