### PR TITLE
[fei4413.2.usingfetchpolicies] Implement fetch policy in useCachedEffect

### DIFF
--- a/.changeset/perfect-spies-help.md
+++ b/.changeset/perfect-spies-help.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": major
+---
+
+Add `fetchPolicy` to `useCachedEffect` options, add `refetch` to `useCachedEffect` return value (return value is now a tuple of [result, refetch]), add abort API to request fulfillment (not truly aborting though)

--- a/packages/wonder-blocks-data/src/__docs__/exports.request-fulfillment.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.request-fulfillment.stories.mdx
@@ -23,14 +23,25 @@ The `RequestFulfillment` class encapsulates tracking of inflight asynchronous ac
             hydrate?: boolean,
         |},
     ) => Promise<Result<TData>>;
+
+    abort: (id: string) => void;
+
+    abortAll: () => void;
 ```
 
-There is a single function on the `RequestFulfillment` class, called `fulfill`.
+There are three functions on the `RequestFulfillment` class, called `fulfill`, `abort`, and `abortAll`.
 
+### `fulfull()`
 The `fulfill` method takes the request identifier (used to deduplicate requests) and an options object. The options object contains the following properties:
 
  * `handler`: A function that returns a promise resolving to the result of the request. This is the asynchronous work that will be tracked by the given identifier.
  * `hydrate`: A boolean indicating whether the data should be hydrated. This is used during server-side rendering to determine if the response data should be included in the hydration cache. This defaults to `true` and should only be set to `false` if you are performing server-side rendering of the request and you know that the data will not be needed for hydration to succeed.
+
+ ### `abort()`
+The `abort` method takes the request identifier and aborts any pending request for that identifier. Currently, full abort signalling is not implemented. This will simply remove that request from the tracking and sharing of inflight requests.
+
+### `abortAll()`
+The `abortAll` method aborts all pending requests. Currently, full abort signalling is not implemented. This will simply remove all requests from the tracking and sharing of inflight requests.
 
 ## RequestFulfillment.Default
 The `RequestFulfillment` class provides a static instance, `RequestFulfillment.Default`, which is used by the Wonder Blocks Data framework. However, a custom instance can be constructed should your specific use case need to be isolated from others.

--- a/packages/wonder-blocks-data/src/__docs__/exports.use-cached-effect.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.use-cached-effect.stories.mdx
@@ -19,9 +19,9 @@ function useCachedEffect<TData: ValidCacheData>(
 ): [Result<TData>, () => void];
 ```
 
-This hook invokes the given handler and caches the result using the [`useSharedCache`](/docs/data-exports-usesharedcache--page) hook. The `requestId` is used to both share identify inflight requests that can be shared, and to identify the cached value to use.
+This hook invokes the given handler and caches the result using the [`useSharedCache`](/docs/data-exports-usesharedcache--page) hook. The `requestId` is used to both identify inflight requests that can be shared, and to identify the cached value to use.
 
-The hook returns an array containing the current state of the requested data, and a function that can be used to `refetch` the data on demand. Note that calling `refetch` while an inflight request is in progress for the given `requestId` will be a no-op.
+The hook returns an array containing the current state of the request, and a function that can be used to `refetch` that request on demand. Calling `refetch` while an inflight request is in progress for the given `requestId` will be a no-op.
 
 The behavior of the hook can be modified with the options.
 

