### PR TITLE
Add ref forwarding to Breadcrumbs

### DIFF
--- a/.changeset/nervous-knives-carry.md
+++ b/.changeset/nervous-knives-carry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-breadcrumbs": minor
+---
+
+Forward refs in Breacrumbs

--- a/consistency-tests/__tests__/ref-forwarded.test.tsx
+++ b/consistency-tests/__tests__/ref-forwarded.test.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import {render} from "@testing-library/react";
 
+import Breadcrumbs from "../../packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs";
+import BreadcrumbsItem from "../../packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item";
 import Text from "../../packages/wonder-blocks-core/src/components/text";
 
 // Typography imports
@@ -50,5 +52,23 @@ describe("Typography elements", () => {
 
         // Assert
         expect(ref.current).toBeInstanceOf(type);
+    });
+});
+
+describe("Breadcrumbs elements", () => {
+    test("Breadcrumbs forwards ref", () => {
+        // Arrange
+        const ref = React.createRef<HTMLElement>();
+
+        // Act
+        render(
+            <Breadcrumbs ref={ref}>
+                <BreadcrumbsItem>First</BreadcrumbsItem>
+                <BreadcrumbsItem>Last</BreadcrumbsItem>
+            </Breadcrumbs>,
+        );
+
+        // Assert
+        expect(ref.current).toBeInstanceOf(HTMLElement);
     });
 });

--- a/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.tsx
@@ -35,20 +35,4 @@ describe("Breadcrumbs", () => {
             "test",
         );
     });
-
-    it("fowards ref", () => {
-        // Arrange
-        const ref = React.createRef<HTMLElement>();
-
-        // Act
-        render(
-            <Breadcrumbs ref={ref}>
-                <BreadcrumbsItem>First</BreadcrumbsItem>
-                <BreadcrumbsItem>Last</BreadcrumbsItem>
-            </Breadcrumbs>,
-        );
-
-        // Assert
-        expect(ref.current).toBeInstanceOf(HTMLElement);
-    });
 });

--- a/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.tsx
@@ -35,4 +35,20 @@ describe("Breadcrumbs", () => {
             "test",
         );
     });
+
+    it("fowards ref", () => {
+        // Arrange
+        const ref = React.createRef<HTMLElement>();
+
+        // Act
+        render(
+            <Breadcrumbs ref={ref}>
+                <BreadcrumbsItem>First</BreadcrumbsItem>
+                <BreadcrumbsItem>Last</BreadcrumbsItem>
+            </Breadcrumbs>,
+        );
+
+        // Assert
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
 });

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.tsx
@@ -15,13 +15,13 @@ type Props = AriaProps & {
           >
         | React.ReactElement<React.ComponentProps<typeof BreadcrumbsItem>>;
     /**
+     * Accessible label for the breadcrumbs.
+     */
+    "aria-label"?: string;
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string;
-};
-
-type DefaultProps = {
-    ["aria-label"]: Props["aria-label"];
 };
 
 const StyledList = addStyle("ol");
@@ -63,28 +63,31 @@ const StyledList = addStyle("ol");
  * </Breadcrumbs>
  * ```
  */
-export default class Breadcrumbs extends React.Component<Props> {
-    // Moved it here, in case we need to override the label for a different
-    // language
-    static defaultProps: DefaultProps = {
-        "aria-label": "Breadcrumbs",
-    };
+const Breadcrumbs = React.forwardRef(
+    (props: Props, ref: React.ForwardedRef<HTMLElement>) => {
+        const {
+            "aria-label": ariaLabel = "Breadcrumbs",
+            children,
+            testId,
+            ...otherProps
+        } = props;
 
-    render(): React.ReactNode {
-        const {children, testId, ...otherProps} = this.props;
         // using React.Children allows to deal with opaque data structures
         // e.g. children = 'string' vs children = []
         const lastChildIndex = React.Children.count(children) - 1;
 
         return (
-            <nav {...otherProps} data-test-id={testId}>
+            <nav
+                {...otherProps}
+                aria-label={ariaLabel}
+                data-test-id={testId}
+                ref={ref}
+            >
                 <StyledList style={styles.container}>
                     {React.Children.map(children, (item, index) => {
                         const isLastChild = index === lastChildIndex;
 
-                        // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                         return React.cloneElement(item, {
-                            // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactElement<{}, string | JSXElementConstructor<any>> | (ReactElement<{}, string | JSXElementConstructor<any>> & string) | ... 12 more ... | (ReactElement<...>[] & ReactPortal)'.
                             ...item.props,
                             showSeparator: !isLastChild,
                             ["aria-current"]: isLastChild ? "page" : undefined,
@@ -93,8 +96,8 @@ export default class Breadcrumbs extends React.Component<Props> {
                 </StyledList>
             </nav>
         );
-    }
-}
+    },
+);
 
 const styles = StyleSheet.create({
     container: {
@@ -105,3 +108,5 @@ const styles = StyleSheet.create({
         overflow: "hidden",
     },
 });
+
+export default Breadcrumbs;


### PR DESCRIPTION
## Summary:
Add ref forwarding to Breadcrumbs. To make this easier, I also
changed it to a functional component.

Issue: https://khanacademy.atlassian.net/browse/WB-424

## Test plan:
`yarn jest packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.tsx`

Confirm that the Breadcrumbs work as expected in storybook