### PR TITLE
Remove span from links without icons

### DIFF
--- a/.changeset/fifty-crabs-develop.md
+++ b/.changeset/fifty-crabs-develop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-link": patch
+---
+
+Remove span element from link without icons

--- a/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`Link <Link tabIndex={-1}> 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -56,7 +55,6 @@ exports[`Link <Link tabIndex={0}> 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -89,7 +87,6 @@ exports[`Link <Link tabIndex={1}> 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -127,7 +124,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false focused 1`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -165,7 +162,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:false focused 2`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -198,7 +194,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 1`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -231,7 +227,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 2`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -264,7 +259,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 1`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -297,7 +292,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 2`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -341,7 +335,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true focused 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -385,7 +379,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:true focused 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -421,7 +414,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -457,7 +450,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -493,7 +485,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -529,7 +521,6 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -567,7 +558,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false focused 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -605,7 +596,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:false focused 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -638,7 +628,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -671,7 +661,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -704,7 +693,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -737,7 +726,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -781,7 +769,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true focused 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -825,7 +813,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:true focused 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -861,7 +848,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -897,7 +884,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -933,7 +919,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -969,7 +955,6 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 2`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1007,7 +992,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1045,7 +1030,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1078,7 +1062,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1111,7 +1095,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1144,7 +1127,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1177,7 +1160,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1221,7 +1203,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1265,7 +1247,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1301,7 +1282,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1337,7 +1318,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1373,7 +1353,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1409,7 +1389,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1447,7 +1426,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1485,7 +1464,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1518,7 +1496,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1551,7 +1529,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1584,7 +1561,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1617,7 +1594,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1661,7 +1637,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1705,7 +1681,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1741,7 +1716,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1777,7 +1752,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1813,7 +1787,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1849,7 +1823,6 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1887,7 +1860,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false focused 1`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1925,7 +1898,6 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false focused 2`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -1958,7 +1930,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 1`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -1991,7 +1963,6 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 2`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -2024,7 +1995,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 1`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -2057,7 +2028,6 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 2`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -2095,7 +2065,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -2133,7 +2103,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "none",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -2166,7 +2135,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -2199,7 +2168,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }
@@ -2232,7 +2200,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
+      "textUnderlineOffset": 1.5,
       "verticalAlign": "bottom",
     }
   }
@@ -2265,7 +2233,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": "3px",
       "verticalAlign": "bottom",
     }
   }

--- a/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false focused 1`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -194,7 +194,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 1`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -259,7 +259,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 1`] = 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -335,7 +335,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true focused 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -414,7 +414,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -485,7 +485,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -558,7 +558,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false focused 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -628,7 +628,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -693,7 +693,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -769,7 +769,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true focused 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -848,7 +848,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -919,7 +919,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 1`] = `
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -992,7 +992,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1062,7 +1062,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1127,7 +1127,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1203,7 +1203,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1282,7 +1282,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1353,7 +1353,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1426,7 +1426,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1496,7 +1496,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1561,7 +1561,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1637,7 +1637,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1716,7 +1716,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1787,7 +1787,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1860,7 +1860,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false focused 1`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1930,7 +1930,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 1`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -1995,7 +1995,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 1`] 
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -2065,7 +2065,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -2135,7 +2135,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }
@@ -2200,7 +2200,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
       "cursor": "pointer",
       "outline": "none",
       "textDecoration": "underline currentcolor solid",
-      "textUnderlineOffset": 1.5,
+      "textUnderlineOffset": 2,
       "verticalAlign": "bottom",
     }
   }

