### PR TITLE
[fei4191.0.errors] Fix up types of errors thrown

### DIFF
--- a/.changeset/red-beers-mate.md
+++ b/.changeset/red-beers-mate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": major
+---
+
+New `DataError` type and changes to the `GqlError` type. Also changes what errors are thrown in various code

--- a/packages/wonder-blocks-data/src/hooks/__tests__/__snapshots__/use-shared-cache.test.js.snap
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/__snapshots__/use-shared-cache.test.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#useSharedCache should throw if the id is  1`] = `[InvalidInputError: id must be a non-empty string]`;
+exports[`#useSharedCache should throw if the id is  1`] = `[InvalidInputDataError: id must be a non-empty string]`;
 
-exports[`#useSharedCache should throw if the id is [Function anonymous] 1`] = `[InvalidInputError: id must be a non-empty string]`;
+exports[`#useSharedCache should throw if the id is [Function anonymous] 1`] = `[InvalidInputDataError: id must be a non-empty string]`;
 
-exports[`#useSharedCache should throw if the id is 5 1`] = `[InvalidInputError: id must be a non-empty string]`;
+exports[`#useSharedCache should throw if the id is 5 1`] = `[InvalidInputDataError: id must be a non-empty string]`;
 
-exports[`#useSharedCache should throw if the id is null 1`] = `[InvalidInputError: id must be a non-empty string]`;
+exports[`#useSharedCache should throw if the id is null 1`] = `[InvalidInputDataError: id must be a non-empty string]`;
 
-exports[`#useSharedCache should throw if the scope is  1`] = `[InvalidInputError: scope must be a non-empty string]`;
+exports[`#useSharedCache should throw if the scope is  1`] = `[InvalidInputDataError: scope must be a non-empty string]`;
 
-exports[`#useSharedCache should throw if the scope is [Function anonymous] 1`] = `[InvalidInputError: scope must be a non-empty string]`;
+exports[`#useSharedCache should throw if the scope is [Function anonymous] 1`] = `[InvalidInputDataError: scope must be a non-empty string]`;
 
-exports[`#useSharedCache should throw if the scope is 5 1`] = `[InvalidInputError: scope must be a non-empty string]`;
+exports[`#useSharedCache should throw if the scope is 5 1`] = `[InvalidInputDataError: scope must be a non-empty string]`;
 
-exports[`#useSharedCache should throw if the scope is null 1`] = `[InvalidInputError: scope must be a non-empty string]`;
+exports[`#useSharedCache should throw if the scope is null 1`] = `[InvalidInputDataError: scope must be a non-empty string]`;

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-gql-router-context.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-gql-router-context.test.js
@@ -16,7 +16,7 @@ describe("#useGqlRouterContext", () => {
 
         // Assert
         expect(result).toMatchInlineSnapshot(
-            `[GqlInternalError: No GqlRouter]`,
+            `[InternalGqlError: No GqlRouter]`,
         );
     });
 

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-gql.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-gql.test.js
@@ -21,7 +21,7 @@ describe("#useGql", () => {
 
         // Assert
         expect(result).toMatchInlineSnapshot(
-            `[GqlInternalError: No GqlRouter]`,
+            `[InternalGqlError: No GqlRouter]`,
         );
     });
 

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.js
@@ -8,7 +8,7 @@ import TrackData from "../../components/track-data.js";
 import {RequestFulfillment} from "../../util/request-fulfillment.js";
 import {SsrCache} from "../../util/ssr-cache.js";
 import {RequestTracker} from "../../util/request-tracking.js";
-import {GqlError} from "../../util/gql-error.js";
+import {DataError} from "../../util/data-error.js";
 import * as UseRequestInterception from "../use-request-interception.js";
 
 import {useServerEffect} from "../use-server-effect.js";
@@ -142,7 +142,7 @@ describe("#useServerEffect", () => {
             // Assert
             expect(result).toEqual({
                 status: "error",
-                error: expect.any(GqlError),
+                error: expect.any(DataError),
             });
         });
     });
