### PR TITLE
Cell: Fix rightAccessory style

### DIFF
--- a/.changeset/neat-cobras-sing.md
+++ b/.changeset/neat-cobras-sing.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+Fixes `CellCore` to set the styles properly (removed `marginLeft: auto` from accessory and expanded the content wrapper).

--- a/packages/wonder-blocks-cell/src/components/__docs__/detail-cell.stories.js
+++ b/packages/wonder-blocks-cell/src/components/__docs__/detail-cell.stories.js
@@ -107,15 +107,16 @@ export const DetailCellWithCustomStyles: StoryComponentType = () => (
         title="Title for article item"
         subtitle1="Subtitle for article item"
         subtitle2="Subtitle for article item"
-        leftAccessory={<Icon icon={icons.contentVideo} size="medium" />}
+        leftAccessory={<Icon icon={icons.caretLeft} size="small" />}
         leftAccessoryStyle={{
-            minWidth: Spacing.xxLarge_48,
             alignSelf: "flex-start",
         }}
         rightAccessory={<Icon icon={icons.caretRight} size="small" />}
         rightAccessoryStyle={{
-            minWidth: Spacing.medium_16,
-            alignSelf: "flex-end",
+            alignSelf: "flex-start",
+        }}
+        style={{
+            textAlign: "center",
         }}
     />
 );

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.js
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.js
@@ -228,6 +228,8 @@ const styles = StyleSheet.create({
 
     content: {
         alignSelf: "center",
+        // Expand the content to fill the available space.
+        flex: 1,
         overflowWrap: "break-word",
     },
 
@@ -244,10 +246,6 @@ const styles = StyleSheet.create({
         // The right accessory will have this color by default. Unless the
         // accessory element overrides that color internally.
         color: Color.offBlack64,
-        // Align the right accessory to the right side of the cell, so we can
-        // prevent the accessory from shifting left, if the content is too
-        // short.
-        marginLeft: "auto",
     },
 
     /**


### PR DESCRIPTION
## Summary:

Fixes `CellCore` to set the styles properly on the `rightAccessory` element. The previous styles where applied incorrectly.

With this fix, now we are applying the remaining space available to the content, so the accessories are correctly aligned to each side.

Issue: XXX-XXXX

## Test plan:

Navigate to http://localhost:6061/?path=/story/cell-detailcell--default-detail-cell&globals=outline:true

https://5e1bf4b385e3fb0020b7073c-nkzomwxcrj.chromatic.com/?path=/story/cell-detailcell--default-detail-cell

Verify that the cells render as expected.

BEFORE:
<img width="487" alt="Screen Shot 2022-04-06 at 10 08 58 AM" src="https://user-images.githubusercontent.com/843075/161994593-8d525e4d-ca66-461c-9e23-2dd01c640122.png">
<img width="462" alt="Screen Shot 2022-04-06 at 10 09 21 AM" src="https://user-images.githubusercontent.com/843075/161994596-9f577b1f-9841-4f67-96ae-127f5f284763.png">

AFTER:
<img width="323" alt="Screen Shot 2022-04-06 at 10 09 46 AM" src="https://user-images.githubusercontent.com/843075/161994611-58622eaa-dde0-435e-9417-4e45b8c9c9fc.png">