--- a/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-link/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -29,16 +29,7 @@ exports[`Link <Link tabIndex={-1}> 1`] = `
   }
   tabIndex={-1}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -71,16 +62,7 @@ exports[`Link <Link tabIndex={0}> 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -113,16 +95,7 @@ exports[`Link <Link tabIndex={1}> 1`] = `
   }
   tabIndex={1}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -160,16 +133,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false focused 1`] = 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -207,16 +171,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false focused 2`] = 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -249,16 +204,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 1`] = 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -291,16 +237,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false hovered 2`] = 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -333,16 +270,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 1`] = 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -375,16 +303,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:false pressed 2`] = 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -428,16 +347,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true focused 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -481,16 +391,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true focused 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -526,16 +427,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -571,16 +463,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true hovered 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -616,16 +499,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -661,16 +535,7 @@ exports[`LinkCore kind:primary href:# light:false visitable:true pressed 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -708,16 +573,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false focused 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -755,16 +611,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false focused 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -797,16 +644,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -839,16 +677,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false hovered 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -881,16 +710,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -923,16 +743,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:false pressed 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -976,16 +787,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true focused 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1029,16 +831,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true focused 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1074,16 +867,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1119,16 +903,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true hovered 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1164,16 +939,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 1`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1209,16 +975,7 @@ exports[`LinkCore kind:primary href:# light:true visitable:true pressed 2`] = `
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1256,16 +1013,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1303,16 +1051,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1345,16 +1084,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1387,16 +1117,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1429,16 +1150,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1471,16 +1183,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:fal
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1524,16 +1227,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1577,16 +1271,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1622,16 +1307,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1667,16 +1343,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1712,16 +1379,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1757,16 +1415,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:false visitable:tru
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1804,16 +1453,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1851,16 +1491,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1893,16 +1524,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1935,16 +1557,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -1977,16 +1590,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2019,16 +1623,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:fals
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2072,16 +1667,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2125,16 +1711,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2170,16 +1747,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2215,16 +1783,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2260,16 +1819,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2305,16 +1855,7 @@ exports[`LinkCore kind:primary href:#non-existent-link light:true visitable:true
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2352,16 +1893,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false focused 1`] 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2399,16 +1931,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false focused 2`] 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2441,16 +1964,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 1`] 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2483,16 +1997,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false hovered 2`] 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2525,16 +2030,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 1`] 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2567,16 +2063,7 @@ exports[`LinkCore kind:secondary href:# light:false visitable:false pressed 2`] 
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2614,16 +2101,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2661,16 +2139,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2703,16 +2172,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2745,16 +2205,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2787,16 +2238,7 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;
 
