### PR TITLE
[fei4127.allowstorybookautogentitles] Allow auto-gen titles in storybook

### DIFF
--- a/.changeset/friendly-boats-argue.md
+++ b/.changeset/friendly-boats-argue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": major
+---
+
+Allow for autogenerating titles in Storybook

--- a/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.js
+++ b/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.js
@@ -38,6 +38,7 @@ describe("#fixtures", () => {
         expect(adapter.declareGroup).toHaveBeenCalledWith({
             title: "TITLE",
             description: "DESCRIPTION",
+            getDefaultTitle: expect.any(Function),
         });
     });
 
@@ -63,11 +64,11 @@ describe("#fixtures", () => {
             },
             jest.fn(),
         );
+        const {getDefaultTitle} = adapter.declareGroup.mock.calls[0][0];
+        const result = getDefaultTitle();
 
         // Assert
-        expect(adapter.declareGroup).toHaveBeenCalledWith({
-            title: "DISPLAYNAME",
-        });
+        expect(result).toBe("DISPLAYNAME");
     });
 
     it("should default the title to the component.name in the absence of component.displayName", () => {
@@ -93,11 +94,11 @@ describe("#fixtures", () => {
             },
             jest.fn(),
         );
+        const {getDefaultTitle} = adapter.declareGroup.mock.calls[0][0];
+        const result = getDefaultTitle();
 
         // Assert
-        expect(adapter.declareGroup).toHaveBeenCalledWith({
-            title: "FUNCTIONNAME",
-        });
+        expect(result).toBe("FUNCTIONNAME");
     });
 
     it("should default the title to 'Component' in the absence of component.name", () => {
@@ -120,11 +121,11 @@ describe("#fixtures", () => {
             },
             jest.fn(),
         );
+        const {getDefaultTitle} = adapter.declareGroup.mock.calls[0][0];
+        const result = getDefaultTitle();
 
         // Assert
-        expect(adapter.declareGroup).toHaveBeenCalledWith({
-            title: "Component",
-        });
+        expect(result).toBe("Component");
     });
 
     it("should invoke the passed fn with function argument", () => {

--- a/packages/wonder-blocks-testing/src/fixtures/adapters/__tests__/adapter-group.test.js
+++ b/packages/wonder-blocks-testing/src/fixtures/adapters/__tests__/adapter-group.test.js
@@ -12,6 +12,9 @@ describe("AdapterGroup", () => {
                 new AdapterGroup(badCloseGroupFn, {
                     title: "TITLE",
                     description: null,
+                    getDefaultTitle: () => {
+                        throw new Error("NOT IMPLEMENTED");
+                    },
                 });
 
             expect(act).toThrowErrorMatchingInlineSnapshot(
@@ -40,6 +43,9 @@ describe("AdapterGroup", () => {
             const groupOptions = {
                 title: "TITLE",
                 description: null,
+                getDefaultTitle: () => {
+                    throw new Error("NOT IMPLEMENTED");
+                },
             };
             const adapterGroup = new AdapterGroup(closeGroupFn, groupOptions);
 
@@ -56,6 +62,9 @@ describe("AdapterGroup", () => {
             const groupOptions = {
                 title: "TITLE",
                 description: null,
+                getDefaultTitle: () => {
+                    throw new Error("NOT IMPLEMENTED");
+                },
             };
             const adapterSpecificOptions = {
                 adapterSpecificOption: "adapterSpecificOption",
@@ -79,6 +88,9 @@ describe("AdapterGroup", () => {
             const groupOptions = {
                 title: "TITLE",
                 description: "DESCRIPTION",
+                getDefaultTitle: () => {
+                    throw new Error("NOT IMPLEMENTED");
+                },
             };
             const adapterGroup = new AdapterGroup(closeGroupFn, groupOptions);
             const fixture = {
@@ -103,6 +115,9 @@ describe("AdapterGroup", () => {
             const groupOptions = {
                 title: "TITLE",
                 description: null,
+                getDefaultTitle: () => {
+                    throw new Error("NOT IMPLEMENTED");
+                },
             };
             const adapterGroup = new AdapterGroup(closeGroupFn, groupOptions);
             adapterGroup.closeGroup();
@@ -126,6 +141,9 @@ describe("AdapterGroup", () => {
                 const groupOptions = {
                     title: "TITLE",
                     description: null,
+                    getDefaultTitle: () => {
+                        throw new Error("NOT IMPLEMENTED");
+                    },
                 };
                 const adapterGroup = new AdapterGroup(
                     closeGroupFn,
@@ -147,6 +165,9 @@ describe("AdapterGroup", () => {
             const groupOptions = {
                 title: "TITLE",
                 description: "DESCRIPTION",
+                getDefaultTitle: () => {
+                    throw new Error("NOT IMPLEMENTED");
+                },
             };
             const adapterGroup = new AdapterGroup(closeGroupFn, groupOptions);
             const fixture1 = {
@@ -178,6 +199,9 @@ describe("AdapterGroup", () => {
             const groupOptions = {
                 title: "TITLE",
                 description: null,
+                getDefaultTitle: () => {
+                    throw new Error("NOT IMPLEMENTED");
+                },
             };
             const adapterGroup = new AdapterGroup(closeGroupFn, groupOptions);
             adapterGroup.closeGroup();

--- a/packages/wonder-blocks-testing/src/fixtures/adapters/__tests__/adapter.test.js
+++ b/packages/wonder-blocks-testing/src/fixtures/adapters/__tests__/adapter.test.js
@@ -56,6 +56,9 @@ describe("Adapter", () => {
             const options = {
                 title: "group_title",
                 description: "group_description",
+                getDefaultTitle: () => {
+                    throw new Error("NOT IMPLEMENTED");
+                },
             };
             const adapterGroupSpy = jest
                 .spyOn(AdapterGroupModule, "AdapterGroup")
@@ -82,6 +85,9 @@ describe("Adapter", () => {
             const result = adapter.declareGroup({
                 title: "group_title",
                 description: "group_description",
+                getDefaultTitle: () => {
+                    throw new Error("NOT IMPLEMENTED");
+                },
             });
 
             // Assert

--- a/packages/wonder-blocks-testing/src/fixtures/adapters/storybook.js
+++ b/packages/wonder-blocks-testing/src/fixtures/adapters/storybook.js
@@ -26,7 +26,7 @@ export type StorybookOptions = {|
 |};
 
 type DefaultExport = {|
-    title: string,
+    title?: ?string,
     ...StorybookOptions,
 |};
 
@@ -47,6 +47,9 @@ export const getAdapter: AdapterFactory<StorybookOptions, Exports<any>> = (
             {
                 title,
                 description: groupDescription,
+                // We don't use the default title in Storybook as storybook
+                // will generate titles for us if we pass a nullish title.
+                getDefaultTitle: _,
             }: $ReadOnly<AdapterGroupOptions>,
             adapterOptions: ?$ReadOnly<StorybookOptions>,
             declaredFixtures: $ReadOnlyArray<AdapterFixtureOptions<TProps>>,

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.basic.stories.js
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.basic.stories.js
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import {setupFixtures, fixtures, adapters} from "../index.js";
 
-// Normally would call setup from the storybook.main.js for a project.
+// Normally would call setup from the storybook.preview.js for a project.
 setupFixtures({
     adapter: adapters.storybook(),
 });

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.defaultwrapper.stories.js
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.defaultwrapper.stories.js
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import {setupFixtures, fixtures, adapters} from "../index.js";
 
-// Normally would call setup from the storybook.main.js for a project.
+// Normally would call setup from the storybook.preview.js for a project.
 setupFixtures({
     adapter: adapters.storybook(),
 });

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.js
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.js
@@ -48,8 +48,10 @@ export const fixtures = <TProps: {...}>(
 
     // 1. Create a new adapter group.
     const group = adapter.declareGroup<TProps>({
-        title: title || component.displayName || component.name || "Component",
+        title,
         description: groupDescription,
+        getDefaultTitle: () =>
+            component.displayName || component.name || "Component",
     });
 
     // 2. Invoke fn with a function that can add a new fixture.

--- a/packages/wonder-blocks-testing/src/fixtures/types.js
+++ b/packages/wonder-blocks-testing/src/fixtures/types.js
@@ -81,13 +81,22 @@ export type AdapterFixtureOptions<TProps: {...}> = {|
 export type AdapterGroupOptions = {|
     /**
      * The title of the group.
+     *
+     * If omitted, the adapter is free to generate a default or ask for one
+     * using the passed getDefaultTitle() function.
      */
-    +title: string,
+    +title: ?string,
 
     /**
      * Description of the group.
      */
     +description: ?string,
+
+    /**
+     * Function that will generate a default title if an adapter cannot
+     * generate its own.
+     */
+    +getDefaultTitle: () => string,
 |};
 
 /**


### PR DESCRIPTION
## Summary:
This makes the `title` field optional/nullable and adds a `getDefaultTitle` function so that adapters that cope with nullish titles can do their own thing, but those that can't (like if we had a React Sandbox adapter) can just use the default title as needed.

Issue: FEI-4127

## Test plan:
`yarn test`
`yarn flow`