### PR TITLE
WB-646: Add Live region to announce available options

### DIFF
--- a/.changeset/curvy-snakes-flow.md
+++ b/.changeset/curvy-snakes-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Add live region to announce the number of options (fixing an iOS issue)

--- a/packages/wonder-blocks-dropdown/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -43,6 +43,26 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      7 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -246,6 +266,26 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      6 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -427,6 +467,26 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      6 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -608,6 +668,26 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      0 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -789,6 +869,26 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      7 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -971,6 +1071,26 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      8 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -1232,6 +1352,26 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
   }
 >
   <span
+    aria-atomic="true"
+    aria-live="polite"
+    aria-relevant="additions text"
+    className=""
+    style={
+      Object {
+        "border": 0,
+        "clip": "rect(0,0,0,0)",
+        "height": 1,
+        "margin": -1,
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "width": 1,
+      }
+    }
+  >
+    7 items
+  </span>
+  <span
     className=""
     data-test-id="teacher-menu-custom-opener"
     disabled={false}
@@ -1309,6 +1449,26 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      3 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -1446,6 +1606,26 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      3 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -1582,6 +1762,26 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      3 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -1744,6 +1944,26 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
         }
       }
     >
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        aria-relevant="additions text"
+        className=""
+        style={
+          Object {
+            "border": 0,
+            "clip": "rect(0,0,0,0)",
+            "height": 1,
+            "margin": -1,
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "width": 1,
+          }
+        }
+      >
+        3 items
+      </span>
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
@@ -1881,6 +2101,26 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      0 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2036,6 +2276,26 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      2 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2174,6 +2434,26 @@ exports[`wonder-blocks-dropdown example 14 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      3 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2389,6 +2669,26 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
     }
   }
 >
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    aria-relevant="additions text"
+    className=""
+    style={
+      Object {
+        "border": 0,
+        "clip": "rect(0,0,0,0)",
+        "height": 1,
+        "margin": -1,
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "width": 1,
+      }
+    }
+  >
+    3 items
+  </span>
   <h2
     className=""
     data-test-id="single-select-custom-opener"
@@ -2474,6 +2774,26 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      1000 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2610,6 +2930,26 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      4 colors
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2747,6 +3087,26 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      8 planets
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2883,6 +3243,26 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      12 interns
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3114,6 +3494,26 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      0 items
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3269,6 +3669,26 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      2 planets
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3407,6 +3827,26 @@ exports[`wonder-blocks-dropdown example 23 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      4 fruits
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3543,6 +3983,26 @@ exports[`wonder-blocks-dropdown example 24 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      4 fruits
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3777,6 +4237,26 @@ exports[`wonder-blocks-dropdown example 25 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    >
+      1003 schools
+    </span>
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3894,6 +4374,26 @@ exports[`wonder-blocks-dropdown example 26 1`] = `
     }
   }
 >
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    aria-relevant="additions text"
+    className=""
+    style={
+      Object {
+        "border": 0,
+        "clip": "rect(0,0,0,0)",
+        "height": 1,
+        "margin": -1,
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "width": 1,
+      }
+    }
+  >
+    4 fruits
+  </span>
   <h2
     className=""
     data-test-id="multi-select-custom-opener"
@@ -3960,6 +4460,26 @@ exports[`wonder-blocks-dropdown example 27 1`] = `
     }
   }
 >
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    aria-relevant="additions text"
+    className=""
+    style={
+      Object {
+        "border": 0,
+        "clip": "rect(0,0,0,0)",
+        "height": 1,
+        "margin": -1,
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "absolute",
+        "width": 1,
+      }
+    }
+  >
+    13 escuelas seleccionadas
+  </span>
   <button
     aria-expanded="false"
     aria-haspopup="listbox"

