### PR TITLE
Update gen-flow-types.ts to better handle JSX.LibraryManagedAttributes

### DIFF
--- a/.changeset/metal-games-compete.md
+++ b/.changeset/metal-games-compete.md
@@ -1,0 +1,5 @@
+---
+"wb-dev-build-settings": patch
+---
+
+Convert JSX.LibraryManagedAttributes<> containing a React.ElementProps<> to React.ElementConfig<>

--- a/build-settings/gen-flow-types.ts
+++ b/build-settings/gen-flow-types.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as fglob from "fast-glob";
 
 const rootDir = path.join(__dirname, "..");
-const files = fglob.sync("packages/wonder-blocks-typography/dist/**/*.d.ts", {
+const files = fglob.sync("packages/wonder-blocks-*/dist/**/*.d.ts", {
     cwd: rootDir,
 });
 

--- a/build-settings/gen-flow-types.ts
+++ b/build-settings/gen-flow-types.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as fglob from "fast-glob";
 
 const rootDir = path.join(__dirname, "..");
-const files = fglob.sync("packages/wonder-blocks-*/dist/**/*.d.ts", {
+const files = fglob.sync("packages/wonder-blocks-typography/dist/**/*.d.ts", {
     cwd: rootDir,
 });
 
@@ -52,7 +52,7 @@ for (const inFile of files) {
         }
         if (contents.includes("JSX.LibraryManagedAttributes")) {
             contents = contents.replace(
-                /JSX\.LibraryManagedAttributes<\s+([^,]+),\s+React\.ComponentProps<[^>]+>\s+>/gm,
+                /JSX\.LibraryManagedAttributes<\s+([^,]+),\s+React\.(Element|Component)Props<[^>]+>\s+>/gm,
                 (substr, group) => {
                     const replacement = `React.ElementConfig<${group}>`;
                     console.log(`replacing '${substr}' with '${replacement}'`);


### PR DESCRIPTION
## Summary:
Some uses of JSX.LibraryManagedAttributes<> use React.ComponentProps and other use React.ElementProps.  This PR updates gen-flow-types.ts to handle both cases.

Issue: None

## Test plan:
- change the glob in gen-flow-types.ts to wonder-blocks-typography
- yarn build:types
- yarn build:flowtypes
- see the following in the console log

  replacing 'JSX.LibraryManagedAttributes<
    typeof Text,
    React.ElementProps<typeof Text>
  >' with 'React.ElementConfig<typeof Text>'