### PR TITLE
Add startIcon and endIcon props to Link

### DIFF
--- a/__docs__/wonder-blocks-link/link.argtypes.ts
+++ b/__docs__/wonder-blocks-link/link.argtypes.ts
@@ -9,6 +9,16 @@ export default {
         type: {name: "string", required: true},
     },
 
+    endIcon: {
+        control: {type: "text"},
+        description: `Icon to appear after the link label. If
+        \`target="_blank"\` and an \`endIcon\` is passed in, \`endIcon\` will
+        override the default \`externalIcon\`.`,
+        table: {
+            type: {summary: "IconAsset"},
+        },
+    },
+
     href: {
         control: {type: "text"},
         description: "URL to navigate to.",
@@ -95,6 +105,14 @@ export default {
         description: "Test ID used for e2e testing.",
         table: {
             type: {summary: "string"},
+        },
+    },
+
+    startIcon: {
+        control: {type: "text"},
+        description: "Icon to appear before the link label.",
+        table: {
+            type: {summary: "IconAsset"},
         },
     },
 

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -22,6 +22,7 @@ import {name, version} from "../../packages/wonder-blocks-link/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import LinkArgTypes from "./link.argtypes";
+import {icons} from "@khanacademy/wonder-blocks-icon";
 
 export default {
     title: "Link",
@@ -197,9 +198,83 @@ export const OpensInANewTab: StoryComponentType = () => (
 
 OpensInANewTab.parameters = {
     docs: {
-        storyDescription: `When \`target="_blank"\`, the external icon is
-        automatically added to the end of the link. This indicates that the link
-        will open in a new tab.`,
+        storyDescription: `When \`target="_blank"\`, the external icon is automatically
+        added to the end of the link. This indicates that the link will open in a new
+        tab.`,
+    },
+};
+
+export const StartAndEndIcons: StoryComponentType = () => (
+    <View>
+        {/* Default (dark) */}
+        <View style={{padding: Spacing.large_24}}>
+            <Link
+                href="#"
+                startIcon={icons.add}
+                style={styles.standaloneLinkWrapper}
+            >
+                This link has a start icon
+            </Link>
+            <Link
+                href="#"
+                endIcon={icons.caretRight}
+                kind="secondary"
+                style={styles.standaloneLinkWrapper}
+            >
+                This link has an end icon
+            </Link>
+            <Link
+                href="#"
+                endIcon={icons.info}
+                target="_blank"
+                style={styles.standaloneLinkWrapper}
+            >
+                This external link has an end icon that is overrides the default
+                external icon
+            </Link>
+        </View>
+        {/* Light */}
+        <View
+            style={{
+                backgroundColor: Color.darkBlue,
+                padding: Spacing.large_24,
+            }}
+        >
+            <Link
+                href="#"
+                startIcon={icons.add}
+                light={true}
+                style={styles.standaloneLinkWrapper}
+            >
+                This link has a start icon
+            </Link>
+            <Link
+                href="#"
+                endIcon={icons.caretRight}
+                light={true}
+                style={styles.standaloneLinkWrapper}
+            >
+                This link has an end icon
+            </Link>
+            <Link
+                href="#"
+                endIcon={icons.info}
+                target="_blank"
+                light={true}
+                style={styles.standaloneLinkWrapper}
+            >
+                This external link has an end icon that is overrides the default
+                external icon
+            </Link>
+        </View>
+    </View>
+);
+
+StartAndEndIcons.parameters = {
+    docs: {
+        storyDescription: `Link can take an optional \`startIcon\` and/or \`endIcon\`. If
+        \`target="_blank"\` and an \`endIcon\` prop is passed in, then \`endIcon\` will
+        override the default \`externalIcon\`.`,
     },
 };
 

--- a/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
@@ -4,6 +4,7 @@ import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Color from "@khanacademy/wonder-blocks-color";
+import {icons} from "@khanacademy/wonder-blocks-icon";
 
 import Link from "../link";
 
@@ -453,7 +454,7 @@ describe("Link", () => {
             expect(link).toHaveAttribute("target", "_blank");
         });
 
-        test("render icon when `target=_blank`", () => {
+        test("render externalIcon when `target=_blank`", () => {
             // Arrange
             render(
                 <Link href="/" target="_blank">
@@ -470,7 +471,7 @@ describe("Link", () => {
             expect(icon).toBeInTheDocument();
         });
 
-        test("does not render icon", () => {
+        test("does not render externalIcon", () => {
             // Arrange
             render(<Link href="/">Click me!</Link>);
 
@@ -479,6 +480,126 @@ describe("Link", () => {
 
             // Assert
             expect(icon).not.toBeInTheDocument();
+        });
+    });
+
+    describe("startIcon and endIcon", () => {
+        test("startIcon passed down correctly", () => {
+            // Arrange
+            render(
+                <Link href="/" startIcon={icons.add}>
+                    Add new item
+                </Link>,
+            );
+
+            // Act
+            const link = screen.getByText("Add new item");
+
+            // Assert
+            expect(link).toHaveAttribute("startIcon", `${icons.add}`);
+        });
+
+        test("render startIcon", () => {
+            // Arrange
+            render(
+                <Link href="/" startIcon={icons.add}>
+                    Add new item
+                </Link>,
+            );
+
+            // Act
+            const link = screen.getByText("Add new item");
+            const icon = screen.getByTestId("start-icon");
+
+            // Assert
+            expect(link.innerHTML).toEqual(expect.stringContaining("<svg"));
+            expect(icon).toBeInTheDocument();
+        });
+
+        test("does not render startIcon", () => {
+            // Arrange
+            render(<Link href="/">Click me!</Link>);
+
+            // Act
+            const icon = screen.queryByTestId("start-icon");
+
+            // Assert
+            expect(icon).not.toBeInTheDocument();
+        });
+
+        test("endIcon passed down correctly", () => {
+            // Arrange
+            render(
+                <Link href="/" endIcon={icons.caretRight}>
+                    Click to go back
+                </Link>,
+            );
+
+            // Act
+            const link = screen.getByText("Click to go back");
+
+            // Assert
+            expect(link).toHaveAttribute("endIcon", `${icons.caretRight}`);
+        });
+
+        test("render endIcon", () => {
+            // Arrange
+            render(
+                <Link href="/" endIcon={icons.caretRight}>
+                    Click to go back
+                </Link>,
+            );
+
+            // Act
+            const link = screen.getByText("Click to go back");
+            const icon = screen.getByTestId("end-icon");
+
+            // Assert
+            expect(link.innerHTML).toEqual(expect.stringContaining("<svg"));
+            expect(icon).toBeInTheDocument();
+        });
+
+        test("does not render endIcon", () => {
+            // Arrange
+            render(<Link href="/">Click me!</Link>);
+
+            // Act
+            const icon = screen.queryByTestId("end-icon");
+
+            // Assert
+            expect(icon).not.toBeInTheDocument();
+        });
+
+        test("does not render externalIcon when endIcon present and `target='_blank'`", () => {
+            // Arrange
+            render(
+                <Link href="/" endIcon={icons.caretRight} target="_blank">
+                    Open a new tab
+                </Link>,
+            );
+
+            // Act
+            const externalIcon = screen.queryByTestId("external-icon");
+
+            // Assert
+            expect(externalIcon).not.toBeInTheDocument();
+        });
+
+        test("render endIcon when `target='_blank'`", () => {
+            // Arrange
+            render(
+                <Link href="/" endIcon={icons.caretRight} target="_blank">
+                    Open a new tab
+                </Link>,
+            );
+
+            // Act
+            const link = screen.getByText("Open a new tab");
+            const endIcon = screen.getByTestId("end-icon");
+
+            // Assert
+            expect(link.innerHTML).toEqual(expect.stringContaining("<svg"));
+            expect(endIcon).toBeInTheDocument();
         });
     });
 });

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -70,6 +70,8 @@ export default class LinkCore extends React.Component<Props> {
             "data-test-id": testId,
             style: [defaultStyles, style],
             target,
+            startIcon,
+            endIcon,
             ...restProps,
         } as const;
 
@@ -88,13 +90,23 @@ export default class LinkCore extends React.Component<Props> {
         );
 
         const startIconChild = startIcon ? (
-            <Icon icon={startIcon} size="small" style={iconStyles.startIcon} />
+            <Icon
+                icon={startIcon}
+                size="small"
+                style={iconStyles.startIcon}
+                testId="start-icon"
+            />
         ) : (
             <></>
         );
 
         const endIconChild = endIcon ? (
-            <Icon icon={endIcon} size="small" style={iconStyles.endIcon} />
+            <Icon
+                icon={endIcon}
+                size="small"
+                style={iconStyles.endIcon}
+                testId="end-icon"
+            />
         ) : (
             target === "_blank" && externalIcon
         );

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -43,6 +43,8 @@ export default class LinkCore extends React.Component<Props> {
             testId,
             waiting: _,
             target,
+            startIcon,
+            endIcon,
             ...restProps
         } = this.props;
 
@@ -71,6 +73,7 @@ export default class LinkCore extends React.Component<Props> {
             ...restProps,
         } as const;
 
+        // Default external icon
         const externalIconPath: IconAsset = {
             small: "M14 6.5C14 6.63261 13.9473 6.75979 13.8536 6.85355C13.7598 6.94732 13.6326 7 13.5 7C13.3674 7 13.2402 6.94732 13.1464 6.85355C13.0527 6.75979 13 6.63261 13 6.5V3.7075L8.85437 7.85375C8.76055 7.94757 8.63331 8.00028 8.50062 8.00028C8.36794 8.00028 8.2407 7.94757 8.14688 7.85375C8.05306 7.75993 8.00035 7.63268 8.00035 7.5C8.00035 7.36732 8.05306 7.24007 8.14688 7.14625L12.2925 3H9.5C9.36739 3 9.24021 2.94732 9.14645 2.85355C9.05268 2.75979 9 2.63261 9 2.5C9 2.36739 9.05268 2.24021 9.14645 2.14645C9.24021 2.05268 9.36739 2 9.5 2H13.5C13.6326 2 13.7598 2.05268 13.8536 2.14645C13.9473 2.24021 14 2.36739 14 2.5V6.5ZM11.5 8C11.3674 8 11.2402 8.05268 11.1464 8.14645C11.0527 8.24021 11 8.36739 11 8.5V13H3V5H7.5C7.63261 5 7.75979 4.94732 7.85355 4.85355C7.94732 4.75979 8 4.63261 8 4.5C8 4.36739 7.94732 4.24021 7.85355 4.14645C7.75979 4.05268 7.63261 4 7.5 4H3C2.73478 4 2.48043 4.10536 2.29289 4.29289C2.10536 4.48043 2 4.73478 2 5V13C2 13.2652 2.10536 13.5196 2.29289 13.7071C2.48043 13.8946 2.73478 14 3 14H11C11.2652 14 11.5196 13.8946 11.7071 13.7071C11.8946 13.5196 12 13.2652 12 13V8.5C12 8.36739 11.9473 8.24021 11.8536 8.14645C11.7598 8.05268 11.6326 8 11.5 8Z",
         };
@@ -79,15 +82,28 @@ export default class LinkCore extends React.Component<Props> {
             <Icon
                 icon={externalIconPath}
                 size="small"
-                style={iconStyles.icon}
+                style={iconStyles.endIcon}
                 testId="external-icon"
             />
         );
 
+        const startIconChild = startIcon ? (
+            <Icon icon={startIcon} size="small" style={iconStyles.startIcon} />
+        ) : (
+            <></>
+        );
+
+        const endIconChild = endIcon ? (
+            <Icon icon={endIcon} size="small" style={iconStyles.endIcon} />
+        ) : (
+            target === "_blank" && externalIcon
+        );
+
         const linkContent = (
             <>
+                {startIconChild}
                 {children}
-                {target === "_blank" && externalIcon}
+                {endIconChild}
             </>
         );
 
@@ -114,7 +130,11 @@ export default class LinkCore extends React.Component<Props> {
 const styles: Record<string, any> = {};
 
 const iconStyles = StyleSheet.create({
-    icon: {
+    startIcon: {
+        marginRight: Spacing.xxxSmall_4,
+    },
+
+    endIcon: {
         marginLeft: Spacing.xxxSmall_4,
     },
 });

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -4,6 +4,7 @@ import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
+import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 import LinkCore from "./link-core";
 
 // TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
@@ -136,6 +137,16 @@ export type SharedProps = AriaProps & {
      * navigation.
      */
     beforeNav?: () => Promise<unknown>;
+    /**
+     * An optional icon displayed before the link label.
+     */
+    startIcon?: IconAsset;
+    /**
+     * An optional icon displayed after the link label.
+     * If `target="_blank"` and `endIcon` is passed in, `endIcon` will override
+     * the default `externalIcon`.
+     */
+    endIcon?: IconAsset;
 };
 
 type DefaultProps = {


### PR DESCRIPTION
## Summary:
- Adds optional `startIcon` and `endIcon` props to `Link`
- `endIcon` overrides the default external icon when `target="_blank"`, so if `endIcon` is passed in, it will show `endIcon` after the link label instead of `externalIcon`.
- Adds story for links with start and end icons, as well as an external link using `endIcon` in place of `externalIcon` (screenshot)

    <img width="602" alt="Screenshot 2023-03-16 at 1 18 39 PM" src="https://user-images.githubusercontent.com/100858764/225700501-d1295d89-6fb6-42e4-ba35-c2c36e9462de.png">

Issue: WB-1085

## Test plan:
- Ran yarn test and yarn typecheck
- Set start and end icons in control panel and inspected change in the DOM
- Set `endIcon` and `target` to `"_blank"`, confirmed that `endIcon` renders instead of `externalIcon`, and inspected in the DOM 
  
  - <img width="123" alt="Screenshot 2023-03-16 at 1 59 59 PM" src="https://user-images.githubusercontent.com/100858764/225711278-19fd1037-9076-4a53-b2e2-508ab8ebe33c.png">
  - <img width="314" alt="Screenshot 2023-03-16 at 2 00 10 PM" src="https://user-images.githubusercontent.com/100858764/225711370-d5e37b4d-0db4-404a-ae87-15e611ff6508.png">
- Added unit tests to check if:
  - icon props are passed down correctly
  - icons are rendered with link when icon props are passed in
  - icons are **not** rendered when icon props are **not** passed in 
  - `endIcon` is rendered instead of `externalIcon` when `target="_blank"`