--- a/packages/wonder-blocks-dropdown/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-dropdown/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -48,6 +48,7 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -60,9 +61,7 @@ exports[`wonder-blocks-dropdown example 1 1`] = `
           "width": 1,
         }
       }
-    >
-      7 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -271,6 +270,7 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -283,9 +283,7 @@ exports[`wonder-blocks-dropdown example 2 1`] = `
           "width": 1,
         }
       }
-    >
-      6 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -472,6 +470,7 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -484,9 +483,7 @@ exports[`wonder-blocks-dropdown example 3 1`] = `
           "width": 1,
         }
       }
-    >
-      6 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -673,6 +670,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -685,9 +683,7 @@ exports[`wonder-blocks-dropdown example 4 1`] = `
           "width": 1,
         }
       }
-    >
-      0 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -874,6 +870,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -886,9 +883,7 @@ exports[`wonder-blocks-dropdown example 5 1`] = `
           "width": 1,
         }
       }
-    >
-      7 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -1076,6 +1071,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -1088,9 +1084,7 @@ exports[`wonder-blocks-dropdown example 6 1`] = `
           "width": 1,
         }
       }
-    >
-      8 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="menu"
@@ -1356,6 +1350,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
     aria-live="polite"
     aria-relevant="additions text"
     className=""
+    data-test-id="dropdown-live-region"
     style={
       Object {
         "border": 0,
@@ -1368,9 +1363,7 @@ exports[`wonder-blocks-dropdown example 7 1`] = `
         "width": 1,
       }
     }
-  >
-    7 items
-  </span>
+  />
   <span
     className=""
     data-test-id="teacher-menu-custom-opener"
@@ -1454,6 +1447,7 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -1466,9 +1460,7 @@ exports[`wonder-blocks-dropdown example 8 1`] = `
           "width": 1,
         }
       }
-    >
-      3 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -1611,6 +1603,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -1623,9 +1616,7 @@ exports[`wonder-blocks-dropdown example 9 1`] = `
           "width": 1,
         }
       }
-    >
-      3 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -1767,6 +1758,7 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -1779,9 +1771,7 @@ exports[`wonder-blocks-dropdown example 10 1`] = `
           "width": 1,
         }
       }
-    >
-      3 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -1949,6 +1939,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
         aria-live="polite"
         aria-relevant="additions text"
         className=""
+        data-test-id="dropdown-live-region"
         style={
           Object {
             "border": 0,
@@ -1961,9 +1952,7 @@ exports[`wonder-blocks-dropdown example 11 1`] = `
             "width": 1,
           }
         }
-      >
-        3 items
-      </span>
+      />
       <button
         aria-expanded="false"
         aria-haspopup="listbox"
@@ -2106,6 +2095,7 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -2118,9 +2108,7 @@ exports[`wonder-blocks-dropdown example 12 1`] = `
           "width": 1,
         }
       }
-    >
-      0 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2281,6 +2269,7 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -2293,9 +2282,7 @@ exports[`wonder-blocks-dropdown example 13 1`] = `
           "width": 1,
         }
       }
-    >
-      2 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2439,6 +2426,7 @@ exports[`wonder-blocks-dropdown example 14 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -2451,9 +2439,7 @@ exports[`wonder-blocks-dropdown example 14 1`] = `
           "width": 1,
         }
       }
-    >
-      3 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2674,6 +2660,7 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
     aria-live="polite"
     aria-relevant="additions text"
     className=""
+    data-test-id="dropdown-live-region"
     style={
       Object {
         "border": 0,
@@ -2686,9 +2673,7 @@ exports[`wonder-blocks-dropdown example 15 1`] = `
         "width": 1,
       }
     }
-  >
-    3 items
-  </span>
+  />
   <h2
     className=""
     data-test-id="single-select-custom-opener"
@@ -2779,6 +2764,7 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -2791,9 +2777,7 @@ exports[`wonder-blocks-dropdown example 16 1`] = `
           "width": 1,
         }
       }
-    >
-      1000 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -2935,6 +2919,7 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -2947,9 +2932,7 @@ exports[`wonder-blocks-dropdown example 17 1`] = `
           "width": 1,
         }
       }
