### PR TITLE
Use solid underline for links (until audit can be completed)

### DIFF
--- a/.changeset/olive-spiders-eat.md
+++ b/.changeset/olive-spiders-eat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-link": patch
+---
+
+Going back to old link styles temporarily

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -261,7 +261,12 @@ export const WithInlineLinks: StoryComponentType = () => (
             text={
                 <LabelSmall>
                     Use inline links in the body of the text instead. Click{" "}
-                    {<Link href="">here</Link>} to go to some other page.
+                    {
+                        <Link href="" inline={true}>
+                            here
+                        </Link>
+                    }{" "}
+                    to go to some other page.
                 </LabelSmall>
             }
             kind="success"

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -536,7 +536,9 @@ export const WithMarkup: StoryComponentType = (args) => {
             description={
                 <span>
                     Description with <strong>strong</strong> text and a{" "}
-                    <Link href="/path/to/resource">link</Link>
+                    <Link href="/path/to/resource" inline={true}>
+                        link
+                    </Link>
                 </span>
             }
         />

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -1,11 +1,9 @@
 // We need to use fireEvent for mouseDown in these tests, none of the userEvent
 // alternatives work. Click includes mouseUp, which removes the pressed style.
-// TODO(wb-): Add back comment: eslint-disable testing-library/prefer-user-event
+/* eslint-disable testing-library/prefer-user-event */
 import {expect} from "@storybook/jest";
 import * as React from "react";
-// TODO(WB-): uncomment this import after updating styles
-// import {within, userEvent, fireEvent} from "@storybook/testing-library";
-import {within} from "@storybook/testing-library";
+import {within, userEvent, fireEvent} from "@storybook/testing-library";
 import {StyleSheet} from "aphrodite";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import type {ComponentStory, ComponentMeta} from "@storybook/react";
@@ -34,9 +32,8 @@ export default {
     argTypes: LinkArgTypes,
 } as ComponentMeta<typeof Link>;
 
-// TODO(WB-): uncomment these variables after updating styles
-// const activeBlue = "#1b50b3";
-// const fadedBlue = "#b5cefb";
+const activeBlue = "#1b50b3";
+const fadedBlue = "#b5cefb";
 
 type StoryComponentType = ComponentStory<typeof Link>;
 
@@ -60,24 +57,27 @@ Primary.parameters = {
     },
 };
 
-// TODO(WB-): uncomment this test after going back to dashed style
-// Primary.play = async ({canvasElement}) => {
-//     const canvas = within(canvasElement);
+Primary.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement);
 
-//     const link = canvas.getByRole("link");
+    const link = canvas.getByRole("link");
 
-//     await expect(link).toHaveStyle(`color: ${Color.blue}`);
+    await expect(link).toHaveStyle(`color: ${Color.blue}`);
 
-//     await userEvent.hover(link);
-//     await expect(link).toHaveStyle(
-//         `text-decoration: underline ${Color.blue} dashed 2px`,
-//     );
+    await userEvent.hover(link);
+    // TODO(WB-1521): Expect the dashed 2px style.
+    // await expect(link).toHaveStyle(
+    //     `text-decoration: underline ${Color.blue} dashed 2px`,
+    // );
+    await expect(link).toHaveStyle(
+        `text-decoration: underline ${Color.blue} solid 1px`,
+    );
 
-//     await fireEvent.mouseDown(link);
-//     await expect(link).toHaveStyle(
-//         `text-decoration: underline solid ${activeBlue} 1px`,
-//     );
-// };
+    await fireEvent.mouseDown(link);
+    await expect(link).toHaveStyle(
+        `text-decoration: underline solid ${activeBlue} 1px`,
+    );
+};
 
 export const Secondary: StoryComponentType = () => (
     <Link href="#" kind="secondary">
@@ -92,24 +92,27 @@ Secondary.parameters = {
     },
 };
 
-// TODO(WB-): uncomment this test after updating styles
-// Secondary.play = async ({canvasElement}) => {
-//     const canvas = within(canvasElement);
+Secondary.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement);
 
-//     const link = canvas.getByRole("link");
+    const link = canvas.getByRole("link");
 
-//     await expect(link).toHaveStyle(`color: ${Color.offBlack64}`);
+    await expect(link).toHaveStyle(`color: ${Color.offBlack64}`);
 
