### PR TITLE
[🔥AUDIT🔥] Fix flaky Dropdown tests

### DIFF
--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import {fireEvent, render, screen} from "@testing-library/react";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import OptionItem from "../option-item.js";
@@ -784,7 +784,9 @@ describe("DropdownCore", () => {
             const searchField = await screen.findByPlaceholderText("Filter");
 
             // Assert
-            expect(searchField).toHaveFocus();
+            waitFor(() => {
+                expect(searchField).toHaveFocus();
+            });
         });
 
         it("should focus on the item after clicking on it", async () => {
@@ -826,7 +828,9 @@ describe("DropdownCore", () => {
             userEvent.click(item);
 
             // Assert
-            expect(item).toHaveFocus();
+            waitFor(() => {
+                expect(item).toHaveFocus();
+            });
         });
     });
 });


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Adds `waitFor` to a couple of Dropdown virtualized tests in `DropdownCore` so we safely assert when the right component receives focus.

We have to use async here due to the virtualized version having to use timeouts/requestAnimationFrame.

Issue: XXX-XXXX

## Test plan:

Verify that unit tests pass fine.