### PR TITLE
[fei4127.simples] Simplify fixtures call for common case

### DIFF
--- a/.changeset/red-zoos-matter.md
+++ b/.changeset/red-zoos-matter.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Add simplified signature for common usage of `fixtures` function

--- a/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.js
+++ b/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.js
@@ -11,6 +11,28 @@ describe("#fixtures", () => {
         jest.clearAllMocks();
     });
 
+    it("should declare a group on the configured adapter based off the given component", () => {
+        // Arrange
+        const fakeGroup = {
+            closeGroup: jest.fn(),
+        };
+        const adapter = {
+            declareGroup: jest.fn().mockReturnValue(fakeGroup),
+            name: "testadapter",
+        };
+        jest.spyOn(SetupModule, "getConfiguration").mockReturnValue({
+            adapter,
+        });
+
+        // Act
+        fixtures(() => "COMPONENT", jest.fn());
+
+        // Assert
+        expect(adapter.declareGroup).toHaveBeenCalledWith({
+            getDefaultTitle: expect.any(Function),
+        });
+    });
+
     it("should declare a group on the configured adapter with the given title and description", () => {
         // Arrange
         const fakeGroup = {
@@ -88,12 +110,7 @@ describe("#fixtures", () => {
         };
 
         // Act
-        fixtures(
-            {
-                component,
-            },
-            jest.fn(),
-        );
+        fixtures(component, jest.fn());
         const {getDefaultTitle} = adapter.declareGroup.mock.calls[0][0];
         const result = getDefaultTitle();
 
@@ -115,12 +132,7 @@ describe("#fixtures", () => {
         });
 
         // Act
-        fixtures(
-            {
-                component: ({}: any),
-            },
-            jest.fn(),
-        );
+        fixtures(() => "test", jest.fn());
         const {getDefaultTitle} = adapter.declareGroup.mock.calls[0][0];
         const result = getDefaultTitle();
 

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.js
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.js
@@ -9,6 +9,35 @@ type FixtureProps<TProps: {...}> =
     | $ReadOnly<TProps>
     | ((options: $ReadOnly<GetPropsOptions>) => $ReadOnly<TProps>);
 
+const normalizeOptions = <TProps: {...}>(
+    componentOrOptions:
+        | React.ComponentType<TProps>
+        | $ReadOnly<FixturesOptions<TProps>>,
+): $ReadOnly<FixturesOptions<TProps>> => {
+    // To differentiate between a React component and a FixturesOptions object,
+    // we have to do some type checking. Since all React components, whether
+    // functional or class-based, are inherently functions in JavaScript
+    // this should do the trick without relying on internal React details like
+    // protoype.isReactComponent. This should be sufficient for our purposes.
+    // Alternatives I considered were:
+    // - Use an additional parameter for the options and then do an arg number
+    //   check, but that always makes typing a function harder and often breaks
+    //   types. I didn't want that battle today.
+    // - Use a tuple when providing component and options with the first element
+    //   being the component and the second being the options. However that
+    //   feels like an obscure API even though it's really easy to do the
+    //   typing.
+    if (typeof componentOrOptions === "function") {
+        return {
+            component: componentOrOptions,
+        };
+    }
+    // We can't test for React.ComponentType at runtime.
+    // Let's assume our simple heuristic above is sufficient.
+    // $FlowIgnore[incompatible-return]
+    return componentOrOptions;
+};
+
 /**
  * Describe a group of fixtures for a given component.
  *
@@ -28,7 +57,9 @@ type FixtureProps<TProps: {...}> =
  * its interface.
  */
 export const fixtures = <TProps: {...}>(
-    options: $ReadOnly<FixturesOptions<TProps>>,
+    componentOrOptions:
+        | React.ComponentType<TProps>
+        | $ReadOnly<FixturesOptions<TProps>>,
     fn: (
         fixture: (
             description: string,
@@ -38,13 +69,14 @@ export const fixtures = <TProps: {...}>(
     ) => void,
 ): ?$ReadOnly<mixed> => {
     const {adapter, defaultAdapterOptions} = getConfiguration();
+
     const {
         title,
         component,
         description: groupDescription,
         defaultWrapper,
         additionalAdapterOptions,
-    } = options;
+    } = normalizeOptions(componentOrOptions);
 
     // 1. Create a new adapter group.
     const group = adapter.declareGroup<TProps>({


### PR DESCRIPTION
## Summary:
This creates a simpler call signature for the common use of `fixtures`.

Issue: FEI-4127

## Test plan:
`yarn flow`
`yarn test`