### PR TITLE
Export ngetpos so that it can be use by handlebars i18n functions in webapp

### DIFF
--- a/.changeset/seven-pots-think.md
+++ b/.changeset/seven-pots-think.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-i18n": minor
+---
+
+Export ngetpos so that it can be use by handlebars i18n functions in webapp

--- a/packages/wonder-blocks-i18n/src/functions/i18n.js
+++ b/packages/wonder-blocks-i18n/src/functions/i18n.js
@@ -244,7 +244,7 @@ export const ngettext: ngettextOverloads = (singular, plural, num, options) => {
  *  - num: The number upon which to toggle the plural forms.
  *  - lang: The language to use as the basis for the pluralization.
  */
-const ngetpos = function (num: number, lang?: Language) {
+export const ngetpos = function (num: number, lang?: Language): number {
     const pluralForm = (lang && allPluralForms[lang]) || allPluralForms["en"];
     const pos = pluralForm(num);
     // Map true to 1 and false to 0, keep any numeric return value the same.

--- a/packages/wonder-blocks-i18n/src/index.js
+++ b/packages/wonder-blocks-i18n/src/index.js
@@ -5,6 +5,7 @@ export {
     ngettext,
     doNotTranslate,
     doNotTranslateYet,
+    ngetpos, // used by handlebars translation functions in webapp
 } from "./functions/i18n.js";
 
 export {localeToFixed, getDecimalSeparator} from "./functions/l10n.js";


### PR DESCRIPTION
## Summary:
I started extracting the handlebars specific functions from shared-package/i18n.js in webapp and noticed that I needed ngetpos() for that change.

Issue: None

## Test plan:
- n/a