### PR TITLE
[fei4357.1.documentparsing] Add document parsing to Wonder Blocks Data

### DIFF
--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -111,6 +111,8 @@ export {Status} from "./util/status.js";
 
 // GraphQL
 export {getGqlRequestId} from "./util/get-gql-request-id.js";
+export {graphQLDocumentNodeParser} from "./util/graphql-document-node-parser.js";
+export {toGqlOperation} from "./util/to-gql-operation.js";
 export {GqlRouter} from "./components/gql-router.js";
 export {useGql} from "./hooks/use-gql.js";
 export {GqlError, GqlErrors} from "./util/gql-error.js";

--- a/packages/wonder-blocks-data/src/util/__tests__/graphql-document-node-parser.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/graphql-document-node-parser.test.js
@@ -1,0 +1,542 @@
+// @flow
+import {graphQLDocumentNodeParser} from "../graphql-document-node-parser.js";
+
+describe("#graphQLDocumentNodeParser", () => {
+    describe("in production - shorter error messages", () => {
+        const NODE_ENV = process.env.NODE_ENV;
+        beforeEach(() => {
+            process.env.NODE_ENV = "production";
+        });
+
+        afterEach(() => {
+            if (NODE_ENV != null) {
+                process.env.NODE_ENV = NODE_ENV;
+            } else {
+                delete process.env.NODE_ENV;
+            }
+        });
+
+        it("should throw if the document lacks the kind property", () => {
+            // Arrange
+            const documentNode = ({}: any);
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Bad DocumentNode"`,
+            );
+        });
+
+        it("should throw if the document contains only fragments", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "FragmentDefinition",
+                        name: {
+                            kind: "Name",
+                            value: "fragment",
+                        },
+                        typeCondition: {
+                            kind: "NamedType",
+                            name: {
+                                kind: "Name",
+                                value: "Query",
+                            },
+                        },
+                        selectionSet: {
+                            kind: "SelectionSet",
+                            selections: [
+                                {
+                                    kind: "Field",
+                                    name: {
+                                        kind: "Name",
+                                        value: "test",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Fragment only"`,
+            );
+        });
+
+        it("should throw if the document contains subscriptions", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "OperationDefinition",
+                        operation: "subscription",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "subscription",
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"No subscriptions"`,
+            );
+        });
+
+        it("should throw if the document contains more than one query", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "OperationDefinition",
+                        operation: "query",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "query",
+                        },
+                    },
+                    {
+                        kind: "OperationDefinition",
+                        operation: "query",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "query",
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Too many ops"`,
+            );
+        });
+
+        it("should throw if the document contains more than one mutation", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "OperationDefinition",
+                        operation: "mutation",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "mutation",
+                        },
+                    },
+                    {
+                        kind: "OperationDefinition",
+                        operation: "mutation",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "mutation",
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Too many ops"`,
+            );
+        });
+
+        it("should throw if the document is a combination of query and mutation", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "OperationDefinition",
+                        operation: "query",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "query",
+                        },
+                    },
+                    {
+                        kind: "OperationDefinition",
+                        operation: "mutation",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "mutation",
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Too many ops"`,
+            );
+        });
+    });
+
+    describe("not in production - more informative error messages", () => {
+        it("should throw if the document lacks the kind property", () => {
+            // Arrange
+            const documentNode = ({}: any);
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Argument of {} passed to parser was not a valid GraphQL DocumentNode. You may need to use 'graphql-tag' or another method to convert your operation into a document"`,
+            );
+        });
+
+        it("should throw if the document contains only fragments", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "FragmentDefinition",
+                        name: {
+                            kind: "Name",
+                            value: "fragment",
+                        },
+                        typeCondition: {
+                            kind: "NamedType",
+                            name: {
+                                kind: "Name",
+                                value: "Query",
+                            },
+                        },
+                        selectionSet: {
+                            kind: "SelectionSet",
+                            selections: [
+                                {
+                                    kind: "Field",
+                                    name: {
+                                        kind: "Name",
+                                        value: "test",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Passing only a fragment to 'graphql' is not supported. You must include a query or mutation as well"`,
+            );
+        });
+
+        it("should throw if the document contains subscriptions", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "OperationDefinition",
+                        operation: "subscription",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "subscription",
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"We do not support subscriptions. {\\"kind\\":\\"Document\\",\\"definitions\\":[{\\"kind\\":\\"OperationDefinition\\",\\"operation\\":\\"subscription\\",\\"variableDefinitions\\":[],\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"subscription\\"}}]} had 1 subscriptions"`,
+            );
+        });
+
+        it("should throw if the document contains more than one query", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "OperationDefinition",
+                        operation: "query",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "query",
+                        },
+                    },
+                    {
+                        kind: "OperationDefinition",
+                        operation: "query",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "query",
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"We only support one query or mutation per component. {\\"kind\\":\\"Document\\",\\"definitions\\":[{\\"kind\\":\\"OperationDefinition\\",\\"operation\\":\\"query\\",\\"variableDefinitions\\":[],\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"query\\"}},{\\"kind\\":\\"OperationDefinition\\",\\"operation\\":\\"query\\",\\"variableDefinitions\\":[],\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"query\\"}}]} had 2 queries and 0 mutations. "`,
+            );
+        });
+
+        it("should throw if the document contains more than one mutation", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "OperationDefinition",
+                        operation: "mutation",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "mutation",
+                        },
+                    },
+                    {
+                        kind: "OperationDefinition",
+                        operation: "mutation",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "mutation",
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"We only support one query or mutation per component. {\\"kind\\":\\"Document\\",\\"definitions\\":[{\\"kind\\":\\"OperationDefinition\\",\\"operation\\":\\"mutation\\",\\"variableDefinitions\\":[],\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"mutation\\"}},{\\"kind\\":\\"OperationDefinition\\",\\"operation\\":\\"mutation\\",\\"variableDefinitions\\":[],\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"mutation\\"}}]} had 0 queries and 2 mutations. "`,
+            );
+        });
+
+        it("should throw if the document is a combination of query and mutation", () => {
+            // Arrange
+            const documentNode = {
+                kind: "Document",
+                definitions: [
+                    {
+                        kind: "OperationDefinition",
+                        operation: "query",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "query",
+                        },
+                    },
+                    {
+                        kind: "OperationDefinition",
+                        operation: "mutation",
+                        variableDefinitions: [],
+                        name: {
+                            kind: "Name",
+                            value: "mutation",
+                        },
+                    },
+                ],
+            };
+
+            // Act
+            const underTest = () => graphQLDocumentNodeParser(documentNode);
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"We only support one query or mutation per component. {\\"kind\\":\\"Document\\",\\"definitions\\":[{\\"kind\\":\\"OperationDefinition\\",\\"operation\\":\\"query\\",\\"variableDefinitions\\":[],\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"query\\"}},{\\"kind\\":\\"OperationDefinition\\",\\"operation\\":\\"mutation\\",\\"variableDefinitions\\":[],\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"mutation\\"}}]} had 1 queries and 1 mutations. "`,
+            );
+        });
+    });
+
+    it("should return the operation name, type, and variables for a query", () => {
+        // Arrange
+        const documentNode: any = {
+            kind: "Document",
+            definitions: [
+                {
+                    kind: "OperationDefinition",
+                    operation: "query",
+                    variableDefinitions: [
+                        {
+                            kind: "VariableDefinition",
+                            variable: {
+                                kind: "Variable",
+                                name: {
+                                    kind: "Name",
+                                    value: "variable",
+                                },
+                            },
+                            type: {
+                                kind: "NamedType",
+                                name: {
+                                    kind: "Name",
+                                    value: "String",
+                                },
+                            },
+                            defaultValue: {
+                                kind: "StringValue",
+                                value: "defaultValue",
+                            },
+                        },
+                    ],
+                    name: {
+                        kind: "Name",
+                        value: "myQuery",
+                    },
+                },
+            ],
+        };
+
+        // Act
+        const result = graphQLDocumentNodeParser(documentNode);
+
+        // Assert
+        expect(result).toEqual({
+            name: "myQuery",
+            type: "query",
+            variables: documentNode.definitions[0].variableDefinitions,
+        });
+    });
+
+    it("should return the operation name, type, and variables for a mutation", () => {
+        // Arrange
+        const documentNode: any = {
+            kind: "Document",
+            definitions: [
+                {
+                    kind: "OperationDefinition",
+                    operation: "mutation",
+                    variableDefinitions: [
+                        {
+                            kind: "VariableDefinition",
+                            variable: {
+                                kind: "Variable",
+                                name: {
+                                    kind: "Name",
+                                    value: "variable",
+                                },
+                            },
+                            type: {
+                                kind: "NamedType",
+                                name: {
+                                    kind: "Name",
+                                    value: "String",
+                                },
+                            },
+                            defaultValue: {
+                                kind: "StringValue",
+                                value: "defaultValue",
+                            },
+                        },
+                    ],
+                    name: {
+                        kind: "Name",
+                        value: "myMutation",
+                    },
+                },
+            ],
+        };
+
+        // Act
+        const result = graphQLDocumentNodeParser(documentNode);
+
+        // Assert
+        expect(result).toEqual({
+            name: "myMutation",
+            type: "mutation",
+            variables: documentNode.definitions[0].variableDefinitions,
+        });
+    });
+
+    it("should use name of data if no name in document", () => {
+        // Arrange
+        const documentNode: any = {
+            kind: "Document",
+            definitions: [
+                {
+                    kind: "OperationDefinition",
+                    operation: "query",
+                },
+            ],
+        };
+
+        // Act
+        const result = graphQLDocumentNodeParser(documentNode);
+
+        // Assert
+        expect(result).toEqual({
+            name: "data",
+            type: "query",
+            variables: [],
+        });
+    });
+
+    it("should cache the output", () => {
+        // Arrange
+        const documentNode: any = {
+            kind: "Document",
+            definitions: [
+                {
+                    kind: "OperationDefinition",
+                    operation: "query",
+                    name: {
+                        kind: "Name",
+                        value: "myQuery",
+                    },
+                },
+            ],
+        };
+
+        // Act
+        const initialResult = graphQLDocumentNodeParser(documentNode);
+        const secondResult = graphQLDocumentNodeParser(documentNode);
+
+        // Assert
+        expect(initialResult).toBe(secondResult);
+    });
+});

