### PR TITLE
Story to document current Link issues from recent updates

### DIFF
--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -822,7 +822,6 @@ WithTitle.parameters = {
 
 WithTitle.play = async ({canvasElement}) => {
     const canvas = within(canvasElement);
-
     const link = canvas.getByRole("link");
 
     // Confirm that the link has a title attribute
@@ -858,6 +857,108 @@ RightToLeftWithIcons.parameters = {
         right-to-left language.`,
     },
 };
+
+export const LinkIssues: StoryComponentType = () => (
+    <View>
+        <View>
+            verticalAlign: bottom in div:
+            <Strut size={Spacing.small_12} />
+            <div
+                style={{
+                    border: "2px solid",
+                    width: "fit-content",
+                    padding: Spacing.medium_16,
+                }}
+            >
+                <div
+                    style={{
+                        display: "inline-block",
+                        margin: "5px",
+                    }}
+                >
+                    Text
+                </div>
+                <Link href="/">Link</Link>
+            </div>
+        </View>
+        <Strut size={Spacing.large_24} />
+        <View>
+            Remove verticalAlign: bottom for inline link with icon:
+            <Strut size={Spacing.small_12} />
+            <Body
+                style={{
+                    border: "2px solid",
+                    width: "fit-content",
+                    padding: Spacing.medium_16,
+                }}
+            >
+                This is an{" "}
+                <Link href="#" inline={true}>
+                    Inline Primary link
+                </Link>{" "}
+                and an{" "}
+                <Link
+                    href="#"
+                    inline={true}
+                    target="_blank"
+                    style={{verticalAlign: "none"}}
+                >
+                    Inline External Primary link
+                </Link>
+            </Body>
+        </View>
+        <Strut size={Spacing.large_24} />
+        <View>
+            Link with Typography & icons:
+            <Strut size={Spacing.small_12} />
+            <View
+                style={{
+                    border: "2px solid",
+                    width: "fit-content",
+                    padding: Spacing.medium_16,
+                }}
+            >
+                <Link
+                    href="#nonexistent-link"
+                    startIcon={icons.caretLeft}
+                    endIcon={icons.caretRight}
+                >
+                    <HeadingSmall>Heading inside a Link element</HeadingSmall>
+                </Link>
+            </View>
+        </View>
+        <Strut size={Spacing.large_24} />
+        Tiny links together with external icon:
+        <Strut size={Spacing.small_12} />
+        <View style={{flexDirection: "row"}} />
+        <View
+            style={{
+                border: "2px solid",
+                width: "fit-content",
+                padding: Spacing.medium_16,
+            }}
+        >
+            <View>
+                <View style={{flexDirection: "row"}}>
+                    <Link href="/" target="_blank" style={{fontSize: "10px"}}>
+                        5372
+                    </Link>
+                    <Link href="/" target="_blank" style={{fontSize: "10px"}}>
+                        AHDK
+                    </Link>
+                </View>
+                <View style={{flexDirection: "row"}}>
+                    <Link href="/" target="_blank" style={{fontSize: "10px"}}>
+                        101.01.6
+                    </Link>
+                    <Link href="/" target="_blank" style={{fontSize: "10px"}}>
+                        3.01.2
+                    </Link>
+                </View>
+            </View>
+        </View>
+    </View>
+);
 
 const styles = StyleSheet.create({
     darkBackground: {


### PR DESCRIPTION
## Summary:
Link issues found and reproduced in SB:
- `verticalAlign: bottom` causes the link to align to the bottom of its parent `div`. Removing `verticalAlign: bottom` fixes the issue here but drops inline links with icons out of alignment with the rest of the text.

<img width="1659" alt="Screenshot 2023-04-21 at 1 42 45 PM" src="https://user-images.githubusercontent.com/100858764/233735726-c918d7d2-ae4d-447f-a712-d127fec580ac.png">

- Links with `Typography` have `display: block` compared to the rest of links that default to `display: inline` . Adding `display: inline-flex` fixes the issue, but keeps inline links from wrapping properly.

<img width="1674" alt="Screenshot 2023-04-21 at 1 56 42 PM" src="https://user-images.githubusercontent.com/100858764/233735762-8fa4e618-19cc-4519-8abf-ba610eeb95de.png">

<img width="1671" alt="Screenshot 2023-04-21 at 2 01 57 PM" src="https://user-images.githubusercontent.com/100858764/233735777-63e32b80-3f2e-4727-9e53-d6da0b0fceb8.png">

<img width="1664" alt="Screenshot 2023-04-21 at 2 07 37 PM" src="https://user-images.githubusercontent.com/100858764/233735798-fdddaa37-8e0a-4563-b273-435091f42a79.png">

- The external icons seem too big for smaller links close together and add extra clutter to the page

<img width="1675" alt="Screenshot 2023-04-21 at 2 11 07 PM" src="https://user-images.githubusercontent.com/100858764/233736116-c1020d53-bc82-44d2-8f96-6b5e6de04dee.png">