-//     await userEvent.hover(link);
-//     await expect(link).toHaveStyle(
-//         `text-decoration: underline ${Color.offBlack64} dashed 2px`,
-//     );
+    await userEvent.hover(link);
+    // TODO(WB-1521): Expect the dashed 2px style.
+    // await expect(link).toHaveStyle(
+    //     `text-decoration: underline ${Color.offBlack64} dashed 2px`,
+    // );
+    await expect(link).toHaveStyle(
+        `text-decoration: underline ${Color.offBlack64} solid 1px`,
+    );
 
-//     await fireEvent.mouseDown(link);
-//     await expect(link).toHaveStyle(
-//         `text-decoration: underline solid ${Color.offBlack} 1px`,
-//     );
-// };
+    await fireEvent.mouseDown(link);
+    await expect(link).toHaveStyle(
+        `text-decoration: underline solid ${Color.offBlack} 1px`,
+    );
+};
 
 export const Visitable: StoryComponentType = () => (
     <Link href="#" visitable={true}>
@@ -143,22 +146,25 @@ LightPrimary.parameters = {
     },
 };
 
-// TODO(WB-): uncomment this test after updating styles
-// LightPrimary.play = async ({canvasElement}) => {
-//     const canvas = within(canvasElement);
+LightPrimary.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement);
 
-//     const link = canvas.getByRole("link");
+    const link = canvas.getByRole("link");
 
-//     await userEvent.hover(link);
-//     await expect(link).toHaveStyle(
-//         `text-decoration: underline ${Color.white} dashed 2px`,
-//     );
+    await userEvent.hover(link);
+    // TODO(WB-1521): Expect the dashed 2px style.
+    // await expect(link).toHaveStyle(
+    //     `text-decoration: underline ${Color.white} dashed 2px`,
+    // );
+    await expect(link).toHaveStyle(
+        `text-decoration: underline ${Color.white} solid 1px`,
+    );
 
-//     await fireEvent.mouseDown(link);
-//     await expect(link).toHaveStyle(
-//         `text-decoration: underline solid ${fadedBlue} 1px`,
-//     );
-// };
+    await fireEvent.mouseDown(link);
+    await expect(link).toHaveStyle(
+        `text-decoration: underline solid ${fadedBlue} 1px`,
+    );
+};
 
 export const LightVisitable: StoryComponentType = () => (
     <Link href="#" light={true} visitable={true}>
@@ -205,39 +211,46 @@ Inline.parameters = {
     },
 };
 
-// TODO(WB-): uncomment this test after updating styles
-// Inline.play = async ({canvasElement}) => {
-//     const canvas = within(canvasElement);
+Inline.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement);
 
-//     const primaryLink = canvas.getByText("Primary link");
-//     const secondaryLink = canvas.getByText("Secondary link");
+    const primaryLink = canvas.getByText("Primary link");
+    const secondaryLink = canvas.getByText("Secondary link");
 
-//     // Primary link styles
-//     await expect(primaryLink).toHaveStyle(`color: ${Color.blue}`);
+    // Primary link styles
+    await expect(primaryLink).toHaveStyle(`color: ${Color.blue}`);
 
-//     await userEvent.hover(primaryLink);
-//     await expect(primaryLink).toHaveStyle(
-//         `text-decoration: underline ${Color.blue} dashed 2px`,
-//     );
+    await userEvent.hover(primaryLink);
+    // TODO(WB-1521): Expect the dashed 2px style.
+    // await expect(primaryLink).toHaveStyle(
+    //     `text-decoration: underline ${Color.blue} dashed 2px`,
+    // );
+    await expect(primaryLink).toHaveStyle(
+        `text-decoration: underline ${Color.blue} solid 1px`,
+    );
 
-//     await fireEvent.mouseDown(primaryLink);
-//     await expect(primaryLink).toHaveStyle(
-//         `text-decoration: underline solid ${activeBlue} 1px`,
-//     );
+    await fireEvent.mouseDown(primaryLink);
+    await expect(primaryLink).toHaveStyle(
+        `text-decoration: underline solid ${activeBlue} 1px`,
+    );
 
-//     // Secondary link styles
-//     await expect(secondaryLink).toHaveStyle(`color: ${Color.offBlack}`);
+    // Secondary link styles
+    await expect(secondaryLink).toHaveStyle(`color: ${Color.offBlack}`);
 
