### PR TITLE
FEI-4966.2: Convert Flow enums to POJOs

### DIFF
--- a/.changeset/stale-rivers-bow.md
+++ b/.changeset/stale-rivers-bow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+"@khanacademy/wonder-blocks-data": minor
+---
+
+Convert enums to POJOs

--- a/packages/wonder-blocks-core/src/components/__tests__/render-state-root.test.js
+++ b/packages/wonder-blocks-core/src/components/__tests__/render-state-root.test.js
@@ -3,10 +3,6 @@ import * as React from "react";
 import {render} from "@testing-library/react";
 
 import {RenderStateRoot} from "../render-state-root";
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 import {RenderState, RenderStateContext} from "../render-state-context";
 
 const {useContext} = React;

--- a/packages/wonder-blocks-core/src/components/render-state-context.js
+++ b/packages/wonder-blocks-core/src/components/render-state-context.js
@@ -1,11 +1,12 @@
 // @flow
 import * as React from "react";
 
-export enum RenderState {
-    Root = "root",
-    Initial = "initial",
-    Standard = "standard",
-}
+// TODO(FEI-5000): Convert to TS enum after all codebases have been migrated
+export const RenderState = {
+    Root: ("root": "root"),
+    Initial: ("initial": "initial"),
+    Standard: ("standard": "standard"),
+};
 
 /**
  * This is the context that tracks who is doing what in our SSR component tree.
@@ -22,5 +23,5 @@ export enum RenderState {
  * standard:
  *   means that we're all now doing non-SSR rendering
  */
-export const RenderStateContext: React.Context<RenderState> =
+export const RenderStateContext: React.Context<$Values<typeof RenderState>> =
     React.createContext(RenderState.Root);

--- a/packages/wonder-blocks-core/src/components/render-state-root.js
+++ b/packages/wonder-blocks-core/src/components/render-state-root.js
@@ -1,10 +1,6 @@
 // @flow
 import * as React from "react";
 
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 import {RenderState, RenderStateContext} from "./render-state-context";
 import {useRenderState} from "../hooks/use-render-state";
 

--- a/packages/wonder-blocks-core/src/components/with-ssr-placeholder.js
+++ b/packages/wonder-blocks-core/src/components/with-ssr-placeholder.js
@@ -1,11 +1,6 @@
 // @flow
 import * as React from "react";
 
-// TODO(FEI-4202): update to use `useContext(RenderStateContext)`
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 import {RenderState, RenderStateContext} from "./render-state-context";
 
 /**
@@ -117,7 +112,7 @@ export default class WithSSRPlaceholder extends React.Component<Props, State> {
         return null;
     }
 
-    _maybeRender(renderState: RenderState): React.Node {
+    _maybeRender(renderState: $Values<typeof RenderState>): React.Node {
         const {children, placeholder} = this.props;
 
         switch (renderState) {

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-render-state.test.js
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-render-state.test.js
@@ -5,10 +5,6 @@ import {renderHook} from "@testing-library/react-hooks";
 
 import {useRenderState} from "../use-render-state";
 import {RenderStateRoot} from "../../components/render-state-root";
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 import {RenderState} from "../../components/render-state-context";
 
 describe("useRenderState", () => {

--- a/packages/wonder-blocks-core/src/hooks/use-render-state.js
+++ b/packages/wonder-blocks-core/src/hooks/use-render-state.js
@@ -1,8 +1,10 @@
 // @flow
 import {useContext} from "react";
 
-import {RenderStateContext} from "../components/render-state-context";
+import {
+    RenderState,
+    RenderStateContext,
+} from "../components/render-state-context";
 
-import type {RenderState} from "../components/render-state-context";
-
-export const useRenderState = (): RenderState => useContext(RenderStateContext);
+export const useRenderState = (): $Values<typeof RenderState> =>
+    useContext(RenderStateContext);

--- a/packages/wonder-blocks-core/src/hooks/use-unique-id.js
+++ b/packages/wonder-blocks-core/src/hooks/use-unique-id.js
@@ -5,13 +5,7 @@ import {useRenderState} from "./use-render-state";
 import SsrIDFactory from "../util/ssr-id-factory";
 import UniqueIDFactory from "../util/unique-id-factory";
 
-import {
-    // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-    // have fixed:
-    // https://github.com/import-js/eslint-plugin-import/issues/2073
-    // eslint-disable-next-line import/named
-    RenderState,
-} from "../components/render-state-context";
+import {RenderState} from "../components/render-state-context";
 
 import type {IIdentifierFactory} from "../util/types";
 

--- a/packages/wonder-blocks-core/src/index.js
+++ b/packages/wonder-blocks-core/src/index.js
@@ -18,10 +18,6 @@ export {useOnMountEffect} from "./hooks/use-on-mount-effect";
 export {useOnline} from "./hooks/use-online";
 export {useRenderState} from "./hooks/use-render-state";
 export {RenderStateRoot} from "./components/render-state-root";
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 export {RenderState} from "./components/render-state-context";
 
 export type {AriaProps, IIdentifierFactory, StyleType};

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.js
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.js
@@ -14,13 +14,7 @@ import {SsrCache} from "../../util/ssr-cache";
 import {RequestTracker} from "../../util/request-tracking";
 import InterceptRequests from "../intercept-requests";
 import Data from "../data";
-import {
-    // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-    // have fixed:
-    // https://github.com/import-js/eslint-plugin-import/issues/2073
-    // eslint-disable-next-line import/named
-    WhenClientSide,
-} from "../../hooks/use-hydratable-effect";
+import {WhenClientSide} from "../../hooks/use-hydratable-effect";
 
 describe("Data", () => {
     beforeEach(() => {

--- a/packages/wonder-blocks-data/src/components/data.js
+++ b/packages/wonder-blocks-data/src/components/data.js
@@ -3,10 +3,6 @@ import * as React from "react";
 
 import {
     useHydratableEffect,
-    // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-    // have fixed:
-    // https://github.com/import-js/eslint-plugin-import/issues/2073
-    // eslint-disable-next-line import/named
     WhenClientSide,
 } from "../hooks/use-hydratable-effect";
 
@@ -41,7 +37,7 @@ type Props<
      *
      * Default is `OnClientRender.ExecuteWhenNoSuccessResult`.
      */
