### PR TITLE
WB-1299: Strip comments out from ES bundles

### DIFF
--- a/.changeset/tame-ghosts-poke.md
+++ b/.changeset/tame-ghosts-poke.md
@@ -1,0 +1,5 @@
+---
+"wb-dev-build-settings": minor
+---
+
+Strip comments out from ES generated bundles

--- a/build-settings/rollup.config.js
+++ b/build-settings/rollup.config.js
@@ -24,6 +24,7 @@ const createConfig = (pkgName) => {
                 plugins,
                 exclude: "node_modules/**",
                 runtimeHelpers: true,
+                comments: false,
             }),
             autoExternal({
                 packagePath: `packages/${pkgName}/package.json`,


### PR DESCRIPTION
## Summary:

Strip comments out from ES bundles (rollup).

Issue: WB-1299

## Test plan:

Verify that the bundle sizes check shows some improvements on each bundled package.