### PR TITLE
Fix issue with some React.Element<> Flow types and more

### DIFF
--- a/.changeset/poor-trainers-join.md
+++ b/.changeset/poor-trainers-join.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-i18n": patch
+---
+
+Update callback props to a ReactNode to be returned

--- a/.changeset/soft-cherries-boil.md
+++ b/.changeset/soft-cherries-boil.md
@@ -1,0 +1,5 @@
+---
+"wb-dev-build-settings": patch
+---
+
+Post-process React.Element<React.ElementProps<T>> to React.Element<T>

--- a/build-settings/gen-flow-types.ts
+++ b/build-settings/gen-flow-types.ts
@@ -71,6 +71,16 @@ for (const inFile of files) {
                 },
             );
         }
+        if (contents.includes("React.Element<React.ElementProps<")) {
+            contents = contents.replace(
+                /React\.Element<(React\.ElementProps<([^>]+)>)>/gm,
+                (substr, group1, group2) => {
+                    const replacement = `React.Element<${group2}>`;
+                    console.log(`replacing '${substr}' with '${replacement}'`);
+                    return replacement;
+                },
+            );
+        }
 
         fs.writeFileSync(
             path.join(rootDir, outFile),

--- a/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.tsx
+++ b/packages/wonder-blocks-i18n/src/components/i18n-inline-markup.tsx
@@ -109,8 +109,8 @@ type Props = {
         elem: React.ReactNode,
         type: string,
         i: number,
-    ) => React.ReactElement;
-    onError?: (e: Error) => React.ReactElement;
+    ) => React.ReactNode;
+    onError?: (e: Error) => React.ReactNode;
 };
 
 export class I18nInlineMarkup extends React.PureComponent<Props> {
@@ -118,7 +118,7 @@ export class I18nInlineMarkup extends React.PureComponent<Props> {
      * If an error occurs, we either call the onError prop, or throw the
      * error.
      */
-    handleError(error: Error): React.ReactElement {
+    handleError(error: Error): React.ReactNode {
         const {onError} = this.props;
 
         if (onError) {


### PR DESCRIPTION
## Summary:
Many of our components use 'children: React.Element<typeof Component>' (Flow) to restrict which components can be used as children.  In TypeScript the pattern is 'React.ReactElement<React.ComponentProps<typeof Component>>' which flowgen was converting to 'React.ReactElement<React.ComponentProps<typeof Component>>' which is wrong for Flow.

This PR updates gen-flow-types.ts to fix this using a regex to post process the incorrect type.  We'll want to port this to flowgen for use with converting perseus and webapp.

Issue: FEI-5042

## Test plan:
- change the glob in gen-flow-types.ts to wonder-blocks-breadcrumbs
- yarn build:types
- yarn build:flowtypes
- check that the generate .js.flow files for wonder-blocks-breadcrumbs are correct