### PR TITLE
Remove default aria-label from WB Clickable

### DIFF
--- a/.changeset/real-rocks-attack.md
+++ b/.changeset/real-rocks-attack.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Remove the default value of aria-label ""

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
@@ -444,6 +444,44 @@ describe("Clickable", () => {
         expect(button).toHaveAttribute("aria-disabled", "true");
     });
 
+    test("should add aria-label if one is passed in", () => {
+        // Arrange
+
+        // Act
+        render(
+            <Clickable
+                testId="clickable-button"
+                aria-label="clickable-button-aria-label"
+            >
+                {(eventState) => <h1>Click Me!</h1>}
+            </Clickable>,
+        );
+
+        const button = screen.getByTestId("clickable-button");
+
+        // Assert
+        expect(button).toHaveAttribute(
+            "aria-label",
+            "clickable-button-aria-label",
+        );
+    });
+
+    test("should not have an aria-label if one is not passed in", () => {
+        // Arrange
+
+        // Act
+        render(
+            <Clickable testId="clickable-button">
+                {(eventState) => <h1>Click Me!</h1>}
+            </Clickable>,
+        );
+
+        const button = screen.getByTestId("clickable-button");
+
+        // Assert
+        expect(button).not.toHaveAttribute("aria-label");
+    });
+
     test("allow keyboard navigation when disabled is set", () => {
         // Arrange
         render(

--- a/packages/wonder-blocks-clickable/src/components/clickable.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.js
@@ -176,7 +176,6 @@ type Props =
 type DefaultProps = {|
     light: $PropertyType<Props, "light">,
     disabled: $PropertyType<Props, "disabled">,
-    "aria-label": $PropertyType<Props, "aria-label">,
 |};
 
 const StyledAnchor = addStyle<"a">("a");
@@ -220,7 +219,6 @@ export default class Clickable extends React.Component<Props> {
     static defaultProps: DefaultProps = {
         light: false,
         disabled: false,
-        "aria-label": "",
     };
 
     getCorrectTag: (


### PR DESCRIPTION
## Summary:
Currently, if no aria label is provided, Clickable components
have `aria-label=""`. Instead of having an empty aria label,
it should just not have the aria label attribute.

- Remove the default value of aria-label in Wonder Blocks Clickable
- Add tests for aria label values

Issue: https://khanacademy.atlassian.net/browse/WB-1429

## Test plan:
`yarn jest packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js`

Storybook
- Go to https://khan.github.io/wonder-blocks/?path=/story/clickable-clickable--basic
- Inspect the <a> element.
- Observe that it has an empty aria-label attribute.
- Now go to http://localhost:6061/?path=/story/clickable-clickable--basic
- Confirm there is no aria-label by default when inspecting the element

Before (prod storybook):
<img width="280" alt="Screen Shot 2022-10-27 at 2 35 13 PM" src="https://user-images.githubusercontent.com/13231763/198402885-3c2b20b7-d7f4-44f1-9c86-0f7dfcb90923.png">


After (local storybook):
<img width="281" alt="Screen Shot 2022-10-27 at 2 35 26 PM" src="https://user-images.githubusercontent.com/13231763/198402901-8aa5f25c-a0b9-43c9-b4c9-ee8c6bd9e88d.png">
