### PR TITLE
add title to link

### DIFF
--- a/.changeset/dull-zoos-learn.md
+++ b/.changeset/dull-zoos-learn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-link": minor
+---
+
+add title prop to link

--- a/.changeset/metal-worms-heal.md
+++ b/.changeset/metal-worms-heal.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/wonder-blocks-link": minor
----
-
-adds title to link.argtypes

--- a/.changeset/metal-worms-heal.md
+++ b/.changeset/metal-worms-heal.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-link": minor
+---
+
+adds title to link.argtypes

--- a/__docs__/wonder-blocks-link/link.argtypes.ts
+++ b/__docs__/wonder-blocks-link/link.argtypes.ts
@@ -101,6 +101,13 @@ export default {
         table: {type: {summary: "string"}},
     },
 
+    title: {
+        control: {type: "text"},
+        description: "An optional title attribute.",
+        table: {type: {summary: "string"}},
+        type: {name: "string", required: false},
+    },
+
     beforeNav: {
         description: `Run async code before navigating to the URL passed to
             \`href\`. If the promise returned rejects then navigation will not

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -479,6 +479,30 @@ Navigation.parameters = {
     },
 };
 
+export const WithTitle: StoryComponentType = () => (
+    <Body>
+        <Link href="#" title={"I am a title 😎"}>
+            This link has a title.
+        </Link>
+    </Body>
+);
+
+WithTitle.parameters = {
+    docs: {
+        storyDescription: `Link can take a title prop. Give a link a title by
+        setting the \`title\` prop to a string. Hover over the link to see its title.`,
+    },
+};
+
+WithTitle.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const heading = canvas.getByText("Hover over me! I have a title!");
+
+    // Confirm that the link has a title attribute
+    await expect(heading).toHaveAttribute("title");
+};
+
 const styles = StyleSheet.create({
     darkBackground: {
         backgroundColor: Color.darkBlue,

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -497,7 +497,7 @@ WithTitle.parameters = {
 WithTitle.play = async ({canvasElement}) => {
     const canvas = within(canvasElement);
 
-    const heading = canvas.getByText("Hover over me! I have a title!");
+    const heading = canvas.getByText("This Link has a title.");
 
     // Confirm that the link has a title attribute
     await expect(heading).toHaveAttribute("title");

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -481,7 +481,7 @@ Navigation.parameters = {
 
 export const WithTitle: StoryComponentType = () => (
     <Body>
-        <Link href="#" title={"I am a title 😎"}>
+        <Link href="#" title="I am a title 😎">
             This link has a title.
         </Link>
     </Body>

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -497,10 +497,10 @@ WithTitle.parameters = {
 WithTitle.play = async ({canvasElement}) => {
     const canvas = within(canvasElement);
 
-    const heading = canvas.getByText("This Link has a title.");
+    const link = canvas.getByText("This link has a title.");
 
     // Confirm that the link has a title attribute
-    await expect(heading).toHaveAttribute("title");
+    await expect(link).toHaveAttribute("title");
 };
 
 const styles = StyleSheet.create({

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -136,6 +136,10 @@ export type SharedProps = AriaProps & {
      * navigation.
      */
     beforeNav?: () => Promise<unknown>;
+    /**
+     * An optional title attribute.
+     */
+    title?: string;
 };
 
 type DefaultProps = {


### PR DESCRIPTION
## Summary:
Add title prop to Link

Issue: WB-1453

## Test plan:
- Ran yarn test & yarn typecheck
- Set title prop in control panel and inspected title attribute change in the DOM
- Added WithTitle story that renders link with a title attribute that appears when hovering over the link
  <img width="156" alt="Screenshot 2023-03-08 at 10 28 42 AM" src="https://user-images.githubusercontent.com/100858764/223758065-200db57c-4fb4-4c43-8084-dae858f0c98e.png">
  <img width="225" alt="Screenshot 2023-03-08 at 10 28 50 AM" src="https://user-images.githubusercontent.com/100858764/223757494-8a46b3d8-1880-4e0f-b143-00a696965796.png">
