### PR TITLE
Add style prop to tooltip

### DIFF
--- a/.changeset/pink-guests-accept.md
+++ b/.changeset/pink-guests-accept.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tooltip": minor
+---
+
+Added an optional style prop to Tooltip

--- a/.changeset/pink-guests-accept.md
+++ b/.changeset/pink-guests-accept.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tooltip": minor
 ---
 
-Added an optional style prop to Tooltip
+Added custom styling for background color, text color, and padding to Tooltip

--- a/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
+++ b/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
@@ -1,11 +1,13 @@
+import Color from "@khanacademy/wonder-blocks-color";
+
 export default {
     placement: {
         description:
             "Where the tooltip should appear in relation to the anchor element. Defaults to `top`.",
         control: {
             type: "select",
-            options: ["top", "bottom", "right", "left"],
         },
+        options: ["top", "bottom", "right", "left"],
     },
     title: {
         description: "Optional title for the tooltip content.",
@@ -21,8 +23,21 @@ export default {
     contentStyle: {
         description:
             "Optional subset of CSS styles for the tooltip content. Currently supports `color` and `padding`.",
+        control: {
+            type: "object",
+        },
+        table: {
+            type: {
+                summary: "ContentStyle",
+                detail: "Only supports color and padding styles.",
+            },
+        },
     },
     backgroundColor: {
         description: "Optional background color for the tooltip content.",
+        control: {
+            type: "select",
+        },
+        options: Object.keys(Color) as Array<string>,
     },
 };

--- a/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
+++ b/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
@@ -1,14 +1,28 @@
 export default {
     placement: {
+        description:
+            "Where the tooltip should appear in relation to the anchor element. Defaults to `top`.",
         control: {
             type: "select",
             options: ["top", "bottom", "right", "left"],
         },
     },
-
     title: {
+        description: "Optional title for the tooltip content.",
         control: {
             type: "text",
         },
+        table: {
+            type: {
+                summary: "string",
+            },
+        },
+    },
+    contentStyle: {
+        description:
+            "Optional subset of CSS styles for the tooltip content. Currently supports `color` and `padding`.",
+    },
+    backgroundColor: {
+        description: "Optional background color for the tooltip content.",
     },
 };

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -315,6 +315,7 @@ export const WithStyle: StoryComponentType = () => {
                 content={`This is a styled tooltip.`}
                 backgroundColor="darkBlue"
                 opened={true}
+                testId="test-tooltip"
             >
                 My tooltip is styled!
             </Tooltip>
@@ -330,6 +331,25 @@ WithStyle.parameters = {
             shows a tooltip with a dark blue background, white text, and 32px of padding.`,
         },
     },
+};
+
+WithStyle.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement.ownerDocument.body);
+
+    // Get HTML elements
+    const tooltipContent = await canvas.findByTestId("test-tooltip-content");
+    const innerTooltipView =
+        // eslint-disable-next-line testing-library/no-node-access
+        (await canvas.findByRole("tooltip")).firstChild;
+
+    // Assert
+    await expect(innerTooltipView).toHaveStyle(
+        "background-color: rgb(11, 33, 73)",
+    );
+    await expect(tooltipContent).toHaveStyle({
+        padding: "32px",
+        color: "#fff",
+    });
 };
 
 const styles = StyleSheet.create({

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -19,25 +19,14 @@ import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import packageConfig from "../../packages/wonder-blocks-tooltip/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
+import TooltipArgTypes from "./tooltip.argtypes";
 
 type StoryComponentType = StoryObj<typeof Tooltip>;
 
 export default {
     title: "Tooltip / Tooltip",
     component: Tooltip as unknown as React.ComponentType<any>,
-    argTypes: {
-        placement: {
-            control: {
-                type: "select",
-                options: ["top", "bottom", "right", "left"],
-            },
-        },
-        title: {
-            control: {
-                type: "text",
-            },
-        },
-    },
+    argTypes: TooltipArgTypes,
     args: {
         forceAnchorFocusivity: true,
         placement: "top",
@@ -312,6 +301,30 @@ Controlled.parameters = {
                to update \`opened\` to \`false\` in response to the
                \`onClose\` callback being triggered.`,
         },
+    },
+};
+
+export const WithStyle: StoryComponentType = () => {
+    return (
+        <View style={[styles.centered, styles.row]}>
+            <Tooltip
+                contentStyle={{
+                    color: Color.white,
+                    padding: Spacing.xLarge_32,
+                }}
+                content={`This is a styled tooltip.`}
+                backgroundColor="darkBlue"
+            >
+                My tooltip is styled!
+            </Tooltip>
+        </View>
+    );
+};
+
+WithStyle.parameters = {
+    docs: {
+        // TODO(marianmwang): update this story description once the props are finalized
+        storyDescription: ``,
     },
 };
 

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -314,6 +314,7 @@ export const WithStyle: StoryComponentType = () => {
                 }}
                 content={`This is a styled tooltip.`}
                 backgroundColor="darkBlue"
