### PR TITLE
[fei4131.reduceboilerplate] Add logHandler to API to simplify event logging in fixture stories

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -1,3 +1,3 @@
 {
-    "allow": ["invalid", "color", "colors", "white", "latin"]
+    "allow": ["invalid", "color", "colors", "white", "latin", "hook", "hooks"]
 }

--- a/.changeset/ninety-tomatoes-wait.md
+++ b/.changeset/ninety-tomatoes-wait.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": minor
+---
+
+Add `logHandler` to GetPropsOptions to simplify generic event logging for common use cases

--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -68,6 +68,13 @@ jobs:
           changed-files: ${{ steps.changed.outputs.files }}
           files: '.eslintrc.js,yarn.lock,.eslintignore'
 
+      - id: flow-reset
+        uses: Khan/actions@filter-files-v0
+        name: Files that would trigger a flow run
+        with:
+          changed-files: ${{ steps.changed.outputs.files }}
+          files: '.flowconfig,yarn.lock'
+
       # Linting / type checking
       - name: Eslint
         uses: Khan/actions@full-or-limited-v0
@@ -78,7 +85,7 @@ jobs:
           limited: yarn lint:ci {}
 
       - name: Run Flow
-        if: steps.js-files.outputs.filtered != '[]'
+        if: steps.js-files.outputs.filtered != '[]' || steps.flow-reset.outputs.filtered != '[]'
         run: yarn flow
 
       - uses: Khan/actions@check-for-changeset-v0

