### PR TITLE
[Experiment] Add jest --shard flag to the PR workflow

### DIFF
--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-  lint_and_test:
-    name: Lint and Test
+  lint:
+    name: Lint
     needs: prime_cache_primary
     runs-on: ${{ matrix.os }}
     strategy:
@@ -74,9 +74,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+test:
+    name: Test
+    needs: prime_cache_primary
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16.x]
+        shard: ["1/2", "2/2"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install & cache node_modules
+        uses: ./.github/actions/shared-node-cache
+        with:
+          node-version: ${{ matrix.node-version }}
       # Testing and coverage
       - name: Run jest tests with coverage
-        run: yarn coverage:ci
+        run: yarn coverage:ci --shard ${{ matrix.shard }}
       - name: Upload Coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-test:
+  test:
     name: Test
     needs: prime_cache_primary
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary:

Experiment to try out the new Jest 28 feature: Sharding.

Also, splited the `lint_and_test` workflow step into `lint` and `test` to be
able to run the tests in two different workers.

The idea is to be able to split tests and run each test running instance in
parallel.

Issue: XXX-XXXX

## Test plan:

Verify that there are new checks.

TODO

- [ ] Update GH required checks if this PR gets approved.