### PR TITLE
[fei4191.2.hooksdocs] Adding more docs!

### DIFF
--- a/packages/wonder-blocks-data/src/__docs__/_overview_.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/_overview_.stories.mdx
@@ -1,4 +1,4 @@
-import {Meta, DocsContext} from "@storybook/addon-docs";
+import {Meta} from "@storybook/addon-docs";
 
 <Meta
     title="Data / Overview"

--- a/packages/wonder-blocks-data/src/__docs__/_overview_graphql.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/_overview_graphql.stories.mdx
@@ -9,4 +9,27 @@ import {Meta} from "@storybook/addon-docs";
     }}
 />
 
-TODO
+# GraphQL in Wonder Blocks Data
+
+Wonder Blocks Data provides some utility types and functionality to assist in performing GraphQL requests. To use them, your React app should include the [`GqlRouter`](/docs/data-exports-gqlrouter--page) component to specify the method responsible for actually making the GraphQL requests, as well as any default context that requests should include.
+
+The [`GqlRouter`](/docs/data-exports-gqlrouter--page) component uses React context to convey this information to the [`useGql`](/docs/data-exports-usegql--page) hook, which provides a wrapper to the fetch function, allowing for simplified invocation of requests that can merge context changes with the default context as well as only provide context and variables when needed.
+
+## Testing
+
+By using the [`GqlRouter`](/docs/data-exports-gqlrouter--page) in combination with the [`mockGqlFetch()`](/docs/testing-exports-mockgqlfetch) API from Wonder Blocks Testing, you can easily mock your GraphQL responses in tests and stories.
+
+```tsx
+const mockFetch = mockGqlFetch()
+    .mockOperation(...);
+
+<GqlRouter fetch={mockFetch} defaultContext={{}}>
+    <MyComponent />
+</GqlRouter>
+```
+
+## Server-side rendering and hydration of GraphQL
+
+Server-side rendering and hydration of GraphQL data can be achieved by combining the [`useGql`](/docs/data-exports-usegql--page) hook with the [`useHydrationEffect`](/docs/data-exports/usehydrationeffect--page) hook.
+
+More details about server-side rendering with Wonder Blocks Data can be found in the [relevant overview section](/docs/data-server-side-rendering-and-hydration--page).

--- a/packages/wonder-blocks-data/src/__docs__/_overview_testing_.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/_overview_testing_.stories.mdx
@@ -9,4 +9,115 @@ import {Meta} from "@storybook/addon-docs";
     }}
 />
 
-TODO
+# Testing Support
+
+Wonder Blocks Data has been designed to support testing in a variety of environments including jest and storybook. In order to support the various ways in which folks need to test their code, we have considered a number of approaches to testing Wonder Blocks Data.
+
+## Spies
+If you are writing unit tests, you may just want to spy on the methods you are calling using `jest.spyOn` or similar. This can be a really easy way to intercept the request handler passed to the [`useCachedEffect`](/docs/data-exports-usecachedeffect--page) hook, for example, and check that it is the handler you expect.
+
+## Interceptors
+
+Each request used by Wonder Blocks Data has to have an identifier. The [`InterceptRequests`](/docs/data-exports-interceptrequests--page) component allows you to wrap the code under test with an interceptor. Interceptors are given the request identifier and get to choose, based off that identifier, if they want to provide their own response rather than let the original request handler deal with it.
+
+Multiple interceptors can be registered by nesting the [`InterceptRequests`](/docs/data-exports-interceptrequests--page) component as is necessary. Registered interceptors are invoked in ancestral order, with the nearest ancestor to the intercepted request being invoked first.
+
+When hooks like [`useServerEffect`](/docs/data-exports-useservereffect--page), [`useCachedEffect`](/docs/data-exports-usecachedeffect--page), or [`useHydratedEffect`](/docs/data-exports-usehydratedeffect--page) run, they get the chain of registered interceptors and chain those with the original handler in order to determine what to actually do when executing the request.
+
+This allows you to mock out requests in unit tests, stories, and other scenarios.
+
+## GqlRouter, mockGqlFetch, and RespondWith
+
+If you are testing GraphQL operations, you can configure [`GqlRouter`](/docs/data-exports-gqlrouter--page) with your own function for the `fetch` prop. However, crafting the right response to give
+the result you want is a bit tricky.
+
+```tsx
+const myFakeGqlFetch = (
+    operation: GqlOperation<TData, TVariables>,
+    variables: ?TVariables,
+    context: TContext,
+): Promise<Response> {
+    if (operation.id === "myQuery" && variables?.someVar === 5) {
+        return Promise.resolve({
+            status: 200,
+            text: () =>
+                Promise.resolve(
+                    JSON.stringify({
+                        data: {
+                            myQuery: {
+                                someField: "someValue",
+                            },
+                        },
+                    }),
+                ),
+        });
+    }
+
+    return Promise.resolve({
+        status: 404,
+        text: () => Promise.resolve(JSON.stringify({})),
+    });
+}
+
+<GqlRouter fetch={myFakeGqlFetch} defaultContext={{some: "sort of context"}}>
+    <ComponentUnderTest />
+</GqlRouter>
+```
+
+As shown above, you can interrogate parts of the requested operation to decide how to respond. However, this can get cumbersome if you have GraphQL requests nested in more complex components as each test has to mock out suitable responses for each one. To help with this the Wonder Blocks Testing package provides a [`RespondWith`](/docs/testing-exports-respondwith--page) type for defining responses that fit a specific scenario, and the [`mockGqlFetch()`](/docs/testing-exports-mockgqlfetch--page) API.
+
+```tsx
+const myFakeGqlFetch = mockGqlFetch()
+    .mockOperationOnce(
+        {
+            operation: MyQueryOperation,
+            variables: {
+                someVar: 5,
+            },
+        },
+        RespondWith.success({
+            data: {
+                myQuery: {
+                    someField: "someValue",
+                },
+            },
+        }),
+    );
+
+<GqlRouter fetch={myFakeGqlFetch} defaultContext={{some: "sort of context"}}>
+    <ComponentUnderTest />
+</GqlRouter>
+```
+
+In the above example, we now only mock our specific operation once. If something
+tries to request this data a second time, it will give an error instead. Not only that, but with a little refactoring, we can create a helper to set this mock up that others can call if they need to mock our operation for their own tests.
+
+```ts
+const mockMyQuery = (mockGqlFetchFn: GqlFetchMockFn): GqlFetchMockFn =>
+    mockGqlFetchFn()
+        .mockOperationOnce(
+            {
+                operation: MyQueryOperation,
+                variables: {
+                    someVar: 5,
+                },
+            },
+            RespondWith.success({
+                data: {
+                    myQuery: {
+                        someField: "someValue",
+                    },
+                },
+            }),
+        );
+
+const myFakeGqlFetch = mockMyQuery(mockGqlFetch());
+
+<GqlRouter fetch={myFakeGqlFetch} defaultContext={{some: "sort of context"}}>
+    <ComponentUnderTest />
+</GqlRouter>
+```
+
+Now, using a compose function, multiple mocks can be setup on the same `mockGqlFetch` instance.
+
+For more details on this and other testing utilities, see the [Wonder Blocks Testing documentation](/docs/testing-overview--page).

