### PR TITLE
[🔥AUDIT🔥] [fixmockgqlfetch] Fix the indentation for outputting GQL operations

### DIFF
--- a/.changeset/dull-trainers-peel.md
+++ b/.changeset/dull-trainers-peel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Fix indentation change in mockGqlFetch

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.ts
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.ts
@@ -8,8 +8,11 @@ import type {GqlFetchMockFn, GqlMockOperation} from "./types";
 export const mockGqlFetch = (): GqlFetchMockFn =>
     mockRequester<GqlMockOperation<any, any, any>, any>(
         gqlRequestMatchesMock,
+        // Note that the identation at the start of each line is important.
         (operation, variables, context) =>
             `Operation: ${operation.type} ${operation.id}
-Variables: ${variables == null ? "None" : JSON.stringify(variables, null, 2)}
-Context: ${JSON.stringify(context, null, 2)}`,
+    Variables: ${
+        variables == null ? "None" : JSON.stringify(variables, null, 2)
+    }
+    Context: ${JSON.stringify(context, null, 2)}`,
     );


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The codemod used for the changes in https://github.com/Khan/wonder-blocks/pull/1749 stripped the indentation from this template literal. This fixes that.

Issue: FEI-5042

## Test plan:
The snapshot tests in webapp caught this. If they pass without udpate, we know it's fixed.