### PR TITLE
FEI-4966.2: Add 'format' script

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,9 @@
 docs
 *.css
 *.yml
+flow-typed
 flow-typed/npm
+coverage
+storybook-static
+.storybook
+__docs__

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "coverage:ci": "yarn run jest --coverage",
     "flow-ci": "flow check --max-workers 0",
     "flow": "flow",
+    "format": "prettier --write .",
     "jest": "jest --config config/jest/test.config.js",
     "lint:watch": "esw --watch --config ./eslint/eslintrc packages",
     "lint": "eslint --config .eslintrc.js .",


### PR DESCRIPTION
## Summary:
This will come in handy later on to fix formatting issues after running the codemod.  The reason for not using 'eslint --fix' is that it's super slow.  Running 'prettier' directly only takes 6s to format all of our .js files.

Issue: FEI-4966

## Test plan:
- add some formatting lint to a file
- run 'yarn format'
- see that it's fixed