### PR TITLE
[wb1556.1.notail] Make popover tail optional

### DIFF
--- a/.changeset/fuzzy-sheep-dream.md
+++ b/.changeset/fuzzy-sheep-dream.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-popover": minor
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+Allow the popover tail to be optional. This is a non-breaking change as it defaults to being visible as before. The TooltipTail export of wonder-blocks-tooltip is modified to support this, but it is a minor change that does not impact the primary API and hence is a patch update. While the Popover change is similar, it has a direct impact to primary uses and so is a minor update.

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -91,6 +91,31 @@ Default.args = {
 };
 
 /**
+ * No tail
+ */
+
+export const NoTail: StoryComponentType = Template.bind({});
+
+NoTail.args = {
+    children: <Button>Open popover without tail</Button>,
+    content: (
+        <PopoverContent
+            closeButtonVisible
+            title="Title"
+            content="The popover content. This popover does not have a tail."
+        />
+    ),
+
+    placement: "top",
+    dismissEnabled: true,
+    id: "",
+    initialFocusId: "",
+    testId: "",
+    onClose: () => {},
+    showTail: false,
+};
+
+/**
  * Using a trigger element
  */
 

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-dialog.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-dialog.test.tsx
@@ -15,7 +15,7 @@ describe("PopoverDialog", () => {
 
         // Act
         render(
-            <PopoverDialog placement="top" onUpdate={jest.fn()}>
+            <PopoverDialog showTail={true} placement="top" onUpdate={jest.fn()}>
                 <PopoverContentCore color="darkBlue">
                     popover content
                 </PopoverContentCore>
@@ -33,7 +33,11 @@ describe("PopoverDialog", () => {
         // Arrange
         const onUpdateMock = jest.fn();
         const UnderTest = ({placement}: {placement: Placement}) => (
-            <PopoverDialog placement={placement} onUpdate={onUpdateMock}>
+            <PopoverDialog
+                showTail={true}
+                placement={placement}
+                onUpdate={onUpdateMock}
+            >
                 <PopoverContentCore>popover content</PopoverContentCore>
             </PopoverDialog>
         );
@@ -52,7 +56,11 @@ describe("PopoverDialog", () => {
         const onUpdateMock = jest.fn();
 
         const UnderTest = ({placement}: {placement: Placement}) => (
-            <PopoverDialog placement={placement} onUpdate={onUpdateMock}>
+            <PopoverDialog
+                showTail={true}
+                placement={placement}
+                onUpdate={onUpdateMock}
+            >
                 <PopoverContentCore>popover content</PopoverContentCore>
             </PopoverDialog>
         );
@@ -64,5 +72,27 @@ describe("PopoverDialog", () => {
 
         // Assert
         expect(onUpdateMock).not.toBeCalled();
+    });
+
+    it("should not render a tail if showTail is false", () => {
+        // Arrange
+        const tooltipTailSpy = jest.spyOn(Tooltip, "TooltipTail");
+
+        // Act
+        render(
+            <PopoverDialog
+                showTail={false}
+                placement="top"
+                onUpdate={jest.fn()}
+            >
+                <PopoverContentCore>popover content</PopoverContentCore>
+            </PopoverDialog>,
+        );
+
+        // Assert
+        expect(tooltipTailSpy).toHaveBeenCalledWith(
+            expect.objectContaining({show: false}),
+            {},
+        );
     });
 });

--- a/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
@@ -35,6 +35,10 @@ type Props = AriaProps &
          * Called when popper changes its placement
          */
         onUpdate: (placement: Placement) => unknown;
+        /**
+         * Whether to show the popover tail or not.
+         */
+        showTail: boolean;
     };
 
 /**
@@ -71,6 +75,7 @@ export default class PopoverDialog extends React.Component<Props> {
             updateTailRef,
             tailOffset,
             style,
+            showTail,
             "aria-describedby": ariaDescribedby,
         } = this.props;
 
@@ -97,6 +102,7 @@ export default class PopoverDialog extends React.Component<Props> {
                 >
                     {children}
                     <TooltipTail
+                        show={showTail}
                         color={color}
                         updateRef={updateTailRef}
                         placement={placement}

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -95,6 +95,10 @@ type Props = AriaProps &
          * Test ID used for e2e testing.
          */
         testId?: string;
+        /**
+         * Whether to show the popover tail or not. Defaults to true.
+         */
+        showTail: boolean;
     }>;
 
 type State = Readonly<{
@@ -114,6 +118,7 @@ type State = Readonly<{
 
 type DefaultProps = Readonly<{
     placement: Props["placement"];
+    showTail: Props["showTail"];
 }>;
 
 /**
@@ -142,6 +147,7 @@ type DefaultProps = Readonly<{
 export default class Popover extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
         placement: "top",
+        showTail: true,
     };
 
     /**
@@ -212,7 +218,7 @@ export default class Popover extends React.Component<Props, State> {
     }
 
     renderPopper(uniqueId: string): React.ReactNode {
-        const {initialFocusId, placement} = this.props;
+        const {initialFocusId, placement, showTail} = this.props;
         const {anchorElement} = this.state;
 
         return (
@@ -230,6 +236,7 @@ export default class Popover extends React.Component<Props, State> {
                             aria-describedby={`${uniqueId}-anchor`}
                             id={uniqueId}
                             onUpdate={(placement) => this.setState({placement})}
+                            showTail={showTail}
                         >
                             {this.renderContent()}
                         </PopoverDialog>

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
@@ -36,5 +36,100 @@ describe("TooltipTail", () => {
                 expect(testee).not.toThrowError();
             }
         });
+
+        it("should render a visible tail", () => {
+            // Arrange
+            const nodes = <TooltipTail placement="top" />;
+
+            // Act
+            const {container} = render(nodes);
+
+            // Assert
+            expect(container).toMatchInlineSnapshot(`
+                <div>
+                  <div
+                    class=""
+                    data-placement="top"
+                    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="arrow_oo4scr"
+                      height="12"
+                      style="margin-left: 8px; margin-right: 8px; padding-bottom: 8px;"
+                      width="24"
+                    >
+                      <filter
+                        height="200%"
+                        id="tooltip-dropshadow-top-3"
+                        width="200%"
+                        x="-50%"
+                        y="-50%"
+                      >
+                        <fegaussianblur
+                          in="SourceAlpha"
+                          stdDeviation="3"
+                        />
+                        <fecomponenttransfer>
+                          <fefunca
+                            slope="0.3"
+                            type="linear"
+                          />
+                        </fecomponenttransfer>
+                      </filter>
+                      <g
+                        transform="translate(0,5.5)"
+                      >
+                        <polyline
+                          fill="rgba(33,36,44,0.16)"
+                          filter="url(#tooltip-dropshadow-top-3)"
+                          points="0,0 12,12 24,0"
+                          stroke="rgba(33,36,44,0.32)"
+                        />
+                      </g>
+                      <polyline
+                        fill="#ffffff"
+                        points="0,0 12,12 24,0"
+                        stroke="#ffffff"
+                      />
+                      <polyline
+                        fill="#ffffff"
+                        points="0,0 12,12 24,0"
+                        stroke="rgba(33,36,44,0.16)"
+                      />
+                      <polyline
+                        points="0,-0.5 24,-0.5"
+                        stroke="#ffffff"
+                      />
+                    </svg>
+                  </div>
+                </div>
+            `);
+        });
+
+        it("should render a spacer when show is false", () => {
+            // Arrange
+            const nodes = <TooltipTail placement="top" show={false} />;
+
+            // Act
+            const {container} = render(nodes);
+
+            // Assert
+            expect(container).toMatchInlineSnapshot(`
+                <div>
+                  <div
+                    class=""
+                    data-placement="top"
+                    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class=""
+                      style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0; width: 12px; flex-basis: 12px; flex-shrink: 0;"
+                    />
+                  </div>
+                </div>
+            `);
+        });
     });
 });

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -84,6 +84,7 @@ export default class TooltipBubble extends React.Component<Props, State> {
             >
                 <View style={styles.content}>{children}</View>
                 <TooltipTail
+                    show={true}
                     updateRef={updateTailRef}
                     placement={placement}
                     offset={tailOffset}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -84,7 +84,6 @@ export default class TooltipBubble extends React.Component<Props, State> {
             >
                 <View style={styles.content}>{children}</View>
                 <TooltipTail
-                    show={true}
                     updateRef={updateTailRef}
                     placement={placement}
                     offset={tailOffset}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
@@ -39,9 +39,7 @@ export default class TooltipPopper extends React.Component<Props> {
         // We'll hide some complexity from the children here and ensure
         // that our placement always has a value.
         const placement: Placement =
-            // We know that popperProps.placement will only be one of our
-            // supported values, so just cast it.
-            (popperProps.placement as any) || this.props.placement;
+            popperProps.placement || this.props.placement;
 
         // Just in case the callbacks have changed, let's update our reference
         // trackers.

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -4,6 +4,7 @@ import {css, StyleSheet} from "aphrodite";
 import Colors from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import type {getRefFn, Placement, Offset} from "../util/types";
@@ -23,10 +24,14 @@ export type Props = {
     placement: Placement;
     /** A callback to update the ref of the tail element. */
     updateRef?: getRefFn;
+    /** When true, the tail is shown; otherwise, it is not but it still takes
+     * space in the layout. */
+    show: boolean;
 };
 
 type DefaultProps = {
     color: Props["color"];
+    show: Props["show"];
 };
 
 type Dimensions = {
@@ -49,6 +54,7 @@ let tempIdCounter = 0;
 export default class TooltipTail extends React.Component<Props> {
     static defaultProps: DefaultProps = {
         color: "white",
+        show: true,
     };
 
     _calculateDimensionsFromPlacement(): Dimensions {
@@ -344,7 +350,13 @@ export default class TooltipTail extends React.Component<Props> {
         const {trimlinePoints, points, height, width} =
             this._calculateDimensionsFromPlacement();
 
-        const {color} = this.props;
+        const {color, show} = this.props;
+
+        if (!show) {
+            // If we aren't showing the tail, we still need to take up space
+            // so we render a strut instead.
+            return <Strut size={height} />;
+        }
 
         return (
             <svg


### PR DESCRIPTION
## Summary:
This makes it so that the popover tail can be hidden for designs that warrant it. This new prop defaults to true so that existing uses are unchanged.

I made this a minor update for popover since it's a new prop on the primary usage. I made it only patch for tooltip as the primary usage is unchanged (it's only the TooltipTail component that changes).

Here's the default story for the popover that shows the tail:
<img width="231" alt="Screen Shot 2023-06-07 at 14 36 24" src="https://github.com/Khan/wonder-blocks/assets/1266297/e6c5f165-7265-48b7-8fcc-eb6dde1c9413">

Here's the new No Tail story that shows the popover without the tail:
<img width="337" alt="Screen Shot 2023-06-07 at 14 36 18" src="https://github.com/Khan/wonder-blocks/assets/1266297/8267e32d-9ea1-4511-b3c3-61e072267890">

Issue: WB-1556

## Test plan:
`yarn start` and view the new story (and the old ones) to see that it works.