### PR TITLE
Update wonder-blocks-clickable tests to use @testing-library

### DIFF
--- a/.changeset/flat-snails-tease.md
+++ b/.changeset/flat-snails-tease.md
@@ -1,5 +1,2 @@
 ---
-"@khanacademy/wonder-blocks-clickable": patch
 ---
-
-Remove uses of enzyme from wonder-blocks-clickable tests

--- a/.changeset/flat-snails-tease.md
+++ b/.changeset/flat-snails-tease.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Remove uses of enzyme from wonder-blocks-clickable tests


### PR DESCRIPTION
## Summary:
I'd like to add a `useClickable` hook and update `ClickableBehavior` to use it.  This will allow use to get rid of `getClickable` since we'll be able to determine if there's a router or not by simply using `useHistory`.  Before we can do any of that though, we need to convert all of our enzyme tests to testing library because enzyme (our at least the version we're on) doesn't support testing components using hooks.

The reason why I want to create a `useClickable` hook is that I was going through the "Advanced React Patterns" workshop that's part of Epic React and learned about hooks that return a props object.  That seemed pretty similar to what `ClickableBehavior` does expect it's a full blown component that provides props for its children to spread into some other component.

Updating all of the tests to use `@testing-library` is going to take some time though.  I'm going to spread this work out and do a little bit here and there when I have time.  I'll open an epic to track this.

Issue: None

## Test plan:
- yarn jest clickable