--- a/packages/wonder-blocks-data/src/util/__tests__/to-gql-operation.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/to-gql-operation.test.js
@@ -1,0 +1,42 @@
+// @flow
+import {toGqlOperation} from "../to-gql-operation.js";
+import * as GDNP from "../graphql-document-node-parser.js";
+
+jest.mock("../graphql-document-node-parser.js");
+
+describe("#toGqlOperation", () => {
+    it("should parse the document node", () => {
+        // Arrange
+        const documentNode: any = {};
+        const parserSpy = jest
+            .spyOn(GDNP, "graphQLDocumentNodeParser")
+            .mockReturnValue({
+                name: "operationName",
+                type: "query",
+            });
+
+        // Act
+        toGqlOperation(documentNode);
+
+        // Assert
+        expect(parserSpy).toHaveBeenCalledWith(documentNode);
+    });
+
+    it("should return the Wonder Blocks Data representation of the given document node", () => {
+        // Arrange
+        const documentNode: any = {};
+        jest.spyOn(GDNP, "graphQLDocumentNodeParser").mockReturnValue({
+            name: "operationName",
+            type: "mutation",
+        });
+
+        // Act
+        const result = toGqlOperation(documentNode);
+
+        // Assert
+        expect(result).toStrictEqual({
+            id: "operationName",
+            type: "mutation",
+        });
+    });
+});

