### PR TITLE
[🔥AUDIT🔥] Fix DocumentNode Flow type

### DIFF
--- a/.changeset/good-lemons-stare.md
+++ b/.changeset/good-lemons-stare.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+---
+
+Fix DocumentNode type definition

--- a/packages/wonder-blocks-data/src/util/graphql-types.js.flow
+++ b/packages/wonder-blocks-data/src/util/graphql-types.js.flow
@@ -1,0 +1,30 @@
+// @flow
+// NOTE(somewhatabstract):
+// These types are bare minimum to support document parsing. They're derived
+// from graphql@14.5.8, the last version that provided flow types.
+// Doing this avoids us having to take a dependency on that library just for
+// these types.
+export interface DefinitionNode {
+    +kind: string;
+}
+
+export type VariableDefinitionNode = {
+    +kind: "VariableDefinition",
+    ...
+};
+
+export interface OperationDefinitionNode extends DefinitionNode {
+    +kind: "OperationDefinition";
+    +operation: string;
+    +variableDefinitions: $ReadOnlyArray<VariableDefinitionNode>;
+    +name?: {|
+        +kind: mixed,
+        +value: string,
+    |};
+}
+
+export type DocumentNode = {
+    +kind: "Document",
+    +definitions: $ReadOnlyArray<DefinitionNode>,
+    ...
+};

--- a/packages/wonder-blocks-data/src/util/graphql-types.ts
+++ b/packages/wonder-blocks-data/src/util/graphql-types.ts
@@ -1,3 +1,4 @@
+// WARNING: If you modify this file you must update graphql-types.js.flow.
 // NOTE(somewhatabstract):
 // These types are bare minimum to support document parsing. They're derived
 // from graphql@14.5.8, the last version that provided TypeScript types.


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Fixing #1803 revealed other issues in the Flow type definitions for wonder-blocks-data.  I'm not sure why these didn't show up when I was testing the changes from #1803 in webapp.

Issue: None

## Test plan:
- apply the changes manually in webapp, restart flow, see all of the DocumentNode errors go away