### PR TITLE
[🔥AUDIT🔥] [fei4370.typesexportfix] Fix test harness types

### DIFF
--- a/.changeset/olive-weeks-knock.md
+++ b/.changeset/olive-weeks-knock.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Fix test harness types

--- a/packages/wonder-blocks-testing/src/harness/__tests__/types.flowtest.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/types.flowtest.js
@@ -1,0 +1,115 @@
+// @flow
+import * as React from "react";
+
+import type {
+    TestHarnessAdapter,
+    TestHarnessAdapters,
+    TestHarnessConfig,
+    TestHarnessConfigs,
+} from "../types.js";
+
+/**
+ * TestHarnessAdapter<TConfig>
+ */
+
+//>  should assert type of config.
+((
+    children: React.Node,
+    // TConfig is string, but we typed this arg as a number
+    // $FlowExpectedError[incompatible-cast]
+    config: number,
+): React.Element<any> => <div />: TestHarnessAdapter<string>);
+//<
+
+//>  should work for correct definition
+((children: React.Node, config: string): React.Element<any> => (
+    <div />
+): TestHarnessAdapter<string>);
+//<
+
+/**
+ * TestHarnessAdapters
+ */
+
+//>  should work for empty case
+({}: TestHarnessAdapters);
+//<
+
+//>  should assert if adapter is not Adapter<TConfig>
+({
+    // String is not a adapter function
+    // $FlowExpectedError[incompatible-cast]
+    adapterString: "string",
+}: TestHarnessAdapters);
+//<
+
+//>  should work for a function matching Adapter<TConfig>
+({
+    adapterA: (children, config) => <div>test</div>,
+}: TestHarnessAdapters);
+//<
+
+/**
+ * TestHarnessConfig<TAdapter>
+ */
+//> should give the config type of an adapter
+("string": TestHarnessConfig<TestHarnessAdapter<string>>);
+//<
+
+//> should error if the config type is wrong
+// 45 is not a string
+// $FlowExpectedError[incompatible-cast]
+(45: TestHarnessConfig<TestHarnessAdapter<string>>);
+//<
+
+/**
+ * TestHarnessConfigs<TAdapters>
+ *
+ * NOTE: This only works if the properties of the passed THarnasses type
+ * are explicitly typed as `TestHarnessAdapter<TConfig>` so if passing in a
+ * non-Adapters type (which we should be, to get strong TConfig types instead
+ * of `any`), then that object should make sure that each adapter is strongly
+ * marked as `TestHarnessAdapter<TConfig>` - flow does not appear to pattern
+ * match against the type definition when invoking the ExtractConfig type and I
+ * haven't worked out how to get it to multi-dispatch so that it matches
+ * functions too. Even worse, if the type doesn't match, it just allows `any`
+ * in the configs object, rather than indicating any kind of problem.
+ */
+const notadapters = "this is wrong";
+const adapterA: TestHarnessAdapter<string> = (
+    children: React.Node,
+    config: ?string,
+): React.Element<any> => <div />;
+const adapterB: TestHarnessAdapter<number> = (
+    children: React.Node,
+    config: ?number,
+): React.Element<any> => <div />;
+const adapters = {
+    adapterA,
+    adapterB,
+};
+
+//>  should assert if parameterized type is not valid Adapters
+// string is not a valid Adapter
+// $FlowExpectedError[incompatible-use]
+// $FlowExpectedError[incompatible-type-arg]
+({}: TestHarnessConfigs<typeof notadapters>);
+//<
+
+//>  should expect one config per adapter
+// both adapter configs missing
+// $FlowExpectedError[incompatible-exact]
+({}: TestHarnessConfigs<typeof adapters>);
+// adapterB config missing
+// $FlowExpectedError[prop-missing]
+({adapterA: "test"}: TestHarnessConfigs<typeof adapters>);
+//<
+
+//>  should assert if config does not match adapter config
+({
+    adapterA: "a string, this is correct",
+    // the config type here is a number, not a string
+    // $FlowExpectedError[incompatible-cast]
+    adapterB: "a string, but it should be a number",
+}: TestHarnessConfigs<typeof adapters>);
+//<

--- a/packages/wonder-blocks-testing/src/harness/types.js
+++ b/packages/wonder-blocks-testing/src/harness/types.js
@@ -4,7 +4,7 @@ import * as React from "react";
 /**
  * A adapter to be composed with our test harnass infrastructure.
  */
