### PR TITLE
[fixdependencies] Make wonder-blocks package deps be peers

### DIFF
--- a/.changeset/famous-crabs-sit.md
+++ b/.changeset/famous-crabs-sit.md
@@ -1,0 +1,25 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-data": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-icon": patch
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-layout": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-progress-spinner": patch
+"@khanacademy/wonder-blocks-testing": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-typography": patch
+---
+
+Make sure WB packages reference each other as peer dependencies

--- a/packages/wonder-blocks-birthday-picker/package.json
+++ b/packages/wonder-blocks-birthday-picker/package.json
@@ -13,7 +13,12 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
+    "@babel/runtime": "^7.16.3"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "moment": "^2.24.0",
+    "react": "16.14.0",
     "@khanacademy/wonder-blocks-color": "^1.1.20",
     "@khanacademy/wonder-blocks-core": "^4.2.0",
     "@khanacademy/wonder-blocks-dropdown": "^2.6.4",
@@ -21,11 +26,6 @@
     "@khanacademy/wonder-blocks-layout": "^1.4.6",
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-typography": "^1.1.28"
-  },
-  "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "moment": "^2.24.0",
-    "react": "16.14.0"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-breadcrumbs/package.json
+++ b/packages/wonder-blocks-breadcrumbs/package.json
@@ -15,15 +15,15 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
+    "@babel/runtime": "^7.16.3"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "16.14.0",
     "@khanacademy/wonder-blocks-color": "^1.1.20",
     "@khanacademy/wonder-blocks-core": "^4.2.1",
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-typography": "^1.1.29"
-  },
-  "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "16.14.0"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -15,7 +15,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
+    "@babel/runtime": "^7.16.3"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "16.14.0",
+    "react-router": "5.2.1",
+    "react-router-dom": "5.3.0",
     "@khanacademy/wonder-blocks-clickable": "^2.2.3",
     "@khanacademy/wonder-blocks-color": "^1.1.20",
     "@khanacademy/wonder-blocks-core": "^4.2.1",
@@ -23,12 +29,6 @@
     "@khanacademy/wonder-blocks-progress-spinner": "^1.1.29",
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-typography": "^1.1.29"
-  },
-  "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "16.14.0",
-    "react-router": "5.2.1",
-    "react-router-dom": "5.3.0"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-cell/package.json
+++ b/packages/wonder-blocks-cell/package.json
@@ -13,17 +13,17 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
+    "@babel/runtime": "^7.16.3"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "16.14.0",
     "@khanacademy/wonder-blocks-clickable": "^2.2.3",
     "@khanacademy/wonder-blocks-color": "^1.1.20",
     "@khanacademy/wonder-blocks-core": "^4.2.1",
     "@khanacademy/wonder-blocks-layout": "^1.4.7",
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-typography": "^1.1.29"
-  },
-  "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "16.14.0"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -15,15 +15,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-core": "^4.2.1"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router": "5.2.1",
-    "react-router-dom": "5.3.0"
+    "react-router-dom": "5.3.0",
+    "@khanacademy/wonder-blocks-core": "^4.2.1"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -13,15 +13,15 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router": "5.2.1",
-    "react-router-dom": "5.3.0"
+    "react-router-dom": "5.3.0",
+    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-data/package.json
+++ b/packages/wonder-blocks-data/package.json
@@ -13,12 +13,12 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-core": "^4.2.1"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "@khanacademy/wonder-stuff-core": "^0.1.2",
-    "react": "16.14.0"
+    "react": "16.14.0",
+    "@khanacademy/wonder-blocks-core": "^4.2.1"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -15,7 +15,17 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
+    "@babel/runtime": "^7.16.3"
+  },
+  "peerDependencies": {
+    "@popperjs/core": "^2.10.1",
+    "aphrodite": "^1.2.5",
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
+    "react-popper": "^2.0.0",
+    "react-router": "5.2.1",
+    "react-router-dom": "5.3.0",
+    "react-window": "^1.8.5",
     "@khanacademy/wonder-blocks-button": "^2.11.2",
     "@khanacademy/wonder-blocks-clickable": "^2.2.3",
     "@khanacademy/wonder-blocks-color": "^1.1.20",
@@ -27,16 +37,6 @@
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-timing": "^2.1.0",
     "@khanacademy/wonder-blocks-typography": "^1.1.29"
-  },
-  "peerDependencies": {
-    "@popperjs/core": "^2.10.1",
-    "aphrodite": "^1.2.5",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
-    "react-popper": "^2.0.0",
-    "react-router": "5.2.1",
-    "react-router-dom": "5.3.0",
-    "react-window": "^1.8.5"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -15,7 +15,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
+    "@babel/runtime": "^7.16.3"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "16.14.0",
     "@khanacademy/wonder-blocks-clickable": "^2.2.3",
     "@khanacademy/wonder-blocks-color": "^1.1.20",
     "@khanacademy/wonder-blocks-core": "^4.2.1",
@@ -23,10 +27,6 @@
     "@khanacademy/wonder-blocks-layout": "^1.4.7",
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-typography": "^1.1.29"
-  },
-  "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "16.14.0"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-grid/package.json
+++ b/packages/wonder-blocks-grid/package.json
@@ -15,14 +15,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-color": "^1.1.20",
-    "@khanacademy/wonder-blocks-core": "^4.2.1",
-    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "16.14.0"
+    "react": "16.14.0",
+    "@khanacademy/wonder-blocks-color": "^1.1.20",
+    "@khanacademy/wonder-blocks-core": "^4.2.1",
+    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -15,17 +15,17 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-clickable": "^2.2.3",
-    "@khanacademy/wonder-blocks-color": "^1.1.20",
-    "@khanacademy/wonder-blocks-core": "^4.2.1",
-    "@khanacademy/wonder-blocks-icon": "^1.2.25"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
     "react": "16.14.0",
     "react-router": "5.2.1",
