### PR TITLE
WB-1132.2: Add Storybook stories to IDProvider and UniqueIDProvider

### DIFF
--- a/packages/wonder-blocks-core/src/components/__docs__/id-provider.stories.js
+++ b/packages/wonder-blocks-core/src/components/__docs__/id-provider.stories.js
@@ -1,0 +1,83 @@
+// @flow
+import * as React from "react";
+
+import {IDProvider, View} from "@khanacademy/wonder-blocks-core";
+
+import type {StoryComponentType} from "@storybook/react";
+
+import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import {name, version} from "../../../package.json";
+
+export default {
+    title: "Core / IDProvider",
+    component: IDProvider,
+    args: {
+        scope: "field",
+        id: "",
+        testId: "",
+    },
+    parameters: {
+        componentSubtitle: ((
+            <ComponentInfo name={name} version={version} />
+        ): any),
+        docs: {
+            description: {
+                component: null,
+            },
+            source: {
+                // See https://github.com/storybookjs/storybook/issues/12596
+                excludeDecorators: true,
+            },
+        },
+    },
+    decorators: [(Story: any): React.Node => <View>{Story()}</View>],
+};
+
+export const Default: StoryComponentType = (args) => (
+    <IDProvider {...args}>
+        {(uniqueId) => (
+            <label htmlFor={uniqueId}>
+                Label with ID {uniqueId}:
+                <input type="text" id={uniqueId} />
+            </label>
+        )}
+    </IDProvider>
+);
+
+export const WithFormFields: StoryComponentType = () => (
+    <IDProvider scope="field">
+        {(uniqueId) => (
+            <label htmlFor={uniqueId}>
+                Label with ID {uniqueId}:
+                <input type="text" id={uniqueId} />
+            </label>
+        )}
+    </IDProvider>
+);
+
+WithFormFields.parameters = {
+    docs: {
+        storyDescription:
+            "This example allows you to generate an unique ID and make it available to associate the `<label>` and `<input>` elements. To see this example in action, check that `label[for]` and `input[id]` are using the same id.",
+    },
+};
+
+export const IdProvided: StoryComponentType = () => (
+    <IDProvider scope="field" id="some-user-id">
+        {(uniqueId) => (
+            <label htmlFor={uniqueId}>
+                Label with ID {uniqueId}:
+                <input type="text" id={uniqueId} />
+            </label>
+        )}
+    </IDProvider>
+);
+
+IdProvided.storyName = "Identifier provided by parent component";
+
+IdProvided.parameters = {
+    docs: {
+        storyDescription:
+            "In some cases, a parent component using `IDProvider` could have an identifier as well. For this particular scenario, we can reuse this ID and pass it down to `IDProvider`. This will avoid generating a unique identifier, and it will reuse the passed identifier instead.",
+    },
+};

--- a/packages/wonder-blocks-core/src/components/__docs__/unique-id-provider.stories.js
+++ b/packages/wonder-blocks-core/src/components/__docs__/unique-id-provider.stories.js
@@ -1,0 +1,125 @@
+// @flow
+import * as React from "react";
+
+import {UniqueIDProvider, View} from "@khanacademy/wonder-blocks-core";
+import Button from "@khanacademy/wonder-blocks-button";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+
+import type {StoryComponentType} from "@storybook/react";
+
+import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import {name, version} from "../../../package.json";
+
+export default {
+    title: "Core / UniqueIDProvider",
+    component: UniqueIDProvider,
+    args: {
+        scope: "field",
+        mockOnFirstRender: false,
+    },
+    parameters: {
+        componentSubtitle: ((
+            <ComponentInfo name={name} version={version} />
+        ): any),
+        docs: {
+            description: {
+                component: null,
+            },
+            source: {
+                // See https://github.com/storybookjs/storybook/issues/12596
+                excludeDecorators: true,
+            },
+        },
+    },
+    decorators: [(Story: any): React.Node => <View>{Story()}</View>],
+};
+
+const Template = (args) => {
+    const [count, setCount] = React.useState(0);
+    const renders = React.useRef([]);
+    const handleClick = () => {
+        setCount(count + 1);
+    };
+
+    return (
+        <View>
+            <Button onClick={handleClick} style={{width: 200}}>
+                Re-render
+            </Button>
+            <Strut size={16} />
+
+            <HeadingSmall>The UniqueIDProvider:</HeadingSmall>
+
+            <UniqueIDProvider {...args}>
+                {(ids) => {
+                    renders.current.push(ids.get("my-unique-id"));
+
+                    return renders.current.map((value, index) => (
+                        <View>
+                            Render {index}: {value}
+                        </View>
+                    ));
+                }}
+            </UniqueIDProvider>
+        </View>
+    );
+};
+
+export const Default: StoryComponentType = Template.bind({});
+
+Default.parameters = {
+    docs: {
+        storyDescription:
+            "By default, `mockOnFirstRender` is `false`. The `children` prop is only called after the initial render. Each call provides the same identifier factory, meaning the same identifier gets returned. Try it below.",
+    },
+};
+
+export const WithMockOnFirstRender: StoryComponentType = Template.bind({});
+
+WithMockOnFirstRender.args = {
+    mockOnFirstRender: true,
+};
+
+WithMockOnFirstRender.storyName = "With mockOnFirstRender";
+
+WithMockOnFirstRender.parameters = {
+    docs: {
+        storyDescription:
+            "When specifying `mockOnFirstRender` to be `true`, the first render will use a mock identifier factory that doesn't guarantee identifier uniqueness. Mock mode can help things appear on the screen during the initial render, but is not the default, because it is not always safe (e.g., we need actual IDs for some SVG constructs).",
+    },
+};
+
+export const Scoped: StoryComponentType = () => {
+    const children = (ids) => (
+        <View>
+            <Body>
+                The id returned for "my-identifier": {ids.get("my-identifier")}
+            </Body>
+        </View>
+    );
+
+    return (
+        <View>
+            <HeadingSmall>First Provider with scope: first</HeadingSmall>
+            <UniqueIDProvider mockOnFirstRender={false} scope="first">
+                {children}
+            </UniqueIDProvider>
+            <HeadingSmall>Second Provider with scope: second</HeadingSmall>
+            <UniqueIDProvider mockOnFirstRender={false} scope="second">
+                {children}
+            </UniqueIDProvider>
+        </View>
+    );
+};
+
+Scoped.args = {
+    mockOnFirstRender: true,
+};
+
+Scoped.parameters = {
+    docs: {
+        storyDescription:
+            "`UniqueIDProvider` ensures every identifier factory is unique using a unique number for each one. However, this isn't very readable when wanting to differentiate the types of things using unique identifiers. If we want to, we can provide a `scope` prop that adds some text to each identifier provided. This can be useful for providing some quick at-a-glance component identification to identifiers when there are multiple providers.",
+    },
+};

