### PR TITLE
Forward refs for Title and Text

### DIFF
--- a/.changeset/few-chicken-help.md
+++ b/.changeset/few-chicken-help.md
@@ -1,6 +1,6 @@
 ---
-"@khanacademy/wonder-blocks-typography": patch
-"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-typography": minor
+"@khanacademy/wonder-blocks-core": minor
 ---
 
 Forward refs for Text and Title

--- a/.changeset/few-chicken-help.md
+++ b/.changeset/few-chicken-help.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-typography": patch
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Forward refs for Text and Title

--- a/packages/wonder-blocks-core/src/components/__tests__/text.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/text.test.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import {render, waitFor} from "@testing-library/react";
+import {render} from "@testing-library/react";
 
 import Text from "../text";
 
 describe("Title", () => {
-    test("forwards the ref to the heading element", async () => {
+    test("forwards the ref to the heading element", () => {
         // Arrange
         const ref: React.RefObject<HTMLSpanElement> = React.createRef();
 
@@ -12,8 +12,6 @@ describe("Title", () => {
         render(<Text ref={ref}>Some text</Text>);
 
         // Assert
-        await waitFor(() => {
-            expect(ref.current).toBeInstanceOf(HTMLSpanElement);
-        });
+        expect(ref.current).toBeInstanceOf(HTMLSpanElement);
     });
 });

--- a/packages/wonder-blocks-core/src/components/__tests__/text.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/text.test.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import {render, waitFor} from "@testing-library/react";
+
+import Text from "../text";
+
+describe("Title", () => {
+    test("forwards the ref to the heading element", async () => {
+        // Arrange
+        const ref: React.RefObject<HTMLSpanElement> = React.createRef();
+
+        // Act
+        render(<Text ref={ref}>Some text</Text>);
+
+        // Assert
+        await waitFor(() => {
+            expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+        });
+    });
+});

--- a/packages/wonder-blocks-core/src/components/text.tsx
+++ b/packages/wonder-blocks-core/src/components/text.tsx
@@ -7,11 +7,7 @@ import {processStyleList} from "../util/util";
 import type {TextViewSharedProps} from "../util/types";
 
 type Props = TextViewSharedProps & {
-    tag: string;
-};
-
-type DefaultProps = {
-    tag: Props["tag"];
+    tag?: string;
 };
 
 const isHeaderRegex = /^h[1-6]$/;
@@ -44,14 +40,11 @@ const styles = StyleSheet.create({
  * - An `aphrodite` StyleSheet style
  * - An array combining the above
  */
-export default class Text extends React.Component<Props> {
-    static defaultProps: DefaultProps = {
-        tag: "span",
-    };
-
-    render(): React.ReactNode {
-        const {children, style, tag: Tag, testId, ...otherProps} = this.props;
-
+const Text = React.forwardRef(
+    (
+        {children, style, tag: Tag = "span", testId, ...otherProps}: Props,
+        ref,
+    ) => {
         const isHeader = isHeaderRegex.test(Tag);
         const styleAttributes = processStyleList([
             styles.text,
@@ -66,9 +59,12 @@ export default class Text extends React.Component<Props> {
                 style={styleAttributes.style}
                 className={styleAttributes.className}
                 data-test-id={testId}
+                ref={ref}
             >
                 {children}
             </Tag>
         );
-    }
-}
+    },
+);
+
+export default Text;

--- a/packages/wonder-blocks-typography/src/components/__tests__/title.test.tsx
+++ b/packages/wonder-blocks-typography/src/components/__tests__/title.test.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import {render, waitFor} from "@testing-library/react";
+
+import Title from "../title";
+
+describe("Title", () => {
+    test("forwards the ref to the heading element", async () => {
+        // Arrange
+        const ref: React.RefObject<HTMLHeadingElement> = React.createRef();
+
+        // Act
+        render(<Title ref={ref}>This is a title</Title>);
+
+        // Assert
+        await waitFor(() => {
+            expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+        });
+    });
+});

--- a/packages/wonder-blocks-typography/src/components/__tests__/title.test.tsx
+++ b/packages/wonder-blocks-typography/src/components/__tests__/title.test.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import {render, waitFor} from "@testing-library/react";
+import {render} from "@testing-library/react";
 
 import Title from "../title";
 
 describe("Title", () => {
-    test("forwards the ref to the heading element", async () => {
+    test("forwards the ref to the heading element", () => {
         // Arrange
         const ref: React.RefObject<HTMLHeadingElement> = React.createRef();
 
@@ -12,8 +12,6 @@ describe("Title", () => {
         render(<Title ref={ref}>This is a title</Title>);
 
         // Assert
-        await waitFor(() => {
-            expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
-        });
+        expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
     });
 });

--- a/packages/wonder-blocks-typography/src/components/title.tsx
+++ b/packages/wonder-blocks-typography/src/components/title.tsx
@@ -5,23 +5,19 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-type DefaultProps = {
-    tag: Props["tag"];
-};
-
-// TODO(alex): Once style prop validation works, if all of the style prop TypeScript
-//             types are the same then switch to using functional components.
-export default class Title extends React.Component<Props> {
-    static defaultProps: DefaultProps = {
-        tag: "h1",
-    };
-
-    render(): React.ReactNode {
-        const {style, children, ...otherProps} = this.props;
+const Title = React.forwardRef(
+    ({style, children, tag = "h1", ...otherProps}: Props, ref) => {
         return (
-            <Text {...otherProps} style={[styles.Title, style]}>
+            <Text
+                {...otherProps}
+                tag={tag}
+                style={[styles.Title, style]}
+                ref={ref}
+            >
                 {children}
             </Text>
         );
-    }
-}
+    },
+);
+
+export default Title;


### PR DESCRIPTION
## Summary:
We want to add ref forwarding for Title. This also means we need to
forward refs for Text.

To make this easier, I converted both Title and Text to functional
components.

Issue: https://khanacademy.atlassian.net/browse/WB-424

## Test plan:
`yarn jest packages/wonder-blocks-typography/src/components/__tests__/title.test.tsx`
`yarn jest packages/wonder-blocks-core/src/components/__tests__/text.test.tsx`

Check that local storybook typography page matches the prod storybook typography page.