### PR TITLE
add aria-hidden to tooltip-tail

### DIFF
--- a/.changeset/sour-otters-poke.md
+++ b/.changeset/sour-otters-poke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+hide tooltip-tail from screen readers

--- a/packages/wonder-blocks-tooltip/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
+++ b/packages/wonder-blocks-tooltip/src/__tests__/__snapshots__/generated-snapshot.test.js.snap
@@ -831,6 +831,7 @@ exports[`wonder-blocks-tooltip example 10 1`] = `
     }
   >
     <svg
+      aria-hidden={true}
       className="arrow_oo4scr"
       height={12}
       style={
@@ -1144,6 +1145,7 @@ exports[`wonder-blocks-tooltip example 11 1`] = `
     }
   >
     <svg
+      aria-hidden={true}
       className="arrow_oo4scr"
       height={24}
       style={
@@ -1352,6 +1354,7 @@ exports[`wonder-blocks-tooltip example 12 1`] = `
     }
   >
     <svg
+      aria-hidden={true}
       className="arrow_oo4scr"
       height={12}
       style={
@@ -1427,6 +1430,7 @@ exports[`wonder-blocks-tooltip example 13 1`] = `
     }
   >
     <svg
+      aria-hidden={true}
       className="arrow_oo4scr"
       height={24}
       style={
@@ -1720,6 +1724,7 @@ exports[`wonder-blocks-tooltip example 14 1`] = `
       }
     >
       <svg
+        aria-hidden={true}
         className="arrow_oo4scr"
         height={12}
         style={
@@ -1909,6 +1914,7 @@ exports[`wonder-blocks-tooltip example 15 1`] = `
       }
     >
       <svg
+        aria-hidden={true}
         className="arrow_oo4scr"
         height={24}
         style={
@@ -2098,6 +2104,7 @@ exports[`wonder-blocks-tooltip example 16 1`] = `
       }
     >
       <svg
+        aria-hidden={true}
         className="arrow_oo4scr"
         height={12}
         style={
@@ -2259,6 +2266,7 @@ exports[`wonder-blocks-tooltip example 17 1`] = `
       }
     >
       <svg
+        aria-hidden={true}
         className="arrow_oo4scr"
         height={24}
         style={
@@ -2449,6 +2457,7 @@ exports[`wonder-blocks-tooltip example 18 1`] = `
       }
     >
       <svg
+        aria-hidden={true}
         className="arrow_oo4scr"
         height={12}
         style={
@@ -2614,6 +2623,7 @@ exports[`wonder-blocks-tooltip example 19 1`] = `
       }
     >
       <svg
+        aria-hidden={true}
         className="arrow_oo4scr"
         height={12}
         style={

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.js
@@ -374,6 +374,7 @@ export default class TooltipTail extends React.Component<Props> {
                 style={this._getArrowStyle()}
                 width={width}
                 height={height}
+                aria-hidden
             >
                 {this._maybeRenderDropshadow(points)}
 


### PR DESCRIPTION
Slack convo: https://khanacademy.slack.com/archives/C8Z9DSKC7/p1662657335181759

The tooltip-tail is an SVG which the OSX VoiceOver was seeing as an image. The image is decorative and isn't super useful for users using screen readers, so I'm hiding it from screen readers with [aria-hidden](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden).

I can write a unit test if that's helpful, but I figured it'd be more noise than anything. I manually tested with Storybook and the results of using aria-hidden were what I was hoping for.

<img width="663" alt="Screen Shot 2022-09-08 at 12 10 08 PM" src="https://user-images.githubusercontent.com/16308368/189213623-79438f4f-b741-46f8-8c60-7529774e2991.png">