-//     await userEvent.hover(secondaryLink);
-//     await expect(secondaryLink).toHaveStyle(
-//         `text-decoration: underline ${Color.offBlack} dashed 2px`,
-//     );
+    await userEvent.hover(secondaryLink);
+    // TODO(WB-1521): Expect the dashed 2px style.
+    // await expect(secondaryLink).toHaveStyle(
+    //     `text-decoration: underline ${Color.offBlack} dashed 2px`,
+    // );
+    await expect(secondaryLink).toHaveStyle(
+        `text-decoration: underline ${Color.offBlack} solid 1px`,
+    );
 
-//     await fireEvent.mouseDown(secondaryLink);
-//     await expect(secondaryLink).toHaveStyle(
-//         `text-decoration: underline solid ${activeBlue} 1px`,
-//     );
-// };
+    await fireEvent.mouseDown(secondaryLink);
+    await expect(secondaryLink).toHaveStyle(
+        `text-decoration: underline solid ${activeBlue} 1px`,
+    );
+};
 
 export const InlineLight: StoryComponentType = () => (
     <Body style={{color: Color.white}}>
@@ -266,24 +279,27 @@ InlineLight.parameters = {
     },
 };
 
-// TODO(WB-): uncomment this test after updating styles
-// InlineLight.play = async ({canvasElement}) => {
-//     const canvas = within(canvasElement);
+InlineLight.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement);
 
-//     const primaryLink = canvas.getByText("Primary link");
+    const primaryLink = canvas.getByText("Primary link");
 
-//     await expect(primaryLink).toHaveStyle(`color: ${Color.white}`);
+    await expect(primaryLink).toHaveStyle(`color: ${Color.white}`);
 
-//     await userEvent.hover(primaryLink);
-//     await expect(primaryLink).toHaveStyle(
-//         `text-decoration: underline ${Color.white} dashed 2px`,
-//     );
+    await userEvent.hover(primaryLink);
+    // TODO(WB-1521): Expect the dashed 2px style.
+    // await expect(primaryLink).toHaveStyle(
+    //     `text-decoration: underline ${Color.white} dashed 2px`,
+    // );
+    await expect(primaryLink).toHaveStyle(
+        `text-decoration: underline ${Color.white} solid 1px`,
+    );
 
-//     await fireEvent.mouseDown(primaryLink);
-//     await expect(primaryLink).toHaveStyle(
-//         `text-decoration: underline solid ${fadedBlue} 1px`,
-//     );
-// };
+    await fireEvent.mouseDown(primaryLink);
+    await expect(primaryLink).toHaveStyle(
+        `text-decoration: underline solid ${fadedBlue} 1px`,
+    );
+};
 
 export const Variants: StoryComponentType = () => (
     <View>

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -70,12 +70,12 @@ Primary.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.blue} dashed 2px`,
     // );
     await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.blue} solid 1px`,
+        `text-decoration: underline ${Color.blue} solid`,
     );
 
     await fireEvent.mouseDown(link);
     await expect(link).toHaveStyle(
-        `text-decoration: underline solid ${activeBlue} 1px`,
+        `text-decoration: underline solid ${activeBlue}`,
     );
 };
 
@@ -105,12 +105,12 @@ Secondary.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.offBlack64} dashed 2px`,
     // );
     await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.offBlack64} solid 1px`,
+        `text-decoration: underline ${Color.offBlack64} solid`,
     );
 
     await fireEvent.mouseDown(link);
     await expect(link).toHaveStyle(
-        `text-decoration: underline solid ${Color.offBlack} 1px`,
+        `text-decoration: underline solid ${Color.offBlack}`,
     );
 };
 
@@ -157,12 +157,12 @@ LightPrimary.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.white} dashed 2px`,
     // );
     await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.white} solid 1px`,
+        `text-decoration: underline ${Color.white} solid`,
     );
 
     await fireEvent.mouseDown(link);
     await expect(link).toHaveStyle(
-        `text-decoration: underline solid ${fadedBlue} 1px`,
+        `text-decoration: underline solid ${fadedBlue}`,
     );
 };
 
@@ -226,12 +226,12 @@ Inline.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.blue} dashed 2px`,
     // );
     await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.blue} solid 1px`,
