### PR TITLE
Make the refetch callback from `useCachedEffect` return a promise

### DIFF
--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
@@ -744,5 +744,25 @@ describe("#useCachedEffect", () => {
                 expect(onResultChanged).toHaveBeenCalledTimes(1);
             },
         );
+
+        it("should resolve the promise returned by refetch with the result of the request", async () => {
+            // Arrange
+            const response = Promise.resolve("DATA");
+            const fakeHandler = jest.fn().mockReturnValue(response);
+
+            // Act
+            const {
+                result: {
+                    current: [, refetch],
+                },
+            } = clientRenderHook(() => useCachedEffect("ID", fakeHandler));
+            let result;
+            await act(async () => {
+                result = await refetch();
+            });
+
+            // Assert
+            expect(result).toStrictEqual(Status.success("DATA"));
+        });
     });
 });

--- a/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
@@ -96,7 +96,7 @@ export const useCachedEffect = <TData: ValidCacheData>(
     options: CachedEffectOptions<TData> = ({}: $Shape<
         CachedEffectOptions<TData>,
     >),
-): [Result<TData>, () => void] => {
+): [Result<TData>, () => Promise<Result<TData>>] => {
     const {
         fetchPolicy = FetchPolicy.CacheBeforeNetwork,
         skip: hardSkip = false,
@@ -163,7 +163,7 @@ export const useCachedEffect = <TData: ValidCacheData>(
                 // The request inflight is the same, so do nothing.
                 // NOTE: Perhaps if invoked via a refetch, we will want to
                 // override this behavior and force a new request?
-                return;
+                return request;
             }
 
             // Clear the last network result.
@@ -213,6 +213,8 @@ export const useCachedEffect = <TData: ValidCacheData>(
                     RequestFulfillment.Default.abort(requestId);
                 },
             };
+
+            return request;
         };
 
         // Now we can return the new fetch function.


### PR DESCRIPTION
## Summary:
This makes it easier to track whether the current data is stale, and react to non-stale data arriving.

## Test plan:
`yarn test`