### PR TITLE
[forceupdatefix2] Tweak implementation so this works in all scenarios

### DIFF
--- a/.changeset/five-dodos-count.md
+++ b/.changeset/five-dodos-count.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Update useForceUpdate to ensure consuming hooks properly refresh

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.tsx
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.tsx
@@ -93,25 +93,29 @@ describe("#useForceUpdate", () => {
 
         it("should cause a consuming hook to update without a render", async () => {
             // Arrange
+            jest.useRealTimers();
             const useTestHook = (): [number, () => void] => {
                 const countRef = React.useRef(0);
                 const forceUpdate = useForceUpdate();
                 const updateMe = React.useCallback(() => {
-                    countRef.current++;
-                    forceUpdate();
+                    setTimeout(() => {
+                        countRef.current++;
+                        forceUpdate();
+                    }, 50);
                 }, [forceUpdate]);
                 return [countRef.current, updateMe];
             };
 
             // Act
-            const {result} = renderHook(() => useTestHook());
+            const {result, waitForNextUpdate} = renderHook(() => useTestHook());
             const [, updateMe] = result.current;
-            act(() => {
-                updateMe();
-            });
+            act(() => updateMe());
+            await waitForNextUpdate();
+            act(() => updateMe());
+            await waitForNextUpdate();
 
             // Assert
-            expect(result.current[0]).toBe(1);
+            expect(result.current[0]).toBe(2);
         });
     });
 });

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.tsx
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-force-update.test.tsx
@@ -90,5 +90,28 @@ describe("#useForceUpdate", () => {
             // Assert
             expect(result).toBe("4");
         });
+
+        it("should cause a consuming hook to update without a render", async () => {
+            // Arrange
+            const useTestHook = (): [number, () => void] => {
+                const countRef = React.useRef(0);
+                const forceUpdate = useForceUpdate();
+                const updateMe = React.useCallback(() => {
+                    countRef.current++;
+                    forceUpdate();
+                }, [forceUpdate]);
+                return [countRef.current, updateMe];
+            };
+
+            // Act
+            const {result} = renderHook(() => useTestHook());
+            const [, updateMe] = result.current;
+            act(() => {
+                updateMe();
+            });
+
+            // Assert
+            expect(result.current[0]).toBe(1);
+        });
     });
 });

--- a/packages/wonder-blocks-core/src/hooks/use-force-update.ts
+++ b/packages/wonder-blocks-core/src/hooks/use-force-update.ts
@@ -13,25 +13,17 @@ import * as React from "react";
  * @returns {() => void} A function that forces the component to update.
  */
 export const useForceUpdate = (): (() => void) => {
-    const updatePendingRef = React.useRef(false);
-    const [, setUpdateToggle] = React.useState(false);
+    const [, setUpdateState] = React.useState(0);
 
     const forceUpdate = React.useCallback(() => {
-        if (updatePendingRef.current) {
-            // If an update is already pending, then we do nothing.
-            return;
-        }
-
-        // Otherwise, if we haven't been asked to force an update since our
-        // last render then we toggle the state to invoke a render.
-        setUpdateToggle((toggle) => !toggle);
-        updatePendingRef.current = true;
+        setUpdateState((state) => {
+            let newState = Math.random();
+            while (state === newState) {
+                newState = Math.random();
+            }
+            return newState;
+        });
     }, []);
-
-    // Reset to false when we've rendered.
-    // This ensures that we reset our counter the next time we're asked to
-    // force an update.
-    updatePendingRef.current = false;
 
     return forceUpdate;
 };

--- a/packages/wonder-blocks-core/src/hooks/use-force-update.ts
+++ b/packages/wonder-blocks-core/src/hooks/use-force-update.ts
@@ -13,16 +13,15 @@ import * as React from "react";
  * @returns {() => void} A function that forces the component to update.
  */
 export const useForceUpdate = (): (() => void) => {
-    const [, setUpdateState] = React.useState(0);
+    const [, setUpdateState] = React.useState({});
 
     const forceUpdate = React.useCallback(() => {
-        setUpdateState((state) => {
-            let newState = Math.random();
-            while (state === newState) {
-                newState = Math.random();
-            }
-            return newState;
-        });
+        // We leverage here that every new object instance will be seen
+        // as a state change. This is a little hacky but it works better than
+        // a boolean that would just flip-flop and could not trigger a render,
+        // or a random number that could repeat values and also then not
+        // trigger a render. This will always work.
+        setUpdateState({});
     }, []);
 
     return forceUpdate;


### PR DESCRIPTION
## Summary:
While the previous "fix" corrected the issue of multiple calls before a render, it broke the situation where a hook that is based off `useForceUpdate` may need to trigger an async update outside of a render.

I discovered the issue when integrating the update into webapp where a hook failed because of the issue resolved by this PR.

This change ensures that every call to force an update will do a change, and thus make sure that calling hooks can trigger updates asynchronously between renders.

I have added an additional test case to capture the scenario where things broke. The original implementation handled it, but the updated one did not. This implementation should handle both situations.

Issue: FEI-5213

## Test plan:
`yarn test`