+        `text-decoration: underline ${Color.blue} solid`,
     );
 
     await fireEvent.mouseDown(primaryLink);
     await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline solid ${activeBlue} 1px`,
+        `text-decoration: underline solid ${activeBlue}`,
     );
 
     // Secondary link styles
@@ -243,12 +243,12 @@ Inline.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.offBlack} dashed 2px`,
     // );
     await expect(secondaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.offBlack} solid 1px`,
+        `text-decoration: underline ${Color.offBlack} solid`,
     );
 
     await fireEvent.mouseDown(secondaryLink);
     await expect(secondaryLink).toHaveStyle(
-        `text-decoration: underline solid ${activeBlue} 1px`,
+        `text-decoration: underline solid ${activeBlue}`,
     );
 };
 
@@ -292,12 +292,12 @@ InlineLight.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.white} dashed 2px`,
     // );
     await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.white} solid 1px`,
+        `text-decoration: underline ${Color.white} solid`,
     );
 
     await fireEvent.mouseDown(primaryLink);
     await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline solid ${fadedBlue} 1px`,
+        `text-decoration: underline solid ${fadedBlue}`,
     );
 };
 
@@ -410,7 +410,7 @@ WithTypography.play = async ({canvasElement}) => {
 
     const heading = canvas.getByText("Heading inside a Link element");
 
-    // Confirm that the default font size (16px) and line height (22px)
+    // Confirm that the default font size and line height
     // are successfully overridden by typography.
     await expect(heading).toHaveStyle("font-size: 20px");
     await expect(heading).toHaveStyle("lineHeight: 24px");

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -1,9 +1,11 @@
 // We need to use fireEvent for mouseDown in these tests, none of the userEvent
 // alternatives work. Click includes mouseUp, which removes the pressed style.
-/* eslint-disable testing-library/prefer-user-event */
+// TODO(wb-): Add back comment: eslint-disable testing-library/prefer-user-event
 import {expect} from "@storybook/jest";
 import * as React from "react";
-import {within, userEvent, fireEvent} from "@storybook/testing-library";
+// TODO(WB-): uncomment this import after updating styles
+// import {within, userEvent, fireEvent} from "@storybook/testing-library";
+import {within} from "@storybook/testing-library";
 import {StyleSheet} from "aphrodite";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import type {ComponentStory, ComponentMeta} from "@storybook/react";
@@ -32,8 +34,9 @@ export default {
     argTypes: LinkArgTypes,
 } as ComponentMeta<typeof Link>;
 
-const activeBlue = "#1b50b3";
-const fadedBlue = "#b5cefb";
+// TODO(WB-): uncomment these variables after updating styles
+// const activeBlue = "#1b50b3";
+// const fadedBlue = "#b5cefb";
 
 type StoryComponentType = ComponentStory<typeof Link>;
 

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -57,23 +57,24 @@ Primary.parameters = {
     },
 };
 
-Primary.play = async ({canvasElement}) => {
-    const canvas = within(canvasElement);
+// TODO(WB-): uncomment this test after going back to dashed style
+// Primary.play = async ({canvasElement}) => {
+//     const canvas = within(canvasElement);
 
-    const link = canvas.getByRole("link");
+//     const link = canvas.getByRole("link");
 
-    await expect(link).toHaveStyle(`color: ${Color.blue}`);
+//     await expect(link).toHaveStyle(`color: ${Color.blue}`);
 
-    await userEvent.hover(link);
-    await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.blue} dashed 2px`,
-    );
+//     await userEvent.hover(link);
+//     await expect(link).toHaveStyle(
+//         `text-decoration: underline ${Color.blue} dashed 2px`,
+//     );
 
-    await fireEvent.mouseDown(link);
-    await expect(link).toHaveStyle(
-        `text-decoration: underline solid ${activeBlue} 1px`,
-    );
-};
+//     await fireEvent.mouseDown(link);
+//     await expect(link).toHaveStyle(
+//         `text-decoration: underline solid ${activeBlue} 1px`,
+//     );
+// };
 
 export const Secondary: StoryComponentType = () => (
     <Link href="#" kind="secondary">
@@ -88,23 +89,24 @@ Secondary.parameters = {
     },
 };
 
-Secondary.play = async ({canvasElement}) => {
-    const canvas = within(canvasElement);
+// TODO(WB-): uncomment this test after updating styles
+// Secondary.play = async ({canvasElement}) => {
+//     const canvas = within(canvasElement);
 
-    const link = canvas.getByRole("link");
+//     const link = canvas.getByRole("link");
 
-    await expect(link).toHaveStyle(`color: ${Color.offBlack64}`);
+//     await expect(link).toHaveStyle(`color: ${Color.offBlack64}`);
 
-    await userEvent.hover(link);
-    await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.offBlack64} dashed 2px`,
-    );
+//     await userEvent.hover(link);
+//     await expect(link).toHaveStyle(
+//         `text-decoration: underline ${Color.offBlack64} dashed 2px`,
+//     );
 
