### PR TITLE
[🔥AUDIT🔥] Storybook: Use relative paths on images

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,4 +1,4 @@
-<link rel="preload" href="/lato.css" />
+<link rel="preload" href="./lato.css" />
 <link
     rel="preload"
     href="https://fonts.googleapis.com/css?family=Inconsolata"

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="/lato.css" />
+<link rel="stylesheet" href="./lato.css" />
 <link
     rel="stylesheet"
     href="https://fonts.googleapis.com/css?family=Inconsolata"

--- a/.storybook/wonder-blocks-theme.js
+++ b/.storybook/wonder-blocks-theme.js
@@ -8,7 +8,7 @@ export default create({
     base: "light",
     brandTitle: "Wonder Blocks",
     brandUrl: "/",
-    brandImage: "/logo.svg",
+    brandImage: "./logo.svg",
 
     // Typography
     fontBase: '"Lato", sans-serif',

--- a/packages/wonder-blocks-cell/src/components/__docs__/compact-cell.argtypes.js
+++ b/packages/wonder-blocks-cell/src/components/__docs__/compact-cell.argtypes.js
@@ -27,7 +27,7 @@ export const AccessoryMappings = {
         </View>
     ): React.Element<typeof View>),
     withImage: ((
-        <img src="/avatar.png" alt="ItemAvatar" width={48} height={48} />
+        <img src="./avatar.png" alt="ItemAvatar" width={48} height={48} />
     ): React$Element<"img">),
 };
 

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.stories.js
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.stories.js
@@ -81,7 +81,7 @@ export const Simple: StoryComponentType = () => {
 
 const styles = StyleSheet.create({
     above: {
-        background: "url(/modal-above.png)",
+        background: "url(./modal-above.png)",
         width: 874,
         height: 551,
         position: "absolute",
@@ -90,7 +90,7 @@ const styles = StyleSheet.create({
     },
 
     below: {
-        background: "url(/modal-below.png)",
+        background: "url(./modal-below.png)",
         width: 868,
         height: 521,
         position: "absolute",


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Fixed all the absolute paths in Storybook. This prevented us from displaying
some images and loading correctly the Lato font in the Storybook static version.

Issue: XXX-XXXX

## Test plan:

1. Run `yarn build-storybook`
2. Verify that the WB logo is displayed on the top left.