### PR TITLE
[fei4762.1.betterrequestids] Handle non-standard objects better

### DIFF
--- a/.changeset/breezy-wasps-allow.md
+++ b/.changeset/breezy-wasps-allow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": major
+---
+
+Make sure request ID generation handles objects like Date and Error instances better

--- a/packages/wonder-blocks-data/src/util/__tests__/get-gql-request-id.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/get-gql-request-id.test.js
@@ -104,4 +104,31 @@ describe("#getGqlRequestId", () => {
             `variable1=value1&variable2=42&variable3=&variable4=null&variable5=true&variable6.nested1=nested1&variable6.nested2=nested2&variable7.0=1&variable7.1=2&variable7.2=3`,
         );
     });
+
+    it("should handle non-primitive values in variables", () => {
+        // Arrange
+        const operation = {
+            type: "query",
+            id: "myQuery",
+        };
+        const variables = {
+            variable1: {
+                date: new Date("2020-01-01"),
+                error: new Error("BOOM!"),
+            },
+        };
+
+        // Act
+        const requestId = getGqlRequestId(operation, variables, {
+            module: "MODULE",
+            curriculum: "CURRICULUM",
+            targetLocale: "LOCALE",
+        });
+        const result = new Set(requestId.split("|"));
+
+        // Assert
+        expect(result).toContain(
+            `variable1.date=2020-01-01T00%3A00%3A00.000Z&variable1.error=Error%3A+BOOM%21`,
+        );
+    });
 });


### PR DESCRIPTION
## Summary:
Although I think we really should only use primitive types within variables, there are currently some cases where we pass `Date` objects (and maybe other non-primitive object types).

Previously, the request ID generation ignored these because they went down a path that only converted them if `Object.entries` returned any entries.

Now, we do a little more effort to ensure that even if there are no results from `Object.entries`, we still get that object value represented in the ID somehow.

Issue: FEI-4762

## Test plan:
`yarn test`