### PR TITLE
Add support for custom actions to Banner

### DIFF
--- a/.changeset/gentle-pianos-travel.md
+++ b/.changeset/gentle-pianos-travel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": minor
+---
+
+Allow for custom actions in Banner

--- a/packages/wonder-blocks-banner/src/components/__docs__/banner.stories.js
+++ b/packages/wonder-blocks-banner/src/components/__docs__/banner.stories.js
@@ -417,15 +417,17 @@ export const WithCustomAction: StoryComponentType = () => (
 
 WithCustomAction.parameters = {
     docs: {
-        storyDescription: `There are a number of other props that
-            Buttons and Links may have that are not currently supported by
-            the \`actions\` prop in Banner. These would require the use of
-            custom actions. If it absolutely necessary to have a custom
-            action, it can be done by passing in an object into the \`actions\`
-            prop array that has \`type: "custom"\`, and your desired element
-            in the \`node\` field. Here is an example of a case where
-            the built in actions may not be enough - a button with a
-            \`spinner\` prop would need a custom implementation here.`,
+        storyDescription: `**NOTE: Custom actions are discouraged**
+            **and should only be used as a last resort!**\n\nThere are a
+            number of other props that Buttons and Links may have that are
+            not currently supported by the \`actions\` prop in Banner.
+            These would require the use of custom actions. If it absolutely
+            necessary to have a custom action, it can be done by passing
+            in an object into the \`actions\` prop array that has
+            \`type:"custom"\`, and your desired element in the \`node\`
+            field. Here is an example of a case where the built in actions
+            may not be enough - a button with a \`spinner\` prop would need
+            a custom implementation here.`,
     },
 };
 

--- a/packages/wonder-blocks-banner/src/components/__docs__/banner.stories.js
+++ b/packages/wonder-blocks-banner/src/components/__docs__/banner.stories.js
@@ -393,6 +393,83 @@ WithDismissal.parameters = {
     },
 };
 
+export const WithCustomAction: StoryComponentType = () => (
+    <Banner
+        text="some text"
+        layout="floating"
+        actions={[
+            {
+                type: "custom",
+                node: (
+                    <Button
+                        kind="tertiary"
+                        size="small"
+                        onClick={() => {}}
+                        spinner={true}
+                    >
+                        Spinner Button
+                    </Button>
+                ),
+            },
+        ]}
+    />
+);
+
+WithCustomAction.parameters = {
+    docs: {
+        storyDescription: `There are a number of other props that
+            Buttons and Links may have that are not currently supported by
+            the \`actions\` prop in Banner. These would require the use of
+            custom actions. If it absolutely necessary to have a custom
+            action, it can be done by passing in an object into the \`actions\`
+            prop array that has \`type: "custom"\`, and your desired element
+            in the \`node\` field. Here is an example of a case where
+            the built in actions may not be enough - a button with a
+            \`spinner\` prop would need a custom implementation here.`,
+    },
+};
+
+export const WithMixedActions: StoryComponentType = () => (
+    <Banner
+        text="some text"
+        layout="floating"
+        actions={[
+            {
+                title: "Normal button",
+                onClick: () => {},
+            },
+            {
+                type: "custom",
+                node: (
+                    <Button kind="tertiary" size="small" onClick={() => {}}>
+                        Custom button
+                    </Button>
+                ),
+            },
+            {
+                type: "custom",
+                node: (
+                    <Button
+                        kind="tertiary"
+                        size="small"
+                        onClick={() => {}}
+                        spinner={true}
+                    >
+                        Spinner Button
+                    </Button>
+                ),
+            },
+        ]}
+    />
+);
+
+WithMixedActions.parameters = {
+    docs: {
+        storyDescription: `Here is an example that includes both a
+            normal action and a custom action.`,
+    },
+};
+
 export const RightToLeft: StoryComponentType = () => (
     <View style={styles.rightToLeft}>
         <Banner

--- a/packages/wonder-blocks-banner/src/components/__tests__/banner.test.js
+++ b/packages/wonder-blocks-banner/src/components/__tests__/banner.test.js
@@ -2,6 +2,8 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
+import Button from "@khanacademy/wonder-blocks-button";
+
 import Banner from "../banner.js";
 
 describe("Banner", () => {
@@ -82,6 +84,38 @@ describe("Banner", () => {
         expect(link).toBeInTheDocument();
     });
 
+    test("passing a custom action causes the action to appear", async () => {
+        // Arrange
+
+        // Act
+        render(
+            <Banner
+                text="some text"
+                layout="floating"
+                actions={[
+                    {
+                        type: "custom",
+                        node: (
+                            <Button
+                                kind="tertiary"
+                                size="small"
+                                onClick={() => {}}
+                                spinner={true}
+                                testId="custom-button-in-banner"
+                            >
+                                Spinner Button
+                            </Button>
+                        ),
+                    },
+                ]}
+            />,
+        );
+
+        // Assert
+        const button = await screen.findByTestId("custom-button-in-banner");
+        expect(button).toBeInTheDocument();
+    });
+
     test("passing multiple actions causes multiple actions to appear", async () => {
         // Arrange
 
@@ -93,7 +127,19 @@ describe("Banner", () => {
                 actions={[
                     {title: "button 1", onClick: () => {}},
                     {title: "button 2", onClick: () => {}},
-                    {title: "button 3", onClick: () => {}},
+                    {
+                        type: "custom",
+                        node: (
+                            <Button
+                                kind="tertiary"
+                                size="small"
+                                onClick={() => {}}
+                                spinner={true}
+                            >
+                                Spinner Button
+                            </Button>
+                        ),
+                    },
                 ]}
             />,
         );

--- a/packages/wonder-blocks-banner/src/components/banner.js
+++ b/packages/wonder-blocks-banner/src/components/banner.js
@@ -29,7 +29,15 @@ type ActionTriggerWithLink = {|
     onClick?: () => void,
 |};
 
-type ActionTrigger = ActionTriggerWithButton | ActionTriggerWithLink;
+type ActionTriggerCustom = {|
+    type: "custom",
+    node: React.Node,
+|};
+
+type ActionTrigger =
+    | ActionTriggerWithButton
+    | ActionTriggerWithLink
+    | ActionTriggerCustom;
 
 type BannerKind =
     /**
@@ -181,8 +189,17 @@ const Banner = (props: Props): React.Node => {
     } = props;
 
     const renderActions = () => {
-        return actions?.filter(Boolean).map((action) => {
+        return actions?.filter(Boolean).map((action, i) => {
+            if (action.type === "custom") {
+                return (
+                    <View style={styles.action} key={`custom-action-${i}`}>
+                        {action.node}
+                    </View>
+                );
+            }
+
             const handleClick = action.onClick;
+
             if (action.href) {
                 return (
                     <View style={styles.action} key={action.title}>


### PR DESCRIPTION
## Summary:
Sometimes the actions need more stuff than the current
implementation allows them to do (for example: button
with spinner, button with beforeNav).

Here, Banner actions can now have custom actions using
the "custom" type with a node passed in.

Issue: none

## Test plan:
http://localhost:6061/?path=/docs/banner--with-mixed-actions

yarn jest packages/wonder-blocks-banner/src/components/__tests__/banner.test.js

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/13231763/205777240-d04821ed-e12d-475a-a124-2c1b2dd49692.png">
