### PR TITLE
WB-1131.2: Migrate `wonder-blocks-clickable` to Storybook - ClickableBehavior

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -11,4 +11,7 @@ import wonderBlocksTheme from "./wonder-blocks-theme.js";
  */
 addons.setConfig({
     theme: wonderBlocksTheme,
+    sidebar: {
+        showRoots: false,
+    },
 });

--- a/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.argtypes.js
+++ b/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.argtypes.js
@@ -3,10 +3,7 @@ import clickableArgtypes from "./clickable.argtypes.js";
 export default {
     children: {
         description:
-            "A function that returns the a React `Element`.  The function is passed an object with three boolean properties: hovered, focused, and pressed, and a `childrenProps` argument that contains all the event handlers that should be passed to the React `Element` itself.",
-        control: {
-            type: "text",
-        },
+            "A function that returns the a React `Element`. The function is passed an object with three boolean properties: hovered, focused, and pressed, and a `childrenProps` argument that contains all the event handlers that should be passed to the React `Element` itself.",
         type: {
             required: true,
         },

--- a/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.argtypes.js
+++ b/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.argtypes.js
@@ -1,0 +1,58 @@
+import clickableArgtypes from "./clickable.argtypes.js";
+
+export default {
+    children: {
+        description:
+            "A function that returns the a React `Element`.  The function is passed an object with three boolean properties: hovered, focused, and pressed, and a `childrenProps` argument that contains all the event handlers that should be passed to the React `Element` itself.",
+        control: {
+            type: "text",
+        },
+        type: {
+            required: true,
+        },
+        table: {
+            type: {
+                summary:
+                    "(state: ClickableState, childrenProps: ChildrenProps) => React.Node",
+            },
+        },
+    },
+    /**
+     * States
+     */
+    disabled: {
+        ...clickableArgtypes.disabled,
+        description:
+            "Whether the component is disabled.\n\n" +
+            "If the component is disabled, this component will return handlers that do nothing.",
+    },
+    /**
+     * Events
+     */
+    onClick: {
+        ...clickableArgtypes.onClick,
+        description:
+            "An onClick function which ClickableBehavior can execute when clicked.",
+    },
+    onkeyDown: clickableArgtypes.onkeyDown,
+    onKeyUp: clickableArgtypes.onKeyUp,
+    /**
+     * Navigation
+     */
+    skipClientNav: clickableArgtypes.skipClientNav,
+    rel: clickableArgtypes.rel,
+    target: clickableArgtypes.target,
+    href: {
+        ...clickableArgtypes.href,
+        description:
+            "Optional `href` which `ClickableBehavior` should direct to, uses client-side routing by default if react-router is present.\n\n" +
+            "For keyboard navigation, the default is that both an enter and space press would also navigate to this location. See the triggerOnEnter and triggerOnSpace props for more details",
+    },
+    beforeNav: clickableArgtypes.beforeNav,
+    safeWithNav: clickableArgtypes.safeWithNav,
+
+    /**
+     * Accessibility
+     */
+    role: clickableArgtypes.role,
+};

--- a/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.stories.js
+++ b/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.stories.js
@@ -1,0 +1,92 @@
+// @flow
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
+import {View} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+
+import type {StoryComponentType} from "@storybook/react";
+import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import {name, version} from "../../../package.json";
+import argTypes from "./clickable-behavior.argtypes.js";
+
+const ClickableBehavior: React.ComponentType<
+    React.ElementConfig<typeof ClickableBehavior>,
+> = getClickableBehavior();
+
+export default {
+    title: "Clickable / ClickableBehavior",
+    component: ClickableBehavior,
+    argTypes: argTypes,
+    args: {
+        disabled: false,
+    },
+    parameters: {
+        componentSubtitle: ((
+            <ComponentInfo name={name} version={version} />
+        ): any),
+        docs: {
+            description: {
+                component: null,
+            },
+            source: {
+                // See https://github.com/storybookjs/storybook/issues/12596
+                excludeDecorators: true,
+            },
+        },
+    },
+};
+
+export const Default: StoryComponentType = (args) => {
+    const ClickableBehavior = getClickableBehavior();
+
+    return (
+        <ClickableBehavior role="button" {...args}>
+            {(state, childrenProps) => {
+                const {pressed, hovered, focused} = state;
+                return (
+                    <View
+                        style={[
+                            styles.clickable,
+                            hovered && styles.hovered,
+                            focused && styles.focused,
+                            pressed && styles.pressed,
+                        ]}
+                        {...childrenProps}
+                    >
+                        This is an element wrapped with ClickableBehavior
+                    </View>
+                );
+            }}
+        </ClickableBehavior>
+    );
+};
+
+Default.parameters = {
+    chromatic: {
+        // we don't need screenshots because this story only displays the
+        // resting/default state.
+        disableSnapshot: true,
+    },
+};
+
+const styles = StyleSheet.create({
+    clickable: {
+        cursor: "pointer",
+        padding: Spacing.medium_16,
+        textAlign: "center",
+    },
+    hovered: {
+        textDecoration: "underline",
+        backgroundColor: Color.blue,
+        color: Color.white,
+    },
+    pressed: {
+        backgroundColor: Color.darkBlue,
+    },
+    focused: {
+        outline: `solid 4px ${Color.lightBlue}`,
+    },
+});

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
@@ -261,18 +261,19 @@ const startState: ClickableState = {
  * 3. Keyup (spacebar/enter) -> focus state
  *
  * Warning: The event handlers returned (onClick, onMouseEnter, onMouseLeave,
- * onMouseDown, onMouseUp, onDragStart, onTouchStart, onTouchEnd, onTouchCancel, onKeyDown,
- * onKeyUp, onFocus, onBlur, tabIndex) should be passed on to the component
- * that has the ClickableBehavior. You cannot override these handlers without
- * potentially breaking the functionality of ClickableBehavior.
+ * onMouseDown, onMouseUp, onDragStart, onTouchStart, onTouchEnd, onTouchCancel,
+ * onKeyDown, onKeyUp, onFocus, onBlur, tabIndex) should be passed on to the
+ * component that has the ClickableBehavior. You cannot override these handlers
+ * without potentially breaking the functionality of ClickableBehavior.
  *
- * There are internal props triggerOnEnter and triggerOnSpace that can be set
- * to false if one of those keys shouldn't count as a click on this component.
- * Be careful about setting those to false -- make certain that the component
+ * There are internal props triggerOnEnter and triggerOnSpace that can be set to
+ * false if one of those keys shouldn't count as a click on this component. Be
+ * careful about setting those to false -- make certain that the component
  * shouldn't process that key.
  *
- * See [this document](https://docs.google.com/document/d/1DG5Rg2f0cawIL5R8UqnPQpd7pbdObk8OyjO5ryYQmBM/edit#)
- * for a more thorough explanation of expected behaviors and potential cavaets.
+ * See [this
+   document](https://docs.google.com/document/d/1DG5Rg2f0cawIL5R8UqnPQpd7pbdObk8OyjO5ryYQmBM/edit#)
+   for a more thorough explanation of expected behaviors and potential cavaets.
  *
  * `ClickableBehavior` accepts a function as `children` which is passed state
  * and an object containing event handlers and some other props. The `children`
@@ -280,32 +281,30 @@ const startState: ClickableState = {
  *
  * Example:
  *
- * ```js
- * class MyClickableComponent extends React.Component<Props> {
- *     render(): React.Node {
- *         const ClickableBehavior = getClickableBehavior();
- *         return <ClickableBehavior
- *             disabled={this.props.disabled}
- *             onClick={this.props.onClick}
- *         >
- *             {({hovered}, childrenProps) =>
- *                 <RoundRect
- *                      textcolor='white'
- *                      backgroundColor={hovered ? 'red' : 'blue'}}
- *                      {...childrenProps}
- *                 >
- *                      {this.props.children}
- *                 </RoundRect>
- *             }
- *         </ClickableBehavior>
- *     }
+ * ```jsx
+ * function MyClickableComponent(props: Props) {
+ *   const ClickableBehavior = getClickableBehavior();
+ *
+ *   return (
+ *       <ClickableBehavior disabled={props.disabled} onClick={props.onClick}>
+ *           {({hovered}, childrenProps) => (
+ *               <RoundRect
+ *                   textcolor="white"
+ *                   backgroundColor={hovered ? "red" : "blue"}
+ *                   {...childrenProps}
+ *               >
+ *                   {props.children}
+ *               </RoundRect>
+ *           )}
+ *      </ClickableBehavior>
+ *   );
  * }
  * ```
  *
- * This follows a pattern called [Function as Child Components]
- * (https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9).
+ * This follows a pattern called [Function as Child
+ * Components](https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9).
  *
- * WARNING: Do not use this component directly, use getClickableBehavior
+ * **WARNING:** Do not use this component directly, use getClickableBehavior
  * instead. getClickableBehavior takes three arguments (href, directtNav, and
  * router) and returns either the default ClickableBehavior or a react-router
  * aware version.
@@ -313,9 +312,9 @@ const startState: ClickableState = {
  * The react-router aware version is returned if `router` is a react-router-dom
  * router, `skipClientNav` is not `true`, and `href` is an internal URL.
  *
- * The `router` can be accessed via __RouterContext (imported from 'react-router')
- * from a component rendered as a descendant of a BrowserRouter.
- * See https://reacttraining.com/react-router/web/guides/basic-components.
+ * The `router` can be accessed via __RouterContext (imported from
+   'react-router') from a component rendered as a descendant of a BrowserRouter.
+   See https://reacttraining.com/react-router/web/guides/basic-components.
  */
 export default class ClickableBehavior extends React.Component<
     Props,


### PR DESCRIPTION
## Summary:

- Add stories for the `ClickableBehavior` component.
- Reuse from of the argtypes defined for `Clickable`.
- Modify JSDocs to improve the way the comments are displayed in Storybook docs.

NOTE: This component doesn't include any accessibility notes as the recommended
approach is to use `Clickable` for an improved and more robust experience.

Issue: WB-1131

## Test plan:

1. Navigate to the newly created `ClickableBehavior` section in storybook.
2. Verify that there's a new story explaining how to use that component.
3. Verify that the props table is displayed correctly.

https://5e1bf4b385e3fb0020b7073c-wjhmfkabvs.chromatic.com/?path=/story/clickable-clickablebehavior--default
<img width="1255" alt="Screen Shot 2022-04-20 at 12 57 09 PM" src="https://user-images.githubusercontent.com/843075/164283779-62f5663c-3e76-4bd4-8896-294eeb25b8d4.png">
<img width="1233" alt="Screen Shot 2022-04-20 at 12 57 22 PM" src="https://user-images.githubusercontent.com/843075/164283799-6d939237-fb3a-4bd0-a9a1-8c42393bf2c2.png">