-    await fireEvent.mouseDown(link);
-    await expect(link).toHaveStyle(
-        `text-decoration: underline solid ${Color.offBlack} 1px`,
-    );
-};
+//     await fireEvent.mouseDown(link);
+//     await expect(link).toHaveStyle(
+//         `text-decoration: underline solid ${Color.offBlack} 1px`,
+//     );
+// };
 
 export const Visitable: StoryComponentType = () => (
     <Link href="#" visitable={true}>
@@ -138,21 +140,22 @@ LightPrimary.parameters = {
     },
 };
 
-LightPrimary.play = async ({canvasElement}) => {
-    const canvas = within(canvasElement);
+// TODO(WB-): uncomment this test after updating styles
+// LightPrimary.play = async ({canvasElement}) => {
+//     const canvas = within(canvasElement);
 
-    const link = canvas.getByRole("link");
+//     const link = canvas.getByRole("link");
 
-    await userEvent.hover(link);
-    await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.white} dashed 2px`,
-    );
+//     await userEvent.hover(link);
+//     await expect(link).toHaveStyle(
+//         `text-decoration: underline ${Color.white} dashed 2px`,
+//     );
 
-    await fireEvent.mouseDown(link);
-    await expect(link).toHaveStyle(
-        `text-decoration: underline solid ${fadedBlue} 1px`,
-    );
-};
+//     await fireEvent.mouseDown(link);
+//     await expect(link).toHaveStyle(
+//         `text-decoration: underline solid ${fadedBlue} 1px`,
+//     );
+// };
 
 export const LightVisitable: StoryComponentType = () => (
     <Link href="#" light={true} visitable={true}>
@@ -199,38 +202,39 @@ Inline.parameters = {
     },
 };
 
-Inline.play = async ({canvasElement}) => {
-    const canvas = within(canvasElement);
+// TODO(WB-): uncomment this test after updating styles
+// Inline.play = async ({canvasElement}) => {
+//     const canvas = within(canvasElement);
 
-    const primaryLink = canvas.getByText("Primary link");
-    const secondaryLink = canvas.getByText("Secondary link");
+//     const primaryLink = canvas.getByText("Primary link");
+//     const secondaryLink = canvas.getByText("Secondary link");
 
-    // Primary link styles
-    await expect(primaryLink).toHaveStyle(`color: ${Color.blue}`);
+//     // Primary link styles
+//     await expect(primaryLink).toHaveStyle(`color: ${Color.blue}`);
 
-    await userEvent.hover(primaryLink);
-    await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.blue} dashed 2px`,
-    );
+//     await userEvent.hover(primaryLink);
+//     await expect(primaryLink).toHaveStyle(
+//         `text-decoration: underline ${Color.blue} dashed 2px`,
+//     );
 
-    await fireEvent.mouseDown(primaryLink);
-    await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline solid ${activeBlue} 1px`,
-    );
+//     await fireEvent.mouseDown(primaryLink);
+//     await expect(primaryLink).toHaveStyle(
+//         `text-decoration: underline solid ${activeBlue} 1px`,
+//     );
 
-    // Secondary link styles
-    await expect(secondaryLink).toHaveStyle(`color: ${Color.offBlack}`);
+//     // Secondary link styles
+//     await expect(secondaryLink).toHaveStyle(`color: ${Color.offBlack}`);
 
-    await userEvent.hover(secondaryLink);
-    await expect(secondaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.offBlack} dashed 2px`,
-    );
+//     await userEvent.hover(secondaryLink);
+//     await expect(secondaryLink).toHaveStyle(
+//         `text-decoration: underline ${Color.offBlack} dashed 2px`,
+//     );
 
