### PR TITLE
Change Result type to include the error object instead of string

### DIFF
--- a/.changeset/small-rockets-repeat.md
+++ b/.changeset/small-rockets-repeat.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-data": minor
 ---
 
-Change `Result<TData>` error status so that error field is an error object, not a string
+Changed `Result<TData>` error status so that error field is an error object, not a string

--- a/.changeset/small-rockets-repeat.md
+++ b/.changeset/small-rockets-repeat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": minor
+---
+
+Change `Result<TData>` error status so that error field is an error object, not a string

--- a/packages/wonder-blocks-data/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-data/src/__tests__/generated-snapshot.test.js
@@ -119,7 +119,7 @@ describe("wonder-blocks-data", () => {
                                         color: Color.red,
                                     }}
                                 >
-                                    ERROR: {result.error}
+                                    ERROR: {result.error.message}
                                 </BodyMonospace>
                             );
                         }}

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -131,7 +131,7 @@ describe("Data", () => {
                 expect(fakeChildrenFn).toHaveBeenCalledTimes(2);
                 expect(fakeChildrenFn).toHaveBeenLastCalledWith({
                     status: "error",
-                    error: "OH NOES!",
+                    error: expect.any(Error),
                 });
             });
 
@@ -164,52 +164,45 @@ describe("Data", () => {
                 });
             });
 
