### PR TITLE
[fei4322.fix] Fix bug where changing requestId after hydrating result would actually update

### DIFF
--- a/.changeset/funny-deers-grab.md
+++ b/.changeset/funny-deers-grab.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+---
+
+[FIX] Make sure hydratable effect properly renders when requestId changes

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
@@ -413,6 +413,26 @@ describe("#useHydratableEffect", () => {
             expect(fakeHandler).toHaveBeenCalledTimes(2);
         });
 
+        it("should default shared cache to hydrate value for new requestId", async () => {
+            // Arrange
+            const fakeHandler = jest.fn().mockResolvedValue("data");
+            jest.spyOn(UseServerEffect, "useServerEffect")
+                .mockReturnValueOnce(Status.success("BADDATA"))
+                .mockReturnValue(null);
+
+            // Act
+            const {rerender, result} = clientRenderHook(
+                ({requestId}) => useHydratableEffect(requestId, fakeHandler),
+                {
+                    initialProps: {requestId: "ID"},
+                },
+            );
+            rerender({requestId: "ID2"});
+
+            // Assert
+            expect(result.current).toStrictEqual(Status.loading());
+        });
+
         it("should update shared cache with result when request is fulfilled", async () => {
             // Arrange
             const setCacheFn = jest.fn();

--- a/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
@@ -178,9 +178,16 @@ export const useHydratableEffect = <TData: ValidCacheData>(
                 }
                 return null;
         }
-        // There is no reason for this to change after the first render.
+        // There is no reason for this to change after the first render,
+        // you might thing, but the function closes around serverResult and if
+        // the requestId changes, it still returns the hydrate result of the
+        // first render of the previous requestId. This then means that the
+        // hydrate result is still the same, and the effect is not re-executed
+        // because the cache gets incorrectly defaulted.
+        // However, we don't want to bother doing anything with this on
+        // client behavior changing since that truly is irrelevant.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [serverResult]);
 
     // Instead of using state, which would be local to just this hook instance,
     // we use a shared in-memory cache.

--- a/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
@@ -179,7 +179,7 @@ export const useHydratableEffect = <TData: ValidCacheData>(
                 return null;
         }
         // There is no reason for this to change after the first render,
-        // you might thing, but the function closes around serverResult and if
+        // you might think, but the function closes around serverResult and if
         // the requestId changes, it still returns the hydrate result of the
         // first render of the previous requestId. This then means that the
         // hydrate result is still the same, and the effect is not re-executed


### PR DESCRIPTION
## Summary:
In investigating an SSR issue I saw, I found this client-side bug. It doesn't explain why the SSR was not working in the case I saw, but it is definitely a bug. I've added a test case to cover this issue which failed before I implemented the fix.

Issue: FEI-4322

## Test plan:
`yarn test`

Tried this out in dev server for webapp to verify it fixed the client-side bug I saw. Interestingly, SSR and hydration is working in dev which makes me think the SSR issue I saw in staging was down to something else entirely.