### PR TITLE
Allow I18nInlineMarkup to be used with LabeledTextField

### DIFF
--- a/.changeset/moody-poems-bow.md
+++ b/.changeset/moody-poems-bow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Allow 'label' and 'description' props on LabeledTextfield to accept a <I18nInlineMarkup> element

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -29,6 +29,7 @@
     "react": "16.14.0"
   },
   "devDependencies": {
+    "@khanacademy/wonder-blocks-i18n": "^1.0.1",
     "wb-dev-build-settings": "^0.4.0"
   }
 }

--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
@@ -4,6 +4,13 @@ import {mount} from "enzyme";
 import "jest-enzyme";
 import {StyleSheet} from "aphrodite";
 
+import {I18nInlineMarkup} from "@khanacademy/wonder-blocks-i18n";
+import {
+    Body,
+    LabelMedium,
+    LabelSmall,
+} from "@khanacademy/wonder-blocks-typography";
+
 import FieldHeading from "../field-heading.js";
 import TextField from "../text-field.js";
 
@@ -179,5 +186,38 @@ describe("FieldHeading", () => {
         // Assert
         const container = wrapper.find("View").at(0);
         expect(container).toHaveStyle(styles.style1);
+    });
+
+    it("should render a LabelSmall when the 'label' prop is a I18nInlineMarkup", () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label={<I18nInlineMarkup>Hello, world!</I18nInlineMarkup>}
+            />,
+        );
+
+        // Assert
+        const label = wrapper.find(LabelMedium);
+        expect(label).toExist();
+    });
+
+    it("should render a LabelSmall when the 'description' prop is a I18nInlineMarkup", () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label={<Body>Hello, world</Body>}
+                description={<I18nInlineMarkup>description</I18nInlineMarkup>}
+            />,
+        );
+
+        // Assert
+        const label = wrapper.find(LabelSmall);
+        expect(label).toExist();
     });
 });

--- a/packages/wonder-blocks-form/src/components/field-heading.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.js
@@ -4,6 +4,7 @@ import {StyleSheet} from "aphrodite";
 
 import {View, addStyle, type StyleType} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
+import {typeof I18nInlineMarkup} from "@khanacademy/wonder-blocks-i18n";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {
@@ -21,12 +22,12 @@ type Props = {|
     /**
      * The title for the label element.
      */
-    label: string | React.Element<Typography>,
+    label: string | React.Element<Typography | I18nInlineMarkup>,
 
     /**
      * The text for the description element.
      */
-    description?: string | React.Element<Typography>,
+    description?: string | React.Element<Typography | I18nInlineMarkup>,
 
     /**
      * Whether this field is required to continue.
@@ -76,7 +77,8 @@ export default class FieldHeading extends React.Component<Props> {
 
         return (
             <React.Fragment>
-                {typeof label === "string" ? (
+                {typeof label === "string" ||
+                label.type?.__I18N_INLINE_MARKUP__ ? (
                     <LabelMedium
                         style={styles.label}
                         tag="label"
@@ -103,7 +105,8 @@ export default class FieldHeading extends React.Component<Props> {
 
         return (
             <React.Fragment>
-                {typeof description === "string" ? (
+                {typeof description === "string" ||
+                description.type?.__I18N_INLINE_MARKUP__ ? (
                     <LabelSmall
                         style={styles.description}
                         testId={testId && `${testId}-description`}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 
 import {IDProvider, type StyleType} from "@khanacademy/wonder-blocks-core";
+import {typeof I18nInlineMarkup} from "@khanacademy/wonder-blocks-i18n";
 import {type Typography} from "@khanacademy/wonder-blocks-typography";
 
 import FieldHeading from "./field-heading.js";
@@ -24,12 +25,12 @@ type Props = {|
     /**
      * Provide a label for the TextField.
      */
-    label: string | React.Element<Typography>,
+    label: string | React.Element<Typography | I18nInlineMarkup>,
 
     /**
      * Provide a description for the TextField.
      */
-    description?: string | React.Element<Typography>,
+    description?: string | React.Element<Typography | I18nInlineMarkup>,
 
     /**
      * The input value.

--- a/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.js
+++ b/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.js
@@ -110,6 +110,8 @@ type Props = {|
 |};
 
 export class I18nInlineMarkup extends React.PureComponent<Props> {
+    static __I18N_INLINE_MARKUP__: boolean = true;
+
     render(): React.Node {
         const {children, elementWrapper, onError, ...renderers} = this.props;
         let tree: $ReadOnlyArray<SimpleHtmlNode>;


### PR DESCRIPTION
## Summary:
This PR updates LabeledTextField to accept <I18nInlineMarkup> for the 'label' and 'description' props and updates field-heading.js to wrap them in the appropriate typography component.  If developers need to customize the styling they can do so by wrapping <I18nInlineMarkup> in another component.

Issue: None

## Test plan:
- yarn jest wonder-blocks-form