### PR TITLE
[fei4327.6.useCachedEffect] Implement useCachedEffect

### DIFF
--- a/.changeset/curly-parents-allow.md
+++ b/.changeset/curly-parents-allow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": major
+---
+
+[NEW] `useCachedEffect` hook for performing asynchronous work client-side and caching the result. Updated `useHydratableEffect` to use `useCachedEffect`. `useServerEffect` handler is now interceptable with Wonder Blocks Data `InterceptData` component.

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
@@ -1,0 +1,507 @@
+// @flow
+import {
+    renderHook as clientRenderHook,
+    act,
+} from "@testing-library/react-hooks";
+import {renderHook as serverRenderHook} from "@testing-library/react-hooks/server";
+
+import {Server} from "@khanacademy/wonder-blocks-core";
+import {Status} from "../../util/status.js";
+
+import {RequestFulfillment} from "../../util/request-fulfillment.js";
+import * as UseRequestInterception from "../use-request-interception.js";
+import * as UseSharedCache from "../use-shared-cache.js";
+
+import {useCachedEffect} from "../use-cached-effect.js";
+
+jest.mock("../use-request-interception.js");
+jest.mock("../use-shared-cache.js");
+
+describe("#useCachedEffect", () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        // When we have request aborting and things, this can be nicer, but
+        // for now, let's just clear out inflight requests between tests
+        // by being cheeky.
+        RequestFulfillment.Default._requests = {};
+
+        // Simple implementation of request interception that just returns
+        // the handler.
+        jest.spyOn(
+            UseRequestInterception,
+            "useRequestInterception",
+        ).mockImplementation((_, handler) => handler);
+
+        // We need the cache to work a little so that we get our result.
+        const cache = {};
+        jest.spyOn(UseSharedCache, "useSharedCache").mockImplementation(
+            (id, _, defaultValue) => {
+                const setCache = (v) => (cache[id] = v);
+                return [cache[id] ?? defaultValue, setCache];
+            },
+        );
+    });
+
+    describe("when server-side", () => {
+        beforeEach(() => {
+            jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+        });
+
+        it("should call useRequestInterception", () => {
+            // Arrange
+            const useRequestInterceptSpy = jest
+                .spyOn(UseRequestInterception, "useRequestInterception")
+                .mockReturnValue(jest.fn());
+            const fakeHandler = jest.fn();
+
+            // Act
+            serverRenderHook(() => useCachedEffect("ID", fakeHandler));
+
+            // Assert
+            expect(useRequestInterceptSpy).toHaveBeenCalledWith(
+                "ID",
+                fakeHandler,
+            );
+        });
+
+        it.each`
+            scope        | expectedScope
+            ${undefined} | ${"useCachedEffect"}
+            ${"foo"}     | ${"foo"}
+        `(
+            "should call useSharedCache with id, scope=$scope, without a default",
+            ({scope, cachedResult, expectedScope}) => {
+                const fakeHandler = jest.fn();
+                const useSharedCacheSpy = jest.spyOn(
+                    UseSharedCache,
+                    "useSharedCache",
+                );
+
+                // Act
+                serverRenderHook(() =>
+                    useCachedEffect("ID", fakeHandler, {scope}),
+                );
+
+                // Assert
+                expect(useSharedCacheSpy).toHaveBeenCalledWith(
+                    "ID",
+                    expectedScope,
+                );
+            },
+        );
+
+        it("should not request data", () => {
+            // Arrange
+            const fakeHandler = jest.fn().mockResolvedValue("data");
+
+            // Act
+            serverRenderHook(() => useCachedEffect("ID", fakeHandler));
+
+            // Assert
+            expect(fakeHandler).not.toHaveBeenCalled();
+        });
+
+        describe("without cached result", () => {
+            it("should return a loading result", () => {
+                // Arrange
+                const fakeHandler = jest.fn();
+
+                // Act
+                const {
+                    result: {current: result},
+                } = serverRenderHook(() => useCachedEffect("ID", fakeHandler));
+
+                // Assert
+                expect(result).toStrictEqual(Status.loading());
+            });
+        });
+
+        describe("with cached result", () => {
+            it("should return the result", () => {
+                // Arrange
+                const fakeHandler = jest.fn();
+                const cachedResult = Status.success("data");
+                jest.spyOn(UseSharedCache, "useSharedCache").mockReturnValue([
+                    cachedResult,
+                    jest.fn(),
+                ]);
+
+                // Act
+                const {
+                    result: {current: result},
+                } = serverRenderHook(() => useCachedEffect("ID", fakeHandler));
+
+                // Assert
+                expect(result).toEqual(cachedResult);
+            });
+        });
+    });
+
+    describe("when client-side", () => {
+        beforeEach(() => {
+            jest.spyOn(Server, "isServerSide").mockReturnValue(false);
+        });
+
+        it("should call useRequestInterception", () => {
+            // Arrange
+            const useRequestInterceptSpy = jest
+                .spyOn(UseRequestInterception, "useRequestInterception")
+                .mockReturnValue(jest.fn());
+            const fakeHandler = jest.fn();
+
+            // Act
+            clientRenderHook(() => useCachedEffect("ID", fakeHandler));
+
+            // Assert
+            expect(useRequestInterceptSpy).toHaveBeenCalledWith(
+                "ID",
+                fakeHandler,
+            );
+        });
+
+        it("should fulfill request when there is no cached value", () => {
+            // Arrange
+            const fakeHandler = jest.fn();
+            jest.spyOn(UseSharedCache, "useSharedCache").mockReturnValue([
+                null,
+                jest.fn(),
+            ]);
+
+            // Act
+            clientRenderHook(() => useCachedEffect("ID", fakeHandler));
+
+            // Assert
+            expect(fakeHandler).toHaveBeenCalled();
+        });
+
+        it("should share inflight requests for the same requestId", () => {
+            // Arrange
+            const pending = new Promise((resolve, reject) => {
+                /*pending*/
+            });
+            const fakeHandler = jest.fn().mockReturnValue(pending);
+
+            // Act
+            clientRenderHook(() => useCachedEffect("ID", fakeHandler));
+            clientRenderHook(() => useCachedEffect("ID", fakeHandler));
+
+            // Assert
+            expect(fakeHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it.each`
+            cachedResult
+            ${Status.error(new Error("some error"))}
+            ${Status.success("data")}
+            ${Status.aborted()}
+        `(
+            "should not fulfill request when there is a cached response of $cachedResult",
+            ({cachedResult}) => {
+                const fakeHandler = jest.fn();
+                jest.spyOn(UseSharedCache, "useSharedCache").mockReturnValue([
+                    cachedResult,
+                    jest.fn(),
+                ]);
+
+                // Act
+                clientRenderHook(() => useCachedEffect("ID", fakeHandler));
+
+                // Assert
+                expect(fakeHandler).not.toHaveBeenCalled();
+            },
+        );
+
+        it("should fulfill request once only if requestId does not change", async () => {
+            // Arrange
+            const fakeHandler = jest.fn().mockResolvedValue("data");
+
+            // Act
+            const {rerender, waitForNextUpdate} = clientRenderHook(() =>
+                useCachedEffect("ID", fakeHandler),
+            );
+            rerender();
+            await waitForNextUpdate();
+
+            // Assert
+            expect(fakeHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it("should fulfill request again if requestId changes", async () => {
+            // Arrange
+            const fakeHandler = jest.fn().mockResolvedValue("data");
+
+            // Act
+            const {rerender, waitForNextUpdate} = clientRenderHook(
+                ({requestId}) => useCachedEffect(requestId, fakeHandler),
+                {
+                    initialProps: {requestId: "ID"},
+                },
+            );
+            rerender({requestId: "ID2"});
+            await waitForNextUpdate();
+
+            // Assert
+            expect(fakeHandler).toHaveBeenCalledTimes(2);
+        });
+
+        it("should update shared cache with result when request is fulfilled", async () => {
+            // Arrange
+            const setCacheFn = jest.fn();
+            jest.spyOn(UseSharedCache, "useSharedCache").mockReturnValue([
+                null,
+                setCacheFn,
+            ]);
+            const fakeHandler = jest.fn().mockResolvedValue("DATA");
+
+            // Act
+            const {waitForNextUpdate} = clientRenderHook(() =>
+                useCachedEffect("ID", fakeHandler),
+            );
+            await waitForNextUpdate();
+
+            // Assert
+            expect(setCacheFn).toHaveBeenCalledWith(Status.success("DATA"));
+        });
+
+        it("should ignore inflight request if requestId changes", async () => {
+            // Arrange
+            const response1 = Promise.resolve("DATA1");
+            const response2 = Promise.resolve("DATA2");
+            const fakeHandler = jest
+                .fn()
+                .mockReturnValueOnce(response1)
+                .mockReturnValueOnce(response2);
+
+            // Act
+            const {rerender, result} = clientRenderHook(
+                ({requestId}) => useCachedEffect(requestId, fakeHandler),
+                {
+                    initialProps: {requestId: "ID"},
+                },
+            );
+            rerender({requestId: "ID2"});
+            await act((): Promise<mixed> =>
+                Promise.all([response1, response2]),
+            );
+
+            // Assert
+            expect(result.all).not.toContainEqual(Status.success("DATA1"));
+        });
+
+        it("should return result of fulfilled request for current requestId", async () => {
+            // Arrange
+            const response1 = Promise.resolve("DATA1");
+            const response2 = Promise.resolve("DATA2");
+            const fakeHandler = jest
+                .fn()
+                .mockReturnValueOnce(response1)
+                .mockReturnValueOnce(response2);
+
+            // Act
+            const {rerender, result} = clientRenderHook(
+                ({requestId}) => useCachedEffect(requestId, fakeHandler),
+                {
+                    initialProps: {requestId: "ID"},
+                },
+            );
+            rerender({requestId: "ID2"});
+            await act((): Promise<mixed> =>
+                Promise.all([response1, response2]),
+            );
+
+            // Assert
+            expect(result.current).toStrictEqual(Status.success("DATA2"));
+        });
+
+        it("should not fulfill request when skip is true", () => {
+            // Arrange
+            const fakeHandler = jest.fn();
+
+            // Act
+            clientRenderHook(() =>
+                useCachedEffect("ID", fakeHandler, {skip: true}),
+            );
+
+            // Assert
+            expect(fakeHandler).not.toHaveBeenCalled();
+        });
+
+        it("should ignore inflight request if skip changes", async () => {
+            // Arrange
+            const response1 = Promise.resolve("DATA1");
+            const fakeHandler = jest.fn().mockReturnValueOnce(response1);
+
+            // Act
+            const {rerender, result} = clientRenderHook(
+                ({skip}) => useCachedEffect("ID", fakeHandler, {skip}),
+                {
+                    initialProps: {skip: false},
+                },
+            );
+            rerender({skip: true});
+            await act((): Promise<mixed> => response1);
+
+            // Assert
+            expect(result.all).not.toContainEqual(Status.success("DATA1"));
+        });
+
+        it("should not ignore inflight request if handler changes", async () => {
+            // Arrange
+            const response1 = Promise.resolve("DATA1");
+            const response2 = Promise.resolve("DATA2");
+            const fakeHandler1 = jest.fn().mockReturnValueOnce(response1);
+            const fakeHandler2 = jest.fn().mockReturnValueOnce(response2);
+
+            // Act
+            const {rerender, result} = clientRenderHook(
+                ({handler}) => useCachedEffect("ID", handler),
+                {
+                    initialProps: {handler: fakeHandler1},
+                },
+            );
+            rerender({handler: fakeHandler2});
+            await act((): Promise<mixed> =>
+                Promise.all([response1, response2]),
+            );
+
+            // Assert
+            expect(result.current).toStrictEqual(Status.success("DATA1"));
+        });
+
+        it("should not ignore inflight request if options (other than skip) change", async () => {
+            // Arrange
+            const response1 = Promise.resolve("DATA1");
+            const fakeHandler = jest.fn().mockReturnValueOnce(response1);
+
+            // Act
+            const {rerender, result} = clientRenderHook(
+                ({options}) => useCachedEffect("ID", fakeHandler),
+                {
+                    initialProps: {options: undefined},
+                },
+            );
+            rerender({
+                options: {
+                    scope: "BLAH!",
+                },
+            });
+            await act((): Promise<mixed> => response1);
+
+            // Assert
+            expect(result.current).toStrictEqual(Status.success("DATA1"));
+        });
+
+        it("should return previous result when requestId changes and retainResultOnChange is true", async () => {
+            // Arrange
+            const response1 = Promise.resolve("DATA1");
+            const response2 = Promise.resolve("DATA2");
+            const fakeHandler = jest
+                .fn()
+                .mockReturnValueOnce(response1)
+                .mockReturnValueOnce(response2);
+
+            // Act
+            const {
+                rerender,
+                result: hookResult,
+                waitForNextUpdate,
+            } = clientRenderHook(
+                ({requestId}) =>
+                    useCachedEffect(requestId, fakeHandler, {
+                        retainResultOnChange: true,
+                    }),
+                {
+                    initialProps: {requestId: "ID"},
+                },
+            );
+            await act((): Promise<mixed> => response1);
+            rerender({requestId: "ID2"});
+            const result = hookResult.current;
+            await waitForNextUpdate();
+
+            // Assert
+            expect(result).toStrictEqual(Status.success("DATA1"));
+        });
+
+        it("should return loading status when requestId changes and retainResultOnChange is false", async () => {
+            // Arrange
+            const response1 = Promise.resolve("DATA1");
+            const response2 = new Promise(() => {
+                /*pending*/
+            });
+            const fakeHandler = jest
+                .fn()
+                .mockReturnValueOnce(response1)
+                .mockReturnValueOnce(response2);
+
+            // Act
+            const {rerender, result} = clientRenderHook(
+                ({requestId}) =>
+                    useCachedEffect(requestId, fakeHandler, {
+                        retainResultOnChange: false,
+                    }),
+                {
+                    initialProps: {requestId: "ID"},
+                },
+            );
+            await act((): Promise<mixed> => response1);
+            rerender({requestId: "ID2"});
+
+            // Assert
+            expect(result.current).toStrictEqual(Status.loading());
+        });
+
+        it("should trigger render when request is fulfilled and onResultChanged is undefined", async () => {
+            // Arrange
+            const response = Promise.resolve("DATA");
+            const fakeHandler = jest.fn().mockReturnValue(response);
+
+            // Act
+            const {result} = clientRenderHook(() =>
+                useCachedEffect("ID", fakeHandler),
+            );
+            await act((): Promise<mixed> => response);
+
+            // Assert
+            expect(result.current).toStrictEqual(Status.success("DATA"));
+        });
+
+        it("should not trigger render when request is fulfilled and onResultChanged is defined", async () => {
+            // Arrange
+            const response = Promise.resolve("DATA");
+            const fakeHandler = jest.fn().mockReturnValue(response);
+
+            // Act
+            const {result} = clientRenderHook(() =>
+                useCachedEffect("ID", fakeHandler, {
+                    onResultChanged: () => {},
+                }),
+            );
+            await act((): Promise<mixed> => response);
+
+            // Assert
+            expect(result.current).toStrictEqual(Status.loading());
+        });
+
+        it("should call onResultChanged when request is fulfilled and onResultChanged is defined", async () => {
+            // Arrange
+            const response = Promise.resolve("DATA");
+            const fakeHandler = jest.fn().mockReturnValue(response);
+            const onResultChanged = jest.fn();
+
+            // Act
+            clientRenderHook(() =>
+                useCachedEffect("ID", fakeHandler, {
+                    onResultChanged,
+                }),
+            );
+            await act((): Promise<mixed> => response);
+
+            // Assert
+            expect(onResultChanged).toHaveBeenCalledWith(
+                Status.success("DATA"),
+            );
+        });
+    });
+});

--- a/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
@@ -1,0 +1,225 @@
+// @flow
+import * as React from "react";
+import {useForceUpdate} from "@khanacademy/wonder-blocks-core";
+
+import {RequestFulfillment} from "../util/request-fulfillment.js";
+import {Status} from "../util/status.js";
+
+import {useSharedCache} from "./use-shared-cache.js";
+import {useRequestInterception} from "./use-request-interception.js";
+
+import type {Result, ValidCacheData} from "../util/types.js";
+
+type CachedEffectOptions<TData: ValidCacheData> = {|
+    /**
+     * When `true`, the effect will not be executed; otherwise, the effect will
+     * be executed.
+     *
+     * If this is set to `true` while the effect is still pending, the pending
+     * effect will be cancelled.
+     *
+     * Default is `false`.
+     */
+    skip?: boolean,
+
+    /**
+     * When `true`, the effect will not reset the result to the loading status
+     * while executing if the requestId changes, instead, returning
+     * the existing result from before the change; otherwise, the result will
+     * be set to loading status.
+     *
+     * If the status is loading when the changes are made, it will remain as
+     * loading; old pending effects are discarded on changes and as such this
+     * value has no effect in that case.
+     */
+    retainResultOnChange?: boolean,
+
+    /**
+     * Callback that is invoked if the result for the given hook has changed.
+     *
+     * When defined, the hook will invoke this callback whenever it has reason
+     * to change the result and will not otherwise affect component rendering
+     * directly.
+     *
+     * When not defined, the hook will ensure the component re-renders to pick
+     * up the latest result.
+     */
+    onResultChanged?: (result: Result<TData>) => void,
+
+    /**
+     * Scope to use with the shared cache.
+     *
+     * When specified, the given scope will be used to isolate this hook's
+     * cached results. Otherwise, a shared default scope will be used.
+     *
+     * Changing this value after the first call is not supported.
+     */
+    scope?: string,
+|};
+
+const DefaultScope = "useCachedEffect";
+
+/**
+ * Hook to execute and cache an async operation on the client.
+ *
+ * This hook executes the given handler on the client if there is no
+ * cached result to use.
+ *
+ * Results are cached so they can be shared between equivalent invocations.
+ * In-flight requests are also shared, so that concurrent calls will
+ * behave as one might exect. Cache updates invoked by one hook instance
+ * do not trigger renders in components that use the same requestID; however,
+ * that should not matter since concurrent requests will share the same
+ * in-flight request, and subsequent renders will grab from the cache.
+ *
+ * Once the request has been tried once and a non-loading response has been
+ * cached, the request will not executed made again.
+ */
+export const useCachedEffect = <TData: ValidCacheData>(
+    requestId: string,
+    handler: () => Promise<TData>,
+    options: CachedEffectOptions<TData> = ({}: $Shape<
+        CachedEffectOptions<TData>,
+    >),
+): Result<TData> => {
+    const {
+        skip: hardSkip = false,
+        retainResultOnChange = false,
+        onResultChanged,
+        scope = DefaultScope,
+    } = options;
+
+    // Plug in to the request interception framework for code that wants
+    // to use that.
+    const interceptedHandler = useRequestInterception(requestId, handler);
+
+    // Instead of using state, which would be local to just this hook instance,
+    // we use a shared in-memory cache.
+    const [mostRecentResult, setMostRecentResult] = useSharedCache<
+        Result<TData>,
+    >(
+        requestId, // The key of the cached item
+        scope, // The scope of the cached items
+        // No default value. We don't want the loading status there; to ensure
+        // that all calls when the request is in-flight will update once that
+        // request is done, we want the cache to be empty until that point.
+    );
+
+    // Build a function that will update the cache and either invoke the
+    // callback provided in options, or force an update.
+    const forceUpdate = useForceUpdate();
+    const setCacheAndNotify = React.useCallback(
+        (value: Result<TData>) => {
+            setMostRecentResult(value);
+
+            // If our caller provided a cacheUpdated callback, we use that.
+            // Otherwise, we toggle our little state update.
+            if (onResultChanged != null) {
+                onResultChanged(value);
+            } else {
+                forceUpdate();
+            }
+        },
+        [setMostRecentResult, onResultChanged, forceUpdate],
+    );
+
+    // We need to trigger a re-render when the request ID changes as that
+    // indicates its a different request. We don't default the current id as
+    // this is a proxy for the first render, where we will make the request
+    // if we don't already have a cached value.
+    const requestIdRef = React.useRef();
+    const previousRequestId = requestIdRef.current;
+
+    // Calculate our soft skip state.
+    // Soft skip changes are things that should skip the effect if something
+    // else triggers the effect to run, but should not itself trigger the effect
+    // (which would cancel a previous invocation).
+    const softSkip = React.useMemo(() => {
+        if (requestId === previousRequestId) {
+            // If the requestId is unchanged, it means we already rendered at
+            // least once and so we already made the request at least once. So
+            // we can bail out right here.
+            return true;
+        }
+
+        // If we already have a cached value, we're going to skip.
+        if (mostRecentResult != null) {
+            return true;
+        }
+
+        return false;
+    }, [requestId, previousRequestId, mostRecentResult]);
+
+    // So now we make sure the client-side request happens per our various
+    // options.
+    React.useEffect(() => {
+        let cancel = false;
+
+        // We don't do anything if we've been told to hard skip (a hard skip
+        // means we should cancel the previous request and is therefore a
+        // dependency on that), or we have determined we have already done
+        // enough and can soft skip (a soft skip doesn't trigger the request
+        // to re-run; we don't want to cancel the in progress effect if we're
+        // soft skipping.
+        if (hardSkip || softSkip) {
+            return;
+        }
+
+        // If we got here, we're going to perform the request.
+        // Let's make sure our ref is set to the most recent requestId.
+        requestIdRef.current = requestId;
+
+        // OK, we've done all our checks and things. It's time to make the
+        // request. We use our request fulfillment here so that in-flight
+        // requests are shared.
+        // NOTE: Our request fulfillment handles the error cases here.
+        // Catching shouldn't serve a purpose.
+        // eslint-disable-next-line promise/catch-or-return
+        RequestFulfillment.Default.fulfill(requestId, {
+            handler: interceptedHandler,
+        }).then((result) => {
+            if (cancel) {
+                // We don't modify our result if an earlier effect was
+                // cancelled as it means that this hook no longer cares about
+                // that old request.
+                return;
+            }
+
+            setCacheAndNotify(result);
+            return; // Shut up eslint always-return rule.
+        });
+
+        return () => {
+            // TODO(somewhatabstract, FEI-4276): Eventually, we will want to be
+            // able abort in-flight requests, but for now, we don't have that.
+            // (Of course, we will only want to abort them if no one is waiting
+            // on them)
+            // For now, we just block cancelled requests from changing our
+            // cache.
+            cancel = true;
+        };
+        // We only want to run this effect if the requestId, or skip values
+        // change. These are the only two things that should affect the
+        // cancellation of a pending request. We do not update if the handler
+        // changes, in order to simplify the API - otherwise, callers would
+        // not be able to use inline functions with this hook.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [hardSkip, requestId]);
+
+    // We track the last result we returned in order to support the
+    // "retainResultOnChange" option.
+    const lastResultAgnosticOfIdRef = React.useRef(Status.loading());
+    const loadingResult = retainResultOnChange
+        ? lastResultAgnosticOfIdRef.current
+        : Status.loading();
+
+    // Loading is a transient state, so we only use it here; it's not something
+    // we cache.
+    const result = React.useMemo(
+        () => mostRecentResult ?? loadingResult,
+        [mostRecentResult, loadingResult],
+    );
+    lastResultAgnosticOfIdRef.current = result;
+
+    return result;
+};

--- a/packages/wonder-blocks-data/src/hooks/use-shared-cache.js
+++ b/packages/wonder-blocks-data/src/hooks/use-shared-cache.js
@@ -94,11 +94,13 @@ export const useSharedCache = <TValue: ValidCacheData>(
         const value =
             typeof initialValue === "function" ? initialValue() : initialValue;
 
-        // Update the cache.
-        cacheValue(value);
+        if (value != null) {
+            // Update the cache.
+            cacheValue(value);
 
-        // Make sure we return this value as our current value.
-        currentValue = value;
+            // Make sure we return this value as our current value.
+            currentValue = value;
+        }
     }
 
     // Now we have everything, let's return it.

--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -49,6 +49,7 @@ export {default as TrackData} from "./components/track-data.js";
 export {default as Data} from "./components/data.js";
 export {default as InterceptRequests} from "./components/intercept-requests.js";
 export {useServerEffect} from "./hooks/use-server-effect.js";
+export {useCachedEffect} from "./hooks/use-cached-effect.js";
 export {useRequestInterception} from "./hooks/use-request-interception.js";
 export {useSharedCache, clearSharedCache} from "./hooks/use-shared-cache.js";
 export {


### PR DESCRIPTION
## Summary:
This is the last of the main Wonder Blocks Data updates.
This splits out the client-side work into its own effect hook, and updates our `useHydrateableEffect` (introduced in the last PR) to use this new hook.

Issue: FEI-4327

## Test plan:
`yarn test`
`yarn flow`