### PR TITLE
Fix Flow errors in wonder-blocks-from and wonder-blocks-testing

### DIFF
--- a/.changeset/cool-spiders-yell.md
+++ b/.changeset/cool-spiders-yell.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Fix flow types

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint-plugin-testing-library": "^5.0.0",
     "eslint-watch": "^8.0.0",
     "fast-glob": "^3.2.12",
-    "flowgen": "git+https://git@github.com/Khan/flowgen.git#20605c0e2d9cf68c5609c999369373a8414d4631",
+    "flowgen": "git+https://git@github.com/Khan/flowgen.git#a098eaf64c752760c2ec5dc003062e3ad26e42b5",
     "jest": "^29.5.0",
     "jest-date-mock": "^1.0.8",
     "jest-environment-jsdom": "^28.1.2",

--- a/packages/wonder-blocks-testing/src/harness/make-test-harness.js.flow
+++ b/packages/wonder-blocks-testing/src/harness/make-test-harness.js.flow
@@ -1,0 +1,22 @@
+// @flow
+import * as React from "react";
+import type {TestHarnessAdapters, TestHarnessConfigs} from "./types";
+
+/**
+ * Create a test harness method for use with React components.
+ *
+ * This returns a test harness method that applies the default configurations
+ * to the given adapters, wrapping a given component.
+ * @param {TAdapters} adapters All the adapters to be supported by the returned
+ * test harness.
+ * @param {Configs<TAdapters>} defaultConfigs Default configuration values for
+ * the adapters.
+ * @returns A test harness.
+ */
+declare export var makeTestHarness: <TAdapters: TestHarnessAdapters>(
+    adapters: TAdapters,
+    defaultConfigs: TestHarnessConfigs<TAdapters>,
+) => <-TProps, +Instance = mixed>(
+    Component: React.AbstractComponent<TProps, Instance>,
+    configs?: $Shape<TestHarnessConfigs<TAdapters>>,
+) => React.AbstractComponent<TProps, Instance>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8071,9 +8071,9 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
-"flowgen@git+https://git@github.com/Khan/flowgen.git#20605c0e2d9cf68c5609c999369373a8414d4631":
+"flowgen@git+https://git@github.com/Khan/flowgen.git#a098eaf64c752760c2ec5dc003062e3ad26e42b5":
   version "1.21.0"
-  resolved "git+https://git@github.com/Khan/flowgen.git#20605c0e2d9cf68c5609c999369373a8414d4631"
+  resolved "git+https://git@github.com/Khan/flowgen.git#a098eaf64c752760c2ec5dc003062e3ad26e42b5"
   dependencies:
     "@babel/code-frame" "^7.16.7"
     "@babel/highlight" "^7.16.7"


### PR DESCRIPTION
## Summary:
This PR updates flowgen to include https://github.com/Khan/flowgen/pull/9 which fixes issues with refs not working with HTML elements.  It also adds a .js.flow override for makeTestHarness. Previously I had fixed one issue with the types that flowgen was generating for that file, but this uncovered a new issue that wasn't detected until I updated wonder-blocks in webapp earlier this afternoon.  That file contains pretty complicated types. It's easier to use an override and use the Flow types we used to use for makeTestHarness.

Issue: None

## Test plan:
- yarn build:types
- yarn build:flowtypes
- check that the types for LabeledTextFiela dn TestField and using 'forwardRef: {|current: HTMLInputElement | null|}
- check that the override types for makeTestHarness got copied over into the dist folder