### PR TITLE
Don't bundle 'react' in dist bundle for wonder-blocks-i18n

### DIFF
--- a/.changeset/poor-keys-ring.md
+++ b/.changeset/poor-keys-ring.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-i18n": patch
+---
+
+Don't package 'react' in the dist bundles

--- a/packages/wonder-blocks-i18n/package.json
+++ b/packages/wonder-blocks-i18n/package.json
@@ -17,6 +17,9 @@
   "dependencies": {
     "@babel/runtime": "^7.16.3"
   },
+  "peerDependencies": {
+    "react": "16.14.0"
+  },
   "devDependencies": {
     "wb-dev-build-settings": "^0.3.0"
   }


### PR DESCRIPTION
## Summary:
This will save some bytes and hopefully also fix some errors I was seeing in webapp tests around "key" prop missing when using some of the i18n functions.

Issue: none

## Test plan:
- yarn build:all
- check the dist bundles for wonder-blocks-i18n, grep for "Facebook", see no hits