### PR TITLE
Fix moment import

### DIFF
--- a/.changeset/metal-carrots-wonder.md
+++ b/.changeset/metal-carrots-wonder.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": patch
+---
+
+Don't use named imports when importing 'moment' since it doesn't work with vite

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -1,4 +1,4 @@
-import moment from "moment"; // NOTE: 'moment' does not support named imports
+import moment from "moment"; // NOTE: DO NOT use named imports; 'moment' does not support named imports
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -1,4 +1,4 @@
-import moment, {monthsShort} from "moment";
+import moment from "moment"; // NOTE: 'moment' does not support named imports
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
@@ -276,7 +276,8 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 style={{minWidth}}
                 testId="birthday-picker-month"
             >
-                {monthsShort().map((month, i) => (
+                {/* eslint-disable-next-line import/no-named-as-default-member */}
+                {moment.monthsShort().map((month, i) => (
                     <OptionItem key={month} label={month} value={String(i)} />
                 ))}
             </SingleSelect>


### PR DESCRIPTION
## Summary:
Using a named import confuses vite since moment doesn't have true named exports.  It isn't an ES6 module.

Issue: None

## Test plan:
- apply this change manually in webapp's node_modules folder
- clear the vite cache by deleting node_modules/.vite
- restart vite
- see that the logged out homepage loads at localhost:8224/