### PR TITLE
Handle `aria-describedby` in `OnePaneDialog` and `ModalDialog`, and remove unused aria props from Flow types

### DIFF
--- a/.changeset/odd-paws-hang.md
+++ b/.changeset/odd-paws-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": major
+---
+
+Handle `aria-describedby` in `OnePaneDialog`, and remove unused aria props from Flow types

--- a/.changeset/seven-bikes-sing.md
+++ b/.changeset/seven-bikes-sing.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/wonder-blocks-modal": minor
----
-
-Make OnePaneDialog and ModalDialog pass down AriaProps. Previously these components accepted AriaProps, but did not do anything with them.

--- a/.changeset/seven-bikes-sing.md
+++ b/.changeset/seven-bikes-sing.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": minor
+---
+
+Make OnePaneDialog and ModalDialog pass down AriaProps. Previously these components accepted AriaProps, but did not do anything with them.

--- a/packages/wonder-blocks-modal/src/components/__docs__/modal-launcher.stories.js
+++ b/packages/wonder-blocks-modal/src/components/__docs__/modal-launcher.stories.js
@@ -433,7 +433,7 @@ export const FocusTrap: StoryComponentType = () => {
             closeButtonVisible={false}
             content={
                 <>
-                    <Body>
+                    <Body id="focus-trap-story-body-text">
                         This modal demonstrates how the focus trap works with
                         form elements (or focusable elements). Also demonstrates
                         how the focus trap is moved to the next modal when it is
@@ -467,6 +467,7 @@ export const FocusTrap: StoryComponentType = () => {
                     </Button>
                 </>
             }
+            aria-describedby="focus-trap-story-body-text"
         />
     );
 

--- a/packages/wonder-blocks-modal/src/components/__docs__/one-pane-dialog.argtypes.js
+++ b/packages/wonder-blocks-modal/src/components/__docs__/one-pane-dialog.argtypes.js
@@ -99,4 +99,10 @@ export default {
             not provided, a unique id will be generated.`,
         table: {type: {summary: "string"}},
     },
+    "aria-describedby": {
+        control: {type: "text"},
+        description:
+            "The ID of the content describing this dialog, if applicable",
+        table: {type: {summary: "string"}},
+    },
 };

--- a/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.js
@@ -68,4 +68,21 @@ describe("OnePaneDialog", () => {
         // Assert
         expect(screen.getByLabelText("Breadcrumbs")).toBeInTheDocument();
     });
+
+    it("applies aria-describedby to the modal", () => {
+        // Arrange
+        render(
+            <OnePaneDialog
+                title="unused"
+                content={<p id="description">cool dialog</p>}
+                aria-describedby="description"
+            />,
+        );
+
+        // Act
+        const modal = screen.getByRole("dialog");
+
+        // Assert
+        expect(modal).toHaveDescription(/cool dialog/i);
+    });
 });

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.js
@@ -7,12 +7,11 @@ import {
     MEDIA_MODAL_SPEC,
 } from "@khanacademy/wonder-blocks-layout";
 import {View} from "@khanacademy/wonder-blocks-core";
-import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import type {MediaLayoutContextValue} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 type Props = {|
-    ...AriaProps,
     /**
      * The dialog content
      */
@@ -48,6 +47,21 @@ type Props = {|
      * Test ID used for e2e testing.
      */
     testId?: string,
+
+    /**
+     * The label for this dialog, if applicable.
+     */
+    "aria-label"?: string,
+
+    /**
+     * The ID of the content labelling this dialog, if applicable.
+     */
+    "aria-labelledby"?: string,
+
+    /**
+     * The ID of the content describing this dialog, if applicable.
+     */
+    "aria-describedby"?: string,
 |};
 
 type DefaultProps = {|
@@ -70,8 +84,17 @@ export default class ModalDialog extends React.Component<Props> {
     };
 
     render(): React.Node {
-        const {above, below, role, style, children, testId, ...ariaProps} =
-            this.props;
+        const {
+            above,
+            below,
+            role,
+            style,
+            children,
+            testId,
+            "aria-labelledby": ariaLabelledBy,
+            "aria-label": ariaLabel,
+            "aria-describedby": ariaDescribedBy,
+        } = this.props;
 
         const contextValue: MediaLayoutContextValue = {
             ssrSize: "large",
@@ -86,8 +109,10 @@ export default class ModalDialog extends React.Component<Props> {
                             {below && <View style={styles.below}>{below}</View>}
                             <View
                                 role={role}
-                                {...ariaProps}
                                 aria-modal="true"
+                                aria-labelledby={ariaLabelledBy}
+                                aria-label={ariaLabel}
+                                aria-describedby={ariaDescribedBy}
                                 style={styles.dialog}
                                 testId={testId}
                             >

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.js
@@ -49,11 +49,6 @@ type Props = {|
     testId?: string,
 
     /**
-     * The label for this dialog, if applicable.
-     */
-    "aria-label"?: string,
-
-    /**
      * The ID of the content labelling this dialog, if applicable.
      */
     "aria-labelledby"?: string,
@@ -94,7 +89,6 @@ export default class ModalDialog extends React.Component<Props> {
             /* eslint-disable react/prop-types */
             // the react/prop-types plugin does not like these
             "aria-labelledby": ariaLabelledBy,
-            "aria-label": ariaLabel,
             "aria-describedby": ariaDescribedBy,
             /* eslint-enable react/prop-types */
         } = this.props;
@@ -114,7 +108,6 @@ export default class ModalDialog extends React.Component<Props> {
                                 role={role}
                                 aria-modal="true"
                                 aria-labelledby={ariaLabelledBy}
-                                aria-label={ariaLabel}
                                 aria-describedby={ariaDescribedBy}
                                 style={styles.dialog}
                                 testId={testId}

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.js
@@ -70,16 +70,8 @@ export default class ModalDialog extends React.Component<Props> {
     };
 
     render(): React.Node {
-        const {
-            above,
-            below,
-            role,
-            style,
-            children,
-            testId,
-            "aria-labelledby": ariaLabelledBy,
-            "aria-label": ariaLabel,
-        } = this.props;
+        const {above, below, role, style, children, testId, ...ariaProps} =
+            this.props;
 
         const contextValue: MediaLayoutContextValue = {
             ssrSize: "large",
@@ -94,9 +86,8 @@ export default class ModalDialog extends React.Component<Props> {
                             {below && <View style={styles.below}>{below}</View>}
                             <View
                                 role={role}
+                                {...ariaProps}
                                 aria-modal="true"
-                                aria-labelledby={ariaLabelledBy}
-                                aria-label={ariaLabel}
                                 style={styles.dialog}
                                 testId={testId}
                             >

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.js
@@ -91,9 +91,12 @@ export default class ModalDialog extends React.Component<Props> {
             style,
             children,
             testId,
+            /* eslint-disable react/prop-types */
+            // the react/prop-types plugin does not like these
             "aria-labelledby": ariaLabelledBy,
             "aria-label": ariaLabel,
             "aria-describedby": ariaDescribedBy,
+            /* eslint-enable react/prop-types */
         } = this.props;
 
         const contextValue: MediaLayoutContextValue = {

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {typeof Breadcrumbs} from "@khanacademy/wonder-blocks-breadcrumbs";
 import {MediaLayout} from "@khanacademy/wonder-blocks-layout";
-import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import {IDProvider} from "@khanacademy/wonder-blocks-core";
 import ModalDialog from "./modal-dialog.js";
@@ -11,8 +11,6 @@ import ModalPanel from "./modal-panel.js";
 import ModalHeader from "./modal-header.js";
 
 type Common = {|
-    ...AriaProps,
-
     /**
      * The content of the modal, appearing between the titlebar and footer.
      */
@@ -84,6 +82,11 @@ type Common = {|
      * not provided, a unique id will be generated.
      */
     titleId?: string,
+
+    /**
+     * The ID of the content describing this dialog, if applicable.
+     */
+    "aria-describedby"?: string,
 |};
 
 type WithSubtitle = {|
@@ -195,10 +198,7 @@ export default class OnePaneDialog extends React.Component<Props> {
             testId,
             titleId,
             role,
-            breadcrumbs: _,
-            subtitle: __,
-            title: ___,
-            ...ariaProps
+            "aria-describedby": ariaDescribedBy,
         } = this.props;
 
         return (
@@ -211,8 +211,8 @@ export default class OnePaneDialog extends React.Component<Props> {
                                 above={above}
                                 below={below}
                                 testId={testId}
-                                {...ariaProps}
                                 aria-labelledby={uniqueId}
+                                aria-describedby={ariaDescribedBy}
                                 role={role}
                             >
                                 <ModalPanel

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
@@ -195,6 +195,10 @@ export default class OnePaneDialog extends React.Component<Props> {
             testId,
             titleId,
             role,
+            breadcrumbs: _,
+            subtitle: __,
+            title: ___,
+            ...ariaProps
         } = this.props;
 
         return (
@@ -207,6 +211,7 @@ export default class OnePaneDialog extends React.Component<Props> {
                                 above={above}
                                 below={below}
                                 testId={testId}
+                                {...ariaProps}
                                 aria-labelledby={uniqueId}
                                 role={role}
                             >


### PR DESCRIPTION
## Summary:
This allows us to add attributes like `aria-describedby` to the modal. Note that these props were already in the types, but did nothing.

Issue: TP-7580

## Test plan:
Open `ModalLauncher`'s "navigation with focus trap" story in Safari with VoiceOver enabled and verify that it reads the body text