### PR TITLE
WB-1430: Update form component types to accept React.Node

### DIFF
--- a/.changeset/pink-plums-cross.md
+++ b/.changeset/pink-plums-cross.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Update label, description, and error props in form components to accept React.Node

--- a/packages/wonder-blocks-form/src/components/__docs__/checkbox-group.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/checkbox-group.stories.js
@@ -257,7 +257,6 @@ const styles = StyleSheet.create({
         justifyContent: "center",
     },
     description: {
-        marginTop: 5,
         color: Color.offBlack64,
     },
     last: {

--- a/packages/wonder-blocks-form/src/components/__docs__/labeled-text-field.argtypes.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/labeled-text-field.argtypes.js
@@ -34,7 +34,7 @@ export default {
         type: {required: true},
         table: {
             type: {
-                summary: "string | React.Element<Typography>",
+                summary: "React.Node",
             },
         },
         control: {
@@ -45,7 +45,7 @@ export default {
         description: "Provide a description for the TextField.",
         table: {
             type: {
-                summary: "string | React.Element<Typography>",
+                summary: "React.Node",
             },
         },
         control: {

--- a/packages/wonder-blocks-form/src/components/__docs__/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/labeled-text-field.stories.js
@@ -528,6 +528,27 @@ CustomStyle.parameters = {
     },
 };
 
+export const WithMarkup: StoryComponentType = (args) => {
+    return (
+        <LabeledTextField
+            {...args}
+            label="Name"
+            description={
+                <span>
+                    Please enter your <strong>name</strong>
+                </span>
+            }
+        />
+    );
+};
+
+WithMarkup.parameters = {
+    docs: {
+        storyDescription: `\`LabeledTextField\`'s \`label\` and \`description\` props
+        can accept \`React.Node\`s.`,
+    },
+};
+
 export const Ref: StoryComponentType = () => {
     const [value, setValue] = React.useState("Khan");
     const inputRef = React.createRef();

--- a/packages/wonder-blocks-form/src/components/__docs__/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/labeled-text-field.stories.js
@@ -9,6 +9,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Button from "@khanacademy/wonder-blocks-button";
+import Link from "@khanacademy/wonder-blocks-link";
 
 import type {StoryComponentType} from "@storybook/react";
 
@@ -535,7 +536,8 @@ export const WithMarkup: StoryComponentType = (args) => {
             label="Name"
             description={
                 <span>
-                    Please enter your <strong>name</strong>
+                    Description with <strong>strong</strong> text and a{" "}
+                    <Link href="/path/to/resource">link</Link>
                 </span>
             }
         />
@@ -545,7 +547,9 @@ export const WithMarkup: StoryComponentType = (args) => {
 WithMarkup.parameters = {
     docs: {
         storyDescription: `\`LabeledTextField\`'s \`label\` and \`description\` props
-        can accept \`React.Node\`s.`,
+        can accept \`React.Node\`s.  This is helpful when you need to decorate or use
+        specific elements in your form field (e.g. including Popovers, Tooltips or
+        emphasized text)`,
     },
 };
 

--- a/packages/wonder-blocks-form/src/components/__tests__/checkbox-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/checkbox-group.test.js
@@ -88,51 +88,49 @@ describe("CheckboxGroup", () => {
     describe("flexible props", () => {
         it("should render with a React.Node label", () => {
             // Arrange, Act
-            const action = () =>
-                render(
-                    <CheckboxGroup
-                        label={
-                            <span>
-                                label with <strong>strong</strong> text
-                            </span>
-                        }
-                        groupName="test"
-                        onChange={() => {}}
-                        selectedValues={[]}
-                    >
-                        <Choice label="a" value="a" aria-labelledby="test-a" />
-                        <Choice label="b" value="b" aria-labelledby="test-b" />
-                        <Choice label="c" value="c" aria-labelledby="test-c" />
-                    </CheckboxGroup>,
-                );
+            render(
+                <CheckboxGroup
+                    label={
+                        <span>
+                            label with <strong>strong</strong> text
+                        </span>
+                    }
+                    groupName="test"
+                    onChange={() => {}}
+                    selectedValues={[]}
+                >
+                    <Choice label="a" value="a" aria-labelledby="test-a" />
+                    <Choice label="b" value="b" aria-labelledby="test-b" />
+                    <Choice label="c" value="c" aria-labelledby="test-c" />
+                </CheckboxGroup>,
+            );
 
             // Assert
-            expect(action).not.toThrow();
+            expect(screen.getByText("strong")).toBeInTheDocument();
         });
 
         it("should render with a React.Node description", () => {
             // Arrange, Act
-            const action = () =>
-                render(
-                    <CheckboxGroup
-                        label="label"
-                        description={
-                            <span>
-                                description with <strong>strong</strong> text
-                            </span>
-                        }
-                        groupName="test"
-                        onChange={() => {}}
-                        selectedValues={[]}
-                    >
-                        <Choice label="a" value="a" aria-labelledby="test-a" />
-                        <Choice label="b" value="b" aria-labelledby="test-b" />
-                        <Choice label="c" value="c" aria-labelledby="test-c" />
-                    </CheckboxGroup>,
-                );
+            render(
+                <CheckboxGroup
+                    label="label"
+                    description={
+                        <span>
+                            description with <strong>strong</strong> text
+                        </span>
+                    }
+                    groupName="test"
+                    onChange={() => {}}
+                    selectedValues={[]}
+                >
+                    <Choice label="a" value="a" aria-labelledby="test-a" />
+                    <Choice label="b" value="b" aria-labelledby="test-b" />
+                    <Choice label="c" value="c" aria-labelledby="test-c" />
+                </CheckboxGroup>,
+            );
 
             // Assert
-            expect(action).not.toThrow();
+            expect(screen.getByText("strong")).toBeInTheDocument();
         });
     });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
@@ -4,6 +4,13 @@ import {mount} from "enzyme";
 import "jest-enzyme";
 import {StyleSheet} from "aphrodite";
 
+import {I18nInlineMarkup} from "@khanacademy/wonder-blocks-i18n";
+import {
+    Body,
+    LabelMedium,
+    LabelSmall,
+} from "@khanacademy/wonder-blocks-typography";
+
 import FieldHeading from "../field-heading.js";
 import TextField from "../text-field.js";
 
@@ -179,5 +186,38 @@ describe("FieldHeading", () => {
         // Assert
         const container = wrapper.find("View").at(0);
         expect(container).toHaveStyle(styles.style1);
+    });
+
+    it("should render a LabelSmall when the 'label' prop is a I18nInlineMarkup", () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label={<I18nInlineMarkup>Hello, world!</I18nInlineMarkup>}
+            />,
+        );
+
+        // Assert
+        const label = wrapper.find(LabelMedium);
+        expect(label).toExist();
+    });
+
+    it("should render a LabelSmall when the 'description' prop is a I18nInlineMarkup", () => {
+        // Arrange
+
+        // Act
+        const wrapper = mount(
+            <FieldHeading
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label={<Body>Hello, world</Body>}
+                description={<I18nInlineMarkup>description</I18nInlineMarkup>}
+            />,
+        );
+
+        // Assert
+        const label = wrapper.find(LabelSmall);
+        expect(label).toExist();
     });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
@@ -1,85 +1,158 @@
 //@flow
 import * as React from "react";
-import {mount} from "enzyme";
-import "jest-enzyme";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import RadioGroup from "../radio-group.js";
 import Choice from "../choice.js";
 
 describe("RadioGroup", () => {
-    let group;
-    const onChange = jest.fn();
-
-    beforeEach(() => {
-        group = mount(
+    const TestComponent = ({
+        errorMessage,
+        onChange,
+    }: {|
+        errorMessage?: string,
+        onChange?: () => mixed,
+    |}) => {
+        const [selectedValue, setSelectedValue] = React.useState("a");
+        const handleChange = (selectedValue) => {
+            setSelectedValue(selectedValue);
+            onChange?.();
+        };
+        return (
             <RadioGroup
                 label="Test"
                 description="test description"
                 groupName="test"
-                onChange={onChange}
-                selectedValue="a"
+                onChange={handleChange}
+                selectedValue={selectedValue}
+                errorMessage={errorMessage}
             >
                 <Choice label="a" value="a" aria-labelledby="test-a" />
                 <Choice label="b" value="b" aria-labelledby="test-b" />
                 <Choice label="c" value="c" aria-labelledby="test-c" />
-            </RadioGroup>,
+            </RadioGroup>
         );
+    };
+
+    describe("behavior", () => {
+        it("selects only one item at a time", () => {
+            // Arrange, Act
+            render(<TestComponent />);
+
+            const radios = screen.getAllByRole("radio");
+
+            // Assert
+            // a starts off checked
+            expect(radios[0]).toBeChecked();
+            expect(radios[1]).not.toBeChecked();
+            expect(radios[2]).not.toBeChecked();
+        });
+
+        it("changes selection when selectedValue changes", () => {
+            // Arrange
+            render(<TestComponent />);
+
+            const radios = screen.getAllByRole("radio");
+
+            // Act
+            userEvent.click(radios[1]);
+
+            // Assert
+            // a starts off checked
+            expect(radios[0]).not.toBeChecked();
+            expect(radios[1]).toBeChecked();
+            expect(radios[2]).not.toBeChecked();
+        });
+
+        it("should set aria-invalid on choices when there's an error message", () => {
+            // Arrange, Act
+            render(<TestComponent errorMessage="there's an error" />);
+
+            const radios = screen.getAllByRole("radio");
+
+            // Assert
+            expect(radios[0]).toHaveAttribute("aria-invalid", "true");
+            expect(radios[1]).toHaveAttribute("aria-invalid", "true");
+            expect(radios[2]).toHaveAttribute("aria-invalid", "true");
+        });
+
+        it("doesn't change when an already selected item is reselected", () => {
+            // Arrange
+            const handleChange = jest.fn();
+            render(<TestComponent onChange={handleChange} />);
+
+            const radios = screen.getAllByRole("radio");
+
+            // Act
+            // a is already selected, onChange shouldn't be called
+            userEvent.click(radios[0]);
+
+            // Assert
+            expect(handleChange).toHaveBeenCalledTimes(0);
+        });
+
+        it("checks that aria attributes have been added correctly", () => {
+            // Arrange, Act
+            render(<TestComponent />);
+
+            const radios = screen.getAllByRole("radio");
+
+            // Assert
+            expect(radios[0]).toHaveAttribute("aria-labelledby", "test-a");
+            expect(radios[1]).toHaveAttribute("aria-labelledby", "test-b");
+            expect(radios[2]).toHaveAttribute("aria-labelledby", "test-c");
+        });
     });
 
-    it("selects only one item at a time", () => {
-        const a = group.find(Choice).at(0);
-        const b = group.find(Choice).at(1);
-        const c = group.find(Choice).at(2);
+    describe("flexible props", () => {
+        it("should render with a React.Node label", () => {
+            // Arrange, Act
+            const action = () =>
+                render(
+                    <RadioGroup
+                        label={
+                            <span>
+                                label with <strong>strong</strong> text
+                            </span>
+                        }
+                        groupName="test"
+                        onChange={() => {}}
+                        selectedValue={"a"}
+                    >
+                        <Choice label="a" value="a" aria-labelledby="test-a" />
+                        <Choice label="b" value="b" aria-labelledby="test-b" />
+                        <Choice label="c" value="c" aria-labelledby="test-c" />
+                    </RadioGroup>,
+                );
 
-        // a starts off checked
-        expect(a.prop("checked")).toEqual(true);
-        expect(b.prop("checked")).toEqual(false);
-        expect(c.prop("checked")).toEqual(false);
-    });
+            // Assert
+            expect(action).not.toThrow();
+        });
 
-    it("changes selection when selectedValue changes", () => {
-        group.setProps({selectedValue: "b"});
-        const a = group.find(Choice).at(0);
-        const b = group.find(Choice).at(1);
-        const c = group.find(Choice).at(2);
+        it("should render with a React.Node description", () => {
+            // Arrange, Act
+            const action = () =>
+                render(
+                    <RadioGroup
+                        label="label"
+                        description={
+                            <span>
+                                description with <strong>strong</strong> text
+                            </span>
+                        }
+                        groupName="test"
+                        onChange={() => {}}
+                        selectedValue={"a"}
+                    >
+                        <Choice label="a" value="a" aria-labelledby="test-a" />
+                        <Choice label="b" value="b" aria-labelledby="test-b" />
+                        <Choice label="c" value="c" aria-labelledby="test-c" />
+                    </RadioGroup>,
+                );
 
-        // now b is checked
-        expect(a.prop("checked")).toEqual(false);
-        expect(b.prop("checked")).toEqual(true);
-        expect(c.prop("checked")).toEqual(false);
-    });
-
-    it("displays error state for all Choice children", () => {
-        group.setProps({errorMessage: "there's an error"});
-        const a = group.find(Choice).at(0);
-        const b = group.find(Choice).at(1);
-        const c = group.find(Choice).at(2);
-
-        expect(a.prop("error")).toEqual(true);
-        expect(b.prop("error")).toEqual(true);
-        expect(c.prop("error")).toEqual(true);
-    });
-
-    it("doesn't change when an already selected item is reselected", () => {
-        // a is already selected, onChange shouldn't be called
-        const a = group.find(Choice).at(0);
-        const aTarget = a.find("ClickableBehavior");
-        aTarget.simulate("click");
-        expect(onChange).toHaveBeenCalledTimes(0);
-
-        // now b is clicked, onChange should be called
-        const b = group.find(Choice).at(1);
-        const bTarget = b.find("ClickableBehavior");
-        bTarget.simulate("click");
-        expect(onChange).toHaveBeenCalledTimes(1);
-    });
-
-    it("checks that aria attributes have been added correctly", () => {
-        const a = group.find(Choice).at(0);
-        const b = group.find(Choice).at(1);
-        const c = group.find(Choice).at(2);
-        expect(a.find("input").prop("aria-labelledby")).toEqual("test-a");
-        expect(b.find("input").prop("aria-labelledby")).toEqual("test-b");
-        expect(c.find("input").prop("aria-labelledby")).toEqual("test-c");
+            // Assert
+            expect(action).not.toThrow();
+        });
     });
 });

--- a/packages/wonder-blocks-form/src/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.js
@@ -132,19 +132,15 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps> {
             <StyledFieldset data-test-id={testId} style={styles.fieldset}>
                 {/* We have a View here because fieldset cannot be used with flexbox*/}
                 <View style={style}>
-                    {typeof label === "string" ? (
+                    {label && (
                         <StyledLegend style={styles.legend}>
                             <LabelMedium>{label}</LabelMedium>
                         </StyledLegend>
-                    ) : (
-                        label && label
                     )}
-                    {typeof description === "string" ? (
+                    {description && (
                         <LabelSmall style={styles.description}>
                             {description}
                         </LabelSmall>
-                    ) : (
-                        description && description
                     )}
                     {errorMessage && (
                         <LabelSmall style={styles.error}>

--- a/packages/wonder-blocks-form/src/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.js
@@ -5,11 +5,7 @@ import * as React from "react";
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
-import {
-    type Typography,
-    LabelMedium,
-    LabelSmall,
-} from "@khanacademy/wonder-blocks-typography";
+import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import styles from "./group-styles.js";
@@ -32,12 +28,12 @@ type CheckboxGroupProps = {|
      * Optional label for the group. This label is optional to allow for
      * greater flexibility in implementing checkbox and radio groups.
      */
-    label?: string | React.Element<Typography>,
+    label?: React.Node,
 
     /**
      * Optional description for the group.
      */
-    description?: string | React.Element<Typography>,
+    description?: React.Node,
 
     /**
      * Optional error message. If supplied, the group will be displayed in an

--- a/packages/wonder-blocks-form/src/components/checkbox.js
+++ b/packages/wonder-blocks-form/src/components/checkbox.js
@@ -33,12 +33,12 @@ type ChoiceComponentProps = {|
     /**
      * Optional label for the field.
      */
-    label?: string,
+    label?: React.Node,
 
     /**
      * Optional description for the field.
      */
-    description?: string,
+    description?: React.Node,
 
     /**
      * Unique identifier attached to the HTML input element. If used, need to

--- a/packages/wonder-blocks-form/src/components/choice-internal.js
+++ b/packages/wonder-blocks-form/src/components/choice-internal.js
@@ -52,10 +52,10 @@ type Props = {|
     /**
      * Label for the field.
      */
-    label?: string,
+    label?: React.Node,
 
     /** Optional description for the field. */
-    description?: string,
+    description?: React.Node,
 
     /** Auto-populated by parent's groupName prop if in a group. */
     groupName?: string,
@@ -142,7 +142,9 @@ type DefaultProps = {|
         return (
             <UniqueIDProvider mockOnFirstRender={true} scope="choice">
                 {(ids) => {
-                    const descriptionId = description && ids.get("description");
+                    const descriptionId = description
+                        ? ids.get("description")
+                        : undefined;
 
                     return (
                         <View style={style} className={className}>

--- a/packages/wonder-blocks-form/src/components/choice.js
+++ b/packages/wonder-blocks-form/src/components/choice.js
@@ -10,10 +10,10 @@ type Props = {|
     ...AriaProps,
 
     /** User-defined. Label for the field. */
-    label: string,
+    label: React.Node,
 
     /** User-defined. Optional description for the field. */
-    description?: string,
+    description?: React.Node,
 
     /** User-defined. Should be distinct for each item in the group. */
     value: string,

--- a/packages/wonder-blocks-form/src/components/field-heading.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.js
@@ -6,11 +6,7 @@ import {View, addStyle, type StyleType} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
-import {
-    type Typography,
-    LabelMedium,
-    LabelSmall,
-} from "@khanacademy/wonder-blocks-typography";
+import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 type Props = {|
     /**
@@ -21,12 +17,12 @@ type Props = {|
     /**
      * The title for the label element.
      */
-    label: string | React.Element<Typography>,
+    label: React.Node,
 
     /**
      * The text for the description element.
      */
-    description?: string | React.Element<Typography>,
+    description?: React.Node,
 
     /**
      * Whether this field is required to continue.
@@ -36,7 +32,7 @@ type Props = {|
     /**
      * The message for the error element.
      */
-    error?: string | React.Element<Typography>,
+    error?: React.Node,
 
     /**
      * Custom styles for the field heading container.

--- a/packages/wonder-blocks-form/src/components/field-heading.js
+++ b/packages/wonder-blocks-form/src/components/field-heading.js
@@ -72,19 +72,15 @@ export default class FieldHeading extends React.Component<Props> {
 
         return (
             <React.Fragment>
-                {typeof label === "string" ? (
-                    <LabelMedium
-                        style={styles.label}
-                        tag="label"
-                        htmlFor={id && `${id}-field`}
-                        testId={testId && `${testId}-label`}
-                    >
-                        {label}
-                        {required && requiredIcon}
-                    </LabelMedium>
-                ) : (
-                    label
-                )}
+                <LabelMedium
+                    style={styles.label}
+                    tag="label"
+                    htmlFor={id && `${id}-field`}
+                    testId={testId && `${testId}-label`}
+                >
+                    {label}
+                    {required && requiredIcon}
+                </LabelMedium>
                 <Strut size={Spacing.xxxSmall_4} />
             </React.Fragment>
         );
@@ -99,16 +95,12 @@ export default class FieldHeading extends React.Component<Props> {
 
         return (
             <React.Fragment>
-                {typeof description === "string" ? (
-                    <LabelSmall
-                        style={styles.description}
-                        testId={testId && `${testId}-description`}
-                    >
-                        {description}
-                    </LabelSmall>
-                ) : (
-                    description
-                )}
+                <LabelSmall
+                    style={styles.description}
+                    testId={testId && `${testId}-description`}
+                >
+                    {description}
+                </LabelSmall>
                 <Strut size={Spacing.xxxSmall_4} />
             </React.Fragment>
         );
@@ -124,18 +116,14 @@ export default class FieldHeading extends React.Component<Props> {
         return (
             <React.Fragment>
                 <Strut size={Spacing.small_12} />
-                {typeof error === "string" ? (
-                    <LabelSmall
-                        style={styles.error}
-                        role="alert"
-                        id={id && `${id}-error`}
-                        testId={testId && `${testId}-error`}
-                    >
-                        {error}
-                    </LabelSmall>
-                ) : (
-                    error
-                )}
+                <LabelSmall
+                    style={styles.error}
+                    role="alert"
+                    id={id && `${id}-error`}
+                    testId={testId && `${testId}-error`}
+                >
+                    {error}
+                </LabelSmall>
             </React.Fragment>
         );
     }

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -2,7 +2,6 @@
 import * as React from "react";
 
 import {IDProvider, type StyleType} from "@khanacademy/wonder-blocks-core";
-import {type Typography} from "@khanacademy/wonder-blocks-typography";
 
 import FieldHeading from "./field-heading.js";
 import TextField, {type TextFieldType} from "./text-field.js";
@@ -24,12 +23,12 @@ type Props = {|
     /**
      * Provide a label for the TextField.
      */
-    label: string | React.Element<Typography>,
+    label: React.Node,
 
     /**
      * Provide a description for the TextField.
      */
-    description?: string | React.Element<Typography>,
+    description?: React.Node,
 
     /**
      * The input value.

--- a/packages/wonder-blocks-form/src/components/radio-group.js
+++ b/packages/wonder-blocks-form/src/components/radio-group.js
@@ -28,12 +28,12 @@ type RadioGroupProps = {|
      * Optional label for the group. This label is optional to allow for
      * greater flexibility in implementing checkbox and radio groups.
      */
-    label?: string,
+    label?: React.Node,
 
     /**
      * Optional description for the group.
      */
-    description?: string,
+    description?: React.Node,
 
     /**
      * Optional error message. If supplied, the group will be displayed in an

--- a/packages/wonder-blocks-form/src/components/radio.js
+++ b/packages/wonder-blocks-form/src/components/radio.js
@@ -33,12 +33,12 @@ type ChoiceComponentProps = {|
     /**
      * Optional label for the field.
      */
-    label?: string,
+    label?: React.Node,
 
     /**
      * Optional description for the field.
      */
-    description?: string,
+    description?: React.Node,
 
     /**
      * Unique identifier attached to the HTML input element. If used, need to


### PR DESCRIPTION
## Summary:

label, description, and error props on components in wonder-blocks-form are too restrictive (sometimes accepting just strings).  Sometimes designs call for markup in these props such as links or bolded words.  This PR makes these props accept any React.Node so that developers can implement designs without having to use workarounds.

## Test Plan:
- yarn jest
- yarn flow

<img width="730" alt="Screen Shot 2022-10-21 at 4 00 38 PM" src="https://user-images.githubusercontent.com/1044413/197279301-97dcf2c2-9653-488c-b5e9-a24972ef22b0.png">