--- a/packages/wonder-blocks-data/src/util/graphql-document-node-parser.js
+++ b/packages/wonder-blocks-data/src/util/graphql-document-node-parser.js
@@ -1,0 +1,133 @@
+// @flow
+import type {
+    DocumentNode,
+    DefinitionNode,
+    VariableDefinitionNode,
+    OperationDefinitionNode,
+} from "./graphql-types.js";
+import {DataError, DataErrors} from "./data-error.js";
+
+export const DocumentTypes = Object.freeze({
+    query: "query",
+    mutation: "mutation",
+});
+
+export type DocumentType = $Values<typeof DocumentTypes>;
+
+export interface IDocumentDefinition {
+    type: DocumentType;
+    name: string;
+    variables: $ReadOnlyArray<VariableDefinitionNode>;
+}
+
+const cache = new Map<DocumentNode, IDocumentDefinition>();
+
+/**
+ * Parse a GraphQL document node to determine some info about it.
+ *
+ * This is based on:
+ * https://github.com/apollographql/react-apollo/blob/3bc993b2ea91704bd6a2667f42d1940656c071ff/src/parser.ts
+ */
+export function graphQLDocumentNodeParser(
+    document: DocumentNode,
+): IDocumentDefinition {
+    const cached = cache.get(document);
+    if (cached) {
+        return cached;
+    }
+
+    /**
+     * Saftey check for proper usage.
+     */
+    if (!document?.kind) {
+        if (process.env.NODE_ENV === "production") {
+            throw new DataError("Bad DocumentNode", DataErrors.InvalidInput);
+        } else {
+            throw new DataError(
+                `Argument of ${JSON.stringify(
+                    document,
+                )} passed to parser was not a valid GraphQL ` +
+                    `DocumentNode. You may need to use 'graphql-tag' or another method ` +
+                    `to convert your operation into a document`,
+                DataErrors.InvalidInput,
+            );
+        }
+    }
+
+    const fragments = document.definitions.filter(
+        (x: DefinitionNode) => x.kind === "FragmentDefinition",
+    );
+
+    const queries = document.definitions.filter(
+        (x: DefinitionNode) =>
+            // $FlowIgnore[prop-missing]
+            x.kind === "OperationDefinition" && x.operation === "query",
+    );
+
+    const mutations = document.definitions.filter(
+        (x: DefinitionNode) =>
+            // $FlowIgnore[prop-missing]
+            x.kind === "OperationDefinition" && x.operation === "mutation",
+    );
+
+    const subscriptions = document.definitions.filter(
+        (x: DefinitionNode) =>
+            // $FlowIgnore[prop-missing]
+            x.kind === "OperationDefinition" && x.operation === "subscription",
+    );
+
+    if (fragments.length && !queries.length && !mutations.length) {
+        if (process.env.NODE_ENV === "production") {
+            throw new DataError("Fragment only", DataErrors.InvalidInput);
+        } else {
+            throw new DataError(
+                `Passing only a fragment to 'graphql' is not supported. ` +
+                    `You must include a query or mutation as well`,
+                DataErrors.InvalidInput,
+            );
+        }
+    }
+
+    if (subscriptions.length) {
+        if (process.env.NODE_ENV === "production") {
+            throw new DataError("No subscriptions", DataErrors.InvalidInput);
+        } else {
+            throw new DataError(
+                `We do not support subscriptions. ` +
+                    `${JSON.stringify(document)} had ${
+                        subscriptions.length
+                    } subscriptions`,
+                DataErrors.InvalidInput,
+            );
+        }
+    }
+
+    if (queries.length + mutations.length > 1) {
+        if (process.env.NODE_ENV === "production") {
+            throw new DataError("Too many ops", DataErrors.InvalidInput);
+        } else {
+            throw new DataError(
+                `We only support one query or mutation per component. ` +
+                    `${JSON.stringify(document)} had ${
+                        queries.length
+                    } queries and ` +
+                    `${mutations.length} mutations. `,
+                DataErrors.InvalidInput,
+            );
+        }
+    }
+
+    const type = queries.length ? DocumentTypes.query : DocumentTypes.mutation;
+    const definitions = queries.length ? queries : mutations;
+
+    const definition: OperationDefinitionNode = (definitions[0]: any);
+    const variables = definition.variableDefinitions || [];
+
+    // fallback to using data if no name
+    const name =
+        definition.name?.kind === "Name" ? definition.name.value : "data";
+
+    const payload: IDocumentDefinition = {name, type, variables};
+    cache.set(document, payload);
+    return payload;
+}

