### PR TITLE
Fix the issue where the anchor is no longer shift-tabbable after closing popover

### DIFF
--- a/.changeset/tidy-islands-juggle.md
+++ b/.changeset/tidy-islands-juggle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+---
+
+Fix bug where shift-tab wouldn't go back to the anchor

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import {View} from "@khanacademy/wonder-blocks-core";
+import Button from "@khanacademy/wonder-blocks-button";
+
 import Popover from "../popover";
 import PopoverContent from "../popover-content";
 import {PopoverContentCore} from "../../index";
@@ -180,5 +183,59 @@ describe("Popover", () => {
         await waitFor(() => {
             expect(screen.queryByText("Title")).not.toBeInTheDocument();
         });
+    });
+
+    it("should shift-tab back to the anchor after popover is closed", async () => {
+        // Arrange
+        const PopoverComponent = () => {
+            const [opened, setOpened] = React.useState(true);
+            return (
+                <View>
+                    <Popover
+                        opened={opened}
+                        onClose={() => {
+                            setOpened(false);
+                        }}
+                        content={({close}) => (
+                            <PopoverContent
+                                title="Controlled popover"
+                                content="This popover is controlled programatically."
+                                actions={
+                                    <Button
+                                        onClick={() => {
+                                            close();
+                                        }}
+                                    >
+                                        Click to close the popover
+                                    </Button>
+                                }
+                            />
+                        )}
+                    >
+                        <Button>Anchor element</Button>
+                    </Popover>
+                    <Button onClick={() => setOpened(true)}>
+                        Outside button (click here to re-open the popover)
+                    </Button>
+                </View>
+            );
+        };
+
+        render(<PopoverComponent />);
+
+        // Act
+        const closeButton = screen.getByRole("button", {
+            name: "Click to close the popover",
+        });
+        closeButton.click();
+        // Shift-tab over to the anchor button
+        userEvent.tab({shift: true});
+        userEvent.tab({shift: true});
+
+        // Assert
+        const anchorButton = screen.getByRole("button", {
+            name: "Anchor element",
+        });
+        expect(anchorButton).toHaveFocus();
     });
 });

--- a/packages/wonder-blocks-popover/src/components/focus-manager.tsx
+++ b/packages/wonder-blocks-popover/src/components/focus-manager.tsx
@@ -118,7 +118,7 @@ export default class FocusManager extends React.Component<Props> {
     getNextFocusableElement: () => HTMLElement | null | undefined = () => {
         const {anchorElement} = this.props;
 
-        if (!anchorElement || this.nextElementAfterPopover) {
+        if (!anchorElement) {
             return;
         }
 


### PR DESCRIPTION
## Summary:
Currently, you can't tab back to the anchor after closing a popover.
It seems to be caused by the line changed in this PR.

For context, the `|| this.nextElementAfterPopover` was added
in order to reduce the number of re-calculations, but it
seems like removing this condition is necessary for correct behavior.

Issue: https://khanacademy.atlassian.net/browse/WB-1559

## Test plan:
`yarn jest packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx`

^ I confirmed that the test fails with the old code (`if (!anchorElement || this.nextElementAfterPopover)`) and passes with the new code (`if (!anchorElement)` ) 🎉 

## Demo (includes both before and after in video)

https://github.com/Khan/wonder-blocks/assets/13231763/cf5e3d1e-25ba-410f-896a-7150af22fb15