--- a/packages/wonder-blocks-data/src/__docs__/exports.use-cached-effect.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.use-cached-effect.stories.mdx
@@ -16,13 +16,14 @@ function useCachedEffect<TData: ValidCacheData>(
     requestId: string,
     handler: () => Promise<TData>,
     options?: CachedEffectOptions<TData>,
-): Result<TData>;
+): [Result<TData>, () => void];
 ```
 
-This hook is a wrapper around `useEffect`. Internally it uses the [`useSharedCache`](/docs/data-exports-usesharedcache--page) hook to store the result of the effect and, if that result is available, returns it without rerunning the effect. The precise behavior of the
-hook can be modified using the options.
+This hook invokes the given handler and caches the result using the [`useSharedCache`](/docs/data-exports-usesharedcache--page) hook. The `requestId` is used to both share identify inflight requests that can be shared, and to identify the cached value to use.
 
-There is currently no way to reinvoke the effect without changing the `requestId`.
+The hook returns an array containing the current state of the requested data, and a function that can be used to `refetch` the data on demand. Note that calling `refetch` while an inflight request is in progress for the given `requestId` will be a no-op.
+
+The behavior of the hook can be modified with the options.
 
 ```ts
 type CachedEffectOptions<TData: ValidCacheData> = {|
@@ -30,6 +31,7 @@ type CachedEffectOptions<TData: ValidCacheData> = {|
     retainResultOnChange?: boolean,
     onResultChanged?: (result: Result<TData>) => void,
     scope?: string,
+    fetchPolicy?: FetchPolicy,
 |};
 ```
 
@@ -39,3 +41,4 @@ type CachedEffectOptions<TData: ValidCacheData> = {|
 | `retainResultOnChange` | `false` | When `true`, the effect will not reset the result to the loading status while executing if the requestId changes, instead, returning the existing result from before the change; otherwise, the result will be set to loading status.  If the status is loading when the changes are made, it will remain as loading; old pending effects are discarded on changes and as such this value has no effect in that case.|
 | `onResultChanged` | `undefined` | Callback that is invoked if the result for the given hook has changed. When defined, the hook will invoke this callback whenever it has reason to change the result and will not otherwise affect component rendering directly. When not defined, the hook will ensure the component re-renders to pick up the latest result. |
 | `scope` | `"useCachedEffect"` | Scope to use with the shared cache. When specified, the given scope will be used to isolate this hook's cached results. Otherwise, the default scope will be used. Changing this value after the first call is not supported. |
+| `fetchPolicy` | [`FetchPolicy`](/docs/data-types-fetchpolicy--page) | Fetch policy to use when fetching the data. Defaults to `FetchPolicy.CacheBeforeNetwork`. |

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -28,11 +28,11 @@ describe("Data", () => {
 
         const responseCache = new SsrCache();
         jest.spyOn(SsrCache, "Default", "get").mockReturnValue(responseCache);
-        jest.spyOn(RequestTracker, "Default", "get").mockReturnValue(
-            new RequestTracker(responseCache),
-        );
         jest.spyOn(RequestFulfillment, "Default", "get").mockReturnValue(
             new RequestFulfillment(),
+        );
+        jest.spyOn(RequestTracker, "Default", "get").mockReturnValue(
+            new RequestTracker(responseCache),
         );
     });
 
@@ -90,7 +90,7 @@ describe("Data", () => {
                 });
             });
 
-            it("should share single request across all uses", async () => {
+            it("should share single request across all uses", () => {
                 // Arrange
                 const fakeHandler = jest.fn(
                     () => new Promise((resolve, reject) => {}),

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -28,16 +28,12 @@ describe("Data", () => {
 
         const responseCache = new SsrCache();
         jest.spyOn(SsrCache, "Default", "get").mockReturnValue(responseCache);
-        jest.spyOn(RequestFulfillment, "Default", "get").mockReturnValue(
-            new RequestFulfillment(),
-        );
         jest.spyOn(RequestTracker, "Default", "get").mockReturnValue(
             new RequestTracker(responseCache),
         );
-    });
-
-    afterEach(() => {
-        jest.resetAllMocks();
+        jest.spyOn(RequestFulfillment, "Default", "get").mockReturnValue(
+            new RequestFulfillment(),
+        );
     });
 
     describe("CSR: isServerSide false", () => {
@@ -94,7 +90,7 @@ describe("Data", () => {
                 });
             });
 
-            it("should share single request across all uses", () => {
+            it("should share single request across all uses", async () => {
                 // Arrange
                 const fakeHandler = jest.fn(
                     () => new Promise((resolve, reject) => {}),

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
@@ -109,7 +109,9 @@ describe("#useCachedEffect", () => {
 
                 // Act
                 const {
-                    result: {current: result},
+                    result: {
+                        current: [result],
+                    },
                 } = serverRenderHook(() => useCachedEffect("ID", fakeHandler));
 
                 // Assert
@@ -129,7 +131,9 @@ describe("#useCachedEffect", () => {
 
                 // Act
                 const {
-                    result: {current: result},
+                    result: {
+                        current: [result],
+                    },
                 } = serverRenderHook(() => useCachedEffect("ID", fakeHandler));
 
                 // Assert
@@ -311,7 +315,7 @@ describe("#useCachedEffect", () => {
             );
 
             // Assert
-            expect(result.current).toStrictEqual(Status.success("DATA2"));
+            expect(result.current[0]).toStrictEqual(Status.success("DATA2"));
         });
 
         it("should not fulfill request when skip is true", () => {
@@ -366,7 +370,7 @@ describe("#useCachedEffect", () => {
             );
 
             // Assert
-            expect(result.current).toStrictEqual(Status.success("DATA1"));
+            expect(result.current[0]).toStrictEqual(Status.success("DATA1"));
         });
 
         it("should not ignore inflight request if options (other than skip) change", async () => {
@@ -389,7 +393,7 @@ describe("#useCachedEffect", () => {
             await act((): Promise<mixed> => response1);
 
             // Assert
-            expect(result.current).toStrictEqual(Status.success("DATA1"));
+            expect(result.current[0]).toStrictEqual(Status.success("DATA1"));
         });
 
         it("should return previous result when requestId changes and retainResultOnChange is true", async () => {
@@ -417,7 +421,7 @@ describe("#useCachedEffect", () => {
             );
             await act((): Promise<mixed> => response1);
             rerender({requestId: "ID2"});
-            const result = hookResult.current;
+            const [result] = hookResult.current;
             await waitForNextUpdate();
 
             // Assert
@@ -449,7 +453,7 @@ describe("#useCachedEffect", () => {
             rerender({requestId: "ID2"});
 
             // Assert
-            expect(result.current).toStrictEqual(Status.loading());
+            expect(result.current[0]).toStrictEqual(Status.loading());
         });
 
         it("should trigger render when request is fulfilled and onResultChanged is undefined", async () => {
@@ -464,7 +468,7 @@ describe("#useCachedEffect", () => {
             await act((): Promise<mixed> => response);
 
             // Assert
-            expect(result.current).toStrictEqual(Status.success("DATA"));
+            expect(result.current[0]).toStrictEqual(Status.success("DATA"));
         });
 
         it("should not trigger render when request is fulfilled and onResultChanged is defined", async () => {
@@ -481,7 +485,7 @@ describe("#useCachedEffect", () => {
             await act((): Promise<mixed> => response);
 
             // Assert
-            expect(result.current).toStrictEqual(Status.loading());
+            expect(result.current[0]).toStrictEqual(Status.loading());
         });
 
         it("should call onResultChanged when request is fulfilled and onResultChanged is defined", async () => {

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
@@ -25,6 +25,10 @@ import {FetchPolicy} from "../../util/types.js";
 jest.mock("../use-request-interception.js");
 jest.mock("../use-shared-cache.js");
 
+const allPolicies = Array.from(FetchPolicy.members());
+const allPoliciesBut = (policy: FetchPolicy) =>
+    allPolicies.filter((p) => p !== policy);
+
 describe("#useCachedEffect", () => {
     beforeEach(() => {
         jest.resetAllMocks();
@@ -100,7 +104,7 @@ describe("#useCachedEffect", () => {
             },
         );
 
-        it.each(Array.from(FetchPolicy.members()))(
+        it.each(allPolicies)(
             "should not request data for FetchPolicy.%s",
             (fetchPolicy) => {
                 // Arrange
@@ -116,7 +120,7 @@ describe("#useCachedEffect", () => {
             },
         );
 
-        describe.each(Array.from(FetchPolicy.members()))(
+        describe.each(allPolicies)(
             "with FetchPolicy.%s without cached result",
             (fetchPolicy) => {
                 it("should return a loading result", () => {
@@ -138,33 +142,32 @@ describe("#useCachedEffect", () => {
             },
         );
 
-        describe.each(
-            Array.from(FetchPolicy.members()).filter(
-                (e) => e !== FetchPolicy.NetworkOnly,
-            ),
-        )("with FetchPolicy.%s with cached result", (fetchPolicy) => {
-            it("should return the result", () => {
-                // Arrange
-                const fakeHandler = jest.fn();
-                const cachedResult = Status.success("data");
-                jest.spyOn(UseSharedCache, "useSharedCache").mockReturnValue([
-                    cachedResult,
-                    jest.fn(),
-                ]);
+        describe.each(allPoliciesBut(FetchPolicy.NetworkOnly))(
+            "with FetchPolicy.%s with cached result",
+            (fetchPolicy) => {
+                it("should return the result", () => {
+                    // Arrange
+                    const fakeHandler = jest.fn();
+                    const cachedResult = Status.success("data");
+                    jest.spyOn(
+                        UseSharedCache,
+                        "useSharedCache",
+                    ).mockReturnValue([cachedResult, jest.fn()]);
 
-                // Act
-                const {
-                    result: {
-                        current: [result],
-                    },
-                } = serverRenderHook(() =>
-                    useCachedEffect("ID", fakeHandler, {fetchPolicy}),
-                );
+                    // Act
+                    const {
+                        result: {
+                            current: [result],
+                        },
+                    } = serverRenderHook(() =>
+                        useCachedEffect("ID", fakeHandler, {fetchPolicy}),
+                    );
 
-                // Assert
-                expect(result).toEqual(cachedResult);
-            });
-        });
+                    // Assert
+                    expect(result).toEqual(cachedResult);
+                });
+            },
+        );
 
         describe("with FetchPolicy.NetworkOnly with cached result", () => {
             it("should return a loading result", () => {
@@ -229,11 +232,7 @@ describe("#useCachedEffect", () => {
             expect(fakeHandler).toHaveBeenCalledTimes(1);
         });
 
-        it.each(
-            Array.from(FetchPolicy.members()).filter(
-                (e) => e !== FetchPolicy.CacheOnly,
-            ),
-        )(
+        it.each(allPoliciesBut(FetchPolicy.CacheOnly))(
             "should provide function that causes refetch with FetchPolicy.%s",
             async (fetchPolicy) => {
                 // Arrange
@@ -280,11 +279,7 @@ describe("#useCachedEffect", () => {
             );
         });
 
-        it.each(
-            Array.from(FetchPolicy.members()).filter(
-                (e) => e !== FetchPolicy.CacheOnly,
-            ),
-        )(
+        it.each(allPoliciesBut(FetchPolicy.CacheOnly))(
             "should fulfill request when there is no cached value and FetchPolicy.%s",
             (fetchPolicy) => {
                 // Arrange
@@ -619,11 +614,7 @@ describe("#useCachedEffect", () => {
             expect(result.current[0]).toStrictEqual(Status.loading());
         });
 
-        it.each(
-            Array.from(FetchPolicy.members()).filter(
-                (e) => e !== FetchPolicy.CacheOnly,
-            ),
-        )(
+        it.each(allPoliciesBut(FetchPolicy.CacheOnly))(
             "should trigger render when request is fulfilled and onResultChanged is undefined for FetchPolicy.%s",
             async (fetchPolicy) => {
                 // Arrange
@@ -645,11 +636,7 @@ describe("#useCachedEffect", () => {
             },
         );
 
-        it.each(
-            Array.from(FetchPolicy.members()).filter(
-                (e) => e !== FetchPolicy.CacheOnly,
-            ),
-        )(
+        it.each(allPoliciesBut(FetchPolicy.CacheOnly))(
             "should trigger render once per inflight request being fulfilled and onResultChanged is undefined for FetchPolicy.%s",
             async (fetchPolicy) => {
                 // Arrange
@@ -679,11 +666,7 @@ describe("#useCachedEffect", () => {
             },
         );
 
-        it.each(
-            Array.from(FetchPolicy.members()).filter(
-                (e) => e !== FetchPolicy.CacheOnly,
-            ),
-        )(
+        it.each(allPoliciesBut(FetchPolicy.CacheOnly))(
             "should not trigger render when request is fulfilled and onResultChanged is defined for FetchPolicy.%s",
             async (fetchPolicy) => {
                 // Arrange
@@ -708,11 +691,7 @@ describe("#useCachedEffect", () => {
             },
         );
 
-        it.each(
-            Array.from(FetchPolicy.members()).filter(
-                (e) => e !== FetchPolicy.CacheOnly,
-            ),
-        )(
+        it.each(allPoliciesBut(FetchPolicy.CacheOnly))(
             "should call onResultChanged when request is fulfilled and onResultChanged is defined for FetchPolicy.%s",
             async (fetchPolicy) => {
                 // Arrange
@@ -736,11 +715,7 @@ describe("#useCachedEffect", () => {
             },
         );
 
-        it.each(
-            Array.from(FetchPolicy.members()).filter(
-                (e) => e !== FetchPolicy.CacheOnly,
-            ),
-        )(
+        it.each(allPoliciesBut(FetchPolicy.CacheOnly))(
             "should call onResultChanged once per inflight request being fulfilled and onResultChanged is defined for FetchPolicy.%s",
             async (fetchPolicy) => {
                 // Arrange

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
@@ -30,10 +30,8 @@ describe("#useHydratableEffect", () => {
     beforeEach(() => {
         jest.resetAllMocks();
 
-        // When we have request aborting and things, this can be nicer, but
-        // for now, let's just clear out inflight requests between tests
-        // by being cheeky.
-        RequestFulfillment.Default._requests = {};
+        // Clear out inflight requests between tests.
+        RequestFulfillment.Default.abortAll();
 
         // Simple implementation of request interception that just returns
         // the handler.

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
@@ -1,4 +1,5 @@
 // @flow
+import * as React from "react";
 import {
     renderHook as clientRenderHook,
     act,
@@ -44,7 +45,10 @@ describe("#useHydratableEffect", () => {
         const cache = {};
         jest.spyOn(UseSharedCache, "useSharedCache").mockImplementation(
             (id, _, defaultValue) => {
-                const setCache = (v) => (cache[id] = v);
+                const setCache = React.useCallback(
+                    (v) => (cache[id] = v),
+                    [id],
+                );
                 const currentValue =
                     cache[id] ??
                     (typeof defaultValue === "function"
@@ -388,12 +392,16 @@ describe("#useHydratableEffect", () => {
             expect(fakeHandler).toHaveBeenCalledTimes(2);
         });
 
-        it("should default shared cache to hydrate value for new requestId", async () => {
+        it("should default shared cache to hydrate value for new requestId", () => {
             // Arrange
-            const fakeHandler = jest.fn().mockResolvedValue("data");
+            const fakeHandler = jest.fn().mockResolvedValue("NEVER CALLED");
             jest.spyOn(UseServerEffect, "useServerEffect")
+                // First requestId will get hydrated value. No fetch will occur.
+                // The hook result will be this value.
                 .mockReturnValueOnce(Status.success("BADDATA"))
-                .mockReturnValue(null);
+                // Second requestId will get a different hydrated value.
+                // No fetch will occur. The hook will then be this value.
+                .mockReturnValueOnce(Status.success("GOODDATA"));
 
             // Act
             const {rerender, result} = clientRenderHook(
@@ -405,7 +413,7 @@ describe("#useHydratableEffect", () => {
             rerender({requestId: "ID2"});
 
             // Assert
-            expect(result.current).toStrictEqual(Status.loading());
+            expect(result.current).toStrictEqual(Status.success("GOODDATA"));
         });
 
         it("should update shared cache with result when request is fulfilled", async () => {

--- a/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
@@ -198,12 +198,18 @@ export const useCachedEffect = <TData: ValidCacheData>(
                 request,
                 cancel() {
                     cancel = true;
+                    RequestFulfillment.Default.abort(requestId);
                 },
             };
         };
+        // We deliberately ignore the handler here because we want folks to use
+        // interceptor functions inline in props for simplicity. This is OK
+        // since changing the handler without changing the requestId doesn't
+        // really make sense - the same requestId should be handled the same as
+        // each other.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         requestId,
-        interceptedHandler,
         onResultChanged,
         forceUpdate,
         setMostRecentResult,

--- a/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
@@ -171,6 +171,7 @@ export const useCachedEffect = <TData: ValidCacheData>(
             // Catching shouldn't serve a purpose.
             // eslint-disable-next-line promise/catch-or-return
             request.then((result) => {
+                currentRequestRef.current = null;
                 if (cancel) {
                     // We don't modify our result if the request was cancelled
                     // as it means that this hook no longer cares about that old
@@ -195,6 +196,7 @@ export const useCachedEffect = <TData: ValidCacheData>(
             });
 
             currentRequestRef.current = {
+                requestId,
                 request,
                 cancel() {
                     cancel = true;
@@ -236,7 +238,7 @@ export const useCachedEffect = <TData: ValidCacheData>(
                 return false;
 
             case FetchPolicy.CacheBeforeNetwork:
-                // If we don't a cached value or this is a new requestId,
+                // If we don't have a cached value or this is a new requestId,
                 // then we need to fetch.
                 return (
                     mostRecentResult == null ||

--- a/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
@@ -135,8 +135,7 @@ export const useCachedEffect = <TData: ValidCacheData>(
         currentRequestRef.current = null;
         networkResultRef.current = null;
 
-        // Now we can return the new fetch function.
-        return () => {
+        const fetchFn = () => {
             if (fetchPolicy === FetchPolicy.CacheOnly) {
                 throw new DataError(
                     "Cannot fetch with CacheOnly policy",
@@ -204,6 +203,10 @@ export const useCachedEffect = <TData: ValidCacheData>(
                 },
             };
         };
+
+        // Now we can return the new fetch function.
+        return fetchFn;
+
         // We deliberately ignore the handler here because we want folks to use
         // interceptor functions inline in props for simplicity. This is OK
         // since changing the handler without changing the requestId doesn't

--- a/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
@@ -5,6 +5,11 @@ import {useServerEffect} from "./use-server-effect.js";
 import {useSharedCache} from "./use-shared-cache.js";
 import {useCachedEffect} from "./use-cached-effect.js";
 
+// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
+// have fixed:
+// https://github.com/import-js/eslint-plugin-import/issues/2073
+// eslint-disable-next-line import/named
+import {FetchPolicy} from "../util/types.js";
 import type {Result, ValidCacheData} from "../util/types.js";
 
 /**
@@ -191,11 +196,13 @@ export const useHydratableEffect = <TData: ValidCacheData>(
     );
 
     // When we're client-side, we ultimately want the result from this call.
-    const clientResult = useCachedEffect(requestId, handler, {
+    const [clientResult] = useCachedEffect(requestId, handler, {
         skip,
         onResultChanged,
         retainResultOnChange,
         scope,
+        // Be explicit about our fetch policy for clarity.
+        fetchPolicy: FetchPolicy.CacheBeforeNetwork,
     });
 
     // OK, now which result do we return.

--- a/packages/wonder-blocks-data/src/util/data-error.js
+++ b/packages/wonder-blocks-data/src/util/data-error.js
@@ -27,6 +27,12 @@ export const DataErrors = Object.freeze({
     Network: "Network",
 
     /**
+     * There was a problem due to the state of the system not matching the
+     * requested operation or input.
+     */
+    NotAllowed: "NotAllowed",
+
+    /**
      * Response could not be parsed.
      */
     Parse: "Parse",

--- a/packages/wonder-blocks-data/src/util/request-fulfillment.js
+++ b/packages/wonder-blocks-data/src/util/request-fulfillment.js
@@ -97,4 +97,29 @@ export class RequestFulfillment {
 
         return request;
     };
+
+    /**
+     * Abort an inflight request.
+     *
+     * NOTE: Currently, this does not perform an actual abort. It merely
+     * removes the request from being tracked.
+     */
+    abort: (id: string) => void = (id: string): void => {
+        // TODO(somewhatabstract, FEI-4276): Add first class abort
+        // support to the handler API.
+        // For now, we will just clear the request out of the list.
+        // When abort is implemented, the `finally` in the `fulfill` method
+        // would handle the deletion.
+        delete this._requests[id];
+    };
+
+    /**
+     * Abort all inflight requests.
+     *
+     * NOTE: Currently, this does not perform actual aborts. It merely
+     * removes the requests from our tracking.
+     */
+    abortAll: () => void = (): void => {
+        Object.keys(this._requests).forEach(this.abort);
+    };
 }


### PR DESCRIPTION
## Summary:
This reworks `useCachedEffect` to add fetch policy and refetch support.

This was a heavier lift than I originally hoped for, however, it works. I think things will get a little nicer when the RequestFulfillment properly supports aborting requests, but that's a while away (see FEI-4276) as we need to determine how to exactly do that. For now, I've added basic "aborting" to the RequestFulfillment that we'll have to expand later.

Issue: FEI-4413

## Test plan:
`yarn test`