@@ -2829,15 +2271,6 @@ exports[`LinkCore kind:secondary href:#non-existent-link light:false visitable:f
   }
   tabIndex={0}
 >
-  <span
-    className=""
-    style={
-      {
-        "verticalAlign": "middle",
-      }
-    }
-  >
-    Click me
-  </span>
+  Click me
 </a>
 `;

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -49,6 +49,11 @@ export default class LinkCore extends React.Component<Props> {
             ...restProps
         } = this.props;
 
+        // If icon props are present, link `children` will render inside a
+        // `StyledSpan` element to vertically align text with icons and add
+        // `textUnderlineOffset`
+        const withIcon = startIcon || endIcon || target === "_blank";
+
         const linkStyles = _generateStyles(inline, kind, light, visitable);
         const restingStyles = inline
             ? linkStyles.restingInline
@@ -65,6 +70,7 @@ export default class LinkCore extends React.Component<Props> {
             // focused link even after hovering and un-hovering on it.
             !pressed && hovered && linkStyles.hover,
             !pressed && focused && linkStyles.focus,
+            withIcon && sharedStyles.withIcon,
         ];
 
         const commonProps = {
@@ -88,10 +94,6 @@ export default class LinkCore extends React.Component<Props> {
             />
         );
 
-        // If icon props are present, link `children` will render inside a
-        // `StyledSpan` element to vertically align text with icons.
-        const iconPropsPresent = startIcon || endIcon || target === "_blank";
-
         const linkContent = (
             <>
                 {startIcon && (
@@ -106,7 +108,7 @@ export default class LinkCore extends React.Component<Props> {
                         aria-hidden="true"
                     />
                 )}
-                {iconPropsPresent ? (
+                {withIcon ? (
                     <StyledSpan style={linkContentStyles.centered}>
                         {children}
                     </StyledSpan>
@@ -170,8 +172,10 @@ const sharedStyles = StyleSheet.create({
         textDecoration: "none",
         outline: "none",
         verticalAlign: "bottom",
-        textUnderlineOffset: "3px",
         alignItems: "center",
+    },
+    withIcon: {
+        textUnderlineOffset: 3.5,
     },
 });
 
@@ -248,6 +252,7 @@ const _generateStyles = (
             // TODO(WB-1521): Update the underline offset to be 4px after
             // the Link audit.
             // textUnderlineOffset: 4,
+            textUnderlineOffset: 1.5,
             ...defaultVisited,
         },
         hover: {

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -175,7 +175,7 @@ const sharedStyles = StyleSheet.create({
         alignItems: "center",
     },
     withIcon: {
-        textUnderlineOffset: 3.5,
+        textUnderlineOffset: 4,
     },
 });
 
@@ -252,7 +252,7 @@ const _generateStyles = (
             // TODO(WB-1521): Update the underline offset to be 4px after
             // the Link audit.
             // textUnderlineOffset: 4,
-            textUnderlineOffset: 1.5,
+            textUnderlineOffset: 2,
             ...defaultVisited,
         },
         hover: {

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -88,6 +88,10 @@ export default class LinkCore extends React.Component<Props> {
             />
         );
 
+        // If icon props are present, link `children` will render inside a
+        // `StyledSpan` element to vertically align text with icons.
+        const iconPropsPresent = startIcon || endIcon || target === "_blank";
+
         const linkContent = (
             <>
                 {startIcon && (
@@ -102,9 +106,13 @@ export default class LinkCore extends React.Component<Props> {
                         aria-hidden="true"
                     />
                 )}
-                <StyledSpan style={linkContentStyles.centered}>
-                    {children}
-                </StyledSpan>
+                {iconPropsPresent ? (
+                    <StyledSpan style={linkContentStyles.centered}>
+                        {children}
+                    </StyledSpan>
+                ) : (
+                    children
+                )}
                 {endIcon ? (
                     <Icon
                         icon={endIcon}


### PR DESCRIPTION
## Summary:
Initially, the link text/`children` was nested inside a `span` element in order to use `verticalAlign` to center the text with icons.

Nesting `children` in a `span` broke other links that don't have icons (screenshots). 

This change checks first if icon props are present. If true, the text/`children` is nested inside a `span` element.

If the link has no icons, no `span` is needed.

Broken:

<img width="421" alt="Screenshot 2023-04-20 at 1 11 13 PM" src="https://user-images.githubusercontent.com/100858764/233461307-d3259fc9-9bb1-4e1f-a910-957f1e41a621.png">

From production:

<img width="420" alt="Screenshot 2023-04-20 at 1 11 06 PM" src="https://user-images.githubusercontent.com/100858764/233461287-a5254efe-cbcc-4f94-b3c4-6e58b9efa2d6.png">

Also removed `textUnderlineOffset` from `sharedStyles` because without the `span` element, the underline sat too low when inline:

![image](https://user-images.githubusercontent.com/100858764/233480412-119ef1d8-8f00-4c0f-89bc-8a9a5ba101a6.png)

Added `textUnderlineOffset` to `sharedStyles.withIcon` and `restingInline` to match the underline when inline:

<img width="576" alt="Screenshot 2023-04-20 at 4 35 58 PM" src="https://user-images.githubusercontent.com/100858764/233481931-5843a070-f58b-4e52-874d-f6be7a6d235b.png">


Issue: n/a

## Test plan:
For start and end icon props:
- In Storybook, inspect the Default `Link` story. 
- Confirm the link text is not nested inside a `span` element. 
- Add an icon via the control panel and notice in the DOM that a `span` element wraps the link text.

For external icon (since external icon relies on `target` prop:
- In Storybook, inspect the Default `Link` story. 
- Confirm the link text is not nested inside a `span` element. 
- Add "_blank" to `target` prop via the control panel and notice in the DOM that a `span` element wraps the link text.
