### PR TITLE
[fei5213.1.useforceupdatefix] Fix useForceUpdate

### DIFF
--- a/.changeset/tough-beans-matter.md
+++ b/.changeset/tough-beans-matter.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Fix useForceUpdate so that regardless of how many times it is called before a new render, it will always cause a new render

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.tsx
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.tsx
@@ -22,7 +22,47 @@ describe("#useForceUpdate", () => {
             jest.useFakeTimers();
         });
 
-        it("should cause component to render", () => {
+        it("should cause component to render when invoked multiple times before a render", () => {
+            // Arrange
+            const Component = (): React.ReactElement => {
+                const countRef = React.useRef(0);
+                const forceUpdate = useForceUpdate();
+                React.useEffect(() => {
+                    countRef.current++;
+
+                    setTimeout(() => {
+                        // We call an even number of times.
+                        // This is to catch a bug that could occur where we
+                        // just toggle a value on and off, and the end state
+                        // matches the start state, thus causing React to
+                        // believe nothing has changed, and therefore not
+                        // re-render.
+                        forceUpdate();
+                        forceUpdate();
+                        forceUpdate();
+                        forceUpdate();
+                    }, 50);
+                });
+                // @ts-expect-error [FEI-5019] - TS2322 - Type 'number' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
+                return countRef.current;
+            };
+
+            // Act
+            const wrapper = render(<Component />);
+            act(() => {
+                // Advance enough for the timeout to run 4 times.
+                // Which means the component should have rendered 4 times,
+                // with one more pending for the timeout that was setup in
+                // the last render.
+                jest.advanceTimersByTime(204);
+            });
+            const result = wrapper.container.textContent;
+
+            // Assert
+            expect(result).toBe("4");
+        });
+
+        it("should cause component to render each time it is invoked after a render", () => {
             // Arrange
             const Component = (): React.ReactElement => {
                 const countRef = React.useRef(0);

--- a/packages/wonder-blocks-core/src/hooks/use-force-update.ts
+++ b/packages/wonder-blocks-core/src/hooks/use-force-update.ts
@@ -13,10 +13,25 @@ import * as React from "react";
  * @returns {() => void} A function that forces the component to update.
  */
 export const useForceUpdate = (): (() => void) => {
-    const [, setState] = React.useState(false);
-    const forceUpdate = React.useCallback(
-        () => setState((state) => !state),
-        [],
-    );
+    const updatePendingRef = React.useRef(false);
+    const [, setUpdateToggle] = React.useState(false);
+
+    const forceUpdate = React.useCallback(() => {
+        if (updatePendingRef.current) {
+            // If an update is already pending, then we do nothing.
+            return;
+        }
+
+        // Otherwise, if we haven't been asked to force an update since our
+        // last render then we toggle the state to invoke a render.
+        setUpdateToggle((toggle) => !toggle);
+        updatePendingRef.current = true;
+    }, []);
+
+    // Reset to false when we've rendered.
+    // This ensures that we reset our counter the next time we're asked to
+    // force an update.
+    updatePendingRef.current = false;
+
     return forceUpdate;
 };


### PR DESCRIPTION
## Summary:
This update makes sure that no matter how many times `forceUpdate` is called, it will trigger a re-render. Before this change, the new test case would fail because the boolean value, after multiple calls, would not have actually changed, so React never forced a new render.

With this update, things work as intended.

Issue: FEI-5213

## Test plan:
`yarn test`