--- a/packages/wonder-blocks-data/src/__docs__/exports.clear-shared-cache.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.clear-shared-cache.stories.mdx
@@ -1,0 +1,20 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / clearSharedCache()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# clearSharedCache()
+
+```ts
+clearSharedCache(scope?: string): void;
+```
+
+The `clearSharedCache` method can be used to clear the shared in-memory cache used by the [`useSharedCache`](/docs/data-exports-clearsharedcache--page) hook. Either a single scope or all scopes can be cleared.
+
+Common uses for calling this method are during [server-side rendering](/docs/data-server-side-rendering-and-hydration--page) to ensure each render cycle remains isolated, or during testing in a `beforeEach` to cover for where previous test cases may have changed the shared cache.

--- a/packages/wonder-blocks-data/src/__docs__/exports.data-error.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.data-error.stories.mdx
@@ -1,0 +1,23 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / DataError"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# DataError
+
+
+```ts
+new DataError(
+    message: string,
+    kind: $Values<typeof DataErrors>,
+    options?: ErrorOptions,
+);
+```
+
+The `DataError` class is a derivation of the Wonder Blocks Core `KindError` (which is itself a derivation of `Error`). It is used by the Wonder Blocks Data framework to encapsulate errors that can occur when using its API. The different kinds of errors supported are defined by the [`DataErrors`](/docs/data-exports-dataerrors--page) export.

--- a/packages/wonder-blocks-data/src/__docs__/exports.data-errors.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.data-errors.stories.mdx
@@ -1,0 +1,23 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / DataErrors"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# DataErrors
+
+This export defines the error taxonomy used by Wonder Blocks Data to describe the errors that can occur. These are for use with [`DataError`](/docs/data-exports-dataerror--page).
+
+| Kind | Description |
+| ---- | ----------- |
+| `DataErrors.Unknown` | The kind of error is not known. |
+| `DataErrors.Internal` | The error is internal to the executing code. |
+| `DataErrors.InvalidInput` | There was a problem with the provided input. |
+| `DataErrors.Network` | A network error occurred. |
+| `DataErrors.Parse` | Response could not be parsed. |
+| `DataErrors.Hydrated` | An error that occurred during SSR and was hydrated from cache |

--- a/packages/wonder-blocks-data/src/__docs__/exports.data.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.data.stories.mdx
@@ -1,5 +1,5 @@
 import {Meta} from "@storybook/addon-docs";
-import {Data} from "../data.js";
+import {Data} from "../index.js";
 
 <Meta
     title="Data / Exports / Data"

