### PR TITLE
[🔥AUDIT🔥] Fix flow exports

### DIFF
--- a/.changeset/great-readers-jam.md
+++ b/.changeset/great-readers-jam.md
@@ -1,0 +1,5 @@
+---
+"wb-dev-build-settings": minor
+---
+
+Put back flow types with build files.

--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -147,7 +147,7 @@ jobs:
         uses: preactjs/compressed-size-action@v2
         with:
           # Specify our custom build script
-          build-script: "build:es6"
+          build-script: "build"
           # Clean up state between builds
           clean-script: "clean"
           # Any JS files anywhere within a dist directory:

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "scripts": {
     "alex": "alex packages/",
-    "build": "rollup -c ./build-settings/rollup.config.js",
-    "build:es6": "yarn run build",
+    "build": "rollup -c ./build-settings/rollup.config.js && node ./utils/package-flow-types.js",
     "build-storybook": "build-storybook",
     "clean": "rm -rf packages/wonder-blocks-*/dist && rm -rf packages/wonder-blocks-*/node_modules",
     "coverage": "yarn run test:coverage && open coverage/lcov-report/index.html",


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We recenty removed webpack from our build process (#1720) and in the
process I accidentally removed the flow exports that were being done at
the end of the webpack build script. This PR adds them back in.

Issue: XXX-XXXX

## Test plan:

Verify that the build works fine (this can be verified with the check build
sizes workflow step).

https://github.com/Khan/wonder-blocks/actions/runs/4144792470/jobs/7168301496#step:5:218