### PR TITLE
Add autofocus prop to SearchField

### DIFF
--- a/.changeset/seven-hairs-bake.md
+++ b/.changeset/seven-hairs-bake.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-search-field": minor
+"@khanacademy/wonder-blocks-form": minor
+---
+
+Add autocomplete prop to SearchField and TextField

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -731,19 +731,19 @@ export const WithAutofocus: StoryComponentType = () => {
                 autoFocus={true}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
-                style={{flexGrow: 1, marginLeft: 12}}
+                style={{flexGrow: 1, marginLeft: Spacing.small_12}}
             />
         </View>
     );
 
     return (
         <View>
-            <LabelLarge style={{marginBottom: 12}}>
+            <LabelLarge style={{marginBottom: Spacing.small_12}}>
                 Press the button to view the text field with autofocus.
             </LabelLarge>
             <Button
                 onClick={handleShowDemo}
-                style={{width: 300, marginBottom: 24}}
+                style={{width: 300, marginBottom: Spacing.large_24}}
             >
                 Toggle autoFocus demo
             </Button>

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -7,6 +7,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import Button from "@khanacademy/wonder-blocks-button";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {name, version} from "../../packages/wonder-blocks-form/package.json";
@@ -702,6 +703,68 @@ ReadOnly.parameters = {
     },
 };
 