--- a/packages/wonder-blocks-data/src/__docs__/exports.gql-error.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.gql-error.stories.mdx
@@ -1,0 +1,23 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / GqlError"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# GqlError
+
+
+```ts
+new GqlError(
+    message: string,
+    kind: $Values<typeof GqlErrors>,
+    options?: ErrorOptions,
+);
+```
+
+The `GqlError` class is a derivation of the Wonder Blocks Core `KindError` (which is itself a derivation of `Error`). It is used by the Wonder Blocks Data GraphQL framework to encapsulate errors that can occur within the GraphQL API. The different kinds of errors supported are defined by the [`GqlErrors`](/docs/data-exports-gqlerrors--page) export.

--- a/packages/wonder-blocks-data/src/__docs__/exports.gql-errors.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.gql-errors.stories.mdx
@@ -1,0 +1,20 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / GqlErrors"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# GqlErrors
+
+This export defines the error taxonomy used by Wonder Blocks Data to describe the GraphQL-related errors that can occur with GraphQL requests. These are for use with [`GqlError`](/docs/data-exports-gqlerror--page).
+
+| Kind | Description |
+| ---- | ----------- |
+| `GqlErrors.Unknown` | The type of error is unknown. |
+| `GqlErrors.BadResponse` | Response does not have the correct structure for a GraphQL response. |
+| `GqlErrors.ErrorResult` | A valid GraphQL result with errors field in the payload. |

--- a/packages/wonder-blocks-data/src/__docs__/exports.gql-router.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.gql-router.stories.mdx
@@ -1,5 +1,5 @@
 import {Meta} from "@storybook/addon-docs";
-import {GqlRouter} from "../gql-router.js";
+import {GqlRouter} from "../index.js";
 
 <Meta
     title="Data / Exports / GqlRouter"

--- a/packages/wonder-blocks-data/src/__docs__/exports.intercept-requests.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.intercept-requests.stories.mdx
@@ -1,5 +1,5 @@
 import {Meta} from "@storybook/addon-docs";
-import {InterceptRequests} from "../intercept-requests.js";
+import {InterceptRequests} from "../index.js";
 
 <Meta
     title="Data / Exports / InterceptRequests"

--- a/packages/wonder-blocks-data/src/__docs__/exports.request-fulfillment.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.request-fulfillment.stories.mdx
@@ -1,0 +1,36 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / RequestFulfillment"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# RequestFulfillment
+
+The `RequestFulfillment` class encapsulates tracking of inflight asynchronous actions keyed by an identifier. Using this API, callers can request the result of the same asynchronous action multiple times without invoking the underlying action more than is necessary. Instead, any pending request will be shared by all requests for the same identifier.
+
+## Usage
+
+```ts
+    fulfill: <TData: ValidCacheData>(
+        id: string,
+        options: {|
+            handler: () => Promise<TData>,
+            hydrate?: boolean,
+        |},
+    ) => Promise<Result<TData>>;
+```
+
+There is a single function on the `RequestFulfillment` class, called `fulfill`.
+
+The `fulfill` method takes the request identifier (used to deduplicate requests) and an options object. The options object contains the following properties:
+
+ * `handler`: A function that returns a promise resolving to the result of the request. This is the asynchronous work that will be tracked by the given identifier.
+ * `hydrate`: A boolean indicating whether the data should be hydrated. This is used during server-side rendering to determine if the response data should be included in the hydration cache. This defaults to `true` and should only be set to `false` if you are performing server-side rendering of the request and you know that the data will not be needed for hydration to succeed.
+
+## RequestFulfillment.Default
+The `RequestFulfillment` class provides a static instance, `RequestFulfillment.Default`, which is used by the Wonder Blocks Data framework. However, a custom instance can be constructed should your specific use case need to be isolated from others.