+                opened={true}
             >
                 My tooltip is styled!
             </Tooltip>
@@ -323,8 +324,11 @@ export const WithStyle: StoryComponentType = () => {
 
 WithStyle.parameters = {
     docs: {
-        // TODO(marianmwang): update this story description once the props are finalized
-        storyDescription: ``,
+        description: {
+            story: `Tooltips can be styled with the \`backgroundColor\` and \`contentStyle\`
+            props. Currently, \`contentStyle\` supports padding and text color. The example below
+            shows a tooltip with a dark blue background, white text, and 32px of padding.`,
+        },
     },
 };
 

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx
@@ -122,24 +122,22 @@ describe("Tooltip", () => {
                         title="Title"
                         content="Content"
                         backgroundColor="blue"
-                        testId="test-tooltip"
+                        opened={true}
                     >
                         Anchor
                     </Tooltip>
                 </View>,
             );
 
-            const node = screen.getByText("Anchor");
-            userEvent.hover(node);
-            jest.runOnlyPendingTimers();
-
             // Act
-            const tooltipContent = screen.getByTestId("test-tooltip-content");
-            expect(tooltipContent).toBeInTheDocument();
+            const tooltipContent = screen.getByRole("tooltip");
+            // eslint-disable-next-line testing-library/no-node-access
+            const innerTooltipContentView = tooltipContent.firstChild;
+            expect(innerTooltipContentView).toBeInTheDocument();
 
             // Assert
-            expect(tooltipContent.style.backgroundColor).toBe(
-                "rgb(24, 101, 242)",
+            expect(innerTooltipContentView).toHaveStyle(
+                "background-color: rgb(24, 101, 242)",
             );
         });
     });

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx
@@ -113,6 +113,35 @@ describe("Tooltip", () => {
             // Assert
             expect(tooltip).toBeInTheDocument();
         });
