### PR TITLE
[fei4681.1] Introduce response settling

### DIFF
--- a/.changeset/strong-penguins-kneel.md
+++ b/.changeset/strong-penguins-kneel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+`RespondWith` API now supports a signal for controlling the settlement of the promise. Introduces `SettleController` to support this new feature.

--- a/packages/wonder-blocks-testing/src/__docs__/exports.respond-with.stories.mdx
+++ b/packages/wonder-blocks-testing/src/__docs__/exports.respond-with.stories.mdx
@@ -16,19 +16,23 @@ interface RespondWith {
     /**
      * Rejects with an AbortError to simulate an aborted request.
      */
-    abortedRequest: () => MockResponse<any>;
+    abortedRequest: (signal: ?SettleSignal = null) => MockResponse<any>;
 
     /**
      * A non-200 status code with empty text body.
      * Equivalent to calling `ResponseWith.text("", statusCode)`.
      */
-    errorStatusCode: (statusCode: number) => MockResponse<any>;
+    errorStatusCode: (
+        statusCode: number,
+        signal: ?SettleSignal = null,
+    ) => MockResponse<any>;
 
     /**
      * Response with GraphQL data JSON body and status code 200.
      */
     graphQLData: <TData: {...}>(
         data: TData,
+        signal: ?SettleSignal = null,
     ) => MockResponse<GraphQLJson<TData>>;
 
     /**
@@ -36,22 +40,26 @@ interface RespondWith {
      */
     graphQLErrors: (
         errorMessages: $ReadOnlyArray<string>,
+        signal: ?SettleSignal = null,
     ) => MockResponse<any>;
 
     /**
      * Response with JSON body and status code 200.
      */
-    json: <TJson: {...}>(json: TJson): MockResponse<TJson>;
+    json: <TJson: {...}>(
+        json: TJson,
+        signal: ?SettleSignal = null,
+    ): MockResponse<TJson>;
 
     /**
      * Response body that is valid JSON but not a valid GraphQL response.
      */
-    nonGraphQLBody: () => MockResponse<any>;
+    nonGraphQLBody: (signal: ?SettleSignal = null) => MockResponse<any>;
 
     /**
      * Rejects with the given error.
      */
-    reject: (error: Error) => MockResponse<any>;
+    reject: (error: Error, signal: ?SettleSignal = null) => MockResponse<any>;
 
     /**
      * Response with text body and status code.
@@ -60,14 +68,17 @@ interface RespondWith {
     text: <TData = string>(
         text: string,
         statusCode: number = 200,
+        signal: ?SettleSignal = null,
     ) => MockResponse<TData>;
 
     /**
      * Response with body that will not parse as JSON and status code 200.
      */
-    unparseableBody: () => MockResponse<any>;
+    unparseableBody: (signal: ?SettleSignal = null) => MockResponse<any>;
 });
 ```
 
 The `RespondWith` object is a helper for defining mock responses to use with
 mock request methods such as [`mockGqlFetch`](/docs/testing-mocking-exports-mockgqlfetch--page).
+
+Each call takes an optional `signal` that can be used to control when the promise generated from the call resolves. See [`SettleController`](/docs/testing-mocking-exports-settlecontroller--page) for related information.

--- a/packages/wonder-blocks-testing/src/__docs__/exports.settle-controller.stories.mdx
+++ b/packages/wonder-blocks-testing/src/__docs__/exports.settle-controller.stories.mdx
@@ -1,0 +1,32 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Testing / Mocking / Exports / SettleController"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# SettleController
+
+```ts
+class SettleController {
+    /**
+     * The signal to pass to the `RespondWith` API.
+     */
+    get signal(): SettleSignal;
+
+    /**
+     * Settle the signal and therefore any associated responses.
+     *
+     * @throws {Error} if the signal has already been settled.
+     */
+    settle(): void;
+}
+```
+
+The `SettleController` is used to control the settling of a signal. This is specifically created to work with the [`RespondWith`](/docs/testing-mocking-exports-respondwith--page) API. The `signal` property it exposes can be passed to `RespondWith` methods and then the `settle` method can be invoked to settle the signal, causing the related responses to either reject or resolve as appropriate.
+
+This can be useful for tests where the order of operations needs to be controlled in order to verify the expected behaviour of the system under test.

--- a/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
@@ -1,5 +1,6 @@
 // @flow
 import {SettleSignal} from "../settle-signal.js";
+import {SettleController} from "../settle-controller.js";
 import {RespondWith, makeMockResponse} from "../make-mock-response.js";
 
 describe("RespondWith", () => {
@@ -453,19 +454,19 @@ describe("#makeMockResponse", () => {
 
         it("should resolve when signal is settled", async () => {
             // Arrange
-            const signal1 = new SettleSignal();
+            const signal1 = new SettleController();
             const mockResponse1 = RespondWith.graphQLData(
                 {
                     response: "stays pending",
                 },
-                signal1,
+                signal1.signal,
             );
-            const signal2 = new SettleSignal();
+            const signal2 = new SettleController();
             const mockResponse2 = RespondWith.graphQLData(
                 {
                     response: "resolves",
                 },
-                signal2,
+                signal2.signal,
             );
 
             // Act
@@ -512,15 +513,15 @@ describe("#makeMockResponse", () => {
 
         it("should resolve when signal is settled", async () => {
             // Arrange
-            const signal1 = new SettleSignal();
+            const signal1 = new SettleController();
             const mockResponse1 = RespondWith.graphQLData(
                 {
                     response: "stays pending",
                 },
-                signal1,
+                signal1.signal,
             );
-            const signal2 = new SettleSignal();
-            const mockResponse2 = RespondWith.unparseableBody();
+            const signal2 = new SettleController();
+            const mockResponse2 = RespondWith.unparseableBody(signal2.signal);
 
             // Act
             const underTest = Promise.race([
@@ -561,15 +562,15 @@ describe("#makeMockResponse", () => {
 
         it("should reject when signal is settled", async () => {
             // Arrange
-            const signal1 = new SettleSignal();
+            const signal1 = new SettleController();
             const mockResponse1 = RespondWith.graphQLData(
                 {
                     response: "stays pending",
                 },
-                signal1,
+                signal1.signal,
             );
-            const signal2 = new SettleSignal();
-            const mockResponse2 = RespondWith.abortedRequest();
+            const signal2 = new SettleController();
+            const mockResponse2 = RespondWith.abortedRequest(signal2.signal);
 
             // Act
             const underTest = Promise.race([
@@ -598,16 +599,16 @@ describe("#makeMockResponse", () => {
 
         it("should reject when signal is settled", async () => {
             // Arrange
-            const signal1 = new SettleSignal();
+            const signal1 = new SettleController();
             const mockResponse1 = RespondWith.graphQLData(
                 {
                     response: "stays pending",
                 },
-                signal1,
+                signal1.signal,
             );
-            const signal2 = new SettleSignal();
+            const signal2 = new SettleController();
             const error = new Error("BOOM!");
-            const mockResponse2 = RespondWith.reject(error, signal2);
+            const mockResponse2 = RespondWith.reject(error, signal2.signal);
 
             // Act
             const underTest = Promise.race([
@@ -647,15 +648,18 @@ describe("#makeMockResponse", () => {
 
         it("should resolve when signal is settled", async () => {
             // Arrange
-            const signal1 = new SettleSignal();
+            const signal1 = new SettleController();
             const mockResponse1 = RespondWith.graphQLData(
                 {
                     response: "stays pending",
                 },
-                signal1,
+                signal1.signal,
             );
-            const signal2 = new SettleSignal();
-            const mockResponse2 = RespondWith.errorStatusCode(400, signal2);
+            const signal2 = new SettleController();
+            const mockResponse2 = RespondWith.errorStatusCode(
+                400,
+                signal2.signal,
+            );
 
             // Act
             const underTest = Promise.race([
@@ -696,15 +700,15 @@ describe("#makeMockResponse", () => {
 
         it("should resolve when signal is settled", async () => {
             // Arrange
-            const signal1 = new SettleSignal();
+            const signal1 = new SettleController();
             const mockResponse1 = RespondWith.graphQLData(
                 {
                     response: "stays pending",
                 },
-                signal1,
+                signal1.signal,
             );
-            const signal2 = new SettleSignal();
-            const mockResponse2 = RespondWith.nonGraphQLBody(signal2);
+            const signal2 = new SettleController();
+            const mockResponse2 = RespondWith.nonGraphQLBody(signal2.signal);
 
             // Act
             const underTest = Promise.race([
@@ -750,18 +754,18 @@ describe("#makeMockResponse", () => {
 
         it("should resolve when signal is settled", async () => {
             // Arrange
-            const signal1 = new SettleSignal();
+            const signal1 = new SettleController();
             const mockResponse1 = RespondWith.graphQLData(
                 {
                     response: "stays pending",
                 },
-                signal1,
+                signal1.signal,
             );
-            const signal2 = new SettleSignal();
+            const signal2 = new SettleController();
             const errorMessages = ["foo", "bar"];
             const mockResponse2 = RespondWith.graphQLErrors(
                 errorMessages,
-                signal2,
+                signal2.signal,
             );
 
             // Act

--- a/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/make-mock-response.test.js
@@ -1,4 +1,5 @@
 // @flow
+import {SettleSignal} from "../settle-signal.js";
 import {RespondWith, makeMockResponse} from "../make-mock-response.js";
 
 describe("RespondWith", () => {
@@ -23,6 +24,19 @@ describe("RespondWith", () => {
 
             // Assert
             expect(result).toEqual("SOME TEXT");
+        });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const signal = new SettleSignal();
+
+            // Act
+            const mockResponse = RespondWith.text("SOME TEXT", 200, signal);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
         });
     });
 
@@ -51,6 +65,22 @@ describe("RespondWith", () => {
             // Assert
             expect(result).toEqual(JSON.stringify(json));
         });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const signal = new SettleSignal();
+            const json = {
+                foo: "bar",
+            };
+
+            // Act
+            const mockResponse = RespondWith.json(json, signal);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
+        });
     });
 
     describe("#graphQLData", () => {
@@ -78,6 +108,22 @@ describe("RespondWith", () => {
             // Assert
             expect(result).toEqual(JSON.stringify({data}));
         });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const signal = new SettleSignal();
+            const data = {
+                foo: "bar",
+            };
+
+            // Act
+            const mockResponse = RespondWith.graphQLData(data, signal);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
+        });
     });
 
     describe("#unparseableBody", () => {
@@ -103,6 +149,19 @@ describe("RespondWith", () => {
             expect(underTest).toThrowErrorMatchingInlineSnapshot(
                 `"Unexpected token I in JSON at position 0"`,
             );
+        });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const signal = new SettleSignal();
+
+            // Act
+            const mockResponse = RespondWith.unparseableBody(signal);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
         });
     });
 
@@ -130,6 +189,19 @@ describe("RespondWith", () => {
                 `[AbortError: Mock request aborted]`,
             );
         });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const signal = new SettleSignal();
+
+            // Act
+            const mockResponse = RespondWith.abortedRequest(signal);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
+        });
     });
 
     describe("#reject", () => {
@@ -154,6 +226,20 @@ describe("RespondWith", () => {
 
             // Assert
             expect(result).toBe(error);
+        });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const error = new Error("BOOM!");
+            const signal = new SettleSignal();
+
+            // Act
+            const mockResponse = RespondWith.reject(error, signal);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
         });
     });
 
@@ -188,6 +274,19 @@ describe("RespondWith", () => {
             expect(result).toThrowErrorMatchingInlineSnapshot(
                 `"200 is not a valid error status code"`,
             );
+        });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const signal = new SettleSignal();
+
+            // Act
+            const mockResponse = RespondWith.errorStatusCode(400, signal);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
         });
     });
 
@@ -230,6 +329,19 @@ describe("RespondWith", () => {
                 }
             `);
         });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const signal = new SettleSignal();
