### PR TITLE
[fei4413.1.addfetchpolicy] Add FetchPolicy enum

### DIFF
--- a/packages/wonder-blocks-data/src/__docs__/types.fetch-policy.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/types.fetch-policy.stories.mdx
@@ -1,0 +1,44 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Types / FetchPolicy"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# FetchPolicy
+
+```ts
+export enum FetchPolicy {
+    /**
+     * If the data is in the cache, return that; otherwise, fetch from the server.
+     */
+    CacheBeforeNetwork,
+
+    /**
+     * If the data is in the cache, return that; always fetch from the server
+     * regardless of cache.
+     */
+    CacheAndNetwork,
+
+    /**
+     * If the data is in the cache, return that; otherwise, do nothing.
+     */
+    CacheOnly,
+
+    /**
+     * Ignore any existing cached result; fetch from the server.
+     */
+    NetworkOnly,
+}
+```
+
+The `FetchPolicy` type is used with our request framework to define how a request should be fulfilled with respect to the cache and the network.
+
+ * `CacheBeforeNetwork`: If the data is in the cache, return that; otherwise, fetch from the server.
+ * `CacheAndNetwork`:  If the data is in the cache, return that; always fetch from the server regardless of cache.
+ * `CacheOnly`: If the data is in the cache, return that; otherwise, do nothing.
+ * `NetworkOnly`: Ignore any existing cached result; always fetch from the server.

--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -9,6 +9,11 @@ import type {
     ResponseCache,
 } from "./util/types.js";
 
+// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
+// have fixed:
+// https://github.com/import-js/eslint-plugin-import/issues/2073
+// eslint-disable-next-line import/named
+export {FetchPolicy} from "./util/types.js";
 export type {
     ErrorOptions,
     ResponseCache,

--- a/packages/wonder-blocks-data/src/util/types.js
+++ b/packages/wonder-blocks-data/src/util/types.js
@@ -1,6 +1,37 @@
 // @flow
 import type {Metadata} from "@khanacademy/wonder-stuff-core";
 
+// TODO(somewhatabstract, FEI-4172): Update eslint-plugin-flowtype when
+// they've fixed https://github.com/gajus/eslint-plugin-flowtype/issues/502
+/* eslint-disable no-undef */
+/**
+ * Defines the various fetch policies that can be applied to requests.
+ */
+export enum FetchPolicy {
+    /**
+     * If the data is in the cache, return that; otherwise, fetch from the
+     * server.
+     */
+    CacheBeforeNetwork,
+
+    /**
+     * If the data is in the cache, return that; always fetch from the server
+     * regardless of cache.
+     */
+    CacheAndNetwork,
+
+    /**
+     * If the data is in the cache, return that; otherwise, do nothing.
+     */
+    CacheOnly,
+
+    /**
+     * Ignore any existing cached result; always fetch from the server.
+     */
+    NetworkOnly,
+}
+/* eslint-enable no-undef */
+
 /**
  * Define what can be cached.
  *


### PR DESCRIPTION
## Summary:
This adds a `FetchPolicy` enum to Wonder Blocks Data along with docs.

Nothing uses it yet.

Issue: FEI-4413

## Test plan:
`yarn storybook` and check the docs are there.