-export type TestHarnessAdapter<-TConfig> = (
+export type TestHarnessAdapter<TConfig> = (
     children: React.Node,
     config: TConfig,
 ) => React.Element<any>;
@@ -36,7 +36,7 @@ type ExtractMaybeConfig = <TConfig>(TestHarnessAdapter<TConfig>) => ?TConfig;
  *
  * This is the `TestHarnessAdapter` equivalent of `React.ElementConfig`.
  */
-export type TestHarnessConfig<-TAdapter> = $Call<ExtractConfig, TAdapter>;
+export type TestHarnessConfig<TAdapter> = $Call<ExtractConfig, TAdapter>;
 
 /**
  * The `TestHarnessConfigs` type as defined by parsing a given set of adapters.
@@ -51,7 +51,7 @@ export type TestHarnessConfig<-TAdapter> = $Call<ExtractConfig, TAdapter>;
  * functions too. Even worse, if the type doesn't match, it just allows `any`
  * in the `Configs` object, rather than indicating any kind of problem.
  */
-export type TestHarnessConfigs<-TAdapters: TestHarnessAdapters> = $ObjMap<
+export type TestHarnessConfigs<TAdapters: TestHarnessAdapters> = $ObjMap<
     TAdapters,
     ExtractMaybeConfig,
 >;


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I had played around with variance markers and trusted flow to tell me if things stopped working, but instead, of adding an unused suppression warning, it did nothing. Without one of the suppressions in the test file, no error; with the suppression, no unused suppression warning.

I only discovered this while integrating the changes into webapp because I had forgotten to carry over the flowtest file. This audit includes that file and reverts the variance changes. I am pretty sure it was just the `TestHarnessAdapter<>` one that was the issue, but decided not to risk it on the other cases for now.

You can see this for yourself by visiting [this example](https://flow.org/try/#0PTAEAEDMBsHsHcBQBLAtgB1gJwC6gFSgCGAzqAEoCmRAxnpFrKqAERbV0sDciiw++RAVABBYgBMi6HJSygcsUACNKoGk0wlK40PGQ4AFqFgBXOTJJ4DRLADtSZZLYakcWE3TOUAdEPzBESgAPTFx5AE90VQAVSksACRtbOJIRSWlZAB5ogGFYZ2QAcwA+UABeUAAKIVBamgNkaHF2WwAuCg4cbwA5WHFKABoauvzIIvbc0aKhgEpy0qpaLoBRaEpUSlscTKJbcOKePgE-UVBCzdkiaFBUKWNICSkZLDIlcPkDSmQ5ZH6t5DGshIvgIJwAkjgAORkADyAGkPkQ8IZkGRrGQAAa7cIY0CQbAfVTqAqFCJRYhkFGOSmfUAAN1k7yUpEoJwZL2Q+XuxEeGTkWi6oDBtlA7Cu+nCAx5qGwqhIURoAOQNDJqj00GuKlAJi04hOekMhNA1jsKTxJlsdE5thpSO1WhustA8soirGKv6Y1s+mtZFgDwA1rYELYTkR0s9gaBog1qaAAFY65GKEgmdChZG05kOsXQCXc4N4IMIJyFEGCYQAVQdVOMIqc6BMeE0Pvyfts0HC3lAMKbjebsBIrZteIJ4aeQJOJAMpiaoCckFkhO+qvnIplljULMpik2qfYRssjFs503OEipfuJ0MqnHfOBfgCwQzq9iCSSKTSE5e5VAAG8AB9hlAABtO9njBAARdoj1LABdCY4hwRJTRIVIIyybFiiGACAF9Dn4CtCAAWSkdBL0gC0rTbPFGGYIheWeABaPMA1USjLRwa15EUYkxlJc8onLAJBNUZYgjcJY8hJX9smk-jikqN9kI-NCvz5OSphKOYylKSYSR4UTQHEyS6FI8IVHkopZP0hSlKQlDkjUjCsE0klih00oAH5bKKAjjmEaJInYglqCHTtQE9JxL12RjZGhNQtNVcsThjVF5xpVQMWUxzPxc3FKAARxMZA6SuTY8H9UAMUWOhvFWdYKqswoMWEwIQmwZFgujBzVJIZrsnU55SgqAASHIrmgTITKwKStKlaIhtkA5eEI1LaWy3rUP6rSSFxIzSEiygvW0ZR3nQGwhxPHlClKzZnUoSqHnAoEUuEboYWiZYJljOsIvgbAA0cB4b1AdBGCiXBkDiblQYutDTuypaXn24KwwPZ880VHAItEnRDs299tuRtyFNxEhFABMGHEvJxiBOYNbCY5HKW6yp4AaepdDlGcTDnFQpQUM5HudNx8lJbLmtRqJHBtGRwxOKqsT2DEZkFz4RUMO1YCUeNXTwadZx0W42OdLxETwDgjBen4yCPcXOxOW4sDY-HMRyvqSd8kpcSYvE4HgSLYBhwtiHTahzEUC6cGeUNhFuHAuaIQoiCcM9aSMqLvS4rkOfupw6VgANL1BjEZrmklpdvWwdDBE5rAZWxITwAGXdO0wrAQHjhbwfRu9QPmuKY8RUWjrmKYt+c8AT+o4hODjqJHBRYG7ZZG90bAtClKnQcz4OSCb6ekXqbe8ETTdJoQTFsQxE46dL5q9uMXX9alWab3Max6xr5UkRivZQDFxrtycGOs1ioDas+Tqr4tpOR2iSEgg0XIkEQkTOBLMRqgFGjCXWpF0CZGAotZBQxai1HLmZIgFlKDNSGCtI4REepoLyt+UmRRiiPl4HwYApRDZ8x0LIRgPwQa0j4tZIy6V4DHkKFw0AAAWAArBlUAocGKwRPIgSoCjUEqW2gND2xMXKZDUSUDyPAQAEPoalWBKRH5IO-CQdhoJ3qfW+tGX6+R-qA2BkaUBkMuIwyqnDBwp1oiOWCazKI6NVCY2VPoXGwU3bVX0egwx3tijk0pg8eGV1SR0yIAzfIzNkGrnZpzIw8AeZG2UIMbu5wDZi2ut7VUstLDUD1MIJWN81aEk1tYSqL86DOl5nOE2cpzZa0trQa2LklH2xPI7eONhXYUiSdY5yLC0m+39l3cQ+9lGwDwGRCO3do6xydsfa2Kc06ZlUJnY60Uc4ijzt-QuQCBK0nITgZqq5di13rkQRuzcN5tx0B3Y0XchZ1Knv3QeyBh6jwuc6RQEzoUz0+CQeeVFHk7hXsZderct7zmEbc7quy4iHxuBc0+CYkzEA1FfaqN8769KJLtZ+es6BvyRJ8T+sUnAjxoH-a62JAH8pAYwJQ4C2rEk3IWG2ZAKgsFrBIqR3BEAysOS5EQ2jcrrI0sYzB1RSFqAaE0Fo7RapdF6P0EhpDRGFHaF5YxswLWdHquAiqOw9gjVKJkEedJQDcJ4BquKWAABCOrPaGNsCYVAKgsCGuAvURozRNiuqWD0Pogwk1aUdTGuNsgXUdAzQ1DYWwvX7HmKAP1pVA0rRDfK38f5gI2xELa2oNsw1DHwqtbhtReFzmCWEKm9qg4hwOZSxO0zvyJRJBo5txrW3tBYKotwpZ1bpXSuoLA7BODtsDWAUGo6jI8tUOlBi+b41ShUaLLApZgIgCwQAMQDuJBUMhxDLB3dgECTh1AYD-pKygTFBWWDgi2lyEbWCrrvSeKUSgmzQoHToLUF7Y3xpYN2yNujdqZFElVeVpiuEEKAA) and changing line 7 from:

```
export type TestHarnessAdapter<TConfig> = (
```

to

```
export type TestHarnessAdapter<-TConfig> = (
```

NOTE: Suppressions are ignored on TryFlow, but this shows how my change fixes the issue even with the strange unused suppression issue that was there prior.

Issue: FEI-4370

### Location:
This PR was submitted from on board the QM2🛳️ as I sailed across the Atlantic Ocean 🌊.

## Test plan:
`yarn flow` and see no errors. Remove the $ on the FlowExpectedErrors and see that we get errors. I'll annotate the PR with the ones that never warned nor errored before this change.