### PR TITLE
[fei4736.1] Handle array and object variables so that requestIDs are idempotent and readable

### DIFF
--- a/.changeset/brown-elephants-boil.md
+++ b/.changeset/brown-elephants-boil.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": minor
+---
+
+Make sure objects and arrays in variables are sorted and readable in generated request identifiers

--- a/packages/wonder-blocks-data/src/util/__tests__/get-gql-request-id.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/get-gql-request-id.test.js
@@ -71,4 +71,37 @@ describe("#getGqlRequestId", () => {
             `variable1=value1&variable2=42&variable3=&variable4=null&variable5=true`,
         );
     });
+
+    it("should sort nested variable properties", () => {
+        // Arrange
+        const operation = {
+            type: "query",
+            id: "myQuery",
+        };
+        const variables = {
+            variable4: null,
+            variable2: 42,
+            variable1: "value1",
+            variable5: true,
+            variable3: undefined,
+            variable6: {
+                nested2: "nested2",
+                nested1: "nested1",
+            },
+            variable7: [1, 2, 3],
+        };
+
+        // Act
+        const requestId = getGqlRequestId(operation, variables, {
+            module: "MODULE",
+            curriculum: "CURRICULUM",
+            targetLocale: "LOCALE",
+        });
+        const result = new Set(requestId.split("|"));
+
+        // Assert
+        expect(result).toContain(
+            `variable1=value1&variable2=42&variable3=&variable4=null&variable5=true&variable6.nested1=nested1&variable6.nested2=nested2&variable7.0=1&variable7.1=2&variable7.2=3`,
+        );
+    });
 });


### PR DESCRIPTION
## Summary:
This modifies the `getGqlRequestId` method to handle variables that are arrays or objects in a way that is idempotent and readable. Before this change, the nested fields were unsorted which could lead to the same query not sharing cache because of the field orders being different. Of course, we don't sort arrays as array order can have meaning, but this does change how they are encoded in the generated identifier so that they are more readable (i.e. not peppered with %-encodings).

So, now, we turn nested elements and fields into sub-variable keys that are sorted the same way as top-level variables.

For example, an array variable named `x` with the value `[1, 2, 3]`, is now encoded as `x.0=1&x.1=2&x.2=3`, and similarly, an object variable named `y` with the value `{a: 1, b: 2, c: 3}` is encoded as `y.a=1&y.b=2&y.c=3`.

Issue: FEI-4736

## Test plan:
`yarn test`