### PR TITLE
[🔥AUDIT🔥] Allow maybe values on CheckboxGroup errorMessage prop

### DIFF
--- a/.changeset/selfish-gifts-destroy.md
+++ b/.changeset/selfish-gifts-destroy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Allow maybe values for `errorMessage` prop on `CheckboxGroup`

--- a/packages/wonder-blocks-form/src/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.js
@@ -40,7 +40,7 @@ type CheckboxGroupProps = {|
      * error state, along with this error message. If no error state is desired,
      * simply do not supply this prop, or pass along null.
      */
-    errorMessage?: string,
+    errorMessage?: ?string,
 
     /**
      * Custom styling for this group of checkboxes.


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Just a simple typing change that aligns the types with the commented usage and makes using this component a little easier.

Issue: WB-1472

## Test plan:
`yarn flow`