### PR TITLE
WB-1264: Add keyboard support for searching options

### DIFF
--- a/.changeset/fuzzy-boats-boil.md
+++ b/.changeset/fuzzy-boats-boil.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-clickable": minor
+"@khanacademy/wonder-blocks-dropdown": minor
+"@khanacademy/wonder-blocks-birthday-picker": patch
+---
+
+Added keyboard support to search items when the dropdown is focused, included "Enter" as a key to trigger actions with the "option" role

--- a/.changeset/khaki-swans-add.md
+++ b/.changeset/khaki-swans-add.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/wonder-blocks-birthday-picker": patch
----
-
-Included keyboard support to search options when the dropdown opener is focused

--- a/.changeset/khaki-swans-add.md
+++ b/.changeset/khaki-swans-add.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": patch
+---
+
+Included keyboard support to search options when the dropdown opener is focused

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
@@ -495,4 +495,37 @@ describe("BirthdayPicker", () => {
             ).toBeInTheDocument();
         });
     });
+
+    describe("keyboard", () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        it("should find and select an item using the keyboard", () => {
+            // Arrange
+            const onChange = jest.fn();
+
+            render(<BirthdayPicker onChange={onChange} />);
+
+            // Act
+            // Focus on the month selector
+            userEvent.tab();
+            userEvent.keyboard("Jul");
+            jest.advanceTimersByTime(501);
+
+            // Focus on the day selector
+            userEvent.tab();
+            userEvent.keyboard("5");
+            jest.advanceTimersByTime(501);
+
+            // Focus on the year selector
+            userEvent.tab();
+            // It should focus on the first occurrence (2022)
+            userEvent.keyboard("20");
+            jest.advanceTimersByTime(501);
+
+            // Assert
+            expect(onChange).toHaveBeenCalledWith("2022-07-05");
+        });
+    });
 });

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
@@ -25,7 +25,6 @@ const getAppropriateTriggersForRole = (role: ?ClickableRole) => {
         case "checkbox":
         case "radio":
         case "listbox":
-        case "option":
             return {
                 triggerOnEnter: false,
                 triggerOnSpace: true,
@@ -34,6 +33,7 @@ const getAppropriateTriggersForRole = (role: ?ClickableRole) => {
         case "button":
         case "menuitem":
         case "menu":
+        case "option":
         default:
             return {
                 triggerOnEnter: true,

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
@@ -1199,6 +1199,41 @@ describe("MultiSelect", () => {
                 screen.getByText(updatedLabels.selectNoneLabel),
             ).toBeInTheDocument();
         });
+
+        describe("keyboard", () => {
+            beforeEach(() => {
+                // Required due to the `debounce` call.
+                jest.useFakeTimers();
+            });
+
+            it("should find and focus an item using the keyboard", () => {
+                // Arrange
+                const onChangeMock = jest.fn();
+
+                render(
+                    <MultiSelect onChange={onChangeMock}>
+                        <OptionItem label="Mercury" value="mercury" />
+                        <OptionItem label="Venus" value="venus" />
+                        <OptionItem label="Mars" value="mars" />
+                    </MultiSelect>,
+                );
+                userEvent.tab();
+
+                // Act
+                // find first occurrence
+                userEvent.keyboard("v");
+                jest.advanceTimersByTime(501);
+
+                // Assert
+                const filteredOption = screen.getByRole("option", {
+                    name: /Venus/i,
+                });
+                // Verify that the element found is focused.
+                expect(filteredOption).toHaveFocus();
+                // And also verify that the listbox is opened.
+                expect(screen.getByRole("listbox")).toBeInTheDocument();
+            });
+        });
     });
 
     describe("a11y > Live region", () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -99,6 +99,10 @@ describe("SingleSelect", () => {
         });
 
         describe("keyboard", () => {
+            beforeEach(() => {
+                jest.useFakeTimers();
+            });
+
             describe.each([{key: "{enter}"}, {key: "{space}"}])(
                 "$key",
                 ({key}) => {
@@ -129,7 +133,7 @@ describe("SingleSelect", () => {
                 },
             );
 
-            it("should not select an item when pressing {enter}", () => {
+            it("should select an item when pressing {enter}", () => {
                 // Arrange
                 render(uncontrolledSingleSelect);
                 userEvent.tab();
@@ -139,8 +143,8 @@ describe("SingleSelect", () => {
                 userEvent.keyboard("{enter}");
 
                 // Assert
-                expect(onChange).not.toHaveBeenCalled();
-                expect(screen.getByRole("listbox")).toBeInTheDocument();
+                expect(onChange).toHaveBeenCalledWith("1");
+                expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
             });
 
             it("should select an item when pressing {space}", () => {
@@ -154,6 +158,27 @@ describe("SingleSelect", () => {
 
                 // Assert
                 expect(onChange).toHaveBeenCalledWith("1");
+                expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+            });
+
+            it("should find and select an item using the keyboard", () => {
+                // Arrange
+                render(
+                    <SingleSelect onChange={onChange} placeholder="Choose">
+                        <OptionItem label="apple" value="apple" />
+                        <OptionItem label="orange" value="orange" />
+                        <OptionItem label="pear" value="pear" />
+                    </SingleSelect>,
+                );
+                userEvent.tab();
+
+                // Act
+                // find first occurrence
+                userEvent.keyboard("or");
+                jest.advanceTimersByTime(501);
+
+                // Assert
+                expect(onChange).toHaveBeenCalledWith("orange");
                 expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
             });
 

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -312,6 +312,7 @@ class DropdownCore extends React.Component<Props, State> {
         // called on every keydown
         this.handleKeyDownDebounced = debounce(
             this.handleKeyDownDebounceResult,
+            // Leaving enough time for the user to type a valid query (e.g. jul)
             500,
         );
         this.textSuggestion = "";

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -546,7 +546,7 @@ class DropdownCore extends React.Component<Props, State> {
         if (getStringForKey(event.key)) {
             event.stopPropagation();
             this.textSuggestion += event.key;
-            console.log("get text sugg: ", this.textSuggestion);
+            // Trigger the filter logic only after the debounce is resolved.
             this.handleKeyDownDebounced(this.textSuggestion);
         }
 
@@ -630,7 +630,8 @@ class DropdownCore extends React.Component<Props, State> {
                 // Flow doesn't know that the component is an OptionItem
                 // $FlowIgnore[incompatible-use]
                 const label = component.props?.label.toLowerCase();
-                return label.startsWith(key);
+
+                return label.startsWith(key.toLowerCase());
             });
 
         if (foundIndex >= 0) {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -96,6 +96,11 @@ type DefaultProps = {|
      * use when the item is used on a dark background.
      */
     light: boolean,
+
+    /**
+     * Used to determine if we can automatically select an item using the keyboard.
+     */
+    selectionType: "single" | "multi",
 |};
 
 type DropdownAriaRole = "listbox" | "menu";
@@ -169,8 +174,6 @@ type Props = {|
      * top. The items will be filtered by the input.
      */
     isFilterable?: boolean,
-
-    selectionType: "single" | "multi",
 
     ...WithActionSchedulerProps,
 |};
@@ -253,6 +256,7 @@ class DropdownCore extends React.Component<Props, State> {
             someSelected: defaultLabels.someSelected,
         },
         light: false,
+        selectionType: "single",
     };
 
     // This is here to avoid calling React.createRef on each rerender. Instead,

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 // @flow
 // A menu that consists of action items
 
@@ -25,6 +26,7 @@ import SeparatorItem from "./separator-item.js";
 import {defaultLabels, keyCodes} from "../util/constants.js";
 import type {DropdownItem} from "../util/types.js";
 import DropdownPopper from "./dropdown-popper.js";
+import {debounce, getStringForKey} from "../util/helpers.js";
 import {
     generateDropdownMenuStyles,
     getDropdownMenuHeight,
@@ -168,6 +170,8 @@ type Props = {|
      */
     isFilterable?: boolean,
 
+    selectionType: "single" | "multi",
+
     ...WithActionSchedulerProps,
 |};
 
@@ -218,6 +222,10 @@ class DropdownCore extends React.Component<Props, State> {
     virtualizedListRef: {|
         current: null | React.ElementRef<typeof List>,
     |};
+
+    handleKeyDownDebounced: (key: string) => void;
+
+    textSuggestion: string;
 
     // Figure out if the same items are focusable. If an item has been added or
     // removed, this method will return false.
@@ -295,6 +303,14 @@ class DropdownCore extends React.Component<Props, State> {
         };
 
         this.virtualizedListRef = React.createRef();
+
+        // We debounce the keydown handler to get the ASCII chars because it's
+        // called on every keydown
+        this.handleKeyDownDebounced = debounce(
+            this.handleKeyDownDebounceResult,
+            500,
+        );
+        this.textSuggestion = "";
     }
 
     componentDidMount() {
@@ -419,17 +435,23 @@ class DropdownCore extends React.Component<Props, State> {
         }
     };
 
-    scheduleToFocusCurrentItem() {
+    scheduleToFocusCurrentItem(onFocus?: (node: void | HTMLElement) => void) {
         if (this.shouldVirtualizeList()) {
             // wait for windowed items to be recalculated
-            this.props.schedule.animationFrame(() => this.focusCurrentItem());
+            this.props.schedule.animationFrame(() => {
+                this.focusCurrentItem(onFocus);
+            });
         } else {
             // immediately focus the current item if we're not virtualizing
-            this.focusCurrentItem();
+            this.focusCurrentItem(onFocus);
         }
     }
 
-    focusCurrentItem() {
+    /**
+     * Focus on the current item.
+     * @param [onFocus] - Callback to be called when the item is focused.
+     */
+    focusCurrentItem(onFocus?: (node: HTMLElement) => void) {
         const focusedItemRef = this.state.itemRefs[this.focusedIndex];
 
         if (focusedItemRef) {
@@ -452,6 +474,11 @@ class DropdownCore extends React.Component<Props, State> {
                 // Keep track of the original index of the newly focused item.
                 // To be used if the set of focusable items in the menu changes
                 this.focusedOriginalIndex = focusedItemRef.originalIndex;
+
+                if (onFocus) {
+                    // Call the callback with the node that was focused.
+                    onFocus(node);
+                }
             }
         }
     }
@@ -514,6 +541,15 @@ class DropdownCore extends React.Component<Props, State> {
     handleKeyDown: (event: SyntheticKeyboardEvent<>) => void = (event) => {
         const {onOpenChanged, open, searchText} = this.props;
         const keyCode = event.which || event.keyCode;
+
+        // Listen for the keydown events if we are using ASCII characters.
+        if (getStringForKey(event.key)) {
+            event.stopPropagation();
+            this.textSuggestion += event.key;
+            console.log("get text sugg: ", this.textSuggestion);
+            this.handleKeyDownDebounced(this.textSuggestion);
+        }
+
         // If menu isn't open and user presses down, open the menu
         if (!open) {
             if (keyCode === keyCodes.down) {
@@ -581,6 +617,44 @@ class DropdownCore extends React.Component<Props, State> {
                 }
                 return;
         }
+    };
+
+    handleKeyDownDebounceResult: (key: string) => void = (key) => {
+        const foundIndex = this.props.items
+            .filter((item) => item.focusable)
+            .findIndex(({component}) => {
+                if (SeparatorItem.isClassOf(component)) {
+                    return false;
+                }
+
+                // Flow doesn't know that the component is an OptionItem
+                // $FlowIgnore[incompatible-use]
+                const label = component.props?.label.toLowerCase();
+                return label.startsWith(key);
+            });
+
+        if (foundIndex >= 0) {
+            const isClosed = !this.props.open;
+            if (isClosed) {
+                // Open the menu to be able to focus on the item that matches
+                // the text suggested.
+                this.props.onOpenChanged(true);
+            }
+            // Update the focus reference.
+            this.focusedIndex = foundIndex;
+
+            this.scheduleToFocusCurrentItem((node) => {
+                // Force click only if the dropdown is closed and we are using
+                // the SingleSelect component.
+                if (this.props.selectionType === "single" && isClosed && node) {
+                    node.click();
+                    this.props.onOpenChanged(false);
+                }
+            });
+        }
+
+        // Otherwise, reset current text
+        this.textSuggestion = "";
     };
 
     handleClickFocus: (index: number) => void = (index) => {

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.js
@@ -564,6 +564,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 open={open}
                 opener={opener}
                 openerElement={this.state.openerElement}
+                selectionType="multi"
                 style={style}
                 className={className}
                 onSearchTextChanged={

--- a/packages/wonder-blocks-dropdown/src/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.js
@@ -379,6 +379,7 @@ export default class SingleSelect extends React.Component<Props, State> {
         return (
             <DropdownCore
                 role="listbox"
+                selectionType="single"
                 alignment={alignment}
                 dropdownStyle={[
                     isFilterable && filterableDropdownStyle,

--- a/packages/wonder-blocks-dropdown/src/util/__tests__/helpers.test.js
+++ b/packages/wonder-blocks-dropdown/src/util/__tests__/helpers.test.js
@@ -1,0 +1,73 @@
+// @flow
+import {debounce, getStringForKey} from "../helpers.js";
+
+describe("getStringForKey", () => {
+    it("should get a valid string", () => {
+        // Arrange
+
+        // Act
+        const key = getStringForKey("a");
+
+        // Assert
+        expect(key).toBe("a");
+    });
+
+    it("should return empty if we use a glyph modifier key (e.g. Shift)", () => {
+        // Arrange
+
+        // Act
+        const key = getStringForKey("Shift");
+
+        // Assert
+        expect(key).toBe("");
+    });
+});
+
+describe("debounce", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    it("should call the debounced function", () => {
+        // Arrange
+        const callbackFnMock = jest.fn();
+        const debounced = debounce(callbackFnMock, 500);
+
+        // Act
+        debounced();
+        jest.advanceTimersByTime(501);
+
+        // Assert
+        expect(callbackFnMock).toHaveBeenCalled();
+    });
+
+    it("should call the debounced function only once", () => {
+        // Arrange
+        const callbackFnMock = jest.fn();
+        const debounced = debounce(callbackFnMock, 500);
+
+        // Act
+        debounced();
+        debounced();
+        debounced();
+        jest.advanceTimersByTime(501);
+
+        // Assert
+        expect(callbackFnMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should execute the last call with the exact args", () => {
+        // Arrange
+        const callbackFnMock = jest.fn();
+        const debounced = debounce(callbackFnMock, 500);
+
+        // Act
+        debounced("a");
+        debounced("ab");
+        debounced("abc");
+        jest.advanceTimersByTime(501);
+
+        // Assert
+        expect(callbackFnMock).toHaveBeenCalledWith("abc");
+    });
+});

--- a/packages/wonder-blocks-dropdown/src/util/helpers.js
+++ b/packages/wonder-blocks-dropdown/src/util/helpers.js
@@ -1,0 +1,29 @@
+// @flow
+export function getStringForKey(key: string): string {
+    // If the key is of length 1, it is an ASCII value.
+    // Otherwise, if there are no ASCII characters in the key name,
+    // it is a Unicode character.
+    // See https://www.w3.org/TR/uievents-key/
+    if (key.length === 1 || !/^[A-Z]/i.test(key)) {
+        return key;
+    }
+
+    return "";
+}
+
+export function debounce(
+    callback: (...args: any) => void,
+    wait: number,
+): (...args: any) => void {
+    let timeout;
+
+    return function executedFunction(...args) {
+        const later = () => {
+            clearTimeout(timeout);
+            callback(...args);
+        };
+
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+    };
+}

--- a/packages/wonder-blocks-dropdown/src/util/helpers.js
+++ b/packages/wonder-blocks-dropdown/src/util/helpers.js
@@ -20,9 +20,11 @@ export function getStringForKey(key: string): string {
 
 /**
  *
- * @param {*} callback
- * @param {*} wait
- * @returns
+ * @param {fn} callback The function that will be executed after the debounce is resolved.
+ * @param {number} wait The period of time that will be executed the debounced
+ * function.
+ * @returns The function that will be executed after the wait period is
+ * fulfilled.
  */
 export function debounce(
     callback: (...args: any) => void,

--- a/packages/wonder-blocks-dropdown/src/util/helpers.js
+++ b/packages/wonder-blocks-dropdown/src/util/helpers.js
@@ -1,4 +1,11 @@
 // @flow
+
+/**
+ * Checks if a given key is a valid ASCII value.
+ *
+ * @param {string} key The key that is being typed in.
+ * @returns A valid string representation of the given key.
+ */
 export function getStringForKey(key: string): string {
     // If the key is of length 1, it is an ASCII value.
     // Otherwise, if there are no ASCII characters in the key name,
@@ -11,6 +18,12 @@ export function getStringForKey(key: string): string {
     return "";
 }
 
+/**
+ *
+ * @param {*} callback
+ * @param {*} wait
+ * @returns
+ */
 export function debounce(
     callback: (...args: any) => void,
     wait: number,


### PR DESCRIPTION
## Summary:

Added keyboard support to `DropdownCore` so we can try to match a given option
from the listbox.

This is done replicating the behavior from the `<select>` element:

- If the user focuses on the dropdown opener (but dropdown menu is CLOSED),
typing in will automatically SELECT the first occurrence.
- If the user focuses on the dropdown opener (and the dropdown menu is OPEN),
typing in will FOCUS on the first occurrence, but won’t select it unless the
user press space.

Issue: WB-1264

## Test plan:

Navigate to any SingleSelect example and verify that keyboard search is enabled
when you focus on the dropdown.

Navigate to the BirthdayPicker examples and try out the different fields (day,
month, year).

https://user-images.githubusercontent.com/843075/179804174-dbb16c45-257c-4398-8b77-de6d0c990628.mov

https://5e1bf4b385e3fb0020b7073c-dlukqygytd.chromatic.com/?path=/story/birthdaypicker--birthday-picker-default
