### PR TITLE
[🔥AUDIT🔥] Add GitHub pages action to publish storybook in gh-pages branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,18 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Build Storybook
+        # Generate a static version of storybook inside "build/"
+        run: yarn build-storybook
+
+      - name: Deploy to GitHub pages
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        with:
+          # The branch the action should deploy to.
+          branch: gh-pages
+          # The folder the action should deploy.
+          folder: build
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: yarn
 
       - name: Build Storybook
-        # Generate a static version of storybook inside "build/"
+        # Generate a static version of storybook inside "storybook-static/"
         run: yarn build-storybook
 
       - name: Deploy to GitHub pages
@@ -57,7 +57,7 @@ jobs:
           # The branch the action should deploy to.
           branch: gh-pages
           # The folder the action should deploy.
-          folder: build
+          folder: storybook-static
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Adds a new step as part of the Release job to build the Storybook static version
and push those generated files to the `gh-pages` branch.

Issue: XXX-XXXX

## Test plan:

Verify that https://khan.github.io/wonder-blocks works a couple of minutes after
landing this PR.