### PR TITLE
FEI-5042.1: Fix issues with Flow types in wonder-blocks-core

### DIFF
--- a/.changeset/fluffy-geckos-switch.md
+++ b/.changeset/fluffy-geckos-switch.md
@@ -1,0 +1,6 @@
+---
+"wb-dev-build-settings": patch
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Fix issues with generate flow types in wonder-blocks-core

--- a/__docs__/wonder-blocks-core/with-ssr-placeholder.stories.tsx
+++ b/__docs__/wonder-blocks-core/with-ssr-placeholder.stories.tsx
@@ -48,7 +48,6 @@ export const Default: StoryComponentType = (args) => (
 );
 
 export const WithoutPlaceholder: StoryComponentType = (args) => (
-    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
     <WithSSRPlaceholder placeholder={null}>
         {() => (
             <View>

--- a/build-settings/gen-flow-types.ts
+++ b/build-settings/gen-flow-types.ts
@@ -10,14 +10,11 @@ const files = fglob.sync("packages/wonder-blocks-*/dist/**/*.d.ts", {
 
 for (const inFile of files) {
     const outFile = inFile.replace(".d.ts", ".js.flow");
-    const args = [
-        "flowgen",
-        inFile,
-        "-o",
-        outFile,
-        "--add-flow-header",
-        "--no-inexact",
-    ];
+    const args = ["flowgen", inFile, "-o", outFile, "--add-flow-header"];
+    const inexact = ["text.d.ts", "view.d.ts"].includes(path.basename(inFile));
+    if (!inexact) {
+        args.push("--no-inexact");
+    }
 
     try {
         execFileSync("yarn", args, {cwd: rootDir});

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-storybook": "^0.5.12",
     "eslint-plugin-testing-library": "^5.0.0",
     "eslint-watch": "^8.0.0",
-    "flowgen": "git+https://git@github.com/Khan/flowgen.git#4fa6d03d35fc4f0107d2be1aa55e6b9ed6a0326b",
+    "flowgen": "git+https://git@github.com/Khan/flowgen.git#6f8276dcf4ac9d8324d66c99589e3fb9e1cc8125",
     "glob": "^8.0.3",
     "jest": "^29.0.1",
     "jest-date-mock": "^1.0.8",

--- a/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.tsx
@@ -143,7 +143,6 @@ describe("UniqueIDProvider", () => {
             // Arrange
             const foo = jest.fn(() => null);
             const nodes = (
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                 <WithSSRPlaceholder placeholder={null}>
                     {() => (
                         <UniqueIDProvider mockOnFirstRender={false}>

--- a/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/with-ssr-placeholder.test.tsx
@@ -128,7 +128,6 @@ describe("WithSSRPlaceholder", () => {
             const mockChildren = jest.fn(() => null);
 
             const nodes = (
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                 <WithSSRPlaceholder placeholder={null}>
                     {mockChildren}
                 </WithSSRPlaceholder>
@@ -147,7 +146,6 @@ describe("WithSSRPlaceholder", () => {
                 // Arrange
                 const expectation = "CHILD PLACEHOLDER";
                 const placeholder = (
-                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                     <WithSSRPlaceholder placeholder={() => expectation}>
                         {() => "This won't render"}
                     </WithSSRPlaceholder>
@@ -244,7 +242,6 @@ describe("WithSSRPlaceholder", () => {
 
             const nodes = (
                 <RenderStateRoot>
-                    {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. */}
                     <WithSSRPlaceholder placeholder={null}>
                         {mockChildren}
                     </WithSSRPlaceholder>

--- a/packages/wonder-blocks-core/src/components/unique-id-provider.tsx
+++ b/packages/wonder-blocks-core/src/components/unique-id-provider.tsx
@@ -103,7 +103,6 @@ export default class UniqueIDProvider extends React.Component<Props> {
         // when we render and whether we provide a mock or real
         // identifier factory.
         return (
-            // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
             <WithSSRPlaceholder placeholder={() => this._performRender(true)}>
                 {() => this._performRender(false)}
             </WithSSRPlaceholder>

--- a/packages/wonder-blocks-core/src/components/with-ssr-placeholder.tsx
+++ b/packages/wonder-blocks-core/src/components/with-ssr-placeholder.tsx
@@ -22,7 +22,7 @@ type Props = {
      * the server-side renderer and the rehydration -- or it defeats
      * the purpose of using the WithSSRPlaceholder component.
      */
-    placeholder: () => React.ReactElement | null | undefined;
+    placeholder: (() => React.ReactNode) | null;
 };
 
 type State = {

--- a/packages/wonder-blocks-core/src/util/aria-types.ts
+++ b/packages/wonder-blocks-core/src/util/aria-types.ts
@@ -1,5 +1,8 @@
 // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
-export interface AriaAttributes {
+// NOTE(kevinb): This was change from an interface to a type to support
+// spreading of types in the generated Flow types.  Flow doesn't allow
+// spreading of interfaces b/c they're not sealed. 🦭
+export type AriaAttributes = {
     /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
     "aria-activedescendant"?: string | undefined;
     /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
@@ -226,7 +229,7 @@ export interface AriaAttributes {
     "aria-valuenow"?: number | undefined;
     /** Defines the human readable text alternative of aria-valuenow for a range widget. */
     "aria-valuetext"?: string | undefined;
-}
+};
 
 // All the WAI-ARIA 1.1 role attribute values from https://www.w3.org/TR/wai-aria-1.1/#role_definitions
 export type AriaRole =

--- a/yarn.lock
+++ b/yarn.lock
@@ -7985,9 +7985,9 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
-"flowgen@git+https://git@github.com/Khan/flowgen.git#4fa6d03d35fc4f0107d2be1aa55e6b9ed6a0326b":
+"flowgen@git+https://git@github.com/Khan/flowgen.git#6f8276dcf4ac9d8324d66c99589e3fb9e1cc8125":
   version "1.21.0"
-  resolved "git+https://git@github.com/Khan/flowgen.git#4fa6d03d35fc4f0107d2be1aa55e6b9ed6a0326b"
+  resolved "git+https://git@github.com/Khan/flowgen.git#6f8276dcf4ac9d8324d66c99589e3fb9e1cc8125"
   dependencies:
     "@babel/code-frame" "^7.16.7"
     "@babel/highlight" "^7.16.7"


### PR DESCRIPTION
## Summary:
- View and Text's props are now inexact since in the generated types to support random props being added to them in webapp
- AriaAttributes is a type now so that it can be spread in the generate flow types of various components
- ChangeEvent will now be converted to SyntheticInputEvent [flowgen#6f8276dcf4ac9d8324d66c99589e3fb9e1cc8125]
- ComponentType will not longer be changed [flowgen#6f8276dcf4ac9d8324d66c99589e3fb9e1cc8125]

See https://github.com/Khan/flowgen/pull/4 for flowgen changes.

Issue: FEI-5042

## Test plan:
- run flowgen manually on text.d.ts and view.d.ts without the '--no-inexact' flag, see that the generate .js.flow file uses inexact types for their props