### PR TITLE
WB-1081: TextField - Replace all "internal" Class Names to intended Names

### DIFF
--- a/.changeset/green-chicken-rush.md
+++ b/.changeset/green-chicken-rush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Rename `TextFieldInternal` to `TextField` (same with `LabeledTextField`)

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -163,15 +163,11 @@ type State = {|
     focused: boolean,
 |};
 
-// TODO(WB-1081): Change class name back to LabeledTextField after Styleguidist is gone.
 /**
  * A LabeledTextField is an element used to accept a single line of text
  * from the user paired with a label, description, and error field elements.
  */
-class LabeledTextFieldInternal extends React.Component<
-    PropsWithForwardRef,
-    State,
-> {
+class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
     static defaultProps: DefaultProps = {
         type: "text",
         disabled: false,
@@ -288,7 +284,7 @@ class LabeledTextFieldInternal extends React.Component<
 }
 
 type ExportProps = $Diff<
-    React.ElementConfig<typeof LabeledTextFieldInternal>,
+    React.ElementConfig<typeof LabeledTextField>,
     WithForwardRef,
 >;
 
@@ -312,9 +308,7 @@ type ExportProps = $Diff<
  * />
  * ```
  */
-const LabeledTextField: React.AbstractComponent<ExportProps, HTMLInputElement> =
-    React.forwardRef<ExportProps, HTMLInputElement>((props, ref) => (
-        <LabeledTextFieldInternal {...props} forwardedRef={ref} />
-    ));
 
-export default LabeledTextField;
+export default (React.forwardRef<ExportProps, HTMLInputElement>(
+    (props, ref) => <LabeledTextField {...props} forwardedRef={ref} />,
+): React.AbstractComponent<ExportProps, HTMLInputElement>);

--- a/packages/wonder-blocks-form/src/components/text-field.js
+++ b/packages/wonder-blocks-form/src/components/text-field.js
@@ -146,11 +146,10 @@ type State = {|
     focused: boolean,
 |};
 
-// TODO(WB-1081): Change class name back to TextField after Styleguidist is gone.
 /**
  * A TextField is an element used to accept a single line of text from the user.
  */
-class TextFieldInternal extends React.Component<PropsWithForwardRef, State> {
+class TextField extends React.Component<PropsWithForwardRef, State> {
     static defaultProps: DefaultProps = {
         type: "text",
         disabled: false,
@@ -343,10 +342,7 @@ const styles = StyleSheet.create({
     },
 });
 
-type ExportProps = $Diff<
-    React.ElementConfig<typeof TextFieldInternal>,
-    WithForwardRef,
->;
+type ExportProps = $Diff<React.ElementConfig<typeof TextField>, WithForwardRef>;
 
 /**
  * A TextField is an element used to accept a single line of text from the user.
@@ -365,9 +361,6 @@ type ExportProps = $Diff<
  * />
  * ```
  */
-const TextField: React.AbstractComponent<ExportProps, HTMLInputElement> =
-    React.forwardRef<ExportProps, HTMLInputElement>((props, ref) => (
-        <TextFieldInternal {...props} forwardedRef={ref} />
-    ));
-
-export default TextField;
+export default (React.forwardRef<ExportProps, HTMLInputElement>(
+    (props, ref) => <TextField {...props} forwardedRef={ref} />,
+): React.AbstractComponent<ExportProps, HTMLInputElement>);


### PR DESCRIPTION
## Summary:
We had to use "internal" class names for the components used in
`TextField` and `LabeledTextField` because Styleguidist was not able to
resolve the names properly (this was an issue with `Styleguidist` +
`forwardRef`).

Now that Styleguidist is gone, we can replace the "internal" class names
with the intended ones, as this no longer causes any issues with
Storybook.

NOTE: This is a super small change that will help us with better
readability when using React DevTools.

Issue: WB-1081

Test Plan:

Verify that all the checks pass (specially unit tests) and that the
`TextField` and `LabeledTextField` stories work fine.