### PR TITLE
Fix focus issue with filterable dropdowns

### DIFF
--- a/.changeset/giant-otters-judge.md
+++ b/.changeset/giant-otters-judge.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fixed the search field focus bug in dropdowns

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -669,6 +669,12 @@ class DropdownCore extends React.Component<Props, State> {
                     },
                     // apply custom styles
                     style: searchInputStyle,
+                    // TODO(WB-1310): Remove the autofocus prop after making
+                    // the search field sticky.
+                    // Currently autofocusing on the search field to work
+                    // around it losing focus on mount when switching between
+                    // virtualized and non-virtualized dropdown filter results.
+                    autofocus: this.focusedIndex === 0,
                 });
             }
 
@@ -719,6 +725,12 @@ class DropdownCore extends React.Component<Props, State> {
                         itemRef: this.state.itemRefs[focusIndex]
                             ? this.state.itemRefs[focusIndex].ref
                             : null,
+                        // TODO(WB-1310): Remove the autofocus prop after making
+                        // the search field sticky.
+                        // Currently autofocusing on the search field to work
+                        // around it losing focus on mount when switching between
+                        // virtualized and non-virtualized dropdown filter results.
+                        autofocus: this.focusedIndex === 0,
                     },
                 };
             }

--- a/packages/wonder-blocks-dropdown/src/components/search-text-input.js
+++ b/packages/wonder-blocks-dropdown/src/components/search-text-input.js
@@ -51,6 +51,13 @@ type Props = {|
      * Test ID used for e2e testing.
      */
     testId?: string,
+
+    /**
+     * Automatically focus on this search field on mount.
+     * TODO(WB-1310): Remove the autofocus prop after making
+     * the search field sticky in dropdowns.
+     */
+    autofocus?: boolean,
 |};
 
 type DefaultProps = {|
@@ -70,6 +77,21 @@ export default class SearchTextInput extends React.Component<Props> {
             filter: defaultLabels.filter,
         },
     };
+
+    // TODO(WB-1310): Remove `componentDidMount` autofocus on the search field
+    // after making the search field sticky.
+    componentDidMount() {
+        // We need to re-focus on the text input after it mounts because of
+        // the case in which the dropdown switches between virtualized and
+        // non-virtualized. It can rerender the search field as the user is
+        // typing based on the number of search results, which results
+        // in losing focus on the field so the user can't type anymore.
+        // To work around this issue, this temporary fix auto-focuses on the
+        // search field on mount.
+        if (this.props.autofocus) {
+            this.props.itemRef?.current.focus();
+        }
+    }
 
     static __IS_SEARCH_TEXT_INPUT__: boolean = true;
 

--- a/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
@@ -79,6 +79,7 @@ const optionItems = new Array(1000)
     ));
 
 type Props = {|
+    selectedValue: string,
     opened: boolean,
 |};
 
@@ -88,16 +89,18 @@ type State = {|
 |};
 
 type DefaultProps = {|
+    selectedValue: $PropertyType<Props, "selectedValue">,
     opened: $PropertyType<Props, "opened">,
 |};
 
 class SingleSelectWithFilter extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
+        selectedValue: "2",
         opened: false,
     };
 
     state: State = {
-        selectedValue: "2",
+        selectedValue: this.props.selectedValue,
         opened: this.props.opened,
     };
 
@@ -167,28 +170,9 @@ export const WithFilterOpened: StoryComponentType = () => (
     <SingleSelectWithFilter opened={true} />
 );
 
-export const WithFilterOpenedNoValueSelected: StoryComponentType = () => {
-    const [value, setValue] = React.useState(null);
-    const [opened, setOpened] = React.useState(true);
-    return (
-        <SingleSelect
-            onChange={(selected) => setValue(selected)}
-            isFilterable={true}
-            opened={opened}
-            onToggle={(opened) => setOpened(opened)}
-            placeholder="Select a fruit"
-            selectedValue={value}
-        >
-            {optionItems}
-        </SingleSelect>
-    );
-};
-
-WithFilterOpenedNoValueSelected.parameters = {
-    // Set a delay so chromatic takes a screenshot of the whole open
-    // dropdown list, not just the opener element.
-    chromatic: {delay: 300},
-};
+export const WithFilterOpenedNoValueSelected: StoryComponentType = () => (
+    <SingleSelectWithFilter opened={true} selectedValue={null} />
+);
 
 export const DropdownInModal: StoryComponentType = () => {
     const [value, setValue] = React.useState(null);

--- a/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
@@ -184,6 +184,12 @@ export const WithFilterOpenedNoValueSelected: StoryComponentType = () => {
     );
 };
 
