### PR TITLE
Use named functions in all components with forwardRef()

### DIFF
--- a/.changeset/moody-crews-hear.md
+++ b/.changeset/moody-crews-hear.md
@@ -1,0 +1,11 @@
+---
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-typography": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-link": patch
+---
+
+Used named functions in componenets with forwarded refs

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
@@ -29,41 +29,42 @@ const StyledSvg = addStyle("svg");
 /**
  * The BreadcrumbsItem represents an individual item in the breadcrumbs list.
  */
-const BreadcrumbsItem = React.forwardRef(
-    (props: Props, ref: React.ForwardedRef<HTMLLIElement>) => {
-        const {children, showSeparator, testId, ...otherProps} = props;
+const BreadcrumbsItem = React.forwardRef(function BreadCrumbsItem(
+    props: Props,
+    ref: React.ForwardedRef<HTMLLIElement>,
+) {
+    const {children, showSeparator, testId, ...otherProps} = props;
 
-        /**
-         * Renders a separator after the content
-         * It draws a circular bullet point using an SVG circle shape
-         */
-        const _renderSeparator = (): React.ReactNode => {
-            return (
-                <StyledSvg
-                    style={styles.separator}
-                    width={16}
-                    height={16}
-                    viewBox="0 0 16 16"
-                    aria-hidden={true}
-                >
-                    <circle cx="8" cy="9" r="1.5" />
-                </StyledSvg>
-            );
-        };
-
+    /**
+     * Renders a separator after the content
+     * It draws a circular bullet point using an SVG circle shape
+     */
+    const _renderSeparator = (): React.ReactNode => {
         return (
-            <StyledListItem
-                {...otherProps}
-                style={styles.item}
-                data-test-id={testId}
-                ref={ref}
+            <StyledSvg
+                style={styles.separator}
+                width={16}
+                height={16}
+                viewBox="0 0 16 16"
+                aria-hidden={true}
             >
-                {children}
-                {showSeparator && _renderSeparator()}
-            </StyledListItem>
+                <circle cx="8" cy="9" r="1.5" />
+            </StyledSvg>
         );
-    },
-);
+    };
+
+    return (
+        <StyledListItem
+            {...otherProps}
+            style={styles.item}
+            data-test-id={testId}
+            ref={ref}
+        >
+            {children}
+            {showSeparator && _renderSeparator()}
+        </StyledListItem>
+    );
+});
 
 const styles = StyleSheet.create({
     item: {

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
@@ -29,7 +29,7 @@ const StyledSvg = addStyle("svg");
 /**
  * The BreadcrumbsItem represents an individual item in the breadcrumbs list.
  */
-const BreadcrumbsItem = React.forwardRef(function BreadCrumbsItem(
+const BreadcrumbsItem = React.forwardRef(function BreadcrumbsItem(
     props: Props,
     ref: React.ForwardedRef<HTMLLIElement>,
 ) {

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.tsx
@@ -63,41 +63,42 @@ const StyledList = addStyle("ol");
  * </Breadcrumbs>
  * ```
  */
-const Breadcrumbs = React.forwardRef(
-    (props: Props, ref: React.ForwardedRef<HTMLElement>) => {
-        const {
-            "aria-label": ariaLabel = "Breadcrumbs",
-            children,
-            testId,
-            ...otherProps
-        } = props;
+const Breadcrumbs = React.forwardRef(function Breadcrumbs(
+    props: Props,
+    ref: React.ForwardedRef<HTMLElement>,
+) {
+    const {
+        "aria-label": ariaLabel = "Breadcrumbs",
+        children,
+        testId,
+        ...otherProps
+    } = props;
 
-        // using React.Children allows to deal with opaque data structures
-        // e.g. children = 'string' vs children = []
-        const lastChildIndex = React.Children.count(children) - 1;
+    // using React.Children allows to deal with opaque data structures
+    // e.g. children = 'string' vs children = []
+    const lastChildIndex = React.Children.count(children) - 1;
 
-        return (
-            <nav
-                {...otherProps}
-                aria-label={ariaLabel}
-                data-test-id={testId}
-                ref={ref}
-            >
-                <StyledList style={styles.container}>
-                    {React.Children.map(children, (item, index) => {
-                        const isLastChild = index === lastChildIndex;
+    return (
+        <nav
+            {...otherProps}
+            aria-label={ariaLabel}
+            data-test-id={testId}
+            ref={ref}
+        >
+            <StyledList style={styles.container}>
+                {React.Children.map(children, (item, index) => {
+                    const isLastChild = index === lastChildIndex;
 
-                        return React.cloneElement(item, {
-                            ...item.props,
-                            showSeparator: !isLastChild,
-                            ["aria-current"]: isLastChild ? "page" : undefined,
-                        });
-                    })}
-                </StyledList>
-            </nav>
-        );
-    },
-);
+                    return React.cloneElement(item, {
+                        ...item.props,
+                        showSeparator: !isLastChild,
+                        ["aria-current"]: isLastChild ? "page" : undefined,
+                    });
+                })}
+            </StyledList>
+        </nav>
+    );
+});
 
 const styles = StyleSheet.create({
     container: {

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -33,7 +33,7 @@ const ButtonCore: React.ForwardRefExoticComponent<
 > = React.forwardRef<
     typeof Link | HTMLButtonElement | HTMLAnchorElement,
     Props
->((props: Props, ref) => {
+>(function ButtonCore(props: Props, ref) {
     const renderInner = (router: any): React.ReactNode => {
         const {
             children,

--- a/packages/wonder-blocks-button/src/components/button.tsx
+++ b/packages/wonder-blocks-button/src/components/button.tsx
@@ -198,7 +198,7 @@ const Button: React.ForwardRefExoticComponent<
 > = React.forwardRef<
     typeof Link | HTMLButtonElement | HTMLAnchorElement,
     Props
->((props: Props, ref) => {
+>(function Button(props: Props, ref) {
     const {
         href = undefined,
         type = undefined,

--- a/packages/wonder-blocks-core/src/components/text.tsx
+++ b/packages/wonder-blocks-core/src/components/text.tsx
@@ -40,31 +40,29 @@ const styles = StyleSheet.create({
  * - An `aphrodite` StyleSheet style
  * - An array combining the above
  */
-const Text = React.forwardRef(
-    (
-        {children, style, tag: Tag = "span", testId, ...otherProps}: Props,
-        ref,
-    ) => {
-        const isHeader = isHeaderRegex.test(Tag);
-        const styleAttributes = processStyleList([
-            styles.text,
-            isHeader && styles.header,
-            style,
-        ]);
+const Text = React.forwardRef(function Text(
+    {children, style, tag: Tag = "span", testId, ...otherProps}: Props,
+    ref,
+) {
+    const isHeader = isHeaderRegex.test(Tag);
+    const styleAttributes = processStyleList([
+        styles.text,
+        isHeader && styles.header,
+        style,
+    ]);
 
-        return (
-            // @ts-expect-error [FEI-5019] - TS2322 - Type '{ children: ReactNode; style: any; className: string; "data-test-id": string | undefined; tabIndex?: number | undefined; id?: string | undefined; "data-modal-launcher-portal"?: boolean | undefined; ... 69 more ...; onBlur?: ((e: FocusEvent<...>) => unknown) | undefined; }' is not assignable to type 'IntrinsicAttributes'.
-            <Tag
-                {...otherProps}
-                style={styleAttributes.style}
-                className={styleAttributes.className}
-                data-test-id={testId}
-                ref={ref}
-            >
-                {children}
-            </Tag>
-        );
-    },
-);
+    return (
+        // @ts-expect-error [FEI-5019] - TS2322 - Type '{ children: ReactNode; style: any; className: string; "data-test-id": string | undefined; tabIndex?: number | undefined; id?: string | undefined; "data-modal-launcher-portal"?: boolean | undefined; ... 69 more ...; onBlur?: ((e: FocusEvent<...>) => unknown) | undefined; }' is not assignable to type 'IntrinsicAttributes'.
+        <Tag
+            {...otherProps}
+            style={styleAttributes.style}
+            className={styleAttributes.className}
+            data-test-id={testId}
+            ref={ref}
+        >
+            {children}
+        </Tag>
+    );
+});
 
 export default Text;

--- a/packages/wonder-blocks-core/src/components/view.tsx
+++ b/packages/wonder-blocks-core/src/components/view.tsx
@@ -68,7 +68,7 @@ const StyledSection = addStyle("section", styles.default);
 
 const View: React.ForwardRefExoticComponent<
     Props & React.RefAttributes<HTMLElement>
-> = React.forwardRef<HTMLElement, Props>((props, ref) => {
+> = React.forwardRef<HTMLElement, Props>(function View(props, ref) {
     const {testId, tag = "div", ...restProps} = props;
     const commonProps = {
         ...restProps,

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -39,83 +39,77 @@ const indeterminatePath: IconAsset = {
 /**
  * The internal stateless ☑️ Checkbox
  */
-const CheckboxCore = React.forwardRef(
-    (props: ChoiceCoreProps, ref: React.ForwardedRef<HTMLInputElement>) => {
-        const {
-            checked,
-            disabled,
-            error,
-            groupName,
-            id,
-            testId,
-            ...sharedProps
-        } = props;
+const CheckboxCore = React.forwardRef(function CheckboxCore(
+    props: ChoiceCoreProps,
+    ref: React.ForwardedRef<HTMLInputElement>,
+) {
+    const {checked, disabled, error, groupName, id, testId, ...sharedProps} =
+        props;
 
-        const innerRef = React.useRef<HTMLInputElement>(null);
+    const innerRef = React.useRef<HTMLInputElement>(null);
 
-        React.useEffect(() => {
-            // Keep the indeterminate state in sync with the checked prop
-            if (innerRef.current != null) {
-                innerRef.current.indeterminate = checked == null;
-            }
-        }, [checked, innerRef]);
+    React.useEffect(() => {
+        // Keep the indeterminate state in sync with the checked prop
+        if (innerRef.current != null) {
+            innerRef.current.indeterminate = checked == null;
+        }
+    }, [checked, innerRef]);
 
-        const handleChange: () => void = () => {
-            // Empty because change is handled by ClickableBehavior
-            return;
-        };
+    const handleChange: () => void = () => {
+        // Empty because change is handled by ClickableBehavior
+        return;
+    };
 
-        const stateStyles = _generateStyles(checked, error);
+    const stateStyles = _generateStyles(checked, error);
 
-        const defaultStyle = [
-            sharedStyles.inputReset,
-            sharedStyles.default,
-            !disabled && stateStyles.default,
-            disabled && sharedStyles.disabled,
-        ];
+    const defaultStyle = [
+        sharedStyles.inputReset,
+        sharedStyles.default,
+        !disabled && stateStyles.default,
+        disabled && sharedStyles.disabled,
+    ];
 
-        const checkboxIcon = (
-            <Icon
-                color={disabled ? offBlack32 : white}
-                icon={checked ? checkPath : indeterminatePath}
-                size="small"
-                style={sharedStyles.checkboxIcon}
+    const checkboxIcon = (
+        <Icon
+            color={disabled ? offBlack32 : white}
+            icon={checked ? checkPath : indeterminatePath}
+            size="small"
+            style={sharedStyles.checkboxIcon}
+        />
+    );
+
+    const ariaChecked = mapCheckedToAriaChecked(checked);
+
+    return (
+        <React.Fragment>
+            <StyledInput
+                {...sharedProps}
+                ref={(node) => {
+                    // @ts-expect-error: current is not actually read-only
+                    innerRef.current = node;
+                    if (typeof ref === "function") {
+                        ref(node);
+                    } else if (ref != null) {
+                        ref.current = node;
+                    }
+                }}
+                type="checkbox"
+                aria-checked={ariaChecked}
+                aria-invalid={error}
+                checked={checked ?? undefined}
+                disabled={disabled}
+                id={id}
+                name={groupName}
+                // Need to specify because this is a controlled React form
+                // component, but we handle the click via ClickableBehavior
+                onChange={handleChange}
+                style={defaultStyle}
+                data-test-id={testId}
             />
-        );
-
-        const ariaChecked = mapCheckedToAriaChecked(checked);
-
-        return (
-            <React.Fragment>
-                <StyledInput
-                    {...sharedProps}
-                    ref={(node) => {
-                        // @ts-expect-error: current is not actually read-only
-                        innerRef.current = node;
-                        if (typeof ref === "function") {
-                            ref(node);
-                        } else if (ref != null) {
-                            ref.current = node;
-                        }
-                    }}
-                    type="checkbox"
-                    aria-checked={ariaChecked}
-                    aria-invalid={error}
-                    checked={checked ?? undefined}
-                    disabled={disabled}
-                    id={id}
-                    name={groupName}
-                    // Need to specify because this is a controlled React form
-                    // component, but we handle the click via ClickableBehavior
-                    onChange={handleChange}
-                    style={defaultStyle}
-                    data-test-id={testId}
-                />
-                {checked || checked == null ? checkboxIcon : <></>}
-            </React.Fragment>
-        );
-    },
-);
+            {checked || checked == null ? checkboxIcon : <></>}
+        </React.Fragment>
+    );
+});
 
 const size = 16;
 

--- a/packages/wonder-blocks-form/src/components/checkbox-group.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.tsx
@@ -95,88 +95,80 @@ const StyledLegend = addStyle("legend");
  * </CheckboxGroup>
  * ```
  */
-const CheckboxGroup = React.forwardRef(
-    (
-        props: CheckboxGroupProps,
-        ref: React.ForwardedRef<HTMLFieldSetElement>,
+const CheckboxGroup = React.forwardRef(function CheckboxGroup(
+    props: CheckboxGroupProps,
+    ref: React.ForwardedRef<HTMLFieldSetElement>,
+) {
+    const {
+        children,
+        label,
+        description,
+        errorMessage,
+        groupName,
+        onChange,
+        selectedValues,
+        style,
+        testId,
+    } = props;
+
+    const handleChange = (
+        changedValue: string,
+        originalCheckedState: boolean,
     ) => {
-        const {
-            children,
-            label,
-            description,
-            errorMessage,
-            groupName,
-            onChange,
-            selectedValues,
-            style,
-            testId,
-        } = props;
+        if (originalCheckedState) {
+            const index = selectedValues.indexOf(changedValue);
+            const updatedSelection = [
+                ...selectedValues.slice(0, index),
+                ...selectedValues.slice(index + 1),
+            ];
+            onChange(updatedSelection);
+        } else {
+            onChange([...selectedValues, changedValue]);
+        }
+    };
 
-        const handleChange = (
-            changedValue: string,
-            originalCheckedState: boolean,
-        ) => {
-            if (originalCheckedState) {
-                const index = selectedValues.indexOf(changedValue);
-                const updatedSelection = [
-                    ...selectedValues.slice(0, index),
-                    ...selectedValues.slice(index + 1),
-                ];
-                onChange(updatedSelection);
-            } else {
-                onChange([...selectedValues, changedValue]);
-            }
-        };
+    const allChildren = React.Children.toArray(children).filter(Boolean);
 
-        const allChildren = React.Children.toArray(children).filter(Boolean);
+    return (
+        <StyledFieldset data-test-id={testId} style={styles.fieldset} ref={ref}>
+            {/* We have a View here because fieldset cannot be used with flexbox*/}
+            <View style={style}>
+                {label && (
+                    <StyledLegend style={styles.legend}>
+                        <LabelMedium>{label}</LabelMedium>
+                    </StyledLegend>
+                )}
+                {description && (
+                    <LabelSmall style={styles.description}>
+                        {description}
+                    </LabelSmall>
+                )}
+                {errorMessage && (
+                    <LabelSmall style={styles.error}>{errorMessage}</LabelSmall>
+                )}
+                {(label || description || errorMessage) && (
+                    <Strut size={Spacing.small_12} />
+                )}
 
-        return (
-            <StyledFieldset
-                data-test-id={testId}
-                style={styles.fieldset}
-                ref={ref}
-            >
-                {/* We have a View here because fieldset cannot be used with flexbox*/}
-                <View style={style}>
-                    {label && (
-                        <StyledLegend style={styles.legend}>
-                            <LabelMedium>{label}</LabelMedium>
-                        </StyledLegend>
-                    )}
-                    {description && (
-                        <LabelSmall style={styles.description}>
-                            {description}
-                        </LabelSmall>
-                    )}
-                    {errorMessage && (
-                        <LabelSmall style={styles.error}>
-                            {errorMessage}
-                        </LabelSmall>
-                    )}
-                    {(label || description || errorMessage) && (
-                        <Strut size={Spacing.small_12} />
-                    )}
-
-                    {allChildren.map((child, index) => {
-                        // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
-                        const {style, value} = child.props;
-                        const checked = selectedValues.includes(value);
-                        // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
-                        return React.cloneElement(child, {
-                            checked: checked,
-                            error: !!errorMessage,
-                            groupName: groupName,
-                            id: `${groupName}-${value}`,
-                            key: value,
-                            onChange: () => handleChange(value, checked),
-                            style: [index > 0 && styles.defaultLineGap, style],
-                            variant: "checkbox",
-                        });
-                    })}
-                </View>
-            </StyledFieldset>
-        );
-    },
-);
+                {allChildren.map((child, index) => {
+                    // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
+                    const {style, value} = child.props;
+                    const checked = selectedValues.includes(value);
+                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
+                    return React.cloneElement(child, {
+                        checked: checked,
+                        error: !!errorMessage,
+                        groupName: groupName,
+                        id: `${groupName}-${value}`,
+                        key: value,
+                        onChange: () => handleChange(value, checked),
+                        style: [index > 0 && styles.defaultLineGap, style],
+                        variant: "checkbox",
+                    });
+                })}
+            </View>
+        </StyledFieldset>
+    );
+});
 
 export default CheckboxGroup;

--- a/packages/wonder-blocks-form/src/components/checkbox.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox.tsx
@@ -79,23 +79,21 @@ type ChoiceComponentProps = AriaProps & {
  * <Checkbox checked={checked} onChange={setChecked} />
  * ```
  */
-const Checkbox = React.forwardRef(
-    (
-        props: ChoiceComponentProps,
-        ref: React.ForwardedRef<HTMLInputElement>,
-    ) => {
-        const {disabled = false, error = false} = props;
+const Checkbox = React.forwardRef(function Checkbox(
+    props: ChoiceComponentProps,
+    ref: React.ForwardedRef<HTMLInputElement>,
+) {
+    const {disabled = false, error = false} = props;
 
-        return (
-            <ChoiceInternal
-                {...props}
-                variant="checkbox"
-                disabled={disabled}
-                error={error}
-                ref={ref}
-            />
-        );
-    },
-);
+    return (
+        <ChoiceInternal
+            {...props}
+            variant="checkbox"
+            disabled={disabled}
+            error={error}
+            ref={ref}
+        />
+    );
+});
 
 export default Checkbox;

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -55,108 +55,109 @@ type Props = AriaProps & {
  * and RadioGroup. This design allows for more explicit prop typing. For
  * example, we can make onChange a required prop on Checkbox but not on Choice
  * (because for Choice, that prop would be auto-populated by CheckboxGroup).
- */ const ChoiceInternal = React.forwardRef(
-    (props: Props, ref: React.ForwardedRef<HTMLInputElement>) => {
-        const {
-            checked,
-            description,
-            disabled = false,
-            error = false,
-            id,
-            label,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            onChange,
-            style,
-            className,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            variant,
-            // ...coreProps
-        } = props;
+ */ const ChoiceInternal = React.forwardRef(function ChoiceInternal(
+    props: Props,
+    ref: React.ForwardedRef<HTMLInputElement>,
+) {
+    const {
+        checked,
+        description,
+        disabled = false,
+        error = false,
+        id,
+        label,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        onChange,
+        style,
+        className,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        variant,
+        // ...coreProps
+    } = props;
 
-        const handleClick: () => void = () => {
-            // Radio buttons cannot be unchecked
-            if (variant === "radio" && checked) {
-                return;
-            }
-            onChange(!checked);
-        };
+    const handleClick: () => void = () => {
+        // Radio buttons cannot be unchecked
+        if (variant === "radio" && checked) {
+            return;
+        }
+        onChange(!checked);
+    };
 
-        const getChoiceCoreComponent = ():
-            | typeof RadioCore
-            | typeof CheckboxCore => {
-            if (variant === "radio") {
-                return RadioCore;
-            } else {
-                return CheckboxCore;
-            }
-        };
+    const getChoiceCoreComponent = ():
+        | typeof RadioCore
+        | typeof CheckboxCore => {
+        if (variant === "radio") {
+            return RadioCore;
+        } else {
+            return CheckboxCore;
+        }
+    };
 
-        const getLabel = (id: string): React.ReactNode => {
-            return (
-                <LabelMedium
-                    style={[styles.label, disabled && styles.disabledLabel]}
-                >
-                    <label htmlFor={id}>{label}</label>
-                </LabelMedium>
-            );
-        };
-
-        const getDescription = (id?: string): React.ReactNode => {
-            return (
-                <LabelSmall style={styles.description} id={id}>
-                    {description}
-                </LabelSmall>
-            );
-        };
-
-        const ChoiceCore = getChoiceCoreComponent();
-
+    const getLabel = (id: string): React.ReactNode => {
         return (
-            <UniqueIDProvider mockOnFirstRender={true} scope="choice">
-                {(ids) => {
-                    // A choice element should always have a unique ID set
-                    // so that the label can always refer to this element.
-                    // This guarantees that clicking on the label will
-                    // always click on the choice as well. If an ID is
-                    // passed in as a prop, use that one. Otherwise,
-                    // create a unique ID using the provider.
-                    const uniqueId = id || ids.get("main");
-
-                    // Create a unique ID for the description section to be
-                    // used by this element's `aria-describedby`.
-                    const descriptionId = description
-                        ? ids.get("description")
-                        : undefined;
-
-                    return (
-                        <View style={style} className={className}>
-                            <View
-                                style={styles.wrapper}
-                                // We are resetting the tabIndex=0 from handlers
-                                // because the ChoiceCore component will receive
-                                // focus on basis of it being an input element.
-                                tabIndex={-1}
-                            >
-                                <ChoiceCore
-                                    {...props}
-                                    id={uniqueId}
-                                    aria-describedby={descriptionId}
-                                    onClick={handleClick}
-                                    disabled={disabled}
-                                    error={error}
-                                    ref={ref}
-                                />
-                                <Strut size={Spacing.xSmall_8} />
-                                {label && getLabel(uniqueId)}
-                            </View>
-                            {description && getDescription(descriptionId)}
-                        </View>
-                    );
-                }}
-            </UniqueIDProvider>
+            <LabelMedium
+                style={[styles.label, disabled && styles.disabledLabel]}
+            >
+                <label htmlFor={id}>{label}</label>
+            </LabelMedium>
         );
-    },
-);
+    };
+
+    const getDescription = (id?: string): React.ReactNode => {
+        return (
+            <LabelSmall style={styles.description} id={id}>
+                {description}
+            </LabelSmall>
+        );
+    };
+
+    const ChoiceCore = getChoiceCoreComponent();
+
+    return (
+        <UniqueIDProvider mockOnFirstRender={true} scope="choice">
+            {(ids) => {
+                // A choice element should always have a unique ID set
+                // so that the label can always refer to this element.
+                // This guarantees that clicking on the label will
+                // always click on the choice as well. If an ID is
+                // passed in as a prop, use that one. Otherwise,
+                // create a unique ID using the provider.
+                const uniqueId = id || ids.get("main");
+
+                // Create a unique ID for the description section to be
+                // used by this element's `aria-describedby`.
+                const descriptionId = description
+                    ? ids.get("description")
+                    : undefined;
+
+                return (
+                    <View style={style} className={className}>
+                        <View
+                            style={styles.wrapper}
+                            // We are resetting the tabIndex=0 from handlers
+                            // because the ChoiceCore component will receive
+                            // focus on basis of it being an input element.
+                            tabIndex={-1}
+                        >
+                            <ChoiceCore
+                                {...props}
+                                id={uniqueId}
+                                aria-describedby={descriptionId}
+                                onClick={handleClick}
+                                disabled={disabled}
+                                error={error}
+                                ref={ref}
+                            />
+                            <Strut size={Spacing.xSmall_8} />
+                            {label && getLabel(uniqueId)}
+                        </View>
+                        {description && getDescription(descriptionId)}
+                    </View>
+                );
+            }}
+        </UniqueIDProvider>
+    );
+});
 
 const styles = StyleSheet.create({
     wrapper: {

--- a/packages/wonder-blocks-form/src/components/choice.tsx
+++ b/packages/wonder-blocks-form/src/components/choice.tsx
@@ -117,40 +117,41 @@ type Props = AriaProps & {
  * </RadioGroup>
  * ```
  */
-const Choice = React.forwardRef(
-    (props: Props, ref: React.ForwardedRef<HTMLInputElement>) => {
-        const {
-            checked = false,
-            disabled = false,
-            onChange = () => {},
-            // we don't need this going into the ChoiceComponent
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            value,
-            variant,
-            ...remainingProps
-        } = props;
+const Choice = React.forwardRef(function Choice(
+    props: Props,
+    ref: React.ForwardedRef<HTMLInputElement>,
+) {
+    const {
+        checked = false,
+        disabled = false,
+        onChange = () => {},
+        // we don't need this going into the ChoiceComponent
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        value,
+        variant,
+        ...remainingProps
+    } = props;
 
-        const getChoiceComponent = (
-            variant?: string | null,
-        ): typeof Radio | typeof Checkbox => {
-            if (variant === "checkbox") {
-                return Checkbox;
-            } else {
-                return Radio;
-            }
-        };
+    const getChoiceComponent = (
+        variant?: string | null,
+    ): typeof Radio | typeof Checkbox => {
+        if (variant === "checkbox") {
+            return Checkbox;
+        } else {
+            return Radio;
+        }
+    };
 
-        const ChoiceComponent = getChoiceComponent(variant);
-        return (
-            <ChoiceComponent
-                {...remainingProps}
-                checked={checked}
-                disabled={disabled}
-                onChange={onChange}
-                ref={ref}
-            />
-        );
-    },
-);
+    const ChoiceComponent = getChoiceComponent(variant);
+    return (
+        <ChoiceComponent
+            {...remainingProps}
+            checked={checked}
+            disabled={disabled}
+            onChange={onChange}
+            ref={ref}
+        />
+    );
+});
 
 export default Choice;

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -12,53 +12,47 @@ const StyledInput = addStyle("input");
 
 /**
  * The internal stateless 🔘 Radio button
- */ const RadioCore = React.forwardRef(
-    (props: ChoiceCoreProps, ref: React.ForwardedRef<HTMLInputElement>) => {
-        const handleChange = () => {
-            // Empty because change is handled by ClickableBehavior
-            return;
-        };
+ */ const RadioCore = React.forwardRef(function RadioCore(
+    props: ChoiceCoreProps,
+    ref: React.ForwardedRef<HTMLInputElement>,
+) {
+    const handleChange = () => {
+        // Empty because change is handled by ClickableBehavior
+        return;
+    };
 
-        const {
-            checked,
-            disabled,
-            error,
-            groupName,
-            id,
-            testId,
-            ...sharedProps
-        } = props;
+    const {checked, disabled, error, groupName, id, testId, ...sharedProps} =
+        props;
 
-        const stateStyles = _generateStyles(checked, error);
-        const defaultStyle = [
-            sharedStyles.inputReset,
-            sharedStyles.default,
-            !disabled && stateStyles.default,
-            disabled && sharedStyles.disabled,
-        ];
+    const stateStyles = _generateStyles(checked, error);
+    const defaultStyle = [
+        sharedStyles.inputReset,
+        sharedStyles.default,
+        !disabled && stateStyles.default,
+        disabled && sharedStyles.disabled,
+    ];
 
-        return (
-            <React.Fragment>
-                <StyledInput
-                    {...sharedProps}
-                    type="radio"
-                    aria-invalid={error}
-                    checked={checked ?? undefined}
-                    disabled={disabled}
-                    id={id}
-                    name={groupName}
-                    // Need to specify because this is a controlled React form
-                    // component, but we handle the click via ClickableBehavior
-                    onChange={handleChange}
-                    style={defaultStyle}
-                    data-test-id={testId}
-                    ref={ref}
-                />
-                {disabled && checked && <span style={disabledChecked} />}
-            </React.Fragment>
-        );
-    },
-);
+    return (
+        <React.Fragment>
+            <StyledInput
+                {...sharedProps}
+                type="radio"
+                aria-invalid={error}
+                checked={checked ?? undefined}
+                disabled={disabled}
+                id={id}
+                name={groupName}
+                // Need to specify because this is a controlled React form
+                // component, but we handle the click via ClickableBehavior
+                onChange={handleChange}
+                style={defaultStyle}
+                data-test-id={testId}
+                ref={ref}
+            />
+            {disabled && checked && <span style={disabledChecked} />}
+        </React.Fragment>
+    );
+});
 
 const size = 16; // circle with a different color. Here, we add that center circle. // If the checkbox is disabled and selected, it has a border but also an inner
 const disabledChecked = {

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -96,69 +96,64 @@ const StyledLegend = addStyle("legend");
  * </RadioGroup>
  * ```
  */
-const RadioGroup = React.forwardRef(
-    (props: RadioGroupProps, ref: React.ForwardedRef<HTMLFieldSetElement>) => {
-        const {
-            children,
-            label,
-            description,
-            errorMessage,
-            groupName,
-            onChange,
-            selectedValue,
-            style,
-            testId,
-        } = props;
+const RadioGroup = React.forwardRef(function RadioGroup(
+    props: RadioGroupProps,
+    ref: React.ForwardedRef<HTMLFieldSetElement>,
+) {
+    const {
+        children,
+        label,
+        description,
+        errorMessage,
+        groupName,
+        onChange,
+        selectedValue,
+        style,
+        testId,
+    } = props;
 
-        const allChildren = React.Children.toArray(children).filter(Boolean);
+    const allChildren = React.Children.toArray(children).filter(Boolean);
 
-        return (
-            <StyledFieldset
-                data-test-id={testId}
-                style={styles.fieldset}
-                ref={ref}
-            >
-                {/* We have a View here because fieldset cannot be used with flexbox*/}
-                <View style={style}>
-                    {label && (
-                        <StyledLegend style={styles.legend}>
-                            <LabelMedium>{label}</LabelMedium>
-                        </StyledLegend>
-                    )}
-                    {description && (
-                        <LabelSmall style={styles.description}>
-                            {description}
-                        </LabelSmall>
-                    )}
-                    {errorMessage && (
-                        <LabelSmall style={styles.error}>
-                            {errorMessage}
-                        </LabelSmall>
-                    )}
-                    {(label || description || errorMessage) && (
-                        <Strut size={Spacing.small_12} />
-                    )}
+    return (
+        <StyledFieldset data-test-id={testId} style={styles.fieldset} ref={ref}>
+            {/* We have a View here because fieldset cannot be used with flexbox*/}
+            <View style={style}>
+                {label && (
+                    <StyledLegend style={styles.legend}>
+                        <LabelMedium>{label}</LabelMedium>
+                    </StyledLegend>
+                )}
+                {description && (
+                    <LabelSmall style={styles.description}>
+                        {description}
+                    </LabelSmall>
+                )}
+                {errorMessage && (
+                    <LabelSmall style={styles.error}>{errorMessage}</LabelSmall>
+                )}
+                {(label || description || errorMessage) && (
+                    <Strut size={Spacing.small_12} />
+                )}
 
-                    {allChildren.map((child, index) => {
-                        // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
-                        const {style, value} = child.props;
-                        const checked = selectedValue === value;
-                        // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
-                        return React.cloneElement(child, {
-                            checked: checked,
-                            error: !!errorMessage,
-                            groupName: groupName,
-                            id: `${groupName}-${value}`,
-                            key: value,
-                            onChange: () => onChange(value),
-                            style: [index > 0 && styles.defaultLineGap, style],
-                            variant: "radio",
-                        });
-                    })}
-                </View>
-            </StyledFieldset>
-        );
-    },
-);
+                {allChildren.map((child, index) => {
+                    // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
+                    const {style, value} = child.props;
+                    const checked = selectedValue === value;
+                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
+                    return React.cloneElement(child, {
+                        checked: checked,
+                        error: !!errorMessage,
+                        groupName: groupName,
+                        id: `${groupName}-${value}`,
+                        key: value,
+                        onChange: () => onChange(value),
+                        style: [index > 0 && styles.defaultLineGap, style],
+                        variant: "radio",
+                    });
+                })}
+            </View>
+        </StyledFieldset>
+    );
+});
 
 export default RadioGroup;

--- a/packages/wonder-blocks-form/src/components/radio.tsx
+++ b/packages/wonder-blocks-form/src/components/radio.tsx
@@ -62,23 +62,21 @@ type ChoiceComponentProps = AriaProps & {
  *
  * This component should not really be used by itself because radio buttons are
  * often grouped together. See RadioGroup.
- */ const Radio = React.forwardRef(
-    (
-        props: ChoiceComponentProps,
-        ref: React.ForwardedRef<HTMLInputElement>,
-    ) => {
-        const {disabled = false, error = false, ...otherProps} = props;
+ */ const Radio = React.forwardRef(function Radio(
+    props: ChoiceComponentProps,
+    ref: React.ForwardedRef<HTMLInputElement>,
+) {
+    const {disabled = false, error = false, ...otherProps} = props;
 
-        return (
-            <ChoiceInternal
-                {...otherProps}
-                variant="radio"
-                disabled={disabled}
-                error={error}
-                ref={ref}
-            />
-        );
-    },
-);
+    return (
+        <ChoiceInternal
+            {...otherProps}
+            variant="radio"
+            disabled={disabled}
+            error={error}
+            ref={ref}
+        />
+    );
+});
 
 export default Radio;

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -40,7 +40,7 @@ const IconButtonCore: React.ForwardRefExoticComponent<
 > = React.forwardRef<
     typeof Link | HTMLButtonElement | HTMLAnchorElement,
     Props
->((props: Props, ref) => {
+>(function IconButtonCore(props: Props, ref) {
     const {
         skipClientNav,
         color,

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -156,7 +156,7 @@ const IconButton: React.ForwardRefExoticComponent<
 > = React.forwardRef<
     typeof Link | HTMLButtonElement | HTMLAnchorElement,
     SharedProps
->((props: SharedProps, ref) => {
+>(function IconButton(props: SharedProps, ref) {
     const {
         onClick,
         href,

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -26,135 +26,130 @@ type Props = SharedProps &
 const StyledAnchor = addStyle("a");
 const StyledLink = addStyle(Link);
 
-const LinkCore = React.forwardRef(
-    (
-        props: Props,
-        ref: React.ForwardedRef<typeof Link | HTMLAnchorElement>,
-    ) => {
-        const renderInner = (router: any): React.ReactNode => {
-            const {
-                children,
-                skipClientNav,
-                focused,
-                hovered,
-                href,
-                inline = false,
-                kind = "primary",
-                light = false,
-                visitable = false,
-                pressed,
-                style,
-                testId,
-                waiting: _,
-                target,
-                startIcon,
-                endIcon,
-                ...restProps
-            } = props;
+const LinkCore = React.forwardRef(function LinkCore(
+    props: Props,
+    ref: React.ForwardedRef<typeof Link | HTMLAnchorElement>,
+) {
+    const renderInner = (router: any): React.ReactNode => {
+        const {
+            children,
+            skipClientNav,
+            focused,
+            hovered,
+            href,
+            inline = false,
+            kind = "primary",
+            light = false,
+            visitable = false,
+            pressed,
+            style,
+            testId,
+            waiting: _,
+            target,
+            startIcon,
+            endIcon,
+            ...restProps
+        } = props;
 
-            const linkStyles = _generateStyles(inline, kind, light, visitable);
-            const restingStyles = inline
-                ? linkStyles.restingInline
-                : linkStyles.resting;
+        const linkStyles = _generateStyles(inline, kind, light, visitable);
+        const restingStyles = inline
+            ? linkStyles.restingInline
+            : linkStyles.resting;
 
-            const defaultStyles = [
-                sharedStyles.shared,
-                restingStyles,
-                pressed && linkStyles.active,
-                // A11y: The focus ring should always be present when the
-                // the link has focus, even the link is being hovered over.
-                // TODO(WB-1498): Udpate ClickableBehavior so that focus doesn't
-                // stop on mouseleave. We want the focus ring to remain on a
-                // focused link even after hovering and un-hovering on it.
-                !pressed && hovered && linkStyles.hover,
-                !pressed && focused && linkStyles.focus,
-            ];
+        const defaultStyles = [
+            sharedStyles.shared,
+            restingStyles,
+            pressed && linkStyles.active,
+            // A11y: The focus ring should always be present when the
+            // the link has focus, even the link is being hovered over.
+            // TODO(WB-1498): Udpate ClickableBehavior so that focus doesn't
+            // stop on mouseleave. We want the focus ring to remain on a
+            // focused link even after hovering and un-hovering on it.
+            !pressed && hovered && linkStyles.hover,
+            !pressed && focused && linkStyles.focus,
+        ];
 
-            const commonProps = {
-                "data-test-id": testId,
-                style: [defaultStyles, style],
-                target,
-                ...restProps,
-            } as const;
+        const commonProps = {
+            "data-test-id": testId,
+            style: [defaultStyles, style],
+            target,
+            ...restProps,
+        } as const;
 
-            const linkUrl = new URL(href, window.location.origin);
+        const linkUrl = new URL(href, window.location.origin);
 
-            const isExternalLink = linkUrl.origin !== window.location.origin;
+        const isExternalLink = linkUrl.origin !== window.location.origin;
 
-            const externalIconPath: IconAsset = {
-                small: "M14 6.5C14 6.63261 13.9473 6.75979 13.8536 6.85355C13.7598 6.94732 13.6326 7 13.5 7C13.3674 7 13.2402 6.94732 13.1464 6.85355C13.0527 6.75979 13 6.63261 13 6.5V3.7075L8.85437 7.85375C8.76055 7.94757 8.63331 8.00028 8.50062 8.00028C8.36794 8.00028 8.2407 7.94757 8.14688 7.85375C8.05306 7.75993 8.00035 7.63268 8.00035 7.5C8.00035 7.36732 8.05306 7.24007 8.14688 7.14625L12.2925 3H9.5C9.36739 3 9.24021 2.94732 9.14645 2.85355C9.05268 2.75979 9 2.63261 9 2.5C9 2.36739 9.05268 2.24021 9.14645 2.14645C9.24021 2.05268 9.36739 2 9.5 2H13.5C13.6326 2 13.7598 2.05268 13.8536 2.14645C13.9473 2.24021 14 2.36739 14 2.5V6.5ZM11.5 8C11.3674 8 11.2402 8.05268 11.1464 8.14645C11.0527 8.24021 11 8.36739 11 8.5V13H3V5H7.5C7.63261 5 7.75979 4.94732 7.85355 4.85355C7.94732 4.75979 8 4.63261 8 4.5C8 4.36739 7.94732 4.24021 7.85355 4.14645C7.75979 4.05268 7.63261 4 7.5 4H3C2.73478 4 2.48043 4.10536 2.29289 4.29289C2.10536 4.48043 2 4.73478 2 5V13C2 13.2652 2.10536 13.5196 2.29289 13.7071C2.48043 13.8946 2.73478 14 3 14H11C11.2652 14 11.5196 13.8946 11.7071 13.7071C11.8946 13.5196 12 13.2652 12 13V8.5C12 8.36739 11.9473 8.24021 11.8536 8.14645C11.7598 8.05268 11.6326 8 11.5 8Z",
-            };
-
-            const externalIcon = (
-                <Icon
-                    icon={externalIconPath}
-                    size="small"
-                    style={[
-                        linkContentStyles.endIcon,
-                        linkContentStyles.centered,
-                    ]}
-                    testId="external-icon"
-                />
-            );
-
-            const linkContent = (
-                <>
-                    {startIcon && (
-                        <Icon
-                            icon={startIcon}
-                            size="small"
-                            style={[
-                                linkContentStyles.startIcon,
-                                linkContentStyles.centered,
-                            ]}
-                            testId="start-icon"
-                            aria-hidden="true"
-                        />
-                    )}
-                    {children}
-                    {endIcon ? (
-                        <Icon
-                            icon={endIcon}
-                            size="small"
-                            style={[
-                                linkContentStyles.endIcon,
-                                linkContentStyles.centered,
-                            ]}
-                            testId="end-icon"
-                            aria-hidden="true"
-                        />
-                    ) : (
-                        isExternalLink && target === "_blank" && externalIcon
-                    )}
-                </>
-            );
-
-            return router && !skipClientNav && isClientSideUrl(href) ? (
-                <StyledLink
-                    {...commonProps}
-                    to={href}
-                    ref={ref as React.ForwardedRef<typeof Link>}
-                >
-                    {linkContent}
-                </StyledLink>
-            ) : (
-                <StyledAnchor
-                    {...commonProps}
-                    href={href}
-                    ref={ref as React.ForwardedRef<HTMLAnchorElement>}
-                >
-                    {linkContent}
-                </StyledAnchor>
-            );
+        const externalIconPath: IconAsset = {
+            small: "M14 6.5C14 6.63261 13.9473 6.75979 13.8536 6.85355C13.7598 6.94732 13.6326 7 13.5 7C13.3674 7 13.2402 6.94732 13.1464 6.85355C13.0527 6.75979 13 6.63261 13 6.5V3.7075L8.85437 7.85375C8.76055 7.94757 8.63331 8.00028 8.50062 8.00028C8.36794 8.00028 8.2407 7.94757 8.14688 7.85375C8.05306 7.75993 8.00035 7.63268 8.00035 7.5C8.00035 7.36732 8.05306 7.24007 8.14688 7.14625L12.2925 3H9.5C9.36739 3 9.24021 2.94732 9.14645 2.85355C9.05268 2.75979 9 2.63261 9 2.5C9 2.36739 9.05268 2.24021 9.14645 2.14645C9.24021 2.05268 9.36739 2 9.5 2H13.5C13.6326 2 13.7598 2.05268 13.8536 2.14645C13.9473 2.24021 14 2.36739 14 2.5V6.5ZM11.5 8C11.3674 8 11.2402 8.05268 11.1464 8.14645C11.0527 8.24021 11 8.36739 11 8.5V13H3V5H7.5C7.63261 5 7.75979 4.94732 7.85355 4.85355C7.94732 4.75979 8 4.63261 8 4.5C8 4.36739 7.94732 4.24021 7.85355 4.14645C7.75979 4.05268 7.63261 4 7.5 4H3C2.73478 4 2.48043 4.10536 2.29289 4.29289C2.10536 4.48043 2 4.73478 2 5V13C2 13.2652 2.10536 13.5196 2.29289 13.7071C2.48043 13.8946 2.73478 14 3 14H11C11.2652 14 11.5196 13.8946 11.7071 13.7071C11.8946 13.5196 12 13.2652 12 13V8.5C12 8.36739 11.9473 8.24021 11.8536 8.14645C11.7598 8.05268 11.6326 8 11.5 8Z",
         };
 
-        return (
-            <__RouterContext.Consumer>
-                {(router) => renderInner(router)}
-            </__RouterContext.Consumer>
+        const externalIcon = (
+            <Icon
+                icon={externalIconPath}
+                size="small"
+                style={[linkContentStyles.endIcon, linkContentStyles.centered]}
+                testId="external-icon"
+            />
         );
-    },
-);
+
+        const linkContent = (
+            <>
+                {startIcon && (
+                    <Icon
+                        icon={startIcon}
+                        size="small"
+                        style={[
+                            linkContentStyles.startIcon,
+                            linkContentStyles.centered,
+                        ]}
+                        testId="start-icon"
+                        aria-hidden="true"
+                    />
+                )}
+                {children}
+                {endIcon ? (
+                    <Icon
+                        icon={endIcon}
+                        size="small"
+                        style={[
+                            linkContentStyles.endIcon,
+                            linkContentStyles.centered,
+                        ]}
+                        testId="end-icon"
+                        aria-hidden="true"
+                    />
+                ) : (
+                    isExternalLink && target === "_blank" && externalIcon
+                )}
+            </>
+        );
+
+        return router && !skipClientNav && isClientSideUrl(href) ? (
+            <StyledLink
+                {...commonProps}
+                to={href}
+                ref={ref as React.ForwardedRef<typeof Link>}
+            >
+                {linkContent}
+            </StyledLink>
+        ) : (
+            <StyledAnchor
+                {...commonProps}
+                href={href}
+                ref={ref as React.ForwardedRef<HTMLAnchorElement>}
+            >
+                {linkContent}
+            </StyledAnchor>
+        );
+    };
+
+    return (
+        <__RouterContext.Consumer>
+            {(router) => renderInner(router)}
+        </__RouterContext.Consumer>
+    );
+});
 
 const styles: Record<string, any> = {};
 

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -172,113 +172,111 @@ export type SharedProps = AriaProps & {
  * </Link>
  * ```
  */
-const Link = React.forwardRef(
-    (
-        props: SharedProps,
-        ref: React.ForwardedRef<typeof ReactRouterLink | HTMLAnchorElement>,
-    ) => {
-        const {
-            onClick,
-            beforeNav = undefined,
-            safeWithNav,
+const Link = React.forwardRef(function Link(
+    props: SharedProps,
+    ref: React.ForwardedRef<typeof ReactRouterLink | HTMLAnchorElement>,
+) {
+    const {
+        onClick,
+        beforeNav = undefined,
+        safeWithNav,
+        href,
+        skipClientNav,
+        children,
+        tabIndex,
+        onKeyDown,
+        onKeyUp,
+        target = undefined,
+        inline = false,
+        kind = "primary",
+        light = false,
+        visitable = false,
+        ...sharedProps
+    } = props;
+
+    const renderClickableBehavior = (router: any): React.ReactNode => {
+        const ClickableBehavior = getClickableBehavior(
             href,
             skipClientNav,
-            children,
-            tabIndex,
-            onKeyDown,
-            onKeyUp,
-            target = undefined,
-            inline = false,
-            kind = "primary",
-            light = false,
-            visitable = false,
-            ...sharedProps
-        } = props;
-
-        const renderClickableBehavior = (router: any): React.ReactNode => {
-            const ClickableBehavior = getClickableBehavior(
-                href,
-                skipClientNav,
-                router,
-            );
-
-            if (beforeNav) {
-                return (
-                    <ClickableBehavior
-                        disabled={false}
-                        href={href}
-                        role="link"
-                        onClick={onClick}
-                        beforeNav={beforeNav}
-                        safeWithNav={safeWithNav}
-                        onKeyDown={onKeyDown}
-                        onKeyUp={onKeyUp}
-                    >
-                        {(state, {...childrenProps}) => {
-                            return (
-                                <LinkCore
-                                    {...sharedProps}
-                                    {...state}
-                                    {...childrenProps}
-                                    skipClientNav={skipClientNav}
-                                    href={href}
-                                    target={target}
-                                    tabIndex={tabIndex}
-                                    inline={inline}
-                                    kind={kind}
-                                    light={light}
-                                    visitable={visitable}
-                                    ref={ref}
-                                >
-                                    {children}
-                                </LinkCore>
-                            );
-                        }}
-                    </ClickableBehavior>
-                );
-            } else {
-                return (
-                    <ClickableBehavior
-                        disabled={false}
-                        href={href}
-                        role="link"
-                        onClick={onClick}
-                        safeWithNav={safeWithNav}
-                        target={target}
-                        onKeyDown={onKeyDown}
-                        onKeyUp={onKeyUp}
-                    >
-                        {(state, {...childrenProps}) => {
-                            return (
-                                <LinkCore
-                                    {...sharedProps}
-                                    {...state}
-                                    {...childrenProps}
-                                    skipClientNav={skipClientNav}
-                                    href={href}
-                                    target={target}
-                                    tabIndex={tabIndex}
-                                    inline={inline}
-                                    kind={kind}
-                                    light={light}
-                                    visitable={visitable}
-                                    ref={ref}
-                                >
-                                    {children}
-                                </LinkCore>
-                            );
-                        }}
-                    </ClickableBehavior>
-                );
-            }
-        };
-
-        return (
-            <__RouterContext.Consumer>
-                {(router) => renderClickableBehavior(router)}
-            </__RouterContext.Consumer>
+            router,
         );
-    },
-);
+
+        if (beforeNav) {
+            return (
+                <ClickableBehavior
+                    disabled={false}
+                    href={href}
+                    role="link"
+                    onClick={onClick}
+                    beforeNav={beforeNav}
+                    safeWithNav={safeWithNav}
+                    onKeyDown={onKeyDown}
+                    onKeyUp={onKeyUp}
+                >
+                    {(state, {...childrenProps}) => {
+                        return (
+                            <LinkCore
+                                {...sharedProps}
+                                {...state}
+                                {...childrenProps}
+                                skipClientNav={skipClientNav}
+                                href={href}
+                                target={target}
+                                tabIndex={tabIndex}
+                                inline={inline}
+                                kind={kind}
+                                light={light}
+                                visitable={visitable}
+                                ref={ref}
+                            >
+                                {children}
+                            </LinkCore>
+                        );
+                    }}
+                </ClickableBehavior>
+            );
+        } else {
+            return (
+                <ClickableBehavior
+                    disabled={false}
+                    href={href}
+                    role="link"
+                    onClick={onClick}
+                    safeWithNav={safeWithNav}
+                    target={target}
+                    onKeyDown={onKeyDown}
+                    onKeyUp={onKeyUp}
+                >
+                    {(state, {...childrenProps}) => {
+                        return (
+                            <LinkCore
+                                {...sharedProps}
+                                {...state}
+                                {...childrenProps}
+                                skipClientNav={skipClientNav}
+                                href={href}
+                                target={target}
+                                tabIndex={tabIndex}
+                                inline={inline}
+                                kind={kind}
+                                light={light}
+                                visitable={visitable}
+                                ref={ref}
+                            >
+                                {children}
+                            </LinkCore>
+                        );
+                    }}
+                </ClickableBehavior>
+            );
+        }
+    };
+
+    return (
+        <__RouterContext.Consumer>
+            {(router) => renderClickableBehavior(router)}
+        </__RouterContext.Consumer>
+    );
+});
 
 export default Link;

--- a/packages/wonder-blocks-typography/src/components/body-monospace.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-monospace.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const BodyMonospace = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.BodyMonospace, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const BodyMonospace = React.forwardRef(function BodyMonospace(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.BodyMonospace, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default BodyMonospace;

--- a/packages/wonder-blocks-typography/src/components/body-serif-block.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-serif-block.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const BodySerifBlock = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.BodySerifBlock, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const BodySerifBlock = React.forwardRef(function BodySerifBlock(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.BodySerifBlock, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default BodySerifBlock;

--- a/packages/wonder-blocks-typography/src/components/body-serif.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-serif.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const BodySerif = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.BodySerif, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const BodySerif = React.forwardRef(function BodySerif(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.BodySerif, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default BodySerif;

--- a/packages/wonder-blocks-typography/src/components/body.tsx
+++ b/packages/wonder-blocks-typography/src/components/body.tsx
@@ -5,19 +5,15 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const Body = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.Body, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const Body = React.forwardRef(function Body(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text {...otherProps} tag={tag} style={[styles.Body, style]} ref={ref}>
+            {children}
+        </Text>
+    );
+});
 
 export default Body;

--- a/packages/wonder-blocks-typography/src/components/caption.tsx
+++ b/packages/wonder-blocks-typography/src/components/caption.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const Caption = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.Caption, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const Caption = React.forwardRef(function Caption(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.Caption, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default Caption;

--- a/packages/wonder-blocks-typography/src/components/footnote.tsx
+++ b/packages/wonder-blocks-typography/src/components/footnote.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const Footnote = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.Footnote, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const Footnote = React.forwardRef(function Footnote(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.Footnote, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default Footnote;

--- a/packages/wonder-blocks-typography/src/components/heading-large.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-large.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const HeadingLarge = React.forwardRef(
-    ({style, children, tag = "h2", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.HeadingLarge, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const HeadingLarge = React.forwardRef(function HeadingLarge(
+    {style, children, tag = "h2", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.HeadingLarge, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default HeadingLarge;

--- a/packages/wonder-blocks-typography/src/components/heading-medium.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-medium.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const HeadingMedium = React.forwardRef(
-    ({style, children, tag = "h3", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.HeadingMedium, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const HeadingMedium = React.forwardRef(function HeadingMedium(
+    {style, children, tag = "h3", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.HeadingMedium, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default HeadingMedium;

--- a/packages/wonder-blocks-typography/src/components/heading-small.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-small.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const HeadingSmall = React.forwardRef(
-    ({style, children, tag = "h4", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.HeadingSmall, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const HeadingSmall = React.forwardRef(function HeadingSmall(
+    {style, children, tag = "h4", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.HeadingSmall, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default HeadingSmall;

--- a/packages/wonder-blocks-typography/src/components/heading-xsmall.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-xsmall.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const HeadingXSmall = React.forwardRef(
-    ({style, children, tag = "h4", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.HeadingXSmall, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const HeadingXSmall = React.forwardRef(function HeadingXSmall(
+    {style, children, tag = "h4", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.HeadingXSmall, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default HeadingXSmall;

--- a/packages/wonder-blocks-typography/src/components/label-large.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-large.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const LabelLarge = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.LabelLarge, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const LabelLarge = React.forwardRef(function LabelLarge(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.LabelLarge, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default LabelLarge;

--- a/packages/wonder-blocks-typography/src/components/label-medium.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-medium.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const LabelMedium = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.LabelMedium, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const LabelMedium = React.forwardRef(function LabelMedium(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.LabelMedium, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default LabelMedium;

--- a/packages/wonder-blocks-typography/src/components/label-small.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-small.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const LabelSmall = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.LabelSmall, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const LabelSmall = React.forwardRef(function LabelSmall(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.LabelSmall, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default LabelSmall;

--- a/packages/wonder-blocks-typography/src/components/label-xsmall.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-xsmall.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const LabelXSmall = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.LabelXSmall, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const LabelXSmall = React.forwardRef(function LabelXSmall(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.LabelXSmall, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default LabelXSmall;

--- a/packages/wonder-blocks-typography/src/components/tagline.tsx
+++ b/packages/wonder-blocks-typography/src/components/tagline.tsx
@@ -5,19 +5,20 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const Tagline = React.forwardRef(
-    ({style, children, tag = "span", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.Tagline, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const Tagline = React.forwardRef(function Tagline(
+    {style, children, tag = "span", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text
+            {...otherProps}
+            tag={tag}
+            style={[styles.Tagline, style]}
+            ref={ref}
+        >
+            {children}
+        </Text>
+    );
+});
 
 export default Tagline;

--- a/packages/wonder-blocks-typography/src/components/title.tsx
+++ b/packages/wonder-blocks-typography/src/components/title.tsx
@@ -5,19 +5,15 @@ import styles from "../util/styles";
 
 import type {Props} from "../util/types";
 
-const Title = React.forwardRef(
-    ({style, children, tag = "h1", ...otherProps}: Props, ref) => {
-        return (
-            <Text
-                {...otherProps}
-                tag={tag}
-                style={[styles.Title, style]}
-                ref={ref}
-            >
-                {children}
-            </Text>
-        );
-    },
-);
+const Title = React.forwardRef(function Title(
+    {style, children, tag = "h1", ...otherProps}: Props,
+    ref,
+) {
+    return (
+        <Text {...otherProps} tag={tag} style={[styles.Title, style]} ref={ref}>
+            {children}
+        </Text>
+    );
+});
 
 export default Title;


### PR DESCRIPTION
## Summary:
After updating a bunch of components to use forwardRef(),
we realized that most of them were anonymous functions, which
caused the components to be named `<ForwardRef />` instead of
their action name. (This showed up in the snapshots when
attempting to release to webapp.)

Here, I changed all of these to named functions so that they
show up correctly in snapshot tests.

Issue: none

## Test plan:
N/A?