### PR TITLE
Tweak TS Types #1

### DIFF
--- a/.changeset/famous-fishes-hope.md
+++ b/.changeset/famous-fishes-hope.md
@@ -1,0 +1,25 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-data": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-i18n": patch
+"@khanacademy/wonder-blocks-icon": patch
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-layout": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-progress-spinner": patch
+"@khanacademy/wonder-blocks-timing": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-typography": patch
+---
+
+Miscellaneous TS type fixes

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -77,7 +77,7 @@ type Props = {
      * Accessible label for the banner.
      * This is read out before the other contents of the banner.
      */
-    ["aria-label"]?: string;
+    "aria-label"?: string;
     /**
      * Determines the color and icon of the banner.
      */

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -342,7 +342,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
         );
     }
 
-    render(): React.ReactElement<any> {
+    render(): React.ReactNode {
         return (
             <>
                 <View testId="birthday-picker" style={{flexDirection: "row"}}>

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
@@ -48,7 +48,7 @@ export default class BreadcrumbsItem extends React.Component<Props> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children, showSeparator, testId, ...otherProps} = this.props;
 
         return (

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.tsx
@@ -70,7 +70,7 @@ export default class Breadcrumbs extends React.Component<Props> {
         "aria-label": "Breadcrumbs",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children, testId, ...otherProps} = this.props;
         // using React.Children allows to deal with opaque data structures
         // e.g. children = 'string' vs children = []

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -168,7 +168,7 @@ export default class ButtonCore extends React.Component<Props> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderInner(router)}

--- a/packages/wonder-blocks-button/src/components/button.tsx
+++ b/packages/wonder-blocks-button/src/components/button.tsx
@@ -288,7 +288,7 @@ export default class Button extends React.Component<Props> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderClickableBehavior(router)}

--- a/packages/wonder-blocks-cell/src/util/types.ts
+++ b/packages/wonder-blocks-cell/src/util/types.ts
@@ -113,7 +113,7 @@ export type CellProps = {
     /**
      * Used to announce the cell's content to screen readers.
      */
-    ["aria-label"]?: string;
+    "aria-label"?: string;
     /**
      * Optinal href which Cell should direct to, uses client-side routing
      * by default if react-router is present.

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -52,7 +52,7 @@ type Props = {
     children: (
         state: ClickableState,
         childrenProps: ChildrenProps,
-    ) => React.ReactElement;
+    ) => React.ReactNode;
     /**
      * Whether the component is disabled.
      *
@@ -575,7 +575,7 @@ export default class ClickableBehavior extends React.Component<
         this.setState({focused: false, pressed: false});
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const childrenProps: ChildrenProps = this.props.disabled
             ? {
                   ...disabledHandlers,

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -292,7 +292,7 @@ export default class Clickable extends React.Component<Props> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderClickableBehavior(router)}

--- a/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.tsx
@@ -17,7 +17,6 @@ describe("UniqueIDProvider", () => {
             const children = jest.fn(() => null);
             const nodes = (
                 <UniqueIDProvider mockOnFirstRender={false}>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     {children}
                 </UniqueIDProvider>
             );
@@ -34,7 +33,6 @@ describe("UniqueIDProvider", () => {
             const children = jest.fn(() => null);
             const nodes = (
                 <UniqueIDProvider mockOnFirstRender={false}>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     {children}
                 </UniqueIDProvider>
             );
@@ -83,7 +81,6 @@ describe("UniqueIDProvider", () => {
             const children = jest.fn(() => null);
             const nodes = (
                 <UniqueIDProvider mockOnFirstRender={true}>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     {children}
                 </UniqueIDProvider>
             );
@@ -102,7 +99,6 @@ describe("UniqueIDProvider", () => {
             const children = jest.fn(() => null);
             const nodes = (
                 <UniqueIDProvider mockOnFirstRender={true}>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     {children}
                 </UniqueIDProvider>
             );
@@ -122,7 +118,6 @@ describe("UniqueIDProvider", () => {
             const children = jest.fn(() => null);
             const UnderTest = () => (
                 <UniqueIDProvider mockOnFirstRender={true}>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     {children}
                 </UniqueIDProvider>
             );

--- a/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.tsx
@@ -13,7 +13,6 @@ describe("WithSSRPlaceholder", () => {
             await new Promise((resolve: any) => {
                 const nodes = (
                     <WithSSRPlaceholder placeholder={mockPlaceholder}>
-                        {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                         {() => {
                             resolve();
                             return null;
@@ -45,14 +44,12 @@ describe("WithSSRPlaceholder", () => {
 
                     const placeholder = () => (
                         <WithSSRPlaceholder placeholder={nestedPlaceholder}>
-                            {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                             {mockChildrenNotCalled}
                         </WithSSRPlaceholder>
                     );
 
                     const nodes = (
                         <WithSSRPlaceholder placeholder={placeholder}>
-                            {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                             {() => null}
                         </WithSSRPlaceholder>
                     );
@@ -81,7 +78,6 @@ describe("WithSSRPlaceholder", () => {
                                 <WithSSRPlaceholder
                                     placeholder={mockPlaceholderNotCalled}
                                 >
-                                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                                     {() => {
                                         resolve();
                                         return null;
@@ -115,7 +111,6 @@ describe("WithSSRPlaceholder", () => {
 
             const nodes = (
                 <WithSSRPlaceholder placeholder={mockPlaceholder}>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     {mockChildren}
                 </WithSSRPlaceholder>
             );
@@ -160,7 +155,6 @@ describe("WithSSRPlaceholder", () => {
 
                 const nodes = (
                     <WithSSRPlaceholder placeholder={() => placeholder}>
-                        {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                         {() => "This won't render"}
                     </WithSSRPlaceholder>
                 );
@@ -183,7 +177,6 @@ describe("WithSSRPlaceholder", () => {
 
                 const nodes = (
                     <WithSSRPlaceholder placeholder={() => placeholder}>
-                        {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                         {() => "This won't render"}
                     </WithSSRPlaceholder>
                 );
@@ -205,7 +198,6 @@ describe("WithSSRPlaceholder", () => {
                 const nodes = (
                     <RenderStateRoot>
                         <WithSSRPlaceholder placeholder={mockPlaceholder}>
-                            {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                             {() => {
                                 resolve();
                                 return null;
@@ -233,7 +225,6 @@ describe("WithSSRPlaceholder", () => {
             const nodes = (
                 <RenderStateRoot>
                     <WithSSRPlaceholder placeholder={mockPlaceholder}>
-                        {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                         {mockChildren}
                     </WithSSRPlaceholder>
                 </RenderStateRoot>

--- a/packages/wonder-blocks-core/src/components/id-provider.tsx
+++ b/packages/wonder-blocks-core/src/components/id-provider.tsx
@@ -10,7 +10,7 @@ type Props = {
      * use anywhere within children. This provides a way of adding a unique identifier
      * to a given component for a11y purposes.
      */
-    children: (uniqueId: string) => React.ReactElement;
+    children: (uniqueId: string) => React.ReactNode;
     /**
      * Scope for the unique identifier
      */
@@ -69,18 +69,16 @@ export default class IDProvider extends React.Component<Props> {
         return children(uniqueId);
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {id, scope} = this.props;
 
         if (id) {
             // Let's bypass the extra weight of an id provider since we don't
             // need it.
-            // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
             return this.renderChildren();
         } else {
             return (
                 <UniqueIDProvider scope={scope} mockOnFirstRender={true}>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     {(ids) => this.renderChildren(ids)}
                 </UniqueIDProvider>
             );

--- a/packages/wonder-blocks-core/src/components/text.tsx
+++ b/packages/wonder-blocks-core/src/components/text.tsx
@@ -48,7 +48,7 @@ export default class Text extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children, style, tag: Tag, testId, ...otherProps} = this.props;
 
         const isHeader = isHeaderRegex.test(Tag);

--- a/packages/wonder-blocks-core/src/components/unique-id-provider.tsx
+++ b/packages/wonder-blocks-core/src/components/unique-id-provider.tsx
@@ -26,7 +26,7 @@ type Props = {
      *
      * `{get(id: string): string} => React.Node`
      */
-    children: (arg1: IIdentifierFactory) => React.ReactElement;
+    children: (arg1: IIdentifierFactory) => React.ReactNode;
     /**
      * If mockOnFirstRender is false, children is only called
      * after the initial render has occurred.
@@ -98,7 +98,7 @@ export default class UniqueIDProvider extends React.Component<Props> {
         return children(this._idFactory);
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         // Here we use the WithSSRPlaceholder component to control
         // when we render and whether we provide a mock or real
         // identifier factory.

--- a/packages/wonder-blocks-core/src/components/view.tsx
+++ b/packages/wonder-blocks-core/src/components/view.tsx
@@ -73,7 +73,7 @@ export default class View extends React.Component<Props> {
         tag: "div",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {testId, tag, ...restProps} = this.props;
         const props = {
             ...restProps,

--- a/packages/wonder-blocks-core/src/components/with-ssr-placeholder.tsx
+++ b/packages/wonder-blocks-core/src/components/with-ssr-placeholder.tsx
@@ -12,7 +12,7 @@ type Props = {
      * not server-side rendering, or (when server-side rendering) after
      * the initial rehydration has finished.
      */
-    children: () => React.ReactElement;
+    children: () => React.ReactNode;
     /**
      * What to render during server-side rendering, or null not to
      * render anything.
@@ -164,7 +164,7 @@ export default class WithSSRPlaceholder extends React.Component<Props, State> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <RenderStateContext.Consumer>
                 {(value) => this._maybeRender(value)}

--- a/packages/wonder-blocks-core/src/util/types.ts
+++ b/packages/wonder-blocks-core/src/util/types.ts
@@ -80,9 +80,9 @@ export type TextViewSharedProps = {
     tabIndex?: number;
     id?: string;
     // TODO(kevinb) remove the need for this
-    ["data-modal-launcher-portal"]?: boolean;
+    "data-modal-launcher-portal"?: boolean;
     // Used by tooltip bubble
-    ["data-placement"]?: string;
+    "data-placement"?: string;
 } & AriaProps &
     EventHandlers;
 

--- a/packages/wonder-blocks-data/src/components/track-data.tsx
+++ b/packages/wonder-blocks-data/src/components/track-data.tsx
@@ -11,7 +11,7 @@ type TrackDataProps = {
  * Component to enable data request tracking when server-side rendering.
  */
 export default class TrackData extends React.Component<TrackDataProps> {
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         if (!Server.isServerSide()) {
             throw new Error(
                 "This component is not for use during client-side rendering",

--- a/packages/wonder-blocks-dropdown/src/components/__mocks__/dropdown-core-virtualized.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__mocks__/dropdown-core-virtualized.tsx
@@ -14,7 +14,7 @@ type Props = {
  * A minimal mocked version of the Virtualized implementation
  */
 class DropdownCoreVirtualizedMock extends React.Component<Props> {
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {data, listRef} = this.props;
         return (
             <List

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -215,7 +215,7 @@ export default class ActionItem extends React.Component<ActionProps> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderClickableBehavior(router)}

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -41,7 +41,7 @@ const StyledButton = addStyle<"button">("button");
  * - the down caret icon is smaller that the one that would be used by ButtonCore
  */
 export default class ActionMenuOpenerCore extends React.Component<Props> {
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             children,
             disabled: disabledProp,

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
@@ -263,7 +263,7 @@ export default class ActionMenu extends React.Component<Props, State> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {alignment, dropdownStyle, style, className} = this.props;
 
         const items = this.getMenuItems();

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized-item.ts
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core-virtualized-item.ts
@@ -32,7 +32,7 @@ type Props = {
  * react-window make its own calculations.
  */
 class DropdownVirtualizedItem extends React.Component<Props> {
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {data, index, style} = this.props;
         const item = data[index];
 

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -1018,7 +1018,7 @@ class DropdownCore extends React.Component<Props, State> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {open, opener, style, className} = this.props;
 
         return (

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -993,7 +993,6 @@ class DropdownCore extends React.Component<Props, State> {
                 referenceElement={openerElement}
             >
                 {(isReferenceHidden) =>
-                    // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
                     this.renderDropdownMenu(listRenderer, isReferenceHidden)
                 }
             </DropdownPopper>

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
@@ -53,7 +53,7 @@ class DropdownOpener extends React.Component<Props> {
     renderAnchorChildren(
         eventState: ClickableState,
         clickableChildrenProps: ChildrenProps,
-    ): React.ReactNode {
+    ): React.ReactElement {
         const {disabled, testId, text} = this.props;
         const renderedChildren = this.props.children({...eventState, text});
         const childrenProps = renderedChildren.props;
@@ -77,14 +77,13 @@ class DropdownOpener extends React.Component<Props> {
         });
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <ClickableBehavior
                 onClick={this.props.onClick}
                 disabled={this.props.disabled}
             >
                 {(eventState, handlers) =>
-                    // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
                     this.renderAnchorChildren(eventState, handlers)
                 }
             </ClickableBehavior>

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
@@ -25,7 +25,7 @@ type Props = {
     /**
      * The children that will be wrapped by PopperJS.
      */
-    children: (isReferenceHidden: boolean) => React.ReactElement;
+    children: (isReferenceHidden: boolean) => React.ReactNode;
     /**
      * The reference element used to position the popper.
      */

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -517,7 +517,7 @@ export default class MultiSelect extends React.Component<Props, State> {
         return dropdownOpener;
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             alignment,
             light,

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -106,7 +106,7 @@ export default class OptionItem extends React.Component<OptionProps> {
         }
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             disabled,
             label,

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -153,7 +153,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderClickableBehavior(router)}

--- a/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
@@ -28,7 +28,7 @@ export default class SeparatorItem extends React.Component<{
 
     static __IS_SEPARATOR_ITEM__ = true;
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             // pass optional styles from react-window (if applies)
             <View

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -424,7 +424,7 @@ export default class SingleSelect extends React.Component<Props, State> {
         return dropdownOpener;
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             alignment,
             autoFocus,

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -33,7 +33,7 @@ export default class CheckboxCore extends React.Component<Props> {
         return;
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             checked,
             disabled,

--- a/packages/wonder-blocks-form/src/components/checkbox-group.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.tsx
@@ -111,7 +111,7 @@ export default class CheckboxGroup extends React.Component<CheckboxGroupProps> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             children,
             label,

--- a/packages/wonder-blocks-form/src/components/checkbox.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox.tsx
@@ -88,7 +88,7 @@ export default class Checkbox extends React.Component<ChoiceComponentProps> {
         error: false,
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return <ChoiceInternal variant="checkbox" {...this.props} />;
     }
 }

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -111,7 +111,7 @@ type DefaultProps = {
             </LabelSmall>
         );
     }
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             label,
             description,

--- a/packages/wonder-blocks-form/src/components/choice.tsx
+++ b/packages/wonder-blocks-form/src/components/choice.tsx
@@ -139,7 +139,7 @@ export default class Choice extends React.Component<Props> {
             return Radio;
         }
     }
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         // we don't need this going into the ChoiceComponent
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const {value, variant, ...remainingProps} = this.props;

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -121,7 +121,7 @@ export default class FieldHeading extends React.Component<Props> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {field, style} = this.props;
 
         return (

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -193,7 +193,7 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
         });
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             id,
             type,

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -25,7 +25,7 @@ const StyledInput = addStyle("input");
         return;
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             checked,
             disabled,

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -101,7 +101,7 @@ export default class RadioGroup extends React.Component<RadioGroupProps> {
         this.props.onChange(changedValue);
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             children,
             label,

--- a/packages/wonder-blocks-form/src/components/radio.tsx
+++ b/packages/wonder-blocks-form/src/components/radio.tsx
@@ -73,7 +73,7 @@ type DefaultProps = {
         error: false,
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return <ChoiceInternal variant="radio" {...this.props} />;
     }
 }

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -206,7 +206,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
         });
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             id,
             type,

--- a/packages/wonder-blocks-grid/src/components/cell.tsx
+++ b/packages/wonder-blocks-grid/src/components/cell.tsx
@@ -115,7 +115,6 @@ export default class Cell extends React.Component<Props> {
 
         return (
             <MediaLayout>
-                {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                 {({mediaSize, mediaSpec}) => {
                     const spec = mediaSpec[mediaSize];
                     if (!spec) {

--- a/packages/wonder-blocks-grid/src/components/gutter.tsx
+++ b/packages/wonder-blocks-grid/src/components/gutter.tsx
@@ -38,7 +38,6 @@ export default class Gutter extends React.Component<Props> {
     render(): React.ReactElement | null {
         return (
             <MediaLayout>
-                {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                 {({mediaSize, mediaSpec}) => {
                     const spec = mediaSpec[mediaSize];
                     if (!spec) {

--- a/packages/wonder-blocks-grid/src/components/row.tsx
+++ b/packages/wonder-blocks-grid/src/components/row.tsx
@@ -66,7 +66,6 @@ export default class Row extends React.Component<Props> {
 
         return (
             <MediaLayout>
-                {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                 {({mediaSize, mediaSpec}) => {
                     const spec = mediaSpec[mediaSize];
                     if (!spec) {

--- a/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.tsx
+++ b/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.tsx
@@ -128,7 +128,7 @@ export class I18nInlineMarkup extends React.PureComponent<Props> {
         throw error;
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children, elementWrapper, ...restProps} = this.props;
         const renderers: Record<
             string,

--- a/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.tsx
+++ b/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.tsx
@@ -195,7 +195,6 @@ export class I18nInlineMarkup extends React.PureComponent<Props> {
             // istanbul ignore
             return this.handleError(new Error("Unknown child type."));
         });
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode[]' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
         return nodes;
     }
 }

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -102,7 +102,7 @@ export default class IconButtonCore extends React.Component<Props> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderInner(router)}

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -199,7 +199,7 @@ export default class IconButton extends React.Component<SharedProps> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderClickableBehavior(router)}

--- a/packages/wonder-blocks-icon/src/components/icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/icon.tsx
@@ -85,7 +85,7 @@ export default class Icon extends React.PureComponent<Props> {
         size: "small",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {color, icon, size, style, testId, ...sharedProps} = this.props;
 
         const {assetSize, path} = getPathForIcon(icon, size);

--- a/packages/wonder-blocks-layout/src/components/media-layout.tsx
+++ b/packages/wonder-blocks-layout/src/components/media-layout.tsx
@@ -39,7 +39,7 @@ type Props = {
         mediaSize: MediaSize;
         mediaSpec: MediaSpec;
         styles: MockStyleSheet;
-    }) => React.ReactElement;
+    }) => React.ReactNode;
     /**
      * Aphrodite stylesheets to pass through to the styles prop. The
      * stylesheets to render is based on the media size. "all" is always
@@ -210,7 +210,7 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
         return mockStyleSheet;
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children, mediaSpec, ssrSize, overrideSize} = this.props;
 
         // We need to create the MediaQueryLists during the first render in order
@@ -267,7 +267,7 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
  * - `maxWidth: number`
  */
 export default class MediaLayout extends React.Component<Props> {
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         // We listen to the MediaLayoutContext to see what defaults we're
         // being given (this can be overriden by wrapping this component in
         // a MediaLayoutContext.Consumer).

--- a/packages/wonder-blocks-layout/src/components/spring.tsx
+++ b/packages/wonder-blocks-layout/src/components/spring.tsx
@@ -14,7 +14,7 @@ type Props = {
  * Assumes parent is a View.
  */
 export default class Spring extends React.Component<Props> {
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style} = this.props;
         return <View aria-hidden="true" style={[styles.grow, style]} />;
     }

--- a/packages/wonder-blocks-layout/src/components/strut.tsx
+++ b/packages/wonder-blocks-layout/src/components/strut.tsx
@@ -14,7 +14,7 @@ type Props = {
  * Assumes parent is a View.
  */
 export default class Strut extends React.Component<Props> {
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {size, style} = this.props;
         return <View aria-hidden="true" style={[strutStyle(size), style]} />;
     }

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -77,7 +77,7 @@ export default class LinkCore extends React.Component<Props> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderInner(router)}

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -253,7 +253,7 @@ export default class Link extends React.Component<SharedProps> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return (
             <__RouterContext.Consumer>
                 {(router) => this.renderClickableBehavior(router)}

--- a/packages/wonder-blocks-modal/src/components/close-button.tsx
+++ b/packages/wonder-blocks-modal/src/components/close-button.tsx
@@ -32,7 +32,7 @@ type Props = {
 };
 
 export default class CloseButton extends React.Component<Props> {
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {light, onClick, style, testId} = this.props;
 
         return (

--- a/packages/wonder-blocks-modal/src/components/focus-trap.tsx
+++ b/packages/wonder-blocks-modal/src/components/focus-trap.tsx
@@ -110,7 +110,7 @@ export default class FocusTrap extends React.Component<Props> {
         this.focusElementIn(true);
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style} = this.props;
 
         return (

--- a/packages/wonder-blocks-modal/src/components/modal-backdrop.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-backdrop.tsx
@@ -125,7 +125,7 @@ export default class ModalBackdrop extends React.Component<Props> {
         this._mousePressedOutside = false;
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children, testId} = this.props;
         const backdropProps = {
             [ModalLauncherPortalAttributeName]: true,

--- a/packages/wonder-blocks-modal/src/components/modal-content.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-content.tsx
@@ -32,7 +32,7 @@ export default class ModalContent extends React.Component<Props> {
 
     static __IS_MODAL_CONTENT__ = true;
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {scrollOverflow, style, children} = this.props;
 
         return (

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
@@ -70,7 +70,7 @@ export default class ModalDialog extends React.Component<Props> {
         role: "dialog",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             above,
             below,

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
@@ -44,11 +44,11 @@ type Props = {
     /**
      * The ID of the content labelling this dialog, if applicable.
      */
-    ["aria-labelledby"]?: string;
+    "aria-labelledby"?: string;
     /**
      * The ID of the content describing this dialog, if applicable.
      */
-    ["aria-describedby"]?: string;
+    "aria-describedby"?: string;
 };
 
 type DefaultProps = {

--- a/packages/wonder-blocks-modal/src/components/modal-footer.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-footer.tsx
@@ -31,7 +31,7 @@ export default class ModalFooter extends React.Component<Props> {
     }
     static __IS_MODAL_FOOTER__ = true;
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children} = this.props;
         return <View style={styles.footer}>{children}</View>;
     }

--- a/packages/wonder-blocks-modal/src/components/modal-header.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-header.tsx
@@ -103,7 +103,7 @@ export default class ModalHeader extends React.Component<Props> {
         light: true,
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             // @ts-expect-error [FEI-5019] - TS2339 - Property 'breadcrumbs' does not exist on type 'Readonly<Props> & Readonly<{ children?: ReactNode; }>'.
             breadcrumbs = undefined,

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -124,7 +124,7 @@ export default class ModalPanel extends React.Component<Props> {
         });
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             closeButtonVisible,
             footer,

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.tsx
@@ -178,7 +178,7 @@ export default class OnePaneDialog extends React.Component<Props> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             onClose,
             footer,

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.tsx
@@ -74,7 +74,7 @@ type Common = {
     /**
      * The ID of the content describing this dialog, if applicable.
      */
-    ["aria-describedby"]?: string;
+    "aria-describedby"?: string;
 };
 
 type WithSubtitle = Common & {

--- a/packages/wonder-blocks-popover/src/components/close-button.tsx
+++ b/packages/wonder-blocks-popover/src/components/close-button.tsx
@@ -38,7 +38,7 @@ export default class CloseButton extends React.Component<Props> {
         "aria-label": "Close Popover",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {light, "aria-label": ariaLabel, style, testId} = this.props;
         return (
             <PopoverContext.Consumer>

--- a/packages/wonder-blocks-popover/src/components/focus-manager.tsx
+++ b/packages/wonder-blocks-popover/src/components/focus-manager.tsx
@@ -212,7 +212,7 @@ export default class FocusManager extends React.Component<Props> {
         }
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children} = this.props;
 
         return (

--- a/packages/wonder-blocks-popover/src/components/initial-focus.ts
+++ b/packages/wonder-blocks-popover/src/components/initial-focus.ts
@@ -81,7 +81,7 @@ export default class InitialFocus extends React.Component<Props> {
         return focusableElements[0];
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         return this.props.children;
     }
 }

--- a/packages/wonder-blocks-popover/src/components/popover-anchor.ts
+++ b/packages/wonder-blocks-popover/src/components/popover-anchor.ts
@@ -47,7 +47,7 @@ export default class PopoverAnchor extends React.Component<Props> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             children,
             id,

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -69,7 +69,7 @@ export default class PopoverContentCore extends React.Component<Props> {
         closeButtonVisible: false,
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             children,
             closeButtonLight,

--- a/packages/wonder-blocks-popover/src/components/popover-content.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content.tsx
@@ -188,7 +188,7 @@ export default class PopoverContent extends React.Component<Props> {
         );
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             closeButtonLabel,
             closeButtonVisible,

--- a/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
@@ -61,7 +61,7 @@ export default class PopoverDialog extends React.Component<Props> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             placement,
             children,

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -249,7 +249,7 @@ export default class Popover extends React.Component<Props, State> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children, dismissEnabled, id} = this.props;
         const {opened, placement} = this.state;
         const popperHost = this.getHost();

--- a/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
+++ b/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
@@ -67,7 +67,7 @@ export default class CircularSpinner extends React.Component<Props> {
         light: false,
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {size, light, style, testId} = this.props;
 
         const height = heights[size];

--- a/packages/wonder-blocks-timing/src/components/action-scheduler-provider.ts
+++ b/packages/wonder-blocks-timing/src/components/action-scheduler-provider.ts
@@ -8,7 +8,7 @@ type Props = {
      * A function that, when given an instance of `IScheduleActions` will
      * render a `React.Node`.
      */
-    children: (arg1: IScheduleActions) => React.ReactElement;
+    children: (arg1: IScheduleActions) => React.ReactNode;
 };
 
 /**
@@ -28,7 +28,7 @@ export default class ActionSchedulerProvider extends React.Component<Props> {
 
     _actionScheduler: ActionScheduler = new ActionScheduler();
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {children} = this.props;
         return children(this._actionScheduler);
     }

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.ts
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-interval.ts
@@ -68,6 +68,5 @@ export function useScheduledInterval(
 
     useInterval(action, intervalMs, isSet);
 
-    // @ts-expect-error [FEI-5019] - TS2322 - Type 'boolean' is not assignable to type '() => boolean'.
     return {isSet, set, clear};
 }

--- a/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.ts
+++ b/packages/wonder-blocks-timing/src/hooks/use-scheduled-timeout.ts
@@ -75,6 +75,5 @@ export function useScheduledTimeout(
 
     useTimeout(wrappedAction, timeoutMs, isSet);
 
-    // @ts-expect-error [FEI-5019] - TS2322 - Type 'boolean' is not assignable to type '() => boolean'.
     return {isSet, set, clear};
 }

--- a/packages/wonder-blocks-timing/src/util/action-scheduler.ts
+++ b/packages/wonder-blocks-timing/src/util/action-scheduler.ts
@@ -21,7 +21,6 @@ export default class ActionScheduler implements IScheduleActions {
     _registeredActions: Array<() => void> = [];
     static readonly NoopAction: ITimeout & IAnimationFrame & IInterval = {
         set: () => {},
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'boolean' is not assignable to type '(() => boolean) & (() => boolean) & (() => boolean)'.
         get isSet() {
             return false;
         },
@@ -38,7 +37,6 @@ export default class ActionScheduler implements IScheduleActions {
         }
         const timeout = new Timeout(action, period, options?.schedulePolicy);
         this._registeredActions.push(() => timeout.clear(options?.clearPolicy));
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'Timeout' is not assignable to type 'ITimeout'.
         return timeout;
     }
 
@@ -54,7 +52,6 @@ export default class ActionScheduler implements IScheduleActions {
         this._registeredActions.push(() =>
             interval.clear(options?.clearPolicy),
         );
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'Interval' is not assignable to type 'IInterval'.
         return interval;
     }
 
@@ -72,7 +69,6 @@ export default class ActionScheduler implements IScheduleActions {
         this._registeredActions.push(() =>
             animationFrame.clear(options?.clearPolicy),
         );
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'AnimationFrame' is not assignable to type 'IAnimationFrame'.
         return animationFrame;
     }
 

--- a/packages/wonder-blocks-timing/src/util/animation-frame.ts
+++ b/packages/wonder-blocks-timing/src/util/animation-frame.ts
@@ -51,7 +51,6 @@ export default class AnimationFrame implements IAnimationFrame {
      * false.
      * @memberof AnimationFrame
      */
-    // @ts-expect-error [FEI-5019] - TS2416 - Property 'isSet' in type 'AnimationFrame' is not assignable to the same property in base type 'IAnimationFrame'.
     get isSet(): boolean {
         return this._animationFrameId != null;
     }

--- a/packages/wonder-blocks-timing/src/util/interval.ts
+++ b/packages/wonder-blocks-timing/src/util/interval.ts
@@ -59,7 +59,6 @@ export default class Interval implements IInterval {
      * @returns {boolean} true if the interval is active, otherwise false.
      * @memberof Interval
      */
-    // @ts-expect-error [FEI-5019] - TS2416 - Property 'isSet' in type 'Interval' is not assignable to the same property in base type 'IInterval'.
     get isSet(): boolean {
         return this._intervalId != null;
     }

--- a/packages/wonder-blocks-timing/src/util/timeout.ts
+++ b/packages/wonder-blocks-timing/src/util/timeout.ts
@@ -60,7 +60,6 @@ export default class Timeout implements ITimeout {
      * false.
      * @memberof Timeout
      */
-    // @ts-expect-error [FEI-5019] - TS2416 - Property 'isSet' in type 'Timeout' is not assignable to the same property in base type 'ITimeout'.
     get isSet(): boolean {
         return this._timeoutId != null;
     }

--- a/packages/wonder-blocks-timing/src/util/types.ts
+++ b/packages/wonder-blocks-timing/src/util/types.ts
@@ -18,7 +18,7 @@ export interface ITimeout {
      * false.
      * @memberof ITimeout
      */
-    isSet(): boolean;
+    get isSet(): boolean;
     /**
      * Set the timeout.
      *
@@ -60,7 +60,7 @@ export interface IInterval {
      * @returns {boolean} true if the interval is active, otherwise false.
      * @memberof IInterval
      */
-    isSet(): boolean;
+    get isSet(): boolean;
     /**
      * Set the interval.
      *
@@ -102,7 +102,7 @@ export interface IAnimationFrame {
      * false.
      * @memberof IAnimationFrame
      */
-    isSet(): boolean;
+    get isSet(): boolean;
     /**
      * Set the request.
      *

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -82,7 +82,7 @@ export default class Toolbar extends React.Component<Props> {
         size: "medium",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {color, leftContent, rightContent, size, subtitle, title} =
             this.props;
 

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.tsx
@@ -322,7 +322,6 @@ export default class TooltipAnchor
         // so as not to affect styling or layout but still have an element
         // to anchor to.
         if (this.props.ids) {
-            // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
             return this._renderAccessibleChildren(this.props.ids);
         }
         return this._renderAnchorableChildren();

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.tsx
@@ -316,7 +316,7 @@ export default class TooltipAnchor
         });
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         // We need to make sure we can anchor on our content.
         // If the content is just a string, we wrap it in a Text element
         // so as not to affect styling or layout but still have an element

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -55,7 +55,7 @@ export default class TooltipBubble extends React.Component<Props, State> {
         this.props.onActiveChanged(false);
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {
             id,
             children,

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
@@ -59,7 +59,7 @@ export default class TooltipContent extends React.Component<Props> {
         }
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const title = this._renderTitle();
         const children = this._renderChildren();
         const containerStyle = title ? styles.withTitle : styles.withoutTitle;

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
@@ -17,7 +17,7 @@ type Props = {
      *
      * TODO(WB-624): figure out to only allow TooltipBubble and PopoverDialog
      */
-    children: (arg1: PopperElementProps) => React.ReactElement<any>;
+    children: (arg1: PopperElementProps) => React.ReactNode;
     /**
      * The element that anchors the tooltip bubble.
      * This is used to position the bubble.
@@ -78,7 +78,7 @@ export default class TooltipPopper extends React.Component<Props> {
         return children(bubbleProps);
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {anchorElement, placement} = this.props;
         return (
             <Popper

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -387,7 +387,7 @@ export default class TooltipTail extends React.Component<Props> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {offset, placement, updateRef} = this.props;
         return (
             <View

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -264,12 +264,10 @@ export default class Tooltip extends React.Component<Props, State> {
         if (id) {
             // Let's bypass the extra weight of an id provider since we don't
             // need it.
-            // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
             return this._renderTooltipAnchor();
         } else {
             return (
                 <UniqueIDProvider scope="tooltip" mockOnFirstRender={true}>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     {(ids) => this._renderTooltipAnchor(ids)}
                 </UniqueIDProvider>
             );

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -259,7 +259,7 @@ export default class Tooltip extends React.Component<Props, State> {
         );
     }
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {id} = this.props;
         if (id) {
             // Let's bypass the extra weight of an id provider since we don't

--- a/packages/wonder-blocks-typography/src/components/body-monospace.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-monospace.tsx
@@ -14,7 +14,7 @@ export default class BodyMonospace extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.BodyMonospace, style]}>

--- a/packages/wonder-blocks-typography/src/components/body-serif-block.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-serif-block.tsx
@@ -14,7 +14,7 @@ export default class BodySerifBlock extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.BodySerifBlock, style]}>

--- a/packages/wonder-blocks-typography/src/components/body-serif.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-serif.tsx
@@ -14,7 +14,7 @@ export default class BodySerif extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.BodySerif, style]}>

--- a/packages/wonder-blocks-typography/src/components/body.tsx
+++ b/packages/wonder-blocks-typography/src/components/body.tsx
@@ -14,7 +14,7 @@ export default class Body extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.Body, style]}>

--- a/packages/wonder-blocks-typography/src/components/caption.tsx
+++ b/packages/wonder-blocks-typography/src/components/caption.tsx
@@ -14,7 +14,7 @@ export default class Caption extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.Caption, style]}>

--- a/packages/wonder-blocks-typography/src/components/footnote.tsx
+++ b/packages/wonder-blocks-typography/src/components/footnote.tsx
@@ -14,7 +14,7 @@ export default class Footnote extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.Footnote, style]}>

--- a/packages/wonder-blocks-typography/src/components/heading-large.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-large.tsx
@@ -14,7 +14,7 @@ export default class HeadingLarge extends React.Component<Props> {
         tag: "h2",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.HeadingLarge, style]}>

--- a/packages/wonder-blocks-typography/src/components/heading-medium.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-medium.tsx
@@ -14,7 +14,7 @@ export default class HeadingMedium extends React.Component<Props> {
         tag: "h3",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.HeadingMedium, style]}>

--- a/packages/wonder-blocks-typography/src/components/heading-small.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-small.tsx
@@ -14,7 +14,7 @@ export default class HeadingSmall extends React.Component<Props> {
         tag: "h4",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.HeadingSmall, style]}>

--- a/packages/wonder-blocks-typography/src/components/heading-xsmall.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-xsmall.tsx
@@ -14,7 +14,7 @@ export default class HeadingXSmall extends React.Component<Props> {
         tag: "h4",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.HeadingXSmall, style]}>

--- a/packages/wonder-blocks-typography/src/components/label-large.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-large.tsx
@@ -14,7 +14,7 @@ export default class LabelLarge extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.LabelLarge, style]}>

--- a/packages/wonder-blocks-typography/src/components/label-medium.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-medium.tsx
@@ -14,7 +14,7 @@ export default class LabelMedium extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.LabelMedium, style]}>

--- a/packages/wonder-blocks-typography/src/components/label-small.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-small.tsx
@@ -14,7 +14,7 @@ export default class LabelSmall extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.LabelSmall, style]}>

--- a/packages/wonder-blocks-typography/src/components/label-xsmall.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-xsmall.tsx
@@ -14,7 +14,7 @@ export default class LabelXSmall extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.LabelXSmall, style]}>

--- a/packages/wonder-blocks-typography/src/components/tagline.tsx
+++ b/packages/wonder-blocks-typography/src/components/tagline.tsx
@@ -14,7 +14,7 @@ export default class Tagline extends React.Component<Props> {
         tag: "span",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.Tagline, style]}>

--- a/packages/wonder-blocks-typography/src/components/title.tsx
+++ b/packages/wonder-blocks-typography/src/components/title.tsx
@@ -16,7 +16,7 @@ export default class Title extends React.Component<Props> {
         tag: "h1",
     };
 
-    render(): React.ReactElement {
+    render(): React.ReactNode {
         const {style, children, ...otherProps} = this.props;
         return (
             <Text {...otherProps} style={[styles.Title, style]}>


### PR DESCRIPTION
## Summary:
When updating wonder-blocks deps in webapp, I ran into a number of issues.  This PR fixes some of them, namely:
- isSet() is supposed to be a getter, but flow-to-typescript-codemod drop the 'getter'-ness of getters on interfaces
- the 'children' function on function-as-children components should be allowed to return a ReactNode so that children are more flexible in what they can return

I also made the return type of all render methods 'ReactNode' since that's what it is in the React.Component class definition.

Issue: None

## Test plan:
- yarn typecheck
- let CI run