### PR TITLE
WB-1267: Fix top alignment between accessory and content

### DIFF
--- a/.changeset/curly-doors-draw.md
+++ b/.changeset/curly-doors-draw.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+Fix top vertical alignment between accessories and content

--- a/packages/wonder-blocks-cell/src/components/__docs__/detail-cell.stories.js
+++ b/packages/wonder-blocks-cell/src/components/__docs__/detail-cell.stories.js
@@ -110,6 +110,7 @@ export const DetailCellWithCustomStyles: StoryComponentType = () => (
         leftAccessory={<Icon icon={icons.contentVideo} size="medium" />}
         leftAccessoryStyle={{
             minWidth: Spacing.xxLarge_48,
+            alignSelf: "flex-start",
         }}
         rightAccessory={<Icon icon={icons.caretRight} size="small" />}
         rightAccessoryStyle={{

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.js
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.js
@@ -229,7 +229,6 @@ const styles = StyleSheet.create({
     content: {
         alignSelf: "center",
         overflowWrap: "break-word",
-        padding: `${CellMeasurements.contentVerticalSpacing}px 0`,
     },
 
     accessory: {

--- a/packages/wonder-blocks-cell/src/components/internal/common.js
+++ b/packages/wonder-blocks-cell/src/components/internal/common.js
@@ -27,11 +27,6 @@ export const CellMeasurements = {
     },
 
     /**
-     * The extra vertical spacing added to the title/content wrapper.
-     */
-    contentVerticalSpacing: Spacing.xxxSmall_4,
-
-    /**
      * The horizontal spacing between the left and right accessory.
      */
     accessoryHorizontalSpacing: Spacing.medium_16,

--- a/packages/wonder-blocks-cell/src/components/internal/common.js
+++ b/packages/wonder-blocks-cell/src/components/internal/common.js
@@ -14,7 +14,7 @@ export const CellMeasurements = {
      * The cell wrapper's gap.
      */
     cellPadding: {
-        paddingVertical: Spacing.xSmall_8,
+        paddingVertical: Spacing.small_12,
         paddingHorizontal: Spacing.medium_16,
     },
 
@@ -22,7 +22,7 @@ export const CellMeasurements = {
      * The DetailCell wrapper's gap.
      */
     detailCellPadding: {
-        paddingVertical: Spacing.small_12,
+        paddingVertical: Spacing.medium_16,
         paddingHorizontal: Spacing.medium_16,
     },
 


### PR DESCRIPTION
## Summary:

There’s an extra spacing on the content container that doesn’t work well when we try to align the accessory to the top. We need to fix the layout to align both the accessories and the content using the same padding (applies for both Compact and Detail cells).

Issue: https://khanacademy.atlassian.net/browse/WB-1267

## Test plan:

Navigate to the Storybook instance and verify that the
?path=/story/cell-detailcell--detail-cell-with-custom-styles example is now
vertically aligned to the top.

BEFORE

<img width="529" alt="Screen Shot 2022-03-29 at 10 21 08 AM" src="https://user-images.githubusercontent.com/843075/160637690-a3088fd6-4515-4453-9c22-003359fb7640.png">

AFTER
<img width="461" alt="fix" src="https://user-images.githubusercontent.com/843075/160637719-df88006b-5282-4976-8adf-85f841e1d83f.png">

