### PR TITLE
[fei4517.1] Export getGqlDataFromResponse

### DIFF
--- a/.changeset/new-boats-hunt.md
+++ b/.changeset/new-boats-hunt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+---
+
+Export the `getGqlDataFromResponse` method so we can use it in custom `gqlFetch` scenarios for a consistent experience

--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -39,6 +39,7 @@ export {Status} from "./util/status.js";
 // GraphQL
 ////////////////////////////////////////////////////////////////////////////////
 export {getGqlRequestId} from "./util/get-gql-request-id.js";
+export {getGqlDataFromResponse} from "./util/get-gql-data-from-response.js";
 export {graphQLDocumentNodeParser} from "./util/graphql-document-node-parser.js";
 export {toGqlOperation} from "./util/to-gql-operation.js";
 export {GqlRouter} from "./components/gql-router.js";


### PR DESCRIPTION
## Summary:
This just exports an existing method so that we can use it in our non-React implementation of gqlFetch in webapp.

Issue: FEI-4517

## Test plan:
`yarn test`
`yarn flow`