### PR TITLE
[fei4327.1.useForceUpdate] Add useForceUpdate hook

### DIFF
--- a/.changeset/stale-feet-hang.md
+++ b/.changeset/stale-feet-hang.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-core": minor
 ---
 
-NEW: `useForceUpdate` hook
+NEW: `useForceUpdate` hook. This should rarely be used and likely only ever from other hooks.

--- a/.changeset/stale-feet-hang.md
+++ b/.changeset/stale-feet-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+NEW: `useForceUpdate` hook

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.js
@@ -1,0 +1,54 @@
+// @flow
+import * as React from "react";
+import {render, act} from "@testing-library/react";
+import {renderHook} from "@testing-library/react-hooks";
+
+import {useForceUpdate} from "../use-force-update.js";
+
+describe("#useForceUpdate", () => {
+    it("should return a function", () => {
+        // Arrange
+
+        // Act
+        const {
+            result: {current: result},
+        } = renderHook(() => useForceUpdate());
+
+        // Assert
+        expect(result).toBeInstanceOf(Function);
+    });
+
+    describe("returned function", () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        it("should cause component to render", () => {
+            // Arrange
+            const Component = (props): React.Node => {
+                const countRef = React.useRef(0);
+                const forceUpdate = useForceUpdate();
+                React.useEffect(() => {
+                    countRef.current++;
+
+                    setTimeout(forceUpdate, 50);
+                });
+                return countRef.current;
+            };
+
+            // Act
+            const wrapper = render(<Component />);
+            act(() => {
+                // Advance enough for the timeout to run 4 times.
+                // Which means the component should have rendered 4 times,
+                // with one more pending for the timeout that was setup in
+                // the last render.
+                jest.advanceTimersByTime(204);
+            });
+            const result = wrapper.container.textContent;
+
+            // Assert
+            expect(result).toBe("4");
+        });
+    });
+});

--- a/packages/wonder-blocks-core/src/hooks/use-force-update.js
+++ b/packages/wonder-blocks-core/src/hooks/use-force-update.js
@@ -1,0 +1,16 @@
+// @flow
+import * as React from "react";
+
+/**
+ * Hook for forcing a component to update on demand.
+ *
+ * @returns {() => void} A function that forces the component to update.
+ */
+export const useForceUpdate = (): (() => void) => {
+    const [, setState] = React.useState(false);
+    const forceUpdate = React.useCallback(
+        () => setState((state) => !state),
+        [],
+    );
+    return forceUpdate;
+};

--- a/packages/wonder-blocks-core/src/hooks/use-force-update.js
+++ b/packages/wonder-blocks-core/src/hooks/use-force-update.js
@@ -4,6 +4,13 @@ import * as React from "react";
 /**
  * Hook for forcing a component to update on demand.
  *
+ * This is for use inside other hooks that do some advanced
+ * trickery with storing state outside of React's own state
+ * mechanisms. As such this should never be called directly
+ * outside of a hook, and more often than not, is the wrong
+ * choice for whatever you are trying to do. If in doubt,
+ * don't use it.
+ *
  * @returns {() => void} A function that forces the component to update.
  */
 export const useForceUpdate = (): (() => void) => {

--- a/packages/wonder-blocks-core/src/index.js
+++ b/packages/wonder-blocks-core/src/index.js
@@ -12,6 +12,7 @@ export {
     useUniqueIdWithMock,
     useUniqueIdWithoutMock,
 } from "./hooks/use-unique-id.js";
+export {useForceUpdate} from "./hooks/use-force-update.js";
 export {RenderStateRoot} from "./components/render-state-root.js";
 
 export type {AriaProps, IIdentifierFactory, StyleType};


### PR DESCRIPTION
## Summary:
This adds a simple utility hook to allow components and hooks to trigger a re-render without requiring their own state to be updated.
This is useful when, for example, the state of the component comes from some shared cache or other location that doesn't warrant also sharing it in component state.

Issue: FEI-4327

## Test plan:
`yarn test`
`yarn flow`