### PR TITLE
[🔥AUDIT🔥] Rename references to `master` to `main`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
-        autoAcceptChanges: "master"
+        autoAcceptChanges: "main"
     # (else) Run this step on dependabot PRs.
     - name: Skip Chromatic builds
       if: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/node-ci-push.yml
+++ b/.github/workflows/node-ci-push.yml
@@ -1,9 +1,9 @@
-name: Node CI (landed on master)
+name: Node CI (landed on main)
 
 on:
   push:
     branches:
-    - master
+    - main
     - changeset-release/*
     - feature/*
 
@@ -141,7 +141,7 @@ jobs:
         autoAcceptChanges: true
 
   # NOTE: This step is copied from render-gateway. See
-  # https://github.com/Khan/render-gateway/blob/master/.github/workflows/node-ci.yml
+  # https://github.com/Khan/render-gateway/blob/main/.github/workflows/node-ci.yml
   publish_to_branch:
     needs: [prime_cache_primary]
     name: Publish to branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 # This workflow will run changesets depending on two different scenarios:
 #
-# 1. If we are landing a specific commit into master (Author PR), then
+# 1. If we are landing a specific commit into main (Author PR), then
 #    changesets will check if there are changes verifying the Markdown files
 #    generated automatically:
 #
@@ -21,7 +21,7 @@ on:
 #    package.json for each package, and will remove the MD files as part of the
 #    Release PR).
 #
-# 2. If we are landing the Release PR into master, then the changesets action
+# 2. If we are landing the Release PR into main, then the changesets action
 #    will publish the changes to npm.
 #
 # For more info about this workflow, see:

--- a/.storybook/components/component-info.js
+++ b/.storybook/components/component-info.js
@@ -40,7 +40,7 @@ const ComponentInfo = ({name, version}: Props): React.Node => {
             </Caption>
             <Button
                 kind="secondary"
-                href={`https://github.com/Khan/wonder-blocks/tree/master/packages/${packageFolder}`}
+                href={`https://github.com/Khan/wonder-blocks/tree/main/packages/${packageFolder}`}
                 target="_blank"
                 style={{color: "black"}}
                 icon={githubIconAsset}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img width="32" src="./static/logo.svg"> Wonder Blocks
 
-[![CircleCI](https://circleci.com/gh/Khan/wonder-blocks.svg?style=svg)](https://circleci.com/gh/Khan/wonder-blocks) [![codecov](https://codecov.io/gh/Khan/wonder-blocks/branch/master/graph/badge.svg)](https://codecov.io/gh/Khan/wonder-blocks)
+[![CircleCI](https://circleci.com/gh/Khan/wonder-blocks.svg?style=svg)](https://circleci.com/gh/Khan/wonder-blocks) [![codecov](https://codecov.io/gh/Khan/wonder-blocks/branch/main/graph/badge.svg)](https://codecov.io/gh/Khan/wonder-blocks)
 
 The Khan Academy Wonder Blocks design system. This is work-in-progress and a lot
 of things are still in motion.

--- a/packages/wonder-blocks-core/src/util/add-style.md
+++ b/packages/wonder-blocks-core/src/util/add-style.md
@@ -45,7 +45,7 @@ StyleSheet as well inline style objects (see example 4).
 
 #### CSSProperties
 
-[See source file](https://github.com/Khan/wonder-blocks/blob/master/flow-typed/aphrodite.flow.js#L13)
+[See source file](https://github.com/Khan/wonder-blocks/blob/main/flow-typed/aphrodite.flow.js#L13)
 
 
 ### Examples

--- a/packages/wonder-blocks-data/legacy-docs.md
+++ b/packages/wonder-blocks-data/legacy-docs.md
@@ -1,3 +1,3 @@
 Documentation for Wonder Blocks Data is now in Storybook.
 
-Either run `yarn start:storybook` locally, or visit the the stories for the `master` branch on [Chromatic](https://master--5e1bf4b385e3fb0020b7073c.chromatic.com).
+Either run `yarn start:storybook` locally, or visit the the stories for the `main` branch on [Chromatic](https://main--5e1bf4b385e3fb0020b7073c.chromatic.com).


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Just renamed any reference to Wonder Blocks `master` branch to be `main`.

Issue: FEI-4353

## Test plan:
We'll set this to the default branch and update codecov.io, and any other remaining PRs to be based off `main` as needed then see if things just work :)