### PR TITLE
Update <Data>'s 'children' prop to allow a ReactNode to be returned

### DIFF
--- a/.changeset/six-kiwis-divide.md
+++ b/.changeset/six-kiwis-divide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+---
+
+Update <Data>'s 'children' prop to allow a ReactNode to be returned

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.tsx
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.tsx
@@ -54,7 +54,6 @@ describe("Data", () => {
                 // Act
                 render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -74,7 +73,6 @@ describe("Data", () => {
                 // Act
                 render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -98,11 +96,9 @@ describe("Data", () => {
                 render(
                     <View>
                         <Data handler={fakeHandler} requestId="ID">
-                            {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                             {fakeChildrenFn}
                         </Data>
                         <Data handler={fakeHandler} requestId="ID">
-                            {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                             {fakeChildrenFn}
                         </Data>
                     </View>,
@@ -124,7 +120,6 @@ describe("Data", () => {
                 // Act
                 render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -159,7 +154,6 @@ describe("Data", () => {
                 // Act
                 render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -191,7 +185,6 @@ describe("Data", () => {
                 // Act
                 render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -222,7 +215,6 @@ describe("Data", () => {
                 // Act
                 render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -252,7 +244,6 @@ describe("Data", () => {
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -265,7 +256,6 @@ describe("Data", () => {
                 // Act
                 wrapper.rerender(
                     <Data handler={fakeHandler} requestId="NEW_ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -296,13 +286,11 @@ describe("Data", () => {
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = render(
                     <Data handler={oldHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
                 wrapper.rerender(
                     <Data handler={oldHandler} requestId="NEW_ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -332,13 +320,11 @@ describe("Data", () => {
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = render(
                     <Data handler={oldHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
                 wrapper.rerender(
                     <Data handler={oldHandler} requestId="NEW_ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -372,13 +358,11 @@ describe("Data", () => {
                 const fakeChildrenFn = jest.fn(() => null);
                 const wrapper = render(
                     <Data handler={oldHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
                 wrapper.rerender(
                     <Data handler={oldHandler} requestId="NEW_ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -409,7 +393,6 @@ describe("Data", () => {
                     render(
                         <InterceptRequests interceptor={interceptHandler}>
                             <Data handler={fakeHandler} requestId="ID">
-                                {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                                 {fakeChildrenFn}
                             </Data>
                         </InterceptRequests>,
@@ -431,7 +414,6 @@ describe("Data", () => {
                     render(
                         <InterceptRequests interceptor={interceptHandler}>
                             <Data handler={fakeHandler} requestId="ID">
-                                {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                                 {fakeChildrenFn}
                             </Data>
                         </InterceptRequests>,
@@ -459,7 +441,6 @@ describe("Data", () => {
                         requestId="ID1"
                         retainResultOnChange={true}
                     >
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -472,7 +453,6 @@ describe("Data", () => {
                         requestId="ID2"
                         retainResultOnChange={true}
                     >
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -518,7 +498,6 @@ describe("Data", () => {
                 // Act
                 render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -544,7 +523,6 @@ describe("Data", () => {
                             WhenClientSide.ExecuteWhenNoSuccessResult
                         }
                     >
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -565,7 +543,6 @@ describe("Data", () => {
                         requestId="ID"
                         clientBehavior={WhenClientSide.AlwaysExecute}
                     >
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -599,7 +576,6 @@ describe("Data", () => {
                 // Act
                 render(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -634,7 +610,6 @@ describe("Data", () => {
                 // Act
                 ReactDOMServer.renderToString(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -651,7 +626,6 @@ describe("Data", () => {
                 // Act
                 ReactDOMServer.renderToString(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -675,7 +649,6 @@ describe("Data", () => {
                 ReactDOMServer.renderToString(
                     <TrackData>
                         <Data handler={fakeHandler} requestId="ID">
-                            {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                             {fakeChildrenFn}
                         </Data>
                     </TrackData>,
@@ -702,7 +675,6 @@ describe("Data", () => {
                     ReactDOMServer.renderToString(
                         <InterceptRequests interceptor={interceptedHandler}>
                             <Data handler={fakeHandler} requestId="ID">
-                                {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                                 {fakeChildrenFn}
                             </Data>
                         </InterceptRequests>,
@@ -730,7 +702,6 @@ describe("Data", () => {
                         <TrackData>
                             <InterceptRequests interceptor={interceptedHandler}>
                                 <Data handler={fakeHandler} requestId="ID">
-                                    {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                                     {fakeChildrenFn}
                                 </Data>
                             </InterceptRequests>
@@ -766,7 +737,6 @@ describe("Data", () => {
                 // Act
                 ReactDOMServer.renderToString(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -783,7 +753,6 @@ describe("Data", () => {
                 // Act
                 ReactDOMServer.renderToString(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -806,7 +775,6 @@ describe("Data", () => {
                 // Act
                 ReactDOMServer.renderToString(
                     <Data handler={fakeHandler} requestId="ID">
-                        {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                         {fakeChildrenFn}
                     </Data>,
                 );
@@ -831,7 +799,6 @@ describe("Data", () => {
                 ReactDOMServer.renderToString(
                     <TrackData>
                         <Data handler={fakeHandler} requestId="ID">
-                            {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                             {fakeChildrenFn}
                         </Data>
                     </TrackData>,
@@ -857,7 +824,6 @@ describe("Data", () => {
                     ReactDOMServer.renderToString(
                         <InterceptRequests interceptor={interceptHandler}>
                             <Data handler={fakeHandler} requestId="ID">
-                                {/* @ts-expect-error [FEI-5019] - TS2322 - Type 'Mock<null, [], any>' is not assignable to type '((result: Result<TData>) => ReactElement<any, string | JSXElementConstructor<any>>) & ReactNode'. */}
                                 {fakeChildrenFn}
                             </Data>
                         </InterceptRequests>,

--- a/packages/wonder-blocks-data/src/components/data.ts
+++ b/packages/wonder-blocks-data/src/components/data.ts
@@ -48,7 +48,7 @@ type Props<
      * loading state and data or error that gets retrieved from cache or loaded
      * via the request if no cached value is available.
      */
-    children: (result: Result<TData>) => React.ReactElement;
+    children: (result: Result<TData>) => React.ReactNode;
 };
 
 /**
@@ -57,18 +57,18 @@ type Props<
  * support server-side rendering and efficient caching.
  */
 // TODO(FEI-5000): Update this support generic props correctly
-const Data: React.FC<Props<any>> = <TData extends ValidCacheData>({
+const Data: React.FC<Props<any>> = (<TData extends ValidCacheData>({
     requestId,
     handler,
     children,
     retainResultOnChange = false,
     clientBehavior = WhenClientSide.ExecuteWhenNoSuccessResult,
-}: Props<TData>): React.ReactElement => {
+}: Props<TData>): React.ReactNode => {
     const result = useHydratableEffect(requestId, handler, {
         retainResultOnChange,
         clientBehavior,
     });
     return children(result);
-};
+}) as React.FC<Props<any>>;
 
 export default Data;


### PR DESCRIPTION
## Summary:
Callbacks should always allow React.ReactNodes to be returned.  I missed updating this one in wonder-blocks-data.  I'm updating wonder-blocks-data at the same time as wonder-blocks-core.  I tested this change in webapp by editing node_modules directly.

Issue: None

## Test plan:
- yarn build:types
- yarn build:flowtypes
- see that the 'children' prop in data.js.flow now allows a 'React.Node' to be returned.