### PR TITLE
[fei4327.4.firstclassresult] Result<TData> as first class citizen in external API

### DIFF
--- a/.changeset/chilled-students-poke.md
+++ b/.changeset/chilled-students-poke.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-data": major
 ---
 
-`Result<TData>` is main return type, `useGql` supports context modification, and context overrides set explicitly to null now mean those values are deleted when merging
+`Result<TData>` is now the main return type, `useGql` supports context modification, and context overrides that are set explicitly to null now mean those values are deleted when merging

--- a/.changeset/chilled-students-poke.md
+++ b/.changeset/chilled-students-poke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": major
+---
+
+`Result<TData>` is main return type, `useGql` supports context modification, and context overrides set explicitly to null now mean those values are deleted when merging

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -168,14 +168,16 @@ describe("Data", () => {
                 });
             });
 
-            it("should render with aborted if the request resolves to null data", async () => {
+            it("should render with aborted if the request rejects with an abort error", async () => {
                 // Arrange
                 const fulfillSpy = jest.spyOn(
                     RequestFulfillment.Default,
                     "fulfill",
                 );
 
-                const fakeHandler = () => Promise.resolve(null);
+                const abortError = new Error("bang bang, abort!");
+                abortError.name = "AbortError";
+                const fakeHandler = () => Promise.reject(abortError);
                 const fakeChildrenFn = jest.fn(() => null);
 
                 // Act
@@ -523,39 +525,6 @@ describe("Data", () => {
                         requestId="ID"
                         alwaysRequestOnHydration={true}
                     >
-                        {fakeChildrenFn}
-                    </Data>,
-                );
-                await act(() => fakeHandler.mock.results[0].value);
-
-                // Assert
-                expect(fakeHandler).toHaveBeenCalledTimes(1);
-            });
-        });
-
-        describe("with cached abort", () => {
-            beforeEach(() => {
-                /**
-                 * Each of these test cases will start out with a cached abort.
-                 */
-                jest.spyOn(
-                    SsrCache.Default,
-                    "getEntry",
-                    // Fake once because that's how the cache would work,
-                    // deleting the hydrated value as soon as it was used.
-                ).mockReturnValueOnce({
-                    data: null,
-                });
-            });
-
-            it("should request data if cached data value is null (i.e. represents an aborted request)", async () => {
-                // Arrange
-                const fakeHandler = jest.fn().mockResolvedValue("data");
-                const fakeChildrenFn = jest.fn(() => null);
-
-                // Act
-                render(
-                    <Data handler={fakeHandler} requestId="ID">
                         {fakeChildrenFn}
                     </Data>,
                 );

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -139,7 +139,7 @@ describe("Data", () => {
                 });
             });
 
-            it("should render with data if the request resolves with data", async () => {
+            it("should render with data if the handler resolves with data", async () => {
                 // Arrange
                 const fulfillSpy = jest.spyOn(
                     RequestFulfillment.Default,
@@ -200,7 +200,10 @@ describe("Data", () => {
                 // Arrange
                 const fulfillSpy = jest
                     .spyOn(RequestFulfillment.Default, "fulfill")
-                    .mockReturnValue(Promise.reject(new Error("CATASTROPHE!")));
+                    .mockResolvedValue({
+                        status: "error",
+                        error: new Error("CATASTROPHE!"),
+                    });
 
                 const fakeHandler = () => Promise.resolve("YAY!");
                 const fakeChildrenFn = jest.fn(() => null);
@@ -335,7 +338,10 @@ describe("Data", () => {
 
             it("should ignore catastrophic request fulfillment when id changes", async () => {
                 // Arrange
-                const catastrophe = Promise.reject("CATASTROPHE!");
+                const catastrophe = Promise.resolve({
+                    status: "error",
+                    error: new Error("CATASTROPHE!"),
+                });
                 jest.spyOn(
                     RequestFulfillment.Default,
                     "fulfill",
@@ -363,7 +369,7 @@ describe("Data", () => {
                 // Assert
                 expect(fakeChildrenFn).not.toHaveBeenCalledWith({
                     status: "error",
-                    error: "CATASTROPHE!",
+                    error: expect.any(Error),
                 });
             });
 

--- a/packages/wonder-blocks-data/src/components/intercept-requests.js
+++ b/packages/wonder-blocks-data/src/components/intercept-requests.js
@@ -20,7 +20,7 @@ type Props<TData: ValidCacheData> = {|
      * so make sure to only intercept requests that you recognize from the
      * identifier.
      */
-    interceptor: (requestId: string) => ?Promise<?TData>,
+    interceptor: (requestId: string) => ?Promise<TData>,
 
     /**
      * The children to render within this component. Any requests by `Data`

--- a/packages/wonder-blocks-data/src/components/intercept-requests.md
+++ b/packages/wonder-blocks-data/src/components/intercept-requests.md
@@ -15,7 +15,7 @@ different request IDs..
 The `interceptor` intercept function has the form:
 
 ```js static
-(requestId: string) => ?Promise<?TData>;
+(requestId: string) => ?Promise<TData>;
 ```
 
 If this method returns `null`, then the next interceptor in the chain is

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-gql-router-context.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-gql-router-context.test.js
@@ -1,0 +1,133 @@
+// @flow
+import * as React from "react";
+import {renderHook} from "@testing-library/react-hooks";
+
+import {GqlRouterContext} from "../../util/gql-router-context.js";
+import {useGqlRouterContext} from "../use-gql-router-context.js";
+
+describe("#useGqlRouterContext", () => {
+    it("should throw if there is no GqlRouterContext", () => {
+        // Arrange
+
+        // Act
+        const {
+            result: {error: result},
+        } = renderHook(() => useGqlRouterContext());
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(
+            `[GqlInternalError: No GqlRouter]`,
+        );
+    });
+
+    it("should return an equivalent to the GqlRouterContext if no overrides given", () => {
+        // Arrange
+        const baseContext = {
+            fetch: jest.fn(),
+            defaultContext: {
+                foo: "bar",
+            },
+        };
+        const Wrapper = ({children}: any) => (
+            <GqlRouterContext.Provider value={baseContext}>
+                {children}
+            </GqlRouterContext.Provider>
+        );
+
+        // Act
+        const {
+            result: {current: result},
+        } = renderHook(() => useGqlRouterContext(), {wrapper: Wrapper});
+
+        // Assert
+        expect(result).toStrictEqual(baseContext);
+    });
+
+    it("should return the same object if nothing has changed", () => {
+        // Arrange
+        const baseContext = {
+            fetch: jest.fn(),
+            defaultContext: {
+                foo: "bar",
+            },
+        };
+        const Wrapper = ({children}: any) => (
+            <GqlRouterContext.Provider value={baseContext}>
+                {children}
+            </GqlRouterContext.Provider>
+        );
+
+        // Act
+        const wrapper = renderHook(() => useGqlRouterContext(), {
+            wrapper: Wrapper,
+        });
+        const result1 = wrapper.result.current;
+        wrapper.rerender();
+        const result2 = wrapper.result.current;
+
+        // Assert
+        expect(result1).toBe(result2);
+    });
+
+    it("should return the same object if the object adds overrides that don't change the merged context", () => {
+        // Arrange
+        const baseContext = {
+            fetch: jest.fn(),
+            defaultContext: {
+                foo: "bar",
+            },
+        };
+        const Wrapper = ({children}: any) => (
+            <GqlRouterContext.Provider value={baseContext}>
+                {children}
+            </GqlRouterContext.Provider>
+        );
+
+        // Act
+        const wrapper = renderHook(
+            ({overrides}) => useGqlRouterContext(overrides),
+            {
+                wrapper: Wrapper,
+                initialProps: {},
+            },
+        );
+        const result1 = wrapper.result.current;
+        wrapper.rerender({overrides: {foo: "bar"}});
+        const result2 = wrapper.result.current;
+
+        // Assert
+        expect(result1).toBe(result2);
+    });
+
+    it("should return an updated object if the object adds overrides that change the merged context", () => {
+        // Arrange
+        const baseContext = {
+            fetch: jest.fn(),
+            defaultContext: {
+                foo: "bar",
+            },
+        };
+        const Wrapper = ({children}: any) => (
+            <GqlRouterContext.Provider value={baseContext}>
+                {children}
+            </GqlRouterContext.Provider>
+        );
+
+        // Act
+        const wrapper = renderHook(
+            ({overrides}) => useGqlRouterContext(overrides),
+            {
+                wrapper: Wrapper,
+                initialProps: {
+                    overrides: {fiz: "baz"},
+                },
+            },
+        );
+        const result1 = wrapper.result.current;
+        wrapper.rerender({overrides: {}});
+        const result2 = wrapper.result.current;
+
+        // Assert
+        expect(result1).not.toBe(result2);
+    });
+});

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-gql.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-gql.test.js
@@ -167,35 +167,6 @@ describe("#useGql", () => {
             );
         });
 
-        it("should resolve to null if the fetch was aborted", async () => {
-            // Arrange
-            const abortError = new Error("Aborted");
-            abortError.name = "AbortError";
-            const gqlRouterContext = {
-                fetch: jest.fn().mockRejectedValue(abortError),
-                defaultContext: {},
-            };
-            const {
-                result: {current: gqlFetch},
-            } = renderHook(() => useGql(), {
-                wrapper: ({children}) => (
-                    <GqlRouterContext.Provider value={gqlRouterContext}>
-                        {children}
-                    </GqlRouterContext.Provider>
-                ),
-            });
-            const gqlOp = {
-                type: "query",
-                id: "MyQuery",
-            };
-
-            // Act
-            const result = await gqlFetch(gqlOp);
-
-            // Assert
-            expect(result).toBeNull();
-        });
-
         it("should resolve to the response data", async () => {
             // Arrange
             jest.spyOn(

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.js
@@ -8,6 +8,7 @@ import TrackData from "../../components/track-data.js";
 import {RequestFulfillment} from "../../util/request-fulfillment.js";
 import {SsrCache} from "../../util/ssr-cache.js";
 import {RequestTracker} from "../../util/request-tracking.js";
+import {GqlError} from "../../util/gql-error.js";
 
 import {useServerEffect} from "../use-server-effect.js";
 
@@ -95,7 +96,7 @@ describe("#useServerEffect", () => {
             } = serverRenderHook(() => useServerEffect("ID", fakeHandler));
 
             // Assert
-            expect(result).toEqual({data: "DATA", error: null});
+            expect(result).toEqual({status: "success", data: "DATA"});
         });
 
         it("should return error cached result", () => {
@@ -113,8 +114,8 @@ describe("#useServerEffect", () => {
 
             // Assert
             expect(result).toEqual({
-                data: null,
-                error: "ERROR",
+                status: "error",
+                error: expect.any(GqlError),
             });
         });
     });
@@ -151,7 +152,7 @@ describe("#useServerEffect", () => {
             } = clientRenderHook(() => useServerEffect("ID", fakeHandler));
 
             // Assert
-            expect(result).toEqual({data: "DATA", error: null});
+            expect(result).toEqual({status: "success", data: "DATA"});
         });
 
         it("should return error cached result", () => {
@@ -169,8 +170,8 @@ describe("#useServerEffect", () => {
 
             // Assert
             expect(result).toEqual({
-                data: null,
-                error: "ERROR",
+                status: "error",
+                error: expect.any(GqlError),
             });
         });
 

--- a/packages/wonder-blocks-data/src/hooks/use-gql-router-context.js
+++ b/packages/wonder-blocks-data/src/hooks/use-gql-router-context.js
@@ -1,0 +1,48 @@
+// @flow
+import {useContext, useRef, useMemo} from "react";
+
+import {mergeGqlContext} from "../util/merge-gql-context.js";
+import {GqlRouterContext} from "../util/gql-router-context.js";
+import {GqlError, GqlErrors} from "../util/gql-error.js";
+
+import type {GqlRouterConfiguration, GqlContext} from "../util/gql-types.js";
+
+/**
+ * Construct a GqlRouterContext from the current one and partial context.
+ */
+export const useGqlRouterContext = <TContext: GqlContext>(
+    contextOverrides: Partial<TContext> = ({}: $Shape<TContext>),
+): GqlRouterConfiguration<TContext> => {
+    // This hook only works if the `GqlRouter` has been used to setup context.
+    const gqlRouterContext = useContext(GqlRouterContext);
+    if (gqlRouterContext == null) {
+        throw new GqlError("No GqlRouter", GqlErrors.Internal);
+    }
+
+    const {fetch, defaultContext} = gqlRouterContext;
+    const contextRef = useRef<TContext>(defaultContext);
+    const mergedContext = mergeGqlContext(defaultContext, contextOverrides);
+
+    // Now, we can see if this represents a new context and if so,
+    // update our ref and return the merged value.
+    const refKeys = Object.keys(contextRef.current);
+    const mergedKeys = Object.keys(mergedContext);
+    const shouldWeUpdateRef =
+        refKeys.length !== mergedKeys.length ||
+        mergedKeys.every(
+            (key) => contextRef.current[key] === mergedContext[key],
+        );
+    if (shouldWeUpdateRef) {
+        contextRef.current = mergedContext;
+    }
+
+    const finalRouterContext = useMemo(
+        () => ({
+            fetch,
+            defaultContext: contextRef.current,
+        }),
+        [fetch],
+    );
+
+    return finalRouterContext;
+};

--- a/packages/wonder-blocks-data/src/hooks/use-gql-router-context.js
+++ b/packages/wonder-blocks-data/src/hooks/use-gql-router-context.js
@@ -30,18 +30,20 @@ export const useGqlRouterContext = <TContext: GqlContext>(
     const shouldWeUpdateRef =
         refKeys.length !== mergedKeys.length ||
         mergedKeys.every(
-            (key) => contextRef.current[key] === mergedContext[key],
+            (key) => contextRef.current[key] !== mergedContext[key],
         );
     if (shouldWeUpdateRef) {
         contextRef.current = mergedContext;
     }
 
+    // OK, now we're up-to-date, let's memoize our final result.
+    const finalContext = contextRef.current;
     const finalRouterContext = useMemo(
         () => ({
             fetch,
-            defaultContext: contextRef.current,
+            defaultContext: finalContext,
         }),
-        [fetch],
+        [fetch, finalContext],
     );
 
     return finalRouterContext;

--- a/packages/wonder-blocks-data/src/hooks/use-gql.js
+++ b/packages/wonder-blocks-data/src/hooks/use-gql.js
@@ -27,7 +27,7 @@ export const useGql = <TContext: GqlContext>(
 ): (<TData, TVariables: {...}>(
     operation: GqlOperation<TData, TVariables>,
     options?: GqlFetchOptions<TVariables, TContext>,
-) => Promise<?TData>) => {
+) => Promise<TData>) => {
     // This hook only works if the `GqlRouter` has been used to setup context.
     const gqlRouterContext = useGqlRouterContext(context);
     if (gqlRouterContext == null) {
@@ -51,18 +51,6 @@ export const useGql = <TContext: GqlContext>(
             // Invoke the fetch and extract the data.
             return fetch(operation, variables, finalContext).then(
                 getGqlDataFromResponse,
-                (error) => {
-                    // Return null if the request was aborted.
-                    // The only way to detect this reliably, it seems, is to
-                    // check the error name and see if it's "AbortError" (this
-                    // is also what Apollo does).
-                    // Even then, it's reliant on the fetch supporting aborts.
-                    if (error.name === "AbortError") {
-                        return null;
-                    }
-                    // Need to make sure we pass other errors along.
-                    throw error;
-                },
             );
         },
         [gqlRouterContext],

--- a/packages/wonder-blocks-data/src/hooks/use-gql.js
+++ b/packages/wonder-blocks-data/src/hooks/use-gql.js
@@ -4,7 +4,6 @@ import {useCallback} from "react";
 import {mergeGqlContext} from "../util/merge-gql-context.js";
 import {useGqlRouterContext} from "./use-gql-router-context.js";
 import {getGqlDataFromResponse} from "../util/get-gql-data-from-response.js";
-import {GqlError, GqlErrors} from "../util/gql-error.js";
 
 import type {
     GqlContext,
@@ -30,9 +29,6 @@ export const useGql = <TContext: GqlContext>(
 ) => Promise<TData>) => {
     // This hook only works if the `GqlRouter` has been used to setup context.
     const gqlRouterContext = useGqlRouterContext(context);
-    if (gqlRouterContext == null) {
-        throw new GqlError("No GqlRouter", GqlErrors.Internal);
-    }
 
     // Let's memoize the gqlFetch function we create based off our context.
     // That way, even if the context happens to change, if its values don't

--- a/packages/wonder-blocks-data/src/hooks/use-request-interception.js
+++ b/packages/wonder-blocks-data/src/hooks/use-request-interception.js
@@ -18,8 +18,8 @@ import type {ValidCacheData} from "../util/types.js";
  */
 export const useRequestInterception = <TData: ValidCacheData>(
     requestId: string,
-    handler: () => Promise<?TData>,
-): (() => Promise<?TData>) => {
+    handler: () => Promise<TData>,
+): (() => Promise<TData>) => {
     // Get the interceptors that have been registered.
     const interceptors = React.useContext(InterceptContext);
 
@@ -28,7 +28,7 @@ export const useRequestInterception = <TData: ValidCacheData>(
     // if nothing intercepted it.
     // We memoize this so that it only changes if something related to it
     // changes.
-    const interceptedHandler = React.useCallback((): Promise<?TData> => {
+    const interceptedHandler = React.useCallback((): Promise<TData> => {
         // Call the interceptors from closest to furthest.
         // If one returns a non-null result, then we keep that.
         const interceptResponse = interceptors.reduceRight(

--- a/packages/wonder-blocks-data/src/hooks/use-server-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-server-effect.js
@@ -3,8 +3,9 @@ import {Server} from "@khanacademy/wonder-blocks-core";
 import {useContext} from "react";
 import {TrackerContext} from "../util/request-tracking.js";
 import {SsrCache} from "../util/ssr-cache.js";
+import {resultFromCachedResponse} from "../util/result-from-cache-response.js";
 
-import type {CachedResponse, ValidCacheData} from "../util/types.js";
+import type {Result, ValidCacheData} from "../util/types.js";
 
 /**
  * Hook to perform an asynchronous action during server-side rendering.
@@ -23,9 +24,9 @@ import type {CachedResponse, ValidCacheData} from "../util/types.js";
  */
 export const useServerEffect = <TData: ValidCacheData>(
     requestId: string,
-    handler: () => Promise<?TData>,
+    handler: () => Promise<TData>,
     hydrate: boolean = true,
-): ?CachedResponse<TData> => {
+): ?Result<TData> => {
     // If we're server-side or hydrating, we'll have a cached entry to use.
     // So we get that and use it to initialize our state.
     // This works in both hydration and SSR because the very first call to
@@ -41,5 +42,6 @@ export const useServerEffect = <TData: ValidCacheData>(
         maybeTrack?.(requestId, handler, hydrate);
     }
 
-    return cachedResult;
+    // A null result means there was no result to hydrate.
+    return cachedResult == null ? null : resultFromCachedResponse(cachedResult);
 };

--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -52,7 +52,6 @@ export {useServerEffect} from "./hooks/use-server-effect.js";
 export {useRequestInterception} from "./hooks/use-request-interception.js";
 export {useSharedCache, clearSharedCache} from "./hooks/use-shared-cache.js";
 export {ScopedInMemoryCache} from "./util/scoped-in-memory-cache.js";
-export {resultFromCachedResponse} from "./util/result-from-cache-response.js";
 export {RequestFulfillment} from "./util/request-fulfillment.js";
 
 // GraphQL

--- a/packages/wonder-blocks-data/src/util/__tests__/merge-gql-context.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/merge-gql-context.test.js
@@ -1,0 +1,74 @@
+// @flow
+import {mergeGqlContext} from "../merge-gql-context.js";
+
+describe("#mergeGqlContext", () => {
+    it("should combine the default context with the given overrides", () => {
+        // Arrange
+        const baseContext = {
+            foo: "bar",
+        };
+
+        // Act
+        const result = mergeGqlContext<any>(baseContext, {
+            fiz: "baz",
+        });
+
+        // Assert
+        expect(result).toStrictEqual({
+            foo: "bar",
+            fiz: "baz",
+        });
+    });
+
+    it("should overwrite values in the default context with the given overrides", () => {
+        // Arrange
+        const baseContext = {
+            foo: "bar",
+        };
+
+        // Act
+        const result = mergeGqlContext<any>(baseContext, {
+            foo: "boo",
+        });
+
+        // Assert
+        expect(result).toStrictEqual({
+            foo: "boo",
+        });
+    });
+
+    it("should not overwrite values in the default context with undefined values in the given overrides", () => {
+        // Arrange
+        const baseContext = {
+            foo: "bar",
+        };
+
+        // Act
+        const result = mergeGqlContext<any>(baseContext, {
+            foo: undefined,
+        });
+
+        // Assert
+        expect(result).toStrictEqual({
+            foo: "bar",
+        });
+    });
+
+    it("should delete values in the default context when the value is null in the given overrides", () => {
+        // Arrange
+        const baseContext = {
+            foo: "bar",
+            fiz: "baz",
+        };
+
+        // Act
+        const result = mergeGqlContext<any>(baseContext, {
+            fiz: null,
+        });
+
+        // Assert
+        expect(result).toStrictEqual({
+            foo: "bar",
+        });
+    });
+});

--- a/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
@@ -78,7 +78,7 @@ describe("../request-tracking.js", () => {
             it("should track each matching request once", async () => {
                 // Arrange
                 const requestTracker = createRequestTracker();
-                const fakeHandler = jest.fn().mockResolvedValue(null);
+                const fakeHandler = jest.fn().mockResolvedValue("DATA");
 
                 // Act
                 requestTracker.trackDataRequest("ID", fakeHandler, true);
@@ -285,7 +285,7 @@ describe("../request-tracking.js", () => {
             it("should clear the tracked data requests", async () => {
                 // Arrange
                 const requestTracker = createRequestTracker();
-                const fakeHandler = jest.fn().mockResolvedValue(null);
+                const fakeHandler = jest.fn().mockResolvedValue("DATA");
                 requestTracker.trackDataRequest("ID", fakeHandler, true);
 
                 // Act

--- a/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
@@ -244,14 +244,33 @@ describe("../request-tracking.js", () => {
                 });
             });
 
-            it("should cope gracefully with null fulfillments", async () => {
+            it("should ignore loading results", async () => {
                 // Arrange
                 const requestTracker = createRequestTracker();
                 jest.spyOn(
                     requestTracker._requestFulfillment,
                     "fulfill",
-                ).mockReturnValue(null);
-                const fakeValidHandler = () => Promise.resolve("DATA");
+                ).mockResolvedValue({status: "loading"});
+                const fakeValidHandler = () =>
+                    Promise.reject(new Error("Not called for this test case"));
+                requestTracker.trackDataRequest("ID", fakeValidHandler, true);
+
+                // Act
+                const result = await requestTracker.fulfillTrackedRequests();
+
+                // Assert
+                expect(result).toStrictEqual({});
+            });
+
+            it("should ignore aborted results", async () => {
+                // Arrange
+                const requestTracker = createRequestTracker();
+                jest.spyOn(
+                    requestTracker._requestFulfillment,
+                    "fulfill",
+                ).mockResolvedValue({status: "aborted"});
+                const fakeValidHandler = () =>
+                    Promise.reject(new Error("Not called for this test case"));
                 requestTracker.trackDataRequest("ID", fakeValidHandler, false);
 
                 // Act

--- a/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.js
@@ -2,7 +2,7 @@
 import {resultFromCachedResponse} from "../result-from-cache-response.js";
 
 describe("#resultFromCachedResponse", () => {
-    it("should return loading status if cache entry is null", () => {
+    it("should return null cache entry is null", () => {
         // Arrange
         const cacheEntry = null;
 
@@ -10,9 +10,7 @@ describe("#resultFromCachedResponse", () => {
         const result = resultFromCachedResponse(cacheEntry);
 
         // Assert
-        expect(result).toStrictEqual({
-            status: "loading",
-        });
+        expect(result).toBeNull();
     });
 
     it("should return success status if cache entry has data", () => {
@@ -73,6 +71,7 @@ describe("#resultFromCachedResponse", () => {
         };
 
         // Act
+        // $FlowIgnore[incompatible-use]
         // $FlowIgnore[prop-missing]
         const {error} = resultFromCachedResponse(cacheEntry);
 

--- a/packages/wonder-blocks-data/src/util/merge-gql-context.js
+++ b/packages/wonder-blocks-data/src/util/merge-gql-context.js
@@ -1,0 +1,24 @@
+// @flow
+import type {GqlContext} from "./gql-types.js";
+
+/**
+ * Construct a complete GqlContext from current defaults and a partial context.
+ */
+export const mergeGqlContext = <TContext: GqlContext>(
+    defaultContext: TContext,
+    overrides: Partial<TContext>,
+): TContext => {
+    // Let's merge the partial context default context. We deliberately
+    // don't spread because spreading would overwrite default context
+    // values with undefined if the partial context includes a value
+    // explicitly set to undefined
+    return Object.keys(overrides).reduce(
+        (acc, key) => {
+            if (overrides[key] !== undefined) {
+                acc[key] = overrides[key];
+            }
+            return acc;
+        },
+        {...defaultContext},
+    );
+};

--- a/packages/wonder-blocks-data/src/util/merge-gql-context.js
+++ b/packages/wonder-blocks-data/src/util/merge-gql-context.js
@@ -3,6 +3,9 @@ import type {GqlContext} from "./gql-types.js";
 
 /**
  * Construct a complete GqlContext from current defaults and a partial context.
+ *
+ * Values in the partial context that are `undefined` will be ignored.
+ * Values in the partial context that are `null` will be deleted.
  */
 export const mergeGqlContext = <TContext: GqlContext>(
     defaultContext: TContext,
@@ -10,12 +13,19 @@ export const mergeGqlContext = <TContext: GqlContext>(
 ): TContext => {
     // Let's merge the partial context default context. We deliberately
     // don't spread because spreading would overwrite default context
-    // values with undefined if the partial context includes a value
-    // explicitly set to undefined
+    // values with undefined or null if the partial context includes a value
+    // explicitly set to undefined or null.
     return Object.keys(overrides).reduce(
         (acc, key) => {
+            // Undefined values are ignored.
             if (overrides[key] !== undefined) {
-                acc[key] = overrides[key];
+                if (overrides[key] === null) {
+                    // Null indicates we delete this context value.
+                    delete acc[key];
+                } else {
+                    // Otherwise, we set it.
+                    acc[key] = overrides[key];
+                }
             }
             return acc;
         },

--- a/packages/wonder-blocks-data/src/util/request-fulfillment.js
+++ b/packages/wonder-blocks-data/src/util/request-fulfillment.js
@@ -1,10 +1,10 @@
 // @flow
-import type {ValidCacheData} from "./types.js";
+import type {Result, ValidCacheData} from "./types.js";
 
 import {GqlError, GqlErrors} from "./gql-error.js";
 
 type RequestCache = {
-    [id: string]: Promise<any>,
+    [id: string]: Promise<Result<any>>,
     ...
 };
 
@@ -32,19 +32,19 @@ export class RequestFulfillment {
     fulfill: <TData: ValidCacheData>(
         id: string,
         options: {|
-            handler: () => Promise<?TData>,
+            handler: () => Promise<TData>,
             hydrate?: boolean,
         |},
-    ) => Promise<?TData> = <TData: ValidCacheData>(
+    ) => Promise<Result<TData>> = <TData: ValidCacheData>(
         id: string,
         {
             handler,
             hydrate = true,
         }: {|
-            handler: () => Promise<?TData>,
+            handler: () => Promise<TData>,
             hydrate?: boolean,
         |},
-    ): Promise<?TData> => {
+    ): Promise<Result<TData>> => {
         /**
          * If we have an inflight request, we'll provide that.
          */
@@ -57,20 +57,51 @@ export class RequestFulfillment {
          * We don't have an inflight request, so let's set one up.
          */
         const request = handler()
-            .catch((error: string | Error) => {
-                if (error instanceof Error) {
-                    throw error;
+            .then((data: ?TData): Result<TData> => {
+                if (data == null) {
+                    return {
+                        status: "aborted",
+                    };
                 }
-                throw new GqlError("Request failed", GqlErrors.Unknown, {
-                    metadata: {
-                        unexpectedError: error,
-                    },
-                });
+                return {
+                    status: "success",
+                    data,
+                };
+            })
+            .catch((error: string | Error): Result<TData> => {
+                const actualError =
+                    typeof error === "string"
+                        ? new GqlError("Request failed", GqlErrors.Unknown, {
+                              metadata: {
+                                  unexpectedError: error,
+                              },
+                          })
+                        : error;
+
+                // Return aborted result if the request was aborted.
+                // The only way to detect this reliably, it seems, is to
+                // check the error name and see if it's "AbortError" (this
+                // is also what Apollo does).
+                // Even then, it's reliant on the handler supporting aborts.
+                // TODO(somewhatabstract, FEI-4276): Add first class abort
+                // support to the handler API.
+                if (actualError.name === "AbortError") {
+                    return {
+                        status: "aborted",
+                    };
+                }
+                return {
+                    status: "error",
+                    error: actualError,
+                };
             })
             .finally(() => {
                 delete this._requests[id];
             });
+
+        // Store the request in our cache.
         this._requests[id] = request;
+
         return request;
     };
 }

--- a/packages/wonder-blocks-data/src/util/request-fulfillment.js
+++ b/packages/wonder-blocks-data/src/util/request-fulfillment.js
@@ -57,17 +57,10 @@ export class RequestFulfillment {
          * We don't have an inflight request, so let's set one up.
          */
         const request = handler()
-            .then((data: ?TData): Result<TData> => {
-                if (data == null) {
-                    return {
-                        status: "aborted",
-                    };
-                }
-                return {
-                    status: "success",
-                    data,
-                };
-            })
+            .then((data: TData): Result<TData> => ({
+                status: "success",
+                data,
+            }))
             .catch((error: string | Error): Result<TData> => {
                 const actualError =
                     typeof error === "string"

--- a/packages/wonder-blocks-data/src/util/result-from-cache-response.js
+++ b/packages/wonder-blocks-data/src/util/result-from-cache-response.js
@@ -7,18 +7,19 @@ import type {ValidCacheData, CachedResponse, Result} from "./types.js";
  */
 export const resultFromCachedResponse = <TData: ValidCacheData>(
     cacheEntry: ?CachedResponse<TData>,
-): Result<TData> => {
-    // No cache entry means we didn't load one yet.
+): ?Result<TData> => {
+    // No cache entry means no result to be hydrated.
     if (cacheEntry == null) {
-        return {
-            status: "loading",
-        };
+        return null;
     }
 
     const {data, error} = cacheEntry;
     if (error != null) {
         return {
             status: "error",
+            // Let's hydrate the error. We don't persist everything about the
+            // original error on the server, hence why we only superficially
+            // hydrate it to a GqlHydratedError.
             error: new GqlError(error, GqlErrors.Hydrated),
         };
     }
@@ -30,6 +31,7 @@ export const resultFromCachedResponse = <TData: ValidCacheData>(
         };
     }
 
+    // We shouldn't get here since we don't actually cache null data.
     return {
         status: "aborted",
     };

--- a/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
@@ -50,7 +50,7 @@ describe("#mockGqlFetch", () => {
                 id: "getMyStuff",
             };
             const data = {myStuff: "stuff"};
-            const RenderError = () => {
+            const RenderData = () => {
                 const [result, setResult] = React.useState(null);
                 const gqlFetch = useGql();
                 React.useEffect(() => {
@@ -68,7 +68,7 @@ describe("#mockGqlFetch", () => {
             mockFetch.mockOperation({operation: query}, RespondWith.data(data));
             render(
                 <GqlRouter defaultContext={{}} fetch={mockFetch}>
-                    <RenderError />
+                    <RenderData />
                 </GqlRouter>,
             );
             const result = screen.getByTestId("result");
@@ -79,7 +79,7 @@ describe("#mockGqlFetch", () => {
             );
         });
 
-        it("should provide null data if aborted response", async () => {
+        it("should reject when request aborted", async () => {
             // Arrange
             const mockFetch = mockGqlFetch();
             const query = {
@@ -91,8 +91,8 @@ describe("#mockGqlFetch", () => {
                 const gqlFetch = useGql();
                 React.useEffect(() => {
                     // eslint-disable-next-line promise/catch-or-return
-                    gqlFetch(query).then((r) => {
-                        setResult(JSON.stringify(r ?? "(null)"));
+                    gqlFetch(query).catch((e) => {
+                        setResult(e.message);
                         return;
                     });
                 }, [gqlFetch]);
@@ -113,7 +113,7 @@ describe("#mockGqlFetch", () => {
             const result = screen.getByTestId("result");
 
             // Assert
-            await waitFor(() => expect(result).toHaveTextContent('"(null)"'));
+            await waitFor(() => expect(result).toHaveTextContent("aborted"));
         });
 
         it("should reject when request gives failed error code", async () => {

--- a/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
@@ -49,7 +49,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
             id: "getMyStuff",
         };
         const data = {myStuff: "stuff"};
-        const RenderError = () => {
+        const RenderData = () => {
             const [result, setResult] = React.useState(null);
             const gqlFetch = useGql();
             React.useEffect(() => {
@@ -67,7 +67,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
         mockFetch.mockOperation({operation: query}, RespondWith.data(data));
         render(
             <GqlRouter defaultContext={{}} fetch={mockFetch}>
-                <RenderError />
+                <RenderData />
             </GqlRouter>,
         );
         const result = screen.getByTestId("result");
@@ -78,7 +78,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
         );
     });
 
-    it("should respond with null data for RespondWith.abortedRequest", async () => {
+    it("should reject with AbortError for RespondWith.abortedRequest", async () => {
         // Arrange
         const mockFetch = mockGqlFetch();
         const query = {
@@ -90,8 +90,8 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
             const gqlFetch = useGql();
             React.useEffect(() => {
                 // eslint-disable-next-line promise/catch-or-return
-                gqlFetch(query).then((r) => {
-                    setResult(JSON.stringify(r ?? "(null)"));
+                gqlFetch(query).catch((e) => {
+                    setResult(e.message);
                     return;
                 });
             }, [gqlFetch]);
@@ -112,7 +112,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
         const result = screen.getByTestId("result");
 
         // Assert
-        await waitFor(() => expect(result).toHaveTextContent('"(null)"'));
+        await waitFor(() => expect(result).toHaveTextContent("aborted"));
     });
 
     it("should reject with unsuccessful response error for RespondWith.errorStatusCode", async () => {


### PR DESCRIPTION
## Summary:
In this PR:

1. `useGql` delegates some responsibility to `useGqlRouterContext` and the new `mergeGqlContext` function
2. `useGql` can now take context adjustments directly so that the returned fetch can have them applied to all calls
3. `Result<TData` is now the default return of our data architecture, which partly paves the way for a universal "opinion" on how aborts will be done (that is currently unprioritized work), but also simplifies integration to webapp

Issue: FEI-4327

## Test plan:
`yarn test`
`yarn flow`