### PR TITLE
Center inline link text with icon by removing styled span and updating vertical align

### DIFF
--- a/.changeset/stale-buses-walk.md
+++ b/.changeset/stale-buses-walk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-link": patch
+---
+
+Vertically aligned inline text links with icons

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -25,7 +25,6 @@ type Props = SharedProps &
 
 const StyledAnchor = addStyle("a");
 const StyledLink = addStyle(Link);
-const StyledSpan = addStyle("span");
 
 export default class LinkCore extends React.Component<Props> {
     renderInner(router: any): React.ReactNode {
@@ -49,11 +48,6 @@ export default class LinkCore extends React.Component<Props> {
             ...restProps
         } = this.props;
 
-        // If icon props are present, link `children` will render inside a
-        // `StyledSpan` element to vertically align text with icons and add
-        // `textUnderlineOffset`
-        const withIcon = startIcon || endIcon || target === "_blank";
-
         const linkStyles = _generateStyles(inline, kind, light, visitable);
         const restingStyles = inline
             ? linkStyles.restingInline
@@ -70,7 +64,6 @@ export default class LinkCore extends React.Component<Props> {
             // focused link even after hovering and un-hovering on it.
             !pressed && hovered && linkStyles.hover,
             !pressed && focused && linkStyles.focus,
-            withIcon && sharedStyles.withIcon,
         ];
 
         const commonProps = {
@@ -111,13 +104,7 @@ export default class LinkCore extends React.Component<Props> {
                         aria-hidden="true"
                     />
                 )}
-                {withIcon ? (
-                    <StyledSpan style={linkContentStyles.centered}>
-                        {children}
-                    </StyledSpan>
-                ) : (
-                    children
-                )}
+                {children}
                 {endIcon ? (
                     <Icon
                         icon={endIcon}
@@ -165,7 +152,8 @@ const linkContentStyles = StyleSheet.create({
         marginInlineStart: Spacing.xxxSmall_4,
     },
     centered: {
-        verticalAlign: "middle",
+        // Manually align the bottom of start/end icons with the text baseline.
+        verticalAlign: "-10%",
     },
 });
 
@@ -175,10 +163,6 @@ const sharedStyles = StyleSheet.create({
         textDecoration: "none",
         outline: "none",
         alignItems: "center",
-    },
-    withIcon: {
-        verticalAlign: "bottom",
-        textUnderlineOffset: 4,
     },
 });
 


### PR DESCRIPTION
## Summary:
Removed `StyledSpan` from links with icons because the `verticalAlign: center` and underline offset styles were not being applied correctly on Safari.
Also removed `withIcon` styling to keep link underline offset consistent.

| Before (in Safari) | After (in Safari) |
| --- | --- |
|<img width="313" alt="Screen Shot 2023-07-10 at 2 18 28 PM" src="https://github.com/Khan/wonder-blocks/assets/77523470/9998cbde-c66e-4982-952b-3f47806dd3f0"> | <img width="289" alt="Screen Shot 2023-07-10 at 2 18 56 PM" src="https://github.com/Khan/wonder-blocks/assets/77523470/6606e740-5135-41c3-b1ff-74417ff60503"> |

Issue: WB-1550

## Test plan:
- Manual testing by checking storybook Link stories on both Chrome and Safari to ensure no inconsistencies between them
- Run `yarn test`