### PR TITLE
FEI-5161: Update component using getDerivedStateFromProps to have readonly props and state

### DIFF
--- a/.changeset/wise-experts-sell.md
+++ b/.changeset/wise-experts-sell.md
@@ -1,0 +1,11 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-timing": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Update state and props to be readonly in components using getDerivedStateFromProps()

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -42,7 +42,7 @@ const getAppropriateTriggersForRole = (role?: ClickableRole | null) => {
 };
 
 // TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
-type Props = {
+type Props = Readonly<{
     /**
      * A function that returns the a React `Element`.
      *
@@ -139,9 +139,9 @@ type Props = {
      * navigation.
      */
     beforeNav?: () => Promise<unknown>;
-};
+}>;
 
-export type ClickableState = {
+export type ClickableState = Readonly<{
     /**
      * Whether the component is hovered.
      *
@@ -168,13 +168,13 @@ export type ClickableState = {
      * load navigation.
      */
     waiting: boolean;
-};
+}>;
 
-type DefaultProps = {
+type DefaultProps = Readonly<{
     disabled: Props["disabled"];
-};
+}>;
 
-export type ChildrenProps = {
+export type ChildrenProps = Readonly<{
     onClick: (e: React.SyntheticEvent) => unknown;
     onMouseEnter: (e: React.MouseEvent) => unknown;
     onMouseLeave: () => unknown;
@@ -189,7 +189,7 @@ export type ChildrenProps = {
     onBlur: (e: React.FocusEvent) => unknown;
     tabIndex?: number;
     rel?: string;
-};
+}>;
 
 const disabledHandlers = {
     onClick: () => void 0,
@@ -576,6 +576,17 @@ export default class ClickableBehavior extends React.Component<
     };
 
     render(): React.ReactNode {
+        // When the link is set to open in a new window, we want to set some
+        // `rel` attributes. This is to ensure that the links we're sending folks
+        // to can't hijack the existing page.  These defaults can be overriden
+        // by passing in a different value for the `rel` prop.
+        // More info: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/
+        const rel =
+            this.props.rel ||
+            (this.props.target === "_blank"
+                ? "noopener noreferrer"
+                : undefined);
+
         const childrenProps: ChildrenProps = this.props.disabled
             ? {
                   ...disabledHandlers,
@@ -583,6 +594,7 @@ export default class ClickableBehavior extends React.Component<
                   onFocus: this.handleFocus,
                   onBlur: this.handleBlur,
                   tabIndex: this.props.tabIndex,
+                  rel,
               }
             : {
                   onClick: this.handleClick,
@@ -598,18 +610,9 @@ export default class ClickableBehavior extends React.Component<
                   onFocus: this.handleFocus,
                   onBlur: this.handleBlur,
                   tabIndex: this.props.tabIndex,
+                  rel,
               };
 
-        // When the link is set to open in a new window, we want to set some
-        // `rel` attributes. This is to ensure that the links we're sending folks
-        // to can't hijack the existing page.  These defaults can be overriden
-        // by passing in a different value for the `rel` prop.
-        // More info: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/
-        childrenProps.rel =
-            this.props.rel ||
-            (this.props.target === "_blank"
-                ? "noopener noreferrer"
-                : undefined);
         const {children} = this.props;
         return children && children(this.state, childrenProps);
     }

--- a/packages/wonder-blocks-core/src/util/types.ts
+++ b/packages/wonder-blocks-core/src/util/types.ts
@@ -11,9 +11,10 @@ export type StyleType =
     | Falsy
     | NestedArray<CSSProperties | Falsy>;
 
-export type AriaProps = AriaAttributes & {
-    role?: AriaRole;
-};
+export type AriaProps = Readonly<AriaAttributes> &
+    Readonly<{
+        role?: AriaRole;
+    }>;
 
 type MouseEvents = {
     onMouseDown?: (e: React.MouseEvent) => unknown;

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
@@ -10,80 +10,81 @@ import DropdownCore from "./dropdown-core";
 import ActionMenuOpenerCore from "./action-menu-opener-core";
 import type {Item, DropdownItem, OpenerProps} from "../util/types";
 
-type Props = AriaProps & {
-    /**
-     * The items in this dropdown.
-     */
-    children?: Array<Item> | Item;
-    /**
-     * Text for the opener of this menu.
-     */
-    menuText: string;
-    /**
-     * Can be used to override the state of the ActionMenu by parent elements
-     */
-    opened?: boolean;
-    /**
-     * In controlled mode, use this prop in case the parent needs to be notified
-     * when the menu opens/closes.
-     */
-    onToggle?: (opened: boolean) => unknown;
-    /**
-     * A callback that returns items that are newly selected. Use only if this
-     * menu contains select items (and make sure selectedValues is defined).
-     */
-    onChange?: (selectedItems: Array<string>) => unknown;
-    /**
-     * The values of the items that are currently selected. Use only if this
-     * menu contains select items (and make sure onChange is defined).
-     */
-    selectedValues?: Array<string>;
-    /**
-     * Whether this menu should be left-aligned or right-aligned with the
-     * opener component. Defaults to left-aligned.
-     */
-    alignment: "left" | "right";
-    /**
-     * Whether this component is disabled. A disabled dropdown may not be opened
-     * and does not support interaction. Defaults to false.
-     */
-    disabled: boolean;
-    /**
-     * Test ID used for e2e testing.
-     */
-    testId?: string;
-    /**
-     * Styling specific to the dropdown component that isn't part of the opener,
-     * passed by the specific implementation of the dropdown menu,
-     */
-    dropdownStyle?: StyleType;
-    /**
-     * Optional styling for the entire dropdown component.
-     */
-    style?: StyleType;
-    /**
-     * Optional CSS classes for the entire dropdown component.
-     */
-    className?: string;
-    /**
-     * The child function that returns the anchor the ActionMenu will be
-     * activated by. This function takes eventState, which allows the opener
-     * element to access pointer event state.
-     */
-    opener?: (openerProps: OpenerProps) => React.ReactElement<any>;
-};
+type Props = AriaProps &
+    Readonly<{
+        /**
+         * The items in this dropdown.
+         */
+        children?: Array<Item> | Item;
+        /**
+         * Text for the opener of this menu.
+         */
+        menuText: string;
+        /**
+         * Can be used to override the state of the ActionMenu by parent elements
+         */
+        opened?: boolean;
+        /**
+         * In controlled mode, use this prop in case the parent needs to be notified
+         * when the menu opens/closes.
+         */
+        onToggle?: (opened: boolean) => unknown;
+        /**
+         * A callback that returns items that are newly selected. Use only if this
+         * menu contains select items (and make sure selectedValues is defined).
+         */
+        onChange?: (selectedItems: Array<string>) => unknown;
+        /**
+         * The values of the items that are currently selected. Use only if this
+         * menu contains select items (and make sure onChange is defined).
+         */
+        selectedValues?: Array<string>;
+        /**
+         * Whether this menu should be left-aligned or right-aligned with the
+         * opener component. Defaults to left-aligned.
+         */
+        alignment: "left" | "right";
+        /**
+         * Whether this component is disabled. A disabled dropdown may not be opened
+         * and does not support interaction. Defaults to false.
+         */
+        disabled: boolean;
+        /**
+         * Test ID used for e2e testing.
+         */
+        testId?: string;
+        /**
+         * Styling specific to the dropdown component that isn't part of the opener,
+         * passed by the specific implementation of the dropdown menu,
+         */
+        dropdownStyle?: StyleType;
+        /**
+         * Optional styling for the entire dropdown component.
+         */
+        style?: StyleType;
+        /**
+         * Optional CSS classes for the entire dropdown component.
+         */
+        className?: string;
+        /**
+         * The child function that returns the anchor the ActionMenu will be
+         * activated by. This function takes eventState, which allows the opener
+         * element to access pointer event state.
+         */
+        opener?: (openerProps: OpenerProps) => React.ReactElement<any>;
+    }>;
 
-type State = {
+type State = Readonly<{
     /**
      * Whether or not the dropdown is open.
      */
     opened: boolean;
-};
+}>;
 
-type DefaultProps = {
+type DefaultProps = Readonly<{
     alignment: Props["alignment"];
     disabled: Props["disabled"];
-};
+}>;
 
 /**
  * A menu that consists of various types of items.

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -65,7 +65,7 @@ type Labels = {
 // we need to define a DefaultProps type to allow the HOC expose the default
 // values to the parent components that are instantiating this component
 // @see https://flow.org/en/docs/react/hoc/#toc-exporting-wrapped-components
-type DefaultProps = {
+type DefaultProps = Readonly<{
     /**
      * Whether this menu should be left-aligned or right-aligned with the
      * opener component. Defaults to left-aligned.
@@ -107,12 +107,12 @@ type DefaultProps = {
      * Used to determine if we can automatically select an item using the keyboard.
      */
     selectionType: "single" | "multi";
-};
+}>;
 
 type DropdownAriaRole = "listbox" | "menu";
 type ItemAriaRole = "option" | "menuitem";
 
