### PR TITLE
FEI-4966.2b: Remove uses of disjoint props

### DIFF
--- a/.changeset/slimy-shirts-juggle.md
+++ b/.changeset/slimy-shirts-juggle.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-popover": patch
+---
+
+Merge disjoint prop types since the codemod doesn't handle these properly.

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.js
@@ -42,7 +42,8 @@ const getAppropriateTriggersForRole = (role: ?ClickableRole) => {
     }
 };
 
-type CommonProps = {|
+// TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
+type Props = {|
     /**
      * A function that returns the a React `Element`.
      *
@@ -131,6 +132,28 @@ type CommonProps = {|
      * Respond to raw "keyup" event.
      */
     onKeyUp?: (e: SyntheticKeyboardEvent<>) => mixed,
+
+    /**
+     * A target destination window for a link to open in. Should only be used
+     * when `href` is specified.
+     */
+    // TODO(WB-1262): only allow this prop when `href` is also set.
+    target?: "_blank",
+
+    /**
+     * Run async code before navigating to the URL passed to `href`. If the
+     * promise returned rejects then navigation will not occur.
+     *
+     * If both safeWithNav and beforeNav are provided, beforeNav will be run
+     * first and safeWithNav will only be run if beforeNav does not reject.
+     *
+     * WARNING: Using this with `target="_blank"` will trigger built-in popup
+     * blockers in Firefox and Safari.  This is because we do navigation
+     * programmatically and `beforeNav` causes a delay which means that the
+     * browser can't make a directly link between a user action and the
+     * navigation.
+     */
+    beforeNav?: () => Promise<mixed>,
 |};
 
 export type ClickableState = {|
@@ -164,36 +187,6 @@ export type ClickableState = {|
      */
     waiting: boolean,
 |};
-
-type Props =
-    | {|
-          ...CommonProps,
-
-          /**
-           * A target destination window for a link to open in. Should only be used
-           * when `href` is specified.
-           */
-          // TODO(WB-1262): only allow this prop when `href` is also set.
-          target?: "_blank",
-      |}
-    | {|
-          ...CommonProps,
-
-          /**
-           * Run async code before navigating to the URL passed to `href`. If the
-           * promise returned rejects then navigation will not occur.
-           *
-           * If both safeWithNav and beforeNav are provided, beforeNav will be run
-           * first and safeWithNav will only be run if beforeNav does not reject.
-           *
-           * WARNING: Using this with `target="_blank"` will trigger built-in popup
-           * blockers in Firefox and Safari.  This is because we do navigation
-           * programmatically and `beforeNav` causes a delay which means that the
-           * browser can't make a directly link between a user action and the
-           * navigation.
-           */
-          beforeNav?: () => Promise<mixed>,
-      |};
 
 type DefaultProps = {|
     disabled: $PropertyType<Props, "disabled">,

--- a/packages/wonder-blocks-clickable/src/components/clickable.js
+++ b/packages/wonder-blocks-clickable/src/components/clickable.js
@@ -12,7 +12,8 @@ import getClickableBehavior from "../util/get-clickable-behavior";
 import type {ClickableRole, ClickableState} from "./clickable-behavior";
 import {isClientSideUrl} from "../util/is-client-side-url";
 
-type CommonProps = {|
+// TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
+type Props = {|
     /**
      * aria-label should be used when `spinner={true}` to let people using screen
      * readers that the action taken by clicking the button will take some
@@ -103,75 +104,34 @@ type CommonProps = {|
      * a custom focus ring within your own component that uses Clickable.
      */
     hideDefaultFocusRing?: boolean,
+
+    /**
+     * A target destination window for a link to open in.
+     *
+     * TODO(WB-1262): only allow this prop when `href` is also set.t
+     */
+    target?: "_blank",
+
+    /**
+     * Run async code before navigating. If the promise returned rejects then
+     * navigation will not occur.
+     *
+     * If both safeWithNav and beforeNav are provided, beforeNav will be run
+     * first and safeWithNav will only be run if beforeNav does not reject.
+     *
+     * WARNING: This prop must be used with `href` and should not be used with
+     * `target="blank"`.
+     */
+    beforeNav?: () => Promise<mixed>,
+
+    /**
+     * Run async code in the background while client-side navigating. If the
+     * browser does a full page load navigation, the callback promise must be
+     * settled before the navigation will occur. Errors are ignored so that
+     * navigation is guaranteed to succeed.
+     */
+    safeWithNav?: () => Promise<mixed>,
 |};
-
-type Props =
-    | {|
-          ...CommonProps,
-
-          /**
-           * A target destination window for a link to open in.
-           *
-           * TODO(WB-1262): only allow this prop when `href` is also set.t
-           */
-          target?: "_blank",
-      |}
-    | {|
-          ...CommonProps,
-
-          href: string,
-
-          /**
-           * Run async code before navigating. If the promise returned rejects then
-           * navigation will not occur.
-           *
-           * If both safeWithNav and beforeNav are provided, beforeNav will be run
-           * first and safeWithNav will only be run if beforeNav does not reject.
-           */
-          beforeNav: () => Promise<mixed>,
-      |}
-    | {|
-          ...CommonProps,
-
-          href: string,
-
-          /**
-           * Run async code in the background while client-side navigating. If the
-           * browser does a full page load navigation, the callback promise must be
-           * settled before the navigation will occur. Errors are ignored so that
-           * navigation is guaranteed to succeed.
-           */
-          safeWithNav: () => Promise<mixed>,
-
-          /**
-           * A target destination window for a link to open in.
-           *
-           * TODO(WB-1262): only allow this prop when `href` is also set.t
-           */
-          target?: "_blank",
-      |}
-    | {|
-          ...CommonProps,
-
-          href: string,
-
-          /**
-           * Run async code before navigating. If the promise returned rejects then
-           * navigation will not occur.
-           *
-           * If both safeWithNav and beforeNav are provided, beforeNav will be run
-           * first and safeWithNav will only be run if beforeNav does not reject.
-           */
-          beforeNav: () => Promise<mixed>,
-
-          /**
-           * Run async code in the background while client-side navigating. If the
-           * browser does a full page load navigation, the callback promise must be
-           * settled before the navigation will occur. Errors are ignored so that
-           * navigation is guaranteed to succeed.
-           */
-          safeWithNav: () => Promise<mixed>,
-      |};
 
 type DefaultProps = {|
     light: $PropertyType<Props, "light">,

--- a/packages/wonder-blocks-link/src/components/__tests__/link.flowtest.js
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.flowtest.js
@@ -5,10 +5,12 @@ import * as React from "react";
 import Link from "../link";
 
 // $FlowExpectedError[incompatible-type]: href must be used with beforeNav
-<Link beforeNav={() => Promise.resolve()}>Hello, world!</Link>;
+// TODO(FEI-5000): Re-enable test after updating props to be conditional.
+// <Link beforeNav={() => Promise.resolve()}>Hello, world!</Link>;
 
 // $FlowExpectedError[incompatible-type]: href must be used with safeWithNav
-<Link safeWithNav={() => Promise.resolve()}>Hello, world!</Link>;
+// TODO(FEI-5000): Re-enable test after updating props to be conditional.
+// <Link safeWithNav={() => Promise.resolve()}>Hello, world!</Link>;
 
 // It's okay to use onClick with href
 <Link href="/foo" onClick={() => {}}>

--- a/packages/wonder-blocks-link/src/components/link.js
+++ b/packages/wonder-blocks-link/src/components/link.js
@@ -7,7 +7,8 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 import LinkCore from "./link-core";
 
-type CommonProps = {|
+// TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
+export type SharedProps = {|
     ...AriaProps,
 
     /**
@@ -132,38 +133,30 @@ type CommonProps = {|
      * Respond to raw "keyup" event.
      */
     onKeyUp?: (e: SyntheticKeyboardEvent<>) => mixed,
+
+    /**
+     * A target destination window for a link to open in.  We only support
+     * "_blank" which opens the URL in a new tab.
+     *
+     * TODO(WB-1262): only allow this prop when `href` is also set.t
+     */
+    target?: "_blank",
+
+    /**
+     * Run async code before navigating to the URL passed to `href`. If the
+     * promise returned rejects then navigation will not occur.
+     *
+     * If both safeWithNav and beforeNav are provided, beforeNav will be run
+     * first and safeWithNav will only be run if beforeNav does not reject.
+     *
+     * WARNING: Using this with `target="_blank"` will trigger built-in popup
+     * blockers in Firefox and Safari.  This is because we do navigation
+     * programmatically and `beforeNav` causes a delay which means that the
+     * browser can't make a directly link between a user action and the
+     * navigation.
+     */
+    beforeNav?: () => Promise<mixed>,
 |};
-
-export type SharedProps =
-    | {|
-          ...CommonProps,
-
-          /**
-           * A target destination window for a link to open in.  We only support
-           * "_blank" which opens the URL in a new tab.
-           *
-           * TODO(WB-1262): only allow this prop when `href` is also set.t
-           */
-          target?: "_blank",
-      |}
-    | {|
-          ...CommonProps,
-
-          /**
-           * Run async code before navigating to the URL passed to `href`. If the
-           * promise returned rejects then navigation will not occur.
-           *
-           * If both safeWithNav and beforeNav are provided, beforeNav will be run
-           * first and safeWithNav will only be run if beforeNav does not reject.
-           *
-           * WARNING: Using this with `target="_blank"` will trigger built-in popup
-           * blockers in Firefox and Safari.  This is because we do navigation
-           * programmatically and `beforeNav` causes a delay which means that the
-           * browser can't make a directly link between a user action and the
-           * navigation.
-           */
-          beforeNav?: () => Promise<mixed>,
-      |};
 
 type DefaultProps = {|
     inline: $PropertyType<SharedProps, "inline">,

--- a/packages/wonder-blocks-modal/src/components/modal-launcher.js
+++ b/packages/wonder-blocks-modal/src/components/modal-launcher.js
@@ -15,7 +15,8 @@ import ScrollDisabler from "./scroll-disabler";
 import type {ModalElement} from "../util/types";
 import ModalContext from "./modal-context";
 
-type CommonProps = {|
+// TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
+type Props = {|
     /**
      * The modal to render.
      *
@@ -30,13 +31,6 @@ type CommonProps = {|
      * respond to user intearction, like `onClick`.
      */
     modal: ModalElement | (({|closeModal: () => void|}) => ModalElement),
-
-    /**
-     * If the parent needs to be notified when the modal is closed, use this
-     * prop. You probably want to use this instead of `onClose` on the modals
-     * themselves, since this will capture a more complete set of close events.
-     */
-    onClose?: () => mixed,
 
     /**
      * Enables the backdrop to dismiss the modal on click/tap
@@ -61,11 +55,6 @@ type CommonProps = {|
      */
     testId?: string,
 
-    ...WithActionSchedulerProps,
-|};
-
-type ControlledProps = {|
-    ...CommonProps,
     /**
      * Renders the modal when true, renders nothing when false.
      *
@@ -75,28 +64,33 @@ type ControlledProps = {|
      * should never be used with this prop.  Not doing so will result in an
      * error being thrown.
      */
-    opened: boolean,
+    opened?: boolean,
 
     /**
+     * If the parent needs to be notified when the modal is closed, use this
+     * prop. You probably want to use this instead of `onClose` on the modals
+     * themselves, since this will capture a more complete set of close events.
+     *
      * Called when the modal needs to notify the parent component that it should
      * be closed.
      *
      * This prop must be used when the component is being used as a controlled
      * component.
      */
-    onClose: () => mixed,
+    onClose?: () => mixed,
+
+    /**
+     * WARNING: This props should only be used when using the component as a
+     * controlled component.
+     */
+    children?: ({|openModal: () => mixed|}) => React.Node,
+
+    ...WithActionSchedulerProps,
 |};
 
 type DefaultProps = {|
     backdropDismissEnabled: $PropertyType<Props, "backdropDismissEnabled">,
 |};
-
-type UncontrolledProps = {|
-    ...CommonProps,
-    children: ({|openModal: () => mixed|}) => React.Node,
-|};
-
-type Props = ControlledProps | UncontrolledProps;
 
 type State = {|
     /** Whether the modal should currently be open. */

--- a/packages/wonder-blocks-popover/src/components/popover-content.js
+++ b/packages/wonder-blocks-popover/src/components/popover-content.js
@@ -12,7 +12,8 @@ import type {PopoverContextType} from "./popover-context";
 import PopoverContentCore from "./popover-content-core";
 import PopoverContext from "./popover-context";
 
-type CommonProps = {|
+// TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
+type Props = {|
     ...AriaProps,
 
     /**
@@ -66,20 +67,14 @@ type CommonProps = {|
      * the same time with icon.
      */
     image?: React.Element<"img"> | React.Element<"svg">,
-|};
-
-type WithEmphasized = {|
-    ...CommonProps,
 
     /**
      * When true, changes the popover dialog background to blue; otherwise, the
      * popover dialog background is not modified. It can be used only with
      * Text-only popovers. It cannot be used with icon or image.
      */
-    emphasized: boolean,
+    emphasized?: boolean,
 |};
-
-type Props = CommonProps | WithEmphasized;
 
 type DefaultProps = {|
     closeButtonVisible: $PropertyType<Props, "closeButtonVisible">,


### PR DESCRIPTION
## Summary:
TypeScript's pattern for conditional props is different from Flow's pattern for disjoint props and the codemod doesn't know how to do the conversion properly.  Also, there's the issue of having to publishing Flow types until the migration is complete.  This PR addresses the issue by temporarily removing the use of disjoint props.

Issue: FEI-4966

## Test plan:
- yarn flow