### PR TITLE
Fix the text of a popover story button

### DIFF
--- a/.changeset/chilled-pens-fetch.md
+++ b/.changeset/chilled-pens-fetch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+---
+
+Fix button text in the Popover With initialFocusId Storybook story

--- a/.changeset/chilled-pens-fetch.md
+++ b/.changeset/chilled-pens-fetch.md
@@ -1,5 +1,2 @@
 ---
-"@khanacademy/wonder-blocks-popover": patch
 ---
-
-Fix button text in the Popover With initialFocusId Storybook story

--- a/packages/wonder-blocks-popover/src/components/__docs__/popover.stories.js
+++ b/packages/wonder-blocks-popover/src/components/__docs__/popover.stories.js
@@ -258,7 +258,9 @@ export const WithInitialFocusId: StoryComponentType = Template.bind({});
 
 WithInitialFocusId.args = {
     children: (
-        <Button>Open with initial focus on the &quot;Next&quot; button</Button>
+        <Button>
+            Open with initial focus on the &quot;It is focused!&quot; button
+        </Button>
     ),
     content: (
         <PopoverContent


### PR DESCRIPTION
## Summary:
Previously, the button that opens the popover in the "Popover With
initialFocusId" story referenced a "Next" button in the popover, which
doesn't exist. This commit changes the button text to reference the "It
is focused!" button, which does exist.

Issue: none

## Test plan:
- Run `npm run start:storybook`.
- View the Popover > Popover > With initialFocusId story.
- Verify that the button says: Open with initial focus on the "It is
  focused!" button.
- Click the button.
- Verify that the "It is focused!" button in the popover has focus.

Before change:
![popover_before_change](https://user-images.githubusercontent.com/37850/206202814-d83ce2b5-2d8c-4420-8f89-2bb4c1358f20.png)

After change:
![popover_after_change](https://user-images.githubusercontent.com/37850/206203376-491abd79-42ef-416e-83b5-b52012bd190e.png)
