### PR TITLE
[🔥AUDIT🔥] Add turbosnap to only run affected stories on Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -53,6 +53,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
         autoAcceptChanges: "main"
+        # Generate snapshots for only changed stories
+        # See: https://www.chromatic.com/docs/turbosnap
+        onlyChanged: true
     # (else) Run this step on dependabot PRs.
     - name: Skip Chromatic builds
       if: ${{ github.actor == 'dependabot[bot]' }}


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Adding `turbosnap` to optimize visual testing with Chromatic. Adding this change
means that Chromatic will only generate visual snapshots for the stories that
are really affected (instead of generating snapshots for ALL stories).

See https://www.chromatic.com/docs/turbosnap#configure

Issue: XXX-XXXX

## Test plan:

Verify the chromatic action and see if the Chromatic build changes.

For reference: https://www.chromatic.com/docs/turbosnap#how-can-i-tell-if-turbosnap-is-working