### PR TITLE
Replace new TS React types

### DIFF
--- a/.changeset/fluffy-humans-kiss.md
+++ b/.changeset/fluffy-humans-kiss.md
@@ -1,0 +1,32 @@
+---
+"wb-dev-build-settings": patch
+"@khanacademy/wonder-blocks-banner": patch
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-color": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-data": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-i18n": patch
+"@khanacademy/wonder-blocks-icon": patch
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-layout": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-progress-spinner": patch
+"@khanacademy/wonder-blocks-search-field": patch
+"@khanacademy/wonder-blocks-spacing": patch
+"@khanacademy/wonder-blocks-testing": patch
+"@khanacademy/wonder-blocks-timing": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-typography": patch
+---
+
+Ensure that flow lib defs use React.ElementConfig<> isntead of JSX.LibraryManagedAttributes<>

--- a/build-settings/gen-flow-types.ts
+++ b/build-settings/gen-flow-types.ts
@@ -18,15 +18,22 @@ for (const inFile of files) {
 
         // `flowgen` sometimes outputs code that uses `mixins` instead of `extends`
         // so we do some post-processing on the files to clean that up.
-        const contents = fs.readFileSync(path.join(rootDir, outFile), "utf-8");
+        let contents = fs.readFileSync(path.join(rootDir, outFile), "utf-8");
         if (contents.includes(" mixins ")) {
+            contents = contents.replace(/ mixins /g, " extends ");
             console.log("replacing 'mixins' with 'extends'");
-            fs.writeFileSync(
-                path.join(rootDir, outFile),
-                contents.replace(/ mixins /g, " extends "),
-                "utf-8",
+        }
+        if (contents.includes("JSX.LibraryManagedAttributes")) {
+            contents = contents.replace(
+                /JSX\.LibraryManagedAttributes<\s+([^,]+),\s+React\.ComponentProps<[^>]+>\s+>/gm,
+                (substr, group) => {
+                    const replacement = `React.ElementConfig<${group}>`;
+                    console.log(`replacing '${substr}' with '${replacement}'`);
+                    return replacement;
+                },
             );
         }
+        fs.writeFileSync(path.join(rootDir, outFile), contents, "utf-8");
     } catch (e) {
         console.log(`❌ error processing: ${inFile}: ${e}`);
     }


### PR DESCRIPTION
## Summary:
flowgen hasn't been updated in a while and the TS lib def for React keeps getting updated.  As a result there are some new types that the tool doesn't know about.  This PR adds some more post-processing logic to gen-flow-types.ts to rewrite "JSX.LibraryManagedAttributes<>" as "React.ElementConfig<>".

Issue: None

## Test plan:
- test the regex replacement code manually on a test string
- yarn build:types
- yarn build:flowtypes
- see that it's doing the expected replacement in the logging

```
✅ wrote: packages/wonder-blocks-clickable/dist/util/get-clickable-behavior.js.flow
replacing 'JSX.LibraryManagedAttributes<
    typeof ClickableBehavior,
    React.ComponentProps<typeof ClickableBehavior>
  >' with 'React.ElementConfig<typeof ClickableBehavior>'
```