### PR TITLE
Clickable: Allow disabled state to be focusable

### DIFF
--- a/.changeset/beige-rings-dream.md
+++ b/.changeset/beige-rings-dream.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Use `aria-disabled` instead of disabled, fix focused + disabled styles.

--- a/packages/wonder-blocks-cell/src/components/internal/__tests__/cell-core.test.js
+++ b/packages/wonder-blocks-cell/src/components/internal/__tests__/cell-core.test.js
@@ -74,7 +74,10 @@ describe("CellCore", () => {
         );
 
         // Assert
-        expect(screen.getByRole("button")).toBeDisabled();
+        expect(screen.getByRole("button")).toHaveAttribute(
+            "aria-disabled",
+            "true",
+        );
     });
 
     it("should add aria-current if active is set", () => {

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.js
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.js
@@ -285,6 +285,9 @@ const styles = StyleSheet.create({
 
     disabled: {
         color: Color.offBlack32,
+        ":hover": {
+            cursor: "not-allowed",
+        },
     },
 
     accessoryActive: {

--- a/packages/wonder-blocks-clickable/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-clickable/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -21,9 +21,9 @@ exports[`wonder-blocks-clickable example 1 1`] = `
   }
 >
   <button
+    aria-disabled={false}
     aria-label=""
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onDragStart={[Function]}
@@ -128,9 +128,9 @@ exports[`wonder-blocks-clickable example 2 1`] = `
   }
 >
   <button
+    aria-disabled={false}
     aria-label=""
     className=""
-    disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
     onDragStart={[Function]}

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.js
@@ -378,7 +378,7 @@ describe("ClickableBehavior", () => {
         expect(button.state("pressed")).toEqual(false);
 
         button.simulate("focus");
-        expect(button.state("focused")).toEqual(false);
+        expect(button.state("focused")).toEqual(true);
 
         const anchor = shallow(
             <ClickableBehavior
@@ -464,7 +464,7 @@ describe("ClickableBehavior", () => {
 
         expect(button.state("hovered")).toEqual(false);
         expect(button.state("pressed")).toEqual(false);
-        expect(button.state("focused")).toEqual(false);
+        expect(button.state("focused")).toEqual(true);
     });
 
     describe("full page load navigation", () => {

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
@@ -3,6 +3,8 @@ import * as React from "react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {mount} from "enzyme";
 import "jest-enzyme";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import Clickable from "../clickable.js";
@@ -450,6 +452,56 @@ describe("Clickable", () => {
         expect(window.location.assign).not.toHaveBeenCalledWith(
             "/foo" /*not a full page nav*/,
         );
+    });
+
+    test("should add aria-disabled if disabled is set", () => {
+        // Arrange
+
+        // Act
+        render(
+            <Clickable testId="button" disabled={true}>
+                {(eventState) => <h1>Click Me!</h1>}
+            </Clickable>,
+        );
+
+        const button = screen.getByTestId("button");
+
+        // Assert
+        expect(button).toHaveAttribute("aria-disabled", "true");
+    });
+
+    test("allow keyboard navigation when disabled is set", () => {
+        // Arrange
+        render(
+            <Clickable testId="button" disabled={true}>
+                {(eventState) => <h1>Click Me!</h1>}
+            </Clickable>,
+        );
+
+        // Act
+        userEvent.tab();
+
+        const button = screen.getByTestId("button");
+
+        // Assert
+        expect(button).toHaveFocus();
+    });
+
+    test("allow keyboard navigation when disabled is set", () => {
+        // Arrange
+        render(
+            <Clickable testId="button" disabled={true}>
+                {(eventState) => <h1>Click Me!</h1>}
+            </Clickable>,
+        );
+
+        // Act
+        userEvent.tab();
+
+        const button = screen.getByTestId("button");
+
+        // Assert
+        expect(button).toHaveFocus();
     });
 
     describe("raw events", () => {

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
@@ -459,12 +459,12 @@ describe("Clickable", () => {
 
         // Act
         render(
-            <Clickable testId="button" disabled={true}>
+            <Clickable testId="clickable-button" disabled={true}>
                 {(eventState) => <h1>Click Me!</h1>}
             </Clickable>,
         );
 
-        const button = screen.getByTestId("button");
+        const button = screen.getByTestId("clickable-button");
 
         // Assert
         expect(button).toHaveAttribute("aria-disabled", "true");
@@ -473,32 +473,23 @@ describe("Clickable", () => {
     test("allow keyboard navigation when disabled is set", () => {
         // Arrange
         render(
-            <Clickable testId="button" disabled={true}>
-                {(eventState) => <h1>Click Me!</h1>}
-            </Clickable>,
+            <div>
+                <button>First focusable button</button>
+                <Clickable testId="clickable-button" disabled={true}>
+                    {(eventState) => <h1>Click Me!</h1>}
+                </Clickable>
+            </div>,
         );
 
         // Act
+        // RTL's focuses on `document.body` by default, so we need to focus on
+        // the first button
         userEvent.tab();
 
-        const button = screen.getByTestId("button");
-
-        // Assert
-        expect(button).toHaveFocus();
-    });
-
-    test("allow keyboard navigation when disabled is set", () => {
-        // Arrange
-        render(
-            <Clickable testId="button" disabled={true}>
-                {(eventState) => <h1>Click Me!</h1>}
-            </Clickable>,
-        );
-
-        // Act
+        // Then we focus on our Clickable button.
         userEvent.tab();
 
-        const button = screen.getByTestId("button");
+        const button = screen.getByTestId("clickable-button");
 
         // Assert
         expect(button).toHaveFocus();

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
@@ -221,8 +221,6 @@ const disabledHandlers = {
     onTouchCancel: () => void 0,
     onKeyDown: () => void 0,
     onKeyUp: () => void 0,
-    onFocus: () => void 0,
-    onBlur: () => void 0,
     // Clickable components should still be tabbable so they can
     // be used as anchors.
     tabIndex: 0,

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
@@ -334,9 +334,10 @@ export default class ClickableBehavior extends React.Component<
         props: Props,
         state: ClickableState,
     ): ?Partial<ClickableState> {
-        // If new props are disabled, reset the hovered/focused/pressed states
+        // If new props are disabled, reset the hovered/pressed states
         if (props.disabled) {
-            return startState;
+            // Keep the focused state for enabling keyboard navigation.
+            return {...startState, focused: state.focused};
         } else {
             // Cannot return undefined
             return null;
@@ -610,7 +611,12 @@ export default class ClickableBehavior extends React.Component<
 
     render(): React.Node {
         const childrenProps: ChildrenProps = this.props.disabled
-            ? disabledHandlers
+            ? {
+                  ...disabledHandlers,
+                  // Keep these handlers for keyboard accessibility.
+                  onFocus: this.handleFocus,
+                  onBlur: this.handleBlur,
+              }
             : {
                   onClick: this.handleClick,
                   onMouseEnter: this.handleMouseEnter,

--- a/packages/wonder-blocks-clickable/src/components/clickable.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.js
@@ -252,7 +252,7 @@ export default class Clickable extends React.Component<Props> {
                 <StyledButton
                     {...commonProps}
                     type="button"
-                    disabled={this.props.disabled}
+                    aria-disabled={this.props.disabled}
                 >
                     {this.props.children(clickableState)}
                 </StyledButton>


### PR DESCRIPTION
## Summary:

- Clickable: Replaced `disabled` attribute with `aria-disabled` to make Clickable
components keyboard focusable.  
- Cell: Changed styles to include the `not-allowed` cursor when the user hovers
on a disabled `cell`.  
- Fixed unit tests to account for this change.

Issue: WB-1213

## Test plan:

Navigate to http://localhost:6061/?path=/story/cell-compactcell--compact-cell-disabled

Verify that the cell is disabled and it can be navigated using the keyboard.

Also verify that the `not-allowed` cursor is displayed when the user hovers on the cell.

Screenshot:
<img width="402" alt="Screen Shot 2022-02-08 at 11 09 29 AM" src="https://user-images.githubusercontent.com/843075/153027943-0ea4fdbd-0537-4f66-9bf4-a02a5b0fa9f2.png">

Video
https://user-images.githubusercontent.com/843075/153028015-fe0eb112-83cb-4a7c-9d97-04004174dca7.mov


