### PR TITLE
[🔥AUDIT🔥] Fix Breadcrumb stories to match StyleGuidist

### DIFF
--- a/packages/wonder-blocks-breadcrumbs/src/components/__docs__/accessibility.stories.mdx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/__docs__/accessibility.stories.mdx
@@ -8,7 +8,7 @@ import {
 import Link from "@khanacademy/wonder-blocks-link";
 
 <Meta
-    title="Breadcrumbs/Breadcrumbs/Accessibility"
+    title="Breadcrumbs / Accessibility"
     component={Breadcrumbs}
     parameters={{
         previewTabs: {
@@ -42,7 +42,7 @@ This is an example of a component with an accessible label:
                     <Link href="">Unit</Link>
                 </BreadcrumbsItem>
                 <BreadcrumbsItem>
-                    <Link href="">Lesson</Link>
+                    Lesson
                 </BreadcrumbsItem>
             </Breadcrumbs>
         </View>

--- a/packages/wonder-blocks-breadcrumbs/src/components/__docs__/breadcrumbs.stories.js
+++ b/packages/wonder-blocks-breadcrumbs/src/components/__docs__/breadcrumbs.stories.js
@@ -12,7 +12,7 @@ import ComponentInfo from "../../../../../.storybook/components/component-info.j
 import {name, version} from "../../../package.json";
 
 export default {
-    title: "Breadcrumbs / Breadcrumbs",
+    title: "Breadcrumbs",
     component: Breadcrumbs,
     subcomponents: {BreadcrumbsItem},
     argTypes: BreadcrumbsArgTypes,
@@ -27,7 +27,7 @@ export default {
  * Default Breadcrumbs example. It will be rendered as the first/default
  * story and it can be interacted with the controls panel in the Browser.
  */
-export const DefaultBreadcrumbs: StoryComponentType = (args) => (
+export const Default: StoryComponentType = (args) => (
     <Breadcrumbs {...args}>
         <BreadcrumbsItem>
             <Link href="">Course</Link>
@@ -35,8 +35,6 @@ export const DefaultBreadcrumbs: StoryComponentType = (args) => (
         <BreadcrumbsItem>
             <Link href="">Unit</Link>
         </BreadcrumbsItem>
-        <BreadcrumbsItem>
-            <Link href="">Lesson</Link>
-        </BreadcrumbsItem>
+        <BreadcrumbsItem>Lesson</BreadcrumbsItem>
     </Breadcrumbs>
 );

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.js
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.js
@@ -42,6 +42,8 @@ const StyledList = addStyle("ol");
  * 1. `string`
  * 2. `<Link />`
  *
+ * ## Usage
+ *
  * ```jsx
  * import {
  *     Breadcrumbs,
@@ -56,7 +58,7 @@ const StyledList = addStyle("ol");
  *         <Link href="">Unit</Link>
  *     </BreadcrumbsItem>
  *     <BreadcrumbsItem>
- *         <Link href="">Lesson</Link>
+ *         Lesson
  *     </BreadcrumbsItem>
  * </Breadcrumbs>
  * ```


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

- Fixed breadcrumbs example to remove the link from the last item.
- Removed one `Breadcrumbs` item from the side nav.
- Updated usage guide to reflect this change.

Issue: "none"

## Test plan:

Verify that the `Breadcrumbs` example looks as expected (no link in the last item).