+export const WithAutofocus: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+    const [showDemo, setShowDemo] = React.useState(false);
+
+    const handleChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    const handleShowDemo = () => {
+        setShowDemo(!showDemo);
+    };
+
+    const AutoFocusDemo = () => (
+        <View style={{flexDirection: "row"}}>
+            <Button onClick={() => {}}>Some other focusable element</Button>
+            <TextField
+                id="tf-13"
+                value={value}
+                placeholder="Placeholder"
+                autoFocus={true}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                style={{flexGrow: 1, marginLeft: 12}}
+            />
+        </View>
+    );
+
+    return (
+        <View>
+            <LabelLarge style={{marginBottom: 12}}>
+                Press the button to view the text field with autofocus.
+            </LabelLarge>
+            <Button
+                onClick={handleShowDemo}
+                style={{width: 300, marginBottom: 24}}
+            >
+                Toggle autoFocus demo
+            </Button>
+            {showDemo && <AutoFocusDemo />}
+        </View>
+    );
+};
+
+WithAutofocus.parameters = {
+    docs: {
+        storyDescription: `TextField takes an \`autoFocus\` prop, which
+            makes it autofocus on page load. Try to avoid using this if
+            possible as it is bad for accessibility.\n\nPress the button
+            to view this example. Notice that the text field automatically
+            receives focus. Upon pressing the botton, try typing and
+            notice that the text appears directly in the text field. There
+            is another focusable element present to demonstrate that
+            focus skips that element and goes straight to the text field.`,
+    },
+};
+
 export const AutoComplete: StoryComponentType = () => {
     const [value, setValue] = React.useState("");
 
@@ -718,7 +781,7 @@ export const AutoComplete: StoryComponentType = () => {
     return (
         <form>
             <TextField
-                id="tf-13"
+                id="tf-14"
                 type="text"
                 value={value}
                 placeholder="Name"

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -136,19 +136,19 @@ export const WithAutofocus: StoryComponentType = () => {
                 autoFocus={true}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
-                style={{flexGrow: 1, marginLeft: 12}}
+                style={{flexGrow: 1, marginLeft: Spacing.small_12}}
             />
         </View>
     );
 
     return (
         <View>
-            <LabelLarge style={{marginBottom: 12}}>
+            <LabelLarge style={{marginBottom: Spacing.small_12}}>
                 Press the button to view the search field with autofocus.
             </LabelLarge>
             <Button
                 onClick={handleShowDemo}
-                style={{width: 300, marginBottom: 24}}
+                style={{width: 300, marginBottom: Spacing.large_24}}
             >
                 Toggle autoFocus demo
             </Button>

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -4,8 +4,10 @@ import {action} from "@storybook/addon-actions";
 import type {ComponentStory, ComponentMeta} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
+import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import SearchField from "../../packages/wonder-blocks-search-field/src/components/search-field";
 
@@ -104,6 +106,67 @@ Disabled.parameters = {
     docs: {
         storyDescription:
             "SearchField takes a `disabled` prop, which makes it unusable. Try to avoid using this if possible as it is bad for accessibility.",
+    },
+};
+
+export const WithAutofocus: StoryComponentType = () => {
+    const [value, setValue] = React.useState("");
+    const [showDemo, setShowDemo] = React.useState(false);
+
+    const handleChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.currentTarget.blur();
+        }
+    };
+
+    const handleShowDemo = () => {
+        setShowDemo(!showDemo);
+    };
+
+    const AutoFocusDemo = () => (
+        <View style={{flexDirection: "row"}}>
+            <Button onClick={() => {}}>Some other focusable element</Button>
+            <SearchField
+                value={value}
+                placeholder="Placeholder"
+                autoFocus={true}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                style={{flexGrow: 1, marginLeft: 12}}
+            />
+        </View>
+    );
+
+    return (
+        <View>
+            <LabelLarge style={{marginBottom: 12}}>
+                Press the button to view the search field with autofocus.
+            </LabelLarge>
+            <Button
+                onClick={handleShowDemo}
+                style={{width: 300, marginBottom: 24}}
+            >
+                Toggle autoFocus demo
+            </Button>
+            {showDemo && <AutoFocusDemo />}
+        </View>
+    );
+};
+
+WithAutofocus.parameters = {
+    docs: {
+        storyDescription: `SearchField takes an \`autoFocus\` prop, which
+            makes it autofocus on page load. Try to avoid using this if
+            possible as it is bad for accessibility.\n\nPress the button
+            to view this example. Notice that the search field automatically
+            receives focus. Upon pressing the botton, try typing and
+            notice that the text appears directly in the search field.
+            There is another focusable element present to demonstrate that
+            focus skips that element and goes straight to the search field.`,
     },
 };
 

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import {fireEvent, render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import {View} from "@khanacademy/wonder-blocks-core";
+import Button from "@khanacademy/wonder-blocks-button";
+
 import TextField from "../text-field";
 
 describe("TextField", () => {
@@ -401,5 +404,54 @@ describe("TextField", () => {
         // Assert
         const input = screen.getByRole("textbox");
         expect(input).toHaveAttribute("autoComplete", autoComplete);
+    });
+
+    test("has focus if autoFocus is true", () => {
+        // Arrange
+        render(
+            <View>
+                <Button onClick={() => {}}>
+                    Some other focusable element.
+                </Button>
+                <TextField
+                    id="tf-auto-focus-true"
+                    autoFocus
+                    testId="search-field-test"
+                    onChange={() => {}}
+                    value=""
+                />
+                ,
+            </View>,
+        );
+
+        // Act
+        const searchField = screen.getByTestId("search-field-test");
+
+        // Assert
+        expect(searchField).toHaveFocus();
+    });
+
+    test("does not have focus if autoFocus is undefined", () => {
+        // Arrange
+        render(
+            <View>
+                <Button onClick={() => {}}>
+                    Some other focusable element.
+                </Button>
+                <TextField
+                    id="tf-auto-focus-undefined"
+                    testId="search-field-test"
+                    onChange={() => {}}
+                    value=""
+                />
+                ,
+            </View>,
+        );
+
+        // Act
+        const searchField = screen.getByTestId("search-field-test");
+
+        // Assert
+        expect(searchField).not.toHaveFocus();
     });
 });

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -104,6 +104,10 @@ type Props = AriaProps & {
      */
     readOnly?: boolean;
     /**
+     * Whether this field should autofocus on page load.
+     */
+    autoFocus?: boolean;
+    /**
      * Specifies if the input field allows autocomplete.
      */
     autoComplete?: string;
@@ -222,6 +226,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             style,
             testId,
             readOnly,
+            autoFocus,
             autoComplete,
             forwardedRef,
             // The following props are being included here to avoid
@@ -269,6 +274,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                 onBlur={this.handleBlur}
                 data-test-id={testId}
                 readOnly={readOnly}
+                autoFocus={autoFocus}
                 autoComplete={autoComplete}
                 ref={forwardedRef}
                 {...otherProps}

--- a/packages/wonder-blocks-form/tsconfig-build.json
+++ b/packages/wonder-blocks-form/tsconfig-build.json
@@ -6,6 +6,7 @@
         "rootDir": "src",
     },
     "references": [
+        {"path": "../wonder-blocks-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
         {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},

--- a/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
+++ b/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import {View} from "@khanacademy/wonder-blocks-core";
+import Button from "@khanacademy/wonder-blocks-button";
+
 import SearchField from "../search-field";
 
 describe("SearchField", () => {
@@ -347,5 +350,52 @@ describe("SearchField", () => {
 
         // Assert
         expect(searchField.getAttribute("id")).toMatch(/^uid-.*-field$/);
+    });
+
+    test("has focus if autoFocus is true", () => {
+        // Arrange
+        render(
+            <View>
+                <Button onClick={() => {}}>
+                    Some other focusable element.
+                </Button>
+                <SearchField
+                    autoFocus
+                    testId="search-field-test"
+                    onChange={() => {}}
+                    value=""
+                />
+                ,
+            </View>,
+        );
+
+        // Act
+        const searchField = screen.getByTestId("search-field-test");
+
+        // Assert
+        expect(searchField).toHaveFocus();
+    });
+
+    test("does not have focus if autoFocus is undefined", () => {
+        // Arrange
+        render(
+            <View>
+                <Button onClick={() => {}}>
+                    Some other focusable element.
+                </Button>
+                <SearchField
+                    testId="search-field-test"
+                    onChange={() => {}}
+                    value=""
+                />
+                ,
+            </View>,
+        );
+
+        // Act
+        const searchField = screen.getByTestId("search-field-test");
+
+        // Assert
+        expect(searchField).not.toHaveFocus();
     });
 });

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -32,6 +32,10 @@ type Props = AriaProps & {
      */
     placeholder?: string;
     /**
+     * Whether this field should autofocus on page load.
+     */
+    autoFocus?: boolean;
+    /**
      * Makes a read-only input field that cannot be focused.
      * Defaults to false.
      */
@@ -100,6 +104,7 @@ const SearchField: React.ForwardRefExoticComponent<
 ) {
     const {
         clearAriaLabel = defaultLabels.clearSearch,
+        autoFocus,
         disabled = false,
         light = false,
         id,
@@ -159,6 +164,7 @@ const SearchField: React.ForwardRefExoticComponent<
                     <TextField
                         id={`${uniqueId}-field`}
                         type="text"
+                        autoFocus={autoFocus}
                         disabled={disabled}
                         light={light}
                         onChange={onChange}

--- a/packages/wonder-blocks-search-field/tsconfig-build.json
+++ b/packages/wonder-blocks-search-field/tsconfig-build.json
@@ -6,6 +6,7 @@
         "rootDir": "src",
     },
     "references": [
+        {"path": "../wonder-blocks-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-form/tsconfig-build.json"},


### PR DESCRIPTION
## Summary:
Add autofocus prop to SearchField (and TextField) so that
they can receive focus on page load.

The example I added to storybook makes you press a button
to load the autofocus search field, because I didn't
want the story to autofocus when loading the Storybook site.

Issue: none

## Test plan:
`yarn jest`

Storybook

SearchField: https://5e1bf4b385e3fb0020b7073c-uwyyegabqe.chromatic.com/?path=/docs/search-field-searchfield--with-autofocus

TextField: https://5e1bf4b385e3fb0020b7073c-uwyyegabqe.chromatic.com/?path=/docs/form-textfield--with-autofocus