### PR TITLE
Make flow-enums-runtime a peer dependency

### DIFF
--- a/.changeset/plenty-peas-battle.md
+++ b/.changeset/plenty-peas-battle.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-data": patch
+---
+
+Change flow-enums-runtime to be peer dependencies

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint-plugin-testing-library": "^5.0.0",
     "eslint-watch": "^8.0.0",
     "flow-bin": "^0.176.3",
+    "flow-enums-runtime": "^0.0.6",
     "glob": "^7.1.2",
     "husky": "^4.2.5",
     "inquirer": "^8.2.0",

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -25,7 +25,6 @@
     "react-router-dom": "5.3.0"
   },
   "devDependencies": {
-    "flow-enums-runtime": "^0.0.6",
     "wb-dev-build-settings": "^0.4.0"
   },
   "author": "",

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -14,17 +14,18 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-spacing": "^3.0.5",
-    "flow-enums-runtime": "^0.0.6"
+    "@khanacademy/wonder-blocks-spacing": "^3.0.5"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",
+    "flow-enums-runtime": "^0.0.6",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0"
   },
   "devDependencies": {
+    "flow-enums-runtime": "^0.0.6",
     "wb-dev-build-settings": "^0.4.0"
   },
   "author": "",

--- a/packages/wonder-blocks-data/package.json
+++ b/packages/wonder-blocks-data/package.json
@@ -14,11 +14,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.3",
-    "@khanacademy/wonder-blocks-core": "^4.3.1",
-    "flow-enums-runtime": "^0.0.6"
+    "@khanacademy/wonder-blocks-core": "^4.3.1"
   },
   "peerDependencies": {
     "@khanacademy/wonder-stuff-core": "^0.1.2",
+    "flow-enums-runtime": "^0.0.6",
     "react": "16.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary:
The reason for making this change is to avoid having to install this dependency multiple times.

Issue: None

## Test plan:
- let GitHub Actions run all the checks