### PR TITLE
Add support for custom search filter to SingleSelect

### DIFF
--- a/packages/wonder-blocks-dropdown/src/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.js
@@ -110,6 +110,15 @@ type Props = {|
      * top. The items will be filtered by the input.
      */
     isFilterable?: boolean,
+
+    /**
+     * When this is set, and isFilterable is true, the dropdown will filter
+     * elements using the provided function instead of the default text search
+     */
+    searchFilter?: (
+        children: Array<React.Element<OptionItem>>,
+        searchText: string,
+    ) => Array<React.Element<OptionItem>>,
 |};
 
 type State = {|
@@ -251,7 +260,12 @@ export default class SingleSelect extends React.Component<Props, State> {
     filterChildren(
         children: Array<React.Element<OptionItem>>,
     ): Array<React.Element<OptionItem>> {
+        const {searchFilter} = this.props;
         const {searchText} = this.state;
+
+        if (searchFilter) {
+            return searchFilter(children, searchText);
+        }
 
         const lowercasedSearchText = searchText.toLowerCase();
 
@@ -330,6 +344,7 @@ export default class SingleSelect extends React.Component<Props, State> {
             alignment,
             dropdownStyle,
             isFilterable,
+            searchFilter,
             onChange,
             onToggle,
             opened,


### PR DESCRIPTION
## Summary:
When working on adding international school support to our School Picker that's part of the teacher dashboard, we found that some regions in international countries were named with accents. From testing, we figured out that the default search functionality of the SingleSelect dropdown component doesn't normalize the accents in these labels, and as a result, we're unable to allow users to search for "São Paulo" with the search string "Sao", where the "a" isn't accented.

Initially, the proposed solution was that we shouldn't need to match on the base letter only as our users can self-input the accents when appropriate, especially since they would be familiar with the accents as those would be their home regions. Unfortunately, we found that because of the way that the dropdown is rendered when we have more then 500 items, the focus gets shifted as the dropdown component is filtered, and the re-focusing of the element prevents our users for inputting the key-combination required for setting the accent (option-n on mac).

I've attached a screen recording displaying this behavior, but I figured if this component had a general-purpose solution to override the filtering logic, I could normalize the search text and the labels for each `OptionItem` so we can enable base-letter matching. This PR aims to accomplish this by adding a new `searchFilter` property to the component.

https://user-images.githubusercontent.com/8269569/169414018-d969f2ec-5a9d-4482-b6a2-5df429ec4227.mov

### Questions for Reviewers:
- Looking at the confluence docs [1], I see that we're supposed to run `yarn changeset` anytime the public API is altered for a package, but this generated a markdown file in the `.changeset` directory. Should I be committing that file as part of this change?

[1] https://khanacademy.atlassian.net/wiki/spaces/WB/pages/100827261/Developing+Web+Wonder+Blocks

Issue: "none"

## Test plan:

```shell
yarn test
```