### PR TITLE
FEI-4957: Update to use migrated wonder-stuff packages

### DIFF
--- a/.changeset/curly-meals-sing.md
+++ b/.changeset/curly-meals-sing.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+"@khanacademy/wonder-blocks-icon": patch
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Update wonder-stuff dependencies to use newly published packages after migrating wonder-stuff to TypeScript

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-react": "^7.18.6",
     "@changesets/cli": "^2.18.0",
     "@khanacademy/eslint-config": "^0.2.0",
-    "@khanacademy/wonder-stuff-testing": "^0.0.2",
+    "@khanacademy/wonder-stuff-testing": "^2.3.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@storybook/addon-a11y": "^6.5.15",
     "@storybook/addon-essentials": "^6.5.13",
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-stuff-core": "^1.0.1",
+    "@khanacademy/wonder-stuff-core": "^1.2.0",
     "@popperjs/core": "^2.11.5",
     "aphrodite": "^1.2.5",
     "moment": "2.24.0",

--- a/packages/wonder-blocks-data/package.json
+++ b/packages/wonder-blocks-data/package.json
@@ -17,7 +17,7 @@
     "@khanacademy/wonder-blocks-core": "^4.6.2"
   },
   "peerDependencies": {
-    "@khanacademy/wonder-stuff-core": "^1.0.1",
+    "@khanacademy/wonder-stuff-core": "^1.2.0",
     "flow-enums-runtime": "^0.0.6",
     "react": "16.14.0"
   },

