### PR TITLE
[🔥AUDIT🔥] [fixfetchmock] Fix formatting of fetch mock errors

### DIFF
--- a/.changeset/pink-terms-fry.md
+++ b/.changeset/pink-terms-fry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Fix regression in error message formatting for fetch mocking

--- a/packages/wonder-blocks-testing/src/fetch/__tests__/__snapshots__/mock-fetch.test.ts.snap
+++ b/packages/wonder-blocks-testing/src/fetch/__tests__/__snapshots__/mock-fetch.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`#mockFetch should reject with a useful error when there are no matching mocks for %s 1`] = `
 "No matching mock response found for request:
     Input: http://example.com/foo
-Options: None"
+    Options: None"
 `;
 
 exports[`#mockFetch should reject with a useful error when there are no matching mocks for %s 2`] = `
 "No matching mock response found for request:
     Input: "http://example.com/foo"
-Options: {
+    Options: {
   "method": "GET"
 }"
 `;
@@ -23,7 +23,7 @@ exports[`#mockFetch should reject with a useful error when there are no matching
   "compress": true,
   "counter": 0
 }
-Options: {
+    Options: {
   "method": "POST"
 }"
 `;

--- a/packages/wonder-blocks-testing/src/fetch/mock-fetch.ts
+++ b/packages/wonder-blocks-testing/src/fetch/mock-fetch.ts
@@ -8,11 +8,13 @@ import type {FetchMockFn, FetchMockOperation} from "./types";
 export const mockFetch = (): FetchMockFn =>
     mockRequester<FetchMockOperation, any>(
         fetchRequestMatchesMock,
+        // NOTE(somewhatabstract): The indentation is expected on the lines
+        // here.
         (input, init) =>
             `Input: ${
                 typeof input === "string"
                     ? input
                     : JSON.stringify(input, null, 2)
             }
-Options: ${init == null ? "None" : JSON.stringify(init, null, 2)}`,
+    Options: ${init == null ? "None" : JSON.stringify(init, null, 2)}`,
     );


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This fixes a regression that was introduced via the codemod in https://github.com/Khan/wonder-blocks/pull/1749.

Issue: FEI-5042

## Test plan:
`yarn test`
Also will verify that the existing snapshots in webapp pass as-is with this change.