-    await fireEvent.mouseDown(secondaryLink);
-    await expect(secondaryLink).toHaveStyle(
-        `text-decoration: underline solid ${activeBlue} 1px`,
-    );
-};
+//     await fireEvent.mouseDown(secondaryLink);
+//     await expect(secondaryLink).toHaveStyle(
+//         `text-decoration: underline solid ${activeBlue} 1px`,
+//     );
+// };
 
 export const InlineLight: StoryComponentType = () => (
     <Body style={{color: Color.white}}>
@@ -259,23 +263,24 @@ InlineLight.parameters = {
     },
 };
 
-InlineLight.play = async ({canvasElement}) => {
-    const canvas = within(canvasElement);
+// TODO(WB-): uncomment this test after updating styles
+// InlineLight.play = async ({canvasElement}) => {
+//     const canvas = within(canvasElement);
 
-    const primaryLink = canvas.getByText("Primary link");
+//     const primaryLink = canvas.getByText("Primary link");
 
-    await expect(primaryLink).toHaveStyle(`color: ${Color.white}`);
+//     await expect(primaryLink).toHaveStyle(`color: ${Color.white}`);
 
-    await userEvent.hover(primaryLink);
-    await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.white} dashed 2px`,
-    );
+//     await userEvent.hover(primaryLink);
+//     await expect(primaryLink).toHaveStyle(
+//         `text-decoration: underline ${Color.white} dashed 2px`,
+//     );
 
-    await fireEvent.mouseDown(primaryLink);
-    await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline solid ${fadedBlue} 1px`,
-    );
-};
+//     await fireEvent.mouseDown(primaryLink);
+//     await expect(primaryLink).toHaveStyle(
+//         `text-decoration: underline solid ${fadedBlue} 1px`,
+//     );
+// };
 
 export const Variants: StoryComponentType = () => (
     <View>

--- a/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 1`] = 
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -210,7 +210,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 2`] = 
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -241,7 +241,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 1`] = 
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -272,7 +272,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 2`] = 
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -376,7 +376,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 1`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -410,7 +410,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 2`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -444,7 +444,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 1`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -478,7 +478,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 2`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -573,7 +573,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 1`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -604,7 +604,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 2`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -635,7 +635,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 1`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -666,7 +666,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 2`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -770,7 +770,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 1`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -804,7 +804,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 2`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -838,7 +838,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 1`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -872,7 +872,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 2`] = `
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -967,7 +967,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -998,7 +998,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1029,7 +1029,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1060,7 +1060,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1164,7 +1164,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1198,7 +1198,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1232,7 +1232,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1266,7 +1266,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1361,7 +1361,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1392,7 +1392,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1423,7 +1423,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1454,7 +1454,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1558,7 +1558,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1592,7 +1592,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1626,7 +1626,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1660,7 +1660,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1755,7 +1755,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 1`] 
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1786,7 +1786,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 2`] 
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1817,7 +1817,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 1`] 
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1848,7 +1848,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 2`] 
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1943,7 +1943,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -1974,7 +1974,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -2005,7 +2005,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}
@@ -2036,7 +2036,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "display": "inline-flex",
       "outline": "none",
-      "textDecoration": "underline currentcolor solid 1px",
+      "textDecoration": "underline currentcolor solid",
     }
   }
   tabIndex={0}

--- a/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -21,8 +21,6 @@ exports[`Link <Link tabIndex={-1}> 1`] = `
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "none",
     }
@@ -54,8 +52,6 @@ exports[`Link <Link tabIndex={0}> 1`] = `
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "none",
     }
@@ -87,8 +83,6 @@ exports[`Link <Link tabIndex={1}> 1`] = `
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "none",
     }
@@ -121,8 +115,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:false focused 1`] = 
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -155,8 +147,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:false focused 2`] = 
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -188,11 +178,8 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 1`] = 
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -222,11 +209,8 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 2`] = 
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -256,11 +240,8 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 1`] = 
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -290,11 +271,8 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 2`] = 
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -328,8 +306,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:true focused 1`] = `
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -365,8 +341,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:true focused 2`] = `
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -401,11 +375,8 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 1`] = `
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -438,11 +409,8 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 2`] = `
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -475,11 +443,8 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 1`] = `
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -512,11 +477,8 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 2`] = `
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -547,8 +509,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:false focused 1`] = `
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #ffffff",
       "textDecoration": "none",
     }
