### PR TITLE
hack-enzyme.8: Port `wonder-blocks-tooltip` to RTL

### DIFF
--- a/.changeset/rude-spies-enjoy.md
+++ b/.changeset/rude-spies-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+Remove an unused function in TooltipTail: `_minDistanceFromCorners`

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/__snapshots__/tooltip-tail.test.js.snap
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/__snapshots__/tooltip-tail.test.js.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`TooltipTail #render unknown placement, throws 1`] = `"Unknown placement: notaplacement"`;
-
-exports[`TooltipTail INTERNALS _calculateDimensionsFromPlacement throws on bad placement 1`] = `"Unknown placement: notaplacement"`;
-
-exports[`TooltipTail INTERNALS _getFilterPositioning throws on bad placement 1`] = `"Unknown placement: notaplacement"`;
-
-exports[`TooltipTail INTERNALS _minDistanceFromCorners throws on bad placement 1`] = `"Unknown placement: notaplacement"`;

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
@@ -41,11 +41,6 @@ describe("TooltipAnchor", () => {
 
     test("on mount, subscribes to focus and hover events", () => {
         // Arrange
-        const nodes = (
-            <TooltipAnchor anchorRef={() => {}} onActiveChanged={() => {}}>
-                Anchor text
-            </TooltipAnchor>
-        );
         const addEventListenerSpy = jest.spyOn(
             HTMLElement.prototype,
             "addEventListener",
@@ -53,7 +48,11 @@ describe("TooltipAnchor", () => {
         addEventListenerSpy.mockClear();
 
         // Act
-        render(nodes);
+        render(
+            <TooltipAnchor anchorRef={() => {}} onActiveChanged={() => {}}>
+                Anchor text
+            </TooltipAnchor>,
+        );
 
         // Assert
         expect(addEventListenerSpy).toHaveBeenCalledWith(
@@ -76,17 +75,16 @@ describe("TooltipAnchor", () => {
 
     test("on unmount, unsubscribes from focus and hover events", () => {
         // Arrange
-        const nodes = (
-            <TooltipAnchor anchorRef={() => {}} onActiveChanged={() => {}}>
-                Anchor text
-            </TooltipAnchor>
-        );
         const removeEventListenerSpy = jest.spyOn(
             HTMLElement.prototype,
             "removeEventListener",
         );
         removeEventListenerSpy.mockClear();
-        const wrapper = render(nodes);
+        const wrapper = render(
+            <TooltipAnchor anchorRef={() => {}} onActiveChanged={() => {}}>
+                Anchor text
+            </TooltipAnchor>,
+        );
 
         // Act
         wrapper.unmount();
@@ -110,19 +108,39 @@ describe("TooltipAnchor", () => {
         );
     });
 
+    test("ref is properly set", () => {
+        // Arrange
+        const anchorRef = jest.fn();
+
+        render(
+            <TooltipAnchor
+                forceAnchorFocusivity={true}
+                anchorRef={anchorRef}
+                onActiveChanged={() => {}}
+            >
+                <View id="portal">This is the anchor</View>
+            </TooltipAnchor>,
+        );
+
+        // Act
+        const result = screen.getByText("This is the anchor");
+
+        // Assert
+        expect(anchorRef).toHaveBeenCalledWith(result);
+    });
+
     describe("forceAnchorFocusivity is true", () => {
         test("if not set, sets tabindex on anchor target", () => {
             // Arrange
-            const nodes = (
+            render(
                 <TooltipAnchor
                     forceAnchorFocusivity={true}
                     anchorRef={jest.fn()}
                     onActiveChanged={() => {}}
                 >
                     <View id="portal">This is the anchor</View>
-                </TooltipAnchor>
+                </TooltipAnchor>,
             );
-            render(nodes);
 
             // Act
             const result = screen.getByText("This is the anchor");
@@ -133,16 +151,15 @@ describe("TooltipAnchor", () => {
 
         test("if tabindex already set, leaves it as-is", () => {
             // Arrange
-            const nodes = (
+            render(
                 <TooltipAnchor
                     forceAnchorFocusivity={true}
                     anchorRef={jest.fn()}
                     onActiveChanged={() => {}}
                 >
                     <View tabIndex={-1}>This is the anchor</View>
-                </TooltipAnchor>
+                </TooltipAnchor>,
             );
-            render(nodes);
 
             // Act
             const result = screen.getByText("This is the anchor");
@@ -459,7 +476,7 @@ describe("TooltipAnchor", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             let activeState = false;
-            const nodes = (
+            render(
                 <TooltipAnchor
                     anchorRef={jest.fn()}
                     onActiveChanged={(active) => {
@@ -467,9 +484,8 @@ describe("TooltipAnchor", () => {
                     }}
                 >
                     Anchor Text
-                </TooltipAnchor>
+                </TooltipAnchor>,
             );
-            render(nodes);
 
             // Focus the anchor
             userEvent.tab();

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
@@ -1,10 +1,8 @@
-/* eslint-disable max-lines */
-/* eslint-disable no-unused-vars */
 // @flow
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {mount} from "enzyme";
-import "jest-enzyme";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import TooltipAnchor from "../tooltip-anchor.js";
 import {
@@ -55,7 +53,7 @@ describe("TooltipAnchor", () => {
         addEventListenerSpy.mockClear();
 
         // Act
-        mount(nodes);
+        render(nodes);
 
         // Assert
         expect(addEventListenerSpy).toHaveBeenCalledWith(
@@ -88,7 +86,7 @@ describe("TooltipAnchor", () => {
             "removeEventListener",
         );
         removeEventListenerSpy.mockClear();
-        const wrapper = mount(nodes);
+        const wrapper = render(nodes);
 
         // Act
         wrapper.unmount();
@@ -113,122 +111,116 @@ describe("TooltipAnchor", () => {
     });
 
     describe("forceAnchorFocusivity is true", () => {
-        test("if not set, sets tabindex on anchor target", async () => {
+        test("if not set, sets tabindex on anchor target", () => {
             // Arrange
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        forceAnchorFocusivity={true}
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        <View id="portal">This is the anchor</View>
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            const nodes = (
+                <TooltipAnchor
+                    forceAnchorFocusivity={true}
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                >
+                    <View id="portal">This is the anchor</View>
+                </TooltipAnchor>
+            );
+            render(nodes);
 
             // Act
-            const result = ref?.getAttribute("tabindex");
+            const result = screen.getByText("This is the anchor");
 
             // Assert
-            expect(result).toBe("0");
+            expect(result).toHaveAttribute("tabindex", "0");
         });
 
-        test("if tabindex already set, leaves it as-is", async () => {
+        test("if tabindex already set, leaves it as-is", () => {
             // Arrange
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        forceAnchorFocusivity={true}
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        <View tabIndex={-1}>This is the anchor</View>
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            const nodes = (
+                <TooltipAnchor
+                    forceAnchorFocusivity={true}
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                >
+                    <View tabIndex={-1}>This is the anchor</View>
+                </TooltipAnchor>
+            );
+            render(nodes);
 
             // Act
-            const result = ref?.getAttribute("tabindex");
+            const result = screen.getByText("This is the anchor");
 
             // Assert
-            expect(result).toBe("-1");
+            expect(result).toHaveAttribute("tabindex", "-1");
         });
     });
 
     describe("forceAnchorFocusivity is false", () => {
-        test("does not set tabindex on anchor target", async () => {
+        test("does not set tabindex on anchor target", () => {
             // Arrange
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        forceAnchorFocusivity={false}
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        <View>This is the anchor</View>
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            render(
+                <TooltipAnchor
+                    forceAnchorFocusivity={false}
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                >
+                    <View>This is the anchor</View>
+                </TooltipAnchor>,
+            );
 
             // Act
-            const result = ref?.getAttribute("tabindex");
+            const result = screen.getByText("This is the anchor");
 
             // Assert
-            expect(result).toBeNull();
+            expect(result).not.toHaveAttribute("tabindex");
         });
 
         test("if we had added tabindex, removes it", async () => {
             // Arrange
-            let wrapper;
-            const ref = await new Promise((resolve) => {
-                const TestFixture = (props: any) => (
-                    <TooltipAnchor
-                        forceAnchorFocusivity={props.force}
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        <View>This is the anchor</View>
-                    </TooltipAnchor>
-                );
-                wrapper = mount(<TestFixture force={true} />);
-            });
+            const TestFixture = (props: any) => (
+                <TooltipAnchor
+                    forceAnchorFocusivity={props.force}
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                >
+                    <View>This is the anchor</View>
+                </TooltipAnchor>
+            );
+            const {rerender} = render(<TestFixture force={true} />);
 
             // Act
-            const tabindex = ref?.getAttribute("tabindex");
-            expect(tabindex).toBe("0");
+            expect(screen.getByText("This is the anchor")).toHaveAttribute(
+                "tabindex",
+                "0",
+            );
 
-            wrapper?.setProps({force: false});
-            const result = ref?.getAttribute("tabindex");
+            rerender(<TestFixture force={false} />);
 
             // Assert
-            expect(result).toBeNull();
+            expect(screen.getByText("This is the anchor")).not.toHaveAttribute(
+                "tabindex",
+            );
         });
 
         test("if we had not added tabindex, leaves it", async () => {
             // Arrange
-            const ref = await new Promise((resolve) => {
-                const TestFixture = (props: any) => (
-                    <TooltipAnchor
-                        forceAnchorFocusivity={props.force}
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        <View tabIndex={-1}>This is the anchor</View>
-                    </TooltipAnchor>
-                );
-                const wrapper = mount(<TestFixture force={true} />);
-                wrapper.setProps({force: false});
-            });
+            const TestFixture = (props: any) => (
+                <TooltipAnchor
+                    forceAnchorFocusivity={props.force}
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                >
+                    <View tabIndex={-1}>This is the anchor</View>
+                </TooltipAnchor>
+            );
+
+            const wrapper = render(<TestFixture force={true} />);
 
             // Act
-            const result = ref?.getAttribute("tabindex");
+            wrapper.rerender(<TestFixture force={false} />);
 
             // Assert
-            expect(result).not.toBeNull();
+            expect(screen.getByText("This is the anchor")).toHaveAttribute(
+                "tabindex",
+                "-1",
+            );
         });
     });
 
@@ -248,26 +240,20 @@ describe("TooltipAnchor", () => {
 
             let activeState = false;
 
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
             // Act
-            // Let's fake a focusin (this is the event that the anchor gets
-            // whether focused directly or a child is focused). We have to
-            // fake directly because there's no real browser here handling
-            // focus and real events.
-            ref?.dispatchEvent(new FocusEvent("focusin"));
+            // Let's focus the anchor
+            userEvent.tab();
             // Check that we didn't go active before the delay
             expect(activeState).toBe(false);
             expect(timeoutSpy).toHaveBeenLastCalledWith(
@@ -293,26 +279,21 @@ describe("TooltipAnchor", () => {
             mockTracker.steal.mockImplementationOnce(() => true);
 
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
             // Act
-            // Let's fake a focusin (this is the event that the anchor gets
-            // whether focused directly or a child is focused). We have to
-            // fake directly because there's no real browser here handling
-            // focus and real events.
-            ref?.dispatchEvent(new FocusEvent("focusin"));
+            // Let's focus the anchor
+            userEvent.tab();
 
             // Assert
             expect(activeState).toBe(true);
@@ -320,25 +301,24 @@ describe("TooltipAnchor", () => {
     });
 
     describe("loses keyboard focus", () => {
-        test("active state was not stolen, active is set to false with delay", async () => {
+        test("active state was not stolen, active is set to false with delay", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
 
-            ref?.dispatchEvent(new FocusEvent("focusin"));
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+
+            // Let's focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -347,8 +327,8 @@ describe("TooltipAnchor", () => {
             expect(activeState).toBe(true);
 
             // Act
-            ref?.dispatchEvent(new FocusEvent("focusout"));
-            expect(activeState).toBe(true);
+            // Let's blur the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipDisappearanceDelay,
@@ -370,21 +350,19 @@ describe("TooltipAnchor", () => {
             const mockTracker = ActiveTracker.mock.instances[0];
 
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
-            ref?.dispatchEvent(new FocusEvent("focusin"));
+            // Let's focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -393,8 +371,8 @@ describe("TooltipAnchor", () => {
             expect(activeState).toBe(true);
 
             // Act
-            ref?.dispatchEvent(new FocusEvent("focusout"));
-            expect(activeState).toBe(true);
+            // Let's blur the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipDisappearanceDelay,
@@ -405,26 +383,24 @@ describe("TooltipAnchor", () => {
             expect(mockTracker.giveup).toHaveBeenCalledTimes(1);
         });
 
-        test("active state was stolen, active is set to false immediately", async () => {
+        test("active state was stolen, active is set to false immediately", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
-            let wrapper;
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                wrapper = mount(nodes);
-            });
 
-            ref?.dispatchEvent(new FocusEvent("focusin"));
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+
+            // Focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -433,8 +409,9 @@ describe("TooltipAnchor", () => {
             expect(activeState).toBe(true);
 
             // Act
-            ref?.dispatchEvent(new FocusEvent("focusout"));
-            wrapper?.instance().activeStateStolen();
+            // Blur the anchor
+            userEvent.tab();
+            jest.runOnlyPendingTimers();
 
             // Assert
             expect(activeState).toBe(false);
@@ -450,22 +427,19 @@ describe("TooltipAnchor", () => {
             // $FlowFixMe[prop-missing]
             const mockTracker = ActiveTracker.mock.instances[0];
             // Arrange
-            let wrapper;
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                wrapper = mount(nodes);
-            });
-            ref?.dispatchEvent(new FocusEvent("focusin"));
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+            // Focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -474,41 +448,42 @@ describe("TooltipAnchor", () => {
             expect(activeState).toBe(true);
 
             // Act
-            ref?.dispatchEvent(new FocusEvent("focusout"));
-            wrapper?.instance().activeStateStolen();
+            // Blur the anchor
+            userEvent.tab();
 
             // Assert
             expect(mockTracker.giveup).not.toHaveBeenCalled();
         });
 
-        test("if hovered, remains active", async () => {
+        test("if hovered, remains active", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
-            ref?.dispatchEvent(new FocusEvent("focusin"));
+            const nodes = (
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>
+            );
+            render(nodes);
+
+            // Focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
             );
             jest.runOnlyPendingTimers();
             timeoutSpy.mockClear();
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+            userEvent.hover(screen.getByText("Anchor Text"));
 
             // Act
-            ref?.dispatchEvent(new FocusEvent("focusout"));
+            // Blur the anchor
+            userEvent.tab();
 
             // Assert
             // Make sure that we're not delay hiding as well.
@@ -532,22 +507,20 @@ describe("TooltipAnchor", () => {
             mockTracker.steal.mockImplementationOnce(() => false);
 
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+            userEvent.hover(screen.getByText("Anchor Text"));
             // Check that we didn't go active before the delay
             expect(activeState).toBe(false);
             expect(timeoutSpy).toHaveBeenLastCalledWith(
@@ -573,22 +546,20 @@ describe("TooltipAnchor", () => {
             mockTracker.steal.mockImplementationOnce(() => true);
 
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+            userEvent.hover(screen.getByText("Anchor Text"));
 
             // Assert
             expect(activeState).toBe(true);
@@ -596,24 +567,23 @@ describe("TooltipAnchor", () => {
     });
 
     describe("is unhovered", () => {
-        test("active state was not stolen, active is set to false with delay", async () => {
+        test("active state was not stolen, active is set to false with delay", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+
+            userEvent.hover(screen.getByText("Anchor Text"));
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -622,7 +592,7 @@ describe("TooltipAnchor", () => {
             expect(activeState).toBe(true);
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseleave"));
+            userEvent.unhover(screen.getByText("Anchor Text"));
             expect(activeState).toBe(true);
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
@@ -644,20 +614,19 @@ describe("TooltipAnchor", () => {
             // $FlowFixMe[prop-missing]
             const mockTracker = ActiveTracker.mock.instances[0];
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+
+            userEvent.hover(screen.getByText("Anchor Text"));
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -666,7 +635,7 @@ describe("TooltipAnchor", () => {
             expect(activeState).toBe(true);
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseleave"));
+            userEvent.unhover(screen.getByText("Anchor Text"));
             expect(activeState).toBe(true);
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
@@ -678,25 +647,23 @@ describe("TooltipAnchor", () => {
             expect(mockTracker.giveup).toHaveBeenCalledTimes(1);
         });
 
-        test("active state was stolen, active is set to false immediately", async () => {
+        test("active state was stolen, active is set to false immediately", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
-            let wrapper;
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                wrapper = mount(nodes);
-            });
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+
+            userEvent.hover(screen.getByText("Anchor Text"));
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -705,8 +672,8 @@ describe("TooltipAnchor", () => {
             expect(activeState).toBe(true);
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseleave"));
-            wrapper?.instance().activeStateStolen();
+            userEvent.unhover(screen.getByText("Anchor Text"));
+            jest.runOnlyPendingTimers();
 
             // Assert
             expect(activeState).toBe(false);
@@ -722,22 +689,18 @@ describe("TooltipAnchor", () => {
             // $FlowFixMe[prop-missing]
             const mockTracker = ActiveTracker.mock.instances[0];
             // Arrange
-            let wrapper;
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                wrapper = mount(nodes);
-            });
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+            userEvent.hover(screen.getByText("Anchor Text"));
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -746,8 +709,7 @@ describe("TooltipAnchor", () => {
             expect(activeState).toBe(true);
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseleave"));
-            wrapper?.instance().activeStateStolen();
+            userEvent.unhover(screen.getByText("Anchor Text"));
 
             // Assert
             expect(mockTracker.giveup).not.toHaveBeenCalled();
@@ -757,30 +719,28 @@ describe("TooltipAnchor", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+            userEvent.hover(screen.getByText("Anchor Text"));
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
             );
             jest.runOnlyPendingTimers();
             timeoutSpy.mockClear();
-            ref?.dispatchEvent(new FocusEvent("focusin"));
+            // Focus the anchor
+            userEvent.tab();
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseleave"));
+            userEvent.unhover(screen.getByText("Anchor Text"));
 
             // Assert
             // Make sure that we're not delay hiding as well.
@@ -790,24 +750,18 @@ describe("TooltipAnchor", () => {
     });
 
     describe("dismiss behavior", () => {
-        test("subscribes to keydown event on active", async () => {
+        test("subscribes to keydown event on active", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const spy = jest.spyOn(document, "addEventListener");
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            render(
+                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+            userEvent.hover(screen.getByText("Anchor Text"));
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -819,23 +773,18 @@ describe("TooltipAnchor", () => {
             expect(spy).toHaveBeenLastCalledWith("keyup", expect.any(Function));
         });
 
-        test("does not subscribe to keydown event if already active", async () => {
+        test("does not subscribe to keydown event if already active", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const spy = jest.spyOn(document, "addEventListener");
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            render(
+                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
-            ref?.dispatchEvent(new KeyboardEvent("focusin"));
+            // Focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -846,29 +795,24 @@ describe("TooltipAnchor", () => {
             spy.mockClear();
 
             // Act
-            ref?.dispatchEvent(new MouseEvent("mouseenter"));
+            userEvent.hover(screen.getByText("Anchor Text"));
 
             // Assert
             expect(spy).not.toHaveBeenCalled();
         });
 
-        test("unsubscribes from keydown event on inactive", async () => {
+        test("unsubscribes from keydown event on inactive", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const spy = jest.spyOn(document, "removeEventListener");
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            render(
+                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
-            ref?.dispatchEvent(new KeyboardEvent("focusin"));
+            // Focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -876,7 +820,8 @@ describe("TooltipAnchor", () => {
             jest.runOnlyPendingTimers();
 
             // Act
-            ref?.dispatchEvent(new KeyboardEvent("focusout"));
+            // Blur the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipDisappearanceDelay,
@@ -888,24 +833,19 @@ describe("TooltipAnchor", () => {
             expect(spy).toHaveBeenLastCalledWith("keyup", expect.any(Function));
         });
 
-        test("unsubscribes from keydown event on unmount", async () => {
+        test("unsubscribes from keydown event on unmount", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
-            let wrapper;
-            const spy = jest.spyOn(document, "removeEventListener");
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                wrapper = mount(nodes);
-            });
 
-            ref?.dispatchEvent(new KeyboardEvent("focusin"));
+            const spy = jest.spyOn(document, "removeEventListener");
+            const {unmount} = render(
+                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                    Anchor Text
+                </TooltipAnchor>,
+            );
+
+            // Focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
@@ -913,46 +853,38 @@ describe("TooltipAnchor", () => {
             jest.runOnlyPendingTimers();
 
             // Act
-            wrapper?.unmount();
+            unmount();
 
             // Assert
             expect(spy).toHaveBeenCalledTimes(1);
             expect(spy).toHaveBeenLastCalledWith("keyup", expect.any(Function));
         });
 
-        test("when active, escape dismisses tooltip", async () => {
+        test("when active, escape dismisses tooltip", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             let activeState = false;
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={(active) => {
-                            activeState = active;
-                        }}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            render(
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={(active) => {
+                        activeState = active;
+                    }}
+                >
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
-            ref?.dispatchEvent(new KeyboardEvent("focusin"));
+            // Focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,
             );
             jest.runOnlyPendingTimers();
-            const event: KeyboardEvent = (document.createEvent("Event"): any);
-            // $FlowIgnore[cannot-write]
-            event.key = "Escape";
-            // $FlowIgnore[cannot-write]
-            event.which = 27;
-            event.initEvent("keyup", true, true);
 
             // Act
-            document.dispatchEvent(event);
+            userEvent.keyboard("{esc}");
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipDisappearanceDelay,
@@ -966,19 +898,14 @@ describe("TooltipAnchor", () => {
         test("when active, escape stops event propagation", async () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
-            const ref = await new Promise((resolve) => {
-                const nodes = (
-                    <TooltipAnchor
-                        anchorRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        Anchor Text
-                    </TooltipAnchor>
-                );
-                mount(nodes);
-            });
+            render(
+                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                    Anchor Text
+                </TooltipAnchor>,
+            );
 
-            ref?.dispatchEvent(new KeyboardEvent("focusin"));
+            // Focus the anchor
+            userEvent.tab();
             expect(timeoutSpy).toHaveBeenLastCalledWith(
                 expect.any(Function),
                 TooltipAppearanceDelay,

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-bubble.test.js
@@ -1,16 +1,11 @@
 // @flow
 import * as React from "react";
-import * as ReactDOM from "react-dom";
-import {mount} from "enzyme";
-import "jest-enzyme";
+import {render, screen} from "@testing-library/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
 import TooltipBubble from "../tooltip-bubble.js";
 import typeof TooltipContent from "../tooltip-content.js";
-
-const sleep = (duration = 0) =>
-    new Promise((resolve, reject) => setTimeout(resolve, duration));
 
 describe("TooltipBubble", () => {
     // A little helper method to make the actual test more readable.
@@ -27,55 +22,43 @@ describe("TooltipBubble", () => {
 
     test("updates reference to bubble container", async () => {
         // Arrange
-        const bubbleNode = await new Promise((resolve) => {
-            // Get some props and set the ref to our assert, that way we assert
-            // when the bubble component is mounted.
-            const props = makePopperProps();
+        // Get some props and set the ref to our assert, that way we assert
+        // when the bubble component is mounted.
+        const props = makePopperProps();
 
-            // Do some casting to pretend this is `TooltipContent`. That way
-            // we are isolating behaviors a bit more.
-            const fakeContent = (((
-                <View id="content">Some content</View>
-            ): any): React.Element<TooltipContent>);
-            const nodes = (
-                <View>
-                    <TooltipBubble
-                        id="bubble"
-                        placement={props.placement}
-                        tailOffset={props.tailOffset}
-                        updateBubbleRef={resolve}
-                        onActiveChanged={() => {}}
-                    >
-                        {fakeContent}
-                    </TooltipBubble>
-                </View>
-            );
+        // Do some casting to pretend this is `TooltipContent`. That way we are
+        // isolating behaviors a bit more.
+        const fakeContent = (((
+            <View id="content">Some content</View>
+        ): any): React.Element<TooltipContent>);
 
-            // Act
-            mount(nodes);
-        });
-
-        /**
-         * All we're doing is making sure we got called and verifying that
-         * we got called with an element we expect.
-         */
-        // Assert
-        // Did we get a node?
-        expect(bubbleNode).toBeDefined();
+        // Act
+        render(
+            <View>
+                <TooltipBubble
+                    id="bubble"
+                    placement={props.placement}
+                    tailOffset={props.tailOffset}
+                    updateBubbleRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                >
+                    {fakeContent}
+                </TooltipBubble>
+            </View>,
+        );
 
         // Is the node a mounted element?
-        const realElement = ReactDOM.findDOMNode(bubbleNode);
-        expect(realElement instanceof Element).toBeTruthy();
+        const tooltip = await screen.findByRole("tooltip");
 
-        // Keep flow happy...
-        if (realElement instanceof Element) {
-            // Did we apply our data attribute?
-            expect(realElement.getAttribute("data-placement")).toBe("top");
+        /**
+         * All we're doing is making sure we got called and verifying that we
+         * got called with an element we expect.
+         */
+        // Assert
+        // Did we apply our data attribute?
+        expect(tooltip.getAttribute("data-placement")).toBe("top");
 
-            // Did we render our content?
-            await sleep();
-            const contentElement = document.getElementById("content");
-            expect(contentElement).toBeDefined();
-        }
+        // Did we render our content?
+        expect(screen.getByText("Some content")).toBeInTheDocument();
     });
 });

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-popper.test.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {mount} from "enzyme";
-import "jest-enzyme";
+import {render} from "@testing-library/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
@@ -58,7 +57,7 @@ describe("TooltipPopper", () => {
                     <TestHarness placement="bottom" resultRef={resolve} />
                 </View>
             );
-            mount(nodes);
+            render(nodes);
         });
 
         if (!ref) {

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import {shallow} from "enzyme";
+import {render} from "@testing-library/react";
 
 import TooltipTail from "../tooltip-tail.js";
 
@@ -14,10 +14,12 @@ describe("TooltipTail", () => {
             const nodes = <TooltipTail placement={fakePlacement} />;
 
             // Act
-            const underTest = () => shallow(nodes);
+            const underTest = () => render(nodes);
 
             // Assert
-            expect(underTest).toThrowErrorMatchingSnapshot();
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(
+                `"Unknown placement: notaplacement"`,
+            );
         });
 
         test("known placement, does not throw", () => {
@@ -26,92 +28,12 @@ describe("TooltipTail", () => {
             const makeNode = (p) => <TooltipTail placement={p} />;
 
             // Act
-            const testees = testPoints.map((tp) => () => shallow(makeNode(tp)));
+            const testees = testPoints.map((tp) => () => render(makeNode(tp)));
 
             // Assert
             for (const testee of testees) {
                 expect(testee).not.toThrowError();
             }
-        });
-    });
-
-    describe("INTERNALS", () => {
-        // We have some code internally that is there for code maintenance to
-        // catch if we add a new placement string and forget to update one of
-        // our methods. These tests are to verify those maintenance checks
-        // so they poke at the insides of the TooltipTail. We only test the
-        // throw case in these examples and rely on testing the external
-        // behavior of the component to verify the expected execution paths.
-        test("_getFilterPositioning throws on bad placement", () => {
-            // Arrange
-            const fakePlacement = (("notaplacement": any): Placement);
-            // We need an instance so let's make one with a valid placement so
-            // that we can render it.
-            const nodes = <TooltipTail placement="top" />;
-            const wrapper = shallow(nodes);
-            const tailInstance = wrapper.instance();
-            // Sneakily change props so as not to re-render.
-            // This means getting rid of the read-only props and
-            // recreating so that we can write a fake placement value
-            // for testing.
-            const oldProps = tailInstance.props;
-            // $FlowIgnore
-            delete tailInstance.props;
-            tailInstance.props = {
-                ...oldProps,
-                placement: fakePlacement,
-            };
-
-            // Act
-            const underTest = () => tailInstance._getFilterPositioning();
-
-            // Assert
-            expect(underTest).toThrowErrorMatchingSnapshot();
-        });
-
-        test("_calculateDimensionsFromPlacement throws on bad placement", () => {
-            // Arrange
-            const fakePlacement = (("notaplacement": any): Placement);
-            // We need an instance so let's make one with a valid placement so
-            // that we can render it.
-            const nodes = <TooltipTail placement="top" />;
-            const wrapper = shallow(nodes);
-            const tailInstance = wrapper.instance();
-            // Sneakily change props so as not to re-render.
-            // This means getting rid of the read-only props and
-            // recreating so that we can write a fake placement value
-            // for testing.
-            const oldProps = tailInstance.props;
-            // $FlowIgnore
-            delete tailInstance.props;
-            tailInstance.props = {
-                ...oldProps,
-                placement: fakePlacement,
-            };
-
-            // Act
-            const underTest = () =>
-                tailInstance._calculateDimensionsFromPlacement();
-
-            // Assert
-            expect(underTest).toThrowErrorMatchingSnapshot();
-        });
-
-        test("_minDistanceFromCorners throws on bad placement", () => {
-            // Arrange
-            const fakePlacement = (("notaplacement": any): Placement);
-            // We need an instance so let's make one with a valid placement so
-            // that we can render it.
-            const nodes = <TooltipTail placement="top" />;
-            const wrapper = shallow(nodes);
-            const tailInstance = wrapper.instance();
-
-            // Act
-            const underTest = () =>
-                tailInstance._minDistanceFromCorners(fakePlacement);
-
-            // Assert
-            expect(underTest).toThrowErrorMatchingSnapshot();
         });
     });
 });

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.js
@@ -247,24 +247,6 @@ export default class TooltipTail extends React.Component<Props> {
         ];
     }
 
-    _minDistanceFromCorners(placement: Placement): number {
-        const minDistanceFromCornersForTopBottom = Spacing.medium_16;
-        const minDistanceFromCornersForLeftRight = 7;
-
-        switch (placement) {
-            case "top":
-            case "bottom":
-                return minDistanceFromCornersForTopBottom;
-
-            case "left":
-            case "right":
-                return minDistanceFromCornersForLeftRight;
-
-            default:
-                throw new Error(`Unknown placement: ${placement}`);
-        }
-    }
-
     _getFullTailWidth(): number {
         return ARROW_WIDTH + 2 * MIN_DISTANCE_FROM_CORNERS;
     }

--- a/packages/wonder-blocks-tooltip/src/util/__tests__/ref-tracker.test.js
+++ b/packages/wonder-blocks-tooltip/src/util/__tests__/ref-tracker.test.js
@@ -1,9 +1,7 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {mount} from "enzyme";
-import "jest-enzyme";
-
+import {render} from "@testing-library/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 
 import RefTracker from "../ref-tracker.js";
@@ -57,7 +55,7 @@ describe("RefTracker", () => {
                             <View ref={resolve} />
                         </View>
                     );
-                    mount(nodes);
+                    render(nodes);
                 });
                 const domNode = ReactDOM.findDOMNode(ref);
                 tracker.updateRef(ref);
@@ -93,7 +91,7 @@ describe("RefTracker", () => {
                             <View ref={resolve} />
                         </View>
                     );
-                    mount(nodes);
+                    render(nodes);
                 });
 
                 // Act
@@ -115,7 +113,7 @@ describe("RefTracker", () => {
                             <View ref={resolve} />
                         </View>
                     );
-                    mount(nodes);
+                    render(nodes);
                 });
                 const domNode = ReactDOM.findDOMNode(ref);
 
@@ -138,7 +136,7 @@ describe("RefTracker", () => {
                             <View ref={resolve} />
                         </View>
                     );
-                    mount(nodes);
+                    render(nodes);
                 });
                 tracker.updateRef(ref);
                 targetFn.mockClear();


### PR DESCRIPTION
Summary:

Final part of the porting of `wonder-blocks` from Enzyme to RTL.

This ports the `wonder-blocks-tooltip` package.


Test Plan:

```
yarn test
```