### PR TITLE
Export the CJS build as the main entry point

### DIFF
--- a/.changeset/bright-rocks-run.md
+++ b/.changeset/bright-rocks-run.md
@@ -1,0 +1,5 @@
+---
+"wb-dev-build-settings": minor
+---
+
+Re-introducing CJS bundles (using Rollup)

--- a/build-settings/rollup.config.js
+++ b/build-settings/rollup.config.js
@@ -13,10 +13,21 @@ const createConfig = (pkgName) => {
     }
 
     return {
-        output: {
-            file: `packages/${pkgName}/dist/es/index.js`,
-            format: "esm",
-        },
+        output: [
+            // Used by production code.
+            {
+                file: `packages/${pkgName}/dist/es/index.js`,
+                format: "esm",
+            },
+            // Used by Flow enums (and possibly things like Jest, Storybook).
+            // TODO(FEI-5000): We will be able to only use the esm version once
+            // we fully migrate to TypeScript (as we don't have to depend on the
+            // flow-enums-runtime package).
+            {
+                file: `packages/${pkgName}/dist/index.js`,
+                format: "cjs",
+            },
+        ],
         input: `packages/${pkgName}/src/index.js`,
         plugins: [
             babel({


### PR DESCRIPTION
## Summary:
We recently removed Webpack from the build process, but we still need to
export the CJS build as the main entry point.

This is because the CJS build is the only one that works for some
particular cases such as when we use the `flow-enums-runtime` package.

In this Flow enums case, this happens because FlowJS needs to convert
the enums to code that can be executed at runtime. This is done by the
`babel-plugin-transform-flow-enums` plugin, which is configured to
transform enums from:

```
enum Foo {
  Bar,
  Baz,
};
```

to:

```
const Foo = require("flow-enums-runtime").Mirrored(["Bar", "Baz"]);
```

The problem with this is that the `flow-enums-runtime` package expects
us to import the CJS build, so it can import the module via `require`.

I attempted to fix this by changing the
`babel-plugin-transform-flow-enums` plugin to use a custom runtime, but
the problem is that the plugin is not fully configurable, so we cannot
change the output to something that allow us to staticly import the ESM
build.

e.g. (this won't work)
```
import { Mirrored } from "flow-enums-runtime";
const Foo = Mirrored(["Bar", "Baz"]);
```
The `getRuntime` is only capable of transforming the enum in a single
line.

This commit changes the `rollup.config.js` file to export the CJS build
as the main entry point, so we don't break the `flow-enums-runtime`
transform (that is used by Storybook in webapp).

Issue: XXX-XXXX

## Test plan: