### PR TITLE
[namedcontexts] Make sure contexts have a name

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -1,3 +1,3 @@
 {
-    "allow": ["invalid", "color", "colors", "white", "latin", "hook", "hooks"]
+    "allow": ["invalid", "color", "colors", "white", "latin", "hook", "hooks", "trap"]
 }

--- a/.changeset/strong-geckos-build.md
+++ b/.changeset/strong-geckos-build.md
@@ -1,0 +1,9 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-layout": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-data": patch
+---
+
+Make sure that React contexts are named

--- a/packages/wonder-blocks-core/src/components/render-state-context.ts
+++ b/packages/wonder-blocks-core/src/components/render-state-context.ts
@@ -22,7 +22,9 @@ export const RenderState = {
  * standard:
  *   means that we're all now doing non-SSR rendering
  */
-// @ts-expect-error [FEI-5019] - TS2322 - Type 'Context<"root">' is not assignable to type 'Context<"initial" | "root" | "standard">'.
-export const RenderStateContext: React.Context<
+const RenderStateContext = React.createContext<
     typeof RenderState[keyof typeof RenderState]
-> = React.createContext(RenderState.Root);
+>(RenderState.Root);
+RenderStateContext.displayName = "RenderStateContext";
+
+export {RenderStateContext};

--- a/packages/wonder-blocks-data/src/components/intercept-context.ts
+++ b/packages/wonder-blocks-data/src/components/intercept-context.ts
@@ -14,5 +14,6 @@ type InterceptContextData = ReadonlyArray<
  */
 const InterceptContext: React.Context<InterceptContextData> =
     React.createContext<InterceptContextData>([]);
+InterceptContext.displayName = "InterceptContext";
 
 export default InterceptContext;

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.ts
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.ts
@@ -182,9 +182,6 @@ describe("#useServerEffect", () => {
             // Arrange
             const fakeHandler = jest.fn();
             jest.spyOn(SsrCache.Default, "getEntry").mockReturnValueOnce({
-                // @ts-expect-error [FEI-5019] - TS2322 - Type 'null' is not assignable to type 'ValidCacheData'.
-                data: null,
-                // @ts-expect-error [FEI-5019] - TS2322 - Type 'string' is not assignable to type 'undefined'.
                 error: "ERROR",
             });
 
@@ -241,9 +238,6 @@ describe("#useServerEffect", () => {
             // Arrange
             const fakeHandler = jest.fn();
             jest.spyOn(SsrCache.Default, "getEntry").mockReturnValueOnce({
-                // @ts-expect-error [FEI-5019] - TS2322 - Type 'null' is not assignable to type 'ValidCacheData'.
-                data: null,
-                // @ts-expect-error [FEI-5019] - TS2322 - Type 'string' is not assignable to type 'undefined'.
                 error: "ERROR",
             });
 

--- a/packages/wonder-blocks-data/src/util/gql-router-context.ts
+++ b/packages/wonder-blocks-data/src/util/gql-router-context.ts
@@ -1,6 +1,9 @@
 import * as React from "react";
 import type {GqlRouterConfiguration} from "./gql-types";
 
-export const GqlRouterContext: React.Context<
+const GqlRouterContext: React.Context<
     GqlRouterConfiguration<any> | null | undefined
 > = React.createContext<GqlRouterConfiguration<any> | null | undefined>(null);
+GqlRouterContext.displayName = "GqlRouterContext";
+
+export {GqlRouterContext};

--- a/packages/wonder-blocks-data/src/util/request-tracking.ts
+++ b/packages/wonder-blocks-data/src/util/request-tracking.ts
@@ -22,8 +22,10 @@ type RequestCache = {
  *
  * INTERNAL USE ONLY
  */
-export const TrackerContext: React.Context<TrackerFn | null | undefined> =
+const TrackerContext: React.Context<TrackerFn | null | undefined> =
     React.createContext<TrackerFn | null | undefined>(null);
+TrackerContext.displayName = "TrackerContext";
+export {TrackerContext};
 
 /**
  * The default instance is stored here.

--- a/packages/wonder-blocks-layout/src/components/media-layout-context.ts
+++ b/packages/wonder-blocks-layout/src/components/media-layout-context.ts
@@ -50,6 +50,9 @@ const defaultContext: Context = {
     mediaSpec: MEDIA_DEFAULT_SPEC,
 };
 
-export default React.createContext<Context>(
+const MediaLayoutContext = React.createContext<Context>(
     defaultContext,
 ) as React.Context<Context>;
+MediaLayoutContext.displayName = "MediaLayoutContext";
+
+export default MediaLayoutContext;

--- a/packages/wonder-blocks-modal/src/components/modal-context.ts
+++ b/packages/wonder-blocks-modal/src/components/modal-context.ts
@@ -8,6 +8,9 @@ const defaultContext: ContextType = {
     closeModal: undefined,
 };
 
-export default React.createContext<ContextType>(
+const ModalContext = React.createContext<ContextType>(
     defaultContext,
 ) as React.Context<ContextType>;
+ModalContext.displayName = "ModalContext";
+
+export default ModalContext;

--- a/packages/wonder-blocks-popover/src/components/popover-context.ts
+++ b/packages/wonder-blocks-popover/src/components/popover-context.ts
@@ -32,6 +32,9 @@ const defaultContext: PopoverContextType = {
  * 2. Keeps a reference of the TooltipPopper's `placement` value. It can be one
  *    of the following values: "top", "bottom", "left" or "right".
  */
-export default React.createContext<PopoverContextType>(
+const PopoverContext = React.createContext<PopoverContextType>(
     defaultContext,
 ) as React.Context<PopoverContextType>;
+PopoverContext.displayName = "PopoverContext";
+
+export default PopoverContext;


### PR DESCRIPTION
## Summary:
I was debugging some context-related changes in webapp and using React Dev Tools as well as the React Context extension for dev tools. I noticed that many of the contexts were given unhelpful generated names, which made it hard to find the context that I was looking for. This diff adds a display name to all of our contexts so that they can be more easily identified in dev tools.

This was found while working on the guide context stabilization work, so I'm tagging with that issue.

Issue: GL-568

## Test plan:
`yarn test`