--- a/packages/wonder-blocks-icon/package.json
+++ b/packages/wonder-blocks-icon/package.json
@@ -19,7 +19,7 @@
     "@khanacademy/wonder-blocks-core": "^4.6.2"
   },
   "devDependencies": {
-    "@khanacademy/wonder-stuff-core": "^1.0.1",
+    "@khanacademy/wonder-stuff-core": "^1.2.0",
     "wb-dev-build-settings": "^0.7.0"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-icon/src/components/__docs__/icon.stories.js
+++ b/packages/wonder-blocks-icon/src/components/__docs__/icon.stories.js
@@ -5,8 +5,9 @@ import {entries} from "@khanacademy/wonder-stuff-core";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Icon, {icons, type IconAsset} from "@khanacademy/wonder-blocks-icon";
+import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 
 import ComponentInfo from "../../../../../.storybook/components/component-info.js";
 import {name, version} from "../../../package.json";
@@ -96,18 +97,23 @@ Sizes.parameters = {
 };
 
 export const Variants: StoryComponentType = () => {
-    const iconsWithLabels = entries<IconAsset>(icons).map(([name, icon]) => {
-        return (
-            <tr>
-                <td>
-                    <Icon icon={icon} />
-                </td>
-                <td>
-                    <LabelMedium>{name}</LabelMedium>
-                </td>
-            </tr>
-        );
-    });
+    // TODO(FEI-5018): Replace with Object.entries() after TS migration and get rid of
+    // `any` in callback.  We may need to specify `IconAsset` as a type param.  This
+    // doesn't work with Flow + Storybook for some reason.
+    const iconsWithLabels = entries(icons).map(
+        ([name, icon]: [string, any]) => {
+            return (
+                <tr>
+                    <td>
+                        <Icon icon={icon} />
+                    </td>
+                    <td>
+                        <LabelMedium>{name}</LabelMedium>
+                    </td>
+                </tr>
+            );
+        },
+    );
 
     return <table>{iconsWithLabels}</table>;
 };

--- a/packages/wonder-blocks-icon/src/components/__docs__/icon.stories.js
+++ b/packages/wonder-blocks-icon/src/components/__docs__/icon.stories.js
@@ -96,7 +96,7 @@ Sizes.parameters = {
 };
 
 export const Variants: StoryComponentType = () => {
-    const iconsWithLabels = entries(icons).map(([name, icon]) => {
+    const iconsWithLabels = entries<IconAsset>(icons).map(([name, icon]) => {
         return (
             <tr>
                 <td>

--- a/packages/wonder-blocks-icon/src/index.js
+++ b/packages/wonder-blocks-icon/src/index.js
@@ -1,11 +1,8 @@
 // @flow
 import Icon from "./components/icon.js";
-import * as iconAssets from "./util/icon-assets.js";
 import type {IconAsset, IconSize} from "./util/icon-assets.js";
 
-// $FlowIgnore[prop-missing]: Flow doesn't know about __esModule
-const {__esModule: _, ...icons} = iconAssets;
+export * as icons from "./util/icon-assets.js";
 
 export type {IconAsset, IconSize};
-export {icons};
 export default Icon;

--- a/packages/wonder-blocks-testing/package.json
+++ b/packages/wonder-blocks-testing/package.json
@@ -17,8 +17,8 @@
         "@khanacademy/wonder-blocks-data": "^10.0.4"
     },
     "peerDependencies": {
-        "@khanacademy/wonder-stuff-core": "^0.1.2",
-        "@khanacademy/wonder-stuff-testing": "^0.0.2",
+        "@khanacademy/wonder-stuff-core": "^1.2.0",
+        "@khanacademy/wonder-stuff-testing": "^2.3.1",
         "@storybook/addon-actions": "^6.4.8",
         "node-fetch": "^2.6.7",
         "aphrodite": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,15 +1987,17 @@
   resolved "https://registry.yarnpkg.com/@khanacademy/eslint-config/-/eslint-config-0.2.0.tgz#e9f57e743be10f74409eb79df7147081e0a8535f"
   integrity sha512-yCzXifPo1Bo/r2YF7j92TEXAguBUSZOef2scwSD5upDJ5CR+pHW64tBtDfC2NVLm/72CilKXcroxJ7y9B92q1g==
 
-"@khanacademy/wonder-stuff-core@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-stuff-core/-/wonder-stuff-core-1.0.1.tgz#6b24b733989739163246c3ba1870c1f4ff69e69d"
-  integrity sha512-6sedAWBdnZQlLQmc23ATwsF582BZ9XrDmWiawK1JjCJ2DnOITuvjMoeSF+TO4XnXech05xeAhupIK7ldZz2hcg==
+"@khanacademy/wonder-stuff-core@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-stuff-core/-/wonder-stuff-core-1.2.0.tgz#0b9f86e4dd74e1892ed5322077b292dcf08e3258"
+  integrity sha512-8koYnMHN6FuiR2Fthe9IvySa2T7fHAMfwQAJM8VL0QFfYlI/NfGzoCkgg4Sy8PFxc71i/xlG9n77nAFb+nYWOg==
 
-"@khanacademy/wonder-stuff-testing@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-stuff-testing/-/wonder-stuff-testing-0.0.2.tgz#617d3326e4337af52f5dd2eb763f1b490d04eaec"
-  integrity sha512-ho0O7bETUCrLNoRBi3EIQhjl2LilpCeidB9X329bDiY43/YVVvWJ06bCGFJieSdCpz+NHsimOTIVFEL+KoqESw==
+"@khanacademy/wonder-stuff-testing@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-stuff-testing/-/wonder-stuff-testing-2.3.1.tgz#bc1fbd3a46610e2a2fb663226de26dc28e65003e"
+  integrity sha512-OJ/bzp5aPuJrkBTcXU5dMa7gVScCUdkCnNqlnbqJVY4PfVp7kBebCS+4WMSsJYTsgC0dOvHrzgEf3aEwp6KG0A==
+  dependencies:
+    "@khanacademy/wonder-stuff-core" "^1.2.0"
 
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Summary:
This PR also fixes a Flow error with one of the uses of 'entries()' and tweaks out we export icons to use 'export * from'.  We use this pattern in wonder-stuff as well.

Issue: FEI-4957

## Test plan:
- yarn flow
- yarn lint
- yarn start
- verify that http://localhost:6061/?path=/story/icon-icon--variants loads without any issues
- let CI run the remainder of the checks