-    clientBehavior?: WhenClientSide,
+    clientBehavior?: $Values<typeof WhenClientSide>,
 
     /**
      * When true, the children will be rendered with the existing result

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.js
@@ -6,6 +6,7 @@ import {
 } from "@testing-library/react-hooks";
 import {renderHook as serverRenderHook} from "@testing-library/react-hooks/server";
 import {render, act as reactAct} from "@testing-library/react";
+import {values} from "@khanacademy/wonder-stuff-core";
 
 import {Server} from "@khanacademy/wonder-blocks-core";
 import {Status} from "../../util/status";
@@ -16,17 +17,13 @@ import * as UseSharedCache from "../use-shared-cache";
 
 import {useCachedEffect} from "../use-cached-effect";
 
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 import {FetchPolicy} from "../../util/types";
 
 jest.mock("../use-request-interception");
 jest.mock("../use-shared-cache");
 
-const allPolicies = Array.from(FetchPolicy.members());
-const allPoliciesBut = (policy: FetchPolicy) =>
+const allPolicies = Array.from(values(FetchPolicy));
+const allPoliciesBut = (policy: $Values<typeof FetchPolicy>) =>
     allPolicies.filter((p) => p !== policy);
 
 describe("#useCachedEffect", () => {

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.js
@@ -14,14 +14,7 @@ import * as UseRequestInterception from "../use-request-interception";
 import * as UseServerEffect from "../use-server-effect";
 import * as UseSharedCache from "../use-shared-cache";
 
-import {
-    useHydratableEffect,
-    // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-    // have fixed:
-    // https://github.com/import-js/eslint-plugin-import/issues/2073
-    // eslint-disable-next-line import/named
-    WhenClientSide,
-} from "../use-hydratable-effect";
+import {useHydratableEffect, WhenClientSide} from "../use-hydratable-effect";
 
 jest.mock("../use-request-interception");
 jest.mock("../use-server-effect");

--- a/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-cached-effect.js
@@ -11,10 +11,6 @@ import {useRequestInterception} from "./use-request-interception";
 
 import type {Result, ValidCacheData} from "../util/types";
 
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 import {FetchPolicy} from "../util/types";
 
 type CachedEffectOptions<TData: ValidCacheData> = {|
@@ -24,7 +20,7 @@ type CachedEffectOptions<TData: ValidCacheData> = {|
      *
      * Defaults to `FetchPolicy.CacheBeforeNetwork`.
      */
-    fetchPolicy?: FetchPolicy,
+    fetchPolicy?: $Values<typeof FetchPolicy>,
 
     /**
      * When `true`, the effect will not be executed; otherwise, the effect will

--- a/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
+++ b/packages/wonder-blocks-data/src/hooks/use-hydratable-effect.js
@@ -5,17 +5,14 @@ import {useServerEffect} from "./use-server-effect";
 import {useSharedCache} from "./use-shared-cache";
 import {useCachedEffect} from "./use-cached-effect";
 
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 import {FetchPolicy} from "../util/types";
 import type {Result, ValidCacheData} from "../util/types";
 
 /**
  * Policies to define how a hydratable effect should behave client-side.
  */