-type ExportProps = {
+type ExportProps = Readonly<{
     // Required props
 
     /**
@@ -215,11 +215,11 @@ type ExportProps = {
      * Used to determine if we can automatically select an item using the keyboard.
      */
     selectionType?: "single" | "multi";
-};
+}>;
 
 type Props = DefaultProps & ExportProps & WithActionSchedulerProps;
 
-type State = {
+type State = Readonly<{
     /**
      * Refs to use for keyboard focus, contains only those for focusable items.
      * Also keeps track of the original index of the item.
@@ -246,7 +246,7 @@ type State = {
      * resetting focusedIndex and focusedOriginalIndex when an update happens.
      */
     sameItemsFocusable: boolean;
-};
+}>;
 
 /**
  * A core dropdown component that takes an opener and children to display as

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -53,7 +53,7 @@ export type Labels = {
     allSelected: string;
 };
 
-type DefaultProps = {
+type DefaultProps = Readonly<{
     /**
      * Whether this dropdown should be left-aligned or right-aligned with the
      * opener component. Defaults to left-aligned.
@@ -77,10 +77,11 @@ type DefaultProps = {
      * Whether to display shortcuts for Select All and Select None.
      */
     shortcuts: boolean;
-};
+}>;
 
 type Props = AriaProps &
