### PR TITLE
Add cell components to our clickable consistency test suite

### DIFF
--- a/consistency-tests/__tests__/clickables.test.js
+++ b/consistency-tests/__tests__/clickables.test.js
@@ -16,6 +16,7 @@ import Clickable from "@khanacademy/wonder-blocks-clickable";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 import Link from "@khanacademy/wonder-blocks-link";
+import {CompactCell, DetailCell} from "@khanacademy/wonder-blocks-cell";
 
 // We create a wrapper around Clickable since it expects a render function for
 // is children while all of the other components do not.
@@ -33,6 +34,8 @@ describe.each`
     ${ActionItem}        | ${"ActionItem"}
     ${Button}            | ${"Button"}
     ${ClickableWrapper}  | ${"Clickable"}
+    ${CompactCell}       | ${"CompactCell"}
+    ${DetailCell}        | ${"DetailCell"}
     ${IconButtonWrapper} | ${"IconButton"}
     ${Link}              | ${"Link"}
 `("$name with an href", ({Component, name}) => {
@@ -114,6 +117,8 @@ describe.each`
     ${ActionItem}        | ${"ActionItem"}
     ${Button}            | ${"Button"}
     ${ClickableWrapper}  | ${"Clickable"}
+    ${CompactCell}       | ${"CompactCell"}
+    ${DetailCell}        | ${"DetailCell"}
     ${IconButtonWrapper} | ${"IconButton"}
 `("$name without an href", ({Component, name}) => {
     beforeEach(() => {

--- a/packages/wonder-blocks-button/src/components/button.js
+++ b/packages/wonder-blocks-button/src/components/button.js
@@ -90,6 +90,8 @@ export type SharedProps = {|
     /**
      * A target destination window for a link to open in. Should only be used
      * when `href` is specified.
+     *
+     * TODO(WB-1262): only allow this prop when `href` is also set.t
      */
     target?: "_blank",
 

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.js
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.js
@@ -130,6 +130,7 @@ const CellCore = (props: CellCoreProps): React.Node => {
         testId,
         "aria-label": ariaLabel,
         innerStyle,
+        target,
     } = props;
 
     const renderCell = (eventState?: ClickableState): React.Node => {
@@ -200,6 +201,7 @@ const CellCore = (props: CellCoreProps): React.Node => {
                 href={href}
                 hideDefaultFocusRing={true}
                 aria-label={ariaLabel ? ariaLabel : undefined}
+                target={target}
             >
                 {(eventState) => renderCell(eventState)}
             </Clickable>

--- a/packages/wonder-blocks-cell/src/util/types.js
+++ b/packages/wonder-blocks-cell/src/util/types.js
@@ -136,6 +136,8 @@ export type CellProps = {|
     /**
      * A target destination window for a link to open in. Should only be used
      * when `href` is specified.
+     *
+     * TODO(WB-1262): only allow this prop when `href` is also set.t
      */
     target?: "_blank",
 |};

--- a/packages/wonder-blocks-cell/src/util/types.js
+++ b/packages/wonder-blocks-cell/src/util/types.js
@@ -132,4 +132,10 @@ export type CellProps = {|
      * by default if react-router is present.
      */
     href?: string,
+
+    /**
+     * A target destination window for a link to open in. Should only be used
+     * when `href` is specified.
+     */
+    target?: "_blank",
 |};

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
@@ -166,6 +166,7 @@ type Props =
            * A target destination window for a link to open in. Should only be used
            * when `href` is specified.
            */
+          // TODO(WB-1262): only allow this prop when `href` is also set.
           target?: "_blank",
       |}
     | {|

--- a/packages/wonder-blocks-clickable/src/components/clickable.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.js
@@ -111,6 +111,8 @@ type Props =
 
           /**
            * A target destination window for a link to open in.
+           *
+           * TODO(WB-1262): only allow this prop when `href` is also set.t
            */
           target?: "_blank",
       |}
@@ -143,6 +145,8 @@ type Props =
 
           /**
            * A target destination window for a link to open in.
+           *
+           * TODO(WB-1262): only allow this prop when `href` is also set.t
            */
           target?: "_blank",
       |}

--- a/packages/wonder-blocks-dropdown/src/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.js
@@ -46,6 +46,8 @@ type ActionProps = {|
 
     /**
      * A target destination window for a link to open in.
+     *
+     * TODO(WB-1262): only allow this prop when `href` is also set.t
      */
     target?: "_blank",
 

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.js
@@ -81,6 +81,8 @@ export type SharedProps = {|
 
     /**
      * A target destination window for a link to open in.
+     *
+     * TODO(WB-1262): only allow this prop when `href` is also set.t
      */
     target?: "_blank",
 

--- a/packages/wonder-blocks-link/src/components/link.js
+++ b/packages/wonder-blocks-link/src/components/link.js
@@ -134,6 +134,8 @@ export type SharedProps =
           /**
            * A target destination window for a link to open in.  We only support
            * "_blank" which opens the URL in a new tab.
+           *
+           * TODO(WB-1262): only allow this prop when `href` is also set.t
            */
           target?: "_blank",
       |}


### PR DESCRIPTION
## Summary:
The consistency tests found that the 'target' prop was missing.  We may also want to expand this test suite to also include 'tabIndex' in the future since that's another common prop that people may want to use on clickables.  I'll leave that for another day.

Issue: None

## Test plan:
- yarn jest clickables.test.js