-export enum WhenClientSide {
+// TODO(FEI-5000): Convert to TS enum after all codebases have been migrated
+export const WhenClientSide = {
     /**
      * The result from executing the effect server-side will not be hydrated.
      * The effect will always be executed client-side.
@@ -24,7 +21,7 @@ export enum WhenClientSide {
      * for properly hydrating this component (for example, the action invokes
      * Apollo which manages its own cache to ensure things render properly).
      */
-    DoNotHydrate,
+    DoNotHydrate: ("DoNotHydrate": "DoNotHydrate"),
 
     /**
      * The result from executing the effect server-side will be hydrated.
@@ -32,7 +29,7 @@ export enum WhenClientSide {
      * be hydrated (i.e. both error and success hydration results prevent the
      * effect running client-side).
      */
-    ExecuteWhenNoResult,
+    ExecuteWhenNoResult: ("ExecuteWhenNoResult": "ExecuteWhenNoResult"),
 
     /**
      * The result from executing the effect server-side will be hydrated.
@@ -41,15 +38,16 @@ export enum WhenClientSide {
      * If the hydrated result was not a success result, or there was no
      * hydrated result, the effect will not be executed.
      */
-    ExecuteWhenNoSuccessResult,
+    ExecuteWhenNoSuccessResult:
+        ("ExecuteWhenNoSuccessResult": "ExecuteWhenNoSuccessResult"),
 
     /**
      * The result from executing the effect server-side will be hydrated.
      * The effect will always be executed client-side, regardless of the
      * hydrated result status.
      */
-    AlwaysExecute,
-}
+    AlwaysExecute: ("AlwaysExecute": "AlwaysExecute"),
+};
 
 type HydratableEffectOptions<TData: ValidCacheData> = {|
     /**
@@ -62,7 +60,7 @@ type HydratableEffectOptions<TData: ValidCacheData> = {|
      * Changing this value after the first call is irrelevant as it only
      * affects the initial render behavior.
      */
-    clientBehavior?: WhenClientSide,
+    clientBehavior?: $Values<typeof WhenClientSide>,
 
     /**
      * When `true`, the effect will not be executed; otherwise, the effect will

--- a/packages/wonder-blocks-data/src/index.js
+++ b/packages/wonder-blocks-data/src/index.js
@@ -1,8 +1,4 @@
 // @flow
-// TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-// have fixed:
-// https://github.com/import-js/eslint-plugin-import/issues/2073
-// eslint-disable-next-line import/named
 export {FetchPolicy} from "./util/types";
 export type {
     ErrorOptions,
@@ -26,10 +22,6 @@ export {useCachedEffect} from "./hooks/use-cached-effect";
 export {useSharedCache, SharedCache} from "./hooks/use-shared-cache";
 export {
     useHydratableEffect,
-    // TODO(somewhatabstract, FEI-4174): Update eslint-plugin-import when they
-    // have fixed:
-    // https://github.com/import-js/eslint-plugin-import/issues/2073
-    // eslint-disable-next-line import/named
     WhenClientSide,
 } from "./hooks/use-hydratable-effect";
 export {ScopedInMemoryCache} from "./util/scoped-in-memory-cache";

--- a/packages/wonder-blocks-data/src/util/types.js
+++ b/packages/wonder-blocks-data/src/util/types.js
@@ -4,29 +4,30 @@ import type {Metadata} from "@khanacademy/wonder-stuff-core";
 /**
  * Defines the various fetch policies that can be applied to requests.
  */
-export enum FetchPolicy {
+// TODO(FEI-5000): Convert to TS enum after all codebases have been migrated
+export const FetchPolicy = {
     /**
      * If the data is in the cache, return that; otherwise, fetch from the
      * server.
      */
-    CacheBeforeNetwork,
+    CacheBeforeNetwork: ("CacheBeforeNetwork": "CacheBeforeNetwork"),
 
     /**
      * If the data is in the cache, return that; always fetch from the server
      * regardless of cache.
      */
-    CacheAndNetwork,
+    CacheAndNetwork: ("CacheAndNetwork": "CacheAndNetwork"),
 
     /**
      * If the data is in the cache, return that; otherwise, do nothing.
      */
-    CacheOnly,
+    CacheOnly: ("CacheOnly": "CacheOnly"),
 
     /**
      * Ignore any existing cached result; always fetch from the server.
      */
-    NetworkOnly,
-}
+    NetworkOnly: ("NetworkOnly": "NetworkOnly"),
+};
 
 /**
  * Define what can be cached.


### PR DESCRIPTION
## Summary:
The codemod we're using can't deal with Flow enums so we're temporarily converting them to POJOs.

Issue: FEI-4966

## Test plan:
- let CI do its thing