-    DefaultProps & {
+    DefaultProps &
+    Readonly<{
         /**
          * The items in this select.
          */
@@ -147,9 +148,9 @@ type Props = AriaProps &
          * Test ID used for e2e testing.
          */
         testId?: string;
-    };
+    }>;
 
-type State = {
+type State = Readonly<{
     /**
      * Whether or not the dropdown is open.
      */
@@ -174,7 +175,7 @@ type State = {
      * to this element, and also to pass the reference to Popper.js.
      */
     openerElement?: HTMLElement;
-};
+}>;
 
 /**
  * A dropdown that consists of multiple selection items. This select allows

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -34,7 +34,7 @@ export type SingleSelectLabels = {
     someResults: (numOptions: number) => string;
 };
 
-type DefaultProps = {
+type DefaultProps = Readonly<{
     /**
      * Whether this dropdown should be left-aligned or right-aligned with the
      * opener component. Defaults to left-aligned.
@@ -72,10 +72,11 @@ type DefaultProps = {
      * The object containing the custom labels used inside this component.
      */
     labels: SingleSelectLabels;
-};
+}>;
 
 type Props = AriaProps &
-    DefaultProps & {
+    DefaultProps &
+    Readonly<{
         /**
          * The items in this select.
          */
@@ -140,9 +141,9 @@ type Props = AriaProps &
          * top. The items will be filtered by the input.
          */
         isFilterable?: boolean;
-    };
+    }>;
 
-type State = {
+type State = Readonly<{
     /**
      * Whether or not the dropdown is open.
      */
@@ -157,7 +158,7 @@ type State = {
      * to this element, and also to pass the reference to Popper.js.
      */
     openerElement?: HTMLElement;
-};
+}>;
 
 /**
  * The single select allows the selection of one item. Clients are responsible

--- a/packages/wonder-blocks-modal/src/components/modal-launcher.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-launcher.tsx
@@ -12,7 +12,7 @@ import type {ModalElement} from "../util/types";
 import ModalContext from "./modal-context";
 
 // TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
-type Props = {
+type Props = Readonly<{
     /**
      * The modal to render.
      *
@@ -73,16 +73,17 @@ type Props = {
      * controlled component.
      */
     children?: (arg1: {openModal: () => unknown}) => React.ReactNode;
-} & WithActionSchedulerProps;
+}> &
+    WithActionSchedulerProps;
 