+
+        it("should have a background color if one is set", () => {
+            // Arrange
+            render(
+                <View>
+                    <Tooltip
+                        title="Title"
+                        content="Content"
+                        backgroundColor="blue"
+                        testId="test-tooltip"
+                    >
+                        Anchor
+                    </Tooltip>
+                </View>,
+            );
+
+            const node = screen.getByText("Anchor");
+            userEvent.hover(node);
+            jest.runOnlyPendingTimers();
+
+            // Act
+            const tooltipContent = screen.getByTestId("test-tooltip-content");
+            expect(tooltipContent).toBeInTheDocument();
+
+            // Assert
+            expect(tooltipContent.style.backgroundColor).toBe(
+                "rgb(24, 101, 242)",
+            );
+        });
     });
 
     describe("accessibility", () => {

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -8,7 +8,7 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import TooltipContent from "./tooltip-content";
 import TooltipTail from "./tooltip-tail";
 
-import type {getRefFn, Offset, Placement} from "../util/types";
+import type {ContentStyle, getRefFn, Offset, Placement} from "../util/types";
 
 export type PopperElementProps = {
     /** The placement of the bubble with respect to the anchor. */
@@ -31,6 +31,8 @@ export type Props = {
     /** The `TooltipContent` element that will be rendered in the bubble. */
     children: React.ReactElement<React.ComponentProps<typeof TooltipContent>>;
     onActiveChanged: (active: boolean) => unknown;
+    contentStyle?: ContentStyle;
+    backgroundColor?: keyof typeof Colors;
 } & PopperElementProps; // (v3 beta introduces this) // TODO(somewhatabstract): Update react-docgen to support spread operators
 
 type State = {
@@ -65,8 +67,8 @@ export default class TooltipBubble extends React.Component<Props, State> {
             style,
             updateTailRef,
             tailOffset,
+            backgroundColor,
         } = this.props;
-
         return (
             <View
                 id={id}
@@ -87,6 +89,7 @@ export default class TooltipBubble extends React.Component<Props, State> {
                     updateRef={updateTailRef}
                     placement={placement}
                     offset={tailOffset}
+                    color={backgroundColor}
                 />
             </View>
         );

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -8,7 +8,7 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import TooltipContent from "./tooltip-content";
 import TooltipTail from "./tooltip-tail";
 
-import type {ContentStyle, getRefFn, Offset, Placement} from "../util/types";
+import type {getRefFn, Offset, Placement} from "../util/types";
 
 export type PopperElementProps = {
     /** The placement of the bubble with respect to the anchor. */
@@ -31,7 +31,7 @@ export type Props = {
     /** The `TooltipContent` element that will be rendered in the bubble. */
     children: React.ReactElement<React.ComponentProps<typeof TooltipContent>>;
     onActiveChanged: (active: boolean) => unknown;
-    contentStyle?: ContentStyle;
+    /** Optional background color. */
     backgroundColor?: keyof typeof Colors;
 } & PopperElementProps; // (v3 beta introduces this) // TODO(somewhatabstract): Update react-docgen to support spread operators
 
@@ -84,7 +84,16 @@ export default class TooltipBubble extends React.Component<Props, State> {
                     style,
                 ]}
             >
-                <View style={styles.content}>{children}</View>
+                <View
+                    style={[
+                        styles.content,
+                        backgroundColor && {
+                            backgroundColor: Colors[backgroundColor],
+                        },
+                    ]}
+                >
+                    {children}
+                </View>
                 <TooltipTail
                     updateRef={updateTailRef}
                     placement={placement}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
@@ -6,7 +6,6 @@ import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {HeadingSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
-import Color from "@khanacademy/wonder-blocks-color";
 
 import {ContentStyle} from "../util/types";
 
@@ -31,10 +30,6 @@ type Props = {
      * Test ID used for e2e testing.
      */
     testId?: string;
-    /**
-     * Optional background color.
-     */
-    backgroundColor?: keyof typeof Color;
 };
 
 /**
@@ -79,13 +74,7 @@ export default class TooltipContent extends React.Component<Props> {
         const containerStyle = title ? styles.withTitle : styles.withoutTitle;
         return (
             <View
-                style={[
-                    containerStyle,
-                    this.props.contentStyle,
-                    this.props.backgroundColor && {
-                        backgroundColor: Color[this.props.backgroundColor],
-                    },
-                ]}
+                style={[containerStyle, this.props.contentStyle]}
                 testId={this.props.testId}
             >
                 {title}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
@@ -5,8 +5,10 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {HeadingSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
-
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
+import Color from "@khanacademy/wonder-blocks-color";
+
+import {ContentStyle} from "../util/types";
 
 type Props = {
     /**
@@ -21,6 +23,14 @@ type Props = {
         | string
         | React.ReactElement<React.ComponentProps<Typography>>
         | Array<React.ReactElement<React.ComponentProps<Typography>>>;
+    /**
+     * Optional custom styles for the tooltip which are a subset of valid CSS styles
+     */
+    contentStyle?: ContentStyle;
+    /**
+     * Optional background color.
+     */
+    backgroundColor?: keyof typeof Color;
 };
 
 /**
@@ -64,7 +74,15 @@ export default class TooltipContent extends React.Component<Props> {
         const children = this._renderChildren();
         const containerStyle = title ? styles.withTitle : styles.withoutTitle;
         return (
-            <View style={containerStyle}>
+            <View
+                style={[
+                    containerStyle,
+                    this.props.contentStyle,
+                    this.props.backgroundColor && {
+                        backgroundColor: Color[this.props.backgroundColor],
+                    },
+                ]}
+            >
                 {title}
                 {title && children && <Strut size={Spacing.xxxSmall_4} />}
                 {children}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
@@ -28,6 +28,10 @@ type Props = {
      */
     contentStyle?: ContentStyle;
     /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string;
+    /**
      * Optional background color.
      */
     backgroundColor?: keyof typeof Color;
@@ -82,6 +86,7 @@ export default class TooltipContent extends React.Component<Props> {
                         backgroundColor: Color[this.props.backgroundColor],
                     },
                 ]}
+                testId={this.props.testId}
             >
                 {title}
                 {title && children && <Strut size={Spacing.xxxSmall_4} />}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -191,14 +191,12 @@ export default class Tooltip extends React.Component<Props, State> {
     _renderBubbleContent(): React.ReactElement<
         React.ComponentProps<typeof TooltipContent>
     > {
-        const {title, content, contentStyle, backgroundColor, testId} =
-            this.props;
+        const {title, content, contentStyle, testId} = this.props;
         if (typeof content === "string") {
             return (
                 <TooltipContent
                     title={title}
                     contentStyle={contentStyle}
-                    backgroundColor={backgroundColor}
                     testId={testId ? `${testId}-content` : undefined}
                 >
                     {content}
@@ -212,7 +210,7 @@ export default class Tooltip extends React.Component<Props, State> {
     }
 
     _renderPopper(ids?: IIdentifierFactory): React.ReactNode {
-        const {id, contentStyle, backgroundColor} = this.props;
+        const {id, backgroundColor} = this.props;
         const bubbleId = ids ? ids.get(Tooltip.ariaContentId) : id;
         if (!bubbleId) {
             throw new Error("Did not get an identifier factory nor a id prop");
@@ -228,7 +226,6 @@ export default class Tooltip extends React.Component<Props, State> {
                     <TooltipBubble
                         id={bubbleId}
                         style={props.style}
-                        contentStyle={contentStyle}
                         backgroundColor={backgroundColor}
                         tailOffset={props.tailOffset}
                         isReferenceHidden={props.isReferenceHidden}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -27,12 +27,13 @@ import {
 import {maybeGetPortalMountedModalHostElement} from "@khanacademy/wonder-blocks-modal";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
 
 import TooltipAnchor from "./tooltip-anchor";
 import TooltipBubble from "./tooltip-bubble";
 import TooltipContent from "./tooltip-content";
 import TooltipPopper from "./tooltip-popper";
-import type {Placement} from "../util/types";
+import type {ContentStyle, Placement} from "../util/types";
 
 type Props = AriaProps &
     Readonly<{
@@ -42,8 +43,7 @@ type Props = AriaProps &
          */
         children: React.ReactElement<any> | string;
         /**
-         * The title of the tooltip.
-         * Optional.
+         * Optional title for the tooltip content.
          */
         title?: string | React.ReactElement<React.ComponentProps<Typography>>;
         /**
@@ -102,6 +102,14 @@ type Props = AriaProps &
          * Test ID used for e2e testing.
          */
         testId?: string;
+        /**
+         * Optional custom styles for the tooltip content which are a subset of valid CSS styles.
+         */
+        contentStyle?: ContentStyle;
+        /**
+         * Optional background color.
+         */
+        backgroundColor?: keyof typeof Color;
     }>;
 
 type State = Readonly<{
@@ -183,9 +191,17 @@ export default class Tooltip extends React.Component<Props, State> {
     _renderBubbleContent(): React.ReactElement<
         React.ComponentProps<typeof TooltipContent>
     > {
-        const {title, content} = this.props;
+        const {title, content, contentStyle, backgroundColor} = this.props;
         if (typeof content === "string") {
-            return <TooltipContent title={title}>{content}</TooltipContent>;
+            return (
+                <TooltipContent
+                    title={title}
+                    contentStyle={contentStyle}
+                    backgroundColor={backgroundColor}
+                >
+                    {content}
+                </TooltipContent>
+            );
         } else if (title) {
             return React.cloneElement(content, {title});
         } else {
@@ -194,7 +210,7 @@ export default class Tooltip extends React.Component<Props, State> {
     }
 
     _renderPopper(ids?: IIdentifierFactory): React.ReactNode {
-        const {id} = this.props;
+        const {id, contentStyle, backgroundColor} = this.props;
         const bubbleId = ids ? ids.get(Tooltip.ariaContentId) : id;
         if (!bubbleId) {
             throw new Error("Did not get an identifier factory nor a id prop");
@@ -210,6 +226,8 @@ export default class Tooltip extends React.Component<Props, State> {
                     <TooltipBubble
                         id={bubbleId}
                         style={props.style}
+                        contentStyle={contentStyle}
+                        backgroundColor={backgroundColor}
                         tailOffset={props.tailOffset}
                         isReferenceHidden={props.isReferenceHidden}
                         placement={props.placement}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -191,13 +191,15 @@ export default class Tooltip extends React.Component<Props, State> {
     _renderBubbleContent(): React.ReactElement<
         React.ComponentProps<typeof TooltipContent>
     > {
-        const {title, content, contentStyle, backgroundColor} = this.props;
+        const {title, content, contentStyle, backgroundColor, testId} =
+            this.props;
         if (typeof content === "string") {
             return (
                 <TooltipContent
                     title={title}
                     contentStyle={contentStyle}
                     backgroundColor={backgroundColor}
+                    testId={testId ? `${testId}-content` : undefined}
                 >
                     {content}
                 </TooltipContent>

--- a/packages/wonder-blocks-tooltip/src/util/types.ts
+++ b/packages/wonder-blocks-tooltip/src/util/types.ts
@@ -30,3 +30,11 @@ export type Placement =
     | "left"
     | "left-start"
     | "left-end";
+
+/**
+ * Subset of CSS properties to allow overriding some of the default styles
+ */
+export type ContentStyle = {
+    color?: CSSProperties["color"];
+    padding?: CSSProperties["padding"];
+};


### PR DESCRIPTION
## Summary:
Exposed new `contentStyle` (color and padding) and `backgroundColor` props on `Tooltip` to allow some custom styling.
<img width="285" alt="image" src="https://github.com/Khan/wonder-blocks/assets/77523470/9790510c-b873-4e1e-a419-6c616fb17385">


Issue: WB-1410

## Test plan:
- `yarn test packages/wonder-blocks-tooltip`
- Experiment with styles in storybook