### PR TITLE
Try adding generic value type to `RadioGroup` (not working)

### DIFF
--- a/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
@@ -6,6 +6,8 @@ import "jest-enzyme";
 import RadioGroup from "../radio-group.js";
 import Choice from "../choice.js";
 
+function logUnreachableCode(value: empty) {}
+
 describe("RadioGroup", () => {
     let group;
     const onChange = jest.fn();
@@ -16,12 +18,25 @@ describe("RadioGroup", () => {
                 label="Test"
                 description="test description"
                 groupName="test"
-                onChange={onChange}
+                onChange={(value) => {
+                    switch (value) {
+                        case "a":
+                            break;
+                        case "b":
+                            break;
+                        case "c":
+                            break;
+                        default:
+                            // there should be a type error here, since value could be "d"
+                            logUnreachableCode(value);
+                    }
+                }}
                 selectedValue="a"
             >
                 <Choice label="a" value="a" aria-labelledby="test-a" />
                 <Choice label="b" value="b" aria-labelledby="test-b" />
                 <Choice label="c" value="c" aria-labelledby="test-c" />
+                <Choice label="d" value="d" aria-labelledby="test-d" />
             </RadioGroup>,
         );
     });

--- a/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
@@ -19,6 +19,7 @@ describe("RadioGroup", () => {
                 description="test description"
                 groupName="test"
                 onChange={(value) => {
+                    onChange(value);
                     switch (value) {
                         case "a":
                             break;

--- a/packages/wonder-blocks-form/src/components/choice.js
+++ b/packages/wonder-blocks-form/src/components/choice.js
@@ -6,7 +6,7 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import Checkbox from "./checkbox.js";
 import Radio from "./radio.js";
 
-type Props = {|
+type Props<T: string> = {|
     ...AriaProps,
 
     /** User-defined. Label for the field. */
@@ -16,7 +16,7 @@ type Props = {|
     description?: string,
 
     /** User-defined. Should be distinct for each item in the group. */
-    value: string,
+    value: T,
 
     /** User-defined. Whether this choice option is disabled. Default false. */
     disabled: boolean,
@@ -66,10 +66,15 @@ type Props = {|
     variant?: "radio" | "checkbox",
 |};
 
-type DefaultProps = {|
-    checked: $PropertyType<Props, "checked">,
-    disabled: $PropertyType<Props, "disabled">,
-    onChange: $PropertyType<Props, "onChange">,
+type DefaultProps<T: string> = {|
+    checked: $PropertyType<Props<T>, "checked">,
+    disabled: $PropertyType<Props<T>, "disabled">,
+    onChange: $PropertyType<Props<T>, "onChange">,
+|};
+
+export type ChoiceProps<T: string> = {|
+    ...Props<T>,
+    ...Partial<DefaultProps<T>>,
 |};
 
 /**
@@ -138,8 +143,8 @@ type DefaultProps = {|
  * </RadioGroup>
  * ```
  */
-export default class Choice extends React.Component<Props> {
-    static defaultProps: DefaultProps = {
+export default class Choice<T: string> extends React.Component<Props<T>> {
+    static defaultProps: DefaultProps<T> = {
         checked: false,
         disabled: false,
         onChange: () => {},

--- a/packages/wonder-blocks-form/src/components/radio-group.js
+++ b/packages/wonder-blocks-form/src/components/radio-group.js
@@ -9,14 +9,16 @@ import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import styles from "./group-styles.js";
-import typeof Choice from "./choice.js";
+import type {ChoiceProps} from "./choice.js";
+
+React.ElementConfig
 
 // Keep synced with RadioGroupProps in ../util/types.js
-type RadioGroupProps = {|
+type RadioGroupProps<T: string> = {|
     /**
      * Children should be Choice components.
      */
-    children: Array<React.Element<Choice>>,
+    children: Array<React.Element<React.ComponentType<ChoiceProps<T>>>>,
 
     /**
      * Group name for this checkbox or radio group. Should be unique for all
@@ -50,7 +52,7 @@ type RadioGroupProps = {|
     /**
      * Callback for when the selected value of the radio group has changed.
      */
-    onChange: (selectedValue: string) => mixed,
+    onChange: (selectedValue: T) => mixed,
 
     /**
      * Value of the selected radio item.
@@ -101,8 +103,8 @@ const StyledLegend = addStyle<"legend">("legend");
  * </RadioGroup>
  * ```
  */
-export default class RadioGroup extends React.Component<RadioGroupProps> {
-    handleChange(changedValue: string) {
+export default class RadioGroup<T: string> extends React.Component<RadioGroupProps<T>> {
+    handleChange(changedValue: T) {
         this.props.onChange(changedValue);
     }
 


### PR DESCRIPTION
## Summary:
Ideally, this would restrict the argument passed to `onChange` to a type union of the values of the choices, but it seems like Flow isn't actually constraining the types correctly. [Something like this](https://flow.org/try/#0PTAEAEDMBsHsHcBQiCWBbADrATgF1AFSgCGAzqAEoCmxAxvpNrGqAETY32sDcqmO+AN4BXUlQDKuYrioBfUI2ZsOdXD2S4AnhiqgAisKqlcKWADsACkwykAPABUAfKAC8oQQB9EoH6BO5oKgAuUGNsFDMAcwAab19YDBNzUhCAQWxsYk1bTzjfXwBrKk0Q+1j8-LNiNGDQ3HCo8t8PWUcmn3NUgBMAN2IzWlqACjFA+iougGli0oBKV2ce2BQu2JbeREhhAaSzfUNjUzMHELCIyMchwTy-FACqdtAE3dJHzt7+wdjZEIMjXasCTsTlmIWoqgAdAA5WBdXTXfK0ZL4ADaoyo4ymxWioSouHEVDGMixmgAuq5QKIJFIZLYAPxOIZmYTQaCzXj5Di4YTYPZDG75WyOAUVHy2AAWAEZHIJ-IFZLZgFLhaLRbYuigek8zABhcX9SJUFyCIZUHpUMy4eYuZxifGEjHE6aaU3my0QqTYQ24CF9aCGWatEWq3yCZ5HUgQtDEDBDK5FTQ4qo1WTW5z8kOZ3xC4NZ1W2CIYYT4LQ6FzsYga2CsUAJ40J+R+wz14ryZNG2V3eWgYAqvP9wTt2S5-uKvv9nyzQMj7PADU9ceZ2wAI2LuHMM9F5h10BQtAKxvRmOdoAAhG5mazQAAya+gONp7XdPoDKgjB3H4pT4f9xf9qFUAAHrgm6gIqq64OuZh-rOi7sogw6bNs9BHCQgR4EMTa1GcUTzIIiFbDsqFwJEACqZgqLQ+rLoEOqwm+WEhFQmBaHhiFAVgeCgHCkDECyDDIbs+z-Ec1BmHCHDYEMoKUJwPownC7g3FyPJ8rmth-IcG79nKRqsAA6uKmjcSsfjiroVF7kUey0EwpDkLg5mgEwlZ0qwoHhskxooqB+QIhOooJiErCwI5VDYAAtKQKxUKwjwBT47bBfYsCgN6fipWFTxhdgoQxXFvm+LI8V5v5CWFDMbDEEsKwRfAsDQJABXlZU1S1KwKUkDVXRmbo9WNc1CXFaBpI-nm7wvoMxrvkSEyPmVE6kPAdxUfeR7EnhhWirQZC6CFOVRflQRbZmxDobgQzsCgkTirgp6sPBLWqsuKgFByT09mAO1iFV3V1Q1TXHR9n0VGd4UXaw8BMFEoBBJdj0fSAFQvTQb0nfkPF8dAuBA8DvhI7AQKnqA8AWcwNSWhMTzFr1v3LF0-0DaA30POjqpI6QqUwAgaWakYlLkP0oDhUwuXLhifE-XcoAoOQ2z6uJgRdBCbOikjKCQKAmiwMIlIDOTFolk5NGwPuJDLrA5o4o5svCxkOBpbA-PEPAWQq3j+NgDb5C2-A+r4KTJP9CWqV0OKKBmroESUJWpgAOJMMIGDux7ZlMPAoAkeRlHUbR9EzY6c3vQFY1ZrIpcVL2NzwbIQA) does work.

## Test plan:
TODO