### PR TITLE
Add failing test for focus trap

### DIFF
--- a/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.js
@@ -1,0 +1,41 @@
+// @flow
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import FocusTrap from "../focus-trap.js";
+
+describe("FocusTrap", () => {
+    it("finds the first focusable node correctly", () => {
+        render(
+            <>
+                <FocusTrap>
+                    <div tabIndex="-1">
+                        <label>
+                            <input type="radio" name="group" value="1" />
+                            first option
+                        </label>
+                    </div>
+                    <div tabIndex="-1">
+                        <label>
+                            <input type="radio" name="group" value="2" />
+                            second option
+                        </label>
+                    </div>
+                </FocusTrap>
+                <input type="text" />
+            </>,
+        );
+
+        const firstRadioButton = screen.getByRole("radio", {
+            name: /first option/i,
+        });
+
+        firstRadioButton.focus();
+
+        userEvent.tab();
+
+        // eslint-disable-next-line testing-library/no-node-access
+        expect(document.activeElement).toBe(firstRadioButton);
+    });
+});


### PR DESCRIPTION
## Summary:
This demonstrates when `FocusTrap` will focus on a node that cannot naturally be focused after pressing Tab.

Issue: TP-7486

## Test plan:
Run the test