### PR TITLE
WB-1430.2: Don't wrap cloned Choices in fragments

### DIFF
--- a/.changeset/clean-cameras-admire.md
+++ b/.changeset/clean-cameras-admire.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Don't wrap Choices in a Fragment to so that each child has a 'key' prop

--- a/packages/wonder-blocks-form/src/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.js
@@ -156,24 +156,16 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps> {
                     {allChildren.map((child, index) => {
                         const {style, value} = child.props;
                         const checked = selectedValues.includes(value);
-                        return (
-                            <React.Fragment>
-                                {React.cloneElement(child, {
-                                    checked: checked,
-                                    error: !!errorMessage,
-                                    groupName: groupName,
-                                    id: `${groupName}-${value}`,
-                                    key: value,
-                                    onChange: () =>
-                                        this.handleChange(value, checked),
-                                    style: [
-                                        index > 0 && styles.defaultLineGap,
-                                        style,
-                                    ],
-                                    variant: "checkbox",
-                                })}
-                            </React.Fragment>
-                        );
+                        return React.cloneElement(child, {
+                            checked: checked,
+                            error: !!errorMessage,
+                            groupName: groupName,
+                            id: `${groupName}-${value}`,
+                            key: value,
+                            onChange: () => this.handleChange(value, checked),
+                            style: [index > 0 && styles.defaultLineGap, style],
+                            variant: "checkbox",
+                        });
                     })}
                 </View>
             </StyledFieldset>

--- a/packages/wonder-blocks-form/src/components/radio-group.js
+++ b/packages/wonder-blocks-form/src/components/radio-group.js
@@ -146,23 +146,16 @@ export default class RadioGroup extends React.Component<RadioGroupProps> {
                     {allChildren.map((child, index) => {
                         const {style, value} = child.props;
                         const checked = selectedValue === value;
-                        return (
-                            <React.Fragment>
-                                {React.cloneElement(child, {
-                                    checked: checked,
-                                    error: !!errorMessage,
-                                    groupName: groupName,
-                                    id: `${groupName}-${value}`,
-                                    key: value,
-                                    onChange: () => this.handleChange(value),
-                                    style: [
-                                        index > 0 && styles.defaultLineGap,
-                                        style,
-                                    ],
-                                    variant: "radio",
-                                })}
-                            </React.Fragment>
-                        );
+                        return React.cloneElement(child, {
+                            checked: checked,
+                            error: !!errorMessage,
+                            groupName: groupName,
+                            id: `${groupName}-${value}`,
+                            key: value,
+                            onChange: () => this.handleChange(value),
+                            style: [index > 0 && styles.defaultLineGap, style],
+                            variant: "radio",
+                        });
                     })}
                 </View>
             </StyledFieldset>


### PR DESCRIPTION
## Summary:
Converting children to an array in #1631 cause issues in webapp with React complaining about children not having a 'key' prop.  We do set the 'key' prop on the Choice, but React doesn't see this because the Choice is wrapped in a Fragment.  The wrapper isn't necessary and removing it should fix the issue in webapp.

Issue: WB-1430

## Test plan:
- let CI run the tests