### PR TITLE
WB-1258.0: Migrate Dropdown tests to RTL

### DIFF
--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core-virtualized.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core-virtualized.test.js
@@ -1,39 +1,20 @@
 //@flow
 import * as React from "react";
-import {VariableSizeList as List} from "react-window";
-import {mount} from "enzyme";
-import "jest-enzyme";
+import {render, screen} from "@testing-library/react";
 
 import OptionItem from "../option-item.js";
 import SeparatorItem from "../separator-item.js";
 import DropdownCoreVirtualized from "../dropdown-core-virtualized.js";
 import SearchTextInput from "../search-text-input.js";
 
-import {unmountAll} from "../../../../../utils/testing/enzyme-shim.js";
-
 describe("DropdownCoreVirtualized", () => {
     beforeEach(() => {
         jest.useFakeTimers();
-
-        // Jest doesn't fake out the animation frame API, so we're going to do
-        // it here and map it to timeouts, that way we can use the fake timer
-        // API to test our animation frame things.
-        jest.spyOn(global, "requestAnimationFrame").mockImplementation((fn) =>
-            setTimeout(fn, 0),
-        );
-        jest.spyOn(global, "cancelAnimationFrame").mockImplementation((id) =>
-            clearTimeout(id),
-        );
     });
 
     afterEach(() => {
-        // We have to explicitly unmount before clearing mocks, otherwise jest
-        // timers will throw because we'll try to clear an animation frame that
-        // we set with a setTimeout but are clearing with clearAnimationFrame
-        // because we restored the clearAnimationFrame mock (and we won't
-        // have cleared the timeout we actually set!)
-        unmountAll();
-        jest.restoreAllMocks();
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
     });
 
     it("should sort the items on first load", () => {
@@ -64,20 +45,16 @@ describe("DropdownCoreVirtualized", () => {
             },
         ];
 
-        const wrapper = mount(
+        // Act
+        const {container} = render(
             <DropdownCoreVirtualized
                 data={[...initialItems, ...optionItems]}
             />,
         );
 
-        jest.runAllTimers();
-
-        // Act
-        const firstLabel = wrapper.find(OptionItem).first().text();
-
         // Assert
         // make sure we are rendering the longest item first
-        expect(firstLabel).toEqual("ccc");
+        expect(container).toHaveTextContent(/ccc.*bb.*a/i);
     });
 
     it("should render a virtualized list", () => {
@@ -87,7 +64,7 @@ describe("DropdownCoreVirtualized", () => {
                 <OptionItem
                     key={i}
                     value={(i + 1).toString()}
-                    label={`School ${i + 1} in Wizarding World`}
+                    label={`School ${i + 1}`}
                 />
             ),
             focusable: true,
@@ -114,15 +91,23 @@ describe("DropdownCoreVirtualized", () => {
             },
         ];
 
-        const wrapper = mount(
+        const {rerender} = render(
             <DropdownCoreVirtualized data={initialItems} width={300} />,
         );
 
         // Act
         // append items to update container height
-        wrapper.setProps({data: [...initialItems, ...optionItems]});
+        rerender(
+            <DropdownCoreVirtualized
+                data={[...initialItems, ...optionItems]}
+                width={300}
+            />,
+        );
+
+        const option = screen.getAllByRole("option")[0];
 
         // Assert
-        expect(wrapper.find(List)).toExist();
+        // `left` is only injected by the virtualized list
+        expect(option).toHaveStyle("left: 0px");
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core-virtualized.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core-virtualized.test.js
@@ -52,8 +52,8 @@ describe("DropdownCoreVirtualized", () => {
             />,
         );
 
-        // Assert
-        // make sure we are rendering the longest item first
+        // Assert make sure we are rendering from the longest item to the
+        // shortest item.
         expect(container).toHaveTextContent(/ccc.*bb.*a/i);
     });
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -579,5 +579,33 @@ describe("SingleSelect", () => {
             // Assert
             expect(searchInput.textContent).toEqual("");
         });
+
+        it("should move focus to the dismiss button after pressing {tab} on the text input", () => {
+            // Arrange
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    isFilterable={true}
+                    placeholder="Choose"
+                    selectedValue="2"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+            // open the dropdown menu
+            userEvent.click(screen.getByRole("button"));
+
+            const searchInput = screen.getByPlaceholderText("Filter");
+            userEvent.paste(searchInput, "some text");
+
+            // Act
+            userEvent.tab();
+
+            // Assert
+            const dismissBtn = screen.getByLabelText("Clear search");
+            expect(dismissBtn).toHaveFocus();
+        });
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -24,10 +24,8 @@ describe("SingleSelect", () => {
         window.scrollTo.mockClear();
         onChange.mockReset();
         jest.spyOn(console, "error").mockReset();
-    });
-
-    afterEach(() => {
-        window.scrollTo.mockClear();
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
     });
 
     describe("uncontrolled", () => {
@@ -186,43 +184,33 @@ describe("SingleSelect", () => {
             onToggle?: (opened: boolean) => mixed,
         |};
 
-        type State = {|
-            opened?: boolean,
-        |};
+        function ControlledComponent(props: Props) {
+            const [opened, setOpened] = React.useState(props.opened);
 
-        class ControlledComponent extends React.Component<Props, State> {
-            state: State = {
-                opened: this.props.opened,
+            const handleToggleMenu = (opened) => {
+                setOpened(opened);
+
+                props.onToggle && props.onToggle(opened);
             };
 
-            handleToggleMenu = (opened) => {
-                this.setState({
-                    opened: opened,
-                });
-
-                this.props.onToggle && this.props.onToggle(opened);
-            };
-
-            render(): React.Node {
-                return (
-                    <React.Fragment>
-                        <SingleSelect
-                            opened={this.state.opened}
-                            onToggle={this.handleToggleMenu}
-                            onChange={onChange}
-                            placeholder="Choose"
-                        >
-                            <OptionItem label="item 1" value="1" />
-                            <OptionItem label="item 2" value="2" />
-                            <OptionItem label="item 3" value="3" />
-                        </SingleSelect>
-                        <button
-                            data-test-id="parent-button"
-                            onClick={() => this.handleToggleMenu(true)}
-                        />
-                    </React.Fragment>
-                );
-            }
+            return (
+                <React.Fragment>
+                    <SingleSelect
+                        opened={opened}
+                        onToggle={handleToggleMenu}
+                        onChange={onChange}
+                        placeholder="Choose"
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                        <OptionItem label="item 3" value="3" />
+                    </SingleSelect>
+                    <button
+                        data-test-id="parent-button"
+                        onClick={() => handleToggleMenu(true)}
+                    />
+                </React.Fragment>
+            );
         }
 
         it("opens the menu when the parent updates its state", () => {


### PR DESCRIPTION
## Summary:

Pre-work to migrate most of the existing enzyme test in `wb-dropdown` to RTL.

This is done so we can modify the `react-window` logic in the next PR and we can
see what tests need to be updated using RTL as source of truth.

Issue: WB-1258

## Test plan:
```
yarn test
```