### PR TITLE
WB-1318: Add `labels` prop to `SingleSelect` to pass translated strings

### DIFF
--- a/.changeset/cold-items-fix.md
+++ b/.changeset/cold-items-fix.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Added `labels` prop to be able to translate some internal texts (already supported by MultiSelect)

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -16,12 +16,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-button": "^3.0.3",
     "@khanacademy/wonder-blocks-clickable": "^2.3.1",
     "@khanacademy/wonder-blocks-color": "^1.2.0",
     "@khanacademy/wonder-blocks-core": "^4.4.0",
     "@khanacademy/wonder-blocks-icon": "^1.2.30",
-    "@khanacademy/wonder-blocks-icon-button": "^3.4.11",
     "@khanacademy/wonder-blocks-layout": "^1.4.11",
     "@khanacademy/wonder-blocks-modal": "^2.3.7",
     "@khanacademy/wonder-blocks-search-field": "^1.0.9",
@@ -40,6 +38,7 @@
     "react-window": "^1.8.5"
   },
   "devDependencies": {
+    "@khanacademy/wonder-blocks-button": "^3.0.3",
     "wb-dev-build-settings": "^0.4.0"
   }
 }

--- a/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
@@ -17,6 +17,9 @@ import {
     OptionItem,
     SeparatorItem,
 } from "@khanacademy/wonder-blocks-dropdown";
+
+import type {SingleSelectLabels} from "@khanacademy/wonder-blocks-dropdown";
+
 import ComponentInfo from "../../../../../.storybook/components/component-info.js";
 import {name, version} from "../../../package.json";
 import singleSelectArgtypes from "./base-select.argtypes.js";
@@ -459,6 +462,57 @@ CustomOpener.parameters = {
                 "- `eventState`: lets you customize the style for different states, such as pressed, hovered and focused.\n" +
                 "- `text`: Passes the menu label defined in the parent component. This value is passed using the placeholder prop set in the `SingleSelect` component.\n\n" +
                 "**Note:** If you need to use a custom ID for testing the opener, make sure to pass the testId prop inside the opener component/element.",
+        },
+    },
+};
+
+/**
+ * Custom labels
+ */
+const translatedItems = [
+    <OptionItem label="Banano" value="banano" />,
+    <OptionItem label="Fresa" value="fresa" disabled />,
+    <OptionItem label="Pera" value="pera" />,
+    <OptionItem label="Naranja" value="naranja" />,
+    <OptionItem label="Sandia" value="sandia" />,
+    <OptionItem label="Manzana" value="manzana" />,
+    <OptionItem label="Uva" value="uva" />,
+    <OptionItem label="Limon" value="limon" />,
+    <OptionItem label="Mango" value="mango" />,
+];
+
+export const CustomLabels: StoryComponentType = () => {
+    const [value, setValue] = React.useState(null);
+    const [opened, setOpened] = React.useState(true);
+
+    const translatedLabels: $Shape<SingleSelectLabels> = {
+        clearSearch: "Limpiar busqueda",
+        filter: "Filtrar",
+        noResults: "Sin resultados",
+        someResults: (numResults) => `${numResults} frutas`,
+    };
+
+    return (
+        <View style={styles.wrapper}>
+            <SingleSelect
+                isFilterable={true}
+                onChange={setValue}
+                selectedValue={value}
+                labels={translatedLabels}
+                opened={opened}
+                onToggle={setOpened}
+                placeholder="Selecciona una fruta"
+            >
+                {translatedItems}
+            </SingleSelect>
+        </View>
+    );
+};
+
+CustomLabels.parameters = {
+    docs: {
+        description: {
+            story: "This example illustrates how you can pass custom labels to the `SingleSelect` component.",
         },
     },
 };

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 
 import OptionItem from "../option-item.js";
 import SingleSelect from "../single-select.js";
