### PR TITLE
[🔥AUDIT🔥] [fixssrcacheagain] Always init SSR only cache

### DIFF
--- a/.changeset/good-frogs-allow.md
+++ b/.changeset/good-frogs-allow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+---
+
+Always initialize SSR-only cache

--- a/packages/wonder-blocks-data/src/util/__tests__/ssr-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/ssr-cache.test.js
@@ -17,35 +17,8 @@ describe("../ssr-cache.js", () => {
     });
 
     describe("#constructor", () => {
-        const NODE_ENV = process.env.NODE_ENV;
-
-        afterEach(() => {
-            if (NODE_ENV == null) {
-                delete process.env.NODE_ENV;
-            } else {
-                process.env.NODE_ENV = NODE_ENV;
-            }
-        });
-
-        it.each(["development", "production"])(
-            "should default the ssr-only cache to a undefined when client-side in %s",
-            (nodeEnv) => {
-                // Arrange
-                jest.spyOn(Server, "isServerSide").mockReturnValue(false);
-                process.env.NODE_ENV = nodeEnv;
-
-                // Act
-                const cache = new SsrCache();
-
-                // Assert
-                expect(cache._ssrOnlyCache).toBeUndefined();
-            },
-        );
-
-        it("should default the ssr-only cache to a cache instance when client-side in test", () => {
+        it("should default the ssr-only cache to a cache instance", () => {
             // Arrange
-            jest.spyOn(Server, "isServerSide").mockReturnValue(false);
-            process.env.NODE_ENV = "test";
 
             // Act
             const cache = new SsrCache();
@@ -56,22 +29,39 @@ describe("../ssr-cache.js", () => {
             );
         });
 
-        it.each(["development", "production"])(
-            "should default the ssr-only cache to a cache instance when server-side in %s",
-            (nodeEnv) => {
-                // Arrange
-                jest.spyOn(Server, "isServerSide").mockReturnValue(true);
-                process.env.NODE_ENV = nodeEnv;
+        it("should set the hydration cache to the passed instance if there is one", () => {
+            // Arrange
+            const passedInstance = new SerializableInMemoryCache();
 
-                // Act
-                const cache = new SsrCache();
+            // Act
+            const cache = new SsrCache(null, passedInstance);
 
-                // Assert
-                expect(cache._ssrOnlyCache).toBeInstanceOf(
-                    SerializableInMemoryCache,
-                );
-            },
-        );
+            // Assert
+            expect(cache._ssrOnlyCache).toBe(passedInstance);
+        });
+
+        it("should default the hydration cache to a cache instance", () => {
+            // Arrange
+
+            // Act
+            const cache = new SsrCache();
+
+            // Assert
+            expect(cache._hydrationCache).toBeInstanceOf(
+                SerializableInMemoryCache,
+            );
+        });
+
+        it("should set the hydration cache to the passed instance if there is one", () => {
+            // Arrange
+            const passedInstance = new SerializableInMemoryCache();
+
+            // Act
+            const cache = new SsrCache(passedInstance);
+
+            // Assert
+            expect(cache._hydrationCache).toBe(passedInstance);
+        });
     });
 
     describe("@Default", () => {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I had the expectation that the NODE_ENV things weren't applied when wonder blocks was built but instead would be applied when webapp was built; this was incorrect and so my last fix for this problem did not work

Issue: FEI-4371

## Test plan:
`yarn test`

Include in webapp and check that the route tests now work again.