--- a/packages/wonder-blocks-data/src/__docs__/exports.scoped-in-memory-cache.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.scoped-in-memory-cache.stories.mdx
@@ -1,0 +1,92 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / ScopedInMemoryCache"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# ScopedInMemoryCache
+
+This class implements an in-memory cache that can contain different scopes of cached data. This allows for quick removal of entire classes of data as identified by their scopes without having to iterate each cached item to find them.
+
+## constructor()
+
+```ts
+new ScopedInMemoryCache(initialCache?: ScopedCache)
+```
+
+Creates a new instance. An initial state for the cache can be provided.
+
+## inUse
+
+```ts
+    if (cache.inUse) {
+        // Cache is in use
+    }
+```
+
+Is `true` if the cache contains any data; otherwise, `false`.
+
+## set()
+
+```ts
+set<TValue: ValidCacheData>(
+    scope: string,
+    id: string,
+    value: TValue,
+): void;
+```
+
+Sets a value in the cache within a given scope.
+
+### Throws
+
+| Error Type | Error Name | Reason |
+| ------ | ------ | ------ |
+| [`DataError`](/docs/data-exports-dataerror--page) | `InvalidInputDataError` | `id` and `scope` must be non-empty strings |
+| [`DataError`](/docs/data-exports-dataerror--page) | `InvalidInputDataError` | `value` must be a non-function value |
+
+## get()
+
+```ts
+get(scope: string, id: string): ?ValidCacheData;
+```
+
+Gets a value from the cache. If a value with the given identifier (`id`) is not found within the given scope (`scope`) of the cache, `null` is returned.
+
+## purge()
+
+```ts
+purge(scope: string, id: string): void;
+```
+
+Purges the value from the cache. If a value with the given identifier (`id`) is not found within the given scope (`scope`) of the cache, nothing happens.
+
+## purgeScope()
+
+```ts
+purgeScope(
+    scope: string,
+    predicate?: (id: string, value: ValidCacheData) => boolean,
+): void;
+```
+
+Purges items within a given scope (`scope`) of the cache from that scope. If a predicate is provided, only items for which the predicate returns `true` will be purged; otherwise, the entire scope will be purged.
+
+## purgeAll()
+
+```ts
+purgeAll(
+    predicate?: (
+        scope: string,
+        id: string,
+        value: ValidCacheData,
+    ) => boolean,
+): void;
+```
+
+Purges all items from the cache. If a predicate is provided, only items for which the predicate returns `true` will be purged; otherwise, the entire cache will be purged.

--- a/packages/wonder-blocks-data/src/__docs__/exports.serializable-in-memory-cache.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.serializable-in-memory-cache.stories.mdx
@@ -1,0 +1,112 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / SerializableInMemoryCache"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# SerializableInMemoryCache
+
+This class is a specialization of [`ScopedInMemoryCache`](/docs/data-exports-scopedinmemorycache--page). This specialization requires that values added can be serialized to and from strings.
+
+## constructor()
+
+```ts
+new SerializableInMemoryCache(initialCache?: ScopedCache)
+```
+
+Creates a new instance. The `initialCache`, if provided, will be cloned and used as the initial state of the cache.
+
+### Throws
+
+| Error Type | Error Name | Reason |
+| ------ | ------ | ------ |
+| [`DataError`](/docs/data-exports-dataerror--page) | `InvalidInputDataError` | Could not clone the initial cache. |
+
+## inUse
+
+```ts
+    if (cache.inUse) {
+        // Cache is in use
+    }
+```
+
+Is `true` if the cache contains any data; otherwise, `false`.
+
+## set()
+
+```ts
+set<TValue: ValidCacheData>(
+    scope: string,
+    id: string,
+    value: TValue,
+): void;
+```
+
+Sets a value in the cache within a given scope. The value is cloned and the clone is frozen before being added to the cache.
+
+### Throws
+
+| Error Type | Error Name | Reason |
+| ------ | ------ | ------ |
+| [`DataError`](/docs/data-exports-dataerror--page) | `InvalidInputDataError` | `id` and `scope` must be non-empty strings |
+| [`DataError`](/docs/data-exports-dataerror--page) | `InvalidInputDataError` | `value` must be a non-function value |
+
+## get()
+
+```ts
+get(scope: string, id: string): ?ValidCacheData;
+```
+
+Gets a value from the cache. If a value with the given identifier (`id`) is not found within the given scope (`scope`) of the cache, `null` is returned.
+
+## clone()
+
+```ts
+clone(): ScopedCache;
+```
+
+Returns a clone of the current cache.
+
+### Throws
+
+| Error Type | Error Name | Reason |
+| ------ | ------ | ------ |
+| [`DataError`](/docs/data-exports-dataerror--page) | `InternalDataError` | Could not clone the cache. |
+
+## purge()
+
+```ts
+purge(scope: string, id: string): void;
+```
+
+Purges the value from the cache. If a value with the given identifier (`id`) is not found within the given scope (`scope`) of the cache, nothing happens.
+
+## purgeScope()
+
+```ts
+purgeScope(
+    scope: string,
+    predicate?: (id: string, value: ValidCacheData) => boolean,
+): void;
+```
+
+Purges items within a given scope (`scope`) of the cache from that scope. If a predicate is provided, only items for which the predicate returns `true` will be purged; otherwise, the entire scope will be purged.
+
+## purgeAll()
+
+```ts
+purgeAll(
+    predicate?: (
+        scope: string,
+        id: string,
+        value: ValidCacheData,
+    ) => boolean,
+): void;
+```
+
+Purges all items from the cache. If a predicate is provided, only items for which the predicate returns `true` will be purged; otherwise, the entire cache will be purged.

--- a/packages/wonder-blocks-data/src/__docs__/exports.status.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.status.stories.mdx
@@ -1,0 +1,31 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / Status"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# Status
+
+Provides a helper API for creating [`Result<TData>`](/docs/data-types-result--page) instances with specific statuses.
+
+
+## loading()
+
+`Status.loading()` creates a result with the `"loading"` status.
+
+## aborted()
+
+`Status.aborted()` creates a result with the `"aborted"` status.
+
+## success()
+
+`Status.success()` creates a result with the `"success"` status and the given data.
+
+## error()
+
+`Status.error()` creates a result with the `"error"` status and the given error.