+import type {SingleSelectLabels} from "../single-select.js";
 
 describe("SingleSelect", () => {
     const onChange = jest.fn();
@@ -713,6 +714,99 @@ describe("SingleSelect", () => {
             // TODO(WB-1318): Change this assertion to `1 item` after adding the
             // `labels` prop to the component.
             expect(liveRegionText).toEqual("1 items");
+        });
+    });
+
+    describe("Custom labels", () => {
+        const translatedItems = [
+            <OptionItem label="Banano" value="banano" />,
+            <OptionItem label="Fresa" value="fresa" disabled />,
+            <OptionItem label="Pera" value="pera" />,
+            <OptionItem label="Naranja" value="naranja" />,
+            <OptionItem label="Sandia" value="sandia" />,
+            <OptionItem label="Manzana" value="manzana" />,
+            <OptionItem label="Uva" value="uva" />,
+            <OptionItem label="Limon" value="limon" />,
+            <OptionItem label="Mango" value="mango" />,
+        ];
+
+        it("passes the custom label to the search input field", () => {
+            // Arrange
+            const labels: $Shape<SingleSelectLabels> = {
+                filter: "Filtrar",
+            };
+
+            // Act
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Escoge una fruta"
+                    isFilterable={true}
+                    opened={true}
+                    labels={labels}
+                >
+                    {translatedItems}
+                </SingleSelect>,
+            );
+
+            // Assert
+            expect(screen.getByPlaceholderText("Filtrar")).toBeInTheDocument();
+        });
+
+        it("passes the custom label to the dismiss filter icon", () => {
+            // Arrange
+            const labels: $Shape<SingleSelectLabels> = {
+                clearSearch: "Limpiar busqueda",
+                filter: "Filtrar",
+            };
+
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Escoge una fruta"
+                    isFilterable={true}
+                    opened={true}
+                    labels={labels}
+                >
+                    {translatedItems}
+                </SingleSelect>,
+            );
+
+            // Act
+            // Add text to the filter input to display the dismiss icon button.
+            userEvent.type(screen.getByPlaceholderText("Filtrar"), "m");
+
+            // Assert
+            expect(
+                screen.getByLabelText("Limpiar busqueda"),
+            ).toBeInTheDocument();
+        });
+
+        it("passes the custom label to the no results label", () => {
+            // Arrange
+            const labels: $Shape<SingleSelectLabels> = {
+                filter: "Filtrar",
+                noResults: "No hay resultados",
+            };
+
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Escoge una fruta"
+                    isFilterable={true}
+                    opened={true}
+                    labels={labels}
+                >
+                    {translatedItems}
+                </SingleSelect>,
+            );
+
+            // Act
+            // Add text to the filter input with a random word.
+            userEvent.type(screen.getByPlaceholderText("Filtrar"), "invalid");
+
+            // Assert
+            expect(screen.getByText("No hay resultados")).toBeInTheDocument();
         });
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -62,12 +62,10 @@ type Labels = {|
      */
     noResults: string,
     /**
-     * The number total of items available.
-     *
-     * NOTE: We are reusing the same label for both the total number of items
-     * and the number of selected items.
+     * The total number of available options in the dropdown.
+     * These can be all items or only the ones that match the filter.
      */
-    someSelected: (numOptions: number) => string,
+    someResults: (numOptions: number) => string,
 |};
 
 // we need to define a DefaultProps type to allow the HOC expose the default
@@ -253,7 +251,7 @@ class DropdownCore extends React.Component<Props, State> {
             clearSearch: defaultLabels.clearSearch,
             filter: defaultLabels.filter,
             noResults: defaultLabels.noResults,
-            someSelected: defaultLabels.someSelected,
+            someResults: defaultLabels.someSelected,
         },
         light: false,
         selectionType: "single",
@@ -302,6 +300,8 @@ class DropdownCore extends React.Component<Props, State> {
             sameItemsFocusable: false,
             labels: {
                 noResults: defaultLabels.noResults,
+                // In case we are not overriding this from the caller.
+                someResults: defaultLabels.someSelected,
                 ...props.labels,
             },
         };
@@ -945,7 +945,7 @@ class DropdownCore extends React.Component<Props, State> {
                 style={styles.srOnly}
                 data-test-id="dropdown-live-region"
             >
-                {open && labels.someSelected(totalItems)}
+                {open && labels.someResults(totalItems)}
             </StyledSpan>
         );
     }

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.js
@@ -575,7 +575,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                     clearSearch,
                     filter,
                     noResults,