@@ -581,8 +541,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:false focused 2`] = `
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #ffffff",
       "textDecoration": "none",
     }
@@ -614,11 +572,8 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 1`] = `
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -648,11 +603,8 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 2`] = `
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -682,11 +634,8 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 1`] = `
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -716,11 +665,8 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 2`] = `
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -754,8 +700,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:true focused 1`] = `
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #ffffff",
       "textDecoration": "none",
     }
@@ -791,8 +735,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:true focused 2`] = `
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #ffffff",
       "textDecoration": "none",
     }
@@ -827,11 +769,8 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 1`] = `
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -864,11 +803,8 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 2`] = `
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -901,11 +837,8 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 1`] = `
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -938,11 +871,8 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 2`] = `
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -973,8 +903,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -1007,8 +935,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -1040,11 +966,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1074,11 +997,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1108,11 +1028,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1142,11 +1059,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1180,8 +1094,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -1217,8 +1129,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -1253,11 +1163,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1290,11 +1197,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1327,11 +1231,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1364,11 +1265,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1399,8 +1297,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #ffffff",
       "textDecoration": "none",
     }
@@ -1433,8 +1329,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #ffffff",
       "textDecoration": "none",
     }
@@ -1466,11 +1360,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1500,11 +1391,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1534,11 +1422,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1568,11 +1453,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1606,8 +1488,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #ffffff",
       "textDecoration": "none",
     }
@@ -1643,8 +1523,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #ffffff",
       "textDecoration": "none",
     }
@@ -1679,11 +1557,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1716,11 +1591,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1753,11 +1625,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1790,11 +1659,8 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1825,8 +1691,6 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false focused 1`] 
       "color": "#21242c",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -1859,8 +1723,6 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false focused 2`] 
       "color": "rgba(33,36,44,0.64)",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -1892,11 +1754,8 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 1`] 
       "color": "#21242c",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1926,11 +1785,8 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 2`] 
       "color": "rgba(33,36,44,0.64)",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -1960,11 +1816,8 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 1`] 
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -1994,11 +1847,8 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 2`] 
       "color": "#21242c",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -2029,8 +1879,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "color": "#21242c",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -2063,8 +1911,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "color": "rgba(33,36,44,0.64)",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "1px solid #1865f2",
       "textDecoration": "none",
     }
@@ -2096,11 +1942,8 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "color": "#21242c",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -2130,11 +1973,8 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "color": "rgba(33,36,44,0.64)",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
-      "textDecoration": "underline currentcolor dashed 2px",
-      "textUnderlineOffset": 4,
+      "textDecoration": "underline currentcolor solid 1px",
     }
   }
   tabIndex={0}
@@ -2164,11 +2004,8 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}
@@ -2198,11 +2035,8 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "color": "#21242c",
       "cursor": "pointer",
       "display": "inline-flex",
-      "fontSize": 16,
-      "lineHeight": "22px",
       "outline": "none",
       "textDecoration": "underline currentcolor solid 1px",
-      "textUnderlineOffset": 4,
     }
   }
   tabIndex={0}

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -94,8 +94,6 @@ const sharedStyles = StyleSheet.create({
         textDecoration: "none",
         outline: "none",
         display: "inline-flex",
-        fontSize: 16,
-        lineHeight: "22px",
     },
 });
 