--- a/packages/wonder-blocks-data/src/__docs__/exports.track-data.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.track-data.stories.mdx
@@ -1,5 +1,5 @@
 import {Meta} from "@storybook/addon-docs";
-import {TrackData} from "../track-data.js";
+import {TrackData} from "../index.js";
 
 <Meta
     title="Data / Exports / TrackData"

--- a/packages/wonder-blocks-data/src/__docs__/exports.use-cached-effect.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.use-cached-effect.stories.mdx
@@ -1,0 +1,41 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / useCachedEffect()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# useCachedEffect()
+
+```ts
+function useCachedEffect<TData: ValidCacheData>(
+    requestId: string,
+    handler: () => Promise<TData>,
+    options?: CachedEffectOptions<TData>,
+): Result<TData>;
+```
+
+This hook is a wrapper around `useEffect`. Internally it uses the [`useSharedCache`](/docs/data-exports-usesharedcache--page) hook to store the result of the effect and, if that result is available, returns it without rerunning the effect. The precise behavior of the
+hook can be modified using the options.
+
+There is currently no way to reinvoke the effect without changing the `requestId`.
+
+```ts
+type CachedEffectOptions<TData: ValidCacheData> = {|
+    skip?: boolean,
+    retainResultOnChange?: boolean,
+    onResultChanged?: (result: Result<TData>) => void,
+    scope?: string,
+|};
+```
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `skip` | `false` | When `true`, the effect will not be executed; otherwise, the effect will be executed.  If this is set to `true` while the effect is still pending, the pending effect will be cancelled. |
+| `retainResultOnChange` | `false` | When `true`, the effect will not reset the result to the loading status while executing if the requestId changes, instead, returning the existing result from before the change; otherwise, the result will be set to loading status.  If the status is loading when the changes are made, it will remain as loading; old pending effects are discarded on changes and as such this value has no effect in that case.|
+| `onResultChanged` | `undefined` | Callback that is invoked if the result for the given hook has changed. When defined, the hook will invoke this callback whenever it has reason to change the result and will not otherwise affect component rendering directly. When not defined, the hook will ensure the component re-renders to pick up the latest result. |
+| `scope` | `"useCachedEffect"` | Scope to use with the shared cache. When specified, the given scope will be used to isolate this hook's cached results. Otherwise, the default scope will be used. Changing this value after the first call is not supported. |

--- a/packages/wonder-blocks-data/src/__docs__/exports.use-gql.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.use-gql.stories.mdx
@@ -1,0 +1,73 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / useGql()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# useGql()
+
+```ts
+type FetchFn = <TData, TVariables: {...}>(
+    operation: GqlOperation<TData, TVariables>,
+    options?: GqlFetchOptions<TVariables, TContext>,
+) => Promise<TData>;
+
+function useGql<TContext: GqlContext>(
+    context: Partial<TContext> = ({}: $Shape<TContext>),
+): FetchFn;
+```
+
+The `useGql` hook requires that the calling component has been rendered with a [`GqlRouter`](/docs/data-exports-gqlrouter--page) as an ancestor component since it relies on the default context and fetch operation that is specified therein.
+
+The `useGql` hook can take a partial context value which will be combined with the default context to create the context used for a specific request.
+
+The return value of `useGql` is a fetch function that can be used to invoke a GraphQL request. It takes as arguments the [`GqlOperation`](/docs/data-types-gqloperation--page) operation to be performed and some options (which, by their nature, are optional). These options can be used to provide variables for the operation as well as additional customization of the context.
+
+The result of calling the function returned by `useGql` is a promise of the data that the request will return. This is compatible with the [`useServerEffect`](/docs/data-exports-useservereffect--page), [`useCachedEffect`](/docs/data-exports-usecachedeffect--page),  and [`useHydratableEffect`](/docs/data-exports-usehydratableeffect--page) hooks, allowing a variety of scenarios to be easily constructed.
+
+Below is an example request identifier generation function that could be used to generate request identifiers (we hope to include a base implementation for this purpose in a future release of Wonder Blocks Data):
+
+```ts
+const getGqlRequestId = <TData, TVariables: {...}>(
+    operation: GqlOperation<TData, TVariables>,
+    variables: ?TVariables,
+    context: GqlContext,
+): string => {
+    // We add all the bits for this into an array and then join them with
+    // a chosen separator.
+    const parts = [];
+    parts.push(operation.id);
+    if (context != null) {
+        // Turn the context into a string of the form,
+        //     "key1=;key2=value"
+        const sortedContext = Object.keys(context || {})
+            .sort()
+            .map((key) => `${key}=${JSON.stringify(context?.[key]) || ""}`)
+            .join(";");
+        parts.push(sortedContext);
+    }
+    if (variables != null) {
+        // Turn the variables into a string of the form,
+        //     "key1=;key2=value"
+        const sortedVariables = Object.keys(variables || {})
+            .sort()
+            .map((key) => `${key}=${JSON.stringify(variables?.[key]) || ""}`)
+            .join(";");
+        parts.push(sortedVariables);
+    }
+    return parts.join("|");
+};
+```
+
+## Context Merging
+
+Context overrides are combined such that any values that are explicitly or implicitly `undefined` on the partial context will be ignored. Any values that are explicitly `null` on the partial context will be removed from the merged context. The order of precedence is as follows:
+
+ 1. Values from the fetch partial context, then,
+ 2. Values from the `useGql` partial context, then,
+ 3. Values from the default context.

