### PR TITLE
Add 'useRenderState' hook to wonder-blocks-core

### DIFF
--- a/.changeset/stupid-chefs-speak.md
+++ b/.changeset/stupid-chefs-speak.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Add 'useRenderState' hook

--- a/packages/wonder-blocks-core/src/__docs__/exports.use-render-state.stories.mdx
+++ b/packages/wonder-blocks-core/src/__docs__/exports.use-render-state.stories.mdx
@@ -1,0 +1,25 @@
+import {Meta} from "@storybook/addon-docs";
+
+<Meta
+    title="Core / Exports / useRenderState()"
+    parameters={{
+        chromatic: {
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+# useRenderState()
+
+```ts
+function useRenderState(): RenderState;
+```
+
+The `useRenderState` hook will return either:
+- `RenderState.Initial` if the component is being rendered on the server **or** it's
+  the initial rehydration render on the client.
+- `RenderState.Standard` if the component renders on the client after the initial
+  rehydration.
+
+NOTE: Although the `RenderState` enum has a third state `Root`, this value is never
+returned by `useRenderState`.

--- a/packages/wonder-blocks-core/src/components/render-state-root.js
+++ b/packages/wonder-blocks-core/src/components/render-state-root.js
@@ -6,8 +6,9 @@ import * as React from "react";
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
 import {RenderState, RenderStateContext} from "./render-state-context.js";
+import {useRenderState} from "../hooks/use-render-state.js";
 
-const {useContext, useEffect, useState} = React;
+const {useEffect, useState} = React;
 
 type Props = {|
     children: React.Node,
@@ -18,17 +19,14 @@ type Props = {|
     throwIfNested?: boolean,
 |};
 
-export const RenderStateRoot = ({
-    children,
-    throwIfNested,
-}: Props): React.Node => {
+const RenderStateRoot = ({children, throwIfNested}: Props): React.Node => {
     const [firstRender, setFirstRender] = useState<boolean>(true);
-    const contextValue = useContext(RenderStateContext);
+    const renderState = useRenderState();
     useEffect(() => {
         setFirstRender(false);
     }, []); // This effect will only run once.
 
-    if (contextValue !== RenderState.Root) {
+    if (renderState !== RenderState.Root) {
         if (throwIfNested) {
             throw new Error(
                 "There's already a <RenderStateRoot> above this instance in " +
@@ -49,9 +47,10 @@ export const RenderStateRoot = ({
     );
 };
 
-// Flow doesn't know about defaultProps on functional components like this,
-// and it doesn't seem worth the effort to teach it.
-// $FlowIgnore[prop-missing]
+// We can set `defaultProps` on a functional component if we move the `export` to appear
+// afterwards.
 RenderStateRoot.defaultProps = {
     throwIfNested: true,
 };
+
+export {RenderStateRoot};

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-render-state.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-render-state.test.js
@@ -1,0 +1,61 @@
+// @flow
+import * as React from "react";
+import {renderHook as renderHookOnServer} from "@testing-library/react-hooks/server";
+import {renderHook} from "@testing-library/react-hooks";
+
+import {useRenderState} from "../use-render-state.js";
+import {RenderStateRoot} from "../../components/render-state-root.js";
+// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
+// have fixed:
+// https://github.com/import-js/eslint-plugin-import/issues/2073
+// eslint-disable-next-line import/named
+import {RenderState} from "../../components/render-state-context.js";
+
+describe("useRenderState", () => {
+    test("server-side render returns RenderState.Initial", () => {
+        // Arrange
+        const wrapper = ({children}) => (
+            <RenderStateRoot>{children}</RenderStateRoot>
+        );
+
+        // Act
+        const {result} = renderHookOnServer(() => useRenderState(), {
+            wrapper,
+        });
+
+        // Assert
+        expect(result.current).toEqual(RenderState.Initial);
+    });
+
+    describe("client-side rendering", () => {
+        test("first render returns RenderState.Initial", () => {
+            // Arrange
+            const wrapper = ({children}) => (
+                <RenderStateRoot>{children}</RenderStateRoot>
+            );
+
+            // Act
+            const {result} = renderHook(() => useRenderState(), {
+                wrapper,
+            });
+
+            // Assert
+            expect(result.all[0]).toEqual(RenderState.Initial);
+        });
+
+        test("second render returns RenderState.Standard", () => {
+            // Arrange
+            const wrapper = ({children}) => (
+                <RenderStateRoot>{children}</RenderStateRoot>
+            );
+
+            // Act
+            const {result} = renderHook(() => useRenderState(), {
+                wrapper,
+            });
+
+            // Assert
+            expect(result.all[1]).toEqual(RenderState.Standard);
+        });
+    });
+});

--- a/packages/wonder-blocks-core/src/hooks/use-render-state.js
+++ b/packages/wonder-blocks-core/src/hooks/use-render-state.js
@@ -1,0 +1,8 @@
+// @flow
+import {useContext} from "react";
+
+import {RenderStateContext} from "../components/render-state-context.js";
+
+import type {RenderState} from "../components/render-state-context";
+
+export const useRenderState = (): RenderState => useContext(RenderStateContext);

--- a/packages/wonder-blocks-core/src/hooks/use-unique-id.js
+++ b/packages/wonder-blocks-core/src/hooks/use-unique-id.js
@@ -1,6 +1,7 @@
 // @flow
-import {useContext, useRef} from "react";
+import {useRef} from "react";
 
+import {useRenderState} from "./use-render-state.js";
 import SsrIDFactory from "../util/ssr-id-factory.js";
 import UniqueIDFactory from "../util/unique-id-factory.js";
 
@@ -10,7 +11,6 @@ import {
     // https://github.com/import-js/eslint-plugin-import/issues/2073
     // eslint-disable-next-line import/named
     RenderState,
-    RenderStateContext,
 } from "../components/render-state-context.js";
 
 import type {IIdentifierFactory} from "../util/types.js";
@@ -24,7 +24,7 @@ import type {IIdentifierFactory} from "../util/types.js";
  * @returns {IIdentifierFactory}
  */
 export const useUniqueIdWithMock = (scope?: string): IIdentifierFactory => {
-    const renderState = useContext(RenderStateContext);
+    const renderState = useRenderState();
     const idFactory = useRef<?IIdentifierFactory>(null);
 
     if (renderState === RenderState.Root) {
@@ -52,7 +52,7 @@ export const useUniqueIdWithMock = (scope?: string): IIdentifierFactory => {
  * @returns {?IIdentifierFactory}
  */
 export const useUniqueIdWithoutMock = (scope?: string): ?IIdentifierFactory => {
-    const renderState = useContext(RenderStateContext);
+    const renderState = useRenderState();
     const idFactory = useRef<?IIdentifierFactory>(null);
 
     if (renderState === RenderState.Root) {

--- a/packages/wonder-blocks-core/src/index.js
+++ b/packages/wonder-blocks-core/src/index.js
@@ -14,6 +14,12 @@ export {
 } from "./hooks/use-unique-id.js";
 export {useForceUpdate} from "./hooks/use-force-update.js";
 export {useOnline} from "./hooks/use-online.js";
+export {useRenderState} from "./hooks/use-render-state.js";
 export {RenderStateRoot} from "./components/render-state-root.js";
+// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
+// have fixed:
+// https://github.com/import-js/eslint-plugin-import/issues/2073
+// eslint-disable-next-line import/named
+export {RenderState} from "./components/render-state-context.js";
 
 export type {AriaProps, IIdentifierFactory, StyleType};


### PR DESCRIPTION
## Summary
This hook provides access to the value of RenderStateContext which differentiates between initial renders (server and rehydration) to standard renders (on the client after rehydration).  This information can be useful in helping the client avoid rehydration errors.

This work was motivated by https://github.com/Khan/webapp/pull/9508.

## Test Plan:
- let CI run its checks
- yarn start:storybook, check that the docs are appearing as intended

<img width="1072" alt="Screen Shot 2022-11-02 at 10 40 31 PM" src="https://user-images.githubusercontent.com/1044413/199638243-2ae03f27-a97b-4cc6-8d5c-b16307bf3456.png">
