### PR TITLE
Updating tertiary button focus state to be a border instead of underline

### DIFF
--- a/.changeset/fifty-cycles-juggle.md
+++ b/.changeset/fifty-cycles-juggle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-button": patch
+---
+
+Updated focus state for tertiary button to a border instead of underline

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import {expect} from "@storybook/jest";
 import {StyleSheet} from "aphrodite";
 import {withDesign} from "storybook-addon-designs";
 import {action} from "@storybook/addon-actions";
@@ -7,6 +8,7 @@ import type {ComponentStory, ComponentMeta} from "@storybook/react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 
 import type {StyleDeclaration} from "aphrodite";
+import {fireEvent, userEvent, within} from "@storybook/testing-library";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {icons} from "@khanacademy/wonder-blocks-icon";
@@ -60,6 +62,43 @@ Default.parameters = {
         // We already have screenshots of other stories that cover more of the button states
         disableSnapshot: true,
     },
+};
+
+export const Tertiary: StoryComponentType = () => (
+    <Button onClick={() => {}} kind="tertiary">
+        Hello, world!
+    </Button>
+);
+
+Tertiary.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // Get HTML elements
+    const button = canvas.getByRole("button");
+    const computedStyleButton = getComputedStyle(button, ":after");
+    const innerLabel = canvas.getByTestId("button-inner-label");
+    const computedStyleLabel = getComputedStyle(innerLabel, ":after");
+
+    // Resting style
+    await expect(button).toHaveStyle(`color: ${Color.blue}`);
+    await expect(button).toHaveTextContent("Hello, world!");
+
+    // Hover style
+    await userEvent.hover(button);
+    await expect(computedStyleLabel.height).toBe("2px");
+    await expect(computedStyleLabel.color).toBe("rgb(24, 101, 242)");
+
+    // Focus style
+    await fireEvent.focus(button);
+    await expect(computedStyleButton.borderColor).toBe("rgb(24, 101, 242)");
+    await expect(computedStyleButton.borderWidth).toBe("2px");
+
+    // Active (mouse down) style
+    // eslint-disable-next-line testing-library/prefer-user-event
+    await fireEvent.mouseDown(button);
+    await expect(innerLabel).toHaveStyle("color: rgb(27, 80, 179)");
+    await expect(computedStyleLabel.height).toBe("1px");
+    await expect(computedStyleLabel.color).toBe("rgb(27, 80, 179)");
 };
 
 export const styles: StyleDeclaration = StyleSheet.create({

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -65,7 +65,7 @@ Default.parameters = {
 };
 
 export const Tertiary: StoryComponentType = () => (
-    <Button onClick={() => {}} kind="tertiary">
+    <Button onClick={() => {}} kind="tertiary" testId="test-button">
         Hello, world!
     </Button>
 );
@@ -76,7 +76,7 @@ Tertiary.play = async ({canvasElement}) => {
     // Get HTML elements
     const button = canvas.getByRole("button");
     const computedStyleButton = getComputedStyle(button, ":after");
-    const innerLabel = canvas.getByTestId("button-inner-label");
+    const innerLabel = canvas.getByTestId("test-button-inner-label");
     const computedStyleLabel = getComputedStyle(innerLabel, ":after");
 
     // Resting style

--- a/packages/wonder-blocks-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`Button <Link tabIndex={-1}> 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -127,7 +126,6 @@ exports[`Button <Link tabIndex={0}> 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -202,7 +200,6 @@ exports[`Button <Link tabIndex={1}> 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -278,7 +275,6 @@ exports[`ButtonCore kind:primary color:default size:large light:false disabled 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -355,7 +351,6 @@ exports[`ButtonCore kind:primary color:default size:large light:false focused 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -432,7 +427,6 @@ exports[`ButtonCore kind:primary color:default size:large light:false hovered 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -509,7 +503,6 @@ exports[`ButtonCore kind:primary color:default size:large light:false pressed 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -585,7 +578,6 @@ exports[`ButtonCore kind:primary color:default size:large light:true disabled 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -662,7 +654,6 @@ exports[`ButtonCore kind:primary color:default size:large light:true focused 1`]
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -739,7 +730,6 @@ exports[`ButtonCore kind:primary color:default size:large light:true hovered 1`]
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -816,7 +806,6 @@ exports[`ButtonCore kind:primary color:default size:large light:true pressed 1`]
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -892,7 +881,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:false disabled 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -969,7 +957,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:false focused 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1046,7 +1033,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:false hovered 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1123,7 +1109,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:false pressed 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1199,7 +1184,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:true disabled 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1276,7 +1260,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:true focused 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1353,7 +1336,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:true hovered 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1430,7 +1412,6 @@ exports[`ButtonCore kind:primary color:default size:medium light:true pressed 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1506,7 +1487,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1583,7 +1563,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1660,7 +1639,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1737,7 +1715,6 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1813,7 +1790,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1890,7 +1866,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1967,7 +1942,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2044,7 +2018,6 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2120,7 +2093,6 @@ exports[`ButtonCore kind:primary color:destructive size:large light:false disabl
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2197,7 +2169,6 @@ exports[`ButtonCore kind:primary color:destructive size:large light:false focuse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2274,7 +2245,6 @@ exports[`ButtonCore kind:primary color:destructive size:large light:false hovere
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2351,7 +2321,6 @@ exports[`ButtonCore kind:primary color:destructive size:large light:false presse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2427,7 +2396,6 @@ exports[`ButtonCore kind:primary color:destructive size:large light:true disable
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2504,7 +2472,6 @@ exports[`ButtonCore kind:primary color:destructive size:large light:true focused
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2581,7 +2548,6 @@ exports[`ButtonCore kind:primary color:destructive size:large light:true hovered
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2658,7 +2624,6 @@ exports[`ButtonCore kind:primary color:destructive size:large light:true pressed
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2734,7 +2699,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false disab
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2811,7 +2775,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false focus
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2888,7 +2851,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false hover
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2965,7 +2927,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false press
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3041,7 +3002,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true disabl
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3118,7 +3078,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true focuse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3195,7 +3154,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true hovere
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3272,7 +3230,6 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true presse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3348,7 +3305,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3425,7 +3381,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3502,7 +3457,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3579,7 +3533,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3655,7 +3608,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3732,7 +3684,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3809,7 +3760,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3886,7 +3836,6 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3962,7 +3911,6 @@ exports[`ButtonCore kind:primary size:medium spinner:true 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4093,7 +4041,6 @@ exports[`ButtonCore kind:primary size:small spinner:true 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4230,7 +4177,6 @@ exports[`ButtonCore kind:secondary color:default size:large light:false disabled
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4309,7 +4255,6 @@ exports[`ButtonCore kind:secondary color:default size:large light:false focused 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4388,7 +4333,6 @@ exports[`ButtonCore kind:secondary color:default size:large light:false hovered 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4467,7 +4411,6 @@ exports[`ButtonCore kind:secondary color:default size:large light:false pressed 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4549,7 +4492,6 @@ exports[`ButtonCore kind:secondary color:default size:large light:true disabled 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4628,7 +4570,6 @@ exports[`ButtonCore kind:secondary color:default size:large light:true focused 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4707,7 +4648,6 @@ exports[`ButtonCore kind:secondary color:default size:large light:true hovered 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4786,7 +4726,6 @@ exports[`ButtonCore kind:secondary color:default size:large light:true pressed 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4868,7 +4807,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false disable
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4947,7 +4885,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false focused
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5026,7 +4963,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false hovered
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5105,7 +5041,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false pressed
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5187,7 +5122,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true disabled
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5266,7 +5200,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true focused 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5345,7 +5278,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true hovered 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5424,7 +5356,6 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true pressed 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5506,7 +5437,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5585,7 +5515,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5664,7 +5593,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5743,7 +5671,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5825,7 +5752,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5904,7 +5830,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5983,7 +5908,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6062,7 +5986,6 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6144,7 +6067,6 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:false disa
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6223,7 +6145,6 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:false focu
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6302,7 +6223,6 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:false hove
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6381,7 +6301,6 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:false pres
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6463,7 +6382,6 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:true disab
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6542,7 +6460,6 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:true focus
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6621,7 +6538,6 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:true hover
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6700,7 +6616,6 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:true press
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6782,7 +6697,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false dis
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6861,7 +6775,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false foc
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6940,7 +6853,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false hov
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7019,7 +6931,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false pre
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7101,7 +7012,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true disa
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7180,7 +7090,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true focu
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7259,7 +7168,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true hove
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7338,7 +7246,6 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true pres
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7420,7 +7327,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7499,7 +7405,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7578,7 +7483,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7657,7 +7561,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7739,7 +7642,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7818,7 +7720,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7897,7 +7798,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7976,7 +7876,6 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8058,7 +7957,6 @@ exports[`ButtonCore kind:secondary size:medium spinner:true 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8195,7 +8093,6 @@ exports[`ButtonCore kind:secondary size:small spinner:true 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8326,7 +8223,6 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false disabled 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8413,7 +8309,6 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false focused 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8490,7 +8385,6 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false hovered 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -8577,7 +8471,6 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false pressed 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -8659,7 +8552,6 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true disabled 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8746,7 +8638,6 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true focused 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8823,7 +8714,6 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true hovered 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -8910,7 +8800,6 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true pressed 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -8992,7 +8881,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false disabled
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9079,7 +8967,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false focused 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9156,7 +9043,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false hovered 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9243,7 +9129,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false pressed 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9325,7 +9210,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true disabled 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9412,7 +9296,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true focused 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9489,7 +9372,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true hovered 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9576,7 +9458,6 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true pressed 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9658,7 +9539,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9745,7 +9625,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9822,7 +9701,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9909,7 +9787,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9991,7 +9868,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10078,7 +9954,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10155,7 +10030,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10242,7 +10116,6 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10324,7 +10197,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false disab
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10411,7 +10283,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false focus
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10488,7 +10359,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false hover
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10575,7 +10445,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false press
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10657,7 +10526,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true disabl
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10744,7 +10612,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true focuse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10821,7 +10688,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true hovere
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10908,7 +10774,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true presse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10990,7 +10855,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false disa
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11077,7 +10941,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false focu
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11154,7 +11017,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false hove
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11241,7 +11103,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false pres
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11323,7 +11184,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true disab
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11410,7 +11270,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true focus
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11487,7 +11346,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true hover
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11574,7 +11432,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true press
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11656,7 +11513,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11743,7 +11599,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11820,7 +11675,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11907,7 +11761,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11989,7 +11842,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -12076,7 +11928,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -12153,7 +12004,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -12240,7 +12090,6 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -12322,7 +12171,6 @@ exports[`ButtonCore kind:tertiary size:medium spinner:true 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -12454,7 +12302,6 @@ exports[`ButtonCore kind:tertiary size:small spinner:true 1`] = `
 >
   <span
     className=""
-    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",

--- a/packages/wonder-blocks-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`Button <Link tabIndex={-1}> 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -126,6 +127,7 @@ exports[`Button <Link tabIndex={0}> 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -200,6 +202,7 @@ exports[`Button <Link tabIndex={1}> 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -275,6 +278,7 @@ exports[`ButtonCore kind:primary color:default size:large light:false disabled 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -351,6 +355,7 @@ exports[`ButtonCore kind:primary color:default size:large light:false focused 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -427,6 +432,7 @@ exports[`ButtonCore kind:primary color:default size:large light:false hovered 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -503,6 +509,7 @@ exports[`ButtonCore kind:primary color:default size:large light:false pressed 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -578,6 +585,7 @@ exports[`ButtonCore kind:primary color:default size:large light:true disabled 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -654,6 +662,7 @@ exports[`ButtonCore kind:primary color:default size:large light:true focused 1`]
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -730,6 +739,7 @@ exports[`ButtonCore kind:primary color:default size:large light:true hovered 1`]
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -806,6 +816,7 @@ exports[`ButtonCore kind:primary color:default size:large light:true pressed 1`]
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -881,6 +892,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false disabled 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -957,6 +969,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false focused 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1033,6 +1046,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false hovered 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1109,6 +1123,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:false pressed 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1184,6 +1199,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true disabled 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1260,6 +1276,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true focused 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1336,6 +1353,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true hovered 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1412,6 +1430,7 @@ exports[`ButtonCore kind:primary color:default size:medium light:true pressed 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1487,6 +1506,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false disabled 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1563,6 +1583,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false focused 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1639,6 +1660,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false hovered 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1715,6 +1737,7 @@ exports[`ButtonCore kind:primary color:default size:small light:false pressed 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1790,6 +1813,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true disabled 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1866,6 +1890,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true focused 1`]
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -1942,6 +1967,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true hovered 1`]
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2018,6 +2044,7 @@ exports[`ButtonCore kind:primary color:default size:small light:true pressed 1`]
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2093,6 +2120,7 @@ exports[`ButtonCore kind:primary color:destructive size:large light:false disabl
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2169,6 +2197,7 @@ exports[`ButtonCore kind:primary color:destructive size:large light:false focuse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2245,6 +2274,7 @@ exports[`ButtonCore kind:primary color:destructive size:large light:false hovere
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2321,6 +2351,7 @@ exports[`ButtonCore kind:primary color:destructive size:large light:false presse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2396,6 +2427,7 @@ exports[`ButtonCore kind:primary color:destructive size:large light:true disable
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2472,6 +2504,7 @@ exports[`ButtonCore kind:primary color:destructive size:large light:true focused
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2548,6 +2581,7 @@ exports[`ButtonCore kind:primary color:destructive size:large light:true hovered
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2624,6 +2658,7 @@ exports[`ButtonCore kind:primary color:destructive size:large light:true pressed
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2699,6 +2734,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false disab
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2775,6 +2811,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false focus
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2851,6 +2888,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false hover
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -2927,6 +2965,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:false press
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3002,6 +3041,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true disabl
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3078,6 +3118,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true focuse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3154,6 +3195,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true hovere
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3230,6 +3272,7 @@ exports[`ButtonCore kind:primary color:destructive size:medium light:true presse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3305,6 +3348,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false disabl
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3381,6 +3425,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false focuse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3457,6 +3502,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false hovere
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3533,6 +3579,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:false presse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3608,6 +3655,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true disable
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3684,6 +3732,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true focused
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3760,6 +3809,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true hovered
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3836,6 +3886,7 @@ exports[`ButtonCore kind:primary color:destructive size:small light:true pressed
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -3911,6 +3962,7 @@ exports[`ButtonCore kind:primary size:medium spinner:true 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4041,6 +4093,7 @@ exports[`ButtonCore kind:primary size:small spinner:true 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4177,6 +4230,7 @@ exports[`ButtonCore kind:secondary color:default size:large light:false disabled
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4255,6 +4309,7 @@ exports[`ButtonCore kind:secondary color:default size:large light:false focused 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4333,6 +4388,7 @@ exports[`ButtonCore kind:secondary color:default size:large light:false hovered 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4411,6 +4467,7 @@ exports[`ButtonCore kind:secondary color:default size:large light:false pressed 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4492,6 +4549,7 @@ exports[`ButtonCore kind:secondary color:default size:large light:true disabled 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4570,6 +4628,7 @@ exports[`ButtonCore kind:secondary color:default size:large light:true focused 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4648,6 +4707,7 @@ exports[`ButtonCore kind:secondary color:default size:large light:true hovered 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4726,6 +4786,7 @@ exports[`ButtonCore kind:secondary color:default size:large light:true pressed 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4807,6 +4868,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false disable
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4885,6 +4947,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false focused
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -4963,6 +5026,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false hovered
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5041,6 +5105,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:false pressed
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5122,6 +5187,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true disabled
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5200,6 +5266,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true focused 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5278,6 +5345,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true hovered 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5356,6 +5424,7 @@ exports[`ButtonCore kind:secondary color:default size:medium light:true pressed 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5437,6 +5506,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false disabled
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5515,6 +5585,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false focused 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5593,6 +5664,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false hovered 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5671,6 +5743,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:false pressed 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5752,6 +5825,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true disabled 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5830,6 +5904,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true focused 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5908,6 +5983,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true hovered 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -5986,6 +6062,7 @@ exports[`ButtonCore kind:secondary color:default size:small light:true pressed 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6067,6 +6144,7 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:false disa
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6145,6 +6223,7 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:false focu
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6223,6 +6302,7 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:false hove
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6301,6 +6381,7 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:false pres
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6382,6 +6463,7 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:true disab
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6460,6 +6542,7 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:true focus
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6538,6 +6621,7 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:true hover
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6616,6 +6700,7 @@ exports[`ButtonCore kind:secondary color:destructive size:large light:true press
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6697,6 +6782,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false dis
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6775,6 +6861,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false foc
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6853,6 +6940,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false hov
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -6931,6 +7019,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:false pre
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7012,6 +7101,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true disa
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7090,6 +7180,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true focu
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7168,6 +7259,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true hove
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7246,6 +7338,7 @@ exports[`ButtonCore kind:secondary color:destructive size:medium light:true pres
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7327,6 +7420,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false disa
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7405,6 +7499,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false focu
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7483,6 +7578,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false hove
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7561,6 +7657,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:false pres
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7642,6 +7739,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true disab
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7720,6 +7818,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true focus
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7798,6 +7897,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true hover
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7876,6 +7976,7 @@ exports[`ButtonCore kind:secondary color:destructive size:small light:true press
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -7957,6 +8058,7 @@ exports[`ButtonCore kind:secondary size:medium spinner:true 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8093,6 +8195,7 @@ exports[`ButtonCore kind:secondary size:small spinner:true 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8223,6 +8326,7 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false disabled 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8269,6 +8373,16 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false focused 1
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#1865f2",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -8299,18 +8413,9 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false focused 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#1865f2",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -8385,6 +8490,7 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false hovered 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -8471,17 +8577,12 @@ exports[`ButtonCore kind:tertiary color:default size:large light:false pressed 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#1b50b3",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -8558,6 +8659,7 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true disabled 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8604,6 +8706,16 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true focused 1`
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#ffffff",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -8634,18 +8746,9 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true focused 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#ffffff",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -8720,6 +8823,7 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true hovered 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -8806,17 +8910,12 @@ exports[`ButtonCore kind:tertiary color:default size:large light:true pressed 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#b5cefb",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -8893,6 +8992,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false disabled
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -8939,6 +9039,16 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false focused 
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#1865f2",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -8969,18 +9079,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false focused 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#1865f2",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -9055,6 +9156,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false hovered 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9141,17 +9243,12 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:false pressed 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#1b50b3",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -9228,6 +9325,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true disabled 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9274,6 +9372,16 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true focused 1
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#ffffff",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -9304,18 +9412,9 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true focused 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#ffffff",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -9390,6 +9489,7 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true hovered 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9476,17 +9576,12 @@ exports[`ButtonCore kind:tertiary color:default size:medium light:true pressed 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#b5cefb",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -9563,6 +9658,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false disabled 
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9609,6 +9705,16 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#1865f2",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -9639,18 +9745,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false focused 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#1865f2",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -9725,6 +9822,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false hovered 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -9811,17 +9909,12 @@ exports[`ButtonCore kind:tertiary color:default size:small light:false pressed 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#1b50b3",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -9898,6 +9991,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true disabled 1
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -9944,6 +10038,16 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#ffffff",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -9974,18 +10078,9 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true focused 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#ffffff",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -10060,6 +10155,7 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true hovered 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10146,17 +10242,12 @@ exports[`ButtonCore kind:tertiary color:default size:small light:true pressed 1`
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#b5cefb",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -10233,6 +10324,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false disab
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10279,6 +10371,16 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false focus
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#d92916",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -10309,18 +10411,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false focus
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#d92916",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -10395,6 +10488,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false hover
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10481,17 +10575,12 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:false press
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#9e271d",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -10568,6 +10657,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true disabl
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10614,6 +10704,16 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true focuse
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#ffffff",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -10644,18 +10744,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true focuse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#ffffff",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -10730,6 +10821,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true hovere
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -10816,17 +10908,12 @@ exports[`ButtonCore kind:tertiary color:destructive size:large light:true presse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#f3bbb4",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -10903,6 +10990,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false disa
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -10949,6 +11037,16 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false focu
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#d92916",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -10979,18 +11077,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false focu
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#d92916",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -11065,6 +11154,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false hove
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11151,17 +11241,12 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:false pres
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#9e271d",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -11238,6 +11323,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true disab
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11284,6 +11370,16 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true focus
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#ffffff",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -11314,18 +11410,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true focus
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#ffffff",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -11400,6 +11487,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true hover
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11486,17 +11574,12 @@ exports[`ButtonCore kind:tertiary color:destructive size:medium light:true press
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#f3bbb4",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -11573,6 +11656,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false disab
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11619,6 +11703,16 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#d92916",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -11649,18 +11743,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false focus
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#d92916",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -11735,6 +11820,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false hover
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -11821,17 +11907,12 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:false press
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#9e271d",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -11908,6 +11989,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true disabl
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -11954,6 +12036,16 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
       "::MozFocusInner": {
         "border": 0,
       },
+      ":after": {
+        "borderColor": "#ffffff",
+        "borderRadius": 4,
+        "borderStyle": "solid",
+        "borderWidth": 2,
+        "content": "''",
+        "height": "calc(100% - 4px)",
+        "position": "absolute",
+        "width": "calc(100% + 4px)",
+      },
       ":focus": {
         "WebkitTapHighlightColor": "rgba(0,0,0,0)",
       },
@@ -11984,18 +12076,9 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true focuse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
-        ":after": {
-          "background": "#ffffff",
-          "borderRadius": 2,
-          "bottom": 0,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
-        },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
         "alignItems": "center",
@@ -12070,6 +12153,7 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true hovere
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
@@ -12156,17 +12240,12 @@ exports[`ButtonCore kind:tertiary color:destructive size:small light:true presse
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         ":after": {
           "background": "#f3bbb4",
-          "borderRadius": 2,
-          "bottom": -1,
-          "content": "''",
-          "height": 2,
-          "position": "absolute",
-          "right": 0,
-          "width": "calc(100% - 0px)",
+          "height": 1,
         },
         "MozOsxFontSmoothing": "grayscale",
         "WebkitFontSmoothing": "antialiased",
@@ -12243,6 +12322,7 @@ exports[`ButtonCore kind:tertiary size:medium spinner:true 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",
@@ -12374,6 +12454,7 @@ exports[`ButtonCore kind:tertiary size:small spinner:true 1`] = `
 >
   <span
     className=""
+    data-test-id="button-inner-label"
     style={
       {
         "MozOsxFontSmoothing": "grayscale",

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -317,16 +317,14 @@ const _generateStyles = (
                 borderColor: light ? white50 : offBlack50,
                 borderStyle: "solid",
                 borderWidth: 1,
-                paddingLeft: iconWidth ? padding - 4 : padding,
+                paddingLeft: padding,
                 paddingRight: padding,
             },
             focus: {
                 background: light ? "transparent" : white,
                 borderColor: light ? white : color,
                 borderWidth: 2,
-                // The left padding for the button with icon should have 4px
-                // less padding
-                paddingLeft: iconWidth ? padding - 5 : padding - 1,
+                paddingLeft: padding - 1,
                 paddingRight: padding - 1,
             },
             active: {
@@ -336,9 +334,7 @@ const _generateStyles = (
                 borderWidth: 2,
                 // We need to reduce padding to offset the difference
                 // caused by the border becoming thicker on focus.
-                // The left padding for the button with icon should have 4px
-                // less padding
-                paddingLeft: iconWidth ? padding - 5 : padding - 1,
+                paddingLeft: padding - 1,
                 paddingRight: padding - 1,
             },
             disabled: {
@@ -350,9 +346,7 @@ const _generateStyles = (
                     borderWidth: 2,
                     // We need to reduce padding to offset the difference
                     // caused by the border becoming thicker on focus.
-                    // The left padding for the button with icon should have 4px
-                    // less padding
-                    paddingLeft: iconWidth ? padding - 5 : padding - 1,
+                    paddingLeft: padding - 1,
                     paddingRight: padding - 1,
                 },
             },

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -118,6 +118,7 @@ export default class ButtonCore extends React.Component<Props> {
                             ? [buttonStyles.hover, buttonStyles.active]
                             : hovered && buttonStyles.hover),
                 ]}
+                testId="button-inner-label"
             >
                 {icon && (
                     <Icon

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -79,6 +79,12 @@ export default class ButtonCore extends React.Component<Props> {
                 (pressed
                     ? buttonStyles.active
                     : (hovered || focused) && buttonStyles.focus),
+            kind === "tertiary" &&
+                !pressed &&
+                focused && [
+                    buttonStyles.focus,
+                    disabled && buttonStyles.disabledFocus,
+                ],
             size === "small" && sharedStyles.small,
             size === "large" && sharedStyles.large,
         ];
@@ -105,18 +111,12 @@ export default class ButtonCore extends React.Component<Props> {
                     icon && sharedStyles.textWithIcon,
                     spinner && sharedStyles.hiddenText,
                     kind === "tertiary" && sharedStyles.textWithFocus,
-                    // apply focus effect on the label instead
+                    // apply press/hover effects on the label
                     kind === "tertiary" &&
                         !disabled &&
                         (pressed
-                            ? buttonStyles.active
-                            : (hovered || focused) && buttonStyles.focus),
-                    kind === "tertiary" &&
-                        disabled &&
-                        focused && [
-                            buttonStyles.focus,
-                            buttonStyles.disabledFocus,
-                        ],
+                            ? [buttonStyles.hover, buttonStyles.active]
+                            : hovered && buttonStyles.hover),
                 ]}
             >
                 {icon && (
@@ -365,7 +365,7 @@ const _generateStyles = (
                 paddingLeft: 0,
                 paddingRight: 0,
             },
-            focus: {
+            hover: {
                 ":after": {
                     content: "''",
                     position: "absolute",
@@ -377,17 +377,26 @@ const _generateStyles = (
                     borderRadius: 2,
                 },
             },
+            focus: {
+                ":after": {
+                    content: "''",
+                    // Since we are using a pseudo element, we need to manually
+                    // calculate the width/height and use absolute position to
+                    // prevent other elements from being shifted around.
+                    position: "absolute",
+                    width: `calc(100% + 4px)`,
+                    height: `calc(100% - 4px)`,
+                    borderStyle: "solid",
+                    borderColor: light ? white : color,
+                    borderWidth: 2,
+                    borderRadius: 4,
+                },
+            },
             active: {
                 color: light ? fadedColor : activeColor,
                 ":after": {
-                    content: "''",
-                    position: "absolute",
-                    height: 2,
-                    width: `calc(100% - ${iconWidth}px)`,
-                    right: 0,
                     bottom: -1,
                     background: light ? fadedColor : activeColor,
-                    borderRadius: 2,
                 },
             },
             disabled: {
@@ -396,7 +405,7 @@ const _generateStyles = (
             },
             disabledFocus: {
                 ":after": {
-                    background: light ? white : offBlack32,
+                    borderColor: light ? white50 : offBlack32,
                 },
             },
         };

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -390,7 +390,7 @@ const _generateStyles = (
             active: {
                 color: light ? fadedColor : activeColor,
                 ":after": {
-                    bottom: -1,
+                    height: 1,
                     background: light ? fadedColor : activeColor,
                 },
             },

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -118,7 +118,7 @@ export default class ButtonCore extends React.Component<Props> {
                             ? [buttonStyles.hover, buttonStyles.active]
                             : hovered && buttonStyles.hover),
                 ]}
-                testId="button-inner-label"
+                testId={testId ? `${testId}-inner-label` : undefined}
             >
                 {icon && (
                     <Icon
@@ -379,12 +379,12 @@ const _generateStyles = (
                     // calculate the width/height and use absolute position to
                     // prevent other elements from being shifted around.
                     position: "absolute",
-                    width: `calc(100% + 4px)`,
-                    height: `calc(100% - 4px)`,
+                    width: `calc(100% + ${Spacing.xxxSmall_4}px)`,
+                    height: `calc(100% - ${Spacing.xxxSmall_4}px)`,
                     borderStyle: "solid",
                     borderColor: light ? white : color,
-                    borderWidth: 2,
-                    borderRadius: 4,
+                    borderWidth: Spacing.xxxxSmall_2,
+                    borderRadius: Spacing.xxxSmall_4,
                 },
             },
             active: {


### PR DESCRIPTION
## Summary:
Updated styling for tertiary button focus state to be a border instead of underline so that the states can be differentiated. Also updated some styling for other buttons.

Issue: WB-1420

## Test plan:
- Wrote new interaction test/story for tertiary button
- Updated snapshots in unit tests

| Focus state before | Focus state after |
|--------|--------|
| <img width="154" alt="Screen Shot 2023-06-30 at 5 14 46 PM" src="https://github.com/Khan/wonder-blocks/assets/77523470/e648fc41-d6da-4958-97cd-33faf26cd288"> | <img width="196" alt="Screen Shot 2023-07-05 at 10 58 47 AM" src="https://github.com/Khan/wonder-blocks/assets/77523470/80a61809-b8cb-4fa5-a499-08074e34c4c5"> | 