@@ -165,14 +163,24 @@ const _generateStyles = (
         },
         restingInline: {
             color: defaultTextColor,
+            // TODO(WB-): Update text decoration to the dashed underline
+            // after the Link audit.
+            // textDecoration: "underline currentcolor solid 1px",
             textDecoration: "underline currentcolor solid 1px",
-            textUnderlineOffset: 4,
+            // TODO(WB-): Update the underline offset to be 4px after
+            // the Link audit.
+            // textUnderlineOffset: 4,
             ...defaultVisited,
         },
         hover: {
-            textDecoration: "underline currentcolor dashed 2px",
+            // TODO(WB-): Update text decoration to the dashed underline
+            // after the Link audit.
+            // textDecoration: "underline currentcolor dashed 2px",
+            textDecoration: "underline currentcolor solid 1px",
             color: defaultTextColor,
-            textUnderlineOffset: 4,
+            // TODO(WB-): Update the underline offset to be 4px after
+            // the Link audit.
+            // textUnderlineOffset: 4,
             ...defaultVisited,
         },
         focus: {
@@ -184,7 +192,7 @@ const _generateStyles = (
         active: {
             color: activeColor,
             textDecoration: "underline currentcolor solid 1px",
-            textUnderlineOffset: 4,
+            // textUnderlineOffset: 4,
             ...activeVisited,
         },
     };

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -163,22 +163,22 @@ const _generateStyles = (
         },
         restingInline: {
             color: defaultTextColor,
-            // TODO(WB-): Update text decoration to the dashed underline
+            // TODO(WB-1521): Update text decoration to the dashed underline
             // after the Link audit.
             // textDecoration: "underline currentcolor solid 1px",
             textDecoration: "underline currentcolor solid 1px",
-            // TODO(WB-): Update the underline offset to be 4px after
+            // TODO(WB-1521): Update the underline offset to be 4px after
             // the Link audit.
             // textUnderlineOffset: 4,
             ...defaultVisited,
         },
         hover: {
-            // TODO(WB-): Update text decoration to the dashed underline
+            // TODO(WB-1521): Update text decoration to the dashed underline
             // after the Link audit.
             // textDecoration: "underline currentcolor dashed 2px",
             textDecoration: "underline currentcolor solid 1px",
             color: defaultTextColor,
-            // TODO(WB-): Update the underline offset to be 4px after
+            // TODO(WB-1521): Update the underline offset to be 4px after
             // the Link audit.
             // textUnderlineOffset: 4,
             ...defaultVisited,
@@ -192,6 +192,8 @@ const _generateStyles = (
         active: {
             color: activeColor,
             textDecoration: "underline currentcolor solid 1px",
+            // TODO(WB-1521): Update the underline offset to be 4px after
+            // the Link audit.
             // textUnderlineOffset: 4,
             ...activeVisited,
         },

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -163,20 +163,20 @@ const _generateStyles = (
         },
         restingInline: {
             color: defaultTextColor,
-            // TODO(WB-1521): Update text decoration to the dashed underline
-            // after the Link audit.
+            // TODO(WB-1521): Update text decoration to the 1px dashed
+            // underline after the Link audit.
             // textDecoration: "underline currentcolor solid 1px",
-            textDecoration: "underline currentcolor solid 1px",
+            textDecoration: "underline currentcolor solid",
             // TODO(WB-1521): Update the underline offset to be 4px after
             // the Link audit.
             // textUnderlineOffset: 4,
             ...defaultVisited,
         },
         hover: {
-            // TODO(WB-1521): Update text decoration to the dashed underline
-            // after the Link audit.
+            // TODO(WB-1521): Update text decoration to the 1px dashed
+            // underline after the Link audit.
             // textDecoration: "underline currentcolor dashed 2px",
-            textDecoration: "underline currentcolor solid 1px",
+            textDecoration: "underline currentcolor solid",
             color: defaultTextColor,
             // TODO(WB-1521): Update the underline offset to be 4px after
             // the Link audit.
@@ -191,7 +191,7 @@ const _generateStyles = (
         },
         active: {
             color: activeColor,
-            textDecoration: "underline currentcolor solid 1px",
+            textDecoration: "underline currentcolor solid",
             // TODO(WB-1521): Update the underline offset to be 4px after
             // the Link audit.
             // textUnderlineOffset: 4,


### PR DESCRIPTION
## Summary:
While the new dashed link is available, we are updating it to the old underline
style to match the non-wonder blocks links across webapp. An audit is currently
being run so we can update all these to wonder blocks link.

Once all the legacy links have been updated to use Wonder Blocks Link, we can
finally use the dashed link style.

- Update styles so that the links use solid 1px underlines.
- Comment out the old styles and add a TODO comment above them so we can easily go back.
  - The TODOs should reference WB-1521.

Issue: https://khanacademy.atlassian.net/browse/WB-1520

## Test plan:
- Go to http://localhost:53078/?path=/story/link--variants
- Confirm all the chromatic interaction tests are passing
- Confirm all the links have 1px solid underlines with no offset.