-    >
-      4 colors
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3092,6 +3075,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -3104,9 +3088,7 @@ exports[`wonder-blocks-dropdown example 18 1`] = `
           "width": 1,
         }
       }
-    >
-      8 planets
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3248,6 +3230,7 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -3260,9 +3243,7 @@ exports[`wonder-blocks-dropdown example 19 1`] = `
           "width": 1,
         }
       }
-    >
-      12 interns
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3499,6 +3480,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -3511,9 +3493,7 @@ exports[`wonder-blocks-dropdown example 21 1`] = `
           "width": 1,
         }
       }
-    >
-      0 items
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3674,6 +3654,7 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -3686,9 +3667,7 @@ exports[`wonder-blocks-dropdown example 22 1`] = `
           "width": 1,
         }
       }
-    >
-      2 planets
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3832,6 +3811,7 @@ exports[`wonder-blocks-dropdown example 23 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -3844,9 +3824,7 @@ exports[`wonder-blocks-dropdown example 23 1`] = `
           "width": 1,
         }
       }
-    >
-      4 fruits
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -3988,6 +3966,7 @@ exports[`wonder-blocks-dropdown example 24 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -4000,9 +3979,7 @@ exports[`wonder-blocks-dropdown example 24 1`] = `
           "width": 1,
         }
       }
-    >
-      4 fruits
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -4242,6 +4219,7 @@ exports[`wonder-blocks-dropdown example 25 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       className=""
+      data-test-id="dropdown-live-region"
       style={
         Object {
           "border": 0,
@@ -4254,9 +4232,7 @@ exports[`wonder-blocks-dropdown example 25 1`] = `
           "width": 1,
         }
       }
-    >
-      1003 schools
-    </span>
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
@@ -4379,6 +4355,7 @@ exports[`wonder-blocks-dropdown example 26 1`] = `
     aria-live="polite"
     aria-relevant="additions text"
     className=""
+    data-test-id="dropdown-live-region"
     style={
       Object {
         "border": 0,
@@ -4391,9 +4368,7 @@ exports[`wonder-blocks-dropdown example 26 1`] = `
         "width": 1,
       }
     }
-  >
-    4 fruits
-  </span>
+  />
   <h2
     className=""
     data-test-id="multi-select-custom-opener"
@@ -4465,6 +4440,7 @@ exports[`wonder-blocks-dropdown example 27 1`] = `
     aria-live="polite"
     aria-relevant="additions text"
     className=""
+    data-test-id="dropdown-live-region"
     style={
       Object {
         "border": 0,
@@ -4477,9 +4453,7 @@ exports[`wonder-blocks-dropdown example 27 1`] = `
         "width": 1,
       }
     }
-  >
-    13 escuelas seleccionadas
-  </span>
+  />
   <button
     aria-expanded="false"
     aria-haspopup="listbox"

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -31,6 +31,19 @@ const items = [
     },
 ];
 