--- a/packages/wonder-blocks-core/src/components/id-provider.js
+++ b/packages/wonder-blocks-core/src/components/id-provider.js
@@ -31,18 +31,33 @@ type Props = {|
 |};
 
 /**
- * This is a wrapper that returns an identifier. If the `id` prop is set, the component will
- * return the same id to be consumed by its children. Otherwise, a unique id will be provided.
- * This is beneficial for accessibility purposes, among other things.
+ * This is a wrapper that returns an identifier. If the `id` prop is set, the
+ * component will return the same id to be consumed by its children. Otherwise,
+ * a unique id will be provided. This is beneficial for accessibility purposes,
+ * among other things.
  *
- * The main difference with UniqueIDProvider is that IDProvider has a single responsibility,
- * to return an identifier that can by used by the children that are rendered internally.
+ * The main difference with `UniqueIDProvider` is that `IDProvider` has a single
+ * responsibility, to return an identifier that can by used by the children that
+ * are rendered internally.
  *
- * This way, the wrapped component will receive this custom ID and will use it to connect
- * different elements.
+ * This way, the wrapped component will receive this custom ID and will use it
+ * to connect different elements.
  *
- * e.g. It uses the same generated id to connect a Dialog with its main title, or form label
- * with the associated input element, etc.
+ * e.g. It uses the same generated id to connect a Dialog with its main title,
+ * or form label with the associated input element, etc.
+ *
+ * ## Usage
+ *
+ * ```jsx
+ * import {IDProvider} from "@khanacademy/wonder-blocks-core";
+ *
+ * <IDProvider scope="field">
+ *  {(uniqueId) => (
+ *     Unique ID: {uniqueId}
+ *  )}
+ * </IDProvider>
+ * ```
+ *
  */
 export default class IDProvider extends React.Component<Props> {
     static defaultId: string = "wb-id";

--- a/packages/wonder-blocks-core/src/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/src/components/unique-id-provider.js
@@ -60,6 +60,18 @@ type Props = {|
  * unique. Therefore, `get("test")` will always equal `get("test")`, and
  * `get("test2")` will always equal `get("test2")`, but `get("test")` will
  * never equal `get("test2")`.
+ *
+ * ## Usage
+ *
+ * ```jsx
+ * import {UniqueIDProvider} from "@khanacademy/wonder-blocks-core";
+ *
+ * <UniqueIDProvider mockOnFirstRender={false} scope="field">
+ *  {(ids) => (
+ *     <>The id returned for "my-identifier": {ids.get("my-identifier")}</>
+ *  )}
+ * </UniqueIDProvider>
+ * ```
  */
 export default class UniqueIDProvider extends React.Component<Props> {
     _idFactory: IIdentifierFactory;


### PR DESCRIPTION
## Summary:

Second PR related to migrating `wb-core` to Storybook.

- Add docs/stories to UniqueIDProvider.
- Add docs/stories to IDProvider.

Issue: WB-1132

## Test plan:

Open Storybook and navigate to `Core / UniqueIDProvider` and `Core / IDProvider`.

Verify that the examples match with what we have in StyleGuidist.