### PR TITLE
FEI-5092: Remove ref-forwarding from withActionScheduler

### DIFF
--- a/.changeset/sweet-pets-hear.md
+++ b/.changeset/sweet-pets-hear.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-timing": major
+---
+
+Remove ref-forwarding from withActionScheduler

--- a/packages/wonder-blocks-timing/src/components/__tests__/with-action-scheduler.test.tsx
+++ b/packages/wonder-blocks-timing/src/components/__tests__/with-action-scheduler.test.tsx
@@ -8,7 +8,7 @@ import type {WithActionSchedulerProps} from "../../util/types";
 describe("withActionScheduler", () => {
     it("should provide wrapped component with IScheduleActions instance", () => {
         // Arrange
-        const Component = (props: any) => (
+        const Component = (props: WithActionSchedulerProps) => (
             <>{props.schedule != null ? "true" : "false"}</>
         );
 
@@ -18,22 +18,5 @@ describe("withActionScheduler", () => {
 
         // Assert
         expect(screen.getByText("true")).toBeInTheDocument();
-    });
-
-    it("should forward a ref", () => {
-        // Arrange
-        class Component extends React.Component<WithActionSchedulerProps> {
-            render(): React.ReactElement {
-                return <div>Hello, world!</div>;
-            }
-        }
-        const TestComponent = withActionScheduler(Component);
-        let ref: unknown = null;
-
-        // Act
-        render(<TestComponent ref={(node: any) => (ref = node)} />);
-
-        // Assert
-        expect(ref).toBeInstanceOf(Component);
     });
 });

--- a/packages/wonder-blocks-timing/src/components/with-action-scheduler.tsx
+++ b/packages/wonder-blocks-timing/src/components/with-action-scheduler.tsx
@@ -18,15 +18,11 @@ type WithoutActionScheduler<T> = Omit<T, "schedule">;
 export default function withActionScheduler<
     Props extends WithActionSchedulerProps,
 >(WrappedComponent: React.ComponentType<Props>) {
-    return React.forwardRef((props: WithoutActionScheduler<Props>, ref) => (
+    return (props: WithoutActionScheduler<Props>) => (
         <ActionSchedulerProvider>
             {(schedule: IScheduleActions) => (
-                <WrappedComponent
-                    {...(props as Props)}
-                    ref={ref}
-                    schedule={schedule}
-                />
+                <WrappedComponent {...(props as Props)} schedule={schedule} />
             )}
         </ActionSchedulerProvider>
-    ));
+    );
 }


### PR DESCRIPTION
## Summary:
It isn't possible to define HOCs in TS in a such a way that supports ref-forwarding across multiple HOCs. In order to make the TS migration as smoothe as possible, we're removing ref-forwarding from our HOCs so that the types and semantics match both before and after migration.

Since this is a change to the semantics of withActionScheduler, I've bumped wonder-blocks-timing by a major version.

Issue: FEI-5092

## Test plan:
- let CI run the checks