+
+            // Act
+            const mockResponse = RespondWith.nonGraphQLBody(signal);
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
+        });
     });
 
     describe("#graphQLErrors", () => {
@@ -266,10 +378,27 @@ describe("RespondWith", () => {
                 }
             `);
         });
+
+        it("should include the signal if passed one", () => {
+            // Arrange
+            const errorMessages = ["foo", "bar"];
+            const signal = new SettleSignal();
+
+            // Act
+            const mockResponse = RespondWith.graphQLErrors(
+                errorMessages,
+                signal,
+            );
+            // $FlowIgnore[incompatible-use]
+            const result = mockResponse.signal;
+
+            // Assert
+            expect(result).toBe(signal);
+        });
     });
 });
 
-describe("#makeGqlErrorResponse", () => {
+describe("#makeMockResponse", () => {
     it("should throw for unknown response type", () => {
         // Arrange
 
@@ -295,7 +424,7 @@ describe("#makeGqlErrorResponse", () => {
             expect(result.status).toBe(200);
         });
 
-        it("should resolve to response with text() function that resolves to GraphQL data result", async () => {
+        it("should resolve to response with json of GraphQL data result", async () => {
             // Arrange
             const data = {
                 foo: "bar",
@@ -304,10 +433,56 @@ describe("#makeGqlErrorResponse", () => {
 
             // Act
             const response = await makeMockResponse(mockResponse);
-            const result = await response.text();
+            const result = response.json();
 
             // Assert
-            expect(result).toEqual(JSON.stringify({data}));
+            await expect(result).resolves.toEqual({data});
+        });
+
+        it("should resolve is signal is already settled", async () => {
+            // Arrange
+            const signal = SettleSignal.settle();
+            const mockResponse = RespondWith.graphQLData({}, signal);
+
+            // Act
+            const result = makeMockResponse(mockResponse);
+
+            // Assert
+            await expect(result).resolves.toBeDefined();
+        });
+
+        it("should resolve when signal is settled", async () => {
+            // Arrange
+            const signal1 = new SettleSignal();
+            const mockResponse1 = RespondWith.graphQLData(
+                {
+                    response: "stays pending",
+                },
+                signal1,
+            );
+            const signal2 = new SettleSignal();
+            const mockResponse2 = RespondWith.graphQLData(
+                {
+                    response: "resolves",
+                },
+                signal2,
+            );
+
+            // Act
+            const underTest = Promise.race([
+                makeMockResponse(mockResponse1),
+                makeMockResponse(mockResponse2),
+            ]);
+            signal2.settle();
+            const response = await underTest;
+            const result = await response.json();
+
+            // Assert
+            expect(result).toEqual({
+                data: {
+                    response: "resolves",
+                },
+            });
         });
     });
 
@@ -323,17 +498,41 @@ describe("#makeGqlErrorResponse", () => {
             expect(result.status).toBe(200);
         });
 
-        it("should resolve to response with text() function that resolves to non-JSON text", async () => {
+        it("should resolve to response that resolves to non-JSON text", async () => {
             // Arrange
             const mockResponse = RespondWith.unparseableBody();
 
             // Act
             const response = await makeMockResponse(mockResponse);
-            const text = await response.text();
-            const act = () => JSON.parse(text);
+            const act = response.json();
 
             // Assert
-            expect(act).toThrowError();
+            await expect(act).rejects.toThrowError();
+        });
+
+        it("should resolve when signal is settled", async () => {
+            // Arrange
+            const signal1 = new SettleSignal();
+            const mockResponse1 = RespondWith.graphQLData(
+                {
+                    response: "stays pending",
+                },
+                signal1,
+            );
+            const signal2 = new SettleSignal();
+            const mockResponse2 = RespondWith.unparseableBody();
+
+            // Act
+            const underTest = Promise.race([
+                makeMockResponse(mockResponse1),
+                makeMockResponse(mockResponse2),
+            ]);
+            signal2.settle();
+            const response = await underTest;
+            const act = response.json();
+
+            // Assert
+            await expect(act).rejects.toThrowError();
         });
     });
 
@@ -359,6 +558,29 @@ describe("#makeGqlErrorResponse", () => {
             // Assert
             await expect(act).rejects.toHaveProperty("name", "AbortError");
         });
+
+        it("should reject when signal is settled", async () => {
+            // Arrange
+            const signal1 = new SettleSignal();
+            const mockResponse1 = RespondWith.graphQLData(
+                {
+                    response: "stays pending",
+                },
+                signal1,
+            );
+            const signal2 = new SettleSignal();
+            const mockResponse2 = RespondWith.abortedRequest();
+
+            // Act
+            const underTest = Promise.race([
+                makeMockResponse(mockResponse1),
+                makeMockResponse(mockResponse2),
+            ]);
+            signal2.settle();
+
+            // Assert
+            await expect(underTest).rejects.toThrowError();
+        });
     });
 
     describe("rejection", () => {
@@ -373,6 +595,30 @@ describe("#makeGqlErrorResponse", () => {
             // Assert
             await expect(act).rejects.toBe(error);
         });
+
+        it("should reject when signal is settled", async () => {
+            // Arrange
+            const signal1 = new SettleSignal();
+            const mockResponse1 = RespondWith.graphQLData(
+                {
+                    response: "stays pending",
+                },
+                signal1,
+            );
+            const signal2 = new SettleSignal();
+            const error = new Error("BOOM!");
+            const mockResponse2 = RespondWith.reject(error, signal2);
+
+            // Act
+            const underTest = Promise.race([
+                makeMockResponse(mockResponse1),
+                makeMockResponse(mockResponse2),
+            ]);
+            signal2.settle();
+
+            // Assert
+            await expect(underTest).rejects.toThrowError();
+        });
     });
 
     describe("error status code response", () => {
@@ -384,20 +630,42 @@ describe("#makeGqlErrorResponse", () => {
             const result = await makeMockResponse(mockResponse);
 
             // Assert
-            expect(result.status).toBe(400);
+            expect(result).toHaveProperty("status", 400);
         });
 
-        it("should resolve to response with text() function that resolves to some parseable JSON", async () => {
+        it("should resolve to response that resolves to some parseable JSON", async () => {
             // Arrange
             const mockResponse = RespondWith.errorStatusCode(400);
 
             // Act
             const response = await makeMockResponse(mockResponse);
-            const text = await response.text();
-            const act = () => JSON.parse(text);
+            const act = response.json();
 
             // Assert
-            expect(act).not.toThrowError();
+            await expect(act).resolves.not.toThrowError();
+        });
+
+        it("should resolve when signal is settled", async () => {
+            // Arrange
+            const signal1 = new SettleSignal();
+            const mockResponse1 = RespondWith.graphQLData(
+                {
+                    response: "stays pending",
+                },
+                signal1,
+            );
+            const signal2 = new SettleSignal();
+            const mockResponse2 = RespondWith.errorStatusCode(400, signal2);
+
+            // Act
+            const underTest = Promise.race([
+                makeMockResponse(mockResponse1),
+                makeMockResponse(mockResponse2),
+            ]);
+            signal2.settle();
+
+            // Assert
+            await expect(underTest).resolves.toHaveProperty("status", 400);
         });
     });
 
@@ -413,18 +681,42 @@ describe("#makeGqlErrorResponse", () => {
             expect(result.status).toBe(200);
         });
 
-        it("should resolve to response with text() function that resolves to JSON parseable text that is not a valid GraphQL response", async () => {
+        it("should resolve to response that resolves to JSON parseable text that is not a valid GraphQL response", async () => {
             // Arrange
             const mockResponse = RespondWith.nonGraphQLBody();
 
             // Act
             const response = await makeMockResponse(mockResponse);
-            const text = await response.text();
-            const result = JSON.parse(text);
+            const result = await response.json();
 
             // Assert
             expect(result).not.toHaveProperty("data");
             expect(result).not.toHaveProperty("errors");
+        });
+
+        it("should resolve when signal is settled", async () => {
+            // Arrange
+            const signal1 = new SettleSignal();
+            const mockResponse1 = RespondWith.graphQLData(
+                {
+                    response: "stays pending",
+                },
+                signal1,
+            );
+            const signal2 = new SettleSignal();
+            const mockResponse2 = RespondWith.nonGraphQLBody(signal2);
+
+            // Act
+            const underTest = Promise.race([
+                makeMockResponse(mockResponse1),
+                makeMockResponse(mockResponse2),
+            ]);
+            signal2.settle();
+            const response = await underTest;
+            const result = await response.json();
+
+            // Assert
+            expect(result).not.toHaveProperty("data");
         });
     });
 
@@ -440,21 +732,49 @@ describe("#makeGqlErrorResponse", () => {
             expect(result.status).toBe(200);
         });
 
-        it("should resolve to response with text() function that resolves to GraphQL error result", async () => {
+        it("should resolve to response with json of GraphQL error result", async () => {
             // Arrange
             const errorMessages = ["foo", "bar"];
             const mockResponse = RespondWith.graphQLErrors(errorMessages);
 
             // Act
             const response = await makeMockResponse(mockResponse);
-            const text = await response.text();
-            const result = JSON.parse(text);
+            const result = await response.json();
 
             // Assert
             expect(result).toHaveProperty("errors", [
                 {message: "foo"},
                 {message: "bar"},
             ]);
+        });
+
+        it("should resolve when signal is settled", async () => {
+            // Arrange
+            const signal1 = new SettleSignal();
+            const mockResponse1 = RespondWith.graphQLData(
+                {
+                    response: "stays pending",
+                },
+                signal1,
+            );
+            const signal2 = new SettleSignal();
+            const errorMessages = ["foo", "bar"];
+            const mockResponse2 = RespondWith.graphQLErrors(
+                errorMessages,
+                signal2,
+            );
+
+            // Act
+            const underTest = Promise.race([
+                makeMockResponse(mockResponse1),
+                makeMockResponse(mockResponse2),
+            ]);
+            signal2.settle();
+            const response = await underTest;
+            const result = await response.json();
+
+            // Assert
+            expect(result).toHaveProperty("errors");
         });
     });
 });

--- a/packages/wonder-blocks-testing/src/__tests__/settle-controller.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/settle-controller.test.js
@@ -1,0 +1,29 @@
+// @flow
+import {SettleController} from "../settle-controller.js";
+import {SettleSignal} from "../settle-signal.js";
+
+describe("SettleController", () => {
+    it("should have a signal", () => {
+        // Arrange
+
+        // Act
+        const result = new SettleController();
+
+        // Assert
+        expect(result).toHaveProperty("signal", expect.any(SettleSignal));
+    });
+
+    describe("#settle", () => {
+        it("should settle the signal", () => {
+            // Arrange
+            const controller = new SettleController();
+            const signal = controller.signal;
+
+            // Act
+            controller.settle();
+
+            // Assert
+            expect(signal.settled).toBe(true);
+        });
+    });
+});

--- a/packages/wonder-blocks-testing/src/__tests__/settle-signal.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/settle-signal.test.js
@@ -22,13 +22,27 @@ describe("SettleSignal", () => {
         expect(result).toHaveProperty("settled", false);
     });
 
-    describe("#settle", () => {
+    it("should invoke the passed function with a function", () => {
+        // Arrange
+        const setSettleFn = jest.fn();
+
+        // Act
+        // eslint-disable-next-line no-new
+        new SettleSignal(setSettleFn);
+
+        // Assert
+        expect(setSettleFn).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    describe("setSettleFn argument", () => {
         it("should set settled to true", () => {
             // Arrange
-            const signal = new SettleSignal();
+            const setSettleFn = jest.fn();
+            const signal = new SettleSignal(setSettleFn);
+            const settle = setSettleFn.mock.calls[0][0];
 
             // Act
-            signal.settle();
+            settle();
 
             // Assert
             expect(signal.settled).toBe(true);
@@ -36,12 +50,14 @@ describe("SettleSignal", () => {
 
         it("should raise the settled event", () => {
             // Arrange
-            const signal = new SettleSignal();
+            const setSettleFn = jest.fn();
+            const signal = new SettleSignal(setSettleFn);
+            const settle = setSettleFn.mock.calls[0][0];
             const handler = jest.fn();
             signal.addEventListener("settled", handler);
 
             // Act
-            signal.settle();
+            settle();
 
             // Assert
             expect(handler).toHaveBeenCalled();
@@ -49,11 +65,14 @@ describe("SettleSignal", () => {
 
         it("should throw if the signal has already been settled", () => {
             // Arrange
-            const signal = new SettleSignal();
-            signal.settle();
+            const setSettleFn = jest.fn();
+            // eslint-disable-next-line no-new
+            new SettleSignal(setSettleFn);
+            const settle = setSettleFn.mock.calls[0][0];
+            settle();
 
             // Act
-            const result = () => signal.settle();
+            const result = () => settle();
 
             // Assert
             expect(result).toThrowErrorMatchingInlineSnapshot(

--- a/packages/wonder-blocks-testing/src/__tests__/settle-signal.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/settle-signal.test.js
@@ -1,0 +1,86 @@
+// @flow
+import {SettleSignal} from "../settle-signal.js";
+
+describe("SettleSignal", () => {
+    it("should extend EventTarget", () => {
+        // Arrange
+
+        // Act
+        const result = new SettleSignal();
+
+        // Assert
+        expect(result).toBeInstanceOf(EventTarget);
+    });
+
+    it("should start with settled = false", () => {
+        // Arrange
+
+        // Act
+        const result = new SettleSignal();
+
+        // Assert
+        expect(result).toHaveProperty("settled", false);
+    });
+
+    describe("#settle", () => {
+        it("should set settled to true", () => {
+            // Arrange
+            const signal = new SettleSignal();
+
+            // Act
+            signal.settle();
+
+            // Assert
+            expect(signal.settled).toBe(true);
+        });
+
+        it("should raise the settled event", () => {
+            // Arrange
+            const signal = new SettleSignal();
+            const handler = jest.fn();
+            signal.addEventListener("settled", handler);
+
+            // Act
+            signal.settle();
+
+            // Assert
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("should throw if the signal has already been settled", () => {
+            // Arrange
+            const signal = new SettleSignal();
+            signal.settle();
+
+            // Act
+            const result = () => signal.settle();
+
+            // Assert
+            expect(result).toThrowErrorMatchingInlineSnapshot(
+                `"SettleSignal already settled"`,
+            );
+        });
+    });
+
+    describe("#SettleSignal.settle", () => {
+        it("should return a SettleSignal", () => {
+            // Arrange
+
+            // Act
+            const result = SettleSignal.settle();
+
+            // Assert
+            expect(result).toBeInstanceOf(SettleSignal);
+        });
+
+        it("should return a SettleSignal that is already settled", () => {
+            // Arrange
+
+            // Act
+            const result = SettleSignal.settle();
+
+            // Assert
+            expect(result).toHaveProperty("settled", true);
+        });
+    });
+});

--- a/packages/wonder-blocks-testing/src/index.js
+++ b/packages/wonder-blocks-testing/src/index.js
@@ -12,6 +12,7 @@ export type {
 export {mockFetch} from "./fetch/mock-fetch.js";
 export {mockGqlFetch} from "./gql/mock-gql-fetch.js";
 export {RespondWith} from "./make-mock-response.js";
+export {SettleController} from "./settle-controller.js";
 export type {MockResponse} from "./make-mock-response.js";
 export type {FetchMockFn, FetchMockOperation} from "./fetch/types.js";
 export type {GqlFetchMockFn, GqlMockOperation} from "./gql/types.js";

--- a/packages/wonder-blocks-testing/src/make-mock-response.js
+++ b/packages/wonder-blocks-testing/src/make-mock-response.js
@@ -1,4 +1,5 @@
 // @flow
+import {SettleSignal} from "./settle-signal.js";
 import {ResponseImpl} from "./response-impl.js";
 import type {GraphQLJson} from "./types.js";
 
@@ -10,10 +11,12 @@ export opaque type MockResponse<TJson> =
           type: "text",
           text: string | (() => string),
           statusCode: number,
+          signal: ?SettleSignal,
       |}
     | {|
           type: "reject",
           error: Error | (() => Error),
+          signal: ?SettleSignal,
       |};
 
 /**
@@ -21,19 +24,25 @@ export opaque type MockResponse<TJson> =
  */
 const textResponse = <TData>(
     text: string | (() => string),
-    statusCode: number = 200,
+    statusCode: number,
+    signal: ?SettleSignal,
 ): MockResponse<TData> => ({
     type: "text",
     text,
     statusCode,
+    signal,
 });
 
 /**
  * Helper for creating a rejected mock response.
  */
-const rejectResponse = (error: Error | (() => Error)): MockResponse<empty> => ({
+const rejectResponse = (
+    error: Error | (() => Error),
+    signal: ?SettleSignal,
+): MockResponse<empty> => ({
     type: "reject",
     error,
+    signal,
 });
 
 /**
@@ -47,62 +56,79 @@ export const RespondWith = Object.freeze({
     text: <TData = string>(
         text: string,
         statusCode: number = 200,
-    ): MockResponse<TData> => textResponse<TData>(text, statusCode),
+        signal: ?SettleSignal = null,
+    ): MockResponse<TData> => textResponse<TData>(text, statusCode, signal),
 
     /**
      * Response with JSON body and status code 200.
      */
-    json: <TJson: {...}>(json: TJson): MockResponse<TJson> =>
-        textResponse<TJson>(() => JSON.stringify(json)),
+    json: <TJson: {...}>(
+        json: TJson,
+        signal: ?SettleSignal = null,
+    ): MockResponse<TJson> =>
+        textResponse<TJson>(() => JSON.stringify(json), 200, signal),
 
     /**
      * Response with GraphQL data JSON body and status code 200.
      */
     graphQLData: <TData: {...}>(
         data: TData,
+        signal: ?SettleSignal = null,
     ): MockResponse<GraphQLJson<TData>> =>
-        textResponse<GraphQLJson<TData>>(() => JSON.stringify({data})),
+        textResponse<GraphQLJson<TData>>(
+            () => JSON.stringify({data}),
+            200,
+            signal,
+        ),
 
     /**
      * Response with body that will not parse as JSON and status code 200.
      */
-    unparseableBody: (): MockResponse<any> => textResponse("INVALID JSON"),
+    unparseableBody: (signal: ?SettleSignal = null): MockResponse<any> =>
+        textResponse("INVALID JSON", 200, signal),
 
     /**
      * Rejects with an AbortError to simulate an aborted request.
      */
-    abortedRequest: (): MockResponse<any> =>
+    abortedRequest: (signal: ?SettleSignal = null): MockResponse<any> =>
         rejectResponse(() => {
             const abortError = new Error("Mock request aborted");
             abortError.name = "AbortError";
             return abortError;
-        }),
+        }, signal),
 
     /**
      * Rejects with the given error.
      */
-    reject: (error: Error): MockResponse<any> => rejectResponse(error),
+    reject: (error: Error, signal: ?SettleSignal = null): MockResponse<any> =>
+        rejectResponse(error, signal),
 
     /**
      * A non-200 status code with empty text body.
      * Equivalent to calling `ResponseWith.text("", statusCode)`.
      */
-    errorStatusCode: (statusCode: number): MockResponse<any> => {
+    errorStatusCode: (
+        statusCode: number,
+        signal: ?SettleSignal = null,
+    ): MockResponse<any> => {
         if (statusCode < 300) {
             throw new Error(`${statusCode} is not a valid error status code`);
         }
-        return textResponse("{}", statusCode);
+        return textResponse("{}", statusCode, signal);
     },
 
     /**
      * Response body that is valid JSON but not a valid GraphQL response.
      */
-    nonGraphQLBody: (): MockResponse<any> =>
-        textResponse(() =>
-            JSON.stringify({
-                valid: "json",
-                that: "is not a valid graphql response",
-            }),
+    nonGraphQLBody: (signal: ?SettleSignal = null): MockResponse<any> =>
+        textResponse(
+            () =>
+                JSON.stringify({
+                    valid: "json",
+                    that: "is not a valid graphql response",
+                }),
+            200,
+            signal,
         ),
 
     /**
@@ -110,15 +136,32 @@ export const RespondWith = Object.freeze({
      */
     graphQLErrors: (
         errorMessages: $ReadOnlyArray<string>,
+        signal: ?SettleSignal = null,
     ): MockResponse<GraphQLJson<any>> =>
-        textResponse<GraphQLJson<any>>(() =>
-            JSON.stringify({
-                errors: errorMessages.map((e) => ({
-                    message: e,
-                })),
-            }),
+        textResponse<GraphQLJson<any>>(
+            () =>
+                JSON.stringify({
+                    errors: errorMessages.map((e) => ({
+                        message: e,
+                    })),
+                }),
+            200,
+            signal,
         ),
 });
+
+const callOnSettled = (signal: ?SettleSignal, fn: () => void): void => {
+    if (signal == null || signal.settled) {
+        fn();
+        return;
+    }
+
+    const onSettled = () => {
+        signal.removeEventListener("settled", onSettled);
+        fn();
+    };
+    signal.addEventListener("settled", onSettled);
+};
 
 /**
  * Turns a MockResponse value to an actual Response that represents the mock.
@@ -126,23 +169,32 @@ export const RespondWith = Object.freeze({
 export const makeMockResponse = (
     response: MockResponse<any>,
 ): Promise<Response> => {
+    const {signal} = response;
+
     switch (response.type) {
         case "text":
-            const text =
-                typeof response.text === "function"
-                    ? response.text()
-                    : response.text;
-
-            return Promise.resolve(
-                new ResponseImpl(text, {status: response.statusCode}),
-            );
+            return new Promise((resolve, reject) => {
+                callOnSettled(signal, () => {
+                    const text =
+                        typeof response.text === "function"
+                            ? response.text()
+                            : response.text;
+                    resolve(
+                        new ResponseImpl(text, {status: response.statusCode}),
+                    );
+                });
+            });
 
         case "reject":
-            const error =
-                response.error instanceof Error
-                    ? response.error
-                    : response.error();
-            return Promise.reject(error);
+            return new Promise((resolve, reject) => {
+                callOnSettled(signal, () =>
+                    reject(
+                        response.error instanceof Error
+                            ? response.error
+                            : response.error(),
+                    ),
+                );
+            });
 
         default:
             throw new Error(`Unknown response type: ${response.type}`);

--- a/packages/wonder-blocks-testing/src/settle-controller.js
+++ b/packages/wonder-blocks-testing/src/settle-controller.js
@@ -9,6 +9,9 @@ export class SettleController {
     #signal: SettleSignal;
 
     constructor() {
+        // Create our signal.
+        // We pass in a method to capture it's settle function so that
+        // only we can call it.
         this.#signal = new SettleSignal(
             (settleFn) => (this.#settleFn = settleFn),
         );

--- a/packages/wonder-blocks-testing/src/settle-controller.js
+++ b/packages/wonder-blocks-testing/src/settle-controller.js
@@ -1,0 +1,29 @@
+// @flow
+import {SettleSignal} from "./settle-signal.js";
+
+/**
+ * A controller for the `RespondWith` API to control response settlement.
+ */
+export class SettleController {
+    #signal: SettleSignal;
+
+    constructor() {
+        this.#signal = new SettleSignal();
+    }
+
+    /**
+     * The signal to pass to the `RespondWith` API.
+     */
+    get signal(): SettleSignal {
+        return this.#signal;
+    }
+
+    /**
+     * Settle the signal and therefore any associated responses.
+     *
+     * @throws {Error} if the signal has already been settled.
+     */
+    settle(): void {
+        this.#signal.settle();
+    }
+}

--- a/packages/wonder-blocks-testing/src/settle-controller.js
+++ b/packages/wonder-blocks-testing/src/settle-controller.js
@@ -5,10 +5,13 @@ import {SettleSignal} from "./settle-signal.js";
  * A controller for the `RespondWith` API to control response settlement.
  */
 export class SettleController {
+    #settleFn: () => void;
     #signal: SettleSignal;
 
     constructor() {
-        this.#signal = new SettleSignal();
+        this.#signal = new SettleSignal(
+            (settleFn) => (this.#settleFn = settleFn),
+        );
     }
 
     /**
@@ -24,6 +27,6 @@ export class SettleController {
      * @throws {Error} if the signal has already been settled.
      */
     settle(): void {
-        this.#signal.settle();
+        this.#settleFn();
     }
 }

--- a/packages/wonder-blocks-testing/src/settle-signal.js
+++ b/packages/wonder-blocks-testing/src/settle-signal.js
@@ -1,0 +1,39 @@
+// @flow
+/**
+ * A signal for controlling the `RespondWith` API responses.
+ *
+ * This provide finely-grained control over the promise lifecycle to support
+ * complex test scenarios.
+ */
+export class SettleSignal extends EventTarget {
+    #settled: boolean = false;
+
+    /**
+     * Settle the signal.
+     *
+     * This raises the `settled` event.
+     */
+    settle: () => void = () => {
+        if (this.#settled) {
+            throw new Error("SettleSignal already settled");
+        }
+        this.#settled = true;
+        this.dispatchEvent(new Event("settled"));
+    };
+
+    /**
+     * An already settled signal.
+     */
+    static settle(): SettleSignal {
+        const signal = new SettleSignal();
+        signal.#settled = true;
+        return signal;
+    }
+
+    /**
+     * Has this signal been settled yet?
+     */
+    get settled(): boolean {
+        return this.#settled;
+    }
+}

--- a/packages/wonder-blocks-testing/src/settle-signal.js
+++ b/packages/wonder-blocks-testing/src/settle-signal.js
@@ -11,6 +11,9 @@ export class SettleSignal extends EventTarget {
     constructor(setSettleFn: ?(settleFn: () => void) => mixed = null) {
         super();
 
+        // If we were given a function, we call it with a method that will
+        // settle ourselves. This allows the appropriate SettleController
+        // to be in charge of settling this instance.
         setSettleFn?.(() => {
             if (this.#settled) {
                 throw new Error("SettleSignal already settled");

--- a/packages/wonder-blocks-testing/src/settle-signal.js
+++ b/packages/wonder-blocks-testing/src/settle-signal.js
@@ -8,18 +8,17 @@
 export class SettleSignal extends EventTarget {
     #settled: boolean = false;
 
-    /**
-     * Settle the signal.
-     *
-     * This raises the `settled` event.
-     */
-    settle: () => void = () => {
-        if (this.#settled) {
-            throw new Error("SettleSignal already settled");
-        }
-        this.#settled = true;
-        this.dispatchEvent(new Event("settled"));
-    };
+    constructor(setSettleFn: ?(settleFn: () => void) => mixed = null) {
+        super();
+
+        setSettleFn?.(() => {
+            if (this.#settled) {
+                throw new Error("SettleSignal already settled");
+            }
+            this.#settled = true;
+            this.dispatchEvent(new Event("settled"));
+        });
+    }
 
     /**
      * An already settled signal.


### PR DESCRIPTION
## Summary:
This introduces a pattern similar to `AbortController` and `AbortSignal` (but with a little less implementation - adding a `onsettled` event listener property seemed overkill, for example), but for settling a promise.

I chose this pattern so that it was familiar with existing APIs/solutions.

Now folks can create a `SettleController`, then pass it's `signal` property to the various `RespondWith` methods to create a pending outcome that can be settled (rejected or resolved) by calling `settle()` on the `SettleController`.

This means we can support more complex test scenarios where the order of operations is important. Previously, folks would need to create their own promises and responses in order to create this kind of behavior.

In the next PR, I'll be exposing a first class way to turn a `RespondWith` API result directly into a promise so that folks can retrieve a promise directly, as well as a special `RespondWith` call that can take such a promise and use it as the response. When combined with the changes in this PR, it should cater to all the various test scenarios we have encountered.

Issue: FEI-4681

## Test plan:
`yarn test`