@@ -198,7 +198,7 @@ describe("#useServerEffect", () => {
             // Assert
             expect(result).toEqual({
                 status: "error",
-                error: expect.any(GqlError),
+                error: expect.any(DataError),
             });
         });
 

--- a/packages/wonder-blocks-data/src/hooks/use-shared-cache.js
+++ b/packages/wonder-blocks-data/src/hooks/use-shared-cache.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import {KindError, Errors} from "@khanacademy/wonder-stuff-core";
+import {DataError, DataErrors} from "../util/data-error.js";
 import {ScopedInMemoryCache} from "../util/scoped-in-memory-cache.js";
 import type {ValidCacheData} from "../util/types.js";
 
@@ -57,16 +57,16 @@ export const useSharedCache = <TValue: ValidCacheData>(
 ): [?TValue, CacheValueFn<TValue>] => {
     // Verify arguments.
     if (!id || typeof id !== "string") {
-        throw new KindError(
+        throw new DataError(
             "id must be a non-empty string",
-            Errors.InvalidInput,
+            DataErrors.InvalidInput,
         );
     }
 
     if (!scope || typeof scope !== "string") {
-        throw new KindError(
+        throw new DataError(
             "scope must be a non-empty string",
-            Errors.InvalidInput,
+            DataErrors.InvalidInput,
         );
     }
 

--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -10,15 +10,33 @@ import type {
 } from "./util/types.js";
 
 export type {
+    ErrorOptions,
     ResponseCache,
     CachedResponse,
     Result,
     ScopedCache,
+    ValidCacheData,
 } from "./util/types.js";
 
+/**
+ * Initialize the hydration cache.
+ *
+ * @param {ResponseCache} source The cache content to use for initializing the
+ * cache.
+ * @throws {Error} If the cache is already initialized.
+ */
 export const initializeCache = (source: ResponseCache): void =>
     SsrCache.Default.initialize(source);
 
+/**
+ * Fulfill all tracked data requests.
+ *
+ * This is for use with the `TrackData` component during server-side rendering.
+ *
+ * @throws {Error} If executed outside of server-side rendering.
+ * @returns {Promise<void>} A promise that resolves when all tracked requests
+ * have been fulfilled.
+ */
 export const fulfillAllDataRequests = (): Promise<ResponseCache> => {
     if (!Server.isServerSide()) {
         return Promise.reject(
@@ -28,6 +46,15 @@ export const fulfillAllDataRequests = (): Promise<ResponseCache> => {
     return RequestTracker.Default.fulfillTrackedRequests();
 };
 
+/**
+ * Indicate if there are unfulfilled tracked requests.
+ *
+ * This is used in conjunction with `TrackData`.
+ *
+ * @throws {Error} If executed outside of server-side rendering.
+ * @returns {boolean} `true` if there are unfulfilled tracked requests;
+ * otherwise, `false`.
+ */
 export const hasUnfulfilledRequests = (): boolean => {
     if (!Server.isServerSide()) {
         throw new Error("Data requests are not tracked when client-side");
@@ -35,9 +62,21 @@ export const hasUnfulfilledRequests = (): boolean => {
     return RequestTracker.Default.hasUnfulfilledRequests;
 };
 
+/**
+ * Remove the request identified from the cached hydration responses.
+ *
+ * @param {string} id The request ID of the response to remove from the cache.
+ */
 export const removeFromCache = (id: string): boolean =>
     SsrCache.Default.remove(id);
 
+/**
+ * Remove all cached hydration responses that match the given predicate.
+ *
+ * @param {(id: string) => boolean} [predicate] The predicate to match against
+ * the cached hydration responses. If no predicate is provided, all cached
+ * hydration responses will be removed.
+ */
 export const removeAllFromCache = (
     predicate?: (
         key: string,
@@ -48,9 +87,9 @@ export const removeAllFromCache = (
 export {default as TrackData} from "./components/track-data.js";
 export {default as Data} from "./components/data.js";
 export {default as InterceptRequests} from "./components/intercept-requests.js";
+export {DataError, DataErrors} from "./util/data-error.js";
 export {useServerEffect} from "./hooks/use-server-effect.js";
 export {useCachedEffect} from "./hooks/use-cached-effect.js";
-export {useRequestInterception} from "./hooks/use-request-interception.js";
 export {useSharedCache, clearSharedCache} from "./hooks/use-shared-cache.js";
 export {
     useHydratableEffect,
@@ -61,13 +100,14 @@ export {
     WhenClientSide,
 } from "./hooks/use-hydratable-effect.js";
 export {ScopedInMemoryCache} from "./util/scoped-in-memory-cache.js";
+export {SerializableInMemoryCache} from "./util/serializable-in-memory-cache.js";
 export {RequestFulfillment} from "./util/request-fulfillment.js";
 export {Status} from "./util/status.js";
 
 // GraphQL
 export {GqlRouter} from "./components/gql-router.js";
 export {useGql} from "./hooks/use-gql.js";
-export * from "./util/gql-error.js";
+export {GqlError, GqlErrors} from "./util/gql-error.js";
 export type {
     GqlContext,
     GqlOperation,

--- a/packages/wonder-blocks-data/src/util/__tests__/request-fulfillment.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-fulfillment.test.js
@@ -1,6 +1,6 @@
 // @flow
 import {RequestFulfillment} from "../request-fulfillment.js";
-import {GqlError} from "../gql-error.js";
+import {DataError} from "../data-error.js";
 
 describe("RequestFulfillment", () => {
     it("should provide static default instance", () => {
@@ -28,7 +28,7 @@ describe("RequestFulfillment", () => {
             // Assert
             expect(result).toStrictEqual({
                 status: "error",
-                error: expect.any(GqlError),
+                error: expect.any(DataError),
             });
         });
 

--- a/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.js
@@ -76,6 +76,6 @@ describe("#resultFromCachedResponse", () => {
         const {error} = resultFromCachedResponse(cacheEntry);
 
         // Assert
-        expect(error).toMatchInlineSnapshot(`[GqlHydratedError: ERROR]`);
+        expect(error).toMatchInlineSnapshot(`[HydratedDataError: ERROR]`);
     });
 });

--- a/packages/wonder-blocks-data/src/util/data-error.js
+++ b/packages/wonder-blocks-data/src/util/data-error.js
@@ -1,0 +1,58 @@
+// @flow
+import {KindError} from "@khanacademy/wonder-stuff-core";
+import type {ErrorOptions} from "./types.js";
+
+/**
+ * Error kinds for DataError.
+ */
+export const DataErrors = Object.freeze({
+    /**
+     * The kind of error is not known.
+     */
+    Unknown: "Unknown",
+
+    /**
+     * The error is internal to the executing code.
+     */
+    Internal: "Internal",
+
+    /**
+     * There was a problem with the provided input.
+     */
+    InvalidInput: "InvalidInput",
+
+    /**
+     * A network error occurred.
+     */
+    Network: "Network",
+
+    /**
+     * Response could not be parsed.
+     */
+    Parse: "Parse",
+
+    /**
+     * An error that occurred during SSR and was hydrated from cache
+     */
+    Hydrated: "Hydrated",
+});
+
+/**
+ * An error from the Wonder Blocks Data API.
+ *
+ * Errors of this type will have names of the format:
+ *     `${kind}DataError`
+ */
+export class DataError extends KindError {
+    constructor(
+        message: string,
+        kind: $Values<typeof DataErrors>,
+        {metadata, cause}: ErrorOptions = ({}: $Shape<ErrorOptions>),
+    ) {
+        super(message, kind, {
+            metadata,
+            cause,
+            name: "Data",
+        });
+    }
+}

--- a/packages/wonder-blocks-data/src/util/get-gql-data-from-response.js
+++ b/packages/wonder-blocks-data/src/util/get-gql-data-from-response.js
@@ -1,4 +1,5 @@
 // @flow
+import {DataError, DataErrors} from "./data-error.js";
 import {GqlError, GqlErrors} from "./gql-error.js";
 
 /**
@@ -14,7 +15,7 @@ export const getGqlDataFromResponse = async <TData>(
     try {
         result = JSON.parse(bodyText);
     } catch (e) {
-        throw new GqlError("Failed to parse response", GqlErrors.Parse, {
+        throw new DataError("Failed to parse response", DataErrors.Parse, {
             metadata: {
                 statusCode: response.status,
                 bodyText,
@@ -25,7 +26,7 @@ export const getGqlDataFromResponse = async <TData>(
 
     // Check for a bad status code.
     if (response.status >= 300) {
-        throw new GqlError("Response unsuccessful", GqlErrors.Network, {
+        throw new DataError("Response unsuccessful", DataErrors.Network, {
             metadata: {
                 statusCode: response.status,
                 result,

--- a/packages/wonder-blocks-data/src/util/gql-error.js
+++ b/packages/wonder-blocks-data/src/util/gql-error.js
@@ -1,27 +1,16 @@
 // @flow
-import {KindError, Errors} from "@khanacademy/wonder-stuff-core";
-import type {Metadata} from "@khanacademy/wonder-stuff-core";
+import {KindError} from "@khanacademy/wonder-stuff-core";
 
-type GqlErrorOptions = {|
-    metadata?: ?Metadata,
-    cause?: ?Error,
-|};
+import type {ErrorOptions} from "./types.js";
 
 /**
  * Error kinds for GqlError.
  */
 export const GqlErrors = Object.freeze({
-    ...Errors,
-
     /**
-     * A network error occurred.
+     * An internal framework error.
      */
-    Network: "Network",
-
-    /**
-     * Response could not be parsed.
-     */
-    Parse: "Parse",
+    Internal: "Internal",
 
     /**
      * Response does not have the correct structure for a GraphQL response.
@@ -32,26 +21,24 @@ export const GqlErrors = Object.freeze({
      * A valid GraphQL result with errors field in the payload.
      */
     ErrorResult: "ErrorResult",
-
-    /**
-     * An error that occurred during SSR and was hydrated from cache
-     */
-    Hydrated: "Hydrated",
 });
 
 /**
  * An error from the GQL API.
+ *
+ * Errors of this type will have names of the format:
+ *     `${kind}GqlError`
  */
 export class GqlError extends KindError {
     constructor(
         message: string,
         kind: $Values<typeof GqlErrors>,
-        {metadata, cause}: GqlErrorOptions = ({}: $Shape<GqlErrorOptions>),
+        {metadata, cause}: ErrorOptions = ({}: $Shape<ErrorOptions>),
     ) {
         super(message, kind, {
             metadata,
             cause,
-            prefix: "Gql",
+            name: "Gql",
         });
     }
 }

--- a/packages/wonder-blocks-data/src/util/request-fulfillment.js
+++ b/packages/wonder-blocks-data/src/util/request-fulfillment.js
@@ -1,7 +1,7 @@
 // @flow
 import type {Result, ValidCacheData} from "./types.js";
 
-import {GqlError, GqlErrors} from "./gql-error.js";
+import {DataError, DataErrors} from "./data-error.js";
 
 type RequestCache = {
     [id: string]: Promise<Result<any>>,
@@ -64,7 +64,7 @@ export class RequestFulfillment {
             .catch((error: string | Error): Result<TData> => {
                 const actualError =
                     typeof error === "string"
-                        ? new GqlError("Request failed", GqlErrors.Unknown, {
+                        ? new DataError("Request failed", DataErrors.Unknown, {
                               metadata: {
                                   unexpectedError: error,
                               },

--- a/packages/wonder-blocks-data/src/util/result-from-cache-response.js
+++ b/packages/wonder-blocks-data/src/util/result-from-cache-response.js
@@ -1,6 +1,6 @@
 // @flow
 import {Status} from "./status.js";
-import {GqlError, GqlErrors} from "./gql-error.js";
+import {DataError, DataErrors} from "./data-error.js";
 import type {ValidCacheData, CachedResponse, Result} from "./types.js";
 
 /**
@@ -19,7 +19,7 @@ export const resultFromCachedResponse = <TData: ValidCacheData>(
         // Let's hydrate the error. We don't persist everything about the
         // original error on the server, hence why we only superficially
         // hydrate it to a GqlHydratedError.
-        return Status.error(new GqlError(error, GqlErrors.Hydrated));
+        return Status.error(new DataError(error, DataErrors.Hydrated));
     }
 
     if (data != null) {

--- a/packages/wonder-blocks-data/src/util/scoped-in-memory-cache.js
+++ b/packages/wonder-blocks-data/src/util/scoped-in-memory-cache.js
@@ -1,5 +1,5 @@
 // @flow
-import {KindError, Errors} from "@khanacademy/wonder-stuff-core";
+import {DataError, DataErrors} from "./data-error.js";
 import type {ScopedCache, ValidCacheData} from "./types.js";
 
 /**
@@ -30,23 +30,23 @@ export class ScopedInMemoryCache {
         value: TValue,
     ): void {
         if (!id || typeof id !== "string") {
-            throw new KindError(
+            throw new DataError(
                 "id must be non-empty string",
-                Errors.InvalidInput,
+                DataErrors.InvalidInput,
             );
         }
 
         if (!scope || typeof scope !== "string") {
-            throw new KindError(
+            throw new DataError(
                 "scope must be non-empty string",
-                Errors.InvalidInput,
+                DataErrors.InvalidInput,
             );
         }
 
         if (typeof value === "function") {
-            throw new KindError(
+            throw new DataError(
                 "value must be a non-function value",
-                Errors.InvalidInput,
+                DataErrors.InvalidInput,
             );
         }
 

--- a/packages/wonder-blocks-data/src/util/serializable-in-memory-cache.js
+++ b/packages/wonder-blocks-data/src/util/serializable-in-memory-cache.js
@@ -1,19 +1,20 @@
 // @flow
-import {KindError, Errors, clone} from "@khanacademy/wonder-stuff-core";
+import {clone} from "@khanacademy/wonder-stuff-core";
+import {DataError, DataErrors} from "./data-error.js";
 import {ScopedInMemoryCache} from "./scoped-in-memory-cache.js";
 import type {ValidCacheData, ScopedCache} from "./types.js";
 
 /**
- * Describe an in-memory cache.
+ * Describe a serializable in-memory cache.
  */
 export class SerializableInMemoryCache extends ScopedInMemoryCache {
     constructor(initialCache: ScopedCache = {}) {
         try {
             super(clone(initialCache));
         } catch (e) {
-            throw new KindError(
+            throw new DataError(
                 `An error occurred trying to initialize from a response cache snapshot: ${e}`,
-                Errors.InvalidInput,
+                DataErrors.InvalidInput,
             );
         }
     }
@@ -36,9 +37,9 @@ export class SerializableInMemoryCache extends ScopedInMemoryCache {
         try {
             return clone(this._cache);
         } catch (e) {
-            throw new KindError(
+            throw new DataError(
                 "An error occurred while trying to clone the cache",
-                Errors.Internal,
+                DataErrors.Internal,
                 {
                     cause: e,
                 },

--- a/packages/wonder-blocks-data/src/util/types.js
+++ b/packages/wonder-blocks-data/src/util/types.js
@@ -1,4 +1,6 @@
 // @flow
+import type {Metadata} from "@khanacademy/wonder-stuff-core";
+
 /**
  * Define what can be cached.
  *
@@ -68,3 +70,18 @@ export type ScopedCache = {
     },
     ...
 };
+
+/**
+ * Options to pass to error construction.
+ */
+export type ErrorOptions = {|
+    /**
+     * Metadata to attach to the error.
+     */
+    metadata?: ?Metadata,
+
+    /**
+     * The error that caused the error being constructed.
+     */
+    cause?: ?Error,
+|};


### PR DESCRIPTION
## Summary:
During my writing of the docs I found that I had not properly dealt with the error types (returning Gql errors for things that were not Gql specific), so this tidies that up and splits it out from the docs changes I was making (hence the `0` in the branch name).

Issue: FEI-4327

## Test plan:
`yarn test`
`yarn flow`