### PR TITLE
[coverageforhelper] Add a little helper for just getting coverage of a single file, based on its own tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:styleguidist": "yarn run gen-styleguide-prod-config && styleguidist build --config styleguide.prod.config.js",
     "clean": "rm -rf packages/wonder-blocks-*/dist && rm -rf packages/wonder-blocks-*/node_modules",
     "coverage": "yarn run test:coverage && open coverage/lcov-report/index.html",
+    "coveragefor": "bash -c 'yarn --silent jest --coverage --collectCoverageFrom=$0 $(node ./utils/test-file-for.js \"$0\")'",
     "coverage:ci": "yarn run jest --coverage",
     "dry-run-publish": "yarn run publish --skip-npm --skip-git",
     "flow-ci": "flow check --max-workers 0",

--- a/utils/test-file-for.js
+++ b/utils/test-file-for.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-commonjs */
+
+/**
+ * This file is very simple. Given a path, it returns the path of the
+ * associated test file, assuming that our conventions have been followed.
+ */
+const path = require("path");
+
+const getTestPath = (pathToFile) => {
+    const codeFolder = path.dirname(pathToFile);
+    const testFolder = path.join(codeFolder, "__tests__");
+
+    const codeFileName = path.basename(pathToFile);
+    const testFileName = `${codeFileName.replace(/\.js$/, ".test.js")}`;
+
+    return path.join(testFolder, testFileName);
+};
+
+const file = process.argv[2];
+
+console.log(getTestPath(file));


### PR DESCRIPTION
## Summary:
I find myself wanting this often to check that the tests for a given file actually cover that file.
It can be a lot to type out by hand, so now, instead of:

`yarn jest --coverage --collectCoverageFrom=packages/wonder-blocks-data/src/components/data.js packages/wonder-blocks-data/src/components/__tests__/data.test.js`

I can just do:

`yarn coveragefor packages/wonder-blocks-data/src/components/data.js`

Issue: XXX-XXXX

## Versioning:
No version bumps required. This is entirely repo tooling and does not affect package tooling.

## Test plan:
Try it out :)

Example:

```bash
(khan27) ✔ ~/khan/wonder-blocks [fei4327.4.firstclassresult L|✔] 
12:08 $ yarn coveragefor packages/wonder-blocks-data/src/components/data.js
yarn run v1.22.17
$ bash -c 'yarn --silent jest --coverage --collectCoverageFrom=$0 $(node ./utils/test-file-for.js "$0")' packages/wonder-blocks-data/src/components/data.js
 PASS  packages/wonder-blocks-data/src/components/__tests__/data.test.js
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 data.js  |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------
```