### PR TITLE
FEI-4966.1: Remove file extensions from all imports/requires

### DIFF
--- a/.changeset/plenty-buses-design.md
+++ b/.changeset/plenty-buses-design.md
@@ -1,0 +1,31 @@
+---
+"wb-dev-build-settings": patch
+"@khanacademy/wonder-blocks-banner": patch
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-color": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-data": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-i18n": patch
+"@khanacademy/wonder-blocks-icon": patch
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-layout": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-progress-spinner": patch
+"@khanacademy/wonder-blocks-search-field": patch
+"@khanacademy/wonder-blocks-testing": patch
+"@khanacademy/wonder-blocks-timing": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-typography": patch
+---
+
+Remove file extensions from imports

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,7 @@ module.exports = {
         "import/no-named-default": "error",
         "import/extensions": [
             "error",
-            "always",
+            "never",
             {
                 ignorePackages: true,
             },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,9 @@ module.exports = {
             "never",
             {
                 ignorePackages: true,
+                pattern: {
+                    json: "always",
+                },
             },
         ],
         "jest/no-focused-tests": "error",

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,1 +1,1 @@
-module.exports = require("@khanacademy/eslint-config/.prettierrc.js");
+module.exports = require("@khanacademy/eslint-config/.prettierrc");

--- a/.storybook/.babelrc.js
+++ b/.storybook/.babelrc.js
@@ -6,7 +6,7 @@
  * We should remove this when jest is fixed.
  * See FEI-4139 in Jira.
  */
-const babelConfig = require("../build-settings/babel.config.js");
+const babelConfig = require("../build-settings/babel.config");
 module.exports = babelConfig({
     env: () => false,
 });

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -2,7 +2,7 @@
  * Configuration of storybook addons.
  */
 import {addons} from "@storybook/addons";
-import wonderBlocksTheme from "./wonder-blocks-theme.js";
+import wonderBlocksTheme from "./wonder-blocks-theme";
 
 /**
  * Configures a custom theme to add some minor WB branding to our Storybook

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,5 @@
 import React from "react";
-import wonderBlocksTheme from "./wonder-blocks-theme.js";
+import wonderBlocksTheme from "./wonder-blocks-theme";
 import {configure} from "@storybook/testing-library";
 
 import Link from "@khanacademy/wonder-blocks-link";

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,4 +4,4 @@
  * Jest looks for the babel config in the cwd of the project and as such we
  * need a file to tell it where the config really lies or it would use it.
  */
-module.exports = require("./build-settings/babel.config.js");
+module.exports = require("./build-settings/babel.config");

--- a/build-settings/rollup.config.js
+++ b/build-settings/rollup.config.js
@@ -4,7 +4,7 @@ import path from "path";
 import autoExternal from "rollup-plugin-auto-external";
 import babel from "rollup-plugin-babel";
 
-const {presets, plugins} = require("./babel.config.js")({env: () => false});
+const {presets, plugins} = require("./babel.config")({env: () => false});
 
 const createConfig = (pkgName) => {
     const packageJsonPath = path.join("packages", pkgName, "package.json");

--- a/config/jest/test-setup.js
+++ b/config/jest/test-setup.js
@@ -3,7 +3,7 @@ const {configure} = require("@testing-library/dom");
 
 const {
     mockRequestAnimationFrame,
-} = require("../../utils/testing/mock-request-animation-frame.js");
+} = require("../../utils/testing/mock-request-animation-frame");
 
 configure({
     testIdAttribute: "data-test-id",

--- a/config/jest/test.transform.js
+++ b/config/jest/test.transform.js
@@ -1,6 +1,6 @@
 const babelJest = require("babel-jest").default;
 
-const babelConfig = require("../../build-settings/babel.config.js")({
+const babelConfig = require("../../build-settings/babel.config")({
     env: () => true,
 });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,2 +1,2 @@
 /* eslint-disable import/no-commonjs */
-module.exports = require("./config/jest/test.config.js");
+module.exports = require("./config/jest/test.config");

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "flow": "flow",
     "jest": "jest --config config/jest/test.config.js",
     "lint:watch": "esw --watch --config ./eslint/eslintrc packages",
-    "lint": "eslint --config .eslintrc.js packages",
+    "lint": "eslint --config .eslintrc.js .",
     "lint:ci": "eslint --config .eslintrc.js",
     "publish:ci": "node utils/publish/pre-publish-check-ci.js && git diff --stat --exit-code HEAD && yarn build && changeset publish",
     "start": "start-storybook -p 6061",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "flow": "flow",
     "jest": "jest --config config/jest/test.config.js",
     "lint:watch": "esw --watch --config ./eslint/eslintrc packages",
-    "lint": "eslint --config .eslintrc.js .",
+    "lint": "eslint --config .eslintrc.js packages",
     "lint:ci": "eslint --config .eslintrc.js",
     "publish:ci": "node utils/publish/pre-publish-check-ci.js && git diff --stat --exit-code HEAD && yarn build && changeset publish",
     "start": "start-storybook -p 6061",

--- a/packages/wonder-blocks-banner/src/components/__docs__/banner.stories.js
+++ b/packages/wonder-blocks-banner/src/components/__docs__/banner.stories.js
@@ -13,8 +13,8 @@ import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import BannerArgTypes from "./banner.argtypes.js";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import BannerArgTypes from "./banner.argtypes";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 const bannerDescription = `

--- a/packages/wonder-blocks-banner/src/components/__tests__/banner.test.js
+++ b/packages/wonder-blocks-banner/src/components/__tests__/banner.test.js
@@ -4,7 +4,7 @@ import {render, screen} from "@testing-library/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
 
-import Banner from "../banner.js";
+import Banner from "../banner";
 
 describe("Banner", () => {
     test("having no `onDismiss` prop causes the 'X' button NOT to appear", () => {

--- a/packages/wonder-blocks-banner/src/components/banner.js
+++ b/packages/wonder-blocks-banner/src/components/banner.js
@@ -11,7 +11,7 @@ import Link from "@khanacademy/wonder-blocks-link";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
-import * as bannerIcons from "./banner-icons.js";
+import * as bannerIcons from "./banner-icons";
 
 type ActionTriggerBase = {|
     title: string,

--- a/packages/wonder-blocks-banner/src/index.js
+++ b/packages/wonder-blocks-banner/src/index.js
@@ -1,4 +1,4 @@
 // @flow
-import Banner from "./components/banner.js";
+import Banner from "./components/banner";
 
 export default Banner;

--- a/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.argtypes.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.argtypes.js
@@ -1,5 +1,5 @@
 // @flow
-import {defaultLabels} from "../birthday-picker.js";
+import {defaultLabels} from "../birthday-picker";
 
 export default {
     labels: {

--- a/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.stories.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__docs__/birthday-picker.stories.js
@@ -5,11 +5,11 @@ import {View} from "@khanacademy/wonder-blocks-core";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
-import ArgTypes from "./birthday-picker.argtypes.js";
-import BirthdayPicker from "../birthday-picker.js";
+import ArgTypes from "./birthday-picker.argtypes";
+import BirthdayPicker from "../birthday-picker";
 
 export default {
     title: "BirthdayPicker",

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.js
@@ -5,9 +5,9 @@ import {render, screen} from "@testing-library/react";
 import * as DateMock from "jest-date-mock";
 import userEvent from "@testing-library/user-event";
 
-import BirthdayPicker, {defaultLabels} from "../birthday-picker.js";
+import BirthdayPicker, {defaultLabels} from "../birthday-picker";
 
-import type {Labels} from "../birthday-picker.js";
+import type {Labels} from "../birthday-picker";
 
 describe("BirthdayPicker", () => {
     const today = new Date("2021-07-19T09:30:00Z");

--- a/packages/wonder-blocks-birthday-picker/src/index.js
+++ b/packages/wonder-blocks-birthday-picker/src/index.js
@@ -1,6 +1,6 @@
 // @flow
-import BirthdatePicker from "./components/birthday-picker.js";
-import type {Labels} from "./components/birthday-picker.js";
+import BirthdatePicker from "./components/birthday-picker";
+import type {Labels} from "./components/birthday-picker";
 
 export type {Labels};
 export default BirthdatePicker;

--- a/packages/wonder-blocks-breadcrumbs/src/components/__docs__/breadcrumbs.stories.js
+++ b/packages/wonder-blocks-breadcrumbs/src/components/__docs__/breadcrumbs.stories.js
@@ -4,11 +4,11 @@ import * as React from "react";
 import Link from "@khanacademy/wonder-blocks-link";
 import type {StoryComponentType} from "@storybook/react";
 
-import Breadcrumbs from "../breadcrumbs.js";
-import BreadcrumbsItem from "../breadcrumbs-item.js";
+import Breadcrumbs from "../breadcrumbs";
+import BreadcrumbsItem from "../breadcrumbs-item";
 
-import BreadcrumbsArgTypes from "./breadcrumbs.argtypes.js";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import BreadcrumbsArgTypes from "./breadcrumbs.argtypes";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.js
+++ b/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
-import Breadcrumbs from "../breadcrumbs.js";
-import BreadcrumbsItem from "../breadcrumbs-item.js";
+import Breadcrumbs from "../breadcrumbs";
+import BreadcrumbsItem from "../breadcrumbs-item";
 
 describe("Breadcrumbs", () => {
     it("should set aria-current to the last item", () => {

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.js
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.js
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import typeof BreadcrumbsItem from "./breadcrumbs-item.js";
+import typeof BreadcrumbsItem from "./breadcrumbs-item";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-breadcrumbs/src/index.js
+++ b/packages/wonder-blocks-breadcrumbs/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-import Breadcrumbs from "./components/breadcrumbs.js";
-import BreadcrumbsItem from "./components/breadcrumbs-item.js";
+import Breadcrumbs from "./components/breadcrumbs";
+import BreadcrumbsItem from "./components/breadcrumbs-item";
 
 export {Breadcrumbs, BreadcrumbsItem};

--- a/packages/wonder-blocks-button/src/__tests__/custom-snapshot.test.js
+++ b/packages/wonder-blocks-button/src/__tests__/custom-snapshot.test.js
@@ -2,8 +2,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-import ButtonCore from "../components/button-core.js";
-import Button from "../components/button.js";
+import ButtonCore from "../components/button-core";
+import Button from "../components/button";
 
 const defaultHandlers = {
     onClick: () => void 0,

--- a/packages/wonder-blocks-button/src/components/__docs__/button.stories.js
+++ b/packages/wonder-blocks-button/src/components/__docs__/button.stories.js
@@ -15,10 +15,10 @@ import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import type {StoryComponentType} from "@storybook/react";
 import type {StyleDeclaration} from "aphrodite";
 
-import Button from "../button.js";
+import Button from "../button";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
-import ButtonArgTypes from "./button.argtypes.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
+import ButtonArgTypes from "./button.argtypes";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-button/src/components/__tests__/button.flowtest.js
+++ b/packages/wonder-blocks-button/src/components/__tests__/button.flowtest.js
@@ -2,7 +2,7 @@
 /* eslint-disable ft-flow/no-unused-expressions */
 import * as React from "react";
 
-import Button from "../button.js";
+import Button from "../button";
 
 // $FlowExpectedError[incompatible-type]: href must be used with beforeNav
 <Button beforeNav={() => Promise.resolve()}>Hello, world!</Button>;

--- a/packages/wonder-blocks-button/src/components/__tests__/button.test.js
+++ b/packages/wonder-blocks-button/src/components/__tests__/button.test.js
@@ -4,7 +4,7 @@ import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import Button from "../button.js";
+import Button from "../button";
 
 describe("Button", () => {
     const {location} = window;

--- a/packages/wonder-blocks-button/src/components/button-core.js
+++ b/packages/wonder-blocks-button/src/components/button-core.js
@@ -20,7 +20,7 @@ import type {
     ChildrenProps,
     ClickableState,
 } from "@khanacademy/wonder-blocks-clickable";
-import type {SharedProps} from "./button.js";
+import type {SharedProps} from "./button";
 
 type Props = {|
     ...SharedProps,

--- a/packages/wonder-blocks-button/src/components/button.js
+++ b/packages/wonder-blocks-button/src/components/button.js
@@ -5,7 +5,7 @@ import {__RouterContext} from "react-router";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
-import ButtonCore from "./button-core.js";
+import ButtonCore from "./button-core";
 
 export type SharedProps = {|
     /**

--- a/packages/wonder-blocks-button/src/index.js
+++ b/packages/wonder-blocks-button/src/index.js
@@ -1,6 +1,6 @@
 // @flow
-import Button from "./components/button.js";
-import type {SharedProps} from "./components/button.js";
+import Button from "./components/button";
+import type {SharedProps} from "./components/button";
 
 export type {SharedProps as ButtonProps};
 export {Button as default};

--- a/packages/wonder-blocks-cell/src/components/__docs__/compact-cell.stories.js
+++ b/packages/wonder-blocks-cell/src/components/__docs__/compact-cell.stories.js
@@ -12,13 +12,11 @@ import type {StoryComponentType} from "@storybook/react";
 
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import CompactCellArgTypes, {
-    AccessoryMappings,
-} from "./compact-cell.argtypes.js";
+import CompactCellArgTypes, {AccessoryMappings} from "./compact-cell.argtypes";
 
-import CompactCell from "../compact-cell.js";
+import CompactCell from "../compact-cell";
 
 export default {
     title: "Cell / CompactCell",

--- a/packages/wonder-blocks-cell/src/components/__docs__/detail-cell.argtypes.js
+++ b/packages/wonder-blocks-cell/src/components/__docs__/detail-cell.argtypes.js
@@ -1,5 +1,5 @@
 // @flow
-import CompactCellArgTypes from "./compact-cell.argtypes.js";
+import CompactCellArgTypes from "./compact-cell.argtypes";
 
 export default {
     ...CompactCellArgTypes,

--- a/packages/wonder-blocks-cell/src/components/__docs__/detail-cell.stories.js
+++ b/packages/wonder-blocks-cell/src/components/__docs__/detail-cell.stories.js
@@ -10,11 +10,11 @@ import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import DetailCellArgTypes from "./detail-cell.argtypes.js";
+import DetailCellArgTypes from "./detail-cell.argtypes";
 
-import DetailCell from "../detail-cell.js";
+import DetailCell from "../detail-cell";
 
 export default {
     title: "Cell / DetailCell",

--- a/packages/wonder-blocks-cell/src/components/__tests__/compact-cell.test.js
+++ b/packages/wonder-blocks-cell/src/components/__tests__/compact-cell.test.js
@@ -5,7 +5,7 @@ import {render, screen} from "@testing-library/react";
 import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";
 
-import CompactCell from "../compact-cell.js";
+import CompactCell from "../compact-cell";
 
 describe("CompactCell", () => {
     it("should render the default CompactCell component", () => {

--- a/packages/wonder-blocks-cell/src/components/__tests__/detail-cell.test.js
+++ b/packages/wonder-blocks-cell/src/components/__tests__/detail-cell.test.js
@@ -4,7 +4,7 @@ import {render, screen} from "@testing-library/react";
 
 import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";
 
-import DetailCell from "../detail-cell.js";
+import DetailCell from "../detail-cell";
 
 describe("DetailCell", () => {
     it("should render the default DetailCell component", () => {

--- a/packages/wonder-blocks-cell/src/components/compact-cell.js
+++ b/packages/wonder-blocks-cell/src/components/compact-cell.js
@@ -3,9 +3,9 @@ import * as React from "react";
 
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
-import CellCore from "./internal/cell-core.js";
+import CellCore from "./internal/cell-core";
 
-import type {CellProps} from "../util/types.js";
+import type {CellProps} from "../util/types";
 
 /**
  * `CompactCell` is the simplest form of the Cell. It is a compacted-height Cell

--- a/packages/wonder-blocks-cell/src/components/detail-cell.js
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.js
@@ -7,10 +7,10 @@ import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
-import CellCore from "./internal/cell-core.js";
-import {CellMeasurements} from "./internal/common.js";
+import CellCore from "./internal/cell-core";
+import {CellMeasurements} from "./internal/common";
 
-import type {CellProps, TypographyText} from "../util/types.js";
+import type {CellProps, TypographyText} from "../util/types";
 
 type SubtitleProps = {|
     subtitle?: TypographyText,

--- a/packages/wonder-blocks-cell/src/components/internal/__tests__/cell-core.test.js
+++ b/packages/wonder-blocks-cell/src/components/internal/__tests__/cell-core.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import CellCore from "../cell-core.js";
+import CellCore from "../cell-core";
 
 describe("CellCore", () => {
     it("should render the CellCore component", () => {

--- a/packages/wonder-blocks-cell/src/components/internal/__tests__/common.test.js
+++ b/packages/wonder-blocks-cell/src/components/internal/__tests__/common.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {getHorizontalRuleStyles} from "../common.js";
+import {getHorizontalRuleStyles} from "../common";
 
 describe("getHorizontalRuleStyles", () => {
     it("should get 'inset' styles as an array", () => {

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.js
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.js
@@ -11,9 +11,9 @@ import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {ClickableState} from "@khanacademy/wonder-blocks-clickable";
-import {CellMeasurements, getHorizontalRuleStyles} from "./common.js";
+import {CellMeasurements, getHorizontalRuleStyles} from "./common";
 
-import type {CellProps, TypographyText} from "../../util/types.js";
+import type {CellProps, TypographyText} from "../../util/types";
 
 type LeftAccessoryProps = {|
     leftAccessory?: CellProps["leftAccessory"],

--- a/packages/wonder-blocks-cell/src/components/internal/common.js
+++ b/packages/wonder-blocks-cell/src/components/internal/common.js
@@ -5,7 +5,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import type {HorizontalRuleVariant} from "../../util/types.js";
+import type {HorizontalRuleVariant} from "../../util/types";
 
 export const CellMeasurements = {
     cellMinHeight: Spacing.xxLarge_48,

--- a/packages/wonder-blocks-cell/src/index.js
+++ b/packages/wonder-blocks-cell/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-import CompactCell from "./components/compact-cell.js";
-import DetailCell from "./components/detail-cell.js";
+import CompactCell from "./components/compact-cell";
+import DetailCell from "./components/detail-cell";
 
 export {CompactCell, DetailCell};

--- a/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.argtypes.js
+++ b/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.argtypes.js
@@ -1,4 +1,4 @@
-import clickableArgtypes from "./clickable.argtypes.js";
+import clickableArgtypes from "./clickable.argtypes";
 
 export default {
     children: {

--- a/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.stories.js
+++ b/packages/wonder-blocks-clickable/src/components/__docs__/clickable-behavior.stories.js
@@ -8,9 +8,9 @@ import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StoryComponentType} from "@storybook/react";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import argTypes from "./clickable-behavior.argtypes.js";
+import argTypes from "./clickable-behavior.argtypes";
 
 const ClickableBehavior: React.ComponentType<
     React.ElementConfig<typeof ClickableBehavior>,

--- a/packages/wonder-blocks-clickable/src/components/__docs__/clickable.stories.js
+++ b/packages/wonder-blocks-clickable/src/components/__docs__/clickable.stories.js
@@ -11,9 +11,9 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import argTypes from "./clickable.argtypes.js";
+import argTypes from "./clickable.argtypes";
 
 export default {
     title: "Clickable / Clickable",

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.js
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.js
@@ -6,8 +6,8 @@ import {render, screen, fireEvent, waitFor} from "@testing-library/react";
 import {MemoryRouter, Switch, Route} from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 
-import getClickableBehavior from "../../util/get-clickable-behavior.js";
-import ClickableBehavior from "../clickable-behavior.js";
+import getClickableBehavior from "../../util/get-clickable-behavior";
+import ClickableBehavior from "../clickable-behavior";
 import type {ClickableState} from "../clickable-behavior";
 
 const keyCodes = {

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.js
@@ -5,7 +5,7 @@ import {render, screen, fireEvent, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import Clickable from "../clickable.js";
+import Clickable from "../clickable";
 
 describe("Clickable", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-clickable/src/components/clickable.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.js
@@ -8,9 +8,9 @@ import {addStyle} from "@khanacademy/wonder-blocks-core";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 
-import getClickableBehavior from "../util/get-clickable-behavior.js";
-import type {ClickableRole, ClickableState} from "./clickable-behavior.js";
-import {isClientSideUrl} from "../util/is-client-side-url.js";
+import getClickableBehavior from "../util/get-clickable-behavior";
+import type {ClickableRole, ClickableState} from "./clickable-behavior";
+import {isClientSideUrl} from "../util/is-client-side-url";
 
 type CommonProps = {|
     /**

--- a/packages/wonder-blocks-clickable/src/index.js
+++ b/packages/wonder-blocks-clickable/src/index.js
@@ -3,12 +3,12 @@ import type {
     ChildrenProps,
     ClickableState,
     ClickableRole,
-} from "./components/clickable-behavior.js";
-import Clickable from "./components/clickable.js";
+} from "./components/clickable-behavior";
+import Clickable from "./components/clickable";
 
-export {default as ClickableBehavior} from "./components/clickable-behavior.js";
-export {default as getClickableBehavior} from "./util/get-clickable-behavior.js";
-export {isClientSideUrl} from "./util/is-client-side-url.js";
+export {default as ClickableBehavior} from "./components/clickable-behavior";
+export {default as getClickableBehavior} from "./util/get-clickable-behavior";
+export {isClientSideUrl} from "./util/is-client-side-url";
 
 export {Clickable as default};
 

--- a/packages/wonder-blocks-clickable/src/util/__tests__/get-clickable-behavior.test.js
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/get-clickable-behavior.test.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
 import {MemoryRouter} from "react-router-dom";
-import ClickableBehavior from "../../components/clickable-behavior.js";
-import getClickableBehavior from "../get-clickable-behavior.js";
+import ClickableBehavior from "../../components/clickable-behavior";
+import getClickableBehavior from "../get-clickable-behavior";
 
 describe("getClickableBehavior", () => {
     test("Without href, returns ClickableBehavior", () => {

--- a/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/is-client-side-url.js.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {isClientSideUrl} from "../is-client-side-url.js";
+import {isClientSideUrl} from "../is-client-side-url";
 
 describe("isClientSideUrl", () => {
     test("returns boolean based on the url", () => {

--- a/packages/wonder-blocks-clickable/src/util/get-clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/util/get-clickable-behavior.js
@@ -12,8 +12,8 @@
 import * as React from "react";
 import {withRouter} from "react-router-dom";
 
-import ClickableBehavior from "../components/clickable-behavior.js";
-import {isClientSideUrl} from "./is-client-side-url.js";
+import ClickableBehavior from "../components/clickable-behavior";
+import {isClientSideUrl} from "./is-client-side-url";
 
 const ClickableBehaviorWithRouter = withRouter(ClickableBehavior);
 

--- a/packages/wonder-blocks-color/src/docutils/swatch.js
+++ b/packages/wonder-blocks-color/src/docutils/swatch.js
@@ -11,7 +11,7 @@ import {
     LabelSmall,
     LabelXSmall,
 } from "@khanacademy/wonder-blocks-typography";
-import Color from "../index.js";
+import Color from "../index";
 
 type Segments = 1 | 2 | 3;
 

--- a/packages/wonder-blocks-color/src/index.js
+++ b/packages/wonder-blocks-color/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-import {mix, fade} from "./util/utils.js";
+import {mix, fade} from "./util/utils";
 
 const offBlack = "#21242c";
 const white = "#ffffff";

--- a/packages/wonder-blocks-color/src/util/__tests__/utils.test.js
+++ b/packages/wonder-blocks-color/src/util/__tests__/utils.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {fade, mix} from "../utils.js";
+import {fade, mix} from "../utils";
 
 const INVALID_COLORS = ["#NOTVALID", "#12345", "#12", "#ABCDEFG", ""];
 

--- a/packages/wonder-blocks-core/src/components/__docs__/id-provider.stories.js
+++ b/packages/wonder-blocks-core/src/components/__docs__/id-provider.stories.js
@@ -5,7 +5,7 @@ import {IDProvider, View} from "@khanacademy/wonder-blocks-core";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-core/src/components/__docs__/unique-id-provider.stories.js
+++ b/packages/wonder-blocks-core/src/components/__docs__/unique-id-provider.stories.js
@@ -8,7 +8,7 @@ import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-core/src/components/__docs__/view.stories.js
+++ b/packages/wonder-blocks-core/src/components/__docs__/view.stories.js
@@ -13,9 +13,9 @@ import {
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import viewArgTypes from "./view.argtypes.js";
+import viewArgTypes from "./view.argtypes";
 
 export default {
     title: "Core / View",

--- a/packages/wonder-blocks-core/src/components/__docs__/with-ssr-placeholder.stories.js
+++ b/packages/wonder-blocks-core/src/components/__docs__/with-ssr-placeholder.stories.js
@@ -5,7 +5,7 @@ import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-core/src/components/__tests__/id-provider.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/id-provider.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {render} from "@testing-library/react";
 
-import IDProvider from "../id-provider.js";
+import IDProvider from "../id-provider";
 
 const mockIDENTIFIER = `uid-component-0-${IDProvider.defaultId}`;
 

--- a/packages/wonder-blocks-core/src/components/__tests__/render-state-root.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/render-state-root.test.js
@@ -2,12 +2,12 @@
 import * as React from "react";
 import {render} from "@testing-library/react";
 
-import {RenderStateRoot} from "../render-state-root.js";
+import {RenderStateRoot} from "../render-state-root";
 // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-import {RenderState, RenderStateContext} from "../render-state-context.js";
+import {RenderState, RenderStateContext} from "../render-state-context";
 
 const {useContext} = React;
 

--- a/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.js
@@ -1,15 +1,15 @@
 // @flow
 import * as React from "react";
-import * as ReactDOMServer from "react-dom/server.js";
+import * as ReactDOMServer from "react-dom/server";
 import {render} from "@testing-library/react";
 
-import View from "../view.js";
+import View from "../view";
 
-import SsrIDFactory from "../../util/ssr-id-factory.js";
-import UniqueIDFactory from "../../util/unique-id-factory.js";
-import UniqueIDProvider from "../unique-id-provider.js";
-import WithSSRPlaceholder from "../with-ssr-placeholder.js";
-import {RenderStateRoot} from "../render-state-root.js";
+import SsrIDFactory from "../../util/ssr-id-factory";
+import UniqueIDFactory from "../../util/unique-id-factory";
+import UniqueIDProvider from "../unique-id-provider";
+import WithSSRPlaceholder from "../with-ssr-placeholder";
+import {RenderStateRoot} from "../render-state-root";
 
 describe("UniqueIDProvider", () => {
     describe("mockOnFirstRender is default (false)", () => {

--- a/packages/wonder-blocks-core/src/components/__tests__/view.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/view.test.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import renderer from "react-test-renderer";
 
-import View from "../view.js";
+import View from "../view";
 
 describe("View", () => {
     it("Should set the tag to be section", () => {

--- a/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from "react";
-import * as ReactDOMServer from "react-dom/server.js";
+import * as ReactDOMServer from "react-dom/server";
 import {render} from "@testing-library/react";
 
-import WithSSRPlaceholder from "../with-ssr-placeholder.js";
-import {RenderStateRoot} from "../render-state-root.js";
+import WithSSRPlaceholder from "../with-ssr-placeholder";
+import {RenderStateRoot} from "../render-state-root";
 
 describe("WithSSRPlaceholder", () => {
     describe("client-side rendering", () => {

--- a/packages/wonder-blocks-core/src/components/id-provider.js
+++ b/packages/wonder-blocks-core/src/components/id-provider.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
 
-import UniqueIDProvider from "./unique-id-provider.js";
+import UniqueIDProvider from "./unique-id-provider";
 
-import type {IIdentifierFactory} from "../util/types.js";
+import type {IIdentifierFactory} from "../util/types";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-core/src/components/render-state-root.js
+++ b/packages/wonder-blocks-core/src/components/render-state-root.js
@@ -5,8 +5,8 @@ import * as React from "react";
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-import {RenderState, RenderStateContext} from "./render-state-context.js";
-import {useRenderState} from "../hooks/use-render-state.js";
+import {RenderState, RenderStateContext} from "./render-state-context";
+import {useRenderState} from "../hooks/use-render-state";
 
 const {useEffect, useState} = React;
 

--- a/packages/wonder-blocks-core/src/components/text.js
+++ b/packages/wonder-blocks-core/src/components/text.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {processStyleList} from "../util/util.js";
+import {processStyleList} from "../util/util";
 
-import type {TextViewSharedProps} from "../util/types.js";
+import type {TextViewSharedProps} from "../util/types";
 
 // NOTE(jeresig): We want to leave the props for these open so that we can
 // handle uncommon props for elements (e.g. htmlFor for labels).

--- a/packages/wonder-blocks-core/src/components/unique-id-provider.js
+++ b/packages/wonder-blocks-core/src/components/unique-id-provider.js
@@ -1,12 +1,12 @@
 // @flow
 import * as React from "react";
 
-import WithSSRPlaceholder from "./with-ssr-placeholder.js";
+import WithSSRPlaceholder from "./with-ssr-placeholder";
 
-import UniqueIDFactory from "../util/unique-id-factory.js";
-import SsrIDFactory from "../util/ssr-id-factory.js";
+import UniqueIDFactory from "../util/unique-id-factory";
+import SsrIDFactory from "../util/ssr-id-factory";
 
-import type {IIdentifierFactory} from "../util/types.js";
+import type {IIdentifierFactory} from "../util/types";
 
 // TODO(FEI-4202): update to use `useUniqueId`
 type Props = {|

--- a/packages/wonder-blocks-core/src/components/view.js
+++ b/packages/wonder-blocks-core/src/components/view.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import addStyle from "../util/add-style.js";
+import addStyle from "../util/add-style";
 
-import type {TextViewSharedProps} from "../util/types.js";
+import type {TextViewSharedProps} from "../util/types";
 
 const styles = StyleSheet.create({
     // https://github.com/facebook/css-layout#default-values

--- a/packages/wonder-blocks-core/src/components/with-ssr-placeholder.js
+++ b/packages/wonder-blocks-core/src/components/with-ssr-placeholder.js
@@ -6,7 +6,7 @@ import * as React from "react";
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-import {RenderState, RenderStateContext} from "./render-state-context.js";
+import {RenderState, RenderStateContext} from "./render-state-context";
 
 /**
  * We use render functions so that we don't do any work unless we need to.

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {render, act} from "@testing-library/react";
 import {renderHook} from "@testing-library/react-hooks";
 
-import {useForceUpdate} from "../use-force-update.js";
+import {useForceUpdate} from "../use-force-update";
 
 describe("#useForceUpdate", () => {
     it("should return a function", () => {

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-is-mounted.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-is-mounted.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {renderHook} from "@testing-library/react-hooks";
 
-import {useIsMounted} from "../use-is-mounted.js";
+import {useIsMounted} from "../use-is-mounted";
 
 describe("useIsMounted", () => {
     it("should return false on first call", () => {

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-on-mount-effect.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-on-mount-effect.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {renderHook} from "@testing-library/react-hooks";
 
-import {useOnMountEffect} from "../use-on-mount-effect.js";
+import {useOnMountEffect} from "../use-on-mount-effect";
 
 describe("#useOnMountEffect", () => {
     it("should call the callback once", () => {

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-online.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-online.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {render, act as reactAct} from "@testing-library/react";
 import {renderHook} from "@testing-library/react-hooks";
 
-import {useOnline} from "../use-online.js";
+import {useOnline} from "../use-online";
 
 describe("useOnline", () => {
     it("should return true when navigator.onLine is true", () => {

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-render-state.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-render-state.test.js
@@ -3,13 +3,13 @@ import * as React from "react";
 import {renderHook as renderHookOnServer} from "@testing-library/react-hooks/server";
 import {renderHook} from "@testing-library/react-hooks";
 
-import {useRenderState} from "../use-render-state.js";
-import {RenderStateRoot} from "../../components/render-state-root.js";
+import {useRenderState} from "../use-render-state";
+import {RenderStateRoot} from "../../components/render-state-root";
 // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-import {RenderState} from "../../components/render-state-context.js";
+import {RenderState} from "../../components/render-state-context";
 
 describe("useRenderState", () => {
     test("server-side render returns RenderState.Initial", () => {

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-unique-id.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-unique-id.test.js
@@ -3,10 +3,10 @@ import * as React from "react";
 import {render} from "@testing-library/react";
 import {renderHook} from "@testing-library/react-hooks/server";
 
-import SsrIDFactory from "../../util/ssr-id-factory.js";
-import UniqueIDFactory from "../../util/unique-id-factory.js";
-import {useUniqueIdWithMock, useUniqueIdWithoutMock} from "../use-unique-id.js";
-import {RenderStateRoot} from "../../components/render-state-root.js";
+import SsrIDFactory from "../../util/ssr-id-factory";
+import UniqueIDFactory from "../../util/unique-id-factory";
+import {useUniqueIdWithMock, useUniqueIdWithoutMock} from "../use-unique-id";
+import {RenderStateRoot} from "../../components/render-state-root";
 
 describe("useUniqueIdWithoutMock", () => {
     test("server-side render returns null", () => {

--- a/packages/wonder-blocks-core/src/hooks/use-is-mounted.js
+++ b/packages/wonder-blocks-core/src/hooks/use-is-mounted.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import {useOnMountEffect} from "./use-on-mount-effect.js";
+import {useOnMountEffect} from "./use-on-mount-effect";
 
 /**
  * Hook to provide a function for determining component mounted state.

--- a/packages/wonder-blocks-core/src/hooks/use-online.js
+++ b/packages/wonder-blocks-core/src/hooks/use-online.js
@@ -1,6 +1,6 @@
 // @flow
 import {useEffect} from "react";
-import {useForceUpdate} from "./use-force-update.js";
+import {useForceUpdate} from "./use-force-update";
 
 /**
  * Track the online status of the browser.

--- a/packages/wonder-blocks-core/src/hooks/use-render-state.js
+++ b/packages/wonder-blocks-core/src/hooks/use-render-state.js
@@ -1,7 +1,7 @@
 // @flow
 import {useContext} from "react";
 
-import {RenderStateContext} from "../components/render-state-context.js";
+import {RenderStateContext} from "../components/render-state-context";
 
 import type {RenderState} from "../components/render-state-context";
 

--- a/packages/wonder-blocks-core/src/hooks/use-unique-id.js
+++ b/packages/wonder-blocks-core/src/hooks/use-unique-id.js
@@ -1,9 +1,9 @@
 // @flow
 import {useRef} from "react";
 
-import {useRenderState} from "./use-render-state.js";
-import SsrIDFactory from "../util/ssr-id-factory.js";
-import UniqueIDFactory from "../util/unique-id-factory.js";
+import {useRenderState} from "./use-render-state";
+import SsrIDFactory from "../util/ssr-id-factory";
+import UniqueIDFactory from "../util/unique-id-factory";
 
 import {
     // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
@@ -11,9 +11,9 @@ import {
     // https://github.com/import-js/eslint-plugin-import/issues/2073
     // eslint-disable-next-line import/named
     RenderState,
-} from "../components/render-state-context.js";
+} from "../components/render-state-context";
 
-import type {IIdentifierFactory} from "../util/types.js";
+import type {IIdentifierFactory} from "../util/types";
 
 /**
  * Returns a unique identifier factory.  If the parent component hasn't

--- a/packages/wonder-blocks-core/src/index.js
+++ b/packages/wonder-blocks-core/src/index.js
@@ -1,27 +1,27 @@
 // @flow
-import type {AriaProps, IIdentifierFactory, StyleType} from "./util/types.js";
+import type {AriaProps, IIdentifierFactory, StyleType} from "./util/types";
 
-export {default as Text} from "./components/text.js";
-export {default as View} from "./components/view.js";
-export {default as WithSSRPlaceholder} from "./components/with-ssr-placeholder.js";
-export {default as IDProvider} from "./components/id-provider.js";
-export {default as UniqueIDProvider} from "./components/unique-id-provider.js";
-export {default as addStyle} from "./util/add-style.js";
-export {default as Server} from "./util/server.js";
+export {default as Text} from "./components/text";
+export {default as View} from "./components/view";
+export {default as WithSSRPlaceholder} from "./components/with-ssr-placeholder";
+export {default as IDProvider} from "./components/id-provider";
+export {default as UniqueIDProvider} from "./components/unique-id-provider";
+export {default as addStyle} from "./util/add-style";
+export {default as Server} from "./util/server";
 export {
     useUniqueIdWithMock,
     useUniqueIdWithoutMock,
-} from "./hooks/use-unique-id.js";
-export {useForceUpdate} from "./hooks/use-force-update.js";
-export {useIsMounted} from "./hooks/use-is-mounted.js";
-export {useOnMountEffect} from "./hooks/use-on-mount-effect.js";
-export {useOnline} from "./hooks/use-online.js";
-export {useRenderState} from "./hooks/use-render-state.js";
-export {RenderStateRoot} from "./components/render-state-root.js";
+} from "./hooks/use-unique-id";
+export {useForceUpdate} from "./hooks/use-force-update";
+export {useIsMounted} from "./hooks/use-is-mounted";
+export {useOnMountEffect} from "./hooks/use-on-mount-effect";
+export {useOnline} from "./hooks/use-online";
+export {useRenderState} from "./hooks/use-render-state";
+export {RenderStateRoot} from "./components/render-state-root";
 // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-export {RenderState} from "./components/render-state-context.js";
+export {RenderState} from "./components/render-state-context";
 
 export type {AriaProps, IIdentifierFactory, StyleType};

--- a/packages/wonder-blocks-core/src/util/__tests__/add-style.test.js
+++ b/packages/wonder-blocks-core/src/util/__tests__/add-style.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {screen, render} from "@testing-library/react";
 
-import addStyle from "../add-style.js";
+import addStyle from "../add-style";
 
 const StyledDiv = addStyle<"div">("div");
 

--- a/packages/wonder-blocks-core/src/util/__tests__/server.test.js
+++ b/packages/wonder-blocks-core/src/util/__tests__/server.test.js
@@ -1,5 +1,5 @@
 // @flow
-import Server from "../server.js";
+import Server from "../server";
 
 describe("./server.js", () => {
     it("#isServerSide should return false", () => {

--- a/packages/wonder-blocks-core/src/util/__tests__/ssr-id-factory.test.js
+++ b/packages/wonder-blocks-core/src/util/__tests__/ssr-id-factory.test.js
@@ -3,7 +3,7 @@ describe("SsrIDFactory", () => {
     test("returns the same id, regardless of client or server render", async () => {
         // Arrange
         const id = "this-is-the-id";
-        const {default: SsrIDFactory} = await import("../ssr-id-factory.js");
+        const {default: SsrIDFactory} = await import("../ssr-id-factory");
 
         // Act
         const result = SsrIDFactory.get(id);

--- a/packages/wonder-blocks-core/src/util/__tests__/unique-id-factory.test.js
+++ b/packages/wonder-blocks-core/src/util/__tests__/unique-id-factory.test.js
@@ -1,5 +1,5 @@
 // @flow
-import UniqueIDFactory from "../unique-id-factory.js";
+import UniqueIDFactory from "../unique-id-factory";
 
 describe("UniqueIDFactory", () => {
     describe("#constructor", () => {

--- a/packages/wonder-blocks-core/src/util/add-style.js
+++ b/packages/wonder-blocks-core/src/util/add-style.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {processStyleList} from "./util.js";
+import {processStyleList} from "./util";
 
-import type {StyleType} from "./types.js";
+import type {StyleType} from "./types";
 
 // TODO(kevinb): have an a version which uses exact object types
 export default function addStyle<T: React.AbstractComponent<any> | string>(

--- a/packages/wonder-blocks-core/src/util/add-styles.flowtest.js
+++ b/packages/wonder-blocks-core/src/util/add-styles.flowtest.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import addStyle from "./add-style.js";
+import addStyle from "./add-style";
 
 const styles = StyleSheet.create({
     list: {

--- a/packages/wonder-blocks-core/src/util/ssr-id-factory.js
+++ b/packages/wonder-blocks-core/src/util/ssr-id-factory.js
@@ -1,5 +1,5 @@
 // @flow
-import type {IIdentifierFactory} from "./types.js";
+import type {IIdentifierFactory} from "./types";
 
 /**
  * This is NOT for direct use. Instead, see the UniqueIDProvider component.

--- a/packages/wonder-blocks-core/src/util/unique-id-factory.js
+++ b/packages/wonder-blocks-core/src/util/unique-id-factory.js
@@ -1,5 +1,5 @@
 // @flow
-import type {IIdentifierFactory} from "./types.js";
+import type {IIdentifierFactory} from "./types";
 
 /**
  * This is NOT for direct use. Instead, see the UniqueIDProvider component.

--- a/packages/wonder-blocks-core/src/util/util.js
+++ b/packages/wonder-blocks-core/src/util/util.js
@@ -2,7 +2,7 @@
 import {StyleSheet, css} from "aphrodite";
 import type {CSSProperties} from "aphrodite";
 
-import type {StyleType} from "./types.js";
+import type {StyleType} from "./types";
 
 type StyledExport = {|
     style: CSSProperties | Empty,

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -7,20 +7,20 @@ import {render, act} from "@testing-library/react";
 import * as ReactDOMServer from "react-dom/server";
 import {Server, View} from "@khanacademy/wonder-blocks-core";
 
-import {SharedCache} from "../../hooks/use-shared-cache.js";
-import TrackData from "../track-data.js";
-import {RequestFulfillment} from "../../util/request-fulfillment.js";
-import {SsrCache} from "../../util/ssr-cache.js";
-import {RequestTracker} from "../../util/request-tracking.js";
-import InterceptRequests from "../intercept-requests.js";
-import Data from "../data.js";
+import {SharedCache} from "../../hooks/use-shared-cache";
+import TrackData from "../track-data";
+import {RequestFulfillment} from "../../util/request-fulfillment";
+import {SsrCache} from "../../util/ssr-cache";
+import {RequestTracker} from "../../util/request-tracking";
+import InterceptRequests from "../intercept-requests";
+import Data from "../data";
 import {
     // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
     // have fixed:
     // https://github.com/import-js/eslint-plugin-import/issues/2073
     // eslint-disable-next-line import/named
     WhenClientSide,
-} from "../../hooks/use-hydratable-effect.js";
+} from "../../hooks/use-hydratable-effect";
 
 describe("Data", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-data/src/components/__tests__/gql-router.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/gql-router.test.js
@@ -2,8 +2,8 @@
 import * as React from "react";
 import {render} from "@testing-library/react";
 
-import {GqlRouterContext} from "../../util/gql-router-context.js";
-import {GqlRouter} from "../gql-router.js";
+import {GqlRouterContext} from "../../util/gql-router-context";
+import {GqlRouter} from "../gql-router";
 
 describe("GqlRouter", () => {
     it("should provide the GqlRouterContext as configured", async () => {

--- a/packages/wonder-blocks-data/src/components/__tests__/intercept-requests.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/intercept-requests.test.js
@@ -2,8 +2,8 @@
 import * as React from "react";
 import {render} from "@testing-library/react";
 
-import InterceptContext from "../intercept-context.js";
-import InterceptRequests from "../intercept-requests.js";
+import InterceptContext from "../intercept-context";
+import InterceptRequests from "../intercept-requests";
 
 describe("InterceptRequests", () => {
     afterEach(() => {

--- a/packages/wonder-blocks-data/src/components/__tests__/track-data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/track-data.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {Server} from "@khanacademy/wonder-blocks-core";
 import {render, screen} from "@testing-library/react";
 
-import TrackData from "../track-data.js";
-import {RequestTracker, TrackerContext} from "../../util/request-tracking.js";
+import TrackData from "../track-data";
+import {RequestTracker, TrackerContext} from "../../util/request-tracking";
 
 describe("TrackData", () => {
     afterEach(() => {

--- a/packages/wonder-blocks-data/src/components/data.js
+++ b/packages/wonder-blocks-data/src/components/data.js
@@ -8,9 +8,9 @@ import {
     // https://github.com/import-js/eslint-plugin-import/issues/2073
     // eslint-disable-next-line import/named
     WhenClientSide,
-} from "../hooks/use-hydratable-effect.js";
+} from "../hooks/use-hydratable-effect";
 
-import type {Result, ValidCacheData} from "../util/types.js";
+import type {Result, ValidCacheData} from "../util/types";
 
 type Props<
     /**

--- a/packages/wonder-blocks-data/src/components/gql-router.js
+++ b/packages/wonder-blocks-data/src/components/gql-router.js
@@ -1,13 +1,13 @@
 // @flow
 import * as React from "react";
 
-import {GqlRouterContext} from "../util/gql-router-context.js";
+import {GqlRouterContext} from "../util/gql-router-context";
 
 import type {
     GqlContext,
     GqlFetchFn,
     GqlRouterConfiguration,
-} from "../util/gql-types.js";
+} from "../util/gql-types";
 
 type Props<TContext: GqlContext> = {|
     /**

--- a/packages/wonder-blocks-data/src/components/intercept-context.js
+++ b/packages/wonder-blocks-data/src/components/intercept-context.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import type {ValidCacheData} from "../util/types.js";
+import type {ValidCacheData} from "../util/types";
 
 type InterceptContextData = $ReadOnlyArray<
     (requestId: string) => ?Promise<?ValidCacheData>,

--- a/packages/wonder-blocks-data/src/components/intercept-requests.js
+++ b/packages/wonder-blocks-data/src/components/intercept-requests.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
 
-import InterceptContext from "./intercept-context.js";
+import InterceptContext from "./intercept-context";
 
-import type {ValidCacheData} from "../util/types.js";
+import type {ValidCacheData} from "../util/types";
 
 type Props<TData: ValidCacheData> = {|
     /**

--- a/packages/wonder-blocks-data/src/components/track-data.js
+++ b/packages/wonder-blocks-data/src/components/track-data.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {Server} from "@khanacademy/wonder-blocks-core";
 
-import {RequestTracker, TrackerContext} from "../util/request-tracking.js";
+import {RequestTracker, TrackerContext} from "../util/request-tracking";
 
 type TrackDataProps = {|
     children: React.Node,

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
@@ -8,19 +8,19 @@ import {renderHook as serverRenderHook} from "@testing-library/react-hooks/serve
 import {render, act as reactAct} from "@testing-library/react";
 
 import {Server} from "@khanacademy/wonder-blocks-core";
-import {Status} from "../../util/status.js";
+import {Status} from "../../util/status";
 
-import {RequestFulfillment} from "../../util/request-fulfillment.js";
-import * as UseRequestInterception from "../use-request-interception.js";
-import * as UseSharedCache from "../use-shared-cache.js";
+import {RequestFulfillment} from "../../util/request-fulfillment";
+import * as UseRequestInterception from "../use-request-interception";
+import * as UseSharedCache from "../use-shared-cache";
 
-import {useCachedEffect} from "../use-cached-effect.js";
+import {useCachedEffect} from "../use-cached-effect";
 
 // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-import {FetchPolicy} from "../../util/types.js";
+import {FetchPolicy} from "../../util/types";
 
 jest.mock("../use-request-interception.js");
 jest.mock("../use-shared-cache.js");

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
@@ -22,8 +22,8 @@ import {useCachedEffect} from "../use-cached-effect";
 // eslint-disable-next-line import/named
 import {FetchPolicy} from "../../util/types";
 
-jest.mock("../use-request-interception.js");
-jest.mock("../use-shared-cache.js");
+jest.mock("../use-request-interception");
+jest.mock("../use-shared-cache");
 
 const allPolicies = Array.from(FetchPolicy.members());
 const allPoliciesBut = (policy: FetchPolicy) =>

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-gql-router-context.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-gql-router-context.test.js
@@ -2,8 +2,8 @@
 import * as React from "react";
 import {renderHook} from "@testing-library/react-hooks";
 
-import {GqlRouterContext} from "../../util/gql-router-context.js";
-import {useGqlRouterContext} from "../use-gql-router-context.js";
+import {GqlRouterContext} from "../../util/gql-router-context";
+import {useGqlRouterContext} from "../use-gql-router-context";
 
 describe("#useGqlRouterContext", () => {
     it("should throw if there is no GqlRouterContext", () => {

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-gql.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-gql.test.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {renderHook} from "@testing-library/react-hooks";
 
-import * as GetGqlDataFromResponse from "../../util/get-gql-data-from-response.js";
-import {GqlRouterContext} from "../../util/gql-router-context.js";
-import {useGql} from "../use-gql.js";
+import * as GetGqlDataFromResponse from "../../util/get-gql-data-from-response";
+import {GqlRouterContext} from "../../util/gql-router-context";
+import {useGql} from "../use-gql";
 
 describe("#useGql", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
@@ -7,12 +7,12 @@ import {
 import {renderHook as serverRenderHook} from "@testing-library/react-hooks/server";
 
 import {Server} from "@khanacademy/wonder-blocks-core";
-import {Status} from "../../util/status.js";
+import {Status} from "../../util/status";
 
-import {RequestFulfillment} from "../../util/request-fulfillment.js";
-import * as UseRequestInterception from "../use-request-interception.js";
-import * as UseServerEffect from "../use-server-effect.js";
-import * as UseSharedCache from "../use-shared-cache.js";
+import {RequestFulfillment} from "../../util/request-fulfillment";
+import * as UseRequestInterception from "../use-request-interception";
+import * as UseServerEffect from "../use-server-effect";
+import * as UseSharedCache from "../use-shared-cache";
 
 import {
     useHydratableEffect,
@@ -21,7 +21,7 @@ import {
     // https://github.com/import-js/eslint-plugin-import/issues/2073
     // eslint-disable-next-line import/named
     WhenClientSide,
-} from "../use-hydratable-effect.js";
+} from "../use-hydratable-effect";
 
 jest.mock("../use-request-interception.js");
 jest.mock("../use-server-effect.js");

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
@@ -23,9 +23,9 @@ import {
     WhenClientSide,
 } from "../use-hydratable-effect";
 
-jest.mock("../use-request-interception.js");
-jest.mock("../use-server-effect.js");
-jest.mock("../use-shared-cache.js");
+jest.mock("../use-request-interception");
+jest.mock("../use-server-effect");
+jest.mock("../use-shared-cache");
 
 describe("#useHydratableEffect", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-request-interception.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-request-interception.test.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
 import {renderHook} from "@testing-library/react-hooks";
-import InterceptRequests from "../../components/intercept-requests.js";
-import {useRequestInterception} from "../use-request-interception.js";
+import InterceptRequests from "../../components/intercept-requests";
+import {useRequestInterception} from "../use-request-interception";
 
 describe("#useRequestInterception", () => {
     it("should return a function", () => {

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.js
@@ -4,14 +4,14 @@ import {renderHook as serverRenderHook} from "@testing-library/react-hooks/serve
 
 import {Server} from "@khanacademy/wonder-blocks-core";
 
-import TrackData from "../../components/track-data.js";
-import {RequestFulfillment} from "../../util/request-fulfillment.js";
-import {SsrCache} from "../../util/ssr-cache.js";
-import {RequestTracker} from "../../util/request-tracking.js";
-import {DataError} from "../../util/data-error.js";
-import * as UseRequestInterception from "../use-request-interception.js";
+import TrackData from "../../components/track-data";
+import {RequestFulfillment} from "../../util/request-fulfillment";
+import {SsrCache} from "../../util/ssr-cache";
+import {RequestTracker} from "../../util/request-tracking";
+import {DataError} from "../../util/data-error";
+import * as UseRequestInterception from "../use-request-interception";
 
-import {useServerEffect} from "../use-server-effect.js";
+import {useServerEffect} from "../use-server-effect";
 
 jest.mock("../use-request-interception.js");
 

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.js
@@ -13,7 +13,7 @@ import * as UseRequestInterception from "../use-request-interception";
 
 import {useServerEffect} from "../use-server-effect";
 
-jest.mock("../use-request-interception.js");
+jest.mock("../use-request-interception");
 
 describe("#useServerEffect", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-shared-cache.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-shared-cache.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {renderHook as clientRenderHook} from "@testing-library/react-hooks";
 
-import {useSharedCache, SharedCache} from "../use-shared-cache.js";
+import {useSharedCache, SharedCache} from "../use-shared-cache";
 
 describe("#useSharedCache", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
@@ -1,21 +1,21 @@
 // @flow
 import * as React from "react";
 import {useForceUpdate} from "@khanacademy/wonder-blocks-core";
-import {DataError, DataErrors} from "../util/data-error.js";
+import {DataError, DataErrors} from "../util/data-error";
 
-import {RequestFulfillment} from "../util/request-fulfillment.js";
-import {Status} from "../util/status.js";
+import {RequestFulfillment} from "../util/request-fulfillment";
+import {Status} from "../util/status";
 
-import {useSharedCache} from "./use-shared-cache.js";
-import {useRequestInterception} from "./use-request-interception.js";
+import {useSharedCache} from "./use-shared-cache";
+import {useRequestInterception} from "./use-request-interception";
 
-import type {Result, ValidCacheData} from "../util/types.js";
+import type {Result, ValidCacheData} from "../util/types";
 
 // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-import {FetchPolicy} from "../util/types.js";
+import {FetchPolicy} from "../util/types";
 
 type CachedEffectOptions<TData: ValidCacheData> = {|
     /**

--- a/packages/wonder-blocks-data/src/hooks/use-gql-router-context.js
+++ b/packages/wonder-blocks-data/src/hooks/use-gql-router-context.js
@@ -1,11 +1,11 @@
 // @flow
 import {useContext, useRef, useMemo} from "react";
 
-import {mergeGqlContext} from "../util/merge-gql-context.js";
-import {GqlRouterContext} from "../util/gql-router-context.js";
-import {GqlError, GqlErrors} from "../util/gql-error.js";
+import {mergeGqlContext} from "../util/merge-gql-context";
+import {GqlRouterContext} from "../util/gql-router-context";
+import {GqlError, GqlErrors} from "../util/gql-error";
 
-import type {GqlRouterConfiguration, GqlContext} from "../util/gql-types.js";
+import type {GqlRouterConfiguration, GqlContext} from "../util/gql-types";
 
 /**
  * Construct a GqlRouterContext from the current one and partial context.

--- a/packages/wonder-blocks-data/src/hooks/use-gql.js
+++ b/packages/wonder-blocks-data/src/hooks/use-gql.js
@@ -1,15 +1,15 @@
 // @flow
 import {useCallback} from "react";
 
-import {mergeGqlContext} from "../util/merge-gql-context.js";
-import {useGqlRouterContext} from "./use-gql-router-context.js";
-import {getGqlDataFromResponse} from "../util/get-gql-data-from-response.js";
+import {mergeGqlContext} from "../util/merge-gql-context";
+import {useGqlRouterContext} from "./use-gql-router-context";
+import {getGqlDataFromResponse} from "../util/get-gql-data-from-response";
 
 import type {
     GqlContext,
     GqlOperation,
     GqlFetchOptions,
-} from "../util/gql-types.js";
+} from "../util/gql-types";
 
 /**
  * Hook to obtain a gqlFetch function for performing GraphQL requests.

--- a/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
@@ -1,16 +1,16 @@
 // @flow
 import * as React from "react";
 
-import {useServerEffect} from "./use-server-effect.js";
-import {useSharedCache} from "./use-shared-cache.js";
-import {useCachedEffect} from "./use-cached-effect.js";
+import {useServerEffect} from "./use-server-effect";
+import {useSharedCache} from "./use-shared-cache";
+import {useCachedEffect} from "./use-cached-effect";
 
 // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-import {FetchPolicy} from "../util/types.js";
-import type {Result, ValidCacheData} from "../util/types.js";
+import {FetchPolicy} from "../util/types";
+import type {Result, ValidCacheData} from "../util/types";
 
 /**
  * Policies to define how a hydratable effect should behave client-side.

--- a/packages/wonder-blocks-data/src/hooks/use-request-interception.js
+++ b/packages/wonder-blocks-data/src/hooks/use-request-interception.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
 
-import InterceptContext from "../components/intercept-context.js";
-import type {ValidCacheData} from "../util/types.js";
+import InterceptContext from "../components/intercept-context";
+import type {ValidCacheData} from "../util/types";
 
 /**
  * Allow request handling to be intercepted.

--- a/packages/wonder-blocks-data/src/hooks/use-server-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-server-effect.js
@@ -1,12 +1,12 @@
 // @flow
 import {Server} from "@khanacademy/wonder-blocks-core";
 import {useContext} from "react";
-import {TrackerContext} from "../util/request-tracking.js";
-import {SsrCache} from "../util/ssr-cache.js";
-import {resultFromCachedResponse} from "../util/result-from-cache-response.js";
-import {useRequestInterception} from "./use-request-interception.js";
+import {TrackerContext} from "../util/request-tracking";
+import {SsrCache} from "../util/ssr-cache";
+import {resultFromCachedResponse} from "../util/result-from-cache-response";
+import {useRequestInterception} from "./use-request-interception";
 
-import type {Result, ValidCacheData} from "../util/types.js";
+import type {Result, ValidCacheData} from "../util/types";
 
 type ServerEffectOptions = {|
     /**

--- a/packages/wonder-blocks-data/src/hooks/use-shared-cache.js
+++ b/packages/wonder-blocks-data/src/hooks/use-shared-cache.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
-import {DataError, DataErrors} from "../util/data-error.js";
-import {ScopedInMemoryCache} from "../util/scoped-in-memory-cache.js";
-import type {ValidCacheData, ScopedCache} from "../util/types.js";
+import {DataError, DataErrors} from "../util/data-error";
+import {ScopedInMemoryCache} from "../util/scoped-in-memory-cache";
+import type {ValidCacheData, ScopedCache} from "../util/types";
 
 /**
  * A function for inserting a value into the cache or clearing it.

--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -3,7 +3,7 @@
 // have fixed:
 // https://github.com/import-js/eslint-plugin-import/issues/2073
 // eslint-disable-next-line import/named
-export {FetchPolicy} from "./util/types.js";
+export {FetchPolicy} from "./util/types";
 export type {
     ErrorOptions,
     ResponseCache,
@@ -12,18 +12,18 @@ export type {
     RawScopedCache,
     ValidCacheData,
     ScopedCache,
-} from "./util/types.js";
+} from "./util/types";
 
-export * from "./util/hydration-cache-api.js";
-export * from "./util/request-api.js";
-export {purgeCaches} from "./util/purge-caches.js";
-export {default as TrackData} from "./components/track-data.js";
-export {default as Data} from "./components/data.js";
-export {default as InterceptRequests} from "./components/intercept-requests.js";
-export {DataError, DataErrors} from "./util/data-error.js";
-export {useServerEffect} from "./hooks/use-server-effect.js";
-export {useCachedEffect} from "./hooks/use-cached-effect.js";
-export {useSharedCache, SharedCache} from "./hooks/use-shared-cache.js";
+export * from "./util/hydration-cache-api";
+export * from "./util/request-api";
+export {purgeCaches} from "./util/purge-caches";
+export {default as TrackData} from "./components/track-data";
+export {default as Data} from "./components/data";
+export {default as InterceptRequests} from "./components/intercept-requests";
+export {DataError, DataErrors} from "./util/data-error";
+export {useServerEffect} from "./hooks/use-server-effect";
+export {useCachedEffect} from "./hooks/use-cached-effect";
+export {useSharedCache, SharedCache} from "./hooks/use-shared-cache";
 export {
     useHydratableEffect,
     // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
@@ -31,25 +31,25 @@ export {
     // https://github.com/import-js/eslint-plugin-import/issues/2073
     // eslint-disable-next-line import/named
     WhenClientSide,
-} from "./hooks/use-hydratable-effect.js";
-export {ScopedInMemoryCache} from "./util/scoped-in-memory-cache.js";
-export {SerializableInMemoryCache} from "./util/serializable-in-memory-cache.js";
-export {Status} from "./util/status.js";
+} from "./hooks/use-hydratable-effect";
+export {ScopedInMemoryCache} from "./util/scoped-in-memory-cache";
+export {SerializableInMemoryCache} from "./util/serializable-in-memory-cache";
+export {Status} from "./util/status";
 
 ////////////////////////////////////////////////////////////////////////////////
 // GraphQL
 ////////////////////////////////////////////////////////////////////////////////
-export {getGqlRequestId} from "./util/get-gql-request-id.js";
-export {getGqlDataFromResponse} from "./util/get-gql-data-from-response.js";
-export {graphQLDocumentNodeParser} from "./util/graphql-document-node-parser.js";
-export {toGqlOperation} from "./util/to-gql-operation.js";
-export {GqlRouter} from "./components/gql-router.js";
-export {useGql} from "./hooks/use-gql.js";
-export {GqlError, GqlErrors} from "./util/gql-error.js";
+export {getGqlRequestId} from "./util/get-gql-request-id";
+export {getGqlDataFromResponse} from "./util/get-gql-data-from-response";
+export {graphQLDocumentNodeParser} from "./util/graphql-document-node-parser";
+export {toGqlOperation} from "./util/to-gql-operation";
+export {GqlRouter} from "./components/gql-router";
+export {useGql} from "./hooks/use-gql";
+export {GqlError, GqlErrors} from "./util/gql-error";
 export type {
     GqlContext,
     GqlOperation,
     GqlOperationType,
     GqlFetchOptions,
     GqlFetchFn,
-} from "./util/gql-types.js";
+} from "./util/gql-types";

--- a/packages/wonder-blocks-data/src/util/__tests__/get-gql-data-from-response.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/get-gql-data-from-response.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {getGqlDataFromResponse} from "../get-gql-data-from-response.js";
+import {getGqlDataFromResponse} from "../get-gql-data-from-response";
 
 describe("#getGqlDataFromReponse", () => {
     it("should throw if the response cannot be parsed", async () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/get-gql-request-id.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/get-gql-request-id.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {getGqlRequestId} from "../get-gql-request-id.js";
+import {getGqlRequestId} from "../get-gql-request-id";
 
 describe("#getGqlRequestId", () => {
     it("should include the id of the query", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/graphql-document-node-parser.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/graphql-document-node-parser.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {graphQLDocumentNodeParser} from "../graphql-document-node-parser.js";
+import {graphQLDocumentNodeParser} from "../graphql-document-node-parser";
 
 describe("#graphQLDocumentNodeParser", () => {
     describe("in production - shorter error messages", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/hydration-cache-api.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/hydration-cache-api.test.js
@@ -1,10 +1,10 @@
 // @flow
-import {SsrCache} from "../ssr-cache.js";
+import {SsrCache} from "../ssr-cache";
 
 import {
     initializeHydrationCache,
     purgeHydrationCache,
-} from "../hydration-cache-api.js";
+} from "../hydration-cache-api";
 
 describe("#initializeHydrationCache", () => {
     it("should call SsrCache.Default.initialize", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/merge-gql-context.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/merge-gql-context.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {mergeGqlContext} from "../merge-gql-context.js";
+import {mergeGqlContext} from "../merge-gql-context";
 
 describe("#mergeGqlContext", () => {
     it("should combine the default context with the given overrides", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/purge-caches.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/purge-caches.test.js
@@ -1,8 +1,8 @@
 // @flow
-import {SharedCache} from "../../hooks/use-shared-cache.js";
-import * as HydrationCacheApi from "../hydration-cache-api.js";
+import {SharedCache} from "../../hooks/use-shared-cache";
+import * as HydrationCacheApi from "../hydration-cache-api";
 
-import {purgeCaches} from "../purge-caches.js";
+import {purgeCaches} from "../purge-caches";
 
 describe("#purgeCaches", () => {
     it("should purge the shared cache", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/request-api.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-api.test.js
@@ -1,13 +1,13 @@
 // @flow
 import {Server} from "@khanacademy/wonder-blocks-core";
-import {RequestFulfillment} from "../request-fulfillment.js";
-import {RequestTracker} from "../request-tracking.js";
+import {RequestFulfillment} from "../request-fulfillment";
+import {RequestTracker} from "../request-tracking";
 
 import {
     abortInflightRequests,
     fetchTrackedRequests,
     hasTrackedRequestsToBeFetched,
-} from "../request-api.js";
+} from "../request-api";
 
 describe("#fetchTrackedRequests", () => {
     describe("when server-side", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/request-fulfillment.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-fulfillment.test.js
@@ -1,6 +1,6 @@
 // @flow
-import {RequestFulfillment} from "../request-fulfillment.js";
-import {DataError} from "../data-error.js";
+import {RequestFulfillment} from "../request-fulfillment";
+import {DataError} from "../data-error";
 
 describe("RequestFulfillment", () => {
     it("should provide static default instance", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {render} from "@testing-library/react";
 
 import {Server} from "@khanacademy/wonder-blocks-core";
-import {RequestTracker, TrackerContext} from "../request-tracking.js";
-import {SsrCache} from "../ssr-cache.js";
+import {RequestTracker, TrackerContext} from "../request-tracking";
+import {SsrCache} from "../ssr-cache";
 
 describe("../request-tracking.js", () => {
     describe("TrackerContext", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {resultFromCachedResponse} from "../result-from-cache-response.js";
+import {resultFromCachedResponse} from "../result-from-cache-response";
 
 describe("#resultFromCachedResponse", () => {
     it("should return null cache entry is null", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/scoped-in-memory-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/scoped-in-memory-cache.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {ScopedInMemoryCache} from "../scoped-in-memory-cache.js";
+import {ScopedInMemoryCache} from "../scoped-in-memory-cache";
 
 describe("ScopedInMemoryCache", () => {
     describe("#set", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/serializable-in-memory-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/serializable-in-memory-cache.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as WSCore from "@khanacademy/wonder-stuff-core";
-import {SerializableInMemoryCache} from "../serializable-in-memory-cache.js";
+import {SerializableInMemoryCache} from "../serializable-in-memory-cache";
 
 describe("SerializableInMemoryCache", () => {
     describe("#constructor", () => {

--- a/packages/wonder-blocks-data/src/util/__tests__/ssr-cache.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/ssr-cache.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {Server} from "@khanacademy/wonder-blocks-core";
-import {SsrCache} from "../ssr-cache.js";
-import {SerializableInMemoryCache} from "../serializable-in-memory-cache.js";
+import {SsrCache} from "../ssr-cache";
+import {SerializableInMemoryCache} from "../serializable-in-memory-cache";
 
 describe("../ssr-cache.js", () => {
     afterEach(() => {

--- a/packages/wonder-blocks-data/src/util/__tests__/to-gql-operation.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/to-gql-operation.test.js
@@ -1,6 +1,6 @@
 // @flow
-import {toGqlOperation} from "../to-gql-operation.js";
-import * as GDNP from "../graphql-document-node-parser.js";
+import {toGqlOperation} from "../to-gql-operation";
+import * as GDNP from "../graphql-document-node-parser";
 
 jest.mock("../graphql-document-node-parser.js");
 

--- a/packages/wonder-blocks-data/src/util/__tests__/to-gql-operation.test.js
+++ b/packages/wonder-blocks-data/src/util/__tests__/to-gql-operation.test.js
@@ -2,7 +2,7 @@
 import {toGqlOperation} from "../to-gql-operation";
 import * as GDNP from "../graphql-document-node-parser";
 
-jest.mock("../graphql-document-node-parser.js");
+jest.mock("../graphql-document-node-parser");
 
 describe("#toGqlOperation", () => {
     it("should parse the document node", () => {

--- a/packages/wonder-blocks-data/src/util/data-error.js
+++ b/packages/wonder-blocks-data/src/util/data-error.js
@@ -1,6 +1,6 @@
 // @flow
 import {KindError} from "@khanacademy/wonder-stuff-core";
-import type {ErrorOptions} from "./types.js";
+import type {ErrorOptions} from "./types";
 
 /**
  * Error kinds for DataError.

--- a/packages/wonder-blocks-data/src/util/get-gql-data-from-response.js
+++ b/packages/wonder-blocks-data/src/util/get-gql-data-from-response.js
@@ -1,6 +1,6 @@
 // @flow
-import {DataError, DataErrors} from "./data-error.js";
-import {GqlError, GqlErrors} from "./gql-error.js";
+import {DataError, DataErrors} from "./data-error";
+import {GqlError, GqlErrors} from "./gql-error";
 
 /**
  * Validate a GQL operation response and extract the data.

--- a/packages/wonder-blocks-data/src/util/get-gql-request-id.js
+++ b/packages/wonder-blocks-data/src/util/get-gql-request-id.js
@@ -1,6 +1,6 @@
 // @flow
 import {entries} from "@khanacademy/wonder-stuff-core";
-import type {GqlOperation, GqlContext} from "./gql-types.js";
+import type {GqlOperation, GqlContext} from "./gql-types";
 
 const toString = (value: mixed): string => {
     if (typeof value === "string") {

--- a/packages/wonder-blocks-data/src/util/gql-error.js
+++ b/packages/wonder-blocks-data/src/util/gql-error.js
@@ -1,7 +1,7 @@
 // @flow
 import {KindError} from "@khanacademy/wonder-stuff-core";
 
-import type {ErrorOptions} from "./types.js";
+import type {ErrorOptions} from "./types";
 
 /**
  * Error kinds for GqlError.

--- a/packages/wonder-blocks-data/src/util/gql-router-context.js
+++ b/packages/wonder-blocks-data/src/util/gql-router-context.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import type {GqlRouterConfiguration} from "./gql-types.js";
+import type {GqlRouterConfiguration} from "./gql-types";
 
 export const GqlRouterContext: React.Context<?GqlRouterConfiguration<any>> =
     React.createContext<?GqlRouterConfiguration<any>>(null);

--- a/packages/wonder-blocks-data/src/util/graphql-document-node-parser.js
+++ b/packages/wonder-blocks-data/src/util/graphql-document-node-parser.js
@@ -4,8 +4,8 @@ import type {
     DefinitionNode,
     VariableDefinitionNode,
     OperationDefinitionNode,
-} from "./graphql-types.js";
-import {DataError, DataErrors} from "./data-error.js";
+} from "./graphql-types";
+import {DataError, DataErrors} from "./data-error";
 
 export const DocumentTypes = Object.freeze({
     query: "query",

--- a/packages/wonder-blocks-data/src/util/hydration-cache-api.js
+++ b/packages/wonder-blocks-data/src/util/hydration-cache-api.js
@@ -1,7 +1,7 @@
 // @flow
-import {SsrCache} from "./ssr-cache.js";
+import {SsrCache} from "./ssr-cache";
 
-import type {ValidCacheData, CachedResponse, ResponseCache} from "./types.js";
+import type {ValidCacheData, CachedResponse, ResponseCache} from "./types";
 
 /**
  * Initialize the hydration cache.

--- a/packages/wonder-blocks-data/src/util/merge-gql-context.js
+++ b/packages/wonder-blocks-data/src/util/merge-gql-context.js
@@ -1,5 +1,5 @@
 // @flow
-import type {GqlContext} from "./gql-types.js";
+import type {GqlContext} from "./gql-types";
 
 /**
  * Construct a complete GqlContext from current defaults and a partial context.

--- a/packages/wonder-blocks-data/src/util/purge-caches.js
+++ b/packages/wonder-blocks-data/src/util/purge-caches.js
@@ -1,6 +1,6 @@
 // @flow
-import {SharedCache} from "../hooks/use-shared-cache.js";
-import {purgeHydrationCache} from "./hydration-cache-api.js";
+import {SharedCache} from "../hooks/use-shared-cache";
+import {purgeHydrationCache} from "./hydration-cache-api";
 
 /**
  * Purge all caches managed by Wonder Blocks Data.

--- a/packages/wonder-blocks-data/src/util/request-api.js
+++ b/packages/wonder-blocks-data/src/util/request-api.js
@@ -1,10 +1,10 @@
 // @flow
 import {Server} from "@khanacademy/wonder-blocks-core";
-import {RequestTracker} from "./request-tracking.js";
-import {RequestFulfillment} from "./request-fulfillment.js";
-import {DataError, DataErrors} from "./data-error.js";
+import {RequestTracker} from "./request-tracking";
+import {RequestFulfillment} from "./request-fulfillment";
+import {DataError, DataErrors} from "./data-error";
 
-import type {ResponseCache} from "./types.js";
+import type {ResponseCache} from "./types";
 
 const SSRCheck = () => {
     if (Server.isServerSide()) {

--- a/packages/wonder-blocks-data/src/util/request-fulfillment.js
+++ b/packages/wonder-blocks-data/src/util/request-fulfillment.js
@@ -1,7 +1,7 @@
 // @flow
-import type {Result, ValidCacheData} from "./types.js";
+import type {Result, ValidCacheData} from "./types";
 
-import {DataError, DataErrors} from "./data-error.js";
+import {DataError, DataErrors} from "./data-error";
 
 type RequestCache = {
     [id: string]: Promise<Result<any>>,

--- a/packages/wonder-blocks-data/src/util/request-tracking.js
+++ b/packages/wonder-blocks-data/src/util/request-tracking.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
-import {SsrCache} from "./ssr-cache.js";
-import {RequestFulfillment} from "./request-fulfillment.js";
+import {SsrCache} from "./ssr-cache";
+import {RequestFulfillment} from "./request-fulfillment";
 
-import type {ResponseCache, ValidCacheData} from "./types.js";
+import type {ResponseCache, ValidCacheData} from "./types";
 
 type TrackerFn = <TData: ValidCacheData>(
     id: string,

--- a/packages/wonder-blocks-data/src/util/result-from-cache-response.js
+++ b/packages/wonder-blocks-data/src/util/result-from-cache-response.js
@@ -1,7 +1,7 @@
 // @flow
-import {Status} from "./status.js";
-import {DataError, DataErrors} from "./data-error.js";
-import type {ValidCacheData, CachedResponse, Result} from "./types.js";
+import {Status} from "./status";
+import {DataError, DataErrors} from "./data-error";
+import type {ValidCacheData, CachedResponse, Result} from "./types";
 
 /**
  * Turns a cache entry into a stateful result.

--- a/packages/wonder-blocks-data/src/util/scoped-in-memory-cache.js
+++ b/packages/wonder-blocks-data/src/util/scoped-in-memory-cache.js
@@ -1,6 +1,6 @@
 // @flow
-import {DataError, DataErrors} from "./data-error.js";
-import type {ScopedCache, RawScopedCache, ValidCacheData} from "./types.js";
+import {DataError, DataErrors} from "./data-error";
+import type {ScopedCache, RawScopedCache, ValidCacheData} from "./types";
 
 /**
  * Describe an in-memory cache.

--- a/packages/wonder-blocks-data/src/util/serializable-in-memory-cache.js
+++ b/packages/wonder-blocks-data/src/util/serializable-in-memory-cache.js
@@ -1,8 +1,8 @@
 // @flow
 import {clone} from "@khanacademy/wonder-stuff-core";
-import {DataError, DataErrors} from "./data-error.js";
-import {ScopedInMemoryCache} from "./scoped-in-memory-cache.js";
-import type {ValidCacheData, RawScopedCache} from "./types.js";
+import {DataError, DataErrors} from "./data-error";
+import {ScopedInMemoryCache} from "./scoped-in-memory-cache";
+import type {ValidCacheData, RawScopedCache} from "./types";
 
 /**
  * Describe a serializable in-memory cache.

--- a/packages/wonder-blocks-data/src/util/ssr-cache.js
+++ b/packages/wonder-blocks-data/src/util/ssr-cache.js
@@ -1,8 +1,8 @@
 // @flow
 import {Server} from "@khanacademy/wonder-blocks-core";
-import {SerializableInMemoryCache} from "./serializable-in-memory-cache.js";
+import {SerializableInMemoryCache} from "./serializable-in-memory-cache";
 
-import type {ValidCacheData, CachedResponse, ResponseCache} from "./types.js";
+import type {ValidCacheData, CachedResponse, ResponseCache} from "./types";
 
 const DefaultScope = "default";
 

--- a/packages/wonder-blocks-data/src/util/status.js
+++ b/packages/wonder-blocks-data/src/util/status.js
@@ -1,5 +1,5 @@
 // @flow
-import type {Result, ValidCacheData} from "./types.js";
+import type {Result, ValidCacheData} from "./types";
 
 const loadingStatus = Object.freeze({
     status: "loading",

--- a/packages/wonder-blocks-data/src/util/to-gql-operation.js
+++ b/packages/wonder-blocks-data/src/util/to-gql-operation.js
@@ -1,7 +1,7 @@
 // @flow
-import {graphQLDocumentNodeParser} from "./graphql-document-node-parser.js";
-import type {GqlOperation} from "./gql-types.js";
-import type {DocumentNode} from "./graphql-types.js";
+import {graphQLDocumentNodeParser} from "./graphql-document-node-parser";
+import type {GqlOperation} from "./gql-types";
+import type {DocumentNode} from "./graphql-types";
 
 /**
  * Convert a GraphQL DocumentNode to a base Wonder Blocks Data GqlOperation.

--- a/packages/wonder-blocks-dropdown/src/components/__docs__/action-menu.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/__docs__/action-menu.stories.js
@@ -17,11 +17,11 @@ import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
-import actionMenuArgtypes from "./action-menu.argtypes.js";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import actionMenuArgtypes from "./action-menu.argtypes";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
-import type {Item} from "../../util/types.js";
+import type {Item} from "../../util/types";
 
 type ActionMenuProps = React.ElementProps<typeof ActionMenu>;
 

--- a/packages/wonder-blocks-dropdown/src/components/__docs__/multi-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/__docs__/multi-select.stories.js
@@ -15,10 +15,10 @@ import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import multiSelectArgtypes from "./base-select.argtypes.js";
-import {defaultLabels} from "../../util/constants.js";
+import multiSelectArgtypes from "./base-select.argtypes";
+import {defaultLabels} from "../../util/constants";
 
 export default {
     title: "Dropdown / MultiSelect",

--- a/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
+++ b/packages/wonder-blocks-dropdown/src/components/__docs__/single-select.stories.js
@@ -23,10 +23,10 @@ import {
 import type {SingleSelectLabels} from "@khanacademy/wonder-blocks-dropdown";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import singleSelectArgtypes from "./base-select.argtypes.js";
-import {defaultLabels} from "../../util/constants.js";
+import singleSelectArgtypes from "./base-select.argtypes";
+import {defaultLabels} from "../../util/constants";
 
 export default {
     title: "Dropdown / SingleSelect",

--- a/packages/wonder-blocks-dropdown/src/components/__mocks__/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/src/components/__mocks__/dropdown-core-virtualized.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {VariableSizeList as List} from "react-window";
 
-import DropdownVirtualizedItem from "../dropdown-core-virtualized-item.js";
+import DropdownVirtualizedItem from "../dropdown-core-virtualized-item";
 
-import type {DropdownItem} from "../../util/types.js";
+import type {DropdownItem} from "../../util/types";
 
 type Props = {|
     data: Array<DropdownItem>,

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-item.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-item.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import * as ReactRouterDOM from "react-router-dom";
 
-import ActionItem from "../action-item.js";
+import ActionItem from "../action-item";
 
 jest.mock("react-router-dom", () => ({
     __esModule: true,

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.js
@@ -3,10 +3,10 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import ActionItem from "../action-item.js";
-import OptionItem from "../option-item.js";
-import SeparatorItem from "../separator-item.js";
-import ActionMenu from "../action-menu.js";
+import ActionItem from "../action-item";
+import OptionItem from "../option-item";
+import SeparatorItem from "../separator-item";
+import ActionMenu from "../action-menu";
 
 describe("ActionMenu", () => {
     const onClick = jest.fn();

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core-virtualized.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core-virtualized.test.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import OptionItem from "../option-item.js";
-import SeparatorItem from "../separator-item.js";
-import DropdownCoreVirtualized from "../dropdown-core-virtualized.js";
+import OptionItem from "../option-item";
+import SeparatorItem from "../separator-item";
+import DropdownCoreVirtualized from "../dropdown-core-virtualized";
 
 describe("DropdownCoreVirtualized", () => {
     it("should sort the items on first load", () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import OptionItem from "../option-item.js";
-import DropdownCore from "../dropdown-core.js";
+import OptionItem from "../option-item";
+import DropdownCore from "../dropdown-core";
 
 const items = [
     {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-popper.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-popper.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import DropdownPopper from "../dropdown-popper.js";
+import DropdownPopper from "../dropdown-popper";
 
 describe("DropdownPopper", () => {
     it("renders the children if valid props are passed in", () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.js
@@ -6,10 +6,10 @@ import userEvent from "@testing-library/user-event";
 
 import {ngettext} from "@khanacademy/wonder-blocks-i18n";
 
-import OptionItem from "../option-item.js";
-import MultiSelect from "../multi-select.js";
+import OptionItem from "../option-item";
+import MultiSelect from "../multi-select";
 
-import type {Labels} from "../multi-select.js";
+import type {Labels} from "../multi-select";
 
 const labels: $Shape<Labels> = {
     selectAllLabel: (numOptions) => `Sellect all (${numOptions})`,

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.js
@@ -3,9 +3,9 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import OptionItem from "../option-item.js";
-import SingleSelect from "../single-select.js";
-import type {SingleSelectLabels} from "../single-select.js";
+import OptionItem from "../option-item";
+import SingleSelect from "../single-select";
+import type {SingleSelectLabels} from "../single-select";
 
 describe("SingleSelect", () => {
     const onChange = jest.fn();

--- a/packages/wonder-blocks-dropdown/src/components/action-item.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.js
@@ -16,7 +16,7 @@ import {addStyle} from "@khanacademy/wonder-blocks-core";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import {DROPDOWN_ITEM_HEIGHT} from "../util/constants.js";
+import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 
 const {blue, white, offBlack, offBlack32} = Color;
 

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.js
@@ -11,7 +11,7 @@ import {Strut} from "@khanacademy/wonder-blocks-layout";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import type {ClickableState} from "@khanacademy/wonder-blocks-clickable";
 
-import {DROPDOWN_ITEM_HEIGHT} from "../util/constants.js";
+import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 
 type Props = {|
     ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.js
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.js
@@ -4,13 +4,13 @@ import * as React from "react";
 import ReactDOM from "react-dom";
 import {StyleSheet} from "aphrodite";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import DropdownOpener from "./dropdown-opener.js";
-import ActionItem from "./action-item.js";
-import OptionItem from "./option-item.js";
-import DropdownCore from "./dropdown-core.js";
+import DropdownOpener from "./dropdown-opener";
+import ActionItem from "./action-item";
+import OptionItem from "./option-item";
+import DropdownCore from "./dropdown-core";
 
-import ActionMenuOpenerCore from "./action-menu-opener-core.js";
-import type {Item, DropdownItem, OpenerProps} from "../util/types.js";
+import ActionMenuOpenerCore from "./action-menu-opener-core";
+import type {Item, DropdownItem, OpenerProps} from "../util/types";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized-item.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized-item.js
@@ -3,9 +3,9 @@ import * as React from "react";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import SeparatorItem from "./separator-item.js";
+import SeparatorItem from "./separator-item";
 
-import type {DropdownItem} from "../util/types.js";
+import type {DropdownItem} from "../util/types";
 
 // copied from https://github.com/bvaughn/react-window/blob/master/src/createListComponent.js#L17
 type Props = {|

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized.js
@@ -8,17 +8,17 @@ import type {
     WithActionSchedulerProps,
     WithoutActionScheduler,
 } from "@khanacademy/wonder-blocks-timing";
-import DropdownVirtualizedItem from "./dropdown-core-virtualized-item.js";
-import SeparatorItem from "./separator-item.js";
+import DropdownVirtualizedItem from "./dropdown-core-virtualized-item";
+import SeparatorItem from "./separator-item";
 
-import type {DropdownItem} from "../util/types.js";
+import type {DropdownItem} from "../util/types";
 
 import {
     DROPDOWN_ITEM_HEIGHT,
     MAX_VISIBLE_ITEMS,
     SEPARATOR_ITEM_HEIGHT,
-} from "../util/constants.js";
-import {getDropdownMenuHeight} from "../util/dropdown-menu-styles.js";
+} from "../util/constants";
+import {getDropdownMenuHeight} from "../util/dropdown-menu-styles";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.js
@@ -21,16 +21,16 @@ import type {
     WithActionSchedulerProps,
     WithoutActionScheduler,
 } from "@khanacademy/wonder-blocks-timing";
-import DropdownCoreVirtualized from "./dropdown-core-virtualized.js";
-import SeparatorItem from "./separator-item.js";
-import {defaultLabels, keyCodes} from "../util/constants.js";
-import type {DropdownItem} from "../util/types.js";
-import DropdownPopper from "./dropdown-popper.js";
-import {debounce, getStringForKey} from "../util/helpers.js";
+import DropdownCoreVirtualized from "./dropdown-core-virtualized";
+import SeparatorItem from "./separator-item";
+import {defaultLabels, keyCodes} from "../util/constants";
+import type {DropdownItem} from "../util/types";
+import DropdownPopper from "./dropdown-popper";
+import {debounce, getStringForKey} from "../util/helpers";
 import {
     generateDropdownMenuStyles,
     getDropdownMenuHeight,
-} from "../util/dropdown-menu-styles.js";
+} from "../util/dropdown-menu-styles";
 
 /**
  * The number of options to apply the virtualized list to.

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-opener.js
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-opener.js
@@ -9,7 +9,7 @@ import type {
     ClickableState,
 } from "@khanacademy/wonder-blocks-clickable";
 
-import type {OpenerProps} from "../util/types.js";
+import type {OpenerProps} from "../util/types";
 
 type Props = {|
     ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.js
@@ -5,19 +5,19 @@ import ReactDOM from "react-dom";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
-import ActionItem from "./action-item.js";
-import DropdownCore from "./dropdown-core.js";
-import DropdownOpener from "./dropdown-opener.js";
-import SelectOpener from "./select-opener.js";
-import SeparatorItem from "./separator-item.js";
+import ActionItem from "./action-item";
+import DropdownCore from "./dropdown-core";
+import DropdownOpener from "./dropdown-opener";
+import SelectOpener from "./select-opener";
+import SeparatorItem from "./separator-item";
 import {
     defaultLabels,
     selectDropdownStyle,
     filterableDropdownStyle,
-} from "../util/constants.js";
+} from "../util/constants";
 
-import typeof OptionItem from "./option-item.js";
-import type {DropdownItem, OpenerProps} from "../util/types.js";
+import typeof OptionItem from "./option-item";
+import type {DropdownItem, OpenerProps} from "../util/types";
 
 export type Labels = {|
     /**

--- a/packages/wonder-blocks-dropdown/src/components/option-item.js
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.js
@@ -11,9 +11,9 @@ import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
-import {DROPDOWN_ITEM_HEIGHT} from "../util/constants.js";
-import Check from "./check.js";
-import Checkbox from "./checkbox.js";
+import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
+import Check from "./check";
+import Checkbox from "./checkbox";
 
 type OptionProps = {|
     ...AriaProps,

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.js
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.js
@@ -12,7 +12,7 @@ import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import {DROPDOWN_ITEM_HEIGHT} from "../util/constants.js";
+import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 
 const StyledButton = addStyle("button");
 

--- a/packages/wonder-blocks-dropdown/src/components/single-select.js
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.js
@@ -5,17 +5,17 @@ import ReactDOM from "react-dom";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
-import DropdownCore from "./dropdown-core.js";
-import DropdownOpener from "./dropdown-opener.js";
-import SelectOpener from "./select-opener.js";
+import DropdownCore from "./dropdown-core";
+import DropdownOpener from "./dropdown-opener";
+import SelectOpener from "./select-opener";
 import {
     defaultLabels,
     selectDropdownStyle,
     filterableDropdownStyle,
-} from "../util/constants.js";
+} from "../util/constants";
 
-import typeof OptionItem from "./option-item.js";
-import type {DropdownItem, OpenerProps} from "../util/types.js";
+import typeof OptionItem from "./option-item";
+import type {DropdownItem, OpenerProps} from "../util/types";
 
 export type SingleSelectLabels = {|
     /**

--- a/packages/wonder-blocks-dropdown/src/index.js
+++ b/packages/wonder-blocks-dropdown/src/index.js
@@ -1,13 +1,13 @@
 // @flow
-import ActionItem from "./components/action-item.js";
-import OptionItem from "./components/option-item.js";
-import SeparatorItem from "./components/separator-item.js";
-import ActionMenu from "./components/action-menu.js";
-import SingleSelect from "./components/single-select.js";
-import MultiSelect from "./components/multi-select.js";
+import ActionItem from "./components/action-item";
+import OptionItem from "./components/option-item";
+import SeparatorItem from "./components/separator-item";
+import ActionMenu from "./components/action-menu";
+import SingleSelect from "./components/single-select";
+import MultiSelect from "./components/multi-select";
 
-import type {Labels} from "./components/multi-select.js";
-import type {SingleSelectLabels} from "./components/single-select.js";
+import type {Labels} from "./components/multi-select";
+import type {SingleSelectLabels} from "./components/single-select";
 
 export {
     ActionItem,

--- a/packages/wonder-blocks-dropdown/src/util/__tests__/dropdown-menu-styles.test.js
+++ b/packages/wonder-blocks-dropdown/src/util/__tests__/dropdown-menu-styles.test.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
-import OptionItem from "../../components/option-item.js";
-import SeparatorItem from "../../components/separator-item.js";
+import OptionItem from "../../components/option-item";
+import SeparatorItem from "../../components/separator-item";
 
-import {getDropdownMenuHeight} from "../dropdown-menu-styles.js";
+import {getDropdownMenuHeight} from "../dropdown-menu-styles";
 
 const optionItems = [
     {

--- a/packages/wonder-blocks-dropdown/src/util/__tests__/helpers.test.js
+++ b/packages/wonder-blocks-dropdown/src/util/__tests__/helpers.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {debounce, getStringForKey} from "../helpers.js";
+import {debounce, getStringForKey} from "../helpers";
 
 describe("getStringForKey", () => {
     it("should get a valid string", () => {

--- a/packages/wonder-blocks-dropdown/src/util/dropdown-menu-styles.js
+++ b/packages/wonder-blocks-dropdown/src/util/dropdown-menu-styles.js
@@ -7,11 +7,11 @@ import {
     DROPDOWN_ITEM_HEIGHT,
     MAX_VISIBLE_ITEMS,
     SEPARATOR_ITEM_HEIGHT,
-} from "./constants.js";
+} from "./constants";
 
-import SeparatorItem from "../components/separator-item.js";
+import SeparatorItem from "../components/separator-item";
 
-import type {DropdownItem} from "./types.js";
+import type {DropdownItem} from "./types";
 
 /**
  * The list height that is automatically calculated depending on the

--- a/packages/wonder-blocks-dropdown/src/util/types.js
+++ b/packages/wonder-blocks-dropdown/src/util/types.js
@@ -3,9 +3,9 @@
 import * as React from "react";
 import type {ClickableState} from "@khanacademy/wonder-blocks-clickable";
 
-import typeof ActionItem from "../components/action-item.js";
-import typeof OptionItem from "../components/option-item.js";
-import typeof SeparatorItem from "../components/separator-item.js";
+import typeof ActionItem from "../components/action-item";
+import typeof OptionItem from "../components/option-item";
+import typeof SeparatorItem from "../components/separator-item";
 
 //TODO: rename into something more descriptive
 export type Item =

--- a/packages/wonder-blocks-form/src/__tests__/custom-snapshot.test.js
+++ b/packages/wonder-blocks-form/src/__tests__/custom-snapshot.test.js
@@ -2,8 +2,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-import CheckboxCore from "../components/checkbox-core.js";
-import RadioCore from "../components/radio-core.js";
+import CheckboxCore from "../components/checkbox-core";
+import RadioCore from "../components/radio-core";
 
 const states = ["default", "error", "disabled"];
 const clickableStates = ["default", "hovered", "pressed"];

--- a/packages/wonder-blocks-form/src/components/__docs__/checkbox-group.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/checkbox-group.stories.js
@@ -10,7 +10,7 @@ import {LabelLarge, LabelXSmall} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-form/src/components/__docs__/checkbox.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/checkbox.stories.js
@@ -6,9 +6,9 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {StoryComponentType} from "@storybook/react";
 
-import Checkbox from "../checkbox.js";
+import Checkbox from "../checkbox";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-form/src/components/__docs__/choice.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/choice.stories.js
@@ -13,7 +13,7 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-form/src/components/__docs__/labeled-text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/labeled-text-field.stories.js
@@ -13,9 +13,9 @@ import Link from "@khanacademy/wonder-blocks-link";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import LabeledTextFieldArgTypes from "./labeled-text-field.argtypes.js";
+import LabeledTextFieldArgTypes from "./labeled-text-field.argtypes";
 
 export default {
     title: "Form / LabeledTextField",

--- a/packages/wonder-blocks-form/src/components/__docs__/radio-group.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/radio-group.stories.js
@@ -7,7 +7,7 @@ import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-form/src/components/__docs__/radio.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/radio.stories.js
@@ -6,10 +6,10 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
-import Radio from "../radio.js";
+import Radio from "../radio";
 
 export default {
     title: "Form / Radio (internal)",

--- a/packages/wonder-blocks-form/src/components/__docs__/text-field.stories.js
+++ b/packages/wonder-blocks-form/src/components/__docs__/text-field.stories.js
@@ -11,9 +11,9 @@ import Button from "@khanacademy/wonder-blocks-button";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import TextFieldArgTypes from "./text-field.argtypes.js";
+import TextFieldArgTypes from "./text-field.argtypes";
 
 export default {
     title: "Form / TextField",

--- a/packages/wonder-blocks-form/src/components/__tests__/checkbox-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/checkbox-group.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import CheckboxGroup from "../checkbox-group.js";
-import Choice from "../choice.js";
+import CheckboxGroup from "../checkbox-group";
+import Choice from "../choice";
 
 describe("CheckboxGroup", () => {
     describe("behavior", () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.js
@@ -6,8 +6,8 @@ import {StyleSheet} from "aphrodite";
 import {I18nInlineMarkup} from "@khanacademy/wonder-blocks-i18n";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
-import FieldHeading from "../field-heading.js";
-import TextField from "../text-field.js";
+import FieldHeading from "../field-heading";
+import TextField from "../text-field";
 
 describe("FieldHeading", () => {
     it("fieldheading renders the label text", () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.js
@@ -4,7 +4,7 @@ import {render, screen, fireEvent} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {StyleSheet} from "aphrodite";
-import LabeledTextField from "../labeled-text-field.js";
+import LabeledTextField from "../labeled-text-field";
 
 describe("LabeledTextField", () => {
     it("labeledtextfield becomes focused", () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/radio-group.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import RadioGroup from "../radio-group.js";
-import Choice from "../choice.js";
+import RadioGroup from "../radio-group";
+import Choice from "../choice";
 
 describe("RadioGroup", () => {
     const TestComponent = ({

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {fireEvent, render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import TextField from "../text-field.js";
+import TextField from "../text-field";
 
 describe("TextField", () => {
     it("textfield is focused", () => {

--- a/packages/wonder-blocks-form/src/components/checkbox-core.js
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.js
@@ -9,7 +9,7 @@ import Icon from "@khanacademy/wonder-blocks-icon";
 
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 
-import type {ChoiceCoreProps} from "../util/types.js";
+import type {ChoiceCoreProps} from "../util/types";
 
 type Props = {|
     ...ChoiceCoreProps,

--- a/packages/wonder-blocks-form/src/components/checkbox-group.js
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.js
@@ -8,8 +8,8 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import styles from "./group-styles.js";
-import typeof Choice from "./choice.js";
+import styles from "./group-styles";
+import typeof Choice from "./choice";
 
 // Keep synced with CheckboxGroupProps in ../util/types.js
 type CheckboxGroupProps = {|

--- a/packages/wonder-blocks-form/src/components/checkbox.js
+++ b/packages/wonder-blocks-form/src/components/checkbox.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import ChoiceInternal from "./choice-internal.js";
+import ChoiceInternal from "./choice-internal";
 
 // Keep synced with ChoiceComponentProps in ../util/types.js
 type ChoiceComponentProps = {|

--- a/packages/wonder-blocks-form/src/components/choice-internal.js
+++ b/packages/wonder-blocks-form/src/components/choice-internal.js
@@ -10,8 +10,8 @@ import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import CheckboxCore from "./checkbox-core.js";
-import RadioCore from "./radio-core.js";
+import CheckboxCore from "./checkbox-core";
+import RadioCore from "./radio-core";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-form/src/components/choice.js
+++ b/packages/wonder-blocks-form/src/components/choice.js
@@ -3,8 +3,8 @@
 import * as React from "react";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import Checkbox from "./checkbox.js";
-import Radio from "./radio.js";
+import Checkbox from "./checkbox";
+import Radio from "./radio";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.js
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.js
@@ -3,8 +3,8 @@ import * as React from "react";
 
 import {IDProvider, type StyleType} from "@khanacademy/wonder-blocks-core";
 
-import FieldHeading from "./field-heading.js";
-import TextField, {type TextFieldType} from "./text-field.js";
+import FieldHeading from "./field-heading";
+import TextField, {type TextFieldType} from "./text-field";
 
 type WithForwardRef = {|forwardedRef: React.Ref<"input">|};
 

--- a/packages/wonder-blocks-form/src/components/radio-core.js
+++ b/packages/wonder-blocks-form/src/components/radio-core.js
@@ -6,7 +6,7 @@ import {StyleSheet} from "aphrodite";
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 
-import type {ChoiceCoreProps} from "../util/types.js";
+import type {ChoiceCoreProps} from "../util/types";
 
 type Props = {|
     ...ChoiceCoreProps,

--- a/packages/wonder-blocks-form/src/components/radio-group.js
+++ b/packages/wonder-blocks-form/src/components/radio-group.js
@@ -8,8 +8,8 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import styles from "./group-styles.js";
-import typeof Choice from "./choice.js";
+import styles from "./group-styles";
+import typeof Choice from "./choice";
 
 // Keep synced with RadioGroupProps in ../util/types.js
 type RadioGroupProps = {|

--- a/packages/wonder-blocks-form/src/components/radio.js
+++ b/packages/wonder-blocks-form/src/components/radio.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import ChoiceInternal from "./choice-internal.js";
+import ChoiceInternal from "./choice-internal";
 
 // Keep synced with ChoiceComponentProps in ../util/types.js
 type ChoiceComponentProps = {|

--- a/packages/wonder-blocks-form/src/index.js
+++ b/packages/wonder-blocks-form/src/index.js
@@ -1,10 +1,10 @@
 // @flow
-import Checkbox from "./components/checkbox.js";
-import Choice from "./components/choice.js";
-import CheckboxGroup from "./components/checkbox-group.js";
-import RadioGroup from "./components/radio-group.js";
-import TextField from "./components/text-field.js";
-import LabeledTextField from "./components/labeled-text-field.js";
+import Checkbox from "./components/checkbox";
+import Choice from "./components/choice";
+import CheckboxGroup from "./components/checkbox-group";
+import RadioGroup from "./components/radio-group";
+import TextField from "./components/text-field";
+import LabeledTextField from "./components/labeled-text-field";
 
 export {
     Checkbox,

--- a/packages/wonder-blocks-form/src/util/types.js
+++ b/packages/wonder-blocks-form/src/util/types.js
@@ -5,7 +5,7 @@
 // guide.
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
-import typeof Choice from "../components/choice.js";
+import typeof Choice from "../components/choice";
 
 // Shared props for radio-core and checkbox-core
 export type ChoiceCoreProps = {|

--- a/packages/wonder-blocks-grid/src/components/__tests__/row.test.js
+++ b/packages/wonder-blocks-grid/src/components/__tests__/row.test.js
@@ -7,8 +7,8 @@ import {
     MEDIA_DEFAULT_SPEC,
     MediaLayoutContext,
 } from "@khanacademy/wonder-blocks-layout";
-import Row from "../row.js";
-import Cell from "../cell.js";
+import Row from "../row";
+import Cell from "../cell";
 
 describe("Row", () => {
     describe("large", () => {

--- a/packages/wonder-blocks-grid/src/components/cell.js
+++ b/packages/wonder-blocks-grid/src/components/cell.js
@@ -6,8 +6,8 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import type {MediaSize} from "@khanacademy/wonder-blocks-layout";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
-import {flexBasis} from "../util/utils.js";
+import styles from "../util/styles";
+import {flexBasis} from "../util/utils";
 
 type Props = {|
     /** The number of columns this cell should span on a Small Grid. */

--- a/packages/wonder-blocks-grid/src/components/row.js
+++ b/packages/wonder-blocks-grid/src/components/row.js
@@ -9,9 +9,9 @@ import {
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import type {MediaQuery, MediaSize} from "@khanacademy/wonder-blocks-layout";
 
-import styles from "../util/styles.js";
-import Gutter from "./gutter.js";
-import Cell from "./cell.js";
+import styles from "../util/styles";
+import Gutter from "./gutter";
+import Cell from "./cell";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-grid/src/index.js
+++ b/packages/wonder-blocks-grid/src/index.js
@@ -1,3 +1,3 @@
 // @flow
-export {default as Cell} from "./components/cell.js";
-export {default as Row} from "./components/row.js";
+export {default as Cell} from "./components/cell";
+export {default as Row} from "./components/row";

--- a/packages/wonder-blocks-i18n/src/components/__docs__/i18n-inline-markup.stories.js
+++ b/packages/wonder-blocks-i18n/src/components/__docs__/i18n-inline-markup.stories.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
 
-import * as i18n from "../../functions/i18n.js";
+import * as i18n from "../../functions/i18n";
 
-import {I18nInlineMarkup} from "../i18n-inline-markup.js";
+import {I18nInlineMarkup} from "../i18n-inline-markup";
 
 export default {
     title: "Translations/I18nInlineMarkup",

--- a/packages/wonder-blocks-i18n/src/components/__tests__/i18n-inline-markup.test.js
+++ b/packages/wonder-blocks-i18n/src/components/__tests__/i18n-inline-markup.test.js
@@ -2,13 +2,13 @@
 import * as React from "react";
 import {render} from "@testing-library/react";
 
-import * as ParseSimpleHTML from "../parse-simple-html.js";
-import {I18nInlineMarkup} from "../i18n-inline-markup.js";
+import * as ParseSimpleHTML from "../parse-simple-html";
+import {I18nInlineMarkup} from "../i18n-inline-markup";
 import {
     SingleShallowSubstitution,
     MultipleShallowSubstitution,
     ElementWrapper,
-} from "../__docs__/i18n-inline-markup.stories.js";
+} from "../__docs__/i18n-inline-markup.stories";
 
 describe("I18nInlineMarkup", () => {
     test("SingleShallowSubstitution", () => {

--- a/packages/wonder-blocks-i18n/src/components/__tests__/parse-simple-html.test.js
+++ b/packages/wonder-blocks-i18n/src/components/__tests__/parse-simple-html.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {parseSimpleHTML} from "../parse-simple-html.js";
+import {parseSimpleHTML} from "../parse-simple-html";
 
 describe("parseSimpleHTML", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.js
+++ b/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.js
@@ -79,8 +79,8 @@
 
 import * as React from "react";
 
-import {parseSimpleHTML} from "./parse-simple-html.js";
-import type {SimpleHtmlNode} from "./parse-simple-html.js";
+import {parseSimpleHTML} from "./parse-simple-html";
+import type {SimpleHtmlNode} from "./parse-simple-html";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-accents.test.js
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-accents.test.js
@@ -1,5 +1,5 @@
 // @flow
-import Accents from "../i18n-accents.js";
+import Accents from "../i18n-accents";
 
 describe("i18n-accents.js: Accents", () => {
     describe("#constructor", () => {

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-boxes.test.js
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-boxes.test.js
@@ -1,5 +1,5 @@
 // @flow
-import Boxes, {BoxChar} from "../i18n-boxes.js";
+import Boxes, {BoxChar} from "../i18n-boxes";
 
 describe("i18n-boxes.js: Boxes", () => {
     describe("#translate", () => {

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-faketranslate.test.js
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-faketranslate.test.js
@@ -1,8 +1,8 @@
 // @flow
-import * as Locale from "../locale.js";
-import FakeTranslate, {Translators} from "../i18n-faketranslate.js";
+import * as Locale from "../locale";
+import FakeTranslate, {Translators} from "../i18n-faketranslate";
 
-import type {IProvideTranslation} from "../types.js";
+import type {IProvideTranslation} from "../types";
 
 describe("i18n-faketranslate", () => {
     describe("Translators", () => {

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.js
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
 
-import * as Locale from "../locale.js";
-import * as FakeTranslate from "../i18n-faketranslate.js";
-import {_, $_, ngettext, doNotTranslate, doNotTranslateYet} from "../i18n.js";
+import * as Locale from "../locale";
+import * as FakeTranslate from "../i18n-faketranslate";
+import {_, $_, ngettext, doNotTranslate, doNotTranslateYet} from "../i18n";
 
 jest.mock("react", () => {
     return {

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/l10n.test.js
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/l10n.test.js
@@ -1,7 +1,7 @@
 // @flow
-import * as Locale from "../locale.js";
-import * as FakeTranslate from "../i18n-faketranslate.js";
-import {localeToFixed, getDecimalSeparator} from "../l10n.js";
+import * as Locale from "../locale";
+import * as FakeTranslate from "../i18n-faketranslate";
+import {localeToFixed, getDecimalSeparator} from "../l10n";
 
 describe("l10n", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/locale.test.js
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/locale.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {getLocale, setLocale} from "../locale.js";
+import {getLocale, setLocale} from "../locale";
 
 describe("#getLocale/#setLocale", () => {
     afterEach(() => {

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/plural-forms.test.js
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/plural-forms.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {allPluralForms, likeFrench} from "../plural-forms.js";
+import {allPluralForms, likeFrench} from "../plural-forms";
 
 describe("allPluralForms", () => {
     describe("likeFrench", () => {

--- a/packages/wonder-blocks-i18n/src/functions/i18n-accents.js
+++ b/packages/wonder-blocks-i18n/src/functions/i18n-accents.js
@@ -1,5 +1,5 @@
 // @flow
-import type {IProvideTranslation} from "./types.js";
+import type {IProvideTranslation} from "./types";
 
 // This map provides a way to get an "accented" character for any of the
 // 26 english alphabet characters in either upper or lower case.

--- a/packages/wonder-blocks-i18n/src/functions/i18n-boxes.js
+++ b/packages/wonder-blocks-i18n/src/functions/i18n-boxes.js
@@ -1,5 +1,5 @@
 // @flow
-import type {IProvideTranslation} from "./types.js";
+import type {IProvideTranslation} from "./types";
 
 // c.f. http://www.alanflavell.org.uk/unicode/unidata25.html
 // hollow (white) square; also try \u25a0 or \u25aa+b

--- a/packages/wonder-blocks-i18n/src/functions/i18n-faketranslate.js
+++ b/packages/wonder-blocks-i18n/src/functions/i18n-faketranslate.js
@@ -1,9 +1,9 @@
 // @flow
-import Accents from "./i18n-accents.js";
-import Boxes from "./i18n-boxes.js";
-import {getLocale} from "./locale.js";
+import Accents from "./i18n-accents";
+import Boxes from "./i18n-boxes";
+import {getLocale} from "./locale";
 
-import type {IProvideTranslation} from "./types.js";
+import type {IProvideTranslation} from "./types";
 
 type TranslatorMap = {[key: string]: IProvideTranslation, ...};
 

--- a/packages/wonder-blocks-i18n/src/functions/i18n.js
+++ b/packages/wonder-blocks-i18n/src/functions/i18n.js
@@ -4,8 +4,8 @@
 /* To fix, remove an entry above, run ka-lint, and fix errors. */
 import * as React from "react";
 
-import FakeTranslate from "./i18n-faketranslate.js";
-import {allPluralForms} from "./plural-forms.js";
+import FakeTranslate from "./i18n-faketranslate";
+import {allPluralForms} from "./plural-forms";
 
 type InterpolationOptions<T> = {[string]: T, ...};
 

--- a/packages/wonder-blocks-i18n/src/functions/l10n.js
+++ b/packages/wonder-blocks-i18n/src/functions/l10n.js
@@ -1,5 +1,5 @@
 // @flow
-import {getLocale} from "./locale.js";
+import {getLocale} from "./locale";
 
 /**
  * Rounds num to X places, and uses the proper decimal seperator.

--- a/packages/wonder-blocks-i18n/src/index.js
+++ b/packages/wonder-blocks-i18n/src/index.js
@@ -6,8 +6,8 @@ export {
     doNotTranslate,
     doNotTranslateYet,
     ngetpos, // used by handlebars translation functions in webapp
-} from "./functions/i18n.js";
+} from "./functions/i18n";
 
-export {localeToFixed, getDecimalSeparator} from "./functions/l10n.js";
-export {getLocale, setLocale} from "./functions/locale.js";
-export {I18nInlineMarkup} from "./components/i18n-inline-markup.js";
+export {localeToFixed, getDecimalSeparator} from "./functions/l10n";
+export {getLocale, setLocale} from "./functions/locale";
+export {I18nInlineMarkup} from "./components/i18n-inline-markup";

--- a/packages/wonder-blocks-icon-button/src/__tests__/custom-snapshot.test.js
+++ b/packages/wonder-blocks-icon-button/src/__tests__/custom-snapshot.test.js
@@ -4,7 +4,7 @@ import renderer from "react-test-renderer";
 
 import {icons} from "@khanacademy/wonder-blocks-icon";
 
-import IconButtonCore from "../components/icon-button-core.js";
+import IconButtonCore from "../components/icon-button-core";
 
 const defaultHandlers = {
     onClick: () => void 0,

--- a/packages/wonder-blocks-icon-button/src/components/__docs__/icon-button.stories.js
+++ b/packages/wonder-blocks-icon-button/src/components/__docs__/icon-button.stories.js
@@ -12,7 +12,7 @@ import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.js
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.js
@@ -6,8 +6,8 @@ import userEvent from "@testing-library/user-event";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 
-import expectRenderError from "../../../../../utils/testing/expect-render-error.js";
-import IconButton from "../icon-button.js";
+import expectRenderError from "../../../../../utils/testing/expect-render-error";
+import IconButton from "../icon-button";
 
 describe("IconButton", () => {
     const {location} = window;

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.js
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.js
@@ -17,7 +17,7 @@ import type {
     ChildrenProps,
     ClickableState,
 } from "@khanacademy/wonder-blocks-clickable";
-import type {SharedProps} from "./icon-button.js";
+import type {SharedProps} from "./icon-button";
 
 type Props = {|
     ...SharedProps,

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.js
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.js
@@ -5,7 +5,7 @@ import {__RouterContext} from "react-router";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import IconButtonCore from "./icon-button-core.js";
+import IconButtonCore from "./icon-button-core";
 
 export type SharedProps = {|
     ...$Rest<AriaProps, {|"aria-disabled": "true" | "false" | void|}>,

--- a/packages/wonder-blocks-icon-button/src/index.js
+++ b/packages/wonder-blocks-icon-button/src/index.js
@@ -1,4 +1,4 @@
 // @flow
-import IconButton from "./components/icon-button.js";
+import IconButton from "./components/icon-button";
 
 export {IconButton as default};

--- a/packages/wonder-blocks-icon/src/components/__docs__/icon.stories.js
+++ b/packages/wonder-blocks-icon/src/components/__docs__/icon.stories.js
@@ -9,7 +9,7 @@ import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-icon/src/components/__tests__/icon.test.js
+++ b/packages/wonder-blocks-icon/src/components/__tests__/icon.test.js
@@ -39,7 +39,7 @@ describe("Icon", () => {
 
     test("creates a styled svg using addStyle", async () => {
         // Arrange
-        const importModulePromise = import("../icon.js");
+        const importModulePromise = import("../icon");
 
         // Act
         await importModulePromise;
@@ -50,7 +50,7 @@ describe("Icon", () => {
 
     test("applies aria-label to svg", async () => {
         // Arrange
-        const {default: Icon} = await import("../icon.js");
+        const {default: Icon} = await import("../icon");
         const underTest = new Promise((resolve) => {
             const nodes = (
                 <div>
@@ -77,7 +77,7 @@ describe("Icon", () => {
 
     test("calls getPathForIcon", async () => {
         // Arrange
-        const {default: Icon} = await import("../icon.js");
+        const {default: Icon} = await import("../icon");
         const underTest = new Promise((resolve) => {
             const nodes = (
                 <div>
@@ -102,7 +102,7 @@ describe("Icon", () => {
 
     test("calls viewportPixelsForSize with size from props and asset size from getPathForIcon", async () => {
         // Arrange
-        const {default: Icon} = await import("../icon.js");
+        const {default: Icon} = await import("../icon");
         mockGetPathForIcon.mockImplementationOnce(() => ({
             assetSize: "large",
             path: "TESTPATH",
@@ -128,7 +128,7 @@ describe("Icon", () => {
 
     test("sets viewbox to asset dimensions", async () => {
         // Arrange
-        const {default: Icon} = await import("../icon.js");
+        const {default: Icon} = await import("../icon");
         const expectedRenderSize = 42;
         const expectedAssetSize = 7;
         mockViewportPixelsForSize.mockImplementationOnce(
@@ -165,7 +165,7 @@ describe("Icon", () => {
 
     test("sets size to dimensions derived from size prop", async () => {
         // Arrange
-        const {default: Icon} = await import("../icon.js");
+        const {default: Icon} = await import("../icon");
         const expectedRenderSize = 42;
         const expectedAssetSize = 7;
         mockViewportPixelsForSize.mockImplementationOnce(
@@ -203,7 +203,7 @@ describe("Icon", () => {
 
     test("sets inner path fill and d to color prop and path from getPathForIcon", async () => {
         // Arrange
-        const {default: Icon} = await import("../icon.js");
+        const {default: Icon} = await import("../icon");
         mockGetPathForIcon.mockImplementationOnce(() => ({
             assetSize: "small",
             path: "TESTPATH",
@@ -239,7 +239,7 @@ describe("Icon", () => {
 
     test("applies style prop", async () => {
         // Arrange
-        const {default: Icon} = await import("../icon.js");
+        const {default: Icon} = await import("../icon");
         mockGetPathForIcon.mockImplementationOnce(() => ({
             assetSize: "small",
             path: "TESTPATH",

--- a/packages/wonder-blocks-icon/src/components/__tests__/icon.test.js
+++ b/packages/wonder-blocks-icon/src/components/__tests__/icon.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import * as Core from "@khanacademy/wonder-blocks-core";
 import {render} from "@testing-library/react";
 
-import * as icons from "../../util/icon-assets.js";
-import {getPathForIcon, viewportPixelsForSize} from "../../util/icon-util.js";
+import * as icons from "../../util/icon-assets";
+import {getPathForIcon, viewportPixelsForSize} from "../../util/icon-util";
 
 // We mock things out so that we're in control of what really gets rendered.
 // Means we can test that we're using addStyle to generate the component

--- a/packages/wonder-blocks-icon/src/components/icon.js
+++ b/packages/wonder-blocks-icon/src/components/icon.js
@@ -4,9 +4,9 @@ import {StyleSheet} from "aphrodite";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import {getPathForIcon, viewportPixelsForSize} from "../util/icon-util.js";
+import {getPathForIcon, viewportPixelsForSize} from "../util/icon-util";
 
-import type {IconAsset, IconSize} from "../util/icon-assets.js";
+import type {IconAsset, IconSize} from "../util/icon-assets";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-icon/src/index.js
+++ b/packages/wonder-blocks-icon/src/index.js
@@ -1,8 +1,8 @@
 // @flow
-import Icon from "./components/icon.js";
-import type {IconAsset, IconSize} from "./util/icon-assets.js";
+import Icon from "./components/icon";
+import type {IconAsset, IconSize} from "./util/icon-assets";
 
-export * as icons from "./util/icon-assets.js";
+export * as icons from "./util/icon-assets";
 
 export type {IconAsset, IconSize};
 export default Icon;

--- a/packages/wonder-blocks-icon/src/util/icon-assets.test.js
+++ b/packages/wonder-blocks-icon/src/util/icon-assets.test.js
@@ -5,7 +5,7 @@ describe("icons", () => {
 
         // Act
         // $FlowIgnore[prop-missing]: Flow doesn't know about __esModule
-        const {__esModule: _, ...icons} = await import("./icon-assets.js");
+        const {__esModule: _, ...icons} = await import("./icon-assets");
 
         // Assert
         expect(Object.keys(icons).sort()).toEqual(

--- a/packages/wonder-blocks-icon/src/util/icon-util.js
+++ b/packages/wonder-blocks-icon/src/util/icon-util.js
@@ -1,5 +1,5 @@
 // @flow
-import type {IconAsset, IconSize} from "./icon-assets.js";
+import type {IconAsset, IconSize} from "./icon-assets";
 
 /**
  * A simple function that tells us how many viewport pixels each icon size

--- a/packages/wonder-blocks-icon/src/util/icon-util.test.js
+++ b/packages/wonder-blocks-icon/src/util/icon-util.test.js
@@ -1,7 +1,7 @@
 // @flow
-import {getPathForIcon, viewportPixelsForSize} from "./icon-util.js";
+import {getPathForIcon, viewportPixelsForSize} from "./icon-util";
 
-import type {IconSize, IconAsset} from "./icon-assets.js";
+import type {IconSize, IconAsset} from "./icon-assets";
 
 const SIZES = ["small", "medium", "large", "xlarge"];
 

--- a/packages/wonder-blocks-layout/src/components/__docs__/media-layout.stories.js
+++ b/packages/wonder-blocks-layout/src/components/__docs__/media-layout.stories.js
@@ -21,7 +21,7 @@ import {
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-layout/src/components/__docs__/spring.stories.js
+++ b/packages/wonder-blocks-layout/src/components/__docs__/spring.stories.js
@@ -9,7 +9,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-layout/src/components/__docs__/strut.stories.js
+++ b/packages/wonder-blocks-layout/src/components/__docs__/strut.stories.js
@@ -10,7 +10,7 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout-context.test.js
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout-context.test.js
@@ -3,15 +3,15 @@ import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {render} from "@testing-library/react";
 
-import MediaLayout from "../media-layout.js";
-import MediaLayoutContext from "../media-layout-context.js";
-import {resizeWindow, matchMedia} from "../../util/test-util.js";
+import MediaLayout from "../media-layout";
+import MediaLayoutContext from "../media-layout-context";
+import {resizeWindow, matchMedia} from "../../util/test-util";
 
 import {
     MEDIA_DEFAULT_SPEC,
     MEDIA_INTERNAL_SPEC,
     MEDIA_MODAL_SPEC,
-} from "../../util/specs.js";
+} from "../../util/specs";
 
 describe("MediaLayoutContext", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.js
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.js
@@ -4,8 +4,8 @@ import {StyleSheet} from "aphrodite";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {render, screen} from "@testing-library/react";
 
-import MediaLayout from "../media-layout.js";
-import {resizeWindow, matchMedia} from "../../util/test-util.js";
+import MediaLayout from "../media-layout";
+import {resizeWindow, matchMedia} from "../../util/test-util";
 
 describe("MediaLayout", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-layout/src/components/media-layout-context.js
+++ b/packages/wonder-blocks-layout/src/components/media-layout-context.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
 
-import {MEDIA_DEFAULT_SPEC} from "../util/specs.js";
-import type {MediaSize, MediaSpec} from "../util/types.js";
+import {MEDIA_DEFAULT_SPEC} from "../util/specs";
+import type {MediaSize, MediaSpec} from "../util/types";
 
 export type Context = {|
     /**

--- a/packages/wonder-blocks-layout/src/components/media-layout.js
+++ b/packages/wonder-blocks-layout/src/components/media-layout.js
@@ -3,14 +3,14 @@ import * as React from "react";
 import type {StyleDeclaration} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import MediaLayoutContext from "./media-layout-context.js";
-import type {MediaSize, MediaSpec} from "../util/types.js";
-import type {Context} from "./media-layout-context.js";
+import MediaLayoutContext from "./media-layout-context";
+import type {MediaSize, MediaSpec} from "../util/types";
+import type {Context} from "./media-layout-context";
 import {
     MEDIA_DEFAULT_SPEC,
     MEDIA_INTERNAL_SPEC,
     MEDIA_MODAL_SPEC,
-} from "../util/specs.js";
+} from "../util/specs";
 
 const queries = [
     ...Object.values(MEDIA_DEFAULT_SPEC).map((spec: any) => spec.query),

--- a/packages/wonder-blocks-layout/src/index.js
+++ b/packages/wonder-blocks-layout/src/index.js
@@ -1,14 +1,14 @@
 // @flow
-import type {MediaQuery, MediaSize, MediaSpec} from "./util/types.js";
-import type {Context} from "./components/media-layout-context.js";
-import type {MockStyleSheet} from "./components/media-layout.js";
+import type {MediaQuery, MediaSize, MediaSpec} from "./util/types";
+import type {Context} from "./components/media-layout-context";
+import type {MockStyleSheet} from "./components/media-layout";
 
-export {default as MediaLayout} from "./components/media-layout.js";
-export {default as MediaLayoutContext} from "./components/media-layout-context.js";
-export {default as Spring} from "./components/spring.js";
-export {default as Strut} from "./components/strut.js";
-export * from "./util/specs.js";
-export {queryMatchesSize} from "./util/util.js";
+export {default as MediaLayout} from "./components/media-layout";
+export {default as MediaLayoutContext} from "./components/media-layout-context";
+export {default as Spring} from "./components/spring";
+export {default as Strut} from "./components/strut";
+export * from "./util/specs";
+export {queryMatchesSize} from "./util/util";
 export type {
     MediaQuery,
     MediaSize,

--- a/packages/wonder-blocks-layout/src/util/specs.js
+++ b/packages/wonder-blocks-layout/src/util/specs.js
@@ -2,7 +2,7 @@
 
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
-import type {MediaSize, MediaSpec} from "./types.js";
+import type {MediaSize, MediaSpec} from "./types";
 
 // All possible valid media sizes
 export const VALID_MEDIA_SIZES: Array<MediaSize> = ["small", "medium", "large"];

--- a/packages/wonder-blocks-layout/src/util/test-util.js
+++ b/packages/wonder-blocks-layout/src/util/test-util.js
@@ -1,5 +1,5 @@
 // @flow
-import type {MediaSize} from "./types.js";
+import type {MediaSize} from "./types";
 
 /**
  * Helper function for setting the window size, for use in tests.

--- a/packages/wonder-blocks-layout/src/util/test-util.test.js
+++ b/packages/wonder-blocks-layout/src/util/test-util.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {resizeWindow, checkQuery, matchMedia} from "./test-util.js";
+import {resizeWindow, checkQuery, matchMedia} from "./test-util";
 
 describe("Test utils", () => {
     describe("resizeWindow", () => {

--- a/packages/wonder-blocks-layout/src/util/util.js
+++ b/packages/wonder-blocks-layout/src/util/util.js
@@ -1,5 +1,5 @@
 // @flow
-import type {MediaQuery, MediaSize} from "./types.js";
+import type {MediaQuery, MediaSize} from "./types";
 
 /**
  * Return where a media size matches a media query.

--- a/packages/wonder-blocks-layout/src/util/util.test.js
+++ b/packages/wonder-blocks-layout/src/util/util.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {queryMatchesSize} from "./util.js";
+import {queryMatchesSize} from "./util";
 
 describe("queryMatchesSize", () => {
     describe("all", () => {

--- a/packages/wonder-blocks-link/src/__tests__/custom-snapshot.test.js
+++ b/packages/wonder-blocks-link/src/__tests__/custom-snapshot.test.js
@@ -2,8 +2,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-import LinkCore from "../components/link-core.js";
-import Link from "../components/link.js";
+import LinkCore from "../components/link-core";
+import Link from "../components/link";
 
 const defaultHandlers = {
     onClick: () => void 0,

--- a/packages/wonder-blocks-link/src/components/__docs__/link.stories.js
+++ b/packages/wonder-blocks-link/src/components/__docs__/link.stories.js
@@ -20,8 +20,8 @@ import {
 } from "@khanacademy/wonder-blocks-typography";
 import type {StoryComponentType} from "@storybook/react";
 
-import LinkArgTypes from "./link.argtypes.js";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import LinkArgTypes from "./link.argtypes";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-link/src/components/__tests__/link.flowtest.js
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.flowtest.js
@@ -2,7 +2,7 @@
 /* eslint-disable ft-flow/no-unused-expressions */
 import * as React from "react";
 
-import Link from "../link.js";
+import Link from "../link";
 
 // $FlowExpectedError[incompatible-type]: href must be used with beforeNav
 <Link beforeNav={() => Promise.resolve()}>Hello, world!</Link>;

--- a/packages/wonder-blocks-link/src/components/__tests__/link.test.js
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.test.js
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 
 import Color from "@khanacademy/wonder-blocks-color";
 
-import Link from "../link.js";
+import Link from "../link";
 
 describe("Link", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-link/src/components/link-core.js
+++ b/packages/wonder-blocks-link/src/components/link-core.js
@@ -13,7 +13,7 @@ import type {
     ClickableState,
 } from "@khanacademy/wonder-blocks-clickable";
 import type {StyleDeclaration} from "aphrodite";
-import type {SharedProps} from "./link.js";
+import type {SharedProps} from "./link";
 
 type Props = {|
     ...SharedProps,

--- a/packages/wonder-blocks-link/src/components/link.js
+++ b/packages/wonder-blocks-link/src/components/link.js
@@ -5,7 +5,7 @@ import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
-import LinkCore from "./link-core.js";
+import LinkCore from "./link-core";
 
 type CommonProps = {|
     ...AriaProps,

--- a/packages/wonder-blocks-link/src/index.js
+++ b/packages/wonder-blocks-link/src/index.js
@@ -1,4 +1,4 @@
 // @flow
-import Link from "./components/link.js";
+import Link from "./components/link";
 
 export {Link as default};

--- a/packages/wonder-blocks-modal/src/components/__docs__/modal-dialog.stories.js
+++ b/packages/wonder-blocks-modal/src/components/__docs__/modal-dialog.stories.js
@@ -16,7 +16,7 @@ import {Body, Title} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 const customViewports = {

--- a/packages/wonder-blocks-modal/src/components/__docs__/modal-footer.stories.js
+++ b/packages/wonder-blocks-modal/src/components/__docs__/modal-footer.stories.js
@@ -15,7 +15,7 @@ import {Body, LabelLarge, Title} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 const customViewports = {

--- a/packages/wonder-blocks-modal/src/components/__docs__/modal-header.stories.js
+++ b/packages/wonder-blocks-modal/src/components/__docs__/modal-header.stories.js
@@ -17,9 +17,9 @@ import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import ModalHeaderArgtypes from "./modal-header.argtypes.js";
+import ModalHeaderArgtypes from "./modal-header.argtypes";
 
 const customViewports = {
     phone: {

--- a/packages/wonder-blocks-modal/src/components/__docs__/modal-launcher.stories.js
+++ b/packages/wonder-blocks-modal/src/components/__docs__/modal-launcher.stories.js
@@ -17,10 +17,10 @@ import {Body, Title} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import type {ModalElement} from "../../util/types.js";
-import ModalLauncherArgTypes from "./modal-launcher.argtypes.js";
+import type {ModalElement} from "../../util/types";
+import ModalLauncherArgTypes from "./modal-launcher.argtypes";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 const customViewports = {

--- a/packages/wonder-blocks-modal/src/components/__docs__/modal-panel.stories.js
+++ b/packages/wonder-blocks-modal/src/components/__docs__/modal-panel.stories.js
@@ -17,7 +17,7 @@ import {Body, Title} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 const customViewports = {

--- a/packages/wonder-blocks-modal/src/components/__docs__/one-pane-dialog.stories.js
+++ b/packages/wonder-blocks-modal/src/components/__docs__/one-pane-dialog.stories.js
@@ -18,9 +18,9 @@ import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import OnePaneDialogArgTypes from "./one-pane-dialog.argtypes.js";
+import OnePaneDialogArgTypes from "./one-pane-dialog.argtypes";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 const customViewports = {

--- a/packages/wonder-blocks-modal/src/components/__tests__/close-button.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/close-button.test.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import expectRenderError from "../../../../../utils/testing/expect-render-error.js";
-import CloseButton from "../close-button.js";
-import ModalContext from "../modal-context.js";
+import expectRenderError from "../../../../../utils/testing/expect-render-error";
+import CloseButton from "../close-button";
+import ModalContext from "../modal-context";
 
 describe("CloseButton", () => {
     test("ModalContext.Provider and onClose should warn", () => {

--- a/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.js
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import Button from "@khanacademy/wonder-blocks-button";
 import {Choice, RadioGroup} from "@khanacademy/wonder-blocks-form";
 
-import FocusTrap from "../focus-trap.js";
+import FocusTrap from "../focus-trap";
 
 describe("FocusTrap", () => {
     it("Focus should move to the first focusable element", () => {

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {render, screen, fireEvent, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import ModalBackdrop from "../modal-backdrop.js";
-import OnePaneDialog from "../one-pane-dialog.js";
+import ModalBackdrop from "../modal-backdrop";
+import OnePaneDialog from "../one-pane-dialog";
 
 const exampleModal = (
     <OnePaneDialog

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-header.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-header.test.js
@@ -7,7 +7,7 @@ import {
     BreadcrumbsItem,
 } from "@khanacademy/wonder-blocks-breadcrumbs";
 
-import ModalHeader from "../modal-header.js";
+import ModalHeader from "../modal-header";
 
 const exampleBreadcrumbs: React.Element<typeof Breadcrumbs> = (
     <Breadcrumbs>

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.js
@@ -6,8 +6,8 @@ import userEvent from "@testing-library/user-event";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 
-import ModalLauncher from "../modal-launcher.js";
-import OnePaneDialog from "../one-pane-dialog.js";
+import ModalLauncher from "../modal-launcher";
+import OnePaneDialog from "../one-pane-dialog";
 
 const exampleModal = (
     <OnePaneDialog

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-panel.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-panel.test.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import expectRenderError from "../../../../../utils/testing/expect-render-error.js";
-import ModalPanel from "../modal-panel.js";
-import ModalContext from "../modal-context.js";
+import expectRenderError from "../../../../../utils/testing/expect-render-error";
+import ModalPanel from "../modal-panel";
+import ModalContext from "../modal-context";
 
 describe("ModalPanel", () => {
     test("ModalContext.Provider and onClose should warn", () => {

--- a/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.js
+++ b/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.js
@@ -6,7 +6,7 @@ import {
     Breadcrumbs,
     BreadcrumbsItem,
 } from "@khanacademy/wonder-blocks-breadcrumbs";
-import OnePaneDialog from "../one-pane-dialog.js";
+import OnePaneDialog from "../one-pane-dialog";
 
 describe("OnePaneDialog", () => {
     test("testId should be set in the Dialog element", () => {

--- a/packages/wonder-blocks-modal/src/components/close-button.js
+++ b/packages/wonder-blocks-modal/src/components/close-button.js
@@ -4,7 +4,7 @@ import {icons} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import ModalContext from "./modal-context.js";
+import ModalContext from "./modal-context";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-modal/src/components/modal-backdrop.js
+++ b/packages/wonder-blocks-modal/src/components/modal-backdrop.js
@@ -5,11 +5,11 @@ import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {ModalLauncherPortalAttributeName} from "../util/constants.js";
+import {ModalLauncherPortalAttributeName} from "../util/constants";
 
-import {findFocusableNodes} from "../util/find-focusable-nodes.js";
+import {findFocusableNodes} from "../util/find-focusable-nodes";
 
-import type {ModalElement} from "../util/types.js";
+import type {ModalElement} from "../util/types";
 
 type Props = {|
     children: ModalElement,

--- a/packages/wonder-blocks-modal/src/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/src/components/modal-launcher.js
@@ -9,11 +9,11 @@ import type {
     WithoutActionScheduler,
 } from "@khanacademy/wonder-blocks-timing";
 
-import FocusTrap from "./focus-trap.js";
-import ModalBackdrop from "./modal-backdrop.js";
-import ScrollDisabler from "./scroll-disabler.js";
-import type {ModalElement} from "../util/types.js";
-import ModalContext from "./modal-context.js";
+import FocusTrap from "./focus-trap";
+import ModalBackdrop from "./modal-backdrop";
+import ScrollDisabler from "./scroll-disabler";
+import type {ModalElement} from "../util/types";
+import ModalContext from "./modal-context";
 
 type CommonProps = {|
     /**

--- a/packages/wonder-blocks-modal/src/components/modal-panel.js
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.js
@@ -6,10 +6,10 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import ModalContent from "./modal-content.js";
-import ModalHeader from "./modal-header.js";
-import ModalFooter from "./modal-footer.js";
-import CloseButton from "./close-button.js";
+import ModalContent from "./modal-content";
+import ModalHeader from "./modal-header";
+import ModalFooter from "./modal-footer";
+import CloseButton from "./close-button";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.js
@@ -6,9 +6,9 @@ import {MediaLayout} from "@khanacademy/wonder-blocks-layout";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import {IDProvider} from "@khanacademy/wonder-blocks-core";
-import ModalDialog from "./modal-dialog.js";
-import ModalPanel from "./modal-panel.js";
-import ModalHeader from "./modal-header.js";
+import ModalDialog from "./modal-dialog";
+import ModalPanel from "./modal-panel";
+import ModalHeader from "./modal-header";
 
 type Common = {|
     /**

--- a/packages/wonder-blocks-modal/src/index.js
+++ b/packages/wonder-blocks-modal/src/index.js
@@ -1,11 +1,11 @@
 // @flow
-import ModalDialog from "./components/modal-dialog.js";
-import ModalFooter from "./components/modal-footer.js";
-import ModalHeader from "./components/modal-header.js";
-import ModalLauncher from "./components/modal-launcher.js";
-import ModalPanel from "./components/modal-panel.js";
-import OnePaneDialog from "./components/one-pane-dialog.js";
-import maybeGetPortalMountedModalHostElement from "./util/maybe-get-portal-mounted-modal-host-element.js";
+import ModalDialog from "./components/modal-dialog";
+import ModalFooter from "./components/modal-footer";
+import ModalHeader from "./components/modal-header";
+import ModalLauncher from "./components/modal-launcher";
+import ModalPanel from "./components/modal-panel";
+import OnePaneDialog from "./components/one-pane-dialog";
+import maybeGetPortalMountedModalHostElement from "./util/maybe-get-portal-mounted-modal-host-element";
 
 export {
     ModalHeader,

--- a/packages/wonder-blocks-modal/src/util/maybe-get-portal-mounted-modal-host-element.js
+++ b/packages/wonder-blocks-modal/src/util/maybe-get-portal-mounted-modal-host-element.js
@@ -1,5 +1,5 @@
 // @flow
-import {ModalLauncherPortalAttributeName} from "./constants.js";
+import {ModalLauncherPortalAttributeName} from "./constants";
 
 /**
  * From a given element, finds its next ancestor that is a modal launcher portal

--- a/packages/wonder-blocks-modal/src/util/maybe-get-portal-mounted-modal-host-element.test.js
+++ b/packages/wonder-blocks-modal/src/util/maybe-get-portal-mounted-modal-host-element.test.js
@@ -4,10 +4,10 @@ import * as ReactDOM from "react-dom";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import {ModalLauncherPortalAttributeName} from "./constants.js";
-import maybeGetPortalMountedModalHostElement from "./maybe-get-portal-mounted-modal-host-element.js";
-import ModalLauncher from "../components/modal-launcher.js";
-import OnePaneDialog from "../components/one-pane-dialog.js";
+import {ModalLauncherPortalAttributeName} from "./constants";
+import maybeGetPortalMountedModalHostElement from "./maybe-get-portal-mounted-modal-host-element";
+import ModalLauncher from "../components/modal-launcher";
+import OnePaneDialog from "../components/one-pane-dialog";
 
 describe("maybeGetPortalMountedModalHostElement", () => {
     test("when candidate is null, returns null", () => {

--- a/packages/wonder-blocks-popover/src/components/__docs__/popover-content-core.stories.js
+++ b/packages/wonder-blocks-popover/src/components/__docs__/popover-content-core.stories.js
@@ -15,14 +15,14 @@ import {
 
 import type {StoryComponentType} from "@storybook/react";
 import {PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 // NOTE: We are reusing an existing Cell SB Story to test how Popovers can be
 // composed by Cells.
 // eslint-disable-next-line monorepo/no-relative-import
-import {ClickableDetailCell} from "../../../../wonder-blocks-cell/src/components/__docs__/detail-cell.stories.js";
-import popoverContentCoreArgtypes from "./popover-content-core.argtypes.js";
+import {ClickableDetailCell} from "../../../../wonder-blocks-cell/src/components/__docs__/detail-cell.stories";
+import popoverContentCoreArgtypes from "./popover-content-core.argtypes";
 
 export default {
     title: "Popover/PopoverContentCore",

--- a/packages/wonder-blocks-popover/src/components/__docs__/popover-content.stories.js
+++ b/packages/wonder-blocks-popover/src/components/__docs__/popover-content.stories.js
@@ -9,9 +9,9 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StoryComponentType} from "@storybook/react";
 import {PopoverContent} from "@khanacademy/wonder-blocks-popover";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import PopoverContentArgtypes from "./popover-content.argtypes.js";
+import PopoverContentArgtypes from "./popover-content.argtypes";
 
 export default {
     title: "Popover/PopoverContent",

--- a/packages/wonder-blocks-popover/src/components/__docs__/popover.argtypes.js
+++ b/packages/wonder-blocks-popover/src/components/__docs__/popover.argtypes.js
@@ -7,12 +7,12 @@ import {
     Emphasized,
     WithIcon,
     WithIllustration,
-} from "./popover-content.stories.js";
+} from "./popover-content.stories";
 import {
     WithIcon as CoreWithIcon,
     WithDetailCell as CoreWithDetailCell,
     Dark as CoreDark,
-} from "./popover-content-core.stories.js";
+} from "./popover-content-core.stories";
 
 export const ContentMappings: {|[key: string]: React.Node|} = {
     withTextOnly: <Default {...Default.args} />,

--- a/packages/wonder-blocks-popover/src/components/__docs__/popover.stories.js
+++ b/packages/wonder-blocks-popover/src/components/__docs__/popover.stories.js
@@ -11,9 +11,9 @@ import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 import type {Placement} from "@khanacademy/wonder-blocks-tooltip";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
-import PopoverArgtypes from "./popover.argtypes.js";
+import PopoverArgtypes from "./popover.argtypes";
 
 export default {
     title: "Popover/Popover",

--- a/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.js
@@ -4,8 +4,8 @@ import * as ReactDOM from "react-dom";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import FocusManager from "../focus-manager.js";
-import {findFocusableNodes} from "../../util/util.js";
+import FocusManager from "../focus-manager";
+import {findFocusableNodes} from "../../util/util";
 
 describe("FocusManager", () => {
     it("should focus on the first focusable element inside the popover", async () => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/initial-focus.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/initial-focus.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import InitialFocus from "../initial-focus.js";
+import InitialFocus from "../initial-focus";
 
 describe("InitialFocus", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-anchor.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-anchor.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import PopoverAnchor from "../popover-anchor.js";
+import PopoverAnchor from "../popover-anchor";
 
 describe("PopoverAnchor", () => {
     it("should set child node as ref", () => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import PopoverContent from "../popover-content.js";
-import PopoverContext from "../popover-context.js";
+import PopoverContent from "../popover-content";
+import PopoverContext from "../popover-context";
 
 describe("PopoverContent", () => {
     it("should close the popover from the actions", () => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-dialog.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-dialog.test.js
@@ -4,8 +4,8 @@ import {render} from "@testing-library/react";
 import * as Tooltip from "@khanacademy/wonder-blocks-tooltip";
 
 import type {Placement} from "@khanacademy/wonder-blocks-tooltip";
-import PopoverDialog from "../popover-dialog.js";
-import PopoverContentCore from "../popover-content-core.js";
+import PopoverDialog from "../popover-dialog";
+import PopoverContentCore from "../popover-content-core";
 
 jest.mock("@khanacademy/wonder-blocks-tooltip");
 

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-event-listener.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-event-listener.test.js
@@ -4,8 +4,8 @@ import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import PopoverEventListener from "../popover-event-listener.js";
-import PopoverContent from "../popover-content.js";
+import PopoverEventListener from "../popover-event-listener";
+import PopoverContent from "../popover-content";
 
 describe("PopoverKeypressListener", () => {
     it("should call onClose if Escape is pressed", () => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.js
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.js
@@ -3,9 +3,9 @@ import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import Popover from "../popover.js";
-import PopoverContent from "../popover-content.js";
-import {PopoverContentCore} from "../../index.js";
+import Popover from "../popover";
+import PopoverContent from "../popover-content";
+import {PopoverContentCore} from "../../index";
 
 describe("Popover", () => {
     it("should set the anchor as the popover ref", async () => {

--- a/packages/wonder-blocks-popover/src/components/close-button.js
+++ b/packages/wonder-blocks-popover/src/components/close-button.js
@@ -5,7 +5,7 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
-import PopoverContext from "./popover-context.js";
+import PopoverContext from "./popover-context";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-popover/src/components/focus-manager.js
+++ b/packages/wonder-blocks-popover/src/components/focus-manager.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {findFocusableNodes} from "../util/util.js";
-import InitialFocus from "./initial-focus.js";
+import {findFocusableNodes} from "../util/util";
+import InitialFocus from "./initial-focus";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-popover/src/components/initial-focus.js
+++ b/packages/wonder-blocks-popover/src/components/initial-focus.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import {findFocusableNodes} from "../util/util.js";
+import {findFocusableNodes} from "../util/util";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.js
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.js
@@ -7,7 +7,7 @@ import Colors from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
-import CloseButton from "./close-button.js";
+import CloseButton from "./close-button";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-popover/src/components/popover-content.js
+++ b/packages/wonder-blocks-popover/src/components/popover-content.js
@@ -7,10 +7,10 @@ import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
 
-import type {PopoverContextType} from "./popover-context.js";
+import type {PopoverContextType} from "./popover-context";
 
-import PopoverContentCore from "./popover-content-core.js";
-import PopoverContext from "./popover-context.js";
+import PopoverContentCore from "./popover-content-core";
+import PopoverContext from "./popover-context";
 
 type CommonProps = {|
     ...AriaProps,

--- a/packages/wonder-blocks-popover/src/components/popover-dialog.js
+++ b/packages/wonder-blocks-popover/src/components/popover-dialog.js
@@ -12,8 +12,8 @@ import type {
     PopperElementProps,
 } from "@khanacademy/wonder-blocks-tooltip";
 
-import typeof PopoverContent from "./popover-content.js";
-import typeof PopoverContentCore from "./popover-content-core.js";
+import typeof PopoverContent from "./popover-content";
+import typeof PopoverContentCore from "./popover-content-core";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-popover/src/components/popover-event-listener.js
+++ b/packages/wonder-blocks-popover/src/components/popover-event-listener.js
@@ -3,8 +3,8 @@
 import * as React from "react";
 import ReactDOM from "react-dom";
 
-import typeof PopoverContent from "./popover-content.js";
-import typeof PopoverContentCore from "./popover-content-core.js";
+import typeof PopoverContent from "./popover-content";
+import typeof PopoverContentCore from "./popover-content-core";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-popover/src/components/popover.js
+++ b/packages/wonder-blocks-popover/src/components/popover.js
@@ -12,13 +12,13 @@ import type {
     PopperElementProps,
 } from "@khanacademy/wonder-blocks-tooltip";
 
-import typeof PopoverContent from "./popover-content.js";
-import typeof PopoverContentCore from "./popover-content-core.js";
-import PopoverContext from "./popover-context.js";
-import PopoverAnchor from "./popover-anchor.js";
-import PopoverDialog from "./popover-dialog.js";
-import FocusManager from "./focus-manager.js";
-import PopoverEventListener from "./popover-event-listener.js";
+import typeof PopoverContent from "./popover-content";
+import typeof PopoverContentCore from "./popover-content-core";
+import PopoverContext from "./popover-context";
+import PopoverAnchor from "./popover-anchor";
+import PopoverDialog from "./popover-dialog";
+import FocusManager from "./focus-manager";
+import PopoverEventListener from "./popover-event-listener";
 
 type PopoverContents =
     | React.Element<PopoverContent>

--- a/packages/wonder-blocks-popover/src/index.js
+++ b/packages/wonder-blocks-popover/src/index.js
@@ -1,6 +1,6 @@
 // @flow
-import Popover from "./components/popover.js";
-import PopoverContent from "./components/popover-content.js";
-import PopoverContentCore from "./components/popover-content-core.js";
+import Popover from "./components/popover";
+import PopoverContent from "./components/popover-content";
+import PopoverContentCore from "./components/popover-content-core";
 
 export {Popover, PopoverContent, PopoverContentCore};

--- a/packages/wonder-blocks-progress-spinner/src/components/__docs__/circular-spinner.stories.js
+++ b/packages/wonder-blocks-progress-spinner/src/components/__docs__/circular-spinner.stories.js
@@ -9,7 +9,7 @@ import {CircularSpinner} from "@khanacademy/wonder-blocks-progress-spinner";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-progress-spinner/src/index.js
+++ b/packages/wonder-blocks-progress-spinner/src/index.js
@@ -1,2 +1,2 @@
 // @flow
-export {default as CircularSpinner} from "./components/circular-spinner.js";
+export {default as CircularSpinner} from "./components/circular-spinner";

--- a/packages/wonder-blocks-search-field/src/components/__docs__/search-field.stories.js
+++ b/packages/wonder-blocks-search-field/src/components/__docs__/search-field.stories.js
@@ -9,7 +9,7 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import SearchField from "../search-field.js";
+import SearchField from "../search-field";
 
 export default {
     component: SearchField,

--- a/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.js
+++ b/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import SearchField from "../search-field.js";
+import SearchField from "../search-field";
 
 describe("SearchField", () => {
     test("value is updated when text is entered into the field", () => {

--- a/packages/wonder-blocks-search-field/src/components/search-field.js
+++ b/packages/wonder-blocks-search-field/src/components/search-field.js
@@ -11,7 +11,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
-import {defaultLabels} from "../util/constants.js";
+import {defaultLabels} from "../util/constants";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-search-field/src/index.js
+++ b/packages/wonder-blocks-search-field/src/index.js
@@ -1,4 +1,4 @@
 // @flow
-import SearchField from "./components/search-field.js";
+import SearchField from "./components/search-field";
 
 export default SearchField;

--- a/packages/wonder-blocks-testing/src/__tests__/mock-requester.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/mock-requester.test.js
@@ -1,6 +1,6 @@
 // @flow
-import {RespondWith} from "../respond-with.js";
-import {mockRequester} from "../mock-requester.js";
+import {RespondWith} from "../respond-with";
+import {mockRequester} from "../mock-requester";
 
 describe("#mockRequester", () => {
     it("should return a function", () => {

--- a/packages/wonder-blocks-testing/src/__tests__/respond-with.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/respond-with.test.js
@@ -1,6 +1,6 @@
 // @flow
-import {SettleController} from "../settle-controller.js";
-import {RespondWith} from "../respond-with.js";
+import {SettleController} from "../settle-controller";
+import {RespondWith} from "../respond-with";
 
 describe("RespondWith", () => {
     describe("#text.toPromise", () => {

--- a/packages/wonder-blocks-testing/src/__tests__/response-impl.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/response-impl.test.js
@@ -24,7 +24,7 @@ describe("ResponseImpl", () => {
         // Act
         const {ResponseImpl: result, NodeFetchResponse} =
             wst.jest.isolateModules(() => ({
-                ResponseImpl: require("../response-impl.js").ResponseImpl,
+                ResponseImpl: require("../response-impl").ResponseImpl,
                 NodeFetchResponse: require("node-fetch").Response,
             }));
 
@@ -38,7 +38,7 @@ describe("ResponseImpl", () => {
 
         // Act
         const result = wst.jest.isolateModules(
-            () => require("../response-impl.js").ResponseImpl,
+            () => require("../response-impl").ResponseImpl,
         );
 
         // Assert

--- a/packages/wonder-blocks-testing/src/__tests__/settle-controller.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/settle-controller.test.js
@@ -1,6 +1,6 @@
 // @flow
-import {SettleController} from "../settle-controller.js";
-import {SettleSignal} from "../settle-signal.js";
+import {SettleController} from "../settle-controller";
+import {SettleSignal} from "../settle-signal";
 
 describe("SettleController", () => {
     it("should have a signal", () => {

--- a/packages/wonder-blocks-testing/src/__tests__/settle-signal.test.js
+++ b/packages/wonder-blocks-testing/src/__tests__/settle-signal.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {SettleSignal} from "../settle-signal.js";
+import {SettleSignal} from "../settle-signal";
 
 describe("SettleSignal", () => {
     it("should extend EventTarget", () => {

--- a/packages/wonder-blocks-testing/src/fetch/__tests__/fetch-request-matches-mock.test.js
+++ b/packages/wonder-blocks-testing/src/fetch/__tests__/fetch-request-matches-mock.test.js
@@ -1,6 +1,6 @@
 // @flow
 import {Request} from "node-fetch";
-import {fetchRequestMatchesMock} from "../fetch-request-matches-mock.js";
+import {fetchRequestMatchesMock} from "../fetch-request-matches-mock";
 
 const TEST_URL = "http://example.com/foo?querya=1&queryb=elephants#fragment";
 

--- a/packages/wonder-blocks-testing/src/fetch/__tests__/mock-fetch.test.js
+++ b/packages/wonder-blocks-testing/src/fetch/__tests__/mock-fetch.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {Request} from "node-fetch";
-import {RespondWith} from "../../respond-with.js";
-import {mockFetch} from "../mock-fetch.js";
+import {RespondWith} from "../../respond-with";
+import {mockFetch} from "../mock-fetch";
 
 describe("#mockFetch", () => {
     it.each`

--- a/packages/wonder-blocks-testing/src/fetch/fetch-request-matches-mock.js
+++ b/packages/wonder-blocks-testing/src/fetch/fetch-request-matches-mock.js
@@ -1,5 +1,5 @@
 // @flow
-import type {FetchMockOperation} from "./types.js";
+import type {FetchMockOperation} from "./types";
 
 /**
  * Get the URL from the given RequestInfo.

--- a/packages/wonder-blocks-testing/src/fetch/mock-fetch.js
+++ b/packages/wonder-blocks-testing/src/fetch/mock-fetch.js
@@ -1,7 +1,7 @@
 // @flow
-import {fetchRequestMatchesMock} from "./fetch-request-matches-mock.js";
-import {mockRequester} from "../mock-requester.js";
-import type {FetchMockFn, FetchMockOperation} from "./types.js";
+import {fetchRequestMatchesMock} from "./fetch-request-matches-mock";
+import {mockRequester} from "../mock-requester";
+import type {FetchMockFn, FetchMockOperation} from "./types";
 
 /**
  * A mock for the fetch function passed to GqlRouter.

--- a/packages/wonder-blocks-testing/src/fetch/types.js
+++ b/packages/wonder-blocks-testing/src/fetch/types.js
@@ -1,5 +1,5 @@
 //@flow
-import type {MockResponse} from "../respond-with.js";
+import type {MockResponse} from "../respond-with";
 
 export type FetchMockOperation = RegExp | string;
 

--- a/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.js
+++ b/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import * as AddonActionsModule from "@storybook/addon-actions";
-import {fixtures} from "../fixtures.js";
+import {fixtures} from "../fixtures";
 
 jest.mock("@storybook/addon-actions");
 

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.basic.stories.js
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.basic.stories.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import {fixtures} from "../index.js";
+import {fixtures} from "../index";
 
 type Props = {|
     propA: string,

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.defaultwrapper.stories.js
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.defaultwrapper.stories.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import {fixtures} from "../index.js";
+import {fixtures} from "../index";
 
 type Props = {...};
 

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.js
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {action} from "@storybook/addon-actions";
 
-import type {FixtureFn, FixtureProps} from "./types.js";
+import type {FixtureFn, FixtureProps} from "./types";
 
 /**
  * Describe a group of fixtures for a given component.

--- a/packages/wonder-blocks-testing/src/gql/__tests__/gql-request-matches-mock.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/gql-request-matches-mock.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {gqlRequestMatchesMock} from "../gql-request-matches-mock.js";
+import {gqlRequestMatchesMock} from "../gql-request-matches-mock";
 
 describe("#gqlRequestMatchesMock", () => {
     it("should return false if operation types don't match", () => {

--- a/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 
 import {GqlRouter, useGql} from "@khanacademy/wonder-blocks-data";
-import {RespondWith} from "../../respond-with.js";
-import {mockGqlFetch} from "../mock-gql-fetch.js";
+import {RespondWith} from "../../respond-with";
+import {mockGqlFetch} from "../mock-gql-fetch";
 
 describe("#mockGqlFetch", () => {
     describe("with GqlRouter and useGql", () => {

--- a/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.js
@@ -3,8 +3,8 @@ import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 
 import {GqlRouter, useGql} from "@khanacademy/wonder-blocks-data";
-import {RespondWith} from "../../respond-with.js";
-import {mockGqlFetch} from "../mock-gql-fetch.js";
+import {RespondWith} from "../../respond-with";
+import {mockGqlFetch} from "../mock-gql-fetch";
 
 describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
     it("should reject with error indicating there are no mocks", async () => {

--- a/packages/wonder-blocks-testing/src/gql/gql-request-matches-mock.js
+++ b/packages/wonder-blocks-testing/src/gql/gql-request-matches-mock.js
@@ -1,6 +1,6 @@
 // @flow
 import type {GqlOperation, GqlContext} from "@khanacademy/wonder-blocks-data";
-import type {GqlMockOperation} from "./types.js";
+import type {GqlMockOperation} from "./types";
 
 const safeHasOwnProperty = (obj: any, prop: string): boolean =>
     // Flow really shouldn't be raising this error here.

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.js
@@ -1,7 +1,7 @@
 // @flow
-import {gqlRequestMatchesMock} from "./gql-request-matches-mock.js";
-import {mockRequester} from "../mock-requester.js";
-import type {GqlFetchMockFn, GqlMockOperation} from "./types.js";
+import {gqlRequestMatchesMock} from "./gql-request-matches-mock";
+import {mockRequester} from "../mock-requester";
+import type {GqlFetchMockFn, GqlMockOperation} from "./types";
 
 /**
  * A mock for the fetch function passed to GqlRouter.

--- a/packages/wonder-blocks-testing/src/gql/types.js
+++ b/packages/wonder-blocks-testing/src/gql/types.js
@@ -1,7 +1,7 @@
 //@flow
 import type {GqlOperation, GqlContext} from "@khanacademy/wonder-blocks-data";
-import type {GraphQLJson} from "../types.js";
-import type {MockResponse} from "../respond-with.js";
+import type {GraphQLJson} from "../types";
+import type {MockResponse} from "../respond-with";
 
 export type GqlMockOperation<
     TData: {...},

--- a/packages/wonder-blocks-testing/src/harness/__tests__/hook-harness.test.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/hook-harness.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {jest as ws} from "@khanacademy/wonder-stuff-testing";
-import * as MHH from "../make-hook-harness.js";
-import {DefaultAdapters, DefaultConfigs} from "../adapters/adapters.js";
+import * as MHH from "../make-hook-harness";
+import {DefaultAdapters, DefaultConfigs} from "../adapters/adapters";
 
 jest.mock("../make-hook-harness.js", () => {
     const returnValueFake = {

--- a/packages/wonder-blocks-testing/src/harness/__tests__/hook-harness.test.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/hook-harness.test.js
@@ -3,7 +3,7 @@ import {jest as ws} from "@khanacademy/wonder-stuff-testing";
 import * as MHH from "../make-hook-harness";
 import {DefaultAdapters, DefaultConfigs} from "../adapters/adapters";
 
-jest.mock("../make-hook-harness.js", () => {
+jest.mock("../make-hook-harness", () => {
     const returnValueFake = {
         thisisa: "PRETEND REACT COMPONENT",
     };
@@ -21,7 +21,7 @@ describe("#hookHarness", () => {
         const makeHookHarnessSpy = jest.spyOn(MHH, "makeHookHarness");
 
         // Act
-        await ws.isolateModules(() => import("../hook-harness.js"));
+        await ws.isolateModules(() => import("../hook-harness"));
 
         // Assert
         expect(makeHookHarnessSpy).toHaveBeenCalledWith(
@@ -38,8 +38,8 @@ describe("#hookHarness", () => {
         // $FlowIgnore[prop-missing]  - we add this into our mock at the top.
         const [{harnessFake}, {hookHarness}] = await ws.isolateModules(() =>
             Promise.all([
-                import("../make-hook-harness.js"),
-                import("../hook-harness.js"),
+                import("../make-hook-harness"),
+                import("../hook-harness"),
             ]),
         );
 
@@ -58,8 +58,8 @@ describe("#hookHarness", () => {
         // $FlowIgnore[prop-missing]  - we add this into our mock at the top.
         const [{returnValueFake}, {hookHarness}] = await ws.isolateModules(() =>
             Promise.all([
-                import("../make-hook-harness.js"),
-                import("../hook-harness.js"),
+                import("../make-hook-harness"),
+                import("../hook-harness"),
             ]),
         );
 

--- a/packages/wonder-blocks-testing/src/harness/__tests__/make-hook-harness.test.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/make-hook-harness.test.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
 import {render} from "@testing-library/react";
-import {makeHookHarness} from "../make-hook-harness.js";
-import * as MTH from "../make-test-harness.js";
+import {makeHookHarness} from "../make-hook-harness";
+import * as MTH from "../make-test-harness";
 
 describe("#makeHookHarness", () => {
     it("should call makeTestHarness", () => {

--- a/packages/wonder-blocks-testing/src/harness/__tests__/make-test-harness.test.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/make-test-harness.test.js
@@ -3,9 +3,9 @@ import * as React from "react";
 import {Route} from "react-router-dom";
 import {render} from "@testing-library/react";
 
-import * as RA from "../render-adapters.js";
-import {makeTestHarness} from "../make-test-harness.js";
-import {DefaultConfigs, DefaultAdapters} from "../adapters/adapters.js";
+import * as RA from "../render-adapters";
+import {makeTestHarness} from "../make-test-harness";
+import {DefaultConfigs, DefaultAdapters} from "../adapters/adapters";
 
 describe("#makeTestHarness", () => {
     it("should return a function", () => {

--- a/packages/wonder-blocks-testing/src/harness/__tests__/render-adapters.test.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/render-adapters.test.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
-import {renderAdapters} from "../render-adapters.js";
+import {renderAdapters} from "../render-adapters";
 
-import type {TestHarnessAdapter, TestHarnessConfigs} from "../types.js";
+import type {TestHarnessAdapter, TestHarnessConfigs} from "../types";
 
 describe("#renderAdapters", () => {
     it("should return children if no adapters", () => {

--- a/packages/wonder-blocks-testing/src/harness/__tests__/test-harness.test.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/test-harness.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {jest as ws} from "@khanacademy/wonder-stuff-testing";
-import * as MTH from "../make-test-harness.js";
-import {DefaultAdapters, DefaultConfigs} from "../adapters/adapters.js";
+import * as MTH from "../make-test-harness";
+import {DefaultAdapters, DefaultConfigs} from "../adapters/adapters";
 
 jest.mock("../make-test-harness.js", () => {
     const returnValueFake = {

--- a/packages/wonder-blocks-testing/src/harness/__tests__/test-harness.test.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/test-harness.test.js
@@ -3,7 +3,7 @@ import {jest as ws} from "@khanacademy/wonder-stuff-testing";
 import * as MTH from "../make-test-harness";
 import {DefaultAdapters, DefaultConfigs} from "../adapters/adapters";
 
-jest.mock("../make-test-harness.js", () => {
+jest.mock("../make-test-harness", () => {
     const returnValueFake = {
         thisisa: "PRETEND REACT COMPONENT",
     };
@@ -21,7 +21,7 @@ describe("#testHarness", () => {
         const makeTestHarnessSpy = jest.spyOn(MTH, "makeTestHarness");
 
         // Act
-        await ws.isolateModules(() => import("../hook-harness.js"));
+        await ws.isolateModules(() => import("../hook-harness"));
 
         // Assert
         expect(makeTestHarnessSpy).toHaveBeenCalledWith(
@@ -39,8 +39,8 @@ describe("#testHarness", () => {
         // $FlowIgnore[prop-missing]  - we add this into our mock at the top.
         const [{harnessFake}, {testHarness}] = await ws.isolateModules(() =>
             Promise.all([
-                import("../make-test-harness.js"),
-                import("../test-harness.js"),
+                import("../make-test-harness"),
+                import("../test-harness"),
             ]),
         );
 
@@ -60,8 +60,8 @@ describe("#testHarness", () => {
         // $FlowIgnore[prop-missing]  - we add this into our mock at the top.
         const [{returnValueFake}, {testHarness}] = await ws.isolateModules(() =>
             Promise.all([
-                import("../make-test-harness.js"),
-                import("../test-harness.js"),
+                import("../make-test-harness"),
+                import("../test-harness"),
             ]),
         );
 

--- a/packages/wonder-blocks-testing/src/harness/__tests__/types.flowtest.js
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/types.flowtest.js
@@ -6,7 +6,7 @@ import type {
     TestHarnessAdapters,
     TestHarnessConfig,
     TestHarnessConfigs,
-} from "../types.js";
+} from "../types";
 
 /**
  * TestHarnessAdapter<TConfig>

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/css.test.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/css.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import * as Css from "../css.js";
+import * as Css from "../css";
 
 describe("Css.adapter", () => {
     it("should throw if the config is invalid", () => {

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/data.test.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/data.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 import {useCachedEffect} from "@khanacademy/wonder-blocks-data";
-import * as Data from "../data.js";
+import * as Data from "../data";
 
 describe("WonderBlocksData.adapter", () => {
     it("should render children when configuration arrays are empty", () => {

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/portal.test.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/portal.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import * as Portal from "../portal.js";
+import * as Portal from "../portal";
 
 describe("Portal.adapter", () => {
     it("should render a portal root element", () => {

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/router.test.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/router.test.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {withRouter, Prompt} from "react-router-dom";
 import {render} from "@testing-library/react";
-import * as Router from "../router.js";
+import * as Router from "../router";
 
 describe("Router.adapter", () => {
     it("should throw if the config does not match any expecations", () => {

--- a/packages/wonder-blocks-testing/src/harness/adapters/adapters.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/adapters.js
@@ -1,10 +1,10 @@
 // @flow
-import * as css from "./css.js";
-import * as data from "./data.js";
-import * as portal from "./portal.js";
-import * as router from "./router.js";
+import * as css from "./css";
+import * as data from "./data";
+import * as portal from "./portal";
+import * as router from "./router";
 
-import type {TestHarnessConfigs} from "../types.js";
+import type {TestHarnessConfigs} from "../types";
 
 /**
  * NOTE: We do not type `DefaultAdapters` with `Adapters` here because we want

--- a/packages/wonder-blocks-testing/src/harness/adapters/css.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/css.js
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import type {CSSProperties} from "aphrodite";
 
-import type {TestHarnessAdapter} from "../types.js";
+import type {TestHarnessAdapter} from "../types";
 
 type Config =
     | string

--- a/packages/wonder-blocks-testing/src/harness/adapters/data.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/data.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import {InterceptRequests} from "@khanacademy/wonder-blocks-data";
-import type {TestHarnessAdapter} from "../types.js";
+import type {TestHarnessAdapter} from "../types";
 
 type Interceptor = React.ElementConfig<typeof InterceptRequests>["interceptor"];
 

--- a/packages/wonder-blocks-testing/src/harness/adapters/portal.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/portal.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import type {TestHarnessAdapter} from "../types.js";
+import type {TestHarnessAdapter} from "../types";
 
 type Config = string;
 

--- a/packages/wonder-blocks-testing/src/harness/adapters/router.js
+++ b/packages/wonder-blocks-testing/src/harness/adapters/router.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import {StaticRouter, MemoryRouter, Route, Switch} from "react-router-dom";
 
 import type {LocationShape, Location} from "react-router-dom";
-import type {TestHarnessAdapter} from "../types.js";
+import type {TestHarnessAdapter} from "../types";
 
 type MemoryRouterProps = React.ElementConfig<typeof MemoryRouter>;
 

--- a/packages/wonder-blocks-testing/src/harness/hook-harness.js
+++ b/packages/wonder-blocks-testing/src/harness/hook-harness.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from "react";
 
-import {makeHookHarness} from "./make-hook-harness.js";
-import {DefaultAdapters, DefaultConfigs} from "./adapters/adapters.js";
+import {makeHookHarness} from "./make-hook-harness";
+import {DefaultAdapters, DefaultConfigs} from "./adapters/adapters";
 
-import type {TestHarnessConfigs} from "./types.js";
+import type {TestHarnessConfigs} from "./types";
 
 /**
  * Create test wrapper for hook testing with Wonder Blocks default adapters.

--- a/packages/wonder-blocks-testing/src/harness/make-hook-harness.js
+++ b/packages/wonder-blocks-testing/src/harness/make-hook-harness.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
 
-import {makeTestHarness} from "./make-test-harness.js";
+import {makeTestHarness} from "./make-test-harness";
 
-import type {TestHarnessAdapters, TestHarnessConfigs} from "./types.js";
+import type {TestHarnessAdapters, TestHarnessConfigs} from "./types";
 
 const HookHarness = ({children}) => children;
 

--- a/packages/wonder-blocks-testing/src/harness/make-test-harness.js
+++ b/packages/wonder-blocks-testing/src/harness/make-test-harness.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from "react";
 
-import {renderAdapters} from "./render-adapters.js";
+import {renderAdapters} from "./render-adapters";
 
-import type {TestHarnessAdapters, TestHarnessConfigs} from "./types.js";
+import type {TestHarnessAdapters, TestHarnessConfigs} from "./types";
 
 /**
  * Create a test harness method for use with React components.

--- a/packages/wonder-blocks-testing/src/harness/render-adapters.js
+++ b/packages/wonder-blocks-testing/src/harness/render-adapters.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import type {TestHarnessConfigs, TestHarnessAdapters} from "./types.js";
+import type {TestHarnessConfigs, TestHarnessAdapters} from "./types";
 
 /**
  * Render test adapters around a child component.

--- a/packages/wonder-blocks-testing/src/harness/test-harness.js
+++ b/packages/wonder-blocks-testing/src/harness/test-harness.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from "react";
 
-import {makeTestHarness} from "./make-test-harness.js";
-import {DefaultAdapters, DefaultConfigs} from "./adapters/adapters.js";
+import {makeTestHarness} from "./make-test-harness";
+import {DefaultAdapters, DefaultConfigs} from "./adapters/adapters";
 
-import type {TestHarnessConfigs} from "./types.js";
+import type {TestHarnessConfigs} from "./types";
 
 /**
  * Wrap a component with a test harness using Wonder Blocks default adapters.

--- a/packages/wonder-blocks-testing/src/index.js
+++ b/packages/wonder-blocks-testing/src/index.js
@@ -1,26 +1,22 @@
 // @flow
 
 // Fixtures framework
-export {fixtures} from "./fixtures/fixtures.js";
-export type {
-    FixtureFn,
-    FixtureProps,
-    GetPropsOptions,
-} from "./fixtures/types.js";
+export {fixtures} from "./fixtures/fixtures";
+export type {FixtureFn, FixtureProps, GetPropsOptions} from "./fixtures/types";
 
 // Fetch mocking framework
-export {mockFetch} from "./fetch/mock-fetch.js";
-export {mockGqlFetch} from "./gql/mock-gql-fetch.js";
-export {RespondWith} from "./respond-with.js";
-export {SettleController} from "./settle-controller.js";
-export type {MockResponse} from "./respond-with.js";
-export type {FetchMockFn, FetchMockOperation} from "./fetch/types.js";
-export type {GqlFetchMockFn, GqlMockOperation} from "./gql/types.js";
+export {mockFetch} from "./fetch/mock-fetch";
+export {mockGqlFetch} from "./gql/mock-gql-fetch";
+export {RespondWith} from "./respond-with";
+export {SettleController} from "./settle-controller";
+export type {MockResponse} from "./respond-with";
+export type {FetchMockFn, FetchMockOperation} from "./fetch/types";
+export type {GqlFetchMockFn, GqlMockOperation} from "./gql/types";
 
 // Test harness framework
-export * from "./harness/types.js";
-export * as harnessAdapters from "./harness/adapters/adapters.js";
-export {makeHookHarness} from "./harness/make-hook-harness.js";
-export {makeTestHarness} from "./harness/make-test-harness.js";
-export {hookHarness} from "./harness/hook-harness.js";
-export {testHarness} from "./harness/test-harness.js";
+export * from "./harness/types";
+export * as harnessAdapters from "./harness/adapters/adapters";
+export {makeHookHarness} from "./harness/make-hook-harness";
+export {makeTestHarness} from "./harness/make-test-harness";
+export {hookHarness} from "./harness/hook-harness";
+export {testHarness} from "./harness/test-harness";

--- a/packages/wonder-blocks-testing/src/mock-requester.js
+++ b/packages/wonder-blocks-testing/src/mock-requester.js
@@ -1,6 +1,6 @@
 // @flow
-import type {MockResponse} from "./respond-with.js";
-import type {OperationMock, OperationMatcher, MockFn} from "./types.js";
+import type {MockResponse} from "./respond-with";
+import type {OperationMock, OperationMatcher, MockFn} from "./types";
 
 /**
  * A generic mock request function for using when mocking fetch or gqlFetch.

--- a/packages/wonder-blocks-testing/src/respond-with.js
+++ b/packages/wonder-blocks-testing/src/respond-with.js
@@ -1,7 +1,7 @@
 // @flow
-import {SettleSignal} from "./settle-signal.js";
-import {ResponseImpl} from "./response-impl.js";
-import type {GraphQLJson} from "./types.js";
+import {SettleSignal} from "./settle-signal";
+import {ResponseImpl} from "./response-impl";
+import type {GraphQLJson} from "./types";
 
 // We want the parameterization here so that folks can assert a response is
 // of a specific type if passing between various functions. For example,

--- a/packages/wonder-blocks-testing/src/settle-controller.js
+++ b/packages/wonder-blocks-testing/src/settle-controller.js
@@ -1,5 +1,5 @@
 // @flow
-import {SettleSignal} from "./settle-signal.js";
+import {SettleSignal} from "./settle-signal";
 
 /**
  * A controller for the `RespondWith` API to control response settlement.

--- a/packages/wonder-blocks-testing/src/types.js
+++ b/packages/wonder-blocks-testing/src/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type {MockResponse} from "./respond-with.js";
+import type {MockResponse} from "./respond-with";
 
 /**
  * A valid GraphQL response as supported by our mocking framework.

--- a/packages/wonder-blocks-timing/src/components/__tests__/action-scheduler-provider.test.js
+++ b/packages/wonder-blocks-timing/src/components/__tests__/action-scheduler-provider.test.js
@@ -2,8 +2,8 @@
 import * as React from "react";
 import {render} from "@testing-library/react";
 
-import ActionSchedulerProvider from "../action-scheduler-provider.js";
-import ActionScheduler from "../../util/action-scheduler.js";
+import ActionSchedulerProvider from "../action-scheduler-provider";
+import ActionScheduler from "../../util/action-scheduler";
 
 jest.mock("../../util/action-scheduler.js");
 

--- a/packages/wonder-blocks-timing/src/components/__tests__/action-scheduler-provider.test.js
+++ b/packages/wonder-blocks-timing/src/components/__tests__/action-scheduler-provider.test.js
@@ -5,7 +5,7 @@ import {render} from "@testing-library/react";
 import ActionSchedulerProvider from "../action-scheduler-provider";
 import ActionScheduler from "../../util/action-scheduler";
 
-jest.mock("../../util/action-scheduler.js");
+jest.mock("../../util/action-scheduler");
 
 describe("ActionSchedulerProvider", () => {
     it("should render children with action scheduler instance", () => {

--- a/packages/wonder-blocks-timing/src/components/__tests__/with-action-scheduler.test.js
+++ b/packages/wonder-blocks-timing/src/components/__tests__/with-action-scheduler.test.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import withActionScheduler from "../with-action-scheduler.js";
+import withActionScheduler from "../with-action-scheduler";
 
-import type {WithActionSchedulerProps} from "../../util/types.js";
+import type {WithActionSchedulerProps} from "../../util/types";
 
 describe("withActionScheduler", () => {
     it("should provide wrapped component with IScheduleActions instance", () => {

--- a/packages/wonder-blocks-timing/src/components/action-scheduler-provider.js
+++ b/packages/wonder-blocks-timing/src/components/action-scheduler-provider.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from "react";
-import ActionScheduler from "../util/action-scheduler.js";
+import ActionScheduler from "../util/action-scheduler";
 
-import type {IScheduleActions} from "../util/types.js";
+import type {IScheduleActions} from "../util/types";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-timing/src/components/with-action-scheduler.js
+++ b/packages/wonder-blocks-timing/src/components/with-action-scheduler.js
@@ -1,13 +1,13 @@
 // @flow
 import * as React from "react";
 
-import ActionSchedulerProvider from "./action-scheduler-provider.js";
+import ActionSchedulerProvider from "./action-scheduler-provider";
 
 import type {
     IScheduleActions,
     WithActionSchedulerProps,
     WithActionScheduler,
-} from "../util/types.js";
+} from "../util/types";
 
 type WithoutActionScheduler<T> = $Exact<$Diff<T, WithActionSchedulerProps>>;
 

--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-interval.test.js
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-interval.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {renderHook} from "@testing-library/react-hooks";
 
-import {useInterval} from "../use-interval.js";
+import {useInterval} from "../use-interval";
 
 describe("useTimeout", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-scheduled-interval.test.js
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-scheduled-interval.test.js
@@ -1,8 +1,8 @@
 // @flow
 import {renderHook, act} from "@testing-library/react-hooks";
-import {SchedulePolicy, ClearPolicy} from "../../util/policies.js";
+import {SchedulePolicy, ClearPolicy} from "../../util/policies";
 
-import {useScheduledInterval} from "../use-scheduled-interval.js";
+import {useScheduledInterval} from "../use-scheduled-interval";
 
 describe("useScheduledInterval", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-scheduled-timeout.test.js
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-scheduled-timeout.test.js
@@ -1,8 +1,8 @@
 // @flow
 import {renderHook, act} from "@testing-library/react-hooks";
-import {SchedulePolicy, ClearPolicy} from "../../util/policies.js";
+import {SchedulePolicy, ClearPolicy} from "../../util/policies";
 
-import {useScheduledTimeout} from "../use-scheduled-timeout.js";
+import {useScheduledTimeout} from "../use-scheduled-timeout";
 
 describe("useScheduledTimeout", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-timeout.test.js
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-timeout.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {renderHook} from "@testing-library/react-hooks";
 
-import {useTimeout} from "../use-timeout.js";
+import {useTimeout} from "../use-timeout";
 
 describe("useTimeout", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-timing/src/hooks/use-interval.js
+++ b/packages/wonder-blocks-timing/src/hooks/use-interval.js
@@ -1,7 +1,7 @@
 // @flow
 import {useEffect} from "react";
 
-import {useUpdatingRef} from "./internal/use-updating-ref.js";
+import {useUpdatingRef} from "./internal/use-updating-ref";
 
 /**
  * A simple hook for using `setInterval`.

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.js
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.js
@@ -4,11 +4,11 @@ import {useEffect, useState, useCallback} from "react";
 import {
     SchedulePolicy as SchedulePolicies,
     ClearPolicy as ClearPolicies,
-} from "../util/policies.js";
-import type {IInterval, ClearPolicy, Options} from "../util/types.js";
+} from "../util/policies";
+import type {IInterval, ClearPolicy, Options} from "../util/types";
 
-import {useUpdatingRef} from "./internal/use-updating-ref.js";
-import {useInterval} from "./use-interval.js";
+import {useUpdatingRef} from "./internal/use-updating-ref";
+import {useInterval} from "./use-interval";
 
 export function useScheduledInterval(
     action: () => mixed,

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.js
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.js
@@ -4,11 +4,11 @@ import {useEffect, useState, useCallback} from "react";
 import {
     SchedulePolicy as SchedulePolicies,
     ClearPolicy as ClearPolicies,
-} from "../util/policies.js";
-import type {ITimeout, ClearPolicy, Options} from "../util/types.js";
+} from "../util/policies";
+import type {ITimeout, ClearPolicy, Options} from "../util/types";
 
-import {useUpdatingRef} from "./internal/use-updating-ref.js";
-import {useTimeout} from "./use-timeout.js";
+import {useUpdatingRef} from "./internal/use-updating-ref";
+import {useTimeout} from "./use-timeout";
 
 export function useScheduledTimeout(
     action: () => mixed,

--- a/packages/wonder-blocks-timing/src/hooks/use-timeout.js
+++ b/packages/wonder-blocks-timing/src/hooks/use-timeout.js
@@ -1,7 +1,7 @@
 // @flow
 import {useEffect} from "react";
 
-import {useUpdatingRef} from "./internal/use-updating-ref.js";
+import {useUpdatingRef} from "./internal/use-updating-ref";
 
 /**
  * A simple hook for using `setTimeout`.

--- a/packages/wonder-blocks-timing/src/index.js
+++ b/packages/wonder-blocks-timing/src/index.js
@@ -7,7 +7,7 @@ import type {
     WithActionScheduler,
     WithActionSchedulerProps,
     WithoutActionScheduler,
-} from "./util/types.js";
+} from "./util/types";
 
 export type {
     IAnimationFrame,
@@ -19,9 +19,9 @@ export type {
     WithoutActionScheduler,
 };
 
-export {SchedulePolicy, ClearPolicy} from "./util/policies.js";
-export {default as withActionScheduler} from "./components/with-action-scheduler.js";
-export {useInterval} from "./hooks/use-interval.js";
-export {useTimeout} from "./hooks/use-timeout.js";
-export {useScheduledInterval} from "./hooks/use-scheduled-interval.js";
-export {useScheduledTimeout} from "./hooks/use-scheduled-timeout.js";
+export {SchedulePolicy, ClearPolicy} from "./util/policies";
+export {default as withActionScheduler} from "./components/with-action-scheduler";
+export {useInterval} from "./hooks/use-interval";
+export {useTimeout} from "./hooks/use-timeout";
+export {useScheduledInterval} from "./hooks/use-scheduled-interval";
+export {useScheduledTimeout} from "./hooks/use-scheduled-timeout";

--- a/packages/wonder-blocks-timing/src/util/__tests__/action-scheduler.test.js
+++ b/packages/wonder-blocks-timing/src/util/__tests__/action-scheduler.test.js
@@ -1,9 +1,9 @@
 // @flow
-import ActionScheduler from "../action-scheduler.js";
-import Timeout from "../timeout.js";
-import Interval from "../interval.js";
-import AnimationFrame from "../animation-frame.js";
-import {SchedulePolicy, ClearPolicy} from "../policies.js";
+import ActionScheduler from "../action-scheduler";
+import Timeout from "../timeout";
+import Interval from "../interval";
+import AnimationFrame from "../animation-frame";
+import {SchedulePolicy, ClearPolicy} from "../policies";
 
 jest.mock("../timeout.js");
 jest.mock("../interval.js");

--- a/packages/wonder-blocks-timing/src/util/__tests__/action-scheduler.test.js
+++ b/packages/wonder-blocks-timing/src/util/__tests__/action-scheduler.test.js
@@ -5,9 +5,9 @@ import Interval from "../interval";
 import AnimationFrame from "../animation-frame";
 import {SchedulePolicy, ClearPolicy} from "../policies";
 
-jest.mock("../timeout.js");
-jest.mock("../interval.js");
-jest.mock("../animation-frame.js");
+jest.mock("../timeout");
+jest.mock("../interval");
+jest.mock("../animation-frame");
 
 describe("ActionScheduler", () => {
     afterEach(() => {

--- a/packages/wonder-blocks-timing/src/util/__tests__/animation-frame.test.js
+++ b/packages/wonder-blocks-timing/src/util/__tests__/animation-frame.test.js
@@ -1,6 +1,6 @@
 // @flow
-import AnimationFrame from "../animation-frame.js";
-import {SchedulePolicy, ClearPolicy} from "../policies.js";
+import AnimationFrame from "../animation-frame";
+import {SchedulePolicy, ClearPolicy} from "../policies";
 
 describe("AnimationFrame", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-timing/src/util/__tests__/interval.test.js
+++ b/packages/wonder-blocks-timing/src/util/__tests__/interval.test.js
@@ -1,6 +1,6 @@
 // @flow
-import Interval from "../interval.js";
-import {SchedulePolicy, ClearPolicy} from "../policies.js";
+import Interval from "../interval";
+import {SchedulePolicy, ClearPolicy} from "../policies";
 
 describe("Interval", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-timing/src/util/__tests__/timeout.test.js
+++ b/packages/wonder-blocks-timing/src/util/__tests__/timeout.test.js
@@ -1,6 +1,6 @@
 // @flow
-import Timeout from "../timeout.js";
-import {SchedulePolicy, ClearPolicy} from "../policies.js";
+import Timeout from "../timeout";
+import {SchedulePolicy, ClearPolicy} from "../policies";
 
 describe("Timeout", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-timing/src/util/action-scheduler.js
+++ b/packages/wonder-blocks-timing/src/util/action-scheduler.js
@@ -1,7 +1,7 @@
 // @flow
-import Timeout from "./timeout.js";
-import Interval from "./interval.js";
-import AnimationFrame from "./animation-frame.js";
+import Timeout from "./timeout";
+import Interval from "./interval";
+import AnimationFrame from "./animation-frame";
 
 import type {
     IAnimationFrame,
@@ -9,7 +9,7 @@ import type {
     ITimeout,
     IScheduleActions,
     Options,
-} from "./types.js";
+} from "./types";
 
 /**
  * Implements the `IScheduleActions` API to provide timeout, interval, and

--- a/packages/wonder-blocks-timing/src/util/animation-frame.js
+++ b/packages/wonder-blocks-timing/src/util/animation-frame.js
@@ -2,9 +2,9 @@
 import {
     SchedulePolicy as SchedulePolicies,
     ClearPolicy as ClearPolicies,
-} from "./policies.js";
+} from "./policies";
 
-import type {IAnimationFrame, SchedulePolicy, ClearPolicy} from "./types.js";
+import type {IAnimationFrame, SchedulePolicy, ClearPolicy} from "./types";
 
 /**
  * Encapsulates everything associated with calling requestAnimationFrame/

--- a/packages/wonder-blocks-timing/src/util/interval.js
+++ b/packages/wonder-blocks-timing/src/util/interval.js
@@ -2,9 +2,9 @@
 import {
     SchedulePolicy as SchedulePolicies,
     ClearPolicy as ClearPolicies,
-} from "./policies.js";
+} from "./policies";
 
-import type {IInterval, SchedulePolicy, ClearPolicy} from "./types.js";
+import type {IInterval, SchedulePolicy, ClearPolicy} from "./types";
 
 /**
  * Encapsulates everything associated with calling setInterval/clearInterval,

--- a/packages/wonder-blocks-timing/src/util/timeout.js
+++ b/packages/wonder-blocks-timing/src/util/timeout.js
@@ -2,9 +2,9 @@
 import {
     SchedulePolicy as SchedulePolicies,
     ClearPolicy as ClearPolicies,
-} from "./policies.js";
+} from "./policies";
 
-import type {ITimeout, SchedulePolicy, ClearPolicy} from "./types.js";
+import type {ITimeout, SchedulePolicy, ClearPolicy} from "./types";
 
 /**
  * Encapsulates everything associated with calling setTimeout/clearTimeout, and

--- a/packages/wonder-blocks-timing/src/util/types.flowtest.js
+++ b/packages/wonder-blocks-timing/src/util/types.flowtest.js
@@ -4,9 +4,9 @@
  * This file ensures that our flow types are working right.
  */
 import * as React from "react";
-import withActionScheduler from "../components/with-action-scheduler.js";
+import withActionScheduler from "../components/with-action-scheduler";
 
-import type {WithActionSchedulerProps} from "./types.js";
+import type {WithActionSchedulerProps} from "./types";
 
 /**
  * Test WithActionScheduler and withActionScheduler usage.

--- a/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.stories.js
+++ b/packages/wonder-blocks-toolbar/src/components/__docs__/toolbar.stories.js
@@ -7,12 +7,12 @@ import Spacing from "@khanacademy/wonder-blocks-spacing";
 import Toolbar from "@khanacademy/wonder-blocks-toolbar";
 
 import type {StoryComponentType} from "@storybook/react";
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 import ToolbarArgtypes, {
     leftContentMappings,
     rightContentMappings,
-} from "./toolbar.argtypes.js";
+} from "./toolbar.argtypes";
 
 export default {
     title: "Toolbar / Toolbar",

--- a/packages/wonder-blocks-toolbar/src/index.js
+++ b/packages/wonder-blocks-toolbar/src/index.js
@@ -1,4 +1,4 @@
 // @flow
-import Toolbar from "./components/toolbar.js";
+import Toolbar from "./components/toolbar";
 
 export {Toolbar as default};

--- a/packages/wonder-blocks-tooltip/src/components/__docs__/tooltip-content.stories.js
+++ b/packages/wonder-blocks-tooltip/src/components/__docs__/tooltip-content.stories.js
@@ -5,7 +5,7 @@ import {Body, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-tooltip/src/components/__docs__/tooltip.stories.js
+++ b/packages/wonder-blocks-tooltip/src/components/__docs__/tooltip.stories.js
@@ -17,9 +17,9 @@ import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import type {StoryComponentType} from "@storybook/react";
-import TooltipArgtypes from "./tooltip.argtypes.js";
+import TooltipArgtypes from "./tooltip.argtypes";
 
-import ComponentInfo from "../../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../../.storybook/components/component-info";
 import {name, version} from "../../../package.json";
 
 export default {

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
@@ -10,7 +10,7 @@ import {
     TooltipDisappearanceDelay,
 } from "../../util/constants";
 
-jest.mock("../../util/active-tracker.js");
+jest.mock("../../util/active-tracker");
 
 describe("TooltipAnchor", () => {
     beforeEach(async () => {
@@ -28,7 +28,7 @@ describe("TooltipAnchor", () => {
         jest.useFakeTimers();
 
         const {default: ActiveTracker} = await import(
-            "../../util/active-tracker.js"
+            "../../util/active-tracker"
         );
         // We know there's one global instance of this import, so let's
         // reset it.
@@ -245,7 +245,7 @@ describe("TooltipAnchor", () => {
         test("active state was not stolen, delays set active", async () => {
             // Arrange
             const {default: ActiveTracker} = await import(
-                "../../util/active-tracker.js"
+                "../../util/active-tracker"
             );
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             // Let's tell the tooltip it isn't stealing and therefore it should
@@ -286,7 +286,7 @@ describe("TooltipAnchor", () => {
         test("active state was stolen, set active immediately", async () => {
             // Arrange
             const {default: ActiveTracker} = await import(
-                "../../util/active-tracker.js"
+                "../../util/active-tracker"
             );
             // Let's tell the tooltip it is stealing and therefore it should
             // not be using a delay to show the tooltip.
@@ -360,7 +360,7 @@ describe("TooltipAnchor", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const {default: ActiveTracker} = await import(
-                "../../util/active-tracker.js"
+                "../../util/active-tracker"
             );
             // Flow doesn't know this is a mock
             // $FlowFixMe[prop-missing]
@@ -438,7 +438,7 @@ describe("TooltipAnchor", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const {default: ActiveTracker} = await import(
-                "../../util/active-tracker.js"
+                "../../util/active-tracker"
             );
             // Flow doesn't know this is a mock
             // $FlowFixMe[prop-missing]
@@ -513,7 +513,7 @@ describe("TooltipAnchor", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const {default: ActiveTracker} = await import(
-                "../../util/active-tracker.js"
+                "../../util/active-tracker"
             );
             // Let's tell the tooltip it isn't stealing and therefore it should
             // be using a delay to show the tooltip.
@@ -552,7 +552,7 @@ describe("TooltipAnchor", () => {
         test("active state was stolen, set active immediately", async () => {
             // Arrange
             const {default: ActiveTracker} = await import(
-                "../../util/active-tracker.js"
+                "../../util/active-tracker"
             );
             // Let's tell the tooltip it is stealing and therefore it should
             // not be using a delay to show the tooltip.
@@ -624,7 +624,7 @@ describe("TooltipAnchor", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const {default: ActiveTracker} = await import(
-                "../../util/active-tracker.js"
+                "../../util/active-tracker"
             );
             // Flow doesn't know this is a mock
             // $FlowFixMe[prop-missing]
@@ -699,7 +699,7 @@ describe("TooltipAnchor", () => {
             // Arrange
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const {default: ActiveTracker} = await import(
-                "../../util/active-tracker.js"
+                "../../util/active-tracker"
             );
             // Flow doesn't know this is a mock
             // $FlowFixMe[prop-missing]

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.js
@@ -4,11 +4,11 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import TooltipAnchor from "../tooltip-anchor.js";
+import TooltipAnchor from "../tooltip-anchor";
 import {
     TooltipAppearanceDelay,
     TooltipDisappearanceDelay,
-} from "../../util/constants.js";
+} from "../../util/constants";
 
 jest.mock("../../util/active-tracker.js");
 

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-bubble.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-bubble.test.js
@@ -4,8 +4,8 @@ import {render, screen} from "@testing-library/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import TooltipBubble from "../tooltip-bubble.js";
-import typeof TooltipContent from "../tooltip-content.js";
+import TooltipBubble from "../tooltip-bubble";
+import typeof TooltipContent from "../tooltip-content";
 
 describe("TooltipBubble", () => {
     // A little helper method to make the actual test more readable.

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-popper.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-popper.test.js
@@ -5,8 +5,8 @@ import {render} from "@testing-library/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import typeof TooltipBubble from "../tooltip-bubble.js";
-import TooltipPopper from "../tooltip-popper.js";
+import typeof TooltipBubble from "../tooltip-bubble";
+import TooltipPopper from "../tooltip-popper";
 
 type State = {|ref: ?HTMLElement|};
 /**

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {render} from "@testing-library/react";
 
-import TooltipTail from "../tooltip-tail.js";
+import TooltipTail from "../tooltip-tail";
 
-import type {Placement} from "../../util/types.js";
+import type {Placement} from "../../util/types";
 
 describe("TooltipTail", () => {
     describe("#render", () => {

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.integration.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.integration.test.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import {render, screen, fireEvent} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import Tooltip from "../tooltip.js";
+import Tooltip from "../tooltip";
 
 describe("tooltip integration tests", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.js
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.js
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import Tooltip from "../tooltip.js";
+import Tooltip from "../tooltip";
 
 const mockIDENTIFIER = "mock-identifier";
 jest.mock("@khanacademy/wonder-blocks-core", () => {

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.js
@@ -9,13 +9,13 @@ import * as ReactDOM from "react-dom";
 import {Text as WBText} from "@khanacademy/wonder-blocks-core";
 import type {IIdentifierFactory} from "@khanacademy/wonder-blocks-core";
 
-import ActiveTracker from "../util/active-tracker.js";
+import ActiveTracker from "../util/active-tracker";
 import {
     TooltipAppearanceDelay,
     TooltipDisappearanceDelay,
-} from "../util/constants.js";
+} from "../util/constants";
 
-import type {IActiveTrackerSubscriber} from "../util/active-tracker.js";
+import type {IActiveTrackerSubscriber} from "../util/active-tracker";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.js
@@ -6,10 +6,10 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import typeof TooltipContent from "./tooltip-content.js";
-import TooltipTail from "./tooltip-tail.js";
+import typeof TooltipContent from "./tooltip-content";
+import TooltipTail from "./tooltip-tail";
 
-import type {getRefFn, Offset, Placement} from "../util/types.js";
+import type {getRefFn, Offset, Placement} from "../util/types";
 
 export type PopperElementProps = {|
     /** The placement of the bubble with respect to the anchor. */

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-popper.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-popper.js
@@ -7,9 +7,9 @@ import * as React from "react";
 import {Popper} from "react-popper";
 import type {PopperChildrenProps} from "react-popper";
 
-import RefTracker from "../util/ref-tracker.js";
-import type {Placement} from "../util/types.js";
-import type {PopperElementProps} from "./tooltip-bubble.js";
+import RefTracker from "../util/ref-tracker";
+import type {Placement} from "../util/types";
+import type {PopperElementProps} from "./tooltip-bubble";
 
 type Props = {|
     /**

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.js
@@ -7,7 +7,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import type {getRefFn, Placement, Offset} from "../util/types.js";
+import type {getRefFn, Placement, Offset} from "../util/types";
 
 export type Props = {|
     /**

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.js
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.js
@@ -29,11 +29,11 @@ import {maybeGetPortalMountedModalHostElement} from "@khanacademy/wonder-blocks-
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 
-import TooltipAnchor from "./tooltip-anchor.js";
-import TooltipBubble from "./tooltip-bubble.js";
-import TooltipContent from "./tooltip-content.js";
-import TooltipPopper from "./tooltip-popper.js";
-import type {Placement} from "../util/types.js";
+import TooltipAnchor from "./tooltip-anchor";
+import TooltipBubble from "./tooltip-bubble";
+import TooltipContent from "./tooltip-content";
+import TooltipPopper from "./tooltip-popper";
+import type {Placement} from "../util/types";
 
 type Props = {|
     ...AriaProps,

--- a/packages/wonder-blocks-tooltip/src/index.js
+++ b/packages/wonder-blocks-tooltip/src/index.js
@@ -1,11 +1,11 @@
 // @flow
-import type {Placement} from "./util/types.js";
-import type {PopperElementProps} from "./components/tooltip-bubble.js";
+import type {Placement} from "./util/types";
+import type {PopperElementProps} from "./components/tooltip-bubble";
 
-import Tooltip from "./components/tooltip.js";
-import TooltipContent from "./components/tooltip-content.js";
-import TooltipPopper from "./components/tooltip-popper.js";
-import TooltipTail from "./components/tooltip-tail.js";
+import Tooltip from "./components/tooltip";
+import TooltipContent from "./components/tooltip-content";
+import TooltipPopper from "./components/tooltip-popper";
+import TooltipTail from "./components/tooltip-tail";
 
 export {Tooltip as default, TooltipContent, TooltipPopper, TooltipTail};
 

--- a/packages/wonder-blocks-tooltip/src/util/__tests__/active-tracker.test.js
+++ b/packages/wonder-blocks-tooltip/src/util/__tests__/active-tracker.test.js
@@ -1,6 +1,6 @@
 // @flow
-import ActiveTracker from "../active-tracker.js";
-import type {IActiveTrackerSubscriber} from "../active-tracker.js";
+import ActiveTracker from "../active-tracker";
+import type {IActiveTrackerSubscriber} from "../active-tracker";
 
 class MockSubscriber implements IActiveTrackerSubscriber {
     activeStateStolen = jest.fn();

--- a/packages/wonder-blocks-tooltip/src/util/__tests__/ref-tracker.test.js
+++ b/packages/wonder-blocks-tooltip/src/util/__tests__/ref-tracker.test.js
@@ -4,7 +4,7 @@ import * as ReactDOM from "react-dom";
 import {render} from "@testing-library/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import RefTracker from "../ref-tracker.js";
+import RefTracker from "../ref-tracker";
 
 type CallbackFn = (?HTMLElement) => void;
 

--- a/packages/wonder-blocks-typography/src/__docs__/typography.stories.js
+++ b/packages/wonder-blocks-typography/src/__docs__/typography.stories.js
@@ -26,9 +26,9 @@ import {
     Footnote,
 } from "@khanacademy/wonder-blocks-typography";
 
-import ComponentInfo from "../../../../.storybook/components/component-info.js";
+import ComponentInfo from "../../../../.storybook/components/component-info";
 import {name, version} from "../../package.json";
-import TypographyArgTypes from "./typography.argtypes.js";
+import TypographyArgTypes from "./typography.argtypes";
 
 const typographyDescription = `Typography. \`wonder-blocks-typography\`
 provides a set of standardized components for displaying text in a consistent

--- a/packages/wonder-blocks-typography/src/components/body-monospace.js
+++ b/packages/wonder-blocks-typography/src/components/body-monospace.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/body-serif-block.js
+++ b/packages/wonder-blocks-typography/src/components/body-serif-block.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/body-serif.js
+++ b/packages/wonder-blocks-typography/src/components/body-serif.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/body.js
+++ b/packages/wonder-blocks-typography/src/components/body.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/caption.js
+++ b/packages/wonder-blocks-typography/src/components/caption.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/footnote.js
+++ b/packages/wonder-blocks-typography/src/components/footnote.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/heading-large.js
+++ b/packages/wonder-blocks-typography/src/components/heading-large.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/heading-medium.js
+++ b/packages/wonder-blocks-typography/src/components/heading-medium.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/heading-small.js
+++ b/packages/wonder-blocks-typography/src/components/heading-small.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/heading-xsmall.js
+++ b/packages/wonder-blocks-typography/src/components/heading-xsmall.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/label-large.js
+++ b/packages/wonder-blocks-typography/src/components/label-large.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/label-medium.js
+++ b/packages/wonder-blocks-typography/src/components/label-medium.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/label-small.js
+++ b/packages/wonder-blocks-typography/src/components/label-small.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/label-xsmall.js
+++ b/packages/wonder-blocks-typography/src/components/label-xsmall.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/tagline.js
+++ b/packages/wonder-blocks-typography/src/components/tagline.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/components/title.js
+++ b/packages/wonder-blocks-typography/src/components/title.js
@@ -2,9 +2,9 @@
 import * as React from "react";
 import {Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles.js";
+import styles from "../util/styles";
 
-import type {Props} from "../util/types.js";
+import type {Props} from "../util/types";
 
 type DefaultProps = {|
     tag: $PropertyType<Props, "tag">,

--- a/packages/wonder-blocks-typography/src/index.js
+++ b/packages/wonder-blocks-typography/src/index.js
@@ -1,22 +1,22 @@
 // @flow
-import styles from "./util/styles.js";
+import styles from "./util/styles";
 
-import Title from "./components/title.js";
-import HeadingLarge from "./components/heading-large.js";
-import HeadingMedium from "./components/heading-medium.js";
-import HeadingSmall from "./components/heading-small.js";
-import HeadingXSmall from "./components/heading-xsmall.js";
-import BodySerifBlock from "./components/body-serif-block.js";
-import BodySerif from "./components/body-serif.js";
-import BodyMonospace from "./components/body-monospace.js";
-import Body from "./components/body.js";
-import LabelLarge from "./components/label-large.js";
-import LabelMedium from "./components/label-medium.js";
-import LabelSmall from "./components/label-small.js";
-import LabelXSmall from "./components/label-xsmall.js";
-import Tagline from "./components/tagline.js";
-import Caption from "./components/caption.js";
-import Footnote from "./components/footnote.js";
+import Title from "./components/title";
+import HeadingLarge from "./components/heading-large";
+import HeadingMedium from "./components/heading-medium";
+import HeadingSmall from "./components/heading-small";
+import HeadingXSmall from "./components/heading-xsmall";
+import BodySerifBlock from "./components/body-serif-block";
+import BodySerif from "./components/body-serif";
+import BodyMonospace from "./components/body-monospace";
+import Body from "./components/body";
+import LabelLarge from "./components/label-large";
+import LabelMedium from "./components/label-medium";
+import LabelSmall from "./components/label-small";
+import LabelXSmall from "./components/label-xsmall";
+import Tagline from "./components/tagline";
+import Caption from "./components/caption";
+import Footnote from "./components/footnote";
 
 /**
  * Typography components for headings or titles.

--- a/utils/package-flow-types.js
+++ b/utils/package-flow-types.js
@@ -23,7 +23,7 @@ try {
             "dist",
             "index.js.flow",
         );
-        const contents = ["// @flow", 'export * from "../src/index.js";'].join(
+        const contents = ["// @flow", 'export * from "../src/index";'].join(
             "\n",
         );
         fs.writeFileSync(filename, contents, "utf8");

--- a/utils/publish/pre-publish-check-ci.js
+++ b/utils/publish/pre-publish-check-ci.js
@@ -13,7 +13,7 @@ const {
     checkPackageMain,
     checkPackageModule,
     checkPackageSource,
-} = require("./pre-publish-utils.js");
+} = require("./pre-publish-utils");
 
 glob(
     path.join(__dirname, "..", "..", "packages", "**", "package.json"),

--- a/utils/publish/pre-publish-utils.js
+++ b/utils/publish/pre-publish-utils.js
@@ -36,13 +36,13 @@ const checkPackageField = (pkgJson, field, value) => {
 };
 
 const checkPackageMain = (pkgJson) =>
-    checkPackageField(pkgJson, "main", "dist/index.js");
+    checkPackageField(pkgJson, "main", "dist/index");
 
 const checkPackageModule = (pkgJson) =>
-    checkPackageField(pkgJson, "module", "dist/es/index.js");
+    checkPackageField(pkgJson, "module", "dist/es/index");
 
 const checkPackageSource = (pkgJson) =>
-    checkPackageField(pkgJson, "source", "src/index.js");
+    checkPackageField(pkgJson, "source", "src/index");
 
 const checkPackagePrivate = (pkgJson) => {
     if (pkgJson.private) {


### PR DESCRIPTION
## Summary:
Before migrating wonder-blocks files to TypeScript, we need to remove the file extensions from all of the imports since TypeScript doesn't work with them.  This PR also updates the eslint config to disallow file extensions on imports moving forward.

Issue: FEI-4966

## Test plan:
- let CI run lint