-type DefaultProps = {
+type DefaultProps = Readonly<{
     backdropDismissEnabled: Props["backdropDismissEnabled"];
-};
+}>;
 
-type State = {
+type State = Readonly<{
     /** Whether the modal should currently be open. */
     opened: boolean;
-};
+}>;
 
 /**
  * This component enables you to launch a modal, covering the screen.

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -23,78 +23,81 @@ type PopoverContents =
     | React.ReactElement<React.ComponentProps<typeof PopoverContent>>
     | React.ReactElement<React.ComponentProps<typeof PopoverContentCore>>;
 
-type Props = AriaProps & {
-    /**
-     * The element that triggers the popover. This element will be used to
-     * position the popover. It can be either a Node or a function using the
-     * children-as-function pattern to pass an open function for use anywhere
-     * within children. The latter provides a lot of flexibility in terms of
-     * what actions may trigger the `Popover` to launch the popover dialog.
-     */
-    children:
-        | React.ReactElement<any>
-        | ((arg1: {open: () => void}) => React.ReactElement<any>);
-    /**
-     * The content of the popover. You can either use
-     * [PopoverContent](#PopoverContent) with one of the pre-defined variants,
-     * or include your own custom content using
-     * [PopoverContentCore](#PopoverContentCore directly.
-     *
-     * If the popover needs to close itself, the close function provided to this
-     * callback can be called to close the popover.
-     */
-    content: PopoverContents | ((arg1: {close: () => void}) => PopoverContents);
-    /**
-     * Where the popover should try to appear in relation to the trigger element.
-     */
-    placement: Placement;
-    /**
-     * When enabled, user can hide the popover content by pressing the `esc` key
-     * or clicking/tapping outside of it.
-     */
-    dismissEnabled?: boolean;
-    /**
-     * The unique identifier to give to the popover. Provide this in cases where
-     * you want to override the default accessibility solution. This identifier
-     * will be applied to the popover content.
-     *
-     * By providing this identifier, the children that this popover anchors to
-     * will not be automatically given the
-     * [aria-describedby](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby)
-     * attribute. Instead, the accessibility solution is the responsibility of
-     * the caller.
-     *
-     * If this is not provided, the
-     * [aria-describedby](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby)
-     * attribute will be added to the children with a unique identifier pointing
-     * to the popover dialog.
-     */
-    id?: string;
-    /**
-     * The selector for the element that will be focused when the popover
-     * content shows. When not set, the first focusable element within the
-     * popover content will be used.
-     */
-    initialFocusId?: string;
-    /**
-     * Renders the popover when true, renders nothing when false.
-     *
-     * Using this prop makes the component behave as a controlled component. The
-     * parent is responsible for managing the opening/closing of the popover
-     * when using this prop.
-     */
-    opened?: boolean;
-    /**
-     * Called when the popover closes
-     */
-    onClose?: () => unknown;
-    /**
-     * Test ID used for e2e testing.
-     */
-    testId?: string;
-};
+type Props = AriaProps &
+    Readonly<{
+        /**
+         * The element that triggers the popover. This element will be used to
+         * position the popover. It can be either a Node or a function using the
+         * children-as-function pattern to pass an open function for use anywhere
+         * within children. The latter provides a lot of flexibility in terms of
+         * what actions may trigger the `Popover` to launch the popover dialog.
+         */
+        children:
+            | React.ReactElement<any>
+            | ((arg1: {open: () => void}) => React.ReactElement<any>);
+        /**
+         * The content of the popover. You can either use
+         * [PopoverContent](#PopoverContent) with one of the pre-defined variants,
+         * or include your own custom content using
+         * [PopoverContentCore](#PopoverContentCore directly.
+         *
+         * If the popover needs to close itself, the close function provided to this
+         * callback can be called to close the popover.
+         */
+        content:
+            | PopoverContents
+            | ((arg1: {close: () => void}) => PopoverContents);
+        /**
+         * Where the popover should try to appear in relation to the trigger element.
+         */
+        placement: Placement;
+        /**
+         * When enabled, user can hide the popover content by pressing the `esc` key
+         * or clicking/tapping outside of it.
+         */
+        dismissEnabled?: boolean;
+        /**
+         * The unique identifier to give to the popover. Provide this in cases where
+         * you want to override the default accessibility solution. This identifier
+         * will be applied to the popover content.
+         *
+         * By providing this identifier, the children that this popover anchors to
+         * will not be automatically given the
+         * [aria-describedby](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby)
+         * attribute. Instead, the accessibility solution is the responsibility of
+         * the caller.
+         *
+         * If this is not provided, the
+         * [aria-describedby](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby)
+         * attribute will be added to the children with a unique identifier pointing
+         * to the popover dialog.
+         */
+        id?: string;
+        /**
+         * The selector for the element that will be focused when the popover
+         * content shows. When not set, the first focusable element within the
+         * popover content will be used.
+         */
+        initialFocusId?: string;
+        /**
+         * Renders the popover when true, renders nothing when false.
+         *
+         * Using this prop makes the component behave as a controlled component. The
+         * parent is responsible for managing the opening/closing of the popover
+         * when using this prop.
+         */
+        opened?: boolean;
+        /**
+         * Called when the popover closes
+         */
+        onClose?: () => unknown;
+        /**
+         * Test ID used for e2e testing.
+         */
+        testId?: string;
+    }>;
 
