### PR TITLE
[fei4454.2] Add abortInflightRequests export

### DIFF
--- a/.changeset/tough-geckos-boil.md
+++ b/.changeset/tough-geckos-boil.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": minor
+---
+
+Add `abortInflightRequests` to exports

--- a/packages/wonder-blocks-data/src/__docs__/exports.abort-inflight-requests.stories.mdx
+++ b/packages/wonder-blocks-data/src/__docs__/exports.abort-inflight-requests.stories.mdx
@@ -1,0 +1,20 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Data / Exports / abortInflightRequests()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# abortInflightRequests()
+
+```ts
+abortInflightRequests(): void;
+```
+
+Aborts all inflight requests that were started via [`useCachedEffect`](/docs/data-exports-usecachedeffect--page), [`useHydratableEffect`](/docs/data-exports-usehydratableeffect--page), or [`fetchTrackedRequests()`](/docs/data-exports-fetchtrackedrequests--page).
+
+NOTE: Full abort signalling is not currently implemented. The effect of this call is to remove any inflight requests from our inflight request tracking such that a new matching request will cause a new fetch to occur rather than sharing any existing one.

--- a/packages/wonder-blocks-data/src/util/__tests__/request-api.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-api.test.js
@@ -1,8 +1,10 @@
 // @flow
 import {Server} from "@khanacademy/wonder-blocks-core";
+import {RequestFulfillment} from "../request-fulfillment.js";
 import {RequestTracker} from "../request-tracking.js";
 
 import {
+    abortInflightRequests,
     fetchTrackedRequests,
     hasTrackedRequestsToBeFetched,
 } from "../request-api.js";
@@ -169,5 +171,18 @@ describe("#hasTrackedRequestsToBeFetched", () => {
                 );
             });
         });
+    });
+});
+
+describe("#abortInflightRequests", () => {
+    it("should call RequestFulfillment.Default.abortAll", () => {
+        // Arrange
+        const abortAllSpy = jest.spyOn(RequestFulfillment.Default, "abortAll");
+
+        // Act
+        abortInflightRequests();
+
+        // Assert
+        expect(abortAllSpy).toHaveBeenCalled();
     });
 });

--- a/packages/wonder-blocks-data/src/util/request-api.js
+++ b/packages/wonder-blocks-data/src/util/request-api.js
@@ -1,6 +1,7 @@
 // @flow
 import {Server} from "@khanacademy/wonder-blocks-core";
 import {RequestTracker} from "./request-tracking.js";
+import {RequestFulfillment} from "./request-fulfillment.js";
 import {DataError, DataErrors} from "./data-error.js";
 
 import type {ResponseCache} from "./types.js";
@@ -52,4 +53,14 @@ export const hasTrackedRequestsToBeFetched = (): boolean => {
         throw ssrCheck;
     }
     return RequestTracker.Default.hasUnfulfilledRequests;
+};
+
+/**
+ * Abort all in-flight requests.
+ *
+ * This aborts all requests currently inflight via our default request
+ * fulfillment.
+ */
+export const abortInflightRequests = (): void => {
+    RequestFulfillment.Default.abortAll();
 };


### PR DESCRIPTION
## Summary:
This adds a handy `abortInflightRequests` export.

Issue: FEI-4454

## Test plan:
`yarn test`