### PR TITLE
Bug Fix: Toolbar height can become unconstrained in Support Bar in webapp

### DIFF
--- a/.changeset/shy-grapes-melt.md
+++ b/.changeset/shy-grapes-melt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-toolbar": patch
+---
+
+Fix an issue where the toolbar height is unconstrained

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.js
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.js
@@ -159,12 +159,14 @@ const sharedStyles = StyleSheet.create({
         flex: 1,
         flexDirection: "row",
         justifyContent: "space-between",
+        maxHeight: 66,
         minHeight: 66,
         paddingLeft: Spacing.medium_16,
         paddingRight: Spacing.medium_16,
         width: "100%",
     },
     small: {
+        maxHeight: 66,
         minHeight: 50,
     },
     dark: {


### PR DESCRIPTION
## Summary:
In certain circumstances (Chrome + ZND?) the dev support bar height can become quite large.  This component renders the wonder-blocks Toolbar and that appears to be the source of the issue.  I fixed it in the browser by editing the CSS to set the 'max-height' to match the 'min-height'.  This PR implements this same fix.

Issue: None

![Screenshot 2022-11-15 at 2 11 46 PM](https://user-images.githubusercontent.com/1044413/203123439-14e98e77-5d97-443d-9d83-22ed61d7308e.png)

## Test plan:
- Let Chromatic run
- Deploy changes to webapp and see if people are still experiencing this after that