### PR TITLE
WB-1301: Restrict the dropdown menu height

### DIFF
--- a/.changeset/tame-owls-draw.md
+++ b/.changeset/tame-owls-draw.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Adds a max-height value to the dropdown menu to avoid displaying long lists that might cut off on small screen resolutions

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -428,7 +428,6 @@ describe("SingleSelect", () => {
             // open dropdown
             userEvent.click(opener);
             userEvent.click(screen.getByText("Toggle B"));
-            jest.advanceTimersByTime(100);
 
             // Assert
             // NOTE: the opener text is only updated in response to changes to the
@@ -589,6 +588,108 @@ describe("SingleSelect", () => {
             // Assert
             const dismissBtn = screen.getByLabelText("Clear search");
             expect(dismissBtn).toHaveFocus();
+        });
+    });
+
+    describe("Custom listbox styles", () => {
+        it("should apply the default maxHeight to the listbox", () => {
+            // Arrange
+
+            // Act
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    opened={true}
+                    placeholder="Choose"
+                    selectedValue="2"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+
+            // Assert
+            const dropdownMenu = screen.getByRole("listbox");
+            expect(dropdownMenu).toHaveStyle("max-height: 132px");
+        });
+
+        it("should apply the default maxHeight to a filterable listbox", () => {
+            // Arrange
+
+            // Act
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    opened={true}
+                    isFilterable={true}
+                    placeholder="Choose"
+                    selectedValue="2"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+
+            // Assert
+            const dropdownMenu = screen.getByRole("listbox");
+            expect(dropdownMenu).toHaveStyle("max-height: 184px");
+        });
+
+        it("should apply the default maxHeight to a virtualized listbox", () => {
+            // Arrange
+            const optionItems = new Array(1000)
+                .fill(null)
+                .map((_, i) => (
+                    <OptionItem
+                        key={i}
+                        value={(i + 1).toString()}
+                        label={`item ${i + 1}`}
+                    />
+                ));
+
+            // Act
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    opened={true}
+                    isFilterable={true}
+                    placeholder="Choose"
+                    selectedValue="2"
+                >
+                    {optionItems}
+                </SingleSelect>,
+            );
+
+            // Assert
+            const dropdownMenu = screen.getByRole("listbox");
+            // Max allowed height
+            expect(dropdownMenu).toHaveStyle("max-height: 384px");
+        });
+
+        it("should override the default maxHeight to the listbox if a custom dropdownStyle is set", () => {
+            // Arrange
+            const customMaxHeight = 200;
+
+            // Act
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    opened={true}
+                    placeholder="Choose"
+                    selectedValue="2"
+                    dropdownStyle={{maxHeight: customMaxHeight}}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+
+            // Assert
+            const dropdownMenu = screen.getByRole("listbox");
+            expect(dropdownMenu).toHaveStyle("max-height: 200px");
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
@@ -16,9 +16,11 @@ import type {DropdownItem} from "../util/types.js";
 
 import {
     DROPDOWN_ITEM_HEIGHT,
+    MAX_VISIBLE_ITEMS,
     SEARCH_ITEM_HEIGHT,
     SEPARATOR_ITEM_HEIGHT,
 } from "../util/constants.js";
+import {getDropdownMenuHeight} from "../util/dropdown-menu-styles.js";
 
 type Props = {|
     /**
@@ -57,22 +59,18 @@ type State = {|
 |};
 
 /**
- * Maximum visible items inside the dropdown list.
- * Based on the defined height that we're using, this is the maximium
- * number of items that can fit into the visible porition of the
- * dropdowns list box.
- */
-const MAX_VISIBLE_ITEMS = 9;
-
-/**
  * A react-window's List wrapper that instantiates the virtualized list and
  * dynamically calculates the item height depending on the type
  */
 class DropdownCoreVirtualized extends React.Component<Props, State> {
-    state: State = {
-        height: this.getHeight(),
-        width: this.props.width,
-    };
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            height: getDropdownMenuHeight(props.data),
+            width: props.width,
+        };
+    }
 
     componentDidMount() {
         const {schedule} = this.props;
@@ -122,29 +120,8 @@ class DropdownCoreVirtualized extends React.Component<Props, State> {
      */
     setHeight() {
         // calculate dropdown's height depending on the type of items
-        const height = this.getHeight();
+        const height = getDropdownMenuHeight(this.props.data);
         this.setState({height});
-    }
-
-    /**
-     * The list height that is automatically calculated depending on the
-     * component's type of each item (e.g. Separator, Option, Search, etc)
-     */
-    getHeight(): number {
-        // calculate using the first 10 items on the array as we want to display
-        // this number of elements in the visible area
-        return this.props.data
-            .slice(0, MAX_VISIBLE_ITEMS)
-            .reduce((sum, item) => {
-                if (SeparatorItem.isClassOf(item.component)) {
-                    return sum + SEPARATOR_ITEM_HEIGHT;
-                } else if (SearchTextInput.isClassOf(item.component)) {
-                    // search text input height
-                    return sum + SEARCH_ITEM_HEIGHT;
-                } else {
-                    return sum + DROPDOWN_ITEM_HEIGHT;
-                }
-            }, 0);
     }
 
     /**

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -25,6 +25,10 @@ import SearchTextInput from "./search-text-input.js";
 import {defaultLabels, keyCodes, searchInputStyle} from "../util/constants.js";
 import type {DropdownItem} from "../util/types.js";
 import DropdownPopper from "./dropdown-popper.js";
+import {
+    generateDropdownMenuStyles,
+    getDropdownMenuHeight,
+} from "../util/dropdown-menu-styles.js";
 
 /**
  * The number of options to apply the virtualized list to.
@@ -762,6 +766,14 @@ class DropdownCore extends React.Component<Props, State> {
             ? openerStyle.getPropertyValue("width")
             : 0;
 
+        // Vertical padding of the dropdown menu + borders
+        const initialHeight = 12;
+
+        const maxDropdownHeight = getDropdownMenuHeight(
+            this.props.items,
+            initialHeight,
+        );
+
         return (
             <View
                 // Stop propagation to prevent the mouseup listener on the
@@ -772,7 +784,11 @@ class DropdownCore extends React.Component<Props, State> {
                     styles.dropdown,
                     light && styles.light,
                     isReferenceHidden && styles.hidden,
-                    {minWidth: minDropdownWidth},
+                    generateDropdownMenuStyles(
+                        minDropdownWidth,
+                        maxDropdownHeight,
+                    ),
+
                     dropdownStyle,
                 ]}
             >

--- a/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
@@ -52,6 +52,7 @@ export const DefaultSingleSelectOpened: StoryComponentType = (args) => {
             <OptionItem label="Apple" value="apple" />
             <OptionItem label="Grape" value="grape" />
             <OptionItem label="Lemon" value="lemon" />
+            <OptionItem label="Mango" value="mango" />
         </SingleSelectTemplate>
     );
 };

--- a/packages/wonder-blocks-dropdown/src/util/__tests__/dropdown-menu-styles.test.js
+++ b/packages/wonder-blocks-dropdown/src/util/__tests__/dropdown-menu-styles.test.js
@@ -1,0 +1,100 @@
+// @flow
+import * as React from "react";
+import OptionItem from "../../components/option-item.js";
+import SearchTextInput from "../../components/search-text-input.js";
+import SeparatorItem from "../../components/separator-item.js";
+
+import {getDropdownMenuHeight} from "../dropdown-menu-styles.js";
+
+const optionItems = [
+    {
+        component: (
+            <OptionItem testId="item-0" label="item 0" value="0" key="0" />
+        ),
+        focusable: true,
+        populatedProps: {},
+    },
+    {
+        component: (
+            <OptionItem testId="item-1" label="item 1" value="1" key="1" />
+        ),
+        focusable: true,
+        populatedProps: {},
+    },
+    {
+        component: (
+            <OptionItem testId="item-2" label="item 2" value="2" key="2" />
+        ),
+        focusable: true,
+        populatedProps: {},
+    },
+];
+
+const searchFieldItem = {
+    component: (
+        <SearchTextInput
+            testId="item-0"
+            key="search-text-input"
+            onChange={jest.fn()}
+            searchText={""}
+        />
+    ),
+    focusable: true,
+    populatedProps: {},
+};
+
+const separatorItem = {
+    component: <SeparatorItem />,
+    focusable: false,
+    populatedProps: {},
+};
+
+describe("getDropdownMenuHeight", () => {
+    it("should get a valid height for a dropdown with 3 items", () => {
+        // Arrange
+        const items = optionItems;
+
+        // Act
+        const height = getDropdownMenuHeight(items);
+
+        // Assert
+        // 3 option items
+        expect(height).toBe(120);
+    });
+
+    it("should include an initial min height", () => {
+        // Arrange
+        const items = optionItems;
+
+        // Act
+        const height = getDropdownMenuHeight(items, 10);
+
+        // Assert
+        // 3 option items + initial height (e.g. padding)
+        expect(height).toBe(130);
+    });
+
+    it("should get a valid height for a filterable dropdown", () => {
+        // Arrange
+        const items = [searchFieldItem, ...optionItems];
+
+        // Act
+        const height = getDropdownMenuHeight(items);
+
+        // Assert
+        // search field + 3 option items
+        expect(height).toBe(172);
+    });
+
+    it("should get a valid height for a dropdown with a SeparatorItem", () => {
+        // Arrange
+        const items = [separatorItem, ...optionItems];
+
+        // Act
+        const height = getDropdownMenuHeight(items);
+
+        // Assert
+        // separator item + 3 option items
+        expect(height).toBe(129);
+    });
+});

--- a/packages/wonder-blocks-dropdown/src/util/constants.js
+++ b/packages/wonder-blocks-dropdown/src/util/constants.js
@@ -19,7 +19,6 @@ export const selectDropdownStyle = {
 // Note that these can be overridden by the provided style if needed.
 export const filterableDropdownStyle = {
     minHeight: 100,
-    maxHeight: 384,
 };
 
 export const searchInputStyle = {
@@ -29,6 +28,13 @@ export const searchInputStyle = {
 
 // The default item height
 export const DROPDOWN_ITEM_HEIGHT = 40;
+
+/**
+ * Maximum visible items inside the dropdown list. Based on the defined height
+ * that we're using, this is the maximum number of items that can fit into the
+ * visible portion of the dropdown's listbox.
+ */
+export const MAX_VISIBLE_ITEMS = 9;
 
 export const SEPARATOR_ITEM_HEIGHT = 9;
 

--- a/packages/wonder-blocks-dropdown/src/util/dropdown-menu-styles.js
+++ b/packages/wonder-blocks-dropdown/src/util/dropdown-menu-styles.js
@@ -1,0 +1,65 @@
+// @flow
+import {StyleSheet} from "aphrodite";
+
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+import {
+    DROPDOWN_ITEM_HEIGHT,
+    MAX_VISIBLE_ITEMS,
+    SEARCH_ITEM_HEIGHT,
+    SEPARATOR_ITEM_HEIGHT,
+} from "./constants.js";
+
+import SeparatorItem from "../components/separator-item.js";
+import SearchTextInput from "../components/search-text-input.js";
+
+import type {DropdownItem} from "./types.js";
+
+/**
+ * The list height that is automatically calculated depending on the
+ * component's type of each item (e.g. Separator, Option, Search, etc)
+ *
+ * @param {Array<DropdownItem>} items - The list of items to calculate the height
+ * @param {number} initialHeight - The initial height of the list
+ *
+ * @returns {number} The list height
+ */
+export function getDropdownMenuHeight(
+    items: Array<DropdownItem>,
+    initialHeight: number = 0,
+): number {
+    // calculate using the first 10 items on the array as we want to display
+    // this number of elements in the visible area
+    return items.slice(0, MAX_VISIBLE_ITEMS).reduce((sum, item) => {
+        if (SeparatorItem.isClassOf(item.component)) {
+            return sum + SEPARATOR_ITEM_HEIGHT;
+        } else if (SearchTextInput.isClassOf(item.component)) {
+            // search text input height
+            return sum + SEARCH_ITEM_HEIGHT;
+        } else {
+            return sum + DROPDOWN_ITEM_HEIGHT;
+        }
+    }, initialHeight);
+}
+
+/**
+ * Wraps the dynamic styles in an Aphrodite style sheet so we can properly apply
+ * the styles to a merged stylesheet (instead of inlining the styles).
+ *
+ * @param {StyleType} customStyles - The custom styles to apply to the dropdown
+ * menu.
+ * @returns The Aphrodite stylesheet for the dropdown menu.
+ */
+export function generateDropdownMenuStyles(
+    minWidth: number,
+    maxHeight: number,
+): StyleType {
+    const styles = StyleSheet.create({
+        dropdownMenu: {
+            minWidth,
+            maxHeight,
+        },
+    });
+
+    return styles.dropdownMenu;
+}


### PR DESCRIPTION
## Summary:

- Add `maxHeight` to the dropdown menu container (listbox) to avoid overflow
issues when the options list is longer than the screen height.
- Created a new helper to abstract out calculating the dropdown menu height, so it can be used by `DropdownCore` and the virtualized version.
- Added unit tests to verify that the styles are applied correctly.

Issue: WB-1301

## Test plan:

Navigate to any of the Dropdown stories and verify that after opening the
dropdown, you can see a maximum of 9 items in the screen.
<img width="855" alt="Screen Shot 2022-04-20 at 6 00 35 PM" src="https://user-images.githubusercontent.com/843075/164332220-6448ac2d-9caa-40d7-9f68-b11302ce9d2e.png">


Navigate to the `BirthdayPicker` stories and verify that all the dropdowns are
now correctly displayed.

BEFORE
<img width="819" alt="Screen Shot 2022-04-20 at 1 04 30 PM" src="https://user-images.githubusercontent.com/843075/164331979-33b558e0-985f-472f-8ce7-f1cd8de3c0de.png">


AFTER
<img width="813" alt="Screen Shot 2022-04-20 at 1 08 16 PM" src="https://user-images.githubusercontent.com/843075/164332008-fc9dad37-7b46-4edc-b077-8b22832a0732.png">

