### PR TITLE
[fei4127.3.forwardrefs] Cope with React.forwardRef

### DIFF
--- a/.changeset/few-kangaroos-battle.md
+++ b/.changeset/few-kangaroos-battle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Make sure simplified fixtures call copes with return values from React.forwardRef

--- a/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.js
+++ b/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.js
@@ -1,4 +1,5 @@
 // @flow
+import * as React from "react";
 import * as SetupModule from "../setup.js";
 import * as CombineOptionsModule from "../combine-options.js";
 import {fixtures} from "../fixtures.js";
@@ -284,7 +285,7 @@ describe("#fixtures", () => {
     });
 
     describe("injected fixture fn", () => {
-        it("should call group.declareFixture with description and props getter", () => {
+        it("should call group.declareFixture with description, props getter, and component", () => {
             // Arrange
             const fakeGroup = {
                 declareFixture: jest.fn(),
@@ -310,6 +311,36 @@ describe("#fixtures", () => {
                     fixture("FIXTURE_DESCRIPTION", {these: "areProps"});
                 },
             );
+
+            // Assert
+            expect(fakeGroup.declareFixture).toHaveBeenCalledWith({
+                description: "FIXTURE_DESCRIPTION",
+                getProps: expect.any(Function),
+                component,
+            });
+        });
+
+        it("should call group.declareFixture with component if component is forward ref", () => {
+            // Arrange
+            const fakeGroup = {
+                declareFixture: jest.fn(),
+                closeGroup: jest.fn(),
+            };
+            const adapter = {
+                declareGroup: jest.fn().mockReturnValue(fakeGroup),
+                name: "testadapter",
+            };
+            jest.spyOn(SetupModule, "getConfiguration").mockReturnValue({
+                adapter,
+            });
+            const component = React.forwardRef((props, ref) => (
+                <div {...props} ref={ref} />
+            ));
+
+            // Act
+            fixtures(component, (fixture) => {
+                fixture("FIXTURE_DESCRIPTION", {these: "areProps"});
+            });
 
             // Assert
             expect(fakeGroup.declareFixture).toHaveBeenCalledWith({

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.js
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.js
@@ -15,10 +15,8 @@ const normalizeOptions = <TProps: {...}>(
         | $ReadOnly<FixturesOptions<TProps>>,
 ): $ReadOnly<FixturesOptions<TProps>> => {
     // To differentiate between a React component and a FixturesOptions object,
-    // we have to do some type checking. Since all React components, whether
-    // functional or class-based, are inherently functions in JavaScript
-    // this should do the trick without relying on internal React details like
-    // protoype.isReactComponent. This should be sufficient for our purposes.
+    // we have to do some type checking.
+    //
     // Alternatives I considered were:
     // - Use an additional parameter for the options and then do an arg number
     //   check, but that always makes typing a function harder and often breaks
@@ -27,8 +25,20 @@ const normalizeOptions = <TProps: {...}>(
     //   being the component and the second being the options. However that
     //   feels like an obscure API even though it's really easy to do the
     //   typing.
-    if (typeof componentOrOptions === "function") {
+    if (
+        // Most React components, whether functional or class-based, are
+        // inherently functions in JavaScript, so a check for functions is
+        // usually sufficient.
+        typeof componentOrOptions === "function" ||
+        // However, the return of React.forwardRef is not a function,
+        // so we also have to cope with that.
+        // A forwardRef has $$typeof = Symbol(react.forward_ref) and a
+        // render function.
+        // $FlowIgnore[prop-missing]
+        typeof componentOrOptions.render === "function"
+    ) {
         return {
+            // $FlowIgnore[incompatible-return]
             component: componentOrOptions,
         };
     }


### PR DESCRIPTION
## Summary:
Turns out that what React.forwardRef returns does not look like a component at all, so I expanded the heuristic check accordingly.

Issue: FEI-4127

## Test plan:
`yarn test`