### PR TITLE
[fei4429.1] Implement mockFetch

### DIFF
--- a/.changeset/tall-snails-pretend.md
+++ b/.changeset/tall-snails-pretend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": major
+---
+
+Introduced `mockFetch` and expanded `RespondWith` options. `RespondWith` responses will now be real `Response` instances (needs node-fetch peer dependency if no other implementation exists). Breaking changes: `RespondWith.data` is now `RespondWith.graphQLData`.

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "aphrodite": "^1.2.5",
     "flow-enums-runtime": "^0.0.6",
     "moment": "2.24.0",
+    "node-fetch": "^3.2.3",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-popper": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "aphrodite": "^1.2.5",
     "flow-enums-runtime": "^0.0.6",
     "moment": "2.24.0",
-    "node-fetch": "^3.2.3",
+    "node-fetch": "^2.6.7",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-popper": "^2.2.5",

--- a/packages/wonder-blocks-testing/package.json
+++ b/packages/wonder-blocks-testing/package.json
@@ -20,7 +20,7 @@
         "@khanacademy/wonder-stuff-core": "^0.1.2",
         "@khanacademy/wonder-stuff-testing": "^0.0.2",
         "@storybook/addon-actions": "^6.4.8",
-        "node-fetch": "^3.2.3",
+        "node-fetch": "^2.6.7",
         "react": "16.14.0"
     },
     "devDependencies": {

--- a/packages/wonder-blocks-testing/package.json
+++ b/packages/wonder-blocks-testing/package.json
@@ -20,6 +20,7 @@
         "@khanacademy/wonder-stuff-core": "^0.1.2",
         "@khanacademy/wonder-stuff-testing": "^0.0.2",
         "@storybook/addon-actions": "^6.4.8",
+        "node-fetch": "^3.2.3",
         "react": "16.14.0"
     },
     "devDependencies": {

--- a/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
@@ -2,64 +2,170 @@
 import {RespondWith, makeMockResponse} from "../make-mock-response.js";
 
 describe("RespondWith", () => {
-    describe("#data", () => {
-        it("should have type data", () => {
+    describe("#text", () => {
+        it("should have type text", () => {
+            // Arrange
+
+            // Act
+            const result = RespondWith.text("SOME TEXT");
+
+            // Assert
+            expect(result).toHaveProperty("type", "text");
+        });
+
+        it("should provide the given text", () => {
+            // Arrange
+
+            // Act
+            const mockResponse = RespondWith.text("SOME TEXT");
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.text;
+
+            // Assert
+            expect(result).toEqual("SOME TEXT");
+        });
+    });
+
+    describe("#json", () => {
+        it("should have type text", () => {
+            // Arrange
+
+            // Act
+            const result = RespondWith.json({});
+
+            // Assert
+            expect(result).toHaveProperty("type", "text");
+        });
+
+        it("should provide the given data in the text", () => {
+            // Arrange
+            const json = {
+                foo: "bar",
+            };
+
+            // Act
+            const mockResponse = RespondWith.json(json);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.text();
+
+            // Assert
+            expect(result).toEqual(JSON.stringify(json));
+        });
+    });
+
+    describe("#graphQLData", () => {
+        it("should have type text", () => {
             // Arrange
 
             // Act
             const result = RespondWith.graphQLData({});
 
             // Assert
-            expect(result).toHaveProperty("type", "data");
+            expect(result).toHaveProperty("type", "text");
         });
 
-        it("should include the given data", () => {
+        it("should provide the given data in the text", () => {
             // Arrange
             const data = {
                 foo: "bar",
             };
 
             // Act
-            const result = RespondWith.graphQLData(data);
+            const mockResponse = RespondWith.graphQLData(data);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.text();
 
             // Assert
-            expect(result).toHaveProperty("data", data);
+            expect(result).toEqual(JSON.stringify({data}));
         });
     });
 
     describe("#unparseableBody", () => {
-        it("should have type parse", () => {
+        it("should have type text", () => {
             // Arrange
 
             // Act
             const result = RespondWith.unparseableBody();
 
             // Assert
-            expect(result).toHaveProperty("type", "parse");
+            expect(result).toHaveProperty("type", "text");
+        });
+
+        it("should have text that is unparseable json", () => {
+            // Arrange
+
+            // Act
+            const mockResponse = RespondWith.unparseableBody();
+            // $FlowIgnore[incompatible-use]
+            const underTest = () => JSON.parse(mockResponse.text);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Unexpected token I in JSON at position 0"`,
+            );
         });
     });
 
     describe("#abortedRequest", () => {
-        it("should have type abort", () => {
+        it("should have type reject", () => {
             // Arrange
 
             // Act
             const result = RespondWith.abortedRequest();
 
             // Assert
-            expect(result).toHaveProperty("type", "abort");
+            expect(result).toHaveProperty("type", "reject");
+        });
+
+        it("should provide AbortError", () => {
+            // Arrange
+
+            // Act
+            const mockResponse = RespondWith.abortedRequest();
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.error();
+
+            // Assert
+            expect(result).toMatchInlineSnapshot(
+                `[AbortError: Mock request aborted]`,
+            );
+        });
+    });
+
+    describe("#reject", () => {
+        it("should have type reject", () => {
+            // Arrange
+
+            // Act
+            const result = RespondWith.reject(new Error("BOOM!"));
+
+            // Assert
+            expect(result).toHaveProperty("type", "reject");
+        });
+
+        it("should have the given error", () => {
+            // Arrange
+            const error = new Error("BOOM!");
+
+            // Act
+            const mockResponse = RespondWith.reject(error);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.error;
+
+            // Assert
+            expect(result).toBe(error);
         });
     });
 
     describe("#errorStatusCode", () => {
-        it("should have type status", () => {
+        it("should have type text", () => {
             // Arrange
 
             // Act
             const result = RespondWith.errorStatusCode(400);
 
             // Assert
-            expect(result).toHaveProperty("type", "status");
+            expect(result).toHaveProperty("type", "text");
         });
 
         it("should include the given status code", () => {
@@ -93,19 +199,48 @@ describe("RespondWith", () => {
             const result = RespondWith.nonGraphQLBody();
 
             // Assert
-            expect(result).toHaveProperty("type", "invalid");
+            expect(result).toHaveProperty("type", "text");
+        });
+
+        it("should have text that is valid json", () => {
+            // Arrange
+
+            // Act
+            const mockResponse = RespondWith.nonGraphQLBody();
+            // $FlowIgnore[incompatible-use]
+            const underTest = () => JSON.parse(mockResponse.text());
+
+            // Assert
+            expect(underTest).not.toThrow();
+        });
+
+        it("should have text that is not a valid GraphQL response", () => {
+            // Arrange
+
+            // Act
+            const mockResponse = RespondWith.nonGraphQLBody();
+            // $FlowIgnore[incompatible-use]
+            const result = JSON.parse(mockResponse.text());
+
+            // Assert
+            expect(result).toMatchInlineSnapshot(`
+                Object {
+                  "that": "is not a valid graphql response",
+                  "valid": "json",
+                }
+            `);
         });
     });
 
     describe("#graphQLErrors", () => {
-        it("should have type graphql", () => {
+        it("should have type test", () => {
             // Arrange
 
             // Act
             const result = RespondWith.graphQLErrors([]);
 
             // Assert
-            expect(result).toHaveProperty("type", "graphql");
+            expect(result).toHaveProperty("type", "text");
         });
 
         it("should include the given error messages", () => {
@@ -113,10 +248,23 @@ describe("RespondWith", () => {
             const errorMessages = ["foo", "bar"];
 
             // Act
-            const result = RespondWith.graphQLErrors(errorMessages);
+            const mockResponse = RespondWith.graphQLErrors(errorMessages);
+            // $FlowIgnore[incompatible-use]
+            const result = JSON.parse(mockResponse.text());
 
             // Assert
-            expect(result).toHaveProperty("errors", errorMessages);
+            expect(result).toMatchInlineSnapshot(`
+                Object {
+                  "errors": Array [
+                    Object {
+                      "message": "foo",
+                    },
+                    Object {
+                      "message": "bar",
+                    },
+                  ],
+                }
+            `);
         });
     });
 });
@@ -210,6 +358,20 @@ describe("#makeGqlErrorResponse", () => {
 
             // Assert
             await expect(act).rejects.toHaveProperty("name", "AbortError");
+        });
+    });
+
+    describe("rejection", () => {
+        it("should reject with error", async () => {
+            // Arrange
+            const error = new Error("BOOM!");
+            const mockResponse = RespondWith.reject(error);
+
+            // Act
+            const act = () => makeMockResponse(mockResponse);
+
+            // Assert
+            await expect(act).rejects.toBe(error);
         });
     });
 

--- a/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {RespondWith, makeGqlMockResponse} from "../make-gql-mock-response.js";
+import {RespondWith, makeMockResponse} from "../make-mock-response.js";
 
 describe("RespondWith", () => {
     describe("#data", () => {
@@ -127,7 +127,7 @@ describe("#makeGqlErrorResponse", () => {
 
         // Act
         const result = () =>
-            makeGqlMockResponse(({type: "NOT A VALID TYPE"}: any));
+            makeMockResponse(({type: "NOT A VALID TYPE"}: any));
 
         // Assert
         expect(result).toThrowErrorMatchingInlineSnapshot(
@@ -141,7 +141,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.data({});
 
             // Act
-            const result = await makeGqlMockResponse(mockResponse);
+            const result = await makeMockResponse(mockResponse);
 
             // Assert
             expect(result.status).toBe(200);
@@ -155,7 +155,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.data(data);
 
             // Act
-            const response = await makeGqlMockResponse(mockResponse);
+            const response = await makeMockResponse(mockResponse);
             const result = await response.text();
 
             // Assert
@@ -169,7 +169,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.unparseableBody();
 
             // Act
-            const result = await makeGqlMockResponse(mockResponse);
+            const result = await makeMockResponse(mockResponse);
 
             // Assert
             expect(result.status).toBe(200);
@@ -180,7 +180,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.unparseableBody();
 
             // Act
-            const response = await makeGqlMockResponse(mockResponse);
+            const response = await makeMockResponse(mockResponse);
             const text = await response.text();
             const act = () => JSON.parse(text);
 
@@ -195,7 +195,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.abortedRequest();
 
             // Act
-            const act = () => makeGqlMockResponse(mockResponse);
+            const act = () => makeMockResponse(mockResponse);
 
             // Assert
             await expect(act).rejects.toBeInstanceOf(Error);
@@ -206,7 +206,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.abortedRequest();
 
             // Act
-            const act = makeGqlMockResponse(mockResponse);
+            const act = makeMockResponse(mockResponse);
 
             // Assert
             await expect(act).rejects.toHaveProperty("name", "AbortError");
@@ -219,7 +219,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.errorStatusCode(400);
 
             // Act
-            const result = await makeGqlMockResponse(mockResponse);
+            const result = await makeMockResponse(mockResponse);
 
             // Assert
             expect(result.status).toBe(400);
@@ -230,7 +230,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.errorStatusCode(400);
 
             // Act
-            const response = await makeGqlMockResponse(mockResponse);
+            const response = await makeMockResponse(mockResponse);
             const text = await response.text();
             const act = () => JSON.parse(text);
 
@@ -245,7 +245,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.nonGraphQLBody();
 
             // Act
-            const result = await makeGqlMockResponse(mockResponse);
+            const result = await makeMockResponse(mockResponse);
 
             // Assert
             expect(result.status).toBe(200);
@@ -256,7 +256,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.nonGraphQLBody();
 
             // Act
-            const response = await makeGqlMockResponse(mockResponse);
+            const response = await makeMockResponse(mockResponse);
             const text = await response.text();
             const result = JSON.parse(text);
 
@@ -272,7 +272,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.graphQLErrors([]);
 
             // Act
-            const result = await makeGqlMockResponse(mockResponse);
+            const result = await makeMockResponse(mockResponse);
 
             // Assert
             expect(result.status).toBe(200);
@@ -284,7 +284,7 @@ describe("#makeGqlErrorResponse", () => {
             const mockResponse = RespondWith.graphQLErrors(errorMessages);
 
             // Act
-            const response = await makeGqlMockResponse(mockResponse);
+            const response = await makeMockResponse(mockResponse);
             const text = await response.text();
             const result = JSON.parse(text);
 

--- a/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
@@ -7,7 +7,7 @@ describe("RespondWith", () => {
             // Arrange
 
             // Act
-            const result = RespondWith.data({});
+            const result = RespondWith.graphQLData({});
 
             // Assert
             expect(result).toHaveProperty("type", "data");
@@ -20,7 +20,7 @@ describe("RespondWith", () => {
             };
 
             // Act
-            const result = RespondWith.data(data);
+            const result = RespondWith.graphQLData(data);
 
             // Assert
             expect(result).toHaveProperty("data", data);
@@ -138,7 +138,7 @@ describe("#makeGqlErrorResponse", () => {
     describe("data response", () => {
         it("should resolve to have a successful status code", async () => {
             // Arrange
-            const mockResponse = RespondWith.data({});
+            const mockResponse = RespondWith.graphQLData({});
 
             // Act
             const result = await makeMockResponse(mockResponse);
@@ -152,7 +152,7 @@ describe("#makeGqlErrorResponse", () => {
             const data = {
                 foo: "bar",
             };
-            const mockResponse = RespondWith.data(data);
+            const mockResponse = RespondWith.graphQLData(data);
 
             // Act
             const response = await makeMockResponse(mockResponse);

--- a/packages/wonder-blocks-testing/src/__tests__/mock-requester.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/mock-requester.test.js
@@ -1,0 +1,213 @@
+// @flow
+import {RespondWith} from "../make-mock-response.js";
+import {mockRequester} from "../mock-requester.js";
+
+describe("#mockRequester", () => {
+    it("should return a function", () => {
+        // Arrange
+
+        // Act
+        const result = mockRequester(jest.fn(), jest.fn());
+
+        // Assert
+        expect(result).toBeInstanceOf(Function);
+    });
+
+    it("should provide mockOperation API", () => {
+        // Arrange
+
+        // Act
+        const result = mockRequester(jest.fn(), jest.fn());
+
+        // Assert
+        expect(result).toHaveProperty("mockOperation", expect.any(Function));
+    });
+
+    it("should provide mockOperationOnce API", () => {
+        // Arrange
+
+        // Act
+        const result = mockRequester(jest.fn(), jest.fn());
+
+        // Assert
+        expect(result).toHaveProperty(
+            "mockOperationOnce",
+            expect.any(Function),
+        );
+    });
+
+    it("should throw with helpful details formatted by operationToString if no matching mock is found", async () => {
+        // Arrange
+        const mockFn = mockRequester(
+            jest.fn(),
+            (...args) => `TEST FORMATTING: ${JSON.stringify(args)}`,
+        );
+
+        // Act
+        const underTest = mockFn("any", "arguments", {we: {want: 42}});
+
+        // Assert
+        await expect(underTest).rejects.toThrowErrorMatchingInlineSnapshot(`
+                    "No matching mock response found for request:
+                        TEST FORMATTING: [\\"any\\",\\"arguments\\",{\\"we\\":{\\"want\\":42}}]"
+                `);
+    });
+
+    describe("mockOperation", () => {
+        it("should invoke matcher with mock for a request", async () => {
+            // Arrange
+            const matcher = jest.fn().mockReturnValue(true);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.mockOperation(
+                "THE MOCK DESCRIPTION",
+                RespondWith.text("TADA!"),
+            );
+            await mockFn("any", "arguments", {we: {want: 42}});
+
+            // Assert
+            expect(matcher).toHaveBeenCalledWith(
+                "THE MOCK DESCRIPTION",
+                "any",
+                "arguments",
+                {
+                    we: {want: 42},
+                },
+            );
+        });
+
+        it("should return mocked operation response if matcher returns true", async () => {
+            // Arrange
+            const matcher = jest.fn().mockReturnValue(true);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.mockOperation(
+                "THE MOCK DESCRIPTION",
+                RespondWith.text("TADA!"),
+            );
+            const response = await mockFn("DO SOMETHING");
+            const result = response.text();
+
+            // Assert
+            await expect(result).resolves.toBe("TADA!");
+        });
+
+        it("should skip mock if matcher returns false and try more mocks", async () => {
+            // Arrange
+            const matcher = jest
+                .fn()
+                .mockReturnValueOnce(false)
+                .mockReturnValueOnce(true);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.mockOperation(
+                "THE MOCK DESCRIPTION 1",
+                RespondWith.text("ONE"),
+            );
+            mockFn.mockOperation(
+                "THE MOCK DESCRIPTION 2",
+                RespondWith.text("TWO"),
+            );
+            const response = await mockFn("DO SOMETHING");
+            const result = response.text();
+
+            // Assert
+            await expect(result).resolves.toBe("TWO");
+        });
+    });
+
+    describe("mockOperationOnce", () => {
+        it("should invoke matcher with mock for a request", async () => {
+            // Arrange
+            const matcher = jest.fn().mockReturnValue(true);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.mockOperationOnce(
+                "THE MOCK DESCRIPTION",
+                RespondWith.text("TADA!"),
+            );
+            await mockFn("any", "arguments", {we: {want: 42}});
+
+            // Assert
+            expect(matcher).toHaveBeenCalledWith(
+                "THE MOCK DESCRIPTION",
+                "any",
+                "arguments",
+                {
+                    we: {want: 42},
+                },
+            );
+        });
+
+        it("should match once", async () => {
+            // Arrange
+            const matcher = jest.fn().mockReturnValue(true);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.mockOperationOnce(
+                "THE MOCK DESCRIPTION",
+                RespondWith.text("TADA!"),
+            );
+            const response = await mockFn("DO SOMETHING");
+            const result = response.text();
+
+            // Assert
+            await expect(result).resolves.toBe("TADA!");
+        });
+
+        it("should only match once", async () => {
+            // Arrange
+            const matcher = jest.fn().mockReturnValue(true);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.mockOperationOnce(
+                "THE MOCK DESCRIPTION",
+                RespondWith.text("TADA!"),
+            );
+            const result = Promise.all([
+                mockFn("DO SOMETHING"),
+                mockFn("DO SOMETHING"),
+            ]);
+
+            // Assert
+            await expect(result).rejects.toThrowError();
+        });
+
+        it("should skip mock if matcher returns false and try more mocks", async () => {
+            // Arrange
+            const matcher = jest
+                .fn()
+                .mockReturnValueOnce(false)
+                .mockReturnValueOnce(true);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.mockOperationOnce(
+                "THE MOCK DESCRIPTION 1",
+                RespondWith.text("ONE"),
+            );
+            mockFn.mockOperationOnce(
+                "THE MOCK DESCRIPTION 2",
+                RespondWith.text("TWO"),
+            );
+            const response = await mockFn("DO SOMETHING");
+            const result = response.text();
+
+            // Assert
+            await expect(result).resolves.toBe("TWO");
+        });
+    });
+});

--- a/packages/wonder-blocks-testing/src/__tests__/response-impl.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/response-impl.test.js
@@ -1,0 +1,47 @@
+// flow
+import * as wst from "@khanacademy/wonder-stuff-testing";
+
+describe("ResponseImpl", () => {
+    const globalResponse = globalThis.Response;
+
+    beforeEach(() => {
+        if (globalResponse) {
+            delete globalThis.Response;
+        }
+    });
+
+    afterEach(() => {
+        if (globalResponse) {
+            globalThis.Response = globalResponse;
+        } else {
+            delete globalThis.Response;
+        }
+    });
+
+    it("should use Response from node-fetch if Response does not exist", () => {
+        // Arrange
+
+        // Act
+        const {ResponseImpl: result, NodeFetchResponse} =
+            wst.jest.isolateModules(() => ({
+                ResponseImpl: require("../response-impl.js").ResponseImpl,
+                NodeFetchResponse: require("node-fetch").Response,
+            }));
+
+        // Assert
+        expect(result).toBe(NodeFetchResponse);
+    });
+
+    it("should return the existing Response type if it exists", () => {
+        // Arrange
+        globalThis.Response = class CustomResponse {};
+
+        // Act
+        const result = wst.jest.isolateModules(
+            () => require("../response-impl.js").ResponseImpl,
+        );
+
+        // Assert
+        expect(result).toBe(globalThis.Response);
+    });
+});

--- a/packages/wonder-blocks-testing/src/fetch/__tests__/__snapshots__/mock-fetch.test.js.snap
+++ b/packages/wonder-blocks-testing/src/fetch/__tests__/__snapshots__/mock-fetch.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#mockFetch should reject with a useful error when there are no matching mocks for %s 1`] = `
+"No matching mock response found for request:
+    Input: http://example.com/foo
+    Options: None"
+`;
+
+exports[`#mockFetch should reject with a useful error when there are no matching mocks for %s 2`] = `
+"No matching mock response found for request:
+    Input: \\"http://example.com/foo\\"
+    Options: {
+  \\"method\\": \\"GET\\"
+}"
+`;
+
+exports[`#mockFetch should reject with a useful error when there are no matching mocks for %s 3`] = `
+"No matching mock response found for request:
+    Input: {
+  \\"size\\": 0,
+  \\"timeout\\": 0,
+  \\"follow\\": 20,
+  \\"compress\\": true,
+  \\"counter\\": 0
+}
+    Options: {
+  \\"method\\": \\"POST\\"
+}"
+`;

--- a/packages/wonder-blocks-testing/src/fetch/__tests__/fetch-request-matches-mock.test.js
+++ b/packages/wonder-blocks-testing/src/fetch/__tests__/fetch-request-matches-mock.test.js
@@ -1,0 +1,99 @@
+// @flow
+import {Request} from "node-fetch";
+import {fetchRequestMatchesMock} from "../fetch-request-matches-mock.js";
+
+const TEST_URL = "http://example.com/foo?querya=1&queryb=elephants#fragment";
+
+describe("#fetchRequestMatchesMock", () => {
+    it("should throw if mock is not valid", () => {
+        // Arrange
+        const mock = {
+            operation: {
+                id: "foo",
+                type: "query",
+            },
+        };
+
+        // Act
+        const underTest = () =>
+            fetchRequestMatchesMock((mock: any), TEST_URL, null);
+
+        // Assert
+        expect(underTest).toThrowErrorMatchingInlineSnapshot(
+            `"Unsupported mock operation: {\\"operation\\":{\\"id\\":\\"foo\\",\\"type\\":\\"query\\"}}"`,
+        );
+    });
+
+    it("should throw if input is not valid", () => {
+        // Arrange
+        const mock = "http://example.com/foo";
+
+        // Act
+        const underTest = () =>
+            fetchRequestMatchesMock(
+                mock,
+                ({not: "a valid request"}: any),
+                null,
+            );
+
+        // Assert
+        expect(underTest).toThrowErrorMatchingInlineSnapshot(
+            `"Unsupported input type"`,
+        );
+    });
+
+    describe.each([TEST_URL, new URL(TEST_URL), new Request(TEST_URL)])(
+        "for valid inputs",
+        (input) => {
+            it("should return false if mock is a string and it does not match the fetched URL", () => {
+                // Arrange
+                const mock = "http://example.com/bar";
+
+                // Act
+                const result = fetchRequestMatchesMock(mock, input, null);
+
+                // Assert
+                expect(result).toBe(false);
+            });
+
+            it("should return false if the mock is a regular expression and it doesn't match the fetched URL", () => {
+                // Arrange
+                const mock = /\/bar/;
+
+                // Act
+                const result = fetchRequestMatchesMock(mock, input, null);
+
+                // Assert
+                expect(result).toBe(false);
+            });
+
+            it("should return true if the mock is a string and matches the fetched URL", () => {
+                // Arrange
+                const mock = TEST_URL;
+
+                // Act
+                const result = fetchRequestMatchesMock(mock, input, null);
+
+                // Assert
+                expect(result).toBe(true);
+            });
+
+            it.each([
+                /http:\/\/example.com\/foo/,
+                /queryb=elephants/,
+                /^.*#fragment$/,
+            ])(
+                "should return true if the mock is a %s and matches the fetched URL",
+                (regex) => {
+                    // Arrange
+
+                    // Act
+                    const result = fetchRequestMatchesMock(regex, input, null);
+
+                    // Assert
+                    expect(result).toBe(true);
+                },
+            );
+        },
+    );
+});

--- a/packages/wonder-blocks-testing/src/fetch/__tests__/mock-fetch.test.js
+++ b/packages/wonder-blocks-testing/src/fetch/__tests__/mock-fetch.test.js
@@ -1,0 +1,84 @@
+// @flow
+import {Request} from "node-fetch";
+import {RespondWith} from "../../make-mock-response.js";
+import {mockFetch} from "../mock-fetch.js";
+
+describe("#mockFetch", () => {
+    it.each`
+        input                                    | init
+        ${"http://example.com/foo"}              | ${undefined}
+        ${new URL("http://example.com/foo")}     | ${{method: "GET"}}
+        ${new Request("http://example.com/foo")} | ${{method: "POST"}}
+    `(
+        "should reject with a useful error when there are no matching mocks for %s",
+        async ({input, init}) => {
+            // Arrange
+            const mockFn = mockFetch();
+
+            // Act
+            const result = mockFn(input, init);
+
+            // Assert
+            await expect(result).rejects.toThrowErrorMatchingSnapshot();
+        },
+    );
+
+    describe("mockOperation", () => {
+        it("should match a similar operation", async () => {
+            // Arrange
+            const mockFn = mockFetch();
+            const operation = "http://example.com/foo";
+
+            // Act
+            mockFn.mockOperation(operation, RespondWith.text("TADA!"));
+            const result = mockFn(operation, {method: "GET"});
+
+            // Assert
+            await expect(result).resolves.toBeDefined();
+        });
+
+        it("should not match a different operation", async () => {
+            // Arrange
+            const mockFn = mockFetch();
+            const operation = "http://example.com/foo";
+
+            // Act
+            mockFn.mockOperation(operation, RespondWith.text("TADA!"));
+            const result = mockFn("http://example.com/bar", {method: "GET"});
+
+            // Assert
+            await expect(result).rejects.toThrowError();
+        });
+    });
+
+    describe("mockOperationOnce", () => {
+        it("should match once", async () => {
+            // Arrange
+            const mockFn = mockFetch();
+            const operation = "http://example.com/foo";
+
+            // Act
+            mockFn.mockOperationOnce(operation, RespondWith.text("TADA!"));
+            const result = mockFn(operation, {method: "GET"});
+
+            // Assert
+            await expect(result).resolves.toBeDefined();
+        });
+
+        it("should only match once", async () => {
+            // Arrange
+            const mockFn = mockFetch();
+            const operation = "http://example.com/foo";
+
+            // Act
+            mockFn.mockOperationOnce(operation, RespondWith.text("TADA!"));
+            const result = Promise.all([
+                mockFn(operation, {method: "GET"}),
+                mockFn(operation, {method: "POST"}),
+            ]);
+
+            // Assert
+            await expect(result).rejects.toThrowError();
+        });
+    });
+});

--- a/packages/wonder-blocks-testing/src/fetch/fetch-request-matches-mock.js
+++ b/packages/wonder-blocks-testing/src/fetch/fetch-request-matches-mock.js
@@ -1,0 +1,43 @@
+// @flow
+import type {FetchMockOperation} from "./types.js";
+
+/**
+ * Get the URL from the given RequestInfo.
+ *
+ * Since we could be running in Node or in JSDOM, we don't check instance
+ * types, but just use a heuristic so that this works without knowing what
+ * was polyfilling things.
+ */
+const getHref = (input: RequestInfo): string => {
+    if (typeof input === "string") {
+        return input;
+    } else if (typeof input.url === "string") {
+        return input.url;
+    } else if (typeof input.href === "string") {
+        return input.href;
+    } else {
+        throw new Error(`Unsupported input type`);
+    }
+};
+
+/**
+ * Determines if a given fetch invocation matches the given mock.
+ */
+export const fetchRequestMatchesMock = (
+    mock: FetchMockOperation,
+    input: RequestInfo,
+    init: ?RequestOptions,
+): boolean => {
+    // Currently, we only match on the input portion.
+    // This can be a Request, a URL, or a string.
+    const href = getHref(input);
+
+    // Our mock operation is either a string for an exact match, or a regex.
+    if (typeof mock === "string") {
+        return href === mock;
+    } else if (mock instanceof RegExp) {
+        return mock.test(href);
+    } else {
+        throw new Error(`Unsupported mock operation: ${JSON.stringify(mock)}`);
+    }
+};

--- a/packages/wonder-blocks-testing/src/fetch/mock-fetch.js
+++ b/packages/wonder-blocks-testing/src/fetch/mock-fetch.js
@@ -1,0 +1,19 @@
+// @flow
+import {fetchRequestMatchesMock} from "./fetch-request-matches-mock.js";
+import {mockRequester} from "../mock-requester.js";
+import type {FetchMockFn, FetchMockOperation} from "./types.js";
+
+/**
+ * A mock for the fetch function passed to GqlRouter.
+ */
+export const mockFetch = (): FetchMockFn =>
+    mockRequester<FetchMockOperation, _>(
+        fetchRequestMatchesMock,
+        (input, init) =>
+            `Input: ${
+                typeof input === "string"
+                    ? input
+                    : JSON.stringify(input, null, 2)
+            }
+    Options: ${init == null ? "None" : JSON.stringify(init, null, 2)}`,
+    );

--- a/packages/wonder-blocks-testing/src/fetch/types.js
+++ b/packages/wonder-blocks-testing/src/fetch/types.js
@@ -1,0 +1,18 @@
+//@flow
+import type {OperationMock} from "../types.js";
+import type {MockResponse} from "../make-mock-response.js";
+
+export type FetchMockOperation = RegExp | string;
+
+type FetchMockOperationFn = (
+    operation: FetchMockOperation,
+    response: MockResponse<any>,
+) => FetchMockFn;
+
+export type FetchMockFn = {|
+    (input: RequestInfo, init?: RequestOptions): Promise<Response>,
+    mockOperation: FetchMockOperationFn,
+    mockOperationOnce: FetchMockOperationFn,
+|};
+
+export type FetchMock = OperationMock<FetchMockOperation>;

--- a/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 
 import {GqlRouter, useGql} from "@khanacademy/wonder-blocks-data";
-import {RespondWith} from "../make-gql-mock-response.js";
+import {RespondWith} from "../../make-mock-response.js";
 import {mockGqlFetch} from "../mock-gql-fetch.js";
 
 describe("#mockGqlFetch", () => {

--- a/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
@@ -37,7 +37,7 @@ describe("#mockGqlFetch", () => {
             // Assert
             await waitFor(() =>
                 expect(result).toHaveTextContent(
-                    "No matching GraphQL mock response found for request",
+                    "No matching mock response found for request",
                 ),
             );
         });
@@ -174,7 +174,7 @@ describe("#mockGqlFetch", () => {
 
         // Assert
         await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
-                    "No matching GraphQL mock response found for request:
+                    "No matching mock response found for request:
                         Operation: query getMyStuff
                         Variables: {
                       \\"a\\": \\"variable\\"

--- a/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
@@ -65,7 +65,10 @@ describe("#mockGqlFetch", () => {
             };
 
             // Act
-            mockFetch.mockOperation({operation: query}, RespondWith.data(data));
+            mockFetch.mockOperation(
+                {operation: query},
+                RespondWith.graphQLData(data),
+            );
             render(
                 <GqlRouter defaultContext={{}} fetch={mockFetch}>
                     <RenderData />
@@ -195,7 +198,7 @@ describe("#mockGqlFetch", () => {
             };
 
             // Act
-            mockFetch.mockOperation({operation}, RespondWith.data(data));
+            mockFetch.mockOperation({operation}, RespondWith.graphQLData(data));
             const result = mockFetch(
                 operation,
                 {a: "variable"},
@@ -218,7 +221,7 @@ describe("#mockGqlFetch", () => {
             };
 
             // Act
-            mockFetch.mockOperation({operation}, RespondWith.data(data));
+            mockFetch.mockOperation({operation}, RespondWith.graphQLData(data));
             const result = mockFetch(
                 {type: "mutation", id: "putMyStuff"},
                 {a: "variable"},
@@ -246,7 +249,7 @@ describe("#mockGqlFetch", () => {
             // Act
             mockFetch.mockOperation(
                 {operation, variables},
-                RespondWith.data(data),
+                RespondWith.graphQLData(data),
             );
             const result = mockFetch(operation, variables, {my: "context"});
 
@@ -271,7 +274,7 @@ describe("#mockGqlFetch", () => {
             // Act
             mockFetch.mockOperation(
                 {operation, variables},
-                RespondWith.data(data),
+                RespondWith.graphQLData(data),
             );
             const result = mockFetch(
                 operation,
@@ -300,7 +303,7 @@ describe("#mockGqlFetch", () => {
             // Act
             mockFetch.mockOperation(
                 {operation, context},
-                RespondWith.data(data),
+                RespondWith.graphQLData(data),
             );
             const result = mockFetch(operation, {a: "variable"}, context);
 
@@ -325,7 +328,7 @@ describe("#mockGqlFetch", () => {
             // Act
             mockFetch.mockOperation(
                 {operation, context},
-                RespondWith.data(data),
+                RespondWith.graphQLData(data),
             );
             const result = mockFetch(
                 operation,
@@ -357,7 +360,7 @@ describe("#mockGqlFetch", () => {
             // Act
             mockFetch.mockOperation(
                 {operation, variables, context},
-                RespondWith.data(data),
+                RespondWith.graphQLData(data),
             );
             const result = mockFetch(operation, variables, context);
 
@@ -385,7 +388,7 @@ describe("#mockGqlFetch", () => {
             // Act
             mockFetch.mockOperation(
                 {operation, variables, context},
-                RespondWith.data(data),
+                RespondWith.graphQLData(data),
             );
             const response = await mockFetch(operation, variables, context);
             const result = await response.text();
@@ -406,7 +409,7 @@ describe("#mockGqlFetch", () => {
             };
 
             // Act
-            mockFetch.mockOperation({operation}, RespondWith.data(data));
+            mockFetch.mockOperation({operation}, RespondWith.graphQLData(data));
             const result = Promise.all([
                 mockFetch(operation, {a: "variable"}, {my: "context"}),
                 mockFetch(operation, {b: "variable"}, {another: "context"}),
@@ -433,7 +436,10 @@ describe("#mockGqlFetch", () => {
             };
 
             // Act
-            mockFetch.mockOperationOnce({operation}, RespondWith.data(data));
+            mockFetch.mockOperationOnce(
+                {operation},
+                RespondWith.graphQLData(data),
+            );
             const result = mockFetch(
                 operation,
                 {a: "variable"},
@@ -456,7 +462,10 @@ describe("#mockGqlFetch", () => {
             };
 
             // Act
-            mockFetch.mockOperationOnce({operation}, RespondWith.data(data));
+            mockFetch.mockOperationOnce(
+                {operation},
+                RespondWith.graphQLData(data),
+            );
             const result = Promise.all([
                 mockFetch(operation, {a: "variable"}, {my: "context"}),
                 mockFetch(operation, {b: "variable"}, {another: "context"}),

--- a/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
@@ -41,7 +41,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
         );
     });
 
-    it("should resolve with data for RespondWith.data", async () => {
+    it("should resolve with data for RespondWith.graphQLData", async () => {
         // Arrange
         const mockFetch = mockGqlFetch();
         const query = {
@@ -64,7 +64,10 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
         };
 
         // Act
-        mockFetch.mockOperation({operation: query}, RespondWith.data(data));
+        mockFetch.mockOperation(
+            {operation: query},
+            RespondWith.graphQLData(data),
+        );
         render(
             <GqlRouter defaultContext={{}} fetch={mockFetch}>
                 <RenderData />

--- a/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
@@ -36,7 +36,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
         // Assert
         await waitFor(() =>
             expect(result).toHaveTextContent(
-                "No matching GraphQL mock response found for request",
+                "No matching mock response found for request",
             ),
         );
     });

--- a/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 
 import {GqlRouter, useGql} from "@khanacademy/wonder-blocks-data";
-import {RespondWith} from "../make-gql-mock-response.js";
+import {RespondWith} from "../../make-mock-response.js";
 import {mockGqlFetch} from "../mock-gql-fetch.js";
 
 describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
@@ -1,8 +1,8 @@
 // @flow
 import type {GqlContext} from "@khanacademy/wonder-blocks-data";
 import {gqlRequestMatchesMock} from "./gql-request-matches-mock.js";
-import {makeGqlMockResponse} from "./make-gql-mock-response.js";
-import type {GqlMockResponse} from "./make-gql-mock-response.js";
+import {makeMockResponse} from "../make-mock-response.js";
+import type {MockResponse} from "../make-mock-response.js";
 import type {GqlMock, GqlMockOperation, GqlFetchMockFn} from "./types.js";
 
 /**
@@ -54,10 +54,10 @@ export const mockGqlFetch = (): GqlFetchMockFn => {
 
     const addMockedOperation = <TData, TVariables: {...}, TContext: GqlContext>(
         operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: GqlMockResponse<TData>,
+        response: MockResponse<TData>,
         onceOnly: boolean,
     ): GqlFetchMockFn => {
-        const mockResponse = () => makeGqlMockResponse(response);
+        const mockResponse = () => makeMockResponse(response);
         mocks.push({
             operation,
             response: mockResponse,
@@ -73,7 +73,7 @@ export const mockGqlFetch = (): GqlFetchMockFn => {
         TContext: GqlContext,
     >(
         operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: GqlMockResponse<TData>,
+        response: MockResponse<TData>,
     ): GqlFetchMockFn => addMockedOperation(operation, response, false);
 
     gqlFetchMock.mockOperationOnce = <
@@ -82,7 +82,7 @@ export const mockGqlFetch = (): GqlFetchMockFn => {
         TContext: GqlContext,
     >(
         operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: GqlMockResponse<TData>,
+        response: MockResponse<TData>,
     ): GqlFetchMockFn => addMockedOperation(operation, response, true);
 
     return gqlFetchMock;

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
@@ -1,89 +1,18 @@
 // @flow
-import type {GqlContext} from "@khanacademy/wonder-blocks-data";
 import {gqlRequestMatchesMock} from "./gql-request-matches-mock.js";
-import {makeMockResponse} from "../make-mock-response.js";
-import type {MockResponse, GraphQLJson} from "../make-mock-response.js";
-import type {GqlMock, GqlMockOperation, GqlFetchMockFn} from "./types.js";
+import {mockRequester} from "../mock-requester.js";
+import type {GqlFetchMockFn, GqlMockOperation} from "./types.js";
 
 /**
  * A mock for the fetch function passed to GqlRouter.
  */
-export const mockGqlFetch = (): GqlFetchMockFn => {
-    // We want this to work in jest and in fixtures to make life easy for folks.
-    // This is the array of mocked operations that we will traverse and
-    // manipulate.
-    const mocks: Array<GqlMock> = [];
-
-    // What we return has to be a drop in for the fetch function that is
-    // provided to `GqlRouter` which is how folks will then use this mock.
-    const gqlFetchMock: GqlFetchMockFn = (
-        operation,
-        variables,
-        context,
-    ): Promise<Response> => {
-        // Iterate our mocked operations and find the first one that matches.
-        for (const mock of mocks) {
-            if (mock.onceOnly && mock.used) {
-                // This is a once-only mock and it has been used, so skip it.
-                continue;
-            }
-            if (
-                gqlRequestMatchesMock(
-                    mock.operation,
-                    operation,
-                    variables,
-                    context,
-                )
-            ) {
-                mock.used = true;
-                return mock.response();
-            }
-        }
-
-        // Default is to reject with some helpful info on what request
-        // we rejected.
-        return Promise.reject(
-            new Error(`No matching GraphQL mock response found for request:
-    Operation: ${operation.type} ${operation.id}
+export const mockGqlFetch = (): GqlFetchMockFn =>
+    mockRequester<GqlMockOperation<any, any, any>, _>(
+        gqlRequestMatchesMock,
+        (operation, variables, context) =>
+            `Operation: ${operation.type} ${operation.id}
     Variables: ${
         variables == null ? "None" : JSON.stringify(variables, null, 2)
     }
-    Context: ${JSON.stringify(context, null, 2)}`),
-        );
-    };
-
-    const addMockedOperation = <TData, TVariables: {...}, TContext: GqlContext>(
-        operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: MockResponse<GraphQLJson<TData>>,
-        onceOnly: boolean,
-    ): GqlFetchMockFn => {
-        const mockResponse = () => makeMockResponse(response);
-        mocks.push({
-            operation,
-            response: mockResponse,
-            onceOnly,
-            used: false,
-        });
-        return gqlFetchMock;
-    };
-
-    gqlFetchMock.mockOperation = <
-        TData: {...},
-        TVariables: {...},
-        TContext: GqlContext,
-    >(
-        operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: MockResponse<GraphQLJson<TData>>,
-    ): GqlFetchMockFn => addMockedOperation(operation, response, false);
-
-    gqlFetchMock.mockOperationOnce = <
-        TData: {...},
-        TVariables: {...},
-        TContext: GqlContext,
-    >(
-        operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: MockResponse<GraphQLJson<TData>>,
-    ): GqlFetchMockFn => addMockedOperation(operation, response, true);
-
-    return gqlFetchMock;
-};
+    Context: ${JSON.stringify(context, null, 2)}`,
+    );

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
@@ -2,7 +2,7 @@
 import type {GqlContext} from "@khanacademy/wonder-blocks-data";
 import {gqlRequestMatchesMock} from "./gql-request-matches-mock.js";
 import {makeMockResponse} from "../make-mock-response.js";
-import type {MockResponse} from "../make-mock-response.js";
+import type {MockResponse, GraphQLJson} from "../make-mock-response.js";
 import type {GqlMock, GqlMockOperation, GqlFetchMockFn} from "./types.js";
 
 /**
@@ -54,7 +54,7 @@ export const mockGqlFetch = (): GqlFetchMockFn => {
 
     const addMockedOperation = <TData, TVariables: {...}, TContext: GqlContext>(
         operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: MockResponse<TData>,
+        response: MockResponse<GraphQLJson<TData>>,
         onceOnly: boolean,
     ): GqlFetchMockFn => {
         const mockResponse = () => makeMockResponse(response);
@@ -68,21 +68,21 @@ export const mockGqlFetch = (): GqlFetchMockFn => {
     };
 
     gqlFetchMock.mockOperation = <
-        TData,
+        TData: {...},
         TVariables: {...},
         TContext: GqlContext,
     >(
         operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: MockResponse<TData>,
+        response: MockResponse<GraphQLJson<TData>>,
     ): GqlFetchMockFn => addMockedOperation(operation, response, false);
 
     gqlFetchMock.mockOperationOnce = <
-        TData,
+        TData: {...},
         TVariables: {...},
         TContext: GqlContext,
     >(
         operation: GqlMockOperation<TData, TVariables, TContext>,
-        response: MockResponse<TData>,
+        response: MockResponse<GraphQLJson<TData>>,
     ): GqlFetchMockFn => addMockedOperation(operation, response, true);
 
     return gqlFetchMock;

--- a/packages/wonder-blocks-testing/src/gql/types.js
+++ b/packages/wonder-blocks-testing/src/gql/types.js
@@ -1,6 +1,6 @@
 //@flow
 import type {GqlOperation, GqlContext} from "@khanacademy/wonder-blocks-data";
-import type {GqlMockResponse} from "./make-gql-mock-response.js";
+import type {MockResponse} from "../make-mock-response.js";
 
 export type GqlMockOperation<
     TData,
@@ -14,7 +14,7 @@ export type GqlMockOperation<
 
 type GqlMockOperationFn = <TData, TVariables: {...}, TContext: GqlContext>(
     operation: GqlMockOperation<TData, TVariables, TContext>,
-    response: GqlMockResponse<TData>,
+    response: MockResponse<TData>,
 ) => GqlFetchMockFn;
 
 export type GqlFetchMockFn = {|

--- a/packages/wonder-blocks-testing/src/gql/types.js
+++ b/packages/wonder-blocks-testing/src/gql/types.js
@@ -1,6 +1,7 @@
 //@flow
 import type {GqlOperation, GqlContext} from "@khanacademy/wonder-blocks-data";
-import type {MockResponse, GraphQLJson} from "../make-mock-response.js";
+import type {OperationMock, GraphQLJson} from "../types.js";
+import type {MockResponse} from "../make-mock-response.js";
 
 export type GqlMockOperation<
     TData: {...},
@@ -16,9 +17,10 @@ type GqlMockOperationFn = <
     TData: {...},
     TVariables: {...},
     TContext: GqlContext,
+    TResponseData: GraphQLJson<TData>,
 >(
     operation: GqlMockOperation<TData, TVariables, TContext>,
-    response: MockResponse<GraphQLJson<TData>>,
+    response: MockResponse<TResponseData>,
 ) => GqlFetchMockFn;
 
 export type GqlFetchMockFn = {|
@@ -31,9 +33,4 @@ export type GqlFetchMockFn = {|
     mockOperationOnce: GqlMockOperationFn,
 |};
 
-export type GqlMock = {|
-    operation: GqlMockOperation<any, any, any>,
-    onceOnly: boolean,
-    used: boolean,
-    response: () => Promise<Response>,
-|};
+export type GqlMock = OperationMock<GqlMockOperation<any, any, any>>;

--- a/packages/wonder-blocks-testing/src/gql/types.js
+++ b/packages/wonder-blocks-testing/src/gql/types.js
@@ -1,9 +1,9 @@
 //@flow
 import type {GqlOperation, GqlContext} from "@khanacademy/wonder-blocks-data";
-import type {MockResponse} from "../make-mock-response.js";
+import type {MockResponse, GraphQLJson} from "../make-mock-response.js";
 
 export type GqlMockOperation<
-    TData,
+    TData: {...},
     TVariables: {...},
     TContext: GqlContext,
 > = {|
@@ -12,9 +12,13 @@ export type GqlMockOperation<
     context?: TContext,
 |};
 
-type GqlMockOperationFn = <TData, TVariables: {...}, TContext: GqlContext>(
+type GqlMockOperationFn = <
+    TData: {...},
+    TVariables: {...},
+    TContext: GqlContext,
+>(
     operation: GqlMockOperation<TData, TVariables, TContext>,
-    response: MockResponse<TData>,
+    response: MockResponse<GraphQLJson<TData>>,
 ) => GqlFetchMockFn;
 
 export type GqlFetchMockFn = {|

--- a/packages/wonder-blocks-testing/src/index.js
+++ b/packages/wonder-blocks-testing/src/index.js
@@ -19,6 +19,6 @@ export type {
 
 // GraphQL framework
 export {mockGqlFetch} from "./gql/mock-gql-fetch.js";
-export type {GqlMockResponse} from "./gql/make-gql-mock-response.js";
-export {RespondWith} from "./gql/make-gql-mock-response.js";
+export type {MockResponse} from "./make-mock-response.js";
+export {RespondWith} from "./make-mock-response.js";
 export type {GqlFetchMockFn, GqlMock, GqlMockOperation} from "./gql/types.js";

--- a/packages/wonder-blocks-testing/src/index.js
+++ b/packages/wonder-blocks-testing/src/index.js
@@ -17,8 +17,14 @@ export type {
     FixturesOptions,
 } from "./fixtures/types.js";
 
-// GraphQL framework
-export {mockGqlFetch} from "./gql/mock-gql-fetch.js";
+// Fetch mocking framework
 export type {MockResponse} from "./make-mock-response.js";
 export {RespondWith} from "./make-mock-response.js";
+export {mockFetch} from "./fetch/mock-fetch.js";
+export type {
+    FetchMockFn,
+    FetchMock,
+    FetchMockOperation,
+} from "./fetch/types.js";
+export {mockGqlFetch} from "./gql/mock-gql-fetch.js";
 export type {GqlFetchMockFn, GqlMock, GqlMockOperation} from "./gql/types.js";

--- a/packages/wonder-blocks-testing/src/make-mock-response.js
+++ b/packages/wonder-blocks-testing/src/make-mock-response.js
@@ -1,5 +1,5 @@
 // @flow
-export opaque type GqlMockResponse<TData> =
+export opaque type MockResponse<TData> =
     | {|
           type: "data",
           data: TData,
@@ -20,16 +20,16 @@ export opaque type GqlMockResponse<TData> =
     | {|type: "graphql", errors: $ReadOnlyArray<string>|};
 
 /**
- * Helpers to define rejection states for mocking GQL requests.
+ * Helpers to define rejection states for mocking requests.
  */
 export const RespondWith = Object.freeze({
-    data: <TData>(data: TData): GqlMockResponse<TData> => ({
+    data: <TData>(data: TData): MockResponse<TData> => ({
         type: "data",
         data,
     }),
-    unparseableBody: (): GqlMockResponse<any> => ({type: "parse"}),
-    abortedRequest: (): GqlMockResponse<any> => ({type: "abort"}),
-    errorStatusCode: (statusCode: number): GqlMockResponse<any> => {
+    unparseableBody: (): MockResponse<any> => ({type: "parse"}),
+    abortedRequest: (): MockResponse<any> => ({type: "abort"}),
+    errorStatusCode: (statusCode: number): MockResponse<any> => {
         if (statusCode < 300) {
             throw new Error(`${statusCode} is not a valid error status code`);
         }
@@ -38,10 +38,10 @@ export const RespondWith = Object.freeze({
             statusCode,
         };
     },
-    nonGraphQLBody: (): GqlMockResponse<any> => ({type: "invalid"}),
+    nonGraphQLBody: (): MockResponse<any> => ({type: "invalid"}),
     graphQLErrors: (
         errorMessages: $ReadOnlyArray<string>,
-    ): GqlMockResponse<any> => ({
+    ): MockResponse<any> => ({
         type: "graphql",
         errors: errorMessages,
     }),
@@ -51,8 +51,8 @@ export const RespondWith = Object.freeze({
  * Turns an ErrorResponse value in an actual Response that will invoke
  * that error.
  */
-export const makeGqlMockResponse = <TData>(
-    response: GqlMockResponse<TData>,
+export const makeMockResponse = <TData>(
+    response: MockResponse<TData>,
 ): Promise<Response> => {
     switch (response.type) {
         case "data":

--- a/packages/wonder-blocks-testing/src/make-mock-response.js
+++ b/packages/wonder-blocks-testing/src/make-mock-response.js
@@ -121,8 +121,7 @@ export const RespondWith = Object.freeze({
 });
 
 /**
- * Turns an ErrorResponse value in an actual Response that will invoke
- * that error.
+ * Turns a MockResponse value to an actual Response that represents the mock.
  */
 export const makeMockResponse = (
     response: MockResponse<any>,

--- a/packages/wonder-blocks-testing/src/mock-requester.js
+++ b/packages/wonder-blocks-testing/src/mock-requester.js
@@ -1,0 +1,75 @@
+// @flow
+import {makeMockResponse} from "./make-mock-response.js";
+import type {MockResponse} from "./make-mock-response.js";
+import type {OperationMock, OperationMatcher, MockFn} from "./types.js";
+
+/**
+ * A generic mock request function for using when mocking fetch or gqlFetch.
+ */
+export const mockRequester = <
+    TOperationType,
+    TOperationMock: OperationMock<TOperationType>,
+>(
+    operationMatcher: OperationMatcher<any>,
+    operationToString: (
+        operationMock: TOperationMock,
+        ...args: Array<any>
+    ) => string,
+): MockFn<TOperationType> => {
+    // We want this to work in jest and in fixtures to make life easy for folks.
+    // This is the array of mocked operations that we will traverse and
+    // manipulate.
+    const mocks: Array<OperationMock<any>> = [];
+
+    // What we return has to be a drop in for the fetch function that is
+    // provided to `GqlRouter` which is how folks will then use this mock.
+    const mockFn: MockFn<TOperationType> = (
+        ...args: Array<any>
+    ): Promise<Response> => {
+        // Iterate our mocked operations and find the first one that matches.
+        for (const mock of mocks) {
+            if (mock.onceOnly && mock.used) {
+                // This is a once-only mock and it has been used, so skip it.
+                continue;
+            }
+            if (operationMatcher(mock.operation, ...args)) {
+                mock.used = true;
+                return mock.response();
+            }
+        }
+
+        // Default is to reject with some helpful info on what request
+        // we rejected.
+        return Promise.reject(
+            new Error(`No matching mock response found for request:
+    ${operationToString(...args)}`),
+        );
+    };
+
+    const addMockedOperation = <TOperation>(
+        operation: TOperation,
+        response: MockResponse<any>,
+        onceOnly: boolean,
+    ): MockFn<TOperationType> => {
+        const mockResponse = () => makeMockResponse(response);
+        mocks.push({
+            operation,
+            response: mockResponse,
+            onceOnly,
+            used: false,
+        });
+        return mockFn;
+    };
+
+    mockFn.mockOperation = <TOperation>(
+        operation: TOperation,
+        response: MockResponse<any>,
+    ): MockFn<TOperationType> => addMockedOperation(operation, response, false);
+
+    mockFn.mockOperationOnce = <TOperation>(
+        operation: TOperation,
+        response: MockResponse<any>,
+    ): MockFn<TOperationType> => addMockedOperation(operation, response, true);
+
+    return mockFn;
+};

--- a/packages/wonder-blocks-testing/src/response-impl.js
+++ b/packages/wonder-blocks-testing/src/response-impl.js
@@ -1,0 +1,9 @@
+// @flow
+
+// We need a version of Response. When we're in Jest JSDOM environment or a
+// version of Node that supports the fetch API (17 and up, possibly with
+// --experimental-fetch flag), then we're good, but otherwise we need an
+// implementation, so this uses node-fetch as a peer dependency and uses that
+// to provide the implementation if we don't already have one.
+export const ResponseImpl: typeof Response =
+    typeof Response === "undefined" ? require("node-fetch").Response : Response;

--- a/packages/wonder-blocks-testing/src/types.js
+++ b/packages/wonder-blocks-testing/src/types.js
@@ -1,0 +1,39 @@
+// @flow
+import type {MockResponse} from "./make-mock-response.js";
+
+/**
+ * A valid GraphQL response as supported by our mocking framework.
+ * Note that we don't currently support both data and errors being set.
+ */
+export type GraphQLJson<TData: {...}> =
+    | {|
+          data: TData,
+      |}
+    | {|
+          errors: Array<{|
+              message: string,
+          |}>,
+      |};
+
+export type MockFn<TOperationType> = {|
+    (...args: Array<any>): Promise<Response>,
+    mockOperation: MockOperationFn<TOperationType>,
+    mockOperationOnce: MockOperationFn<TOperationType>,
+|};
+
+export type OperationMock<TOperation> = {|
+    operation: TOperation,
+    onceOnly: boolean,
+    used: boolean,
+    response: () => Promise<Response>,
+|};
+
+export type OperationMatcher<TOperation> = (
+    operation: TOperation,
+    ...args: Array<any>
+) => boolean;
+
+export type MockOperationFn<TOperationType> = <TOperation: TOperationType>(
+    operation: TOperation,
+    response: MockResponse<any>,
+) => MockFn<TOperationType>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7428,6 +7428,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 data-urls@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -9092,6 +9097,14 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.5.tgz#0077bf5f3fcdbd9d75a0b5362f77dbb743489863"
+  integrity sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -9382,6 +9395,13 @@ format@^0.2.0, format@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -14238,6 +14258,11 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -14249,6 +14274,15 @@ node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.3.tgz#a03c9cc2044d21d1a021566bd52f080f333719a6"
+  integrity sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -19581,6 +19615,11 @@ web-namespaces@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
+  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7428,11 +7428,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
-  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
-
 data-urls@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -9097,14 +9092,6 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.5.tgz#0077bf5f3fcdbd9d75a0b5362f77dbb743489863"
-  integrity sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -9395,13 +9382,6 @@ format@^0.2.0, format@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -14258,11 +14238,6 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -14275,14 +14250,12 @@ node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-fetch@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.3.tgz#a03c9cc2044d21d1a021566bd52f080f333719a6"
-  integrity sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
+    whatwg-url "^5.0.0"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -18644,6 +18617,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -19616,10 +19594,10 @@ web-namespaces@^2.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
-web-streams-polyfill@^3.0.3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
-  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -19821,6 +19799,14 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^6.4.1:
   version "6.5.0"


### PR DESCRIPTION
## Summary:
This takes the implementation of `mockGqlFetch` and creates a generic approach that is then reused with the new `mockFetch`. This also adds some more things to `RespondWith` to cater to `mockFetch` scenarios and generally refactors things.

The idea is that in webapp stories we can now use `mockFetch` to create a mock of `fetch` for the given story, as well as reset the `fetch` function between stories to prevent overlap.

Issue: FEI-4429

## Test plan:
`yarn test`
`yarn flow`