### PR TITLE
WB-1182: Remove `day` field from the `BirthdayPicker`

### DIFF
--- a/.changeset/little-numbers-join.md
+++ b/.changeset/little-numbers-join.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": minor
+---
+
+Add `monthYearOnly` prop to hide the `day` field from the UI. Passes the first day of the selected month for this case.

--- a/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.stories.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.stories.js
@@ -125,7 +125,10 @@ export const BirthdayPickerWithYearAndMonthOnly: StoryComponentType =
 
 BirthdayPickerWithYearAndMonthOnly.args = {
     monthYearOnly: true,
-    onChange: () => {},
+    onChange: (date: ?string) => {
+        // eslint-disable-next-line no-console
+        console.log("Date selected: ", date);
+    },
 };
 
 BirthdayPickerWithYearAndMonthOnly.parameters = {

--- a/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.stories.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.stories.js
@@ -119,3 +119,18 @@ DisabledBirthdayPicker.parameters = {
             "A BirthdayPicker can be disabled by passing the `disabled` prop. This will disable all the dropdown controls and prevent them from being interacted with.",
     },
 };
+
+export const BirthdayPickerWithYearAndMonthOnly: StoryComponentType =
+    Template.bind({});
+
+BirthdayPickerWithYearAndMonthOnly.args = {
+    monthYearOnly: true,
+    onChange: () => {},
+};
+
+BirthdayPickerWithYearAndMonthOnly.parameters = {
+    docs: {
+        storyDescription:
+            "A BirthdayPicker can be configured to only show the year and month dropdowns. This can be useful when we want to display and collect a birthday that doesn't require the full DOB for privacy reasons.",
+    },
+};

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
@@ -387,7 +387,7 @@ describe("BirthdayPicker", () => {
             expect(onChange).toHaveBeenCalledWith("2018-08-01");
         });
 