--- a/packages/wonder-blocks-data/src/__docs__/exports.use-hydratable-effect.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.use-hydratable-effect.stories.mdx
@@ -1,0 +1,43 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / useHydratableEffect()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# useHydratableEffect()
+
+```ts
+function useHydratableEffect<TData: ValidCacheData>(
+    requestId: string,
+    handler: () => Promise<TData>,
+    options?: HydratableEffectOptions<TData>,
+): Result<TData>;
+```
+
+This hook combines [`useServerEffect`](/docs/data-exports-useservereffect--page) and [`useCachedEffect`](/docs/data-exports-usecachedeffect--page) to form an effect that can execute on the server and hydrate on the client.
+
+More details about server-side rendering with Wonder Blocks Data can be found in the [relevant overview section](/docs/data-server-side-rendering-and-hydration--page).
+
+
+```ts
+type HydratableEffectOptions<TData: ValidCacheData> = {|
+    clientBehavior?: WhenClientSide,
+    skip?: boolean,
+    retainResultOnChange?: boolean,
+    onResultChanged?: (result: Result<TData>) => void,
+    scope?: string,
+|};
+```
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `clientBehavior` | [`WhenClientSide.ExecuteWhenNoSuccessResult`](/docs/data-exports-whenclientside--page#whenclientsideexecutewhennosuccessresult) | How the hook should behave when rendering client-side for the first time. This controls the hydration and execution of the effect on the client. Changing this value after the initial render is inert. For more information on other behaviors, see [`WhenClientSide`](/docs/data-exports-whenclientside--page). |
+| `skip` | `false` | When `true`, the effect will not be executed; otherwise, the effect will be executed.  If this is set to `true` while the effect is still pending, the pending effect will be cancelled. |
+| `retainResultOnChange` | `false` | When `true`, the effect will not reset the result to the loading status while executing if the requestId changes, instead, returning the existing result from before the change; otherwise, the result will be set to loading status.  If the status is loading when the changes are made, it will remain as loading; old pending effects are discarded on changes and as such this value has no effect in that case.|
+| `onResultChanged` | `undefined` | Callback that is invoked if the result for the given hook has changed. When defined, the hook will invoke this callback whenever it has reason to change the result and will not otherwise affect component rendering directly. When not defined, the hook will ensure the component re-renders to pick up the latest result. |
+| `scope` | `"useCachedEffect"` | Scope to use with the shared cache. When specified, the given scope will be used to isolate this hook's cached results. Otherwise, the default scope will be used. Changing this value after the first call is not supported. |

--- a/packages/wonder-blocks-data/src/__docs__/exports.use-server-effect.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.use-server-effect.stories.mdx
@@ -1,0 +1,38 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / useServerEffect()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# useServerEffect()
+
+```ts
+function useServerEffect<TData: ValidCacheData>(
+    requestId: string,
+    handler: () => Promise<TData>,
+    hydrate: boolean = true,
+): ?Result<TData>;
+```
+
+The `useServerEffect` hook is an integral part of server-side rendering. It has different behavior depending on whether it is running on the server (and in what context) or the client.
+
+## Server-side behavior
+
+First, this hook checks the server-side rendering cache for the request identifier; if it finds a cached value, it will return that.
+
+If there is no cached value, it will return a "loading" state. In addition, if the current rendering component has a [`TrackData`](/docs/data-exports-trackdata--page) ancestor, `useServerEffect` will register the request for fulfillment.
+
+This then allows that pending request to be fulfilled with [`fulfillAllDataRequests`](/docs/data-exports-fulfillalldatarequests--page), the response to be placed into the cache, and the render to be reexecuted, at which point, this hook will be able to provide that result instead of "loading.
+
+More details about server-side rendering with Wonder Blocks Data can be found in the [relevant overview section](/docs/data-server-side-rendering-and-hydration--page).
+
+## Client-side behavior
+
+On initial render in the client, this hook will look for a corresponding value in the Wonder Blocks Data hydration cache. If there is one, it will delete it from the hydration cache and return that value.
+
+Otherwise, it will return `null`.

--- a/packages/wonder-blocks-data/src/__docs__/exports.use-shared-cache.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.use-shared-cache.stories.mdx
@@ -1,0 +1,30 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / useSharedCache()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# useSharedCache()
+
+```ts
+function useSharedCache<TValue: ValidCacheData>(
+    id: string,
+    scope: string,
+    initialValue?: ?TValue | (() => ?TValue),
+): [?TValue, CacheValueFn<TValue>];
+```
+
+The `useSharedCache` hook provides access to a shared in-memory cache. This cache is not part of the cache hydrated by Wonder Blocks Data, so [`clearSharedCache`](/docs/data-exports-clearsharedcache--page) must be called between server-side render cycles.
+
+The hook returns a tuple of the currently cached value, or `null` if none is cached, and a function that can be used to set the cached value.
+
+The shared cache is passive and as such does not notify of changes to its contents.
+
+Each cached item is identified by an id and a scope. The scope is used to group items. Whole scopes can be cleared by specifying the specific scope when calling [`clearSharedCache`](/docs/data-exports-clearsharedcache--page).
+
+An optional argument, `initialValue` can be given. This can be either the value to be cached itself or a function that returns the value to be cached  (functions themselves are not valid cachable values). This allows for expensive initialization to only occur when it is necessary.

--- a/packages/wonder-blocks-data/src/__docs__/exports.when-client-side.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.when-client-side.stories.mdx
@@ -1,0 +1,33 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / WhenClientSide"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# WhenClientSide
+
+This enumeration is used with [`useHydratableEffect`](/docs/data-exports-usehydratableeffect--page). It defines how the hook should behave when rendering on the client.
+
+## WhenClientSide.DoNotHydrate
+
+The effect will not be hydrated and as such the effect will always be executed on initial render in the client. This is an advanced use-case that you should avoid unless you are certain of what you are doing.
+
+Without hydration support to ensure the data is available for hydration on the client, your server and client rendered pages may differ and the hydration will fail. This option is useful if something else is responsible for data capture and hydration of the action that gets executed. For example, if the action uses Apollo Client to perform the asynchronous action executed by this effect, then that may be also performing hydration responsibilities. However, be cautious; the code that calls `useHydratableEffect` will have to have access to that data on hydration as `useHydratableEffect` will return a "loading" state on initial render, which is not what you will want.
+
+## WhenClientSide.ExecuteWhenNoResult
+
+On initial render in the client, the effect is hydrated from the server-side rendered result. However, it is only executed if there was no server-side render result to hydrate (this can happen if the server-side rendered request was aborted, or if the component is rendering for the first time on the client and was never part of the server-side rendered content).
+
+## WhenClientSide.ExecuteWhenNoSuccessResult
+
+This behavior will hydrate the server-side result, but it will only execute the effect on the client if the hydrated result is not a success result.
+
+## WhenClientSide.AlwaysExecute
+
+When the effect is executed with this behavior, the server-side result will be hydrated and the effect will be executed on the initial client-side render, regardless of the hydrated result status.
+

--- a/packages/wonder-blocks-data/src/__docs__/types.error-options.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/types.error-options.stories.mdx
@@ -1,0 +1,21 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Types / ErrorOptions"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# ErrorOptions
+
+```ts
+type ErrorOptions = {|
+    metadata?: ?Metadata,
+    cause?: ?Error,
+|};
+```
+
+These options allow for the provision of a causal error instance as well as additional metadata that may be useful to the specific error being constructed (such as [`DataError`](/docs/data-exports-dataerror--page) or [`GqlError`](/docs/data-exports-gqlerror--page)).

--- a/packages/wonder-blocks-data/src/__docs__/types.valid-cache-data.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/types.valid-cache-data.stories.mdx
@@ -1,0 +1,23 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Types / ValidCacheData"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# ValidCacheData
+
+```ts
+type ValidCacheData =
+    | string
+    | boolean
+    | number
+    | {...}
+    | Array<?ValidCacheData>;
+```
+
+This type represents the data that is allowed into the various caches provided and used by Wonder Blocks Data.

--- a/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
@@ -58,10 +58,10 @@ type HydratableEffectOptions<TData: ValidCacheData> = {|
      *
      * This controls how the hook hydrates and executes when client-side.
      *
-     * Default is `OnClientRender.ExecuteWhenNoSuccessResult`.
+     * Default is `WhenClientSide.ExecuteWhenNoSuccessResult`.
      *
      * Changing this value after the first call is irrelevant as it only
-     * affects the initial rende behavior.
+     * affects the initial render behavior.
      */
     clientBehavior?: WhenClientSide,
 

--- a/packages/wonder-blocks-testing/src/__docs__/_overview_.stories.mdx
+++ b/packages/wonder-blocks-testing/src/__docs__/_overview_.stories.mdx
@@ -1,0 +1,19 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Testing / Overview"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# Wonder Blocks Testing
+
+Wonder Blocks Testing provides various utilities to support testing of React components and Wonder Blocks features.
+
+ * [Fixtures Framework](/docs/testing-fixtures-basic--f-1)
+ * Testing Wonder Blocks Data GraphQL
+   * [`mockGqlFetch`](/docs/testing-exports-mockgqlfetch--page)
+   * [`RespondWith`](/docs/testing-exports-respondwith--page)

--- a/packages/wonder-blocks-testing/src/__docs__/exports.mock-gql-fetch.stories.mdx
+++ b/packages/wonder-blocks-testing/src/__docs__/exports.mock-gql-fetch.stories.mdx
@@ -1,0 +1,59 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Testing / Exports / mockGqlFetch()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# mockGqlFetch()
+
+```ts
+mockGqlFetch(): GqlFetchMockFn;
+```
+
+The `mockGqlFetch` function provides an API to easily mock GraphQL responses for use with the [Wonder Blocks Data GraphQL API](/docs/data-graphql--page). It follows the similar patterns of `jest.fn()` and jest mocks whereby the returned value is both a proxy for the fetch function that is used by [`GqlRouter`](/docs/data-exports-gqlrouter--page) as well as an API for modifying the behavior of that function.
+
+# API
+
+Besides being a function that fits the [`GqlFetchFn`](/docs/data-types-gqlfetchfn--page) signature, the return value of `mockGqlFetch()` has an API to customize the behavior of that function. Used in conjunction with the [`RespondWith`](/docs/testing-exports-respondwith--page) API, this can create a variety of GraphQL responses for testing and stories.
+
+| Function | Purpose |
+| -------- | ------- |
+| `mockOperation` | When called, any GraphQL operation that matches the defined mock operation will respond with the given response. |
+| `mockOperationOnce` | When called, the first GraphQL operation that matches the defined mock operation will respond with the given response. The mock is only used by once. |
+
+Both of these functions have the same signature:
+
+```ts
+type GqlMockOperationFn = <TData, TVariables: {...}, TContext: GqlContext>(
+    matchOperation: GqlMockOperation<TData, TVariables, TContext>,
+    response: GqlMockResponse<TData>,
+) => GqlFetchMockFn;
+```
+
+# Operation Matching
+
+The `matchOperation` parameter given to a `mockOperation` or `mockOperationOnce` function is a `GqlMockOperation` defining the actual GraphQL operation to be matched by the mock. The variables and context of the mocked operation change how the mock is matched against requests.
+
+```ts
+ type GqlMockOperation<
+    TData,
+    TVariables: {...},
+    TContext: GqlContext,
+> = {|
+    operation: GqlOperation<TData, TVariables>,
+    variables?: TVariables,
+    context?: TContext,
+|};
+```
+
+1. When `matchOperation.operation` is present but `matchOperation.variables` and `matchOperation.context` are not, the mock will match any request for the
+same operation, regardless of variables or context on the request.
+2. When `matchOperation.variables` is present but `matchOperation.context` is not, the mock will match any request for the same operation with matching variables, regardless of context on the request.
+3. When `matchOperation.context` is present but `matchOperation.variables` is not, the mock will match any request for the same operation with matching context, regardless of variables on the request.
+4. When `matchOperation.variables` and `matchOperation.context` are present, the mock will match any request for the same operation with matching variables and context.
+

--- a/packages/wonder-blocks-testing/src/__docs__/exports.respond-with.stories.mdx
+++ b/packages/wonder-blocks-testing/src/__docs__/exports.respond-with.stories.mdx
@@ -1,0 +1,27 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Testing / Exports / RespondWith"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# RespondWith
+
+```ts
+interface RespondWith {
+    data: <TData>(data: TData) => GqlMockResponse<TData>;
+    unparseableBody: () => GqlMockResponse<any>;
+    abortedRequest: () => GqlMockResponse<any>;
+    errorStatusCode: (statusCode: number) => GqlMockResponse<any>,
+    nonGraphQLBody: () => GqlMockResponse<any>,
+    graphQLErrors: (
+        errorMessages: $ReadOnlyArray<string>,
+    ) => GqlMockResponse<any>,
+});
+```
+
+The `RespondWith` object is a helper for defining mock responses to use with the [`mockGqlFetch`](/docs/testing-exports-mockgqlfetch--page) API.


### PR DESCRIPTION
## Summary:
This adds remaining docs for Wonder Blocks Data and Testing.

The only bit left is to resurrect the live examples for some of our components, where we can, at least - though this isn't a high priority right now, so I think I'll raise a separate task for that for now.

- Also, export `ValidCacheData` type and remove `useRequestInterception` from exports

Issue: FEI-4191

## Test plan:
`yarn start:storybook` and have a little click around :)

https://user-images.githubusercontent.com/1266297/155818861-fcc93aa2-6063-4d3e-ba0c-4b00b6b0be2e.mov


