### PR TITLE
[🔥AUDIT🔥] [fixssrcacheintests] Ensure purgeCaches and purgeHydrationCache will work as devs would expect in tests

### DIFF
--- a/.changeset/cold-falcons-invent.md
+++ b/.changeset/cold-falcons-invent.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+---
+
+Make sure ssr-only cache is initialized when purging caches in test environment

--- a/packages/wonder-blocks-data/src/util/__tests__/ssr-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/ssr-cache.test.js
@@ -16,6 +16,64 @@ describe("../ssr-cache.js", () => {
         jest.restoreAllMocks();
     });
 
+    describe("#constructor", () => {
+        const NODE_ENV = process.env.NODE_ENV;
+
+        afterEach(() => {
+            if (NODE_ENV == null) {
+                delete process.env.NODE_ENV;
+            } else {
+                process.env.NODE_ENV = NODE_ENV;
+            }
+        });
+
+        it.each(["development", "production"])(
+            "should default the ssr-only cache to a undefined when client-side in %s",
+            (nodeEnv) => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(false);
+                process.env.NODE_ENV = nodeEnv;
+
+                // Act
+                const cache = new SsrCache();
+
+                // Assert
+                expect(cache._ssrOnlyCache).toBeUndefined();
+            },
+        );
+
+        it("should default the ssr-only cache to a cache instance when client-side in test", () => {
+            // Arrange
+            jest.spyOn(Server, "isServerSide").mockReturnValue(false);
+            process.env.NODE_ENV = "test";
+
+            // Act
+            const cache = new SsrCache();
+
+            // Assert
+            expect(cache._ssrOnlyCache).toBeInstanceOf(
+                SerializableInMemoryCache,
+            );
+        });
+
+        it.each(["development", "production"])(
+            "should default the ssr-only cache to a cache instance when server-side in %s",
+            (nodeEnv) => {
+                // Arrange
+                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+                process.env.NODE_ENV = nodeEnv;
+
+                // Act
+                const cache = new SsrCache();
+
+                // Assert
+                expect(cache._ssrOnlyCache).toBeInstanceOf(
+                    SerializableInMemoryCache,
+                );
+            },
+        );
+    });
+
     describe("@Default", () => {
         it("should return an instance of SsrCache", () => {
             // Arrange

--- a/packages/wonder-blocks-data/src/util/ssr-cache.js
+++ b/packages/wonder-blocks-data/src/util/ssr-cache.js
@@ -32,9 +32,16 @@ export class SsrCache {
         hydrationCache: ?SerializableInMemoryCache = null,
         ssrOnlyCache: ?SerializableInMemoryCache = null,
     ) {
-        this._ssrOnlyCache = Server.isServerSide()
-            ? ssrOnlyCache || new SerializableInMemoryCache()
-            : undefined;
+        // The default instance gets made on first reference and if that happens
+        // before server-side mode is turned on, the Default instance would
+        // never have an SSR-only cache instance, which would then mean that if
+        // server-side mode got turned on, it wouldn't work right.
+        // This should only be an issue of surprise during testing, so, let's
+        // always have an instance in that circumstance.
+        this._ssrOnlyCache =
+            process.env.NODE_ENV === "test" || Server.isServerSide()
+                ? ssrOnlyCache || new SerializableInMemoryCache()
+                : undefined;
         this._hydrationCache =
             hydrationCache || new SerializableInMemoryCache();
     }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This fixes a bug in the `purgeHydrationCache` call and similar where if it were called before `Server.setServerSide()` or a something that affected the return value of `Server.isServerSide()` (such as a mock), then the internal SSR-only cache wouldn't get initialized and then any future setup that needed it wouldn't work right.

This fixes things by initializing that cache when in the test NODE_ENV. This creates behavior of least surprise for devs in testing, while retaining the existing client-side behavior when in the browser.

Issue: FEI-4371

## Test plan:
`yarn test`