### PR TITLE
Set an aria-label on ModalDialog if one is passed in

### DIFF
--- a/packages/wonder-blocks-modal/src/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.js
@@ -78,6 +78,7 @@ export default class ModalDialog extends React.Component<Props> {
             children,
             testId,
             "aria-labelledby": ariaLabelledBy,
+            "aria-label": ariaLabel,
         } = this.props;
 
         const contextValue: MediaLayoutContextValue = {
@@ -95,6 +96,7 @@ export default class ModalDialog extends React.Component<Props> {
                                 role={role}
                                 aria-modal="true"
                                 aria-labelledby={ariaLabelledBy}
+                                aria-label={ariaLabel}
                                 style={styles.dialog}
                                 testId={testId}
                             >


### PR DESCRIPTION
## Summary:
Doing some accessibility testing on webapp with jest-axe I found a component that uses this dialog and has no way to pass the test if a label cannot be set (a good labelledby attribute isn't available)

Issue: wb-1324

## Test plan:
Set an aria-label attribute
Verify the dialog has the aria-label