-    "react-router-dom": "5.3.0"
+    "react-router-dom": "5.3.0",
+    "@khanacademy/wonder-blocks-clickable": "^2.2.3",
+    "@khanacademy/wonder-blocks-color": "^1.1.20",
+    "@khanacademy/wonder-blocks-core": "^4.2.1",
+    "@khanacademy/wonder-blocks-icon": "^1.2.25"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-icon/package.json
+++ b/packages/wonder-blocks-icon/package.json
@@ -15,14 +15,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-core": "^4.2.1"
+    "@babel/runtime": "^7.16.3"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "16.14.0"
+    "react": "16.14.0",
+    "@khanacademy/wonder-blocks-core": "^4.2.1"
   }
 }

--- a/packages/wonder-blocks-layout/package.json
+++ b/packages/wonder-blocks-layout/package.json
@@ -13,16 +13,16 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-core": "^4.2.1",
-    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
+    "@babel/runtime": "^7.16.3"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "16.14.0"
+    "react": "16.14.0",
+    "@khanacademy/wonder-blocks-core": "^4.2.1",
+    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -15,16 +15,16 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-clickable": "^2.2.3",
-    "@khanacademy/wonder-blocks-color": "^1.1.20",
-    "@khanacademy/wonder-blocks-core": "^4.2.1"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
     "react": "16.14.0",
     "react-router": "5.2.1",