-                    someSelected,
+                    someResults: someSelected,
                 }}
             />
         );

--- a/packages/wonder-blocks-dropdown/src/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.js
@@ -9,12 +9,35 @@ import DropdownCore from "./dropdown-core.js";
 import DropdownOpener from "./dropdown-opener.js";
 import SelectOpener from "./select-opener.js";
 import {
+    defaultLabels,
     selectDropdownStyle,
     filterableDropdownStyle,
 } from "../util/constants.js";
 
 import typeof OptionItem from "./option-item.js";
 import type {DropdownItem, OpenerProps} from "../util/types.js";
+
+export type SingleSelectLabels = {|
+    /**
+     * Label for describing the dismiss icon on the search filter.
+     */
+    clearSearch: string,
+
+    /**
+     * Label for the search placeholder.
+     */
+    filter: string,
+
+    /**
+     * Label for when the filter returns no results.
+     */
+    noResults: string,
+
+    /**
+     * Label for the opening component when there are some items selected.
+     */
+    someResults: (numOptions: number) => string,
+|};
 
 type Props = {|
     ...AriaProps,
@@ -108,6 +131,11 @@ type Props = {|
      * top. The items will be filtered by the input.
      */
     isFilterable?: boolean,
+
+    /**
+     * The object containing the custom labels used inside this component.
+     */
+    labels: SingleSelectLabels,
 |};
 
 type State = {|
@@ -130,9 +158,10 @@ type State = {|
 |};
 
 type DefaultProps = {|
-    alignment: $PropertyType<Props, "alignment">,
-    disabled: $PropertyType<Props, "disabled">,
-    light: $PropertyType<Props, "light">,
+    alignment: Props["alignment"],
+    disabled: Props["disabled"],
+    light: Props["light"],
+    labels: Props["labels"],
 |};
 
 /**
@@ -167,6 +196,12 @@ export default class SingleSelect extends React.Component<Props, State> {
         alignment: "left",
         disabled: false,
         light: false,
+        labels: {
+            clearSearch: defaultLabels.clearSearch,
+            filter: defaultLabels.filter,
+            noResults: defaultLabels.noResults,
+            someResults: defaultLabels.someSelected,
+        },
     };
 
     constructor(props: Props) {
@@ -318,6 +353,7 @@ export default class SingleSelect extends React.Component<Props, State> {
             alignment,
             dropdownStyle,
             isFilterable,
+            labels,
             onChange,
             onToggle,
             opened,
@@ -365,11 +401,12 @@ export default class SingleSelect extends React.Component<Props, State> {
         const {
             alignment,
             children,
+            className,
             dropdownStyle,
             isFilterable,
+            labels,
             light,
             style,
-            className,
         } = this.props;
         const {searchText} = this.state;
         const allChildren = React.Children.toArray(children).filter(Boolean);
@@ -400,6 +437,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                     isFilterable ? this.handleSearchTextChanged : null
                 }
                 searchText={isFilterable ? searchText : ""}
+                labels={labels}
             />
         );
     }

--- a/packages/wonder-blocks-dropdown/src/index.js
+++ b/packages/wonder-blocks-dropdown/src/index.js
@@ -7,6 +7,7 @@ import SingleSelect from "./components/single-select.js";
 import MultiSelect from "./components/multi-select.js";
 
 import type {Labels} from "./components/multi-select.js";
+import type {SingleSelectLabels} from "./components/single-select.js";
 
 export {
     ActionItem,
@@ -17,4 +18,4 @@ export {
     MultiSelect,
 };
 
-export type {Labels};
+export type {Labels, SingleSelectLabels};


### PR DESCRIPTION
## Summary:
We previously created a new functionality to be able to pass translated
strings to `MultiSelect` using a `labels prop` that is used by the consumers
passing `i18n.()...` strings.

This PR is responsible for adding a similar functionality to
`SingleSelect`, but with some minor differences from `MultiSelect` (we
don't need to support all the texts multiselect does).

Also removed some WB interdependencies that are not really used by the
Dropdown package.

JIRA: https://khanacademy.atlassian.net/browse/WB-1318

## Test plan:

Verify that the `Custom Labels` story allows passing different labels.