### PR TITLE
WB-1145.2: Allow more flexibility in Toolbar component

### DIFF
--- a/.changeset/few-eggs-dress.md
+++ b/.changeset/few-eggs-dress.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Remove wonder-blocks-toolbar dependency as it is not used anymore

--- a/.changeset/sharp-otters-sleep.md
+++ b/.changeset/sharp-otters-sleep.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-toolbar": patch
+---
+
+Modify layout to be more flexible

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,10 @@
 import React from "react";
 import wonderBlocksTheme from "./wonder-blocks-theme.js";
 
+/**
+ * WB Official breakpoints
+ * @see https://khanacademy.atlassian.net/wiki/spaces/WB/pages/2099970518/Layout+Breakpoints
+ */
 const wbViewports = {
     small: {
         name: "Small",

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,30 @@
 import React from "react";
 import wonderBlocksTheme from "./wonder-blocks-theme.js";
 
+const wbViewports = {
+    small: {
+        name: "small",
+        styles: {
+            width: "320px",
+            height: "568px",
+        },
+    },
+    medium: {
+        name: "medium",
+        styles: {
+            width: "768px",
+            height: "1024px",
+        },
+    },
+    large: {
+        name: "large",
+        styles: {
+            width: "1024px",
+            height: "935px",
+        },
+    },
+};
+
 export const parameters = {
     backgrounds: {
         default: "light",
@@ -27,5 +51,8 @@ export const parameters = {
     },
     docs: {
         theme: wonderBlocksTheme,
+    },
+    viewport: {
+        viewports: wbViewports,
     },
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,24 +3,31 @@ import wonderBlocksTheme from "./wonder-blocks-theme.js";
 
 const wbViewports = {
     small: {
-        name: "small",
+        name: "Small",
         styles: {
             width: "320px",
             height: "568px",
         },
     },
     medium: {
-        name: "medium",
+        name: "Medium",
         styles: {
             width: "768px",
             height: "1024px",
         },
     },
     large: {
-        name: "large",
+        name: "Large",
         styles: {
             width: "1024px",
-            height: "935px",
+            height: "768px",
+        },
+    },
+    chromebook: {
+        name: "Chromebook",
+        styles: {
+            width: "1366px",
+            height: "768px",
         },
     },
 };

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -23,7 +23,6 @@
     "@khanacademy/wonder-blocks-icon-button": "^3.4.14",
     "@khanacademy/wonder-blocks-layout": "^1.4.12",
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
-    "@khanacademy/wonder-blocks-toolbar": "^2.1.35",
     "@khanacademy/wonder-blocks-typography": "^1.1.34"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-toolbar/package.json
+++ b/packages/wonder-blocks-toolbar/package.json
@@ -18,7 +18,6 @@
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-color": "^1.2.0",
     "@khanacademy/wonder-blocks-core": "^4.5.0",
-    "@khanacademy/wonder-blocks-layout": "^1.4.12",
     "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-typography": "^1.1.34"
   },

--- a/packages/wonder-blocks-toolbar/package.json
+++ b/packages/wonder-blocks-toolbar/package.json
@@ -18,6 +18,8 @@
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-color": "^1.2.0",
     "@khanacademy/wonder-blocks-core": "^4.5.0",
+    "@khanacademy/wonder-blocks-layout": "^1.4.12",
+    "@khanacademy/wonder-blocks-spacing": "^3.0.5",
     "@khanacademy/wonder-blocks-typography": "^1.1.34"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.argtypes.js
+++ b/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.argtypes.js
@@ -14,7 +14,7 @@ const mobile = "@media (max-width: 1023px)";
 
 const styles = StyleSheet.create({
     fillContent: {
-        marginLeft: Spacing.large_24,
+        marginLeft: Spacing.small_12,
         [mobile]: {
             width: "100vw",
         },

--- a/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.argtypes.js
+++ b/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.argtypes.js
@@ -83,10 +83,12 @@ export const rightContentMappings: Mappings = {
 export default {
     leftContent: {
         control: {type: "select"},
-        options: leftContentMappings,
+        options: (Object.keys(leftContentMappings): Array<string>),
+        mapping: leftContentMappings,
     },
     rightContent: {
         control: {type: "select"},
-        options: rightContentMappings,
+        options: (Object.keys(rightContentMappings): Array<string>),
+        mapping: rightContentMappings,
     },
 };

--- a/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.argtypes.js
+++ b/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.argtypes.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {icons} from "@khanacademy/wonder-blocks-icon";
@@ -8,6 +9,22 @@ import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+
+const mobile = "@media (max-width: 1023px)";
+
+const styles = StyleSheet.create({
+    fillContent: {
+        marginLeft: Spacing.large_24,
+        [mobile]: {
+            width: "100vw",
+        },
+    },
+    onlyDesktop: {
+        [mobile]: {
+            display: "none",
+        },
+    },
+});
 
 type Mappings = {[key: string]: React.Node};
 
@@ -51,6 +68,14 @@ export const rightContentMappings: Mappings = {
             </Button>
             <Strut size={Spacing.medium_16} />
             <Button style={buttonStyle}>Next exercise</Button>
+        </>
+    ),
+    responsive: (
+        <>
+            <Button style={styles.onlyDesktop} kind="secondary">
+                Continue
+            </Button>
+            <Button style={styles.fillContent}>Up next: video</Button>
         </>
     ),
 };

--- a/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.stories.js
+++ b/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.stories.js
@@ -163,6 +163,28 @@ HeaderOverflowText.parameters = {
 };
 
 /**
+ * Flexible toolbars.
+ */
+export const Responsive: StoryComponentType = Template.bind({});
+
+Responsive.args = {
+    leftContent: leftContentMappings.hintButton,
+    rightContent: rightContentMappings.responsive,
+};
+
+Responsive.parameters = {
+    docs: {
+        description: {
+            story: "Sometimes there will be cases where we want to fill the content of one of the sides of the toolbar. This example demonstrates how toolbars can be used flexibly without breaking your layouts.",
+        },
+    },
+    chromatic: {
+        // Test responsiveness of the toolbar.
+        viewports: [320, 768, 1024],
+    },
+};
+
+/**
  * Inverted dark-color scheme
  */
 export const Dark: StoryComponentType = Template.bind({});

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.js
@@ -185,6 +185,7 @@ const sharedStyles = StyleSheet.create({
     leftColumn: {
         alignItems: "center",
         flexDirection: "row",
+        flexShrink: 0,
         justifyContent: "flex-start",
     },
     rightColumn: {

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.js
@@ -185,7 +185,6 @@ const sharedStyles = StyleSheet.create({
     leftColumn: {
         alignItems: "center",
         flexDirection: "row",
-        flexShrink: 0,
         justifyContent: "flex-start",
     },
     rightColumn: {

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.js
@@ -7,7 +7,6 @@ import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Spring} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {
     HeadingSmall,

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.js
@@ -185,14 +185,14 @@ const sharedStyles = StyleSheet.create({
     leftColumn: {
         alignItems: "center",
         flexDirection: "row",
+        // TODO(WB-1445): Find a way to replicate this behavior with
+        // rightContent.
+        flexShrink: 0,
         justifyContent: "flex-start",
     },
     rightColumn: {
         alignItems: "center",
         flexDirection: "row",
-        // TODO(WB-1445): Find a way to replicate this behavior with
-        // rightContent.
-        flexShrink: 0,
         justifyContent: "flex-end",
     },
     center: {

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.js
@@ -7,6 +7,8 @@ import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {Spring} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {
     HeadingSmall,
     LabelLarge,
@@ -104,19 +106,22 @@ export default class Toolbar extends React.Component<Props> {
                     size === "small" && sharedStyles.small,
                 ]}
             >
-                <View style={sharedStyles.column}>
-                    <View style={sharedStyles.leftColumn}>{leftContent}</View>
+                <View
+                    style={[
+                        sharedStyles.column,
+                        sharedStyles.leftColumn,
+                        title ? sharedStyles.withTitle : null,
+                    ]}
+                >
+                    {leftContent}
                 </View>
+
                 {title && (
                     <View
                         style={[sharedStyles.column, sharedStyles.wideColumn]}
                     >
                         <View
-                            style={[
-                                sharedStyles.titles,
-                                sharedStyles.verticalAlign,
-                                sharedStyles.center,
-                            ]}
+                            style={[sharedStyles.titles, sharedStyles.center]}
                         >
                             <TitleComponent id="wb-toolbar-title">
                                 {title}
@@ -134,8 +139,15 @@ export default class Toolbar extends React.Component<Props> {
                         </View>
                     </View>
                 )}
-                <View style={sharedStyles.column}>
-                    <View style={sharedStyles.rightColumn}>{rightContent}</View>
+
+                <View
+                    style={[
+                        sharedStyles.column,
+                        sharedStyles.rightColumn,
+                        title ? sharedStyles.withTitle : null,
+                    ]}
+                >
+                    {rightContent}
                 </View>
             </View>
         );
@@ -144,13 +156,13 @@ export default class Toolbar extends React.Component<Props> {
 
 const sharedStyles = StyleSheet.create({
     container: {
-        border: "1px solid rgba(33, 36, 44, 0.16)",
-        display: "flex",
+        border: `1px solid ${Color.offBlack16}`,
+        flex: 1,
         flexDirection: "row",
+        justifyContent: "space-between",
         minHeight: 66,
-        paddingLeft: 16,
-        paddingRight: 16,
-        position: "relative",
+        paddingLeft: Spacing.medium_16,
+        paddingRight: Spacing.medium_16,
         width: "100%",
     },
     small: {
@@ -158,17 +170,17 @@ const sharedStyles = StyleSheet.create({
     },
     dark: {
         backgroundColor: Color.darkBlue,
-        boxShadow: "0 1px 0 0 rgba(255, 255, 255, 0.64)",
+        boxShadow: `0 1px 0 0 ${Color.white64}`,
         color: "white",
     },
-    verticalAlign: {
+    column: {
         justifyContent: "center",
     },
-    column: {
+    withTitle: {
         flex: 1,
-        justifyContent: "center",
     },
     wideColumn: {
+        flex: 1,
         flexBasis: "50%",
     },
     leftColumn: {
@@ -185,9 +197,9 @@ const sharedStyles = StyleSheet.create({
         textAlign: "center",
     },
     subtitle: {
-        color: "rgba(33, 36, 44, 0.64)",
+        color: Color.offBlack64,
     },
     titles: {
-        padding: 12,
+        padding: Spacing.small_12,
     },
 });

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.js
@@ -191,6 +191,9 @@ const sharedStyles = StyleSheet.create({
     rightColumn: {
         alignItems: "center",
         flexDirection: "row",
+        // TODO(WB-1445): Find a way to replicate this behavior with
+        // rightContent.
+        flexShrink: 0,
         justifyContent: "flex-end",
     },
     center: {


### PR DESCRIPTION
## Summary:
We noticed that the current `Toolbar` layout doesn't allow for any of
the content nodes to use all the available space.

This PR modifies the `Toolbar` layout to allow doing this.

See Slack thread: https://khanacademy.slack.com/archives/C8Z9DSKC7/p1667842562518939

While I was at that, I also did a bit of refactoring to reduce the
number of elements rendered and also updated the styles to use WB tokens
(e.g. Spacing and Color).

Issue: WB-1145

Test Plan:

Navigate to the `Toolbar > Responsive` story and resize the window to
verify that the content flows as expected.

https://5e1bf4b385e3fb0020b7073c-wtvdnqhlph.chromatic.com/?path=/story/toolbar-toolbar--responsive

1. In `small` screens, the main button uses all the available space and
   the secondary button is hidden.
2. In `large` screens, the main button is inlined, and another button is
   displayed as well.