-    "react-router-dom": "5.3.0"
+    "react-router-dom": "5.3.0",
+    "@khanacademy/wonder-blocks-clickable": "^2.2.3",
+    "@khanacademy/wonder-blocks-color": "^1.1.20",
+    "@khanacademy/wonder-blocks-core": "^4.2.1"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -15,7 +15,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
+    "@babel/runtime": "^7.16.3"
+  },
+  "peerDependencies": {
+    "aphrodite": "^1.2.5",
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
     "@khanacademy/wonder-blocks-breadcrumbs": "^1.0.28",
     "@khanacademy/wonder-blocks-color": "^1.1.20",
     "@khanacademy/wonder-blocks-core": "^4.2.1",
@@ -25,11 +30,6 @@
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-toolbar": "^2.1.29",
     "@khanacademy/wonder-blocks-typography": "^1.1.29"
-  },
-  "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "16.14.0",
-    "react-dom": "16.14.0"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -15,7 +15,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
+    "@babel/runtime": "^7.16.3"
+  },
+  "peerDependencies": {
+    "@popperjs/core": "^2.10.1",
+    "aphrodite": "^1.2.5",
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
+    "react-popper": "^2.0.0",
     "@khanacademy/wonder-blocks-color": "^1.1.20",
     "@khanacademy/wonder-blocks-core": "^4.2.1",
     "@khanacademy/wonder-blocks-icon": "^1.2.25",
@@ -25,13 +32,6 @@
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-tooltip": "^1.3.7",
     "@khanacademy/wonder-blocks-typography": "^1.1.29"
-  },
-  "peerDependencies": {
-    "@popperjs/core": "^2.10.1",
-    "aphrodite": "^1.2.5",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
-    "react-popper": "^2.0.0"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-progress-spinner/package.json
+++ b/packages/wonder-blocks-progress-spinner/package.json
@@ -15,14 +15,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-color": "^1.1.20",
-    "@khanacademy/wonder-blocks-core": "^4.2.1",
-    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "16.14.0"
+    "react": "16.14.0",
+    "@khanacademy/wonder-blocks-color": "^1.1.20",
+    "@khanacademy/wonder-blocks-core": "^4.2.1",
+    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-testing/package.json
+++ b/packages/wonder-blocks-testing/package.json
@@ -13,14 +13,14 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@babel/runtime": "^7.16.3",
-        "@khanacademy/wonder-blocks-data": "^4.0.0"
+        "@babel/runtime": "^7.16.3"
     },
     "peerDependencies": {
         "@khanacademy/wonder-stuff-core": "^0.1.2",
         "@khanacademy/wonder-stuff-testing": "^0.0.2",
         "@storybook/addon-actions": "^6.4.8",
-        "react": "16.14.0"
+        "react": "16.14.0",
+        "@khanacademy/wonder-blocks-data": "^4.0.0"
     },
     "devDependencies": {
         "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-toolbar/package.json
+++ b/packages/wonder-blocks-toolbar/package.json
@@ -15,14 +15,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-color": "^1.1.20",
-    "@khanacademy/wonder-blocks-core": "^4.2.1",
-    "@khanacademy/wonder-blocks-typography": "^1.1.29"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "16.14.0"
+    "react": "16.14.0",
+    "@khanacademy/wonder-blocks-color": "^1.1.20",
+    "@khanacademy/wonder-blocks-core": "^4.2.1",
+    "@khanacademy/wonder-blocks-typography": "^1.1.29"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -15,20 +15,20 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-color": "^1.1.20",
-    "@khanacademy/wonder-blocks-core": "^4.2.1",
-    "@khanacademy/wonder-blocks-layout": "^1.4.7",
-    "@khanacademy/wonder-blocks-modal": "^2.2.1",
-    "@khanacademy/wonder-blocks-spacing": "^3.0.5",
-    "@khanacademy/wonder-blocks-typography": "^1.1.29"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "@popperjs/core": "^2.10.1",
     "aphrodite": "^1.2.5",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "react-popper": "^2.0.0"
+    "react-popper": "^2.0.0",
+    "@khanacademy/wonder-blocks-color": "^1.1.20",
+    "@khanacademy/wonder-blocks-core": "^4.2.1",
+    "@khanacademy/wonder-blocks-layout": "^1.4.7",
+    "@khanacademy/wonder-blocks-modal": "^2.2.1",
+    "@khanacademy/wonder-blocks-spacing": "^3.0.5",
+    "@khanacademy/wonder-blocks-typography": "^1.1.29"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"

--- a/packages/wonder-blocks-typography/package.json
+++ b/packages/wonder-blocks-typography/package.json
@@ -15,12 +15,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-core": "^4.2.1"
+    "@babel/runtime": "^7.16.3"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
-    "react": "16.14.0"
+    "react": "16.14.0",
+    "@khanacademy/wonder-blocks-core": "^4.2.1"
   },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"


### PR DESCRIPTION
## Summary:
Nisha has been seeing [flow issues](https://khanacademy.slack.com/archives/C4PE1QM5Y/p1644281707112309) when trying to update wonder blocks in webapp. I was also able to replicate this issue.

The flow issue is caused because it is encountering typography as a dependency of form in the form package's own nested node_modules before it encounters it elsewhere and this is causing some conflict. It turns out this is happening because we're bundling wonder-blocks deps with each package and it's loading them in an order that means they're not compatible.

I think having packages reference one another as peer dependencies resolves this for our main packages, but it doesn't necessarily help with when we want to alias a package (like we do with Wonder Blocks modal) - however, I think solving the main issue is relevant here and modal v1 should be fine because it uses the old broken "ship with my fellow packages as dependencies" model.

This is currently just a suggested change. We don't have to accept it, but if we don't then I think Flow is going to continue to get confused about mismatching copies of the exact same library. :(

Issue: XXX-XXXX

## Test plan:
Release this change and try it in webapp.