### PR TITLE
WB-1430.1: Allow falsy children in CheckboxGroup and RadioGroup

### DIFF
--- a/.changeset/stupid-starfishes-heal.md
+++ b/.changeset/stupid-starfishes-heal.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+Allow CheckboxGroup and RadioGroup to accept falsy children

--- a/packages/wonder-blocks-form/src/components/__docs__/checkbox-group.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/checkbox-group.stories.js
@@ -232,6 +232,37 @@ MultipleChoiceStyling.parameters = {
     },
 };
 
+export const FiltersOutFalsyChildren: StoryComponentType = () => {
+    return (
+        <CheckboxGroup
+            groupName="pokemon"
+            selectedValues={["pepperoni", "sausage"]}
+            onChange={() => {}}
+            label="Pokemon"
+            description="Your first Pokemon."
+        >
+            <Choice label="Pepperoni" value="pepperoni" />
+            <Choice
+                label="Sausage"
+                value="sausage"
+                description="Imported from Italy"
+            />
+            <Choice label="Extra cheese" value="cheese" />
+            <Choice label="Green pepper" value="pepper" />
+            {false && <Choice label="Mushroom" value="mushroom" />}
+        </CheckboxGroup>
+    );
+};
+
+FiltersOutFalsyChildren.parameters = {
+    docs: {
+        storyDescription: `This example shows that children can be falsy values and
+        that those falsy values are filtered out when rendering children.  In this
+        case, one of the children is \`{false && <Choice .../>}\` which results in
+        that choice being filtered out.`,
+    },
+};
+
 const styles = StyleSheet.create({
     // Row styling
     wrapper: {

--- a/packages/wonder-blocks-form/src/components/__docs__/checkbox-group.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/checkbox-group.stories.js
@@ -261,6 +261,10 @@ FiltersOutFalsyChildren.parameters = {
         case, one of the children is \`{false && <Choice .../>}\` which results in
         that choice being filtered out.`,
     },
+    chromatic: {
+        // The unit tests already verify that false-y children aren't rendered.
+        disableSnapshot: true,
+    },
 };
 
 const styles = StyleSheet.create({

--- a/packages/wonder-blocks-form/src/components/__docs__/radio-group.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/radio-group.stories.js
@@ -166,6 +166,37 @@ MultipleChoiceStyling.parameters = {
     },
 };
 
+export const FiltersOutFalsyChildren: StoryComponentType = () => {
+    return (
+        <RadioGroup
+            groupName="pokemon"
+            selectedValue="bulbasaur"
+            onChange={() => {}}
+            label="Pokemon"
+            description="Your first Pokemon."
+        >
+            <Choice label="Bulbasaur" value="bulbasaur" />
+            <Choice
+                label="Charmander"
+                value="charmander"
+                description="Oops, we ran out of Charmanders"
+                disabled
+            />
+            <Choice label="Squirtle" value="squirtle" />
+            {false && <Choice label="Pikachu" value="pikachu" />}
+        </RadioGroup>
+    );
+};
+
+FiltersOutFalsyChildren.parameters = {
+    docs: {
+        storyDescription: `This example shows that children can be falsy values and
+        that those falsy values are filtered out when rendering children.  In this
+        case, one of the children is \`{false && <Choice .../>}\` which results in
+        that choice being filtered out.`,
+    },
+};
+
 const styles = StyleSheet.create({
     choice: {
         margin: 0,

--- a/packages/wonder-blocks-form/src/components/__docs__/radio-group.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/radio-group.stories.js
@@ -195,6 +195,10 @@ FiltersOutFalsyChildren.parameters = {
         case, one of the children is \`{false && <Choice .../>}\` which results in
         that choice being filtered out.`,
     },
+    chromatic: {
+        // The unit tests already verify that false-y children aren't rendered.
+        disableSnapshot: true,
+    },
 };
 
 const styles = StyleSheet.create({

--- a/packages/wonder-blocks-form/src/components/__tests__/checkbox-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/checkbox-group.test.js
@@ -132,5 +132,31 @@ describe("CheckboxGroup", () => {
             // Assert
             expect(screen.getByText("strong")).toBeInTheDocument();
         });
+
+        it("should filter out false-y children when rendering", () => {
+            // Arrange, Act
+            render(
+                <CheckboxGroup
+                    label="label"
+                    description="description"
+                    groupName="test"
+                    onChange={() => {}}
+                    selectedValues={[]}
+                >
+                    <Choice label="a" value="a" aria-labelledby="test-a" />
+                    {false && (
+                        <Choice label="b" value="b" aria-labelledby="test-b" />
+                    )}
+                    <Choice label="c" value="c" aria-labelledby="test-c" />
+                    {undefined}
+                    {null}
+                </CheckboxGroup>,
+            );
+
+            // Assert
+            const checkboxes = screen.getAllByRole("checkbox");
+
+            expect(checkboxes).toHaveLength(2);
+        });
     });
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
@@ -108,51 +108,75 @@ describe("RadioGroup", () => {
     describe("flexible props", () => {
         it("should render with a React.Node label", () => {
             // Arrange, Act
-            const action = () =>
-                render(
-                    <RadioGroup
-                        label={
-                            <span>
-                                label with <strong>strong</strong> text
-                            </span>
-                        }
-                        groupName="test"
-                        onChange={() => {}}
-                        selectedValue={"a"}
-                    >
-                        <Choice label="a" value="a" aria-labelledby="test-a" />
-                        <Choice label="b" value="b" aria-labelledby="test-b" />
-                        <Choice label="c" value="c" aria-labelledby="test-c" />
-                    </RadioGroup>,
-                );
+            render(
+                <RadioGroup
+                    label={
+                        <span>
+                            label with <strong>strong</strong> text
+                        </span>
+                    }
+                    groupName="test"
+                    onChange={() => {}}
+                    selectedValue={"a"}
+                >
+                    <Choice label="a" value="a" aria-labelledby="test-a" />
+                    <Choice label="b" value="b" aria-labelledby="test-b" />
+                    <Choice label="c" value="c" aria-labelledby="test-c" />
+                </RadioGroup>,
+            );
 
             // Assert
-            expect(action).not.toThrow();
+            expect(screen.getByText("strong")).toBeInTheDocument();
         });
 
         it("should render with a React.Node description", () => {
             // Arrange, Act
-            const action = () =>
-                render(
-                    <RadioGroup
-                        label="label"
-                        description={
-                            <span>
-                                description with <strong>strong</strong> text
-                            </span>
-                        }
-                        groupName="test"
-                        onChange={() => {}}
-                        selectedValue={"a"}
-                    >
-                        <Choice label="a" value="a" aria-labelledby="test-a" />
-                        <Choice label="b" value="b" aria-labelledby="test-b" />
-                        <Choice label="c" value="c" aria-labelledby="test-c" />
-                    </RadioGroup>,
-                );
+            render(
+                <RadioGroup
+                    label="label"
+                    description={
+                        <span>
+                            description with <strong>strong</strong> text
+                        </span>
+                    }
+                    groupName="test"
+                    onChange={() => {}}
+                    selectedValue={"a"}
+                >
+                    <Choice label="a" value="a" aria-labelledby="test-a" />
+                    <Choice label="b" value="b" aria-labelledby="test-b" />
+                    <Choice label="c" value="c" aria-labelledby="test-c" />
+                </RadioGroup>,
+            );
 
             // Assert
-            expect(action).not.toThrow();
+            expect(screen.getByText("strong")).toBeInTheDocument();
+        });
+
+        it("should filter out false-y children when rendering", () => {
+            // Arrange, Act
+            render(
+                <RadioGroup
+                    label="label"
+                    description="description"
+                    groupName="test"
+                    onChange={() => {}}
+                    selectedValue={"a"}
+                >
+                    <Choice label="a" value="a" aria-labelledby="test-a" />
+                    {false && (
+                        <Choice label="b" value="b" aria-labelledby="test-b" />
+                    )}
+                    <Choice label="c" value="c" aria-labelledby="test-c" />
+                    {undefined}
+                    {null}
+                </RadioGroup>,
+            );
+
+            // Assert
+            const radios = screen.getAllByRole("radio");
+
+            expect(radios).toHaveLength(2);
         });
     });
 });

--- a/packages/wonder-blocks-form/src/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.js
@@ -16,7 +16,7 @@ type CheckboxGroupProps = {|
     /**
      * Children should be Choice components.
      */
-    children: Array<React.Element<Choice>>,
+    children: Array<?(React.Element<Choice> | false)>,
 
     /**
      * Group name for this checkbox or radio group. Should be unique for all
@@ -128,6 +128,8 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps> {
             testId,
         } = this.props;
 
+        const allChildren = React.Children.toArray(children).filter(Boolean);
+
         return (
             <StyledFieldset data-test-id={testId} style={styles.fieldset}>
                 {/* We have a View here because fieldset cannot be used with flexbox*/}
@@ -151,7 +153,7 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps> {
                         <Strut size={Spacing.small_12} />
                     )}
 
-                    {React.Children.map(children, (child, index) => {
+                    {allChildren.map((child, index) => {
                         const {style, value} = child.props;
                         const checked = selectedValues.includes(value);
                         return (

--- a/packages/wonder-blocks-form/src/components/radio-group.js
+++ b/packages/wonder-blocks-form/src/components/radio-group.js
@@ -16,7 +16,7 @@ type RadioGroupProps = {|
     /**
      * Children should be Choice components.
      */
-    children: Array<React.Element<Choice>>,
+    children: Array<?(React.Element<Choice> | false)>,
 
     /**
      * Group name for this checkbox or radio group. Should be unique for all
@@ -118,6 +118,8 @@ export default class RadioGroup extends React.Component<RadioGroupProps> {
             testId,
         } = this.props;
 
+        const allChildren = React.Children.toArray(children).filter(Boolean);
+
         return (
             <StyledFieldset data-test-id={testId} style={styles.fieldset}>
                 {/* We have a View here because fieldset cannot be used with flexbox*/}
@@ -141,7 +143,7 @@ export default class RadioGroup extends React.Component<RadioGroupProps> {
                         <Strut size={Spacing.small_12} />
                     )}
 
-                    {React.Children.map(children, (child, index) => {
+                    {allChildren.map((child, index) => {
                         const {style, value} = child.props;
                         const checked = selectedValue === value;
                         return (


### PR DESCRIPTION
## Summary:
As I was upgrading components in webapp to use v3 of wonder-blocks-form (which removes Radio and requires RadioGroup), I noticed that in some places we provide conditional children.  Neither RadioGroup or CheckboxGroup handle this case, but our dropdown components do.  This PR updates RadioGroup and CheckboxGroup to allow falsy children (and filter them out) when rendering.  This makes them consistent with the dropdown components in terms of how we deal with children.

Issue: WB-1430

## Test plan:
- yarn jest wonder-blocks-form
- yarn start:storybook
- check that the new stories I added render without their last child