### PR TITLE
Fix banner overflow

### DIFF
--- a/.changeset/fuzzy-buses-breathe.md
+++ b/.changeset/fuzzy-buses-breathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": patch
+---
+
+Fix the banner text overflow so that long text line wraps

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -185,6 +185,31 @@ Layouts.parameters = {
     },
 };
 
+export const LongText: StoryComponentType = () => (
+    <Banner
+        layout="floating"
+        kind="critical"
+        onDismiss={() => {}}
+        actions={[
+            {
+                type: "button",
+                title: "Change your email",
+                onClick: () => {},
+            },
+        ]}
+        text="We couldn't deliver your sign-up email to Adolph.Blaine.Charles.David.Earl.Frederick.Gerald.Hubert.Irvin.John.Kenneth.Lloyd.Martin.Nero.Oliver.Paul.Quincy.Randolph.Sherman.Thomas.Uncas.Victor.William.Xerxes.Yancy.Zeus.Wolfe­schlegel­stein­hausen­berger­dorff­welche­vor­altern­waren­gewissen­haft­schafers­wessen­schafe­waren­wohl­gepflege­und­sorg­faltig­keit­be­schutzen­vor­an­greifen­durch­ihr­raub­gierig­feinde­welche­vor­altern­zwolf­hundert­tausend­jah­res­voran­die­er­scheinen­von­der­erste­erde­mensch­der­raum­schiff­genacht­mit­tung­stein­und­sieben­iridium­elek­trisch­motors­ge­brauch­licht­als­sein­ur­sprung­von­kraft­ge­start­sein­lange­fahrt­hin­zwischen­stern­artig­raum­auf­de­suchen­nach­bar­schaft­der­stern­welche­ge­habt­be­wohn­bar­planeten­kreise­drehen­sich­und­wo­hin­der­neue­rasse­von­ver­stand­ig­mensch­lich­keit­konnte­fort­pflanzen­und­sicher­freuen­an­lebens­lang­lich­freude­und­ru­he­mit­nicht­ein­furcht­vor­an­greifen­vor­anderer­intelligent­ge­schopfs­von­hin­zwischen­stern­art­ig­raum.Sr@khanacademy.org. You may need to change it."
+    />
+);
+
+LongText.parameters = {
+    docs: {
+        storyDescription: `Here is an example of a banner with long text.
+            In this case, the email address is one giant word. Notice that
+            the \`overflow-wrap\` property here is set to \`break-word\`
+            so that the email address will wrap to the next line.`,
+    },
+};
+
 export const DarkBackground: StoryComponentType = () => (
     <View style={styles.container}>
         <Banner text="kind: info" kind="info" layout="full-width" />

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -319,6 +319,7 @@ const styles = StyleSheet.create({
         flexShrink: 1,
         margin: Spacing.xSmall_8,
         textAlign: "start",
+        overflowWrap: "break-word",
     },
     actionsContainer: {
         flexDirection: "row",


### PR DESCRIPTION
## Summary:
There are a couple of banners where the copy is being cut off because
of the overflow on the Wonder Blocks banner component. Here, I'm updating
it so that the text in WB Banner has `overflowWrap: break-word` so that
the long text line wraps

Issue: https://khanacademy.atlassian.net/browse/FEI-4898
also https://khanacademy.atlassian.net/browse/FEI-4823

## Test plan:
Storybook

http://localhost:50875/?path=/docs/banner--long-text

- Resize the page and confirm that the text never goes under the
  dismiss button, and that it never gets cut off of to the side.
  The text should wrap.

### Before:
<img width="1238" alt="Screenshot 2023-07-19 at 2 23 03 PM" src="https://github.com/Khan/wonder-blocks/assets/13231763/0f15d3c6-dfa0-4529-83fc-be7a55897106">

### After:
<img width="1234" alt="Screenshot 2023-07-19 at 2 24 48 PM" src="https://github.com/Khan/wonder-blocks/assets/13231763/1298eacf-19fa-4814-b87b-a502b37e7f62">
