### PR TITLE
[🔥AUDIT🔥] [howdidImissthis] Use the shared action for all cache references

### DIFF
--- a/.github/workflows/node-ci-push.yml
+++ b/.github/workflows/node-ci-push.yml
@@ -56,15 +56,10 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     # Cache and install dependencies
-    - name: Cache node modules
-      uses: actions/cache@v2
+    - name: Install & cache node_modules
+      uses: ./.github/actions/shared-node-cache
       with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-modules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-modules-
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile
+        node-version: ${{ matrix.node-version }}
 
     - name: Run Jest with coverage
       run: yarn coverage:ci
@@ -99,15 +94,10 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     # Cache and install dependencies
-    - name: Cache node modules
-      uses: actions/cache@v2
+    - name: Install & cache node_modules
+      uses: ./.github/actions/shared-node-cache
       with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-modules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-modules-
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile
+        node-version: ${{ matrix.node-version }}
 
     - name: Build all packages
       run: yarn build:all


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I forgot to update the two jobs in node ci push workflow.

## Test plan:
Merge into `main` and check that it now runs the shared action for these two jobs.