### PR TITLE
[🔥AUDIT🔥] Handle React.Element<React.ElementProps<...>> spanning multiple lines

### DIFF
--- a/.changeset/famous-donuts-tan.md
+++ b/.changeset/famous-donuts-tan.md
@@ -1,0 +1,5 @@
+---
+"wb-dev-build-settings": patch
+---
+
+Generate proper Flow types for React.Element<React.ElementProps<...>> spanning multiple

--- a/build-settings/gen-flow-types.ts
+++ b/build-settings/gen-flow-types.ts
@@ -73,9 +73,9 @@ for (const inFile of files) {
         }
         if (contents.includes("React.Element<React.ElementProps<")) {
             contents = contents.replace(
-                /React\.Element<(React\.ElementProps<([^>]+)>)>/gm,
+                /React\.Element<\s*(React\.ElementProps<\s*([^>]+)>\s*)>/gm,
                 (substr, group1, group2) => {
-                    const replacement = `React.Element<${group2}>`;
+                    const replacement = `React.Element<${group2.trim()}>`;
                     console.log(`replacing '${substr}' with '${replacement}'`);
                     return replacement;
                 },

--- a/build-settings/gen-flow-types.ts
+++ b/build-settings/gen-flow-types.ts
@@ -71,7 +71,7 @@ for (const inFile of files) {
                 },
             );
         }
-        if (contents.includes("React.Element<React.ElementProps<")) {
+        if (/React\.Element<\s*React\.ElementProps</.test(contents)) {
             contents = contents.replace(
                 /React\.Element<\s*(React\.ElementProps<\s*([^>]+)>\s*)>/gm,
                 (substr, group1, group2) => {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
It turns out that some of these types span multiple lines so we need to handle that.

Issue: None

## Test plan:
- Test the new regex out on regex101.com against single line and multi-line cases

<img width="657" alt="Screen Shot 2023-03-17 at 4 35 27 PM" src="https://user-images.githubusercontent.com/1044413/226036392-d2966c06-7f53-439a-9db8-d17770cf2dfb.png">

- Temporarily change glob to `wonder-blocks-dropdown` and run `yarn build:flowtypes`
- Check the output for dist/util/types.js.flow to see that multi-line instances of these types are being handled correctly

**dist/util/types.js.flow**
```
export type Item =
  | false
  | React.Element<typeof ActionItem | typeof OptionItem | typeof SeparatorItem>;
```