### PR TITLE
Stop dropdown box from shifting position on change from empty to filled state

### DIFF
--- a/.changeset/cold-dingos-smash.md
+++ b/.changeset/cold-dingos-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fixes bug where going from empty to filled shifts the dropdown box’s position when inline with text

--- a/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
@@ -150,6 +150,7 @@ const items = [
     <OptionItem label="Grape" value="grape" key={6} />,
     <OptionItem label="Lemon" value="lemon" key={7} />,
     <OptionItem label="Mango" value="mango" key={8} />,
+    <OptionItem label="" value="" key={9} />,
 ];
 
 const Template = (args) => {
@@ -241,6 +242,58 @@ Disabled.parameters = {
     docs: {
         description: {
             story: "This select is disabled and cannot be interacted with.",
+        },
+    },
+};
+
+/**
+ * TwoWithText
+ */
+export const TwoWithText: StoryComponentType = (args) => {
+    const [selectedValue, setSelectedValue] = React.useState(
+        args.selectedValue,
+    );
+    const [secondSelectedValue, setSecondSelectedValue] = React.useState(
+        args.selectedValue,
+    );
+    const [opened, setOpened] = React.useState(args.opened);
+    const [secondOpened, setSecondOpened] = React.useState(args.opened);
+    React.useEffect(() => {
+        // Only update opened if the args.opened prop changes (using the
+        // controls panel).
+        setOpened(args.opened);
+    }, [args.opened]);
+
+    return (
+        <div>
+            Here is some text to nest the dropdown
+            <SingleSelect
+                {...args}
+                onChange={setSelectedValue}
+                selectedValue={selectedValue}
+                opened={opened}
+                onToggle={setOpened}
+            >
+                {items}
+            </SingleSelect>
+            . And here is more text to compare!
+            <SingleSelect
+                {...args}
+                onChange={setSecondSelectedValue}
+                selectedValue={secondSelectedValue}
+                opened={secondOpened}
+                onToggle={setSecondOpened}
+            >
+                {items}
+            </SingleSelect>
+        </div>
+    );
+};
+
+TwoWithText.parameters = {
+    docs: {
+        description: {
+            story: "This story has two selects nested inline within text.",
         },
     },
 };

--- a/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
@@ -273,6 +273,7 @@ export const TwoWithText: StoryComponentType = (args) => {
                 selectedValue={selectedValue}
                 opened={opened}
                 onToggle={setOpened}
+                style={{display: "inline-block"}}
             >
                 {items}
             </SingleSelect>
@@ -283,6 +284,7 @@ export const TwoWithText: StoryComponentType = (args) => {
                 selectedValue={secondSelectedValue}
                 opened={secondOpened}
                 onToggle={setSecondOpened}
+                style={{display: "inline-block"}}
             >
                 {items}
             </SingleSelect>

--- a/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
@@ -150,7 +150,6 @@ const items = [
     <OptionItem label="Grape" value="grape" key={6} />,
     <OptionItem label="Lemon" value="lemon" key={7} />,
     <OptionItem label="Mango" value="mango" key={8} />,
-    <OptionItem label="" value="" key={9} />,
 ];
 
 const Template = (args) => {
@@ -275,7 +274,7 @@ export const TwoWithText: StoryComponentType = (args) => {
                 onToggle={setOpened}
                 style={{display: "inline-block"}}
             >
-                {items}
+                {[...items, <OptionItem label="" value="" key={9} />]}
             </SingleSelect>
             . And here is more text to compare!
             <SingleSelect
@@ -286,7 +285,7 @@ export const TwoWithText: StoryComponentType = (args) => {
                 onToggle={setSecondOpened}
                 style={{display: "inline-block"}}
             >
-                {items}
+                {[...items, <OptionItem label="" value="" key={9} />]}
             </SingleSelect>
         </div>
     );

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -1002,7 +1002,6 @@ class DropdownCore extends React.Component<Props, State> {
 const styles = StyleSheet.create({
     menuWrapper: {
         width: "fit-content",
-        verticalAlign: "middle",
     },
 
     dropdown: {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -1002,7 +1002,6 @@ class DropdownCore extends React.Component<Props, State> {
 const styles = StyleSheet.create({
     menuWrapper: {
         width: "fit-content",
-        display: "inline-block",
         verticalAlign: "middle",
     },
 

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -1002,6 +1002,8 @@ class DropdownCore extends React.Component<Props, State> {
 const styles = StyleSheet.create({
     menuWrapper: {
         width: "fit-content",
+        display: "inline-block",
+        verticalAlign: "middle",
     },
 
     dropdown: {

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.js
@@ -146,7 +146,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                             {...childrenProps}
                         >
                             <LabelMedium style={styles.text}>
-                                {/* // Note(tamarab): Prevents unwanted vertical
+                                {/* Note(tamarab): Prevents unwanted vertical
                                 shift for empty selection */}
                                 {children || "\u00A0"}
                             </LabelMedium>

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.js
@@ -107,9 +107,6 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
 
         const ClickableBehavior = getClickableBehavior(router);
 
-        // Note(TB): Prevents unwanted vertical shift for empty selection
-        const space = "\u00A0";
-
         return (
             <ClickableBehavior disabled={disabled} onClick={this.handleClick}>
                 {(state, childrenProps) => {
@@ -149,7 +146,9 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                             {...childrenProps}
                         >
                             <LabelMedium style={styles.text}>
-                                {children || space}
+                                {/* // Note(tamarab): Prevents unwanted vertical
+                                shift for empty selection */}
+                                {children || "\u00A0"}
                             </LabelMedium>
                             <Icon
                                 icon={icons.caretDown}

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.js
@@ -107,6 +107,9 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
 
         const ClickableBehavior = getClickableBehavior(router);
 
+        // Note(TB): Prevents unwanted vertical shift for empty selection
+        const space = "\u00A0";
+
         return (
             <ClickableBehavior disabled={disabled} onClick={this.handleClick}>
                 {(state, childrenProps) => {
@@ -146,7 +149,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                             {...childrenProps}
                         >
                             <LabelMedium style={styles.text}>
-                                {children}
+                                {children || space}
                             </LabelMedium>
                             <Icon
                                 icon={icons.caretDown}


### PR DESCRIPTION
## Summary:
A bug was discovered where the dropdown box alignment shifts when the selected option changes from a blank option to an option with text. This PR adds a story to test the behavior of the dropdown box when nested in text as an inline-block, plus adds CSS for inline-block dislay and middle vertical alignment to styles.menuWrapper. As a result, the alignment no longer shifts when an option with text replaces an empty option.

With inline-block setting, before vertical alignment
<img width="919" alt="image" src="https://user-images.githubusercontent.com/60857422/209164636-0b80646e-580e-403b-944c-db5115cc403f.png">

With inline-block setting, after vertical alignment
<img width="915" alt="image" src="https://user-images.githubusercontent.com/60857422/209164870-f5f4dc1b-6b59-4e98-9d8d-f467bb7f9d77.png">

Issue: LP-13114

## Test plan:
- confirm all checks pass
- confirm story works as expected
- confirm other stories work as expected

## Questions:
-> Should there be a changeset for this? If so, is the summary I added to the changeset acceptable?
-> Will changing the display to inline-block for all dropdowns interfere with design decisions?

[LP-13114]: https://khanacademy.atlassian.net/browse/LP-13114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