+const searchFieldItem = {
+    component: (
+        <SearchTextInput
+            testId="search-text-input"
+            key="search-text-input"
+            onChange={jest.fn()}
+            searchText={""}
+        />
+    ),
+    focusable: true,
+    populatedProps: {},
+};
+
 describe("DropdownCore", () => {
     it("should throw for invalid role", () => {
         // Arrange
@@ -342,18 +355,7 @@ describe("DropdownCore", () => {
                 searchText=""
                 // mock the items
                 items={[
-                    {
-                        component: (
-                            <SearchTextInput
-                                testId="search"
-                                key="search-text-input"
-                                onChange={jest.fn()}
-                                searchText={""}
-                            />
-                        ),
-                        focusable: true,
-                        populatedProps: {},
-                    },
+                    searchFieldItem,
                     {
                         component: (
                             <OptionItem
@@ -754,21 +756,7 @@ describe("DropdownCore", () => {
                     onSearchTextChanged={jest.fn()}
                     searchText=""
                     // mock the items
-                    items={[
-                        {
-                            component: (
-                                <SearchTextInput
-                                    testId="search-text-input"
-                                    key="search-text-input"
-                                    onChange={jest.fn()}
-                                    searchText={""}
-                                />
-                            ),
-                            focusable: true,
-                            populatedProps: {},
-                        },
-                        ...optionItems,
-                    ]}
+                    items={[searchFieldItem, ...optionItems]}
                     role="listbox"
                     open={true}
                     // mock the opener elements
@@ -797,21 +785,7 @@ describe("DropdownCore", () => {
                     onSearchTextChanged={jest.fn()}
                     searchText=""
                     // mock the items
-                    items={[
-                        {
-                            component: (
-                                <SearchTextInput
-                                    testId="search-text-input"
-                                    key="search-text-input"
-                                    onChange={jest.fn()}
-                                    searchText={""}
-                                />
-                            ),
-                            focusable: true,
-                            populatedProps: {},
-                        },
-                        ...optionItems,
-                    ]}
+                    items={[searchFieldItem, ...optionItems]}
                     role="listbox"
                     open={true}
                     // mock the opener elements
@@ -831,6 +805,55 @@ describe("DropdownCore", () => {
             waitFor(() => {
                 expect(item).toHaveFocus();
             });
+        });
+    });
+
+    describe("a11y > Live region", () => {
+        it("should render a live region announcing the number of options", async () => {
+            // Arrange
+
+            // Act
+            const {container} = render(
+                <DropdownCore
+                    initialFocusedIndex={undefined}
+                    onSearchTextChanged={jest.fn()}
+                    // mock the items (3 options)
+                    items={items}
+                    role="listbox"
+                    open={true}
+                    // mock the opener elements
+                    opener={<button />}
+                    openerElement={null}
+                    onOpenChanged={jest.fn()}
+                />,
+            );
+
+            // Assert
+            expect(container).toHaveTextContent("3 items");
+        });
+
+        it("shouldn't include the search field as part of the options", async () => {
+            // Arrange
+
+            // Act
+            const {container} = render(
+                <DropdownCore
+                    initialFocusedIndex={undefined}
+                    onSearchTextChanged={jest.fn()}
+                    searchText=""
+                    // mock the items (3 options + search field)
+                    items={[searchFieldItem, ...items]}
+                    role="listbox"
+                    open={true}
+                    // mock the opener elements
+                    opener={<button />}
+                    openerElement={null}
+                    onOpenChanged={jest.fn()}
+                />,
+            );
+
+            // Assert
+            expect(container).toHaveTextContent("3 items");
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
@@ -4,6 +4,8 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import {ngettext} from "@khanacademy/wonder-blocks-i18n";
+
 import OptionItem from "../option-item.js";
 import MultiSelect from "../multi-select.js";
 
@@ -1185,6 +1187,61 @@ describe("MultiSelect", () => {
             expect(
                 screen.getByText(updatedLabels.selectNoneLabel),
             ).toBeInTheDocument();
+        });
+    });
+
+    describe("a11y > Live region", () => {
+        it("should announce the number of options when the listbox is open", async () => {
+            // Arrange
+            const labels: $Shape<Labels> = {
+                someSelected: (numOptions: number): string =>
+                    ngettext("%(num)s school", "%(num)s schools", numOptions),
+            };
+
+            // Act
+            const {container} = render(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    isFilterable={true}
+                    labels={labels}
+                    opened={true}
+                >
+                    <OptionItem label="school 1" value="1" />
+                    <OptionItem label="school 2" value="2" />
+                    <OptionItem label="school 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Assert
+            expect(container).toHaveTextContent("3 schools");
+        });
+
+        it("should change the number of options after using the search filter", async () => {
+            // Arrange
+            const labels: $Shape<Labels> = {
+                someSelected: (numOptions: number): string =>
+                    ngettext("%(num)s planet", "%(num)s planets", numOptions),
+            };
+
+            const {container} = render(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    isFilterable={true}
+                    shortcuts={true}
+                    labels={labels}
+                    opened={true}
+                >
+                    <OptionItem label="Earth" value="earth" />
+                    <OptionItem label="Venus" value="venus" />
+                    <OptionItem label="Mars" value="mars" />
+                </MultiSelect>,
+            );
+
+            // Act
+            userEvent.paste(screen.getByRole("textbox"), "Ear");
+
+            // Assert
+            expect(container).toHaveTextContent("1 planet");
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -692,4 +692,34 @@ describe("SingleSelect", () => {
             expect(dropdownMenu).toHaveStyle("max-height: 200px");
         });
     });
+
+    describe("a11y > Live region", () => {
+        it("should change the number of options after using the search filter", async () => {
+            // Arrange
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    isFilterable={true}
+                    opened={true}
+                >
+                    <OptionItem label="item 0" value="0" />
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </SingleSelect>,
+            );
+
+            // Act
+            userEvent.paste(screen.getByRole("textbox"), "item 0");
+
+            // Assert
+            const liveRegionText = screen.getByTestId(
+                "dropdown-live-region",
+            ).textContent;
+
+            // TODO(WB-1318): Change this assertion to `1 item` after adding the
+            // `labels` prop to the component.
+            expect(liveRegionText).toEqual("1 items");
+        });
+    });
 });

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.js
@@ -556,7 +556,7 @@ export default class MultiSelect extends React.Component<Props, State> {
             isFilterable,
         } = this.props;
         const {open, searchText} = this.state;
-        const {noResults} = this.state.labels;
+        const {noResults, someSelected} = this.state.labels;
 
         const allChildren = React.Children.toArray(children).filter(Boolean);
         const numOptions = allChildren.length;
@@ -590,6 +590,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 searchText={isFilterable ? searchText : ""}
                 labels={{
                     noResults,
+                    someSelected,
                 }}
             />
         );

--- a/packages/wonder-blocks-modal/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-modal/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -232,6 +232,25 @@ exports[`wonder-blocks-modal example 3 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      data-test-id="dropdown-live-region"
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    />
     <button
       aria-expanded="false"
       aria-haspopup="menu"

--- a/packages/wonder-blocks-typography/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-typography/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -1041,6 +1041,25 @@ exports[`wonder-blocks-typography example 6 1`] = `
       }
     }
   >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className=""
+      data-test-id="dropdown-live-region"
+      style={
+        Object {
+          "border": 0,
+          "clip": "rect(0,0,0,0)",
+          "height": 1,
+          "margin": -1,
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "absolute",
+          "width": 1,
+        }
+      }
+    />
     <button
       aria-expanded="false"
       aria-haspopup="listbox"


### PR DESCRIPTION
## Summary:

Fixes an issue with iOS that was not announncing properly the total of options.

- Created new wrapper for announcing the options count when the dropdown menu
(`listbox`) is opened.
- Added unit tests.

NOTE: There's a known issue with the `SingleSelect` not being able to use the correct text when there's a single item in the list. This should be fixed after we allow passing translated strings to this component.


Issue: WB-646

## Test plan:

Using an iPad or iPhone:

1. Activate `Voice Over`.
2. Navigate to any of the dropdown stories.
3. Click on the dropdown opener.
4. Verify that VO announces the # of options (e.g. `9 items`).
5. Focus on the search field and filter some elements by typing in `o`.
6. Verify that VO also announces the filtered # of options (e.g. `4 items`).

https://user-images.githubusercontent.com/843075/168170382-300ea9d3-fda0-4c7d-807f-632385429590.mov