-        it("onChange triggers the first day of the month when defaultValue and monthYearOnly are set", async () => {
+        it("onChange triggers the passed-in day intact when defaultValue and monthYearOnly are set", async () => {
             // Arrange
             const onChange = jest.fn();
 
@@ -417,8 +417,8 @@ describe("BirthdayPicker", () => {
             });
 
             // Assert
-            // Verify that we passed the first day of the month
-            expect(onChange).toHaveBeenCalledWith("2018-08-01");
+            // Verify that we passed the same day originally passed in.
+            expect(onChange).toHaveBeenCalledWith("2018-08-17");
         });
     });
 

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
@@ -181,9 +181,9 @@ describe("BirthdayPicker", () => {
             // Arrange
             const onChange = jest.fn();
 
-            // Act
             render(<BirthdayPicker onChange={onChange} />);
 
+            // Act
             userEvent.click(screen.getByTestId("birthday-picker-month"));
             const monthOption = await screen.findByRole("option", {
                 name: "Jul",
@@ -270,7 +270,6 @@ describe("BirthdayPicker", () => {
             // Arrange
             const onChange = jest.fn();
 
-            // Act
             render(
                 <BirthdayPicker
                     defaultValue="2017-07-17"
@@ -278,6 +277,7 @@ describe("BirthdayPicker", () => {
                 />,
             );
 
+            // Act
             userEvent.click(screen.getByTestId("birthday-picker-month"));
             const monthOption = await screen.findByRole("option", {
                 name: "Aug",
@@ -339,7 +339,6 @@ describe("BirthdayPicker", () => {
             // Arrange
             const onChange = jest.fn();
 
-            // Act
             render(
                 <BirthdayPicker
                     defaultValue="2021-02-31"
@@ -347,6 +346,7 @@ describe("BirthdayPicker", () => {
                 />,
             );
 
+            // Act
             userEvent.click(screen.getByTestId("birthday-picker-year"));
             const yearOption = await screen.findByRole("option", {
                 name: "2020",
@@ -363,9 +363,9 @@ describe("BirthdayPicker", () => {
             // Arrange
             const onChange = jest.fn();
 
-            // Act
             render(<BirthdayPicker monthYearOnly={true} onChange={onChange} />);
 
+            // Act
             userEvent.click(screen.getByTestId("birthday-picker-month"));
             const monthOption = await screen.findByRole("option", {
                 name: "Aug",
@@ -391,7 +391,6 @@ describe("BirthdayPicker", () => {
             // Arrange
             const onChange = jest.fn();
 
-            // Act
             render(
                 <BirthdayPicker
                     defaultValue="2017-07-17"
@@ -400,6 +399,7 @@ describe("BirthdayPicker", () => {
                 />,
             );
 
+            // Act
             userEvent.click(screen.getByTestId("birthday-picker-month"));
             const monthOption = await screen.findByRole("option", {
                 name: "Aug",

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
@@ -34,6 +34,18 @@ describe("BirthdayPicker", () => {
             expect(yearPicker).toHaveTextContent("Year");
         });
 
+        it("renders without the day field if monthYearOnly is set", () => {
+            // Arrange
+
+            // Act
+            render(<BirthdayPicker monthYearOnly={true} onChange={() => {}} />);
+
+            const dayPicker = screen.queryByTestId("birthday-picker-day");
+
+            // Assert
+            expect(dayPicker).not.toBeInTheDocument();
+        });
+
         it("renders with a valid default value", () => {
             // Arrange
             const date = moment(today);
@@ -345,6 +357,68 @@ describe("BirthdayPicker", () => {
 
             // Assert
             expect(onChange).toHaveBeenCalledTimes(1);
+        });
+
+        it("onChange triggers the first day of the month when monthYearOnly is set", async () => {
+            // Arrange
+            const onChange = jest.fn();
+
+            // Act
+            render(<BirthdayPicker monthYearOnly={true} onChange={onChange} />);
+
+            userEvent.click(screen.getByTestId("birthday-picker-month"));
+            const monthOption = await screen.findByRole("option", {
+                name: "Aug",
+            });
+            userEvent.click(monthOption, undefined, {
+                skipPointerEventsCheck: true,
+            });
+
+            userEvent.click(screen.getByTestId("birthday-picker-year"));
+            const yearOption = await screen.findByRole("option", {
+                name: "2018",
+            });
+            userEvent.click(yearOption, undefined, {
+                skipPointerEventsCheck: true,
+            });
+
+            // Assert
+            // Verify that we passed the first day of the month
+            expect(onChange).toHaveBeenCalledWith("2018-08-01");
+        });
+
+        it("onChange triggers the first day of the month when defaultValue and monthYearOnly are set", async () => {
+            // Arrange
+            const onChange = jest.fn();
+
+            // Act
+            render(
+                <BirthdayPicker
+                    defaultValue="2017-07-17"
+                    monthYearOnly={true}
+                    onChange={onChange}
+                />,
+            );
+
+            userEvent.click(screen.getByTestId("birthday-picker-month"));
+            const monthOption = await screen.findByRole("option", {
+                name: "Aug",
+            });
+            userEvent.click(monthOption, undefined, {
+                skipPointerEventsCheck: true,
+            });
+
+            userEvent.click(screen.getByTestId("birthday-picker-year"));
+            const yearOption = await screen.findByRole("option", {
+                name: "2018",
+            });
+            userEvent.click(yearOption, undefined, {
+                skipPointerEventsCheck: true,
+            });
+
+            // Assert
+            // Verify that we passed the first day of the month
+            expect(onChange).toHaveBeenCalledWith("2018-08-01");
         });
     });
 

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.js
@@ -52,10 +52,10 @@ type Props = {|
     /**
      * Whether we want to hide the day field.
      *
-     * **NOTE:** We will set the day to the _FIRST_ day of the _SELECTED_ month
+     * **NOTE:** We will set the day to the _first_ day of the _selected_ month
      * if the day field is hidden. Please make sure to modify the passed date
-     * value to fit different needs (e.g. if you want to set the _FIRST_ day of
-     * the _FOLLOWING_ month instead).
+     * value to fit different needs (e.g. if you want to set the _first_ day of
+     * the _following_ month instead).
      */
     monthYearOnly?: boolean,
 
@@ -99,7 +99,9 @@ export const defaultLabels: Labels = Object.freeze({
 
 // Default minWidth value when we include the full DOB.
 const FIELD_MIN_WIDTH_FULL = 110;
+
 // Alternative minWidth value when we hide the day field.
+// See: https://www.figma.com/file/uJZi9ZvuEz5N8GJ3HqKFAa/(2021)-Account-records?node-id=20%3A398
 const FIELD_MIN_WIDTH_MONTH_YEAR = 167;
 
 /**

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.js
@@ -51,6 +51,11 @@ type Props = {|
 
     /**
      * Whether we want to hide the day field.
+     *
+     * **NOTE:** We will set the day to the _FIRST_ day of the _SELECTED_ month
+     * if the day field is hidden. Please make sure to modify the passed date
+     * value to fit different needs (e.g. if you want to set the _FIRST_ day of
+     * the _FOLLOWING_ month instead).
      */
     monthYearOnly?: boolean,
 
@@ -158,12 +163,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
         // If a default value was provided then we use moment to convert it
         // into a date that we can use to populate the
         if (defaultValue) {
-            let date = moment(defaultValue);
-
-            // Override the default day if monthYearOnly mode is set.
-            if (monthYearOnly) {
-                date = date.startOf("month");
-            }
+            const date = moment(defaultValue);
 
             if (date.isValid()) {
                 initialState.month = String(date.month());


### PR DESCRIPTION
## Summary:

- Added `monthYearOnly` prop to hide the day field from the UI.
- Modified the logic to set the FIRST day of the SELECTED month when setting this new prop.
- Modified the `minWidth` of the components to account for this scenario.
- Added unit tests to cover this prop.

Issue: WB-1182

## Test plan:

Navigate to: http://localhost:6061/?path=/story/birthdaypicker--birthday-picker-with-year-and-month-only

Verify that the UI hides the day field.

<img width="542" alt="Screen Shot 2022-02-09 at 12 33 03 PM" src="https://user-images.githubusercontent.com/843075/153257173-37a52a75-03cd-4c92-8487-23c62c73fcfa.png">

Chromatic: https://5e1bf4b385e3fb0020b7073c-yrgchxqdjx.chromatic.com/?path=/story/birthdaypicker--birthday-picker-with-year-and-month-only

Extra: Inspect the component using React DevTools and verify that the state is setting `day=1`.