### PR TITLE
Update parseSimpleHTML to warn instead of throw when the use of I18nInlineMarkup isn't necessary

### DIFF
--- a/.changeset/orange-baboons-decide.md
+++ b/.changeset/orange-baboons-decide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-i18n": patch
+---
+
+Warn instead of throwing an execption if the use of I18nInlineMarkup isn't necessary

--- a/packages/wonder-blocks-i18n/src/components/__tests__/parse-simple-html.test.js
+++ b/packages/wonder-blocks-i18n/src/components/__tests__/parse-simple-html.test.js
@@ -2,6 +2,10 @@
 import {parseSimpleHTML} from "../parse-simple-html.js";
 
 describe("parseSimpleHTML", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it("Parses a self-closing tag", () => {
         expect(parseSimpleHTML("Test: <myImg />")).toEqual([
             {
@@ -117,21 +121,22 @@ describe("parseSimpleHTML", () => {
         );
     });
 
-    it("Does not accept unnecessary use", () => {
-        const action1 = () => parseSimpleHTML("Test");
-        expect(action1).toThrowErrorMatchingInlineSnapshot(
-            `"Unnecessary use of I18nInlineMarkup."`,
-        );
+    describe("Does warns on unnecessary use", () => {
+        it.each`
+            html
+            ${"Test"}
+            ${" Test "}
+            ${"<hello></hello>"}
+        `("$html", ({html}) => {
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
 
-        const action2 = () => parseSimpleHTML(" Test ");
-        expect(action2).toThrowErrorMatchingInlineSnapshot(
-            `"Unnecessary use of I18nInlineMarkup."`,
-        );
-
-        const action3 = () => parseSimpleHTML("<hello></hello>");
-        expect(action3).toThrowErrorMatchingInlineSnapshot(
-            `"Unnecessary use of I18nInlineMarkup."`,
-        );
+            parseSimpleHTML(html);
+            expect(warnSpy).toHaveBeenCalledWith(
+                "Unnecessary use of I18nInlineMarkup.",
+            );
+        });
     });
 
     it("Parses tag enclosing all text", () => {

--- a/packages/wonder-blocks-i18n/src/components/parse-simple-html.js
+++ b/packages/wonder-blocks-i18n/src/components/parse-simple-html.js
@@ -114,7 +114,8 @@ export function parseSimpleHTML(html: string): $ReadOnlyArray<SimpleHtmlNode> {
         // A tag is allowed to wrap all NL text in the html.
         (result[0].type === "text" || !result[0].children)
     ) {
-        throw new Error("Unnecessary use of I18nInlineMarkup.");
+        // eslint-disable-next-line no-console
+        console.warn("Unnecessary use of I18nInlineMarkup.");
     }
     return result;
 }


### PR DESCRIPTION
## Summary:
The translation isn't correct, but it's better to show the translation than to throw an exception which results in us showing an error screen.

Issue: None

## Test plan:
- yarn jest parse-simple-html