-type State = {
+type State = Readonly<{
     /**
      * Keeps a reference of the dialog state
      */
@@ -107,11 +110,11 @@ type State = {
      * Current popper placement
      */
     placement: Placement;
-};
+}>;
 
-type DefaultProps = {
+type DefaultProps = Readonly<{
     placement: Props["placement"];
-};
+}>;
 
 /**
  * Popovers provide additional information that is related to a particular

--- a/packages/wonder-blocks-timing/src/util/types.ts
+++ b/packages/wonder-blocks-timing/src/util/types.ts
@@ -227,13 +227,13 @@ export interface IScheduleActions {
  * A props object type that can be spread into the a componenet wrapped with
  * the `withActionScheduler` higher order component.
  */
-export type WithActionSchedulerProps = {
+export type WithActionSchedulerProps = Readonly<{
     /**
      * An instance of the `IScheduleActions` API to use for scheduling
      * intervals, timeouts, and animation frame requests.
      */
     schedule: IScheduleActions;
-};
+}>;
 
 export type WithoutActionScheduler<TProps extends object> = Omit<
     TProps,

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -34,76 +34,77 @@ import TooltipContent from "./tooltip-content";
 import TooltipPopper from "./tooltip-popper";
 import type {Placement} from "../util/types";
 
-type Props = AriaProps & {
-    /**
-     * The content for anchoring the tooltip.
-     * This component will be used to position the tooltip.
-     */
-    children: React.ReactElement<any> | string;
-    /**
-     * The title of the tooltip.
-     * Optional.
-     */
-    title?: string | React.ReactElement<React.ComponentProps<Typography>>;
-    /**
-     * The content to render in the tooltip.
-     */
-    content:
-        | string
-        | React.ReactElement<React.ComponentProps<typeof TooltipContent>>;
-    /**
-     * The unique identifier to give to the tooltip. Provide this in cases where
-     * you want to override the default accessibility solution. This identifier
-     * will be applied to the tooltip bubble content.
-     *
-     * By providing this identifier, the children that this tooltip anchors to
-     * will not be automatically given the aria-desribedby attribute. Instead,
-     * the accessibility solution is the responsibility of the caller.
-     *
-     * If this is not provided, the aria-describedby attribute will be added
-     * to the children with a unique identifier pointing to the tooltip bubble
-     * content.
-     */
-    id?: string;
-    /**
-     * When true, if a tabindex attribute is not already present on the element
-     * wrapped by the anchor, the element will be given tabindex=0 to make it
-     * keyboard focusable; otherwise, does not attempt to change the ability to
-     * focus the anchor element.
-     *
-     * Defaults to true.
-     *
-     * One might set this to false in circumstances where the wrapped component
-     * already can receive focus or contains an element that can.
-     * Use good judgement when overriding this value, the tooltip content should
-     * be accessible via keyboard in all circumstances where the tooltip would
-     * appear using the mouse, so verify those use-cases.
-     *
-     * Also, note that the aria-describedby attribute is attached to the root
-     * anchor element, so you may need to implement an additional accessibility
-     * solution when overriding anchor focusivity.
-     */
-    forceAnchorFocusivity?: boolean;
-    /**
-     * Where the tooltip should appear in relation to the anchor element.
-     * Defaults to "top".
-     */
-    placement: Placement;
-    /**
-     * Renders the tooltip when true, renders nothing when false.
-     *
-     * Using this prop makes the component behave as a controlled component. The
-     * parent is responsible for managing the opening/closing of the tooltip
-     * when using this prop.
-     */
-    opened?: boolean;
-    /**
-     * Test ID used for e2e testing.
-     */
-    testId?: string;
-};
+type Props = AriaProps &
+    Readonly<{
+        /**
+         * The content for anchoring the tooltip.
+         * This component will be used to position the tooltip.
+         */
+        children: React.ReactElement<any> | string;
+        /**
+         * The title of the tooltip.
+         * Optional.
+         */
+        title?: string | React.ReactElement<React.ComponentProps<Typography>>;
+        /**
+         * The content to render in the tooltip.
+         */
+        content:
+            | string
+            | React.ReactElement<React.ComponentProps<typeof TooltipContent>>;
+        /**
+         * The unique identifier to give to the tooltip. Provide this in cases where
+         * you want to override the default accessibility solution. This identifier
+         * will be applied to the tooltip bubble content.
+         *
+         * By providing this identifier, the children that this tooltip anchors to
+         * will not be automatically given the aria-desribedby attribute. Instead,
+         * the accessibility solution is the responsibility of the caller.
+         *
+         * If this is not provided, the aria-describedby attribute will be added
+         * to the children with a unique identifier pointing to the tooltip bubble
+         * content.
+         */
+        id?: string;
+        /**
+         * When true, if a tabindex attribute is not already present on the element
+         * wrapped by the anchor, the element will be given tabindex=0 to make it
+         * keyboard focusable; otherwise, does not attempt to change the ability to
+         * focus the anchor element.
+         *
+         * Defaults to true.
+         *
+         * One might set this to false in circumstances where the wrapped component
+         * already can receive focus or contains an element that can.
+         * Use good judgement when overriding this value, the tooltip content should
+         * be accessible via keyboard in all circumstances where the tooltip would
+         * appear using the mouse, so verify those use-cases.
+         *
+         * Also, note that the aria-describedby attribute is attached to the root
+         * anchor element, so you may need to implement an additional accessibility
+         * solution when overriding anchor focusivity.
+         */
+        forceAnchorFocusivity?: boolean;
+        /**
+         * Where the tooltip should appear in relation to the anchor element.
+         * Defaults to "top".
+         */
+        placement: Placement;
+        /**
+         * Renders the tooltip when true, renders nothing when false.
+         *
+         * Using this prop makes the component behave as a controlled component. The
+         * parent is responsible for managing the opening/closing of the tooltip
+         * when using this prop.
+         */
+        opened?: boolean;
+        /**
+         * Test ID used for e2e testing.
+         */
+        testId?: string;
+    }>;
 
-type State = {
+type State = Readonly<{
     /**
      * Whether the tooltip is open by hovering/focusing on the anchor element.
      */
@@ -116,7 +117,7 @@ type State = {
      * The element that activates the tooltip.
      */
     anchorElement?: HTMLElement;
-};
+}>;
 
 type DefaultProps = {
     forceAnchorFocusivity: Props["forceAnchorFocusivity"];


### PR DESCRIPTION
## Summary:
The problem is that 'getDerivedStateFromProps' ends up in the .d.ts files we generate and the React lib defs have its 'props' param wrapped in Readonly<>. This is causing type errors in webapp.  We need to make sure all components that make use of 'getDerivedStateFromProps' are also using readonly props for this static method.  I've updated all props and state types to be readonly. This is generally a good practice since neither of those should be mutated directly.

I've created https://khanacademy.atlassian.net/browse/FEI-5164 to track writing a lint rule for this.  Ideally all components should have readonly props and state.

Issue: FEI-5161

## Test plan:
- yarn tsc
- let the tests run on CI