+WithFilterOpenedNoValueSelected.parameters = {
+    // Set a delay so chromatic takes a screenshot of the whole open
+    // dropdown list, not just the opener element.
+    chromatic: {delay: 300},
+};
+
 export const DropdownInModal: StoryComponentType = () => {
     const [value, setValue] = React.useState(null);
     const [opened, setOpened] = React.useState(true);

--- a/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
@@ -79,12 +79,12 @@ const optionItems = new Array(1000)
     ));
 
 type Props = {|
-    selectedValue: string,
+    selectedValue?: ?string,
     opened: boolean,
 |};
 
 type State = {|
-    selectedValue: string,
+    selectedValue?: ?string,
     opened: boolean,
 |};
 

--- a/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.stories.js
@@ -167,6 +167,23 @@ export const WithFilterOpened: StoryComponentType = () => (
     <SingleSelectWithFilter opened={true} />
 );
 
+export const WithFilterOpenedNoValueSelected: StoryComponentType = () => {
+    const [value, setValue] = React.useState(null);
+    const [opened, setOpened] = React.useState(true);
+    return (
+        <SingleSelect
+            onChange={(selected) => setValue(selected)}
+            isFilterable={true}
+            opened={opened}
+            onToggle={(opened) => setOpened(opened)}
+            placeholder="Select a fruit"
+            selectedValue={value}
+        >
+            {optionItems}
+        </SingleSelect>
+    );
+};
+
 export const DropdownInModal: StoryComponentType = () => {
     const [value, setValue] = React.useState(null);
     const [opened, setOpened] = React.useState(true);

--- a/packages/wonder-blocks-dropdown/src/util/constants.js
+++ b/packages/wonder-blocks-dropdown/src/util/constants.js
@@ -24,6 +24,7 @@ export const filterableDropdownStyle = {
 export const searchInputStyle = {
     margin: Spacing.xSmall_8,
     marginTop: Spacing.xxxSmall_4,
+    minHeight: "auto",
 };
 
 // The default item height

--- a/packages/wonder-blocks-dropdown/src/util/constants.js
+++ b/packages/wonder-blocks-dropdown/src/util/constants.js
@@ -24,6 +24,8 @@ export const filterableDropdownStyle = {
 export const searchInputStyle = {
     margin: Spacing.xSmall_8,
     marginTop: Spacing.xxxSmall_4,
+    // Set `minHeight` to "auto" to stop the search field from having
+    // a height of 0 and being cut off.
     minHeight: "auto",
 };
 


### PR DESCRIPTION
## Summary:
Currently, if a dropdown switches between a virtualized list (125+ results) and
a non-virtualized list (< 125 results), then the search field rerenders and
loses focus. This means that a user is typing in the search field and the filter
results change mid-typing, the focus leaves the text field and the user will have
to click back in to keep typing.

As a temporary fix, here we force focus on the field on mount if the focus was already
previously on the field.

The issue should go away with WB-1310, but we are adding this quick fix as a bandaid for now.

Issue: https://khanacademy.atlassian.net/browse/WB-1281

## Before:
<img width="324" alt="Screen Shot 2022-04-29 at 5 46 49 PM" src="https://user-images.githubusercontent.com/13231763/166083897-2c7cb82f-11ef-4706-a5aa-9491def88e94.png">

https://user-images.githubusercontent.com/13231763/166083939-c26ea043-c6d0-43b0-98b4-10c765965d21.mov


## After:
https://user-images.githubusercontent.com/13231763/166083866-5b3a9284-1444-49e1-8440-8bccfa4f16a7.mov


## Test plan:

Storybook
- Go to storybook
- Go to Dropdown/SingleSelect/With Filter Opened
- Type in "fruit # 5 banana" and confirm that the focus doesn't leave the search field.
- Backspace back to "fruit" and confirm that the focus doesn't leave the search field.

NOTE: I tried adding a unit test in `dropdown-core.test.js` and `single-select.test.js` but it doesn't look like there's a good way to test the behavior with the current implementation of SingleSelect/Dropdown and the current tools in React Testing Library. I wrote some tests that looked like they were intuitively testing the behavior, but when I commented out the bug fix, the tests didn't fail like they were supposed to, due to how the rendering works with dropdowns. So they wouldn't even help prevent this from happening again. While it would be ideal to have unit tests for this, Dropdowns are supposed to be refactored soon as part of WB-1310, so hopefully it's okay to forego adding tests for now.