-            it.each`
-                error
-                ${"CATASTROPHE!"}
-                ${new Error("CATASTROPHE!")}
-            `(
-                "should render with an error if the request rejects with $error",
-                async ({error}) => {
-                    // Arrange
-                    const fulfillSpy = jest
-                        .spyOn(RequestFulfillment.Default, "fulfill")
-                        .mockReturnValue(Promise.reject(error));
+            it("should render with an error if the request rejects with an error", async () => {
+                // Arrange
+                const fulfillSpy = jest
+                    .spyOn(RequestFulfillment.Default, "fulfill")
+                    .mockReturnValue(Promise.reject(new Error("CATASTROPHE!")));
 
-                    const fakeHandler = () => Promise.resolve("YAY!");
-                    const fakeChildrenFn = jest.fn(() => null);
-                    const consoleSpy = jest
-                        .spyOn(console, "error")
-                        .mockImplementation(() => {
-                            /* Just to shut it up */
-                        });
-
-                    // Act
-                    render(
-                        <Data handler={fakeHandler} requestId="ID">
-                            {fakeChildrenFn}
-                        </Data>,
-                    );
-                    /**
-                     * We wait for the fulfillment to reject.
-                     */
-                    await act(() =>
-                        fulfillSpy.mock.results[0].value.catch(() => {}),
-                    );
-
-                    // Assert
-                    expect(fakeChildrenFn).toHaveBeenCalledTimes(2);
-                    expect(fakeChildrenFn).toHaveBeenLastCalledWith({
-                        status: "error",
-                        error: "CATASTROPHE!",
+                const fakeHandler = () => Promise.resolve("YAY!");
+                const fakeChildrenFn = jest.fn(() => null);
+                const consoleSpy = jest
+                    .spyOn(console, "error")
+                    .mockImplementation(() => {
+                        /* Just to shut it up */
                     });
-                    expect(consoleSpy).toHaveBeenCalledWith(
-                        expect.stringMatching(
-                            "Unexpected error occurred during data fulfillment:(?: Error:)? CATASTROPHE!",
-                        ),
-                    );
-                },
-            );
+
+                // Act
+                render(
+                    <Data handler={fakeHandler} requestId="ID">
+                        {fakeChildrenFn}
+                    </Data>,
+                );
+                /**
+                 * We wait for the fulfillment to reject.
+                 */
+                await act(() =>
+                    fulfillSpy.mock.results[0].value.catch(() => {}),
+                );
+
+                // Assert
+                expect(fakeChildrenFn).toHaveBeenCalledTimes(2);
+                expect(fakeChildrenFn).toHaveBeenLastCalledWith({
+                    status: "error",
+                    error: expect.any(Error),
+                });
+                expect(consoleSpy).toHaveBeenCalledWith(
+                    expect.stringMatching(
+                        "Unexpected error occurred during data fulfillment:(?: Error:)? CATASTROPHE!",
+                    ),
+                );
+            });
 
             it("should start loading if the id changes and request not cached", async () => {
                 // Arrange
@@ -765,7 +758,7 @@ describe("Data", () => {
                 // Assert
                 expect(fakeChildrenFn).toHaveBeenCalledWith({
                     status: "error",
-                    error: "OH NO! IT GO BOOM",
+                    error: expect.any(Error),
                 });
             });
 

--- a/packages/wonder-blocks-data/src/components/data.js
+++ b/packages/wonder-blocks-data/src/components/data.js
@@ -87,7 +87,9 @@ const Data = <TData: ValidCacheData>({
         interceptedHandler,
         hydrate,
     );
-    const [currentResult, setResult] = React.useState(hydrateResult);
+    const [currentResult, setResult] = React.useState<Result<TData>>(() =>
+        resultFromCachedResponse(hydrateResult),
+    );
 
     // Here we make sure the request still occurs client-side as needed.
     // This is for legacy usage that expects this. Eventually we will want
@@ -111,9 +113,9 @@ const Data = <TData: ValidCacheData>({
         // If we're not hydrating a result and we're not going to render
         // with old data until we're loaded, we want to make sure we set our
         // result to null so that we're in the loading state.
-        if (!showOldDataWhileLoading) {
+        if (!showOldDataWhileLoading && currentResult.status !== "loading") {
             // Mark ourselves as loading.
-            setResult(null);
+            setResult({status: "loading"});
         }
 
         // We aren't server-side, so let's make the request.
@@ -129,7 +131,7 @@ const Data = <TData: ValidCacheData>({
                 if (cancel) {
                     return;
                 }
-                setResult(result);
+                setResult(resultFromCachedResponse(result));
                 return;
             })
             .catch((e) => {
@@ -145,7 +147,8 @@ const Data = <TData: ValidCacheData>({
                     `Unexpected error occurred during data fulfillment: ${e}`,
                 );
                 setResult({
-                    error: typeof e === "string" ? e : e.message,
+                    status: "error",
+                    error: e,
                 });
                 return;
             });
@@ -166,7 +169,7 @@ const Data = <TData: ValidCacheData>({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [requestId]);
 
-    return children(resultFromCachedResponse(currentResult));
+    return children(currentResult);
 };
 
 export default Data;

--- a/packages/wonder-blocks-data/src/components/data.js
+++ b/packages/wonder-blocks-data/src/components/data.js
@@ -131,6 +131,9 @@ const Data = <TData: ValidCacheData>({
                 if (cancel) {
                     return;
                 }
+                // TODO(somewhatabstract, FEI-4327): separate inflight request
+                // tracking and response caching so that we're not "hydrating"
+                // a non-server error in this scenario.
                 setResult(resultFromCachedResponse(result));
                 return;
             })

--- a/packages/wonder-blocks-data/src/components/data.md
+++ b/packages/wonder-blocks-data/src/components/data.md
@@ -140,7 +140,7 @@ initializeCache({
                 }
 
                 return (
-                    <BodyMonospace style={{color: Color.red}}>ERROR: {result.error}</BodyMonospace>
+                    <BodyMonospace style={{color: Color.red}}>ERROR: {result.error.message}</BodyMonospace>
                 );
             }}
         </Data>

--- a/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.js
@@ -61,7 +61,22 @@ describe("#resultFromCachedResponse", () => {
         // Assert
         expect(result).toStrictEqual({
             status: "error",
-            error: "ERROR",
+            error: expect.any(Error),
         });
+    });
+
+    it("should hydrate the error into an error object", () => {
+        // Arrange
+        const cacheEntry: any = {
+            data: null,
+            error: "ERROR",
+        };
+
+        // Act
+        // $FlowIgnore[prop-missing]
+        const {error} = resultFromCachedResponse(cacheEntry);
+
+        // Assert
+        expect(error).toMatchInlineSnapshot(`[GqlHydratedError: ERROR]`);
     });
 });

--- a/packages/wonder-blocks-data/src/util/gql-error.js
+++ b/packages/wonder-blocks-data/src/util/gql-error.js
@@ -12,10 +12,31 @@ type GqlErrorOptions = {|
  */
 export const GqlErrors = Object.freeze({
     ...Errors,
+
+    /**
+     * A network error occurred.
+     */
     Network: "Network",
+
+    /**
+     * Response could not be parsed.
+     */
     Parse: "Parse",
+
+    /**
+     * Response does not have the correct structure for a GraphQL response.
+     */
     BadResponse: "BadResponse",
+
+    /**
+     * A valid GraphQL result with errors field in the payload.
+     */
     ErrorResult: "ErrorResult",
+
+    /**
+     * An error that occurred during SSR and was hydrated from cache
+     */
+    Hydrated: "Hydrated",
 });
 
 /**

--- a/packages/wonder-blocks-data/src/util/result-from-cache-response.js
+++ b/packages/wonder-blocks-data/src/util/result-from-cache-response.js
@@ -1,4 +1,5 @@
 // @flow
+import {GqlError, GqlErrors} from "./gql-error.js";
 import type {ValidCacheData, CachedResponse, Result} from "./types.js";
 
 /**
@@ -18,7 +19,7 @@ export const resultFromCachedResponse = <TData: ValidCacheData>(
     if (error != null) {
         return {
             status: "error",
-            error,
+            error: new GqlError(error, GqlErrors.Hydrated),
         };
     }
 

--- a/packages/wonder-blocks-data/src/util/types.js
+++ b/packages/wonder-blocks-data/src/util/types.js
@@ -25,7 +25,7 @@ export type Result<TData: ValidCacheData> =
       |}
     | {|
           status: "error",
-          error: string,
+          error: Error,
       |}
     | {|
           status: "aborted",


### PR DESCRIPTION
## Summary:
Having access to the error, where possible, is incredibly useful. This is the first step to supporting that.

The `Data` component doesn't have it all correct yet because the client-side fetch is doing the same as the server-side fetch and as such, is using a "hydrated" error. Changes coming for that.

Issue: FEI-4327

## Test plan:
`yarn test`