--- a/packages/wonder-blocks-data/src/util/graphql-types.js
+++ b/packages/wonder-blocks-data/src/util/graphql-types.js
@@ -1,0 +1,30 @@
+// @flow
+// NOTE(somewhatabstract):
+// These types are bare minimum to support document parsing. They're derived
+// from graphql@14.5.8, the last version that provided flow types.
+// Doing this avoids us having to take a dependency on that library just for
+// these types.
+export interface DefinitionNode {
+    +kind: string;
+}
+
+export type VariableDefinitionNode = {
+    +kind: "VariableDefinition",
+    ...
+};
+
+export interface OperationDefinitionNode extends DefinitionNode {
+    +kind: "OperationDefinition";
+    +operation: string;
+    +variableDefinitions: $ReadOnlyArray<VariableDefinitionNode>;
+    +name?: {|
+        +kind: mixed,
+        +value: string,
+    |};
+}
+
+export type DocumentNode = {
+    +kind: "Document",
+    +definitions: $ReadOnlyArray<DefinitionNode>,
+    ...
+};

--- a/packages/wonder-blocks-data/src/util/to-gql-operation.js
+++ b/packages/wonder-blocks-data/src/util/to-gql-operation.js
@@ -1,0 +1,44 @@
+// @flow
+import {graphQLDocumentNodeParser} from "./graphql-document-node-parser.js";
+import type {GqlOperation} from "./gql-types.js";
+import type {DocumentNode} from "./graphql-types.js";
+
+/**
+ * Convert a GraphQL DocumentNode to a base Wonder Blocks Data GqlOperation.
+ *
+ * If you want to include the query/mutation body, extend the result of this
+ * method and use the `graphql/language/printer` like:
+ *
+ * ```js
+ * import {print} from "graphql/language/printer";
+ *
+ * const gqlOpWithBody = {
+ *     ...toGqlOperation(documentNode),
+ *     query: print(documentNode),
+ * };
+ * ```
+ *
+ * If you want to enforce inclusion of __typename properties, then you can use
+ * `apollo-utilities` first to modify the document:
+ *
+ * ```js
+ * import {print} from "graphql/language/printer";
+ * import {addTypenameToDocument} from "apollo-utilities";
+ *
+ * const documentWithTypenames = addTypenameToDocument(documentNode);
+ * const gqlOpWithBody = {
+ *     ...toGqlOperation(documentWithTypenames),
+ *     query: print(documentWithTypenames),
+ * };
+ * ```
+ */
+export const toGqlOperation = <TData, TVariables: {...}>(
+    documentNode: DocumentNode,
+): GqlOperation<TData, TVariables> => {
+    const definition = graphQLDocumentNodeParser(documentNode);
+    const wbDataOperation: GqlOperation<TData, TVariables> = {
+        id: definition.name,
+        type: definition.type,
+    };
+    return wbDataOperation;
+};


### PR DESCRIPTION
## Summary:
This pulls the `DocumentNode` parsing from webapp (which was from Apollo) into Wonder Blocks Data, with some tweaks around error cases and typing (to avoid taking a dependency on an old `graphql` just for types).

This also adds tests.

Issue: FEI-4357

## Test plan:
`yarn test`