--- a/packages/wonder-blocks-core/src/components/with-ssr-placeholder.js
+++ b/packages/wonder-blocks-core/src/components/with-ssr-placeholder.js
@@ -159,9 +159,9 @@ export default class WithSSRPlaceholder extends React.Component<Props, State> {
             // Then fall through to the root case.
             /* eslint-disable-next-line no-console */
             console.log(
-                `We got a render state we don't understand: "${JSON.stringify(
-                    renderState,
-                )}"`,
+                `We got a render state we don't understand: "${
+                    JSON.stringify(renderState) ?? ""
+                }"`,
             );
             // We "fallthrough" to the root case. This is more obvious
             // and maintainable code than just ignoring the no-fallthrough

--- a/packages/wonder-blocks-i18n/CHANGELOG.md
+++ b/packages/wonder-blocks-i18n/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Minor Changes
 
 -   b2a6a248: Export I18nInlineMarkup from wonder-blocks-i18n package
--   d05a3c4e: Add setLocale()/getLocale() methods so that mobile/webapp can easily set the current locale
+-   d05a3c4e: Add setLocale()/getLocale() methods so that mobile/webapp can set the current locale
 
 ## 1.1.0
 

--- a/packages/wonder-blocks-testing/src/__docs__/types.get-props-options.stories.mdx
+++ b/packages/wonder-blocks-testing/src/__docs__/types.get-props-options.stories.mdx
@@ -17,9 +17,36 @@ type GetPropsOptions = {|
      * A function to call that will log output.
      */
     log: (message: string, ...args: Array<any>) => void,
+
+    /**
+     * A function to make a handler that will log all arguments with the given
+     * name or message. Useful for logging events as it avoids the boilerplate
+     * of the `log` function.
+     */
+    logHandler: (name: string) => (...args: Array<any>) => void,
 |};
 ```
 
 A fixture can provide a callback that the framework invokes to obtain the props for the fixture component. This callback takes a single argument of type `GetPropsOptions`.
 
-This has a single `log` property; a callback for logging output in the context of the fixture. This can be useful for logging event handler invocations, for example.
+This has two calls available.
+
+The `log` callback is for logging output in the context of the fixture. This can be useful for logging information during your fixture. However, in many situations, it is easier to use the `logHandler` callback. The `logHandler` callback takes a single argument of type `string` and returns a function that logs all arguments with the given name or message, allowing easy creation of event handlers that will log that event and its arguments.
+
+For example:
+
+```ts
+    fixture("My fixture that does logging", ({makeLogHandler}) => ({
+        onClick: logHandler("onClick"),
+    }));
+```
+
+is equivalent to:
+
+```ts
+    fixture("My fixture that does logging", ({log}) => ({
+        onClick: (...args) => log("onClick", ...args),
+    }));
+```
+
+

--- a/packages/wonder-blocks-testing/src/__docs__/types.get-props-options.stories.mdx
+++ b/packages/wonder-blocks-testing/src/__docs__/types.get-props-options.stories.mdx
@@ -36,7 +36,7 @@ The `log` callback is for logging output in the context of the fixture. This can
 For example:
 
 ```ts
-    fixture("My fixture that does logging", ({makeLogHandler}) => ({
+    fixture("My fixture that does logging", ({logHandler}) => ({
         onClick: logHandler("onClick"),
     }));
 ```

--- a/packages/wonder-blocks-testing/src/fixtures/adapters/__tests__/storybook.test.js
+++ b/packages/wonder-blocks-testing/src/fixtures/adapters/__tests__/storybook.test.js
@@ -121,6 +121,7 @@ describe("Storybook Adapter", () => {
                 // Assert
                 expect(getPropsStub).toHaveBeenCalledWith({
                     log: expect.any(Function),
+                    logHandler: expect.any(Function),
                 });
             });
 
@@ -155,6 +156,45 @@ describe("Storybook Adapter", () => {
 
                 // Act
                 logFn("MESSAGE", "ARG1", "ARG2");
+
+                // Assert
+                expect(actionSpy).toHaveBeenCalledWith("MESSAGE");
+                expect(actionReturnFn).toHaveBeenCalledWith("ARG1", "ARG2");
+            });
+
+            it("should inject makeLogHandler function that logs to storybook actions", () => {
+                // Arrange
+                const adapterSpy = jest
+                    .spyOn(AdapterModule, "Adapter")
+                    .mockImplementation(() => {});
+                getAdapter();
+                const actionReturnFn = jest.fn();
+                const actionSpy = jest
+                    .spyOn(AddonActionsModule, "action")
+                    .mockReturnValue(actionReturnFn);
+                const closeGroupFn = adapterSpy.mock.calls[0][1];
+                const getPropsStub = jest.fn();
+                closeGroupFn(
+                    {
+                        title: "TITLE",
+                        description: "DESCRIPTION",
+                    },
+                    null,
+                    [
+                        {
+                            description:
+                                "🎉 This is a story with legal and illegal characters",
+                            component: () => "I AM A COMPONENT",
+                            getProps: getPropsStub,
+                        },
+                    ],
+                );
+                const {logHandler: logHandlerFn} =
+                    getPropsStub.mock.calls[0][0];
+
+                // Act
+                const logFn = logHandlerFn("MESSAGE");
+                logFn("ARG1", "ARG2");
 
                 // Assert
                 expect(actionSpy).toHaveBeenCalledWith("MESSAGE");

--- a/packages/wonder-blocks-testing/src/fixtures/adapters/__tests__/storybook.test.js
+++ b/packages/wonder-blocks-testing/src/fixtures/adapters/__tests__/storybook.test.js
@@ -162,7 +162,7 @@ describe("Storybook Adapter", () => {
                 expect(actionReturnFn).toHaveBeenCalledWith("ARG1", "ARG2");
             });
 
-            it("should inject makeLogHandler function that logs to storybook actions", () => {
+            it("should inject logHandler function that logs to storybook actions", () => {
                 // Arrange
                 const adapterSpy = jest
                     .spyOn(AdapterModule, "Adapter")

--- a/packages/wonder-blocks-testing/src/fixtures/adapters/storybook.js
+++ b/packages/wonder-blocks-testing/src/fixtures/adapters/storybook.js
@@ -81,7 +81,7 @@ export const getAdapter: FixturesAdapterFactory<
                     // component. We don't use decorators for the wrapper
                     // because we may not be in a storybook context and it
                     // keeps the framework API simpler this way.
-                    let Template = templateMap.get(Component);
+                    let Template = templateMap.get((Component: any));
                     if (Template == null) {
                         // The MountingComponent is a bit different than just a
                         // Storybook decorator. It's a React component that
@@ -98,7 +98,7 @@ export const getAdapter: FixturesAdapterFactory<
                                   />
                               )
                             : (args) => <Component {...args} />;
-                        templateMap.set(Component, Template);
+                        templateMap.set((Component: any), Template);
                     }
 
                     // Each story that shares that component then reuses that

--- a/packages/wonder-blocks-testing/src/fixtures/adapters/storybook.js
+++ b/packages/wonder-blocks-testing/src/fixtures/adapters/storybook.js
@@ -61,10 +61,7 @@ export const getAdapter: FixturesAdapterFactory<
 
             const getPropsOptions = {
                 log: (message, ...args) => action(message)(...args),
-                logHandler:
-                    (message) =>
-                    (...args) =>
-                        action(message)(...args),
+                logHandler: action,
             };
 
             const exports = declaredFixtures.reduce(

--- a/packages/wonder-blocks-testing/src/fixtures/adapters/storybook.js
+++ b/packages/wonder-blocks-testing/src/fixtures/adapters/storybook.js
@@ -59,7 +59,13 @@ export const getAdapter: FixturesAdapterFactory<
         ): ?$ReadOnly<Exports<TProps>> => {
             const templateMap = new WeakMap();
 
-            const log = (message, ...args) => action(message)(...args);
+            const getPropsOptions = {
+                log: (message, ...args) => action(message)(...args),
+                logHandler:
+                    (message) =>
+                    (...args) =>
+                        action(message)(...args),
+            };
 
             const exports = declaredFixtures.reduce(
                 (acc, {description, getProps, component: Component}, i) => {
@@ -91,7 +97,7 @@ export const getAdapter: FixturesAdapterFactory<
                                   <MountingComponent
                                       component={Component}
                                       props={args}
-                                      log={log}
+                                      log={getPropsOptions.log}
                                   />
                               )
                             : (args) => <Component {...args} />;
@@ -101,7 +107,7 @@ export const getAdapter: FixturesAdapterFactory<
                     // Each story that shares that component then reuses that
                     // template.
                     acc[exportName] = Template.bind({});
-                    acc[exportName].args = getProps({log});
+                    acc[exportName].args = getProps(getPropsOptions);
                     // Adding a story name here means that we don't have to
                     // care about naming the exports correctly, if we don't
                     // want (useful if we need to autogenerate or manually

--- a/packages/wonder-blocks-testing/src/fixtures/types.js
+++ b/packages/wonder-blocks-testing/src/fixtures/types.js
@@ -10,6 +10,13 @@ export type GetPropsOptions = {|
      * A function to call that will log output.
      */
     log: (message: string, ...args: Array<any>) => void,
+
+    /**
+     * A function to make a handler that will log all arguments with the given
+     * name or message. Useful for logging events as it avoids the boilerplate
+     * of the `log` function.
+     */
+    logHandler: (name: string) => (...args: Array<any>) => void,
 |};
 
 /**

--- a/packages/wonder-blocks-timing/CHANGELOG.md
+++ b/packages/wonder-blocks-timing/CHANGELOG.md
@@ -7,5 +7,5 @@
   `interval()` method.
 - c57cd770: Rename `useInterval` and `useTimeout` to `useScheduledInterval`
   and `useScheduledTimeout` respectively.
-- 29766c8e: Add `useInterval` and `useTimeout` hooks to provide a simple API for
+- 29766c8e: Add `useInterval` and `useTimeout` hooks to provide an API for
   using intervals and timeouts.


### PR DESCRIPTION
## Summary:
I was finding that the dominant use-case for logging in props is to log event handlers and the same boilerplate cropped up. This reduces that boilerplate a little. See the updated docs for an example.

Issue: FEI-4131

## Test plan:
`yarn storybook`
`yarn test`