### PR TITLE
WB-1258: Use react-window only for long lists

### DIFF
--- a/.changeset/bright-ears-watch.md
+++ b/.changeset/bright-ears-watch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Use `react-window` conditionally (80+ items)

--- a/packages/wonder-blocks-dropdown/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -2475,7 +2475,7 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
     }
   >
     <button
-      aria-expanded="true"
+      aria-expanded="false"
       aria-haspopup="listbox"
       className=""
       disabled={false}

--- a/packages/wonder-blocks-dropdown/src/__tests__/generated-snapshot.test.js
+++ b/packages/wonder-blocks-dropdown/src/__tests__/generated-snapshot.test.js
@@ -880,7 +880,7 @@ describe("wonder-blocks-dropdown", () => {
             constructor() {
                 super();
                 this.state = {
-                    opened: true,
+                    opened: false,
                     selectedValue: null,
                 };
                 this.handleChange = this.handleChange.bind(this);

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
@@ -13,15 +13,6 @@ describe("ActionMenu", () => {
     const onToggle = jest.fn();
     const onChange = jest.fn();
 
-    beforeEach(() => {
-        jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-        jest.runOnlyPendingTimers();
-        jest.useRealTimers();
-    });
-
     it("opens the menu on mouse click", () => {
         // Arrange
         render(

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
@@ -1,15 +1,12 @@
 //@flow
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
-
-import userEvent from "../../../../../utils/testing/user-event.js";
+import userEvent from "@testing-library/user-event";
 
 import ActionItem from "../action-item.js";
 import OptionItem from "../option-item.js";
 import SeparatorItem from "../separator-item.js";
 import ActionMenu from "../action-menu.js";
-
-jest.mock("../dropdown-core-virtualized.js");
 
 describe("ActionMenu", () => {
     const onClick = jest.fn();

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -1,13 +1,11 @@
 // @flow
 import * as React from "react";
-import {fireEvent, render, screen, waitFor} from "@testing-library/react";
-import userEvent from "../../../../../utils/testing/user-event.js";
+import {fireEvent, render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import OptionItem from "../option-item.js";
 import SearchTextInput from "../search-text-input.js";
 import DropdownCore from "../dropdown-core.js";
-
-jest.mock("../dropdown-core-virtualized.js");
 
 const items = [
     {
@@ -43,7 +41,7 @@ describe("DropdownCore", () => {
         jest.useRealTimers();
     });
 
-    it("focus on the correct option", async () => {
+    it("focus on the correct option", () => {
         // Arrange
         render(
             <DropdownCore
@@ -60,16 +58,13 @@ describe("DropdownCore", () => {
         );
 
         // Act
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
+        const item = screen.getByTestId("item-0");
 
         // Assert
-        waitFor(() => {
-            expect(screen.getByTestId("item-0")).toHaveFocus();
-        });
+        expect(item).toHaveFocus();
     });
 
-    it("handles basic keyboard navigation as expected", async () => {
+    it("handles basic keyboard navigation as expected", () => {
         // Arrange
         const dummyOpener = <button />;
         const openChanged = jest.fn();
@@ -88,13 +83,6 @@ describe("DropdownCore", () => {
             />,
         );
 
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
-        // RTL's focuses on `document.body` by default, so we need to focus on
-        // the dropdown menu
-        userEvent.tab();
-
         // Act
         // navigate down two times
         userEvent.keyboard("{arrowdown}"); // 0 -> 1
@@ -104,7 +92,7 @@ describe("DropdownCore", () => {
         expect(screen.queryByTestId("item-2")).toHaveFocus();
     });
 
-    it("keyboard works backwards as expected", async () => {
+    it("keyboard works backwards as expected", () => {
         // Arrange
         render(
             <DropdownCore
@@ -120,13 +108,6 @@ describe("DropdownCore", () => {
             />,
         );
 
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
-        // RTL's focuses on `document.body` by default, so we need to focus on
-        // the dropdown menu
-        userEvent.tab();
-
         // Act
         // navigate down tree times
         userEvent.keyboard("{arrowdown}"); // 0 -> 1
@@ -141,7 +122,7 @@ describe("DropdownCore", () => {
         expect(screen.getByTestId("item-1")).toHaveFocus();
     });
 
-    it("closes on tab as expected", async () => {
+    it("closes on tab as expected", () => {
         // Arrange
         const handleOpenChangedMock = jest.fn();
 
@@ -158,13 +139,6 @@ describe("DropdownCore", () => {
                 onOpenChanged={handleOpenChangedMock}
             />,
         );
-
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
-        // RTL's focuses on `document.body` by default, so we need to focus on
-        // the dropdown menu
-        userEvent.tab();
 
         // Act
         // close the dropdown by tabbing out
@@ -174,7 +148,7 @@ describe("DropdownCore", () => {
         expect(handleOpenChangedMock).toHaveBeenNthCalledWith(1, false);
     });
 
-    it("closes on escape as expected", async () => {
+    it("closes on escape as expected", () => {
         // Arrange
         const handleOpenChangedMock = jest.fn();
 
@@ -192,13 +166,6 @@ describe("DropdownCore", () => {
             />,
         );
 
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
-        // RTL's focuses on `document.body` by default, so we need to focus on
-        // the dropdown menu
-        userEvent.tab();
-
         // Act
         // close the dropdown by pressing "Escape"
         userEvent.keyboard("{escape}");
@@ -207,7 +174,7 @@ describe("DropdownCore", () => {
         expect(handleOpenChangedMock).toHaveBeenNthCalledWith(1, false);
     });
 
-    it("closes on external mouse click", async () => {
+    it("closes on external mouse click", () => {
         // Arrange
         const handleOpenChangedMock = jest.fn();
 
@@ -227,11 +194,6 @@ describe("DropdownCore", () => {
                 />
             </div>,
         );
-
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-        userEvent.tab();
-        userEvent.keyboard("arrowdown");
 
         // Act
         // close the dropdown by clicking outside the dropdown
@@ -267,7 +229,7 @@ describe("DropdownCore", () => {
         expect(handleOpenChangedMock).toHaveBeenCalledTimes(0);
     });
 
-    it("opens on down key as expected", async () => {
+    it("opens on down key as expected", () => {
         // Arrange
         const handleOpenChangedMock = jest.fn();
         const opener = <button data-test-id="opener" />;
@@ -286,7 +248,7 @@ describe("DropdownCore", () => {
             />,
         );
 
-        const openerElement = await screen.findByTestId("opener");
+        const openerElement = screen.getByTestId("opener");
         openerElement.focus();
 
         // Act
@@ -296,7 +258,7 @@ describe("DropdownCore", () => {
         expect(handleOpenChangedMock).toHaveBeenNthCalledWith(1, true);
     });
 
-    it("selects correct item when starting off at an undefined index", async () => {
+    it("selects correct item when starting off at an undefined index", () => {
         // Arrange
         render(
             <DropdownCore
@@ -312,17 +274,11 @@ describe("DropdownCore", () => {
             />,
         );
 
-        // Act
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
         // Assert
-        waitFor(() => {
-            expect(screen.queryByTestId("item-0")).toHaveFocus();
-        });
+        expect(screen.queryByTestId("item-0")).toHaveFocus();
     });
 
-    it("selects correct item when starting off at an undefined index and a searchbox", async () => {
+    it("selects correct item when starting off at an undefined index and a searchbox", () => {
         // Arrange
         render(
             <DropdownCore
@@ -353,16 +309,13 @@ describe("DropdownCore", () => {
         );
 
         // Act
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
+        const firstItem = screen.queryByTestId("item-0");
 
         // Assert
-        waitFor(() => {
-            expect(screen.queryByTestId("item-0")).toHaveFocus();
-        });
+        expect(firstItem).toHaveFocus();
     });
 
-    it("selects correct item when starting off at a different index and a searchbox", async () => {
+    it("selects correct item when starting off at a different index and a searchbox", () => {
         // Arrange
         render(
             <DropdownCore
@@ -391,7 +344,7 @@ describe("DropdownCore", () => {
                                 key="1"
                             />
                         ),
-                        focusable: false,
+                        focusable: true,
                         populatedProps: {},
                     },
                     {
@@ -417,16 +370,13 @@ describe("DropdownCore", () => {
         );
 
         // Act
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
+        const firstItem = screen.queryByTestId("item-0");
 
         // Assert
-        waitFor(() => {
-            expect(screen.queryByTestId("item-1")).toHaveFocus();
-        });
+        expect(firstItem).toHaveFocus();
     });
 
-    it("selects correct item when starting off at a different index", async () => {
+    it("selects correct item when starting off at a different index", () => {
         // Arrange
         render(
             <DropdownCore
@@ -441,13 +391,6 @@ describe("DropdownCore", () => {
                 onOpenChanged={jest.fn()}
             />,
         );
-
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
-        // RTL's focuses on `document.body` by default, so we need to focus on
-        // the dropdown menu
-        userEvent.tab();
 
         // Act
         // navigate down
@@ -457,7 +400,7 @@ describe("DropdownCore", () => {
         expect(screen.getByTestId("item-0")).toHaveFocus();
     });
 
-    it("focuses correct item with clicking/pressing with initial focused of not 0", async () => {
+    it("focuses correct item with clicking/pressing with initial focused of not 0", () => {
         // Arrange
         render(
             <DropdownCore
@@ -472,13 +415,6 @@ describe("DropdownCore", () => {
                 onOpenChanged={jest.fn()}
             />,
         );
-
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
-        // RTL's focuses on `document.body` by default, so we need to focus on
-        // the dropdown menu
-        userEvent.tab();
 
         // Act
         userEvent.click(screen.getByTestId("item-1"));
@@ -489,7 +425,7 @@ describe("DropdownCore", () => {
         expect(screen.getByTestId("item-2")).toHaveFocus();
     });
 
-    it("focuses correct item with a disabled item", async () => {
+    it("focuses correct item with a disabled item", () => {
         // Arrange
         render(
             <DropdownCore
@@ -515,6 +451,7 @@ describe("DropdownCore", () => {
                                 label="item 1"
                                 value="1"
                                 key="1"
+                                disabled={true}
                             />
                         ),
                         focusable: false,
@@ -536,18 +473,11 @@ describe("DropdownCore", () => {
                 role="listbox"
                 open={true}
                 // mock the opener elements
-                opener={<button />}
+                opener={<button data-test-id="opener" />}
                 openerElement={null}
                 onOpenChanged={jest.fn()}
             />,
         );
-
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
-        // RTL's focuses on `document.body` by default, so we need to focus on
-        // the dropdown menu
-        userEvent.tab();
 
         // Act
         // navigate down
@@ -557,7 +487,7 @@ describe("DropdownCore", () => {
         expect(screen.getByTestId("item-2")).toHaveFocus();
     });
 
-    it("calls correct onclick for an option item", async () => {
+    it("calls correct onclick for an option item", () => {
         // Arrange
         const onClick1 = jest.fn();
         render(
@@ -612,9 +542,6 @@ describe("DropdownCore", () => {
             />,
         );
 
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
         // Act
         userEvent.click(screen.getByTestId("item-1"));
 
@@ -659,7 +586,7 @@ describe("DropdownCore", () => {
         ).toBeInTheDocument();
     });
 
-    it("SearchTextInput should be focused when opened", async () => {
+    it("SearchTextInput should be focused when opened", () => {
         // Arrange
         const handleSearchTextChanged = jest.fn();
         const handleOpen = jest.fn();
@@ -693,16 +620,11 @@ describe("DropdownCore", () => {
             />,
         );
 
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
         // Assert
-        waitFor(() => {
-            expect(screen.getByPlaceholderText("Filter")).toHaveFocus();
-        });
+        expect(screen.getByPlaceholderText("Filter")).toHaveFocus();
     });
 
-    it("When SearchTextInput has input and focused, tab key should not close the select", async () => {
+    it("When SearchTextInput has input and focused, tab key should not close the select", () => {
         // Arrange
         const handleSearchTextChanged = jest.fn();
         const handleOpen = jest.fn();
@@ -734,9 +656,6 @@ describe("DropdownCore", () => {
             />,
         );
 
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-
         // Act
         userEvent.keyboard("{tab}");
 
@@ -745,7 +664,7 @@ describe("DropdownCore", () => {
         expect(screen.getByTestId("item-0")).toHaveFocus();
     });
 
-    it("When SearchTextInput exists and focused, space key pressing should be allowed", async () => {
+    it("When SearchTextInput exists and focused, space key pressing should be allowed", () => {
         // Arrange
         const handleSearchTextChanged = jest.fn();
         const preventDefaultMock = jest.fn();
@@ -777,12 +696,8 @@ describe("DropdownCore", () => {
             />,
         );
 
-        // Wait until the dropdown is open
-        await screen.findByRole("listbox");
-        userEvent.tab();
-
         // Act
-        const searchInput = await screen.findByTestId("item-0");
+        const searchInput = screen.getByTestId("item-0");
         // eslint-disable-next-line testing-library/prefer-user-event
         fireEvent.keyDown(searchInput, {
             keyCode: 32,

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -733,7 +733,7 @@ describe("DropdownCore", () => {
     });
 
     describe("VirtualizedList", () => {
-        const optionItems = new Array(100).fill(null).map((_, i) => ({
+        const optionItems = new Array(200).fill(null).map((_, i) => ({
             component: (
                 <OptionItem
                     key={i}

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-popper.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-popper.test.js
@@ -1,0 +1,51 @@
+// @flow
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+
+import DropdownPopper from "../dropdown-popper.js";
+
+describe("DropdownPopper", () => {
+    it("renders the children if valid props are passed in", () => {
+        // Arrange
+        const referenceElement = document.createElement("button");
+
+        // Act
+        render(
+            <DropdownPopper referenceElement={referenceElement}>
+                {(shouldHide) => (
+                    <div data-test-id="dropdown-container">
+                        dropdown container
+                    </div>
+                )}
+            </DropdownPopper>,
+        );
+
+        // Assert
+        expect(screen.getByTestId("dropdown-container")).toBeInTheDocument();
+    });
+
+    it("renders the dropdown aligned to the right", () => {
+        // Arrange
+        const referenceElement = document.createElement("button");
+
+        // Act
+        render(
+            <DropdownPopper
+                referenceElement={referenceElement}
+                alignment="right"
+            >
+                {(shouldHide) => (
+                    <div data-test-id="dropdown-container">
+                        dropdown container
+                    </div>
+                )}
+            </DropdownPopper>,
+        );
+
+        // Assert
+        expect(screen.getByTestId("dropdown-popper")).toHaveAttribute(
+            "data-placement",
+            "bottom-end",
+        );
+    });
+});

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
@@ -2,15 +2,12 @@
 //@flow
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
-
-import userEvent from "../../../../../utils/testing/user-event.js";
+import userEvent from "@testing-library/user-event";
 
 import OptionItem from "../option-item.js";
 import MultiSelect from "../multi-select.js";
 
 import type {Labels} from "../multi-select.js";
-
-jest.mock("../dropdown-core-virtualized.js");
 
 const labels: $Shape<Labels> = {
     selectAllLabel: (numOptions) => `Sellect all (${numOptions})`,
@@ -306,7 +303,7 @@ describe("MultiSelect", () => {
             expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
         });
 
-        it("selects on item as expected", async () => {
+        it("selects on item as expected", () => {
             // Arrange
             render(<ControlledComponent />);
 
@@ -315,7 +312,7 @@ describe("MultiSelect", () => {
 
             // Act
             // Grab the second item in the list
-            const item = await screen.findByRole("option", {
+            const item = screen.getByRole("option", {
                 name: "item 2",
             });
             userEvent.click(item, undefined, {
@@ -327,7 +324,7 @@ describe("MultiSelect", () => {
             expect(opener).toHaveTextContent("item 2");
         });
 
-        it("dropdown menu is still open after selection", async () => {
+        it("dropdown menu is still open after selection", () => {
             // Arrange
             const onToggleMock = jest.fn();
             render(<ControlledComponent onToggle={onToggleMock} />);
@@ -337,7 +334,7 @@ describe("MultiSelect", () => {
 
             // Act
             // Grab the second item in the list
-            const item = await screen.findByRole("option", {
+            const item = screen.getByRole("option", {
                 name: "item 2",
             });
             userEvent.click(item, undefined, {
@@ -346,7 +343,6 @@ describe("MultiSelect", () => {
 
             // Assert
             expect(onToggleMock).toHaveBeenCalledTimes(1);
-            // expect(screen.getByRole("listbox")).toBeInTheDocument();
         });
 
         it("selects two items as expected", () => {
@@ -802,7 +798,7 @@ describe("MultiSelect", () => {
             expect(opener).toHaveTextContent("No items selected");
         });
 
-        it("passes the current label to the custom opener (1 item selected)", async () => {
+        it("passes the current label to the custom opener (1 item selected)", () => {
             // Arrange
             const ControlledMultiSelect = () => {
                 const [selected, setSelected] = React.useState([]);

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
@@ -17,15 +17,6 @@ const labels: $Shape<Labels> = {
 };
 
 describe("MultiSelect", () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-        jest.runOnlyPendingTimers();
-        jest.useRealTimers();
-    });
-
     describe("uncontrolled", () => {
         const onChange = jest.fn();
         const uncontrolledSingleSelect = (

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -1,11 +1,10 @@
 //@flow
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import OptionItem from "../option-item.js";
 import SingleSelect from "../single-select.js";
-
-import userEvent from "../../../../../utils/testing/user-event.js";
 
 describe("SingleSelect", () => {
     const onChange = jest.fn();

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -10,8 +10,6 @@ describe("SingleSelect", () => {
     const onChange = jest.fn();
 
     beforeEach(() => {
-        jest.useFakeTimers();
-
         window.scrollTo = jest.fn();
 
         // We mock console.error() because React logs a bunch of errors pertaining
@@ -23,8 +21,6 @@ describe("SingleSelect", () => {
         window.scrollTo.mockClear();
         onChange.mockReset();
         jest.spyOn(console, "error").mockReset();
-        jest.runOnlyPendingTimers();
-        jest.useRealTimers();
     });
 
     describe("uncontrolled", () => {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -36,7 +36,7 @@ import DropdownPopper from "./dropdown-popper.js";
  *
  * TODO(juan, WB-1263): Improve performance by refactoring this component.
  */
-const VIRTUALIZE_THRESHOLD = 80;
+const VIRTUALIZE_THRESHOLD = 125;
 
 type Labels = {|
     noResults: string,

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-popper.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-popper.js
@@ -1,0 +1,105 @@
+// @flow
+import * as React from "react";
+import ReactDOM from "react-dom";
+import {Popper} from "react-popper";
+
+import {maybeGetPortalMountedModalHostElement} from "@khanacademy/wonder-blocks-modal";
+
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+const modifiers = [
+    {
+        name: "preventOverflow",
+        options: {
+            rootBoundary: "viewport",
+            // Allows to overlap the popper in case there's no more vertical
+            // room in the viewport.
+            altAxis: true,
+            // Also needed to make sure the Popper will be displayed correctly
+            // in different contexts (e.g inside a Modal)
+            tether: false,
+        },
+    },
+];
+
+type Props = {|
+    /**
+     * The children that will be wrapped by PopperJS.
+     */
+    children: (isReferenceHidden: boolean) => React.Node,
+
+    /**
+     * The reference element used to position the popper.
+     */
+    referenceElement: ?HTMLElement,
+
+    /**
+     * Whether this menu should be left-aligned or right-aligned with the
+     * reference component. Defaults to left-aligned.
+     */
+    alignment?: "left" | "right",
+
+    /**
+     * The popper's reference.
+     * @see https://popper.js.org/react-popper/v2/render-props/#innerref
+     */
+    onPopperElement?: (popperElement: ?HTMLElement) => mixed,
+
+    /**
+     * Styles that will be applied to the children.
+     */
+    style?: StyleType,
+|};
+
+/**
+ * A wrapper for PopperJS that renders the children inside a portal.
+ */
+export default function DropdownPopper({
+    children,
+    alignment = "left",
+    onPopperElement,
+    referenceElement,
+}: Props): React.Node {
+    // If we are in a modal, we find where we should be portalling the menu by
+    // using the helper function from the modal package on the opener element.
+    // If we are not in a modal, we use body as the location to portal to.
+    const modalHost =
+        maybeGetPortalMountedModalHostElement(referenceElement) ||
+        document.querySelector("body");
+
+    if (!modalHost) {
+        return null;
+    }
+
+    return ReactDOM.createPortal(
+        <Popper
+            innerRef={(node: ?HTMLElement) => {
+                if (node && onPopperElement) {
+                    onPopperElement(node);
+                }
+            }}
+            referenceElement={referenceElement}
+            strategy="fixed"
+            placement={alignment === "left" ? "bottom-start" : "bottom-end"}
+            modifiers={modifiers}
+        >
+            {({placement, ref, style, hasPopperEscaped, isReferenceHidden}) => {
+                const shouldHidePopper = !!(
+                    hasPopperEscaped || isReferenceHidden
+                );
+
+                return (
+                    <div
+                        ref={ref}
+                        style={style}
+                        data-test-id="dropdown-popper"
+                        data-placement={placement}
+                    >
+                        {children(shouldHidePopper)}
+                    </div>
+                );
+            }}
+        </Popper>,
+        modalHost,
+    );
+}

--- a/packages/wonder-blocks-dropdown/src/components/single-select.md
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.md
@@ -477,7 +477,7 @@ class ExampleWithFilter extends React.Component {
     constructor() {
         super();
         this.state = {
-            opened: true,
+            opened: false,
             selectedValue: null,
         };
         this.handleChange = this.handleChange.bind(this);

--- a/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
@@ -61,6 +61,8 @@ DefaultSingleSelectOpened.parameters = {
         storyDescription:
             "This select starts with a starting selected item. One of the items is disabled and thus cannot be selected.",
     },
+    // Added to ensure that the dropdown menu is rendered using PopperJS.
+    chromatic: {delay: 200},
 };
 
 const fruits = ["banana", "strawberry", "pear", "orange"];

--- a/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
@@ -15,6 +15,52 @@ import {SingleSelect, OptionItem} from "../index.js";
 
 export default {
     title: "Dropdown / SingleSelect",
+    component: SingleSelect,
+    args: {
+        isFilterable: true,
+        opened: true,
+        disabled: false,
+        light: false,
+        placeholder: "Choose a fruit",
+    },
+};
+
+const SingleSelectTemplate = (args) => <SingleSelect {...args} />;
+
+export const DefaultSingleSelectOpened: StoryComponentType = (args) => {
+    const [selectedValue, setSelectedValue] = React.useState("pear");
+    const [opened, setOpened] = React.useState(args.opened);
+    React.useEffect(() => {
+        // Only update opened if the args.opened prop changes (using the
+        // controls panel).
+        setOpened(args.opened);
+    }, [args.opened]);
+
+    return (
+        <SingleSelectTemplate
+            {...args}
+            onChange={setSelectedValue}
+            selectedValue={selectedValue}
+            opened={opened}
+            onToggle={setOpened}
+        >
+            <OptionItem label="Banana" value="banana" />
+            <OptionItem label="Strawberry" value="strawberry" disabled />
+            <OptionItem label="Pear" value="pear" />
+            <OptionItem label="Orange" value="orange" />
+            <OptionItem label="Watermelon" value="watermelon" />
+            <OptionItem label="Apple" value="apple" />
+            <OptionItem label="Grape" value="grape" />
+            <OptionItem label="Lemon" value="lemon" />
+        </SingleSelectTemplate>
+    );
+};
+
+DefaultSingleSelectOpened.parameters = {
+    docs: {
+        storyDescription:
+            "This select starts with a starting selected item. One of the items is disabled and thus cannot be selected.",
+    },
 };
 
 const fruits = ["banana", "strawberry", "pear", "orange"];
@@ -93,7 +139,7 @@ const styles = StyleSheet.create({
     },
     wrapper: {
         height: "800px",
-        width: "1200px",
+        width: "600px",
     },
     centered: {
         alignItems: "center",

--- a/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
@@ -62,7 +62,7 @@ DefaultSingleSelectOpened.parameters = {
             "This select starts with a starting selected item. One of the items is disabled and thus cannot be selected.",
     },
     // Added to ensure that the dropdown menu is rendered using PopperJS.
-    chromatic: {delay: 200},
+    chromatic: {delay: 400},
 };
 
 const fruits = ["banana", "strawberry", "pear", "orange"];


### PR DESCRIPTION
## Summary:

- Modified `DropdownCore` to only use `react-window` if there are more than 80
options in the menu.
- Improved the performance a bit by avoiding to recalculate rendering the options list on every re-render.
- Created `DropdownPopper` to abstract out the `PopperJS` functionality into a
separate component. This will help us to make improvements in the future (e.g.
porting to hooks, using PopperV3/floating-ui).
- Modified unit tests inside `wb-dropdown` to avoid relying on timers to test the dropdowns.

Current benchmarks for showing the dropdown menu without `react-window`:

BEFORE IMPROVING PERFORMANCE: 173ms for 70 items.

<img width="724" alt="Screen Shot 2022-03-23 at 11 27 27 AM" src="https://user-images.githubusercontent.com/843075/159735500-4795c6f3-9d31-4b67-a1e8-51ea116f823f.png">

AFTER IMPROVING PERFORMANCE: ~90ms for 70 items (average).

<img width="534" alt="dropdown-core-70" src="https://user-images.githubusercontent.com/843075/159735589-5a3ebdf5-435c-4a57-9f33-7677a4af70d1.png">


Issue: WB-1258

## Test plan:

Navigate to the Stories related to Dropdown components and verify that everything continues working as expected.

Verify that this example (that doesn't use `react-window`) works as expected: keyboard navigation works, focus, selecting items, filtering items, etc.

https://5e1bf4b385e3fb0020b7073c-tzbtketfim.chromatic.com/?path=/story/dropdown-singleselect--default-single-select-opened

NO-WINDOWING VERSION
https://user-images.githubusercontent.com/843075/159743719-7ca3078f-3886-41c2-9515-e981077633a1.mov


