### PR TITLE
FEI-4966.12: Improve aphrodite lib def

### DIFF
--- a/.changeset/afraid-lamps-begin.md
+++ b/.changeset/afraid-lamps-begin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Update type narrowing logic to work better with TypeScript

--- a/.changeset/quiet-pets-yell.md
+++ b/.changeset/quiet-pets-yell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Update aphrodite lib def and StyleType

--- a/.changeset/thirty-paws-admire.md
+++ b/.changeset/thirty-paws-admire.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+Tweak 'Offset' type to use React.CSSProperties

--- a/packages/wonder-blocks-core/src/util/add-style.tsx
+++ b/packages/wonder-blocks-core/src/util/add-style.tsx
@@ -16,7 +16,6 @@ export default function addStyle<
     const StyleComponent: React.FC<Props> = (props) => {
         const {className, style, ...otherProps} = props;
         const reset =
-            // @ts-expect-error [FEI-5019] - TS2536 - Type 'T & string' cannot be used to index type '{ button: { margin: number; "::-moz-focus-inner": { border: number; }; }; }'.
             typeof Component === "string" ? overrides[Component] : null;
 
         const {className: aphroditeClassName, style: inlineStyles} =

--- a/packages/wonder-blocks-core/src/util/util.ts
+++ b/packages/wonder-blocks-core/src/util/util.ts
@@ -18,6 +18,8 @@ function flatten(list?: StyleType): Array<CSSProperties> {
             result.push(...flatten(item));
         }
     } else {
+        // @ts-expect-error: TypeScript thinks that `list` is still an array here
+        // even though we handled that case in the preceding block.
         result.push(list);
     }
 

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -235,6 +235,9 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
         } = this.props;
         return (
             <input
+                // @ts-expect-error: we shouldn't be passing `style` to `css()`
+                // here b/c `style` allows nested arrays of styles, but `css()`
+                // only allows a flat array.
                 className={css([
                     styles.input,
                     typographyStyles.LabelMedium,

--- a/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
@@ -91,7 +91,6 @@ export default class PopoverDialog extends React.Component<Props> {
                     data-placement={placement}
                     style={[
                         isReferenceHidden && styles.hide,
-                        // @ts-expect-error [FEI-5019] - TS2551 - Property 'content-auto' does not exist on type '{ hide: { pointerEvents: string; opacity: number; backgroundColor: string; color: string; }; "content-top": { flexDirection: string; }; "content-right": { flexDirection: string; }; "content-bottom": { flexDirection: string; }; "content-left": { ...; }; }'. Did you mean 'content-top'?
                         styles[`content-${placement}`],
                         style,
                     ]}

--- a/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
+++ b/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
@@ -112,6 +112,7 @@ const styles = StyleSheet.create({
     },
     loadingSpinner: {
         transformOrigin: "50% 50%",
+        // @ts-expect-error [FEI-5019]: `animationName` expects a string not an object.
         animationName: rotateKeyFrames,
         animationDuration: "1.1s",
         animationIterationCount: "infinite",

--- a/packages/wonder-blocks-testing/src/harness/adapters/css.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/css.tsx
@@ -31,14 +31,17 @@ const normalizeConfig = (
     }
 
     if (typeof config === "object") {
-        if (config.classes != null && config.style != null) {
-            // @ts-expect-error: This is a heuristic check and by nature isn't perfect.
-            // So we have to tell TypeScript to just accept it.
+        if (
+            "classes" in config &&
+            config.classes != null &&
+            "style" in config &&
+            config.style != null
+        ) {
             return config;
         }
 
-        // Again, since the previous check is heuristic, so is this outcome
-        // and so we still have to assure TypeScript everything is OK.
+        // @ts-expect-error: at this point, `CSSProperties` is the only thing
+        // that `config` can be.
         return {classes: [], style: config};
     }
 

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -79,7 +79,6 @@ export default class TooltipBubble extends React.Component<Props, State> {
                 style={[
                     isReferenceHidden && styles.hide,
                     styles.bubble,
-                    // @ts-expect-error [FEI-5019] - TS2551 - Property 'content-auto' does not exist on type '{ bubble: { position: string; }; hide: { pointerEvents: string; opacity: number; backgroundColor: string; color: string; }; "content-top": { flexDirection: string; }; "content-right": { flexDirection: string; }; "content-bottom": { ...; }; "content-left": { ...; }; content: { ...; }; }'. Did you mean 'content-top'?
                     styles[`content-${placement}`],
                     style,
                 ]}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
@@ -75,7 +75,6 @@ export default class TooltipPopper extends React.Component<Props> {
             updateTailRef: this._tailRefTracker.updateRef,
             isReferenceHidden: popperProps.isReferenceHidden,
         } as const;
-        // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '{ readonly placement: Placement; readonly style: { readonly top: Property.Top<string | number> | undefined; readonly left: Property.Left<string | number> | undefined; readonly bottom: Property.Bottom<...> | undefined; readonly right: Property.Right<...> | undefined; readonly position: Property.Position | undefined; ...' is not assignable to parameter of type 'PopperElementProps'.
         return children(bubbleProps);
     }
 

--- a/packages/wonder-blocks-tooltip/src/util/types.ts
+++ b/packages/wonder-blocks-tooltip/src/util/types.ts
@@ -1,15 +1,17 @@
 import * as React from "react";
 
+import type {CSSProperties} from "aphrodite";
+
 export type getRefFn = (
     arg1?: React.Component<any> | Element | null | undefined,
 ) => void;
 
 export type Offset = {
-    bottom: string | null | undefined;
-    top: string | null | undefined;
-    left: string | null | undefined;
-    right: string | null | undefined;
-    transform: string | null | undefined;
+    bottom: CSSProperties["bottom"];
+    top: CSSProperties["top"];
+    left: CSSProperties["left"];
+    right: CSSProperties["right"];
+    transform: CSSProperties["transform"];
 };
 
 export type Placement =

--- a/types/aphrodite.d.ts
+++ b/types/aphrodite.d.ts
@@ -2,27 +2,35 @@ declare module "aphrodite" {
     import * as React from "react";
 
     type _CSSProperties = React.CSSProperties & {
+        /**
+         * Browser Specific
+         */
         MsFlexBasis?: React.CSSProperties["flexBasis"];
         MsFlexPreferredSize?: React.CSSProperties["flexBasis"];
         WebkitFlexBasis?: React.CSSProperties["flexBasis"];
         flexBasis?: React.CSSProperties["flexBasis"];
+        "::-moz-focus-inner"?: React.CSSProperties;
+
+        /**
+         * Media queries
+         */
+        "@media (max-width: 1023px)"?: React.CSSProperties;
+        "@media (min-width: 1024px)"?: React.CSSProperties;
+        "@media (min-width: 1168px)"?: React.CSSProperties;
     };
 
     /**
      * A CSS property definition.
      */
     export type CSSProperties = _CSSProperties & {
+        /**
+         * Pseudo-selectors
+         */
         "::placeholder"?: _CSSProperties;
         ":after"?: _CSSProperties;
         ":focus-visible"?: _CSSProperties;
         ":focus"?: _CSSProperties;
         ":hover"?: _CSSProperties;
-
-        "@media (max-width: 1023px)"?: _CSSProperties;
-        "@media (min-width: 1024px)"?: _CSSProperties;
-        "@media (min-width: 1168px)"?: _CSSProperties;
-
-        "::-moz-focus-inner"?: _CSSProperties;
     };
 
     /**

--- a/types/aphrodite.d.ts
+++ b/types/aphrodite.d.ts
@@ -1,19 +1,40 @@
 declare module "aphrodite" {
+    import * as React from "react";
+
+    type _CSSProperties = React.CSSProperties & {
+        MsFlexBasis?: React.CSSProperties["flexBasis"];
+        MsFlexPreferredSize?: React.CSSProperties["flexBasis"];
+        WebkitFlexBasis?: React.CSSProperties["flexBasis"];
+        flexBasis?: React.CSSProperties["flexBasis"];
+    };
+
     /**
      * A CSS property definition.
      */
-    export type CSSProperties = Record<string, any>;
+    export type CSSProperties = _CSSProperties & {
+        "::placeholder"?: _CSSProperties;
+        ":after"?: _CSSProperties;
+        ":focus-visible"?: _CSSProperties;
+        ":focus"?: _CSSProperties;
+        ":hover"?: _CSSProperties;
+
+        "@media (max-width: 1023px)"?: _CSSProperties;
+        "@media (min-width: 1024px)"?: _CSSProperties;
+        "@media (min-width: 1168px)"?: _CSSProperties;
+
+        "::-moz-focus-inner"?: _CSSProperties;
+    };
 
     /**
      * Aphrodite style declaration
      */
-    export type StyleDeclaration = Record<string, any>;
+    export type StyleDeclaration = Record<string, CSSProperties>;
 
     export interface StyleSheetStatic {
         /**
          * Create style sheet
          */
-        create<T extends StyleDeclaration>(styles: T): T;
+        create(styles: StyleDeclaration): StyleDeclaration;
         /**
          * Rehydrate class names from server renderer
          */
@@ -22,8 +43,10 @@ declare module "aphrodite" {
 
     export const StyleSheet: StyleSheetStatic;
 
+    type Falsy = false | 0 | null | undefined;
+
     /**
      * Get class names from passed styles
      */
-    export function css(...styles: Array<any>): string;
+    export function css(...styles: Array<CSSProperties | Falsy>): string;
 }


### PR DESCRIPTION
## Summary:
This PR updates the aphrodite lib def to use the 'CSSProperties' from "react".  This should keep the types more up-to-date.  'CSSProperties' is extended with pseudo-selectors, media queries, and a few browser specific properties.

Issue: FEI-4966

## Test plan:
- yarn typecheck
- let CI run