### PR TITLE
Always show error alert for LabeledTextField.

### DIFF
--- a/.changeset/eighty-ducks-grow.md
+++ b/.changeset/eighty-ducks-grow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Always show error alert for LabeledTextField.

--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
@@ -41,6 +41,24 @@ describe("FieldHeading", () => {
         expect(wrapper).toIncludeText(description);
     });
 
+    it("fieldheading renders the error wrapper always", () => {
+        // Arrange
+        const testId = "testid";
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                testId={testId}
+            />,
+        );
+
+        // Assert
+        const error = wrapper.find(`[data-test-id="${testId}-error"]`);
+        expect(error).toExist();
+    });
+
     it("fieldheading renders the error text", () => {
         // Arrange
         const error = "Error";

--- a/packages/wonder-blocks-form/src/components/field-heading.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.js
@@ -121,14 +121,15 @@ export default class FieldHeading extends React.Component<Props> {
     maybeRenderError(): ?React.Node {
         const {error, id, testId} = this.props;
 
-        if (!error) {
-            return null;
-        }
-
+        // NOTE(jeresig, FEI-3472): We need to always display the error
+        // element, even if there is no error. This is because the error
+        // uses an ARIA alert role, which requires that the element be
+        // in the DOM before the text is inserted. Doing otherwise will
+        // mean that the alert will not be read.
         return (
             <React.Fragment>
-                <Strut size={Spacing.small_12} />
-                {typeof error === "string" ? (
+                {error && <Strut size={Spacing.small_12} />}
+                {typeof error === "string" || !error ? (
                     <LabelSmall
                         style={styles.error}
                         role="alert"


### PR DESCRIPTION
## Summary:
In order for Aria alerts to be readable by a screenreader they must exist in a page before the text is inserted into them. So we can fix this by making sure that the alert wrapper exists in the page for all text field components.

See: https://pauljadam.com/demos/aria-alert-assertive-validation.html

Issue: FEI-3472

## Test plan:
Using a screen reader (Voiceover in Safari) I visited:
https://wonder-blocks.netlify.app/#labeledtextfield

And navigated to a field with an error. I confirmed that entering and exiting the field the error text was read as an alert.