### PR TITLE
Fix perf issue in FakeTranslate

### DIFF
--- a/.changeset/chilly-panthers-act.md
+++ b/.changeset/chilly-panthers-act.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-i18n": patch
+---
+
+Pass-through strings if the current locale is not a pseudo-lang

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-faketranslate.test.js
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-faketranslate.test.js
@@ -180,5 +180,34 @@ describe("i18n-faketranslate", () => {
                 expect(result).toEqual(expectation);
             });
         });
+
+        it("should not call document.createElement() for real locales", () => {
+            // Arrange
+            jest.spyOn(Locale, "getLocale").mockImplementation(() => "es");
+            const createElementSpy = jest.spyOn(document, "createElement");
+            const underTest = new FakeTranslate();
+
+            // Act
+            // We use a Symbol to ensure that .translate() is a passthrough.
+            underTest.translate("hello, world");
+
+            // Assert
+            expect(createElementSpy).not.toHaveBeenCalled();
+        });
+
+        it("should passthrough the arg for real locales", () => {
+            // Arrange
+            jest.spyOn(Locale, "getLocale").mockImplementation(() => "es");
+            const underTest = new FakeTranslate();
+            const arg = Symbol("Hello, world!");
+
+            // Act
+            // We use a Symbol to ensure that .translate() is a passthrough.
+            // $FlowIgnore[incompatible-call]
+            const result = underTest.translate(arg);
+
+            // Assert
+            expect(result).toBe(arg);
+        });
     });
 });

--- a/packages/wonder-blocks-i18n/src/functions/i18n-faketranslate.js
+++ b/packages/wonder-blocks-i18n/src/functions/i18n-faketranslate.js
@@ -33,13 +33,7 @@ export default class FakeTranslate implements IProvideTranslation {
     get _translator(): ?IProvideTranslation {
         // We look up our fake translator on the fly in case the kaLocale
         // was changed.
-        const identityTranslator = {
-            translate: (s: string) => s,
-        };
-
-        const language = getLocale();
-        const translator = language && Translators[language];
-        return translator || identityTranslator;
+        return Translators[getLocale()];
     }
 
     _translateSegment(input: string): string {


### PR DESCRIPTION
## Summary:
When I moved i18n-faketranslate.js over from webapp, I tweaked the logic a bit so that we'd call the translator all the time, even in prod.  I made the mistake of also haveing ._translator fallback to the identity function if no translator could be found.  This had the unintended result of _parseAndTranslate() no longer short circuiting for actual locales.  This PR fixes the issue by dropping the fallback.

Issue: None

## Test plan:
- yarn test i18n-faketranslate