### PR TITLE
Hook up data-test-id for CircularSpinner and Icon

### DIFF
--- a/.changeset/nasty-keys-admire.md
+++ b/.changeset/nasty-keys-admire.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-icon": patch
+"@khanacademy/wonder-blocks-progress-spinner": patch
+---
+
+Setting data-test-id attribute based on testId prop

--- a/packages/wonder-blocks-icon/src/components/icon.js
+++ b/packages/wonder-blocks-icon/src/components/icon.js
@@ -94,7 +94,7 @@ export default class Icon extends React.PureComponent<Props> {
     };
 
     render(): React.Node {
-        const {color, icon, size, style, ...sharedProps} = this.props;
+        const {color, icon, size, style, testId, ...sharedProps} = this.props;
 
         const {assetSize, path} = getPathForIcon(icon, size);
         const pixelSize = viewportPixelsForSize(size);
@@ -106,6 +106,7 @@ export default class Icon extends React.PureComponent<Props> {
                 width={pixelSize}
                 height={pixelSize}
                 viewBox={`0 0 ${viewboxPixelSize} ${viewboxPixelSize}`}
+                data-test-id={testId}
             >
                 <path fill={color} d={path} />
             </StyledSVG>

--- a/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.js
+++ b/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.js
@@ -66,7 +66,7 @@ export default class CircularSpinner extends React.Component<Props> {
     };
 
     render(): React.Node {
-        const {size, light, style} = this.props;
+        const {size, light, style, testId} = this.props;
 
         const height = heights[size];
         const path = paths[size];
@@ -78,6 +78,7 @@ export default class CircularSpinner extends React.Component<Props> {
                 width={height}
                 height={height}
                 viewBox={`0 0 ${height} ${height}`}
+                data-test-id={testId}
             >
                 <StyledPath
                     style={[styles.loadingSpinner, {fill: color}]}


### PR DESCRIPTION
## Summary:
These components currently accept a `testId` prop but they don't hook it up to `data-test-id`, which is what we need to look up elements by test id in React testing library.

Issue: XXX-XXXX

## Test plan:
Testing in deploy preview, `data-test-id` appears for both components:

<img width="1137" alt="Screen Shot 2022-05-19 at 2 50 35 PM" src="https://user-images.githubusercontent.com/2308395/169410675-73f56ba7-9ffe-4725-8928-4b44d7a5c3e4.png">
<img width="959" alt="Screen Shot 2022-05-19 at 2 51 20 PM" src="https://user-images.githubusercontent.com/2308395/169410685-42ddbeab-514e-4a57-b26a-899455a76ee5.png">

