### PR TITLE
Use Icon instead of IconAsset in Link

### DIFF
--- a/.changeset/ninety-jobs-hammer.md
+++ b/.changeset/ninety-jobs-hammer.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-icon": minor
+"@khanacademy/wonder-blocks-link": minor
+---
+
+Forward refs in Icon
+Use Icon type instead of IconAsset for startIcon and endIcon in Link

--- a/__docs__/wonder-blocks-link/link.argtypes.tsx
+++ b/__docs__/wonder-blocks-link/link.argtypes.tsx
@@ -1,5 +1,13 @@
+import * as React from "react";
+
 import type {InputType} from "@storybook/csf";
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+
+const iconsMap: Record<string, React.ReactElement<typeof Icon>> = {};
+
+Object.entries(icons).forEach(([iconLabel, iconValue]) => {
+    iconsMap[iconLabel] = <Icon icon={iconValue} />;
+});
 
 export default {
     children: {
@@ -15,11 +23,11 @@ export default {
         description: `Icon to appear after the link label. If
         \`target="_blank"\` and an \`endIcon\` is passed in, \`endIcon\` will
         override the default \`externalIcon\`.`,
-        options: [null, ...Object.keys(icons)],
-        mapping: icons,
+        options: [null, ...Object.keys(iconsMap)],
+        mapping: iconsMap,
         table: {
             category: "Icons",
-            type: {summary: "IconAsset"},
+            type: {summary: "Icon"},
         },
     },
 
@@ -115,11 +123,11 @@ export default {
     startIcon: {
         control: {type: "select", labels: {null: "none"}},
         description: "Icon to appear before the link label.",
-        options: [null, ...Object.keys(icons)],
-        mapping: icons,
+        options: [null, ...Object.keys(iconsMap)],
+        mapping: iconsMap,
         table: {
             category: "Icons",
-            type: {summary: "IconAsset"},
+            type: {summary: "Icon"},
         },
     },
 

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -10,6 +10,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
+import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {
@@ -22,7 +23,6 @@ import packageConfig from "../../packages/wonder-blocks-link/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import LinkArgTypes from "./link.argtypes";
-import {icons} from "@khanacademy/wonder-blocks-icon";
 
 export default {
     title: "Link",
@@ -257,14 +257,14 @@ export const StartAndEndIcons: StoryComponentType = () => (
         <View style={{padding: Spacing.large_24}}>
             <Link
                 href="#"
-                startIcon={icons.add}
+                startIcon={<Icon icon={icons.add} />}
                 style={styles.standaloneLinkWrapper}
             >
                 This link has a start icon
             </Link>
             <Link
                 href="#"
-                endIcon={icons.search}
+                endIcon={<Icon icon={icons.search} />}
                 kind="secondary"
                 style={styles.standaloneLinkWrapper}
             >
@@ -272,7 +272,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="https://stuffonmycat.com/"
-                endIcon={icons.info}
+                endIcon={<Icon icon={icons.info} />}
                 target="_blank"
                 style={styles.standaloneLinkWrapper}
             >
@@ -281,8 +281,8 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                startIcon={icons.caretLeft}
-                endIcon={icons.caretRight}
+                startIcon={<Icon icon={icons.caretLeft} />}
+                endIcon={<Icon icon={icons.caretRight} />}
                 kind="secondary"
                 style={styles.standaloneLinkWrapper}
             >
@@ -290,15 +290,19 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                startIcon={icons.caretLeft}
-                endIcon={icons.caretRight}
+                startIcon={<Icon icon={icons.caretLeft} />}
+                endIcon={<Icon icon={icons.caretRight} />}
                 style={styles.multiLine}
             >
                 This is a multi-line link with start and end icons
             </Link>
             <Body>
                 This is an inline{" "}
-                <Link href="#" inline={true} startIcon={icons.caretLeft}>
+                <Link
+                    href="#"
+                    inline={true}
+                    startIcon={<Icon icon={icons.caretLeft} />}
+                >
                     link with a start icon
                 </Link>{" "}
                 and an inline{" "}
@@ -306,7 +310,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
                     href="#"
                     inline={true}
                     target="_blank"
-                    endIcon={icons.caretRight}
+                    endIcon={<Icon icon={icons.caretRight} />}
                 >
                     link with an end icon
                 </Link>
@@ -322,7 +326,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
         >
             <Link
                 href="#"
-                startIcon={icons.add}
+                startIcon={<Icon icon={icons.add} />}
                 light={true}
                 style={styles.standaloneLinkWrapper}
             >
@@ -330,7 +334,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                endIcon={icons.search}
+                endIcon={<Icon icon={icons.search} />}
                 light={true}
                 style={styles.standaloneLinkWrapper}
             >
@@ -338,7 +342,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="https://stuffonmycat.com/"
-                endIcon={icons.info}
+                endIcon={<Icon icon={icons.info} />}
                 target="_blank"
                 light={true}
                 style={styles.standaloneLinkWrapper}
@@ -348,8 +352,8 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                startIcon={icons.caretLeft}
-                endIcon={icons.caretRight}
+                startIcon={<Icon icon={icons.caretLeft} />}
+                endIcon={<Icon icon={icons.caretRight} />}
                 light={true}
                 style={styles.standaloneLinkWrapper}
             >
@@ -357,8 +361,8 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                startIcon={icons.caretLeft}
-                endIcon={icons.caretRight}
+                startIcon={<Icon icon={icons.caretLeft} />}
+                endIcon={<Icon icon={icons.caretRight} />}
                 light={true}
                 style={styles.multiLine}
             >
@@ -368,7 +372,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
                 This is an inline{" "}
                 <Link
                     href="#"
-                    startIcon={icons.caretLeft}
+                    startIcon={<Icon icon={icons.caretLeft} />}
                     inline={true}
                     light={true}
                 >
@@ -377,7 +381,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
                 and an inline{" "}
                 <Link
                     href="#"
-                    endIcon={icons.caretRight}
+                    endIcon={<Icon icon={icons.caretRight} />}
                     inline={true}
                     light={true}
                     target="_blank"
@@ -910,18 +914,18 @@ WithTitle.play = async ({canvasElement}) => {
 export const RightToLeftWithIcons: StoryComponentType = () => (
     <View style={{padding: Spacing.medium_16}}>
         <View style={styles.rightToLeft}>
-            <Link href="/" startIcon={icons.caretRight}>
+            <Link href="/" startIcon={<Icon icon={icons.caretRight} />}>
                 هذا الرابط مكتوب باللغة العربية
             </Link>
             <Strut size={Spacing.medium_16} />
-            <Link href="/" endIcon={icons.caretLeft}>
+            <Link href="/" endIcon={<Icon icon={icons.caretLeft} />}>
                 هذا الرابط مكتوب باللغة العربية
             </Link>
             <Strut size={Spacing.medium_16} />
             <Link
                 href="/"
-                startIcon={icons.caretRight}
-                endIcon={icons.caretLeft}
+                startIcon={<Icon icon={icons.caretRight} />}
+                endIcon={<Icon icon={icons.caretLeft} />}
             >
                 هذا الرابط مكتوب باللغة العربية
             </Link>

--- a/consistency-tests/__tests__/ref-forwarded.test.tsx
+++ b/consistency-tests/__tests__/ref-forwarded.test.tsx
@@ -3,9 +3,12 @@ import {render, waitFor} from "@testing-library/react";
 import {MemoryRouter, Link as ReactRouterLink} from "react-router-dom";
 import * as ReactDOM from "react-dom";
 
+import {icons} from "@khanacademy/wonder-blocks-icon";
+
 import Breadcrumbs from "../../packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs";
 import BreadcrumbsItem from "../../packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item";
 import Button from "../../packages/wonder-blocks-button/src/components/button";
+import Icon from "../../packages/wonder-blocks-icon/src/components/icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import Link from "../../packages/wonder-blocks-link/src/components/link";
 import Text from "../../packages/wonder-blocks-core/src/components/text";
@@ -35,7 +38,6 @@ import LabelSmall from "../../packages/wonder-blocks-typography/src/components/l
 import LabelXSmall from "../../packages/wonder-blocks-typography/src/components/label-xsmall";
 import Tagline from "../../packages/wonder-blocks-typography/src/components/tagline";
 import Title from "../../packages/wonder-blocks-typography/src/components/title";
-import {icons} from "@khanacademy/wonder-blocks-icon";
 
 describe("Typography elements", () => {
     test.each`
@@ -352,5 +354,18 @@ describe("Form elements", () => {
 
         // Assert
         expect(ref.current).toBeInstanceOf(HTMLFieldSetElement);
+    });
+});
+
+describe("Icon", () => {
+    test("forwards ref to an SVGElement", () => {
+        // Arrange
+        const ref: React.RefObject<SVGSVGElement> = React.createRef();
+
+        // Act
+        render(<Icon ref={ref} icon={icons.add} />);
+
+        // Assert
+        expect(ref.current).toBeInstanceOf(SVGSVGElement);
     });
 });

--- a/packages/wonder-blocks-icon/src/components/icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/icon.tsx
@@ -21,7 +21,7 @@ type Props = AriaProps & {
      * One of `small` (16px), `medium` (24px), `large` (48px),
      * or `xlarge` (96px).
      */
-    size: IconSize;
+    size?: IconSize;
     /**
      * Styles that can be processed by `addStyle` — bare style objects,
      * Aphrodite style objects, or arrays thereof.
@@ -35,11 +35,6 @@ type Props = AriaProps & {
      * Test ID used for e2e testing.
      */
     testId?: string;
-};
-
-type DefaultProps = {
-    color: Props["color"];
-    size: Props["size"];
 };
 
 const StyledSVG = addStyle("svg");
@@ -79,32 +74,36 @@ const StyledSVG = addStyle("svg");
  * These icons should fit into a viewport of 16, 24, 48, and 96 pixels,
  * respectively.
  */
-export default class Icon extends React.PureComponent<Props> {
-    static defaultProps: DefaultProps = {
-        color: "currentColor",
-        size: "small",
-    };
+const Icon = React.forwardRef(function Icon(
+    props: Props,
+    ref: React.ForwardedRef<SVGSVGElement>,
+) {
+    const {
+        color = "currentColor",
+        icon,
+        size = "small",
+        style,
+        testId,
+        ...sharedProps
+    } = props;
 
-    render(): React.ReactNode {
-        const {color, icon, size, style, testId, ...sharedProps} = this.props;
-
-        const {assetSize, path} = getPathForIcon(icon, size);
-        const pixelSize = viewportPixelsForSize(size);
-        const viewboxPixelSize = viewportPixelsForSize(assetSize);
-        return (
-            <StyledSVG
-                {...sharedProps}
-                style={[styles.svg, style]}
-                width={pixelSize}
-                height={pixelSize}
-                viewBox={`0 0 ${viewboxPixelSize} ${viewboxPixelSize}`}
-                data-test-id={testId}
-            >
-                <path fill={color} d={path} />
-            </StyledSVG>
-        );
-    }
-}
+    const {assetSize, path} = getPathForIcon(icon, size);
+    const pixelSize = viewportPixelsForSize(size);
+    const viewboxPixelSize = viewportPixelsForSize(assetSize);
+    return (
+        <StyledSVG
+            {...sharedProps}
+            style={[styles.svg, style]}
+            width={pixelSize}
+            height={pixelSize}
+            viewBox={`0 0 ${viewboxPixelSize} ${viewboxPixelSize}`}
+            data-test-id={testId}
+            ref={ref}
+        >
+            <path fill={color} d={path} />
+        </StyledSVG>
+    );
+});
 
 const styles = StyleSheet.create({
     svg: {
@@ -114,3 +113,5 @@ const styles = StyleSheet.create({
         flexGrow: 0,
     },
 });
+
+export default Icon;

--- a/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
@@ -3,7 +3,7 @@ import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 
 import Link from "../link";
 
@@ -412,7 +412,10 @@ describe("Link", () => {
         test("render icon with link when startIcon prop is passed in", () => {
             // Arrange
             render(
-                <Link href="https://www.khanacademy.org/" startIcon={icons.add}>
+                <Link
+                    href="https://www.khanacademy.org/"
+                    startIcon={<Icon icon={icons.add} />}
+                >
                     Add new item
                 </Link>,
             );
@@ -440,7 +443,10 @@ describe("Link", () => {
         test("startIcon prop passed down correctly", () => {
             // Arrange
             render(
-                <Link href="https://www.khanacademy.org/" startIcon={icons.add}>
+                <Link
+                    href="https://www.khanacademy.org/"
+                    startIcon={<Icon icon={icons.add} />}
+                >
                     Add new item
                 </Link>,
             );
@@ -461,7 +467,7 @@ describe("Link", () => {
             render(
                 <Link
                     href="https://www.khanacademy.org/"
-                    endIcon={icons.caretRight}
+                    endIcon={<Icon icon={icons.caretRight} />}
                 >
                     Click to go back
                 </Link>,
@@ -492,7 +498,7 @@ describe("Link", () => {
             render(
                 <Link
                     href="https://www.google.com/"
-                    endIcon={icons.caretRight}
+                    endIcon={<Icon icon={icons.caretRight} />}
                     target="_blank"
                 >
                     Open a new tab
@@ -511,7 +517,7 @@ describe("Link", () => {
             render(
                 <Link
                     href="https://www.google.com/"
-                    endIcon={icons.caretRight}
+                    endIcon={<Icon icon={icons.caretRight} />}
                     target="_blank"
                 >
                     Open a new tab
@@ -530,7 +536,7 @@ describe("Link", () => {
         test("endIcon prop passed down correctly", () => {
             // Arrange
             render(
-                <Link href="/" endIcon={icons.caretRight}>
+                <Link href="/" endIcon={<Icon icon={icons.caretRight} />}>
                     Click to go back
                 </Link>,
             );

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -93,35 +93,37 @@ const LinkCore = React.forwardRef(function LinkCore(
             />
         );
 
+        let startIconElement;
+        let endIconElement;
+
+        if (startIcon) {
+            startIconElement = React.cloneElement(startIcon, {
+                style: [
+                    linkContentStyles.startIcon,
+                    linkContentStyles.centered,
+                ],
+                testId: "start-icon",
+                "aria-hidden": "true",
+                ...startIcon.props,
+            } as Partial<React.ComponentProps<typeof Icon>>);
+        }
+
+        if (endIcon) {
+            endIconElement = React.cloneElement(endIcon, {
+                style: [linkContentStyles.endIcon, linkContentStyles.centered],
+                testId: "end-icon",
+                "aria-hidden": "true",
+                ...endIcon.props,
+            } as Partial<React.ComponentProps<typeof Icon>>);
+        }
+
         const linkContent = (
             <>
-                {startIcon && (
-                    <Icon
-                        icon={startIcon}
-                        size="small"
-                        style={[
-                            linkContentStyles.startIcon,
-                            linkContentStyles.centered,
-                        ]}
-                        testId="start-icon"
-                        aria-hidden="true"
-                    />
-                )}
+                {startIcon && startIconElement}
                 {children}
-                {endIcon ? (
-                    <Icon
-                        icon={endIcon}
-                        size="small"
-                        style={[
-                            linkContentStyles.endIcon,
-                            linkContentStyles.centered,
-                        ]}
-                        testId="end-icon"
-                        aria-hidden="true"
-                    />
-                ) : (
-                    isExternalLink && target === "_blank" && externalIcon
-                )}
+                {endIcon
+                    ? endIconElement
+                    : isExternalLink && target === "_blank" && externalIcon}
             </>
         );
 

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -4,8 +4,8 @@ import {Link as ReactRouterLink} from "react-router-dom";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+import Icon from "@khanacademy/wonder-blocks-icon";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
-import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 import LinkCore from "./link-core";
 
 // TODO(FEI-5000): Convert back to conditional props after TS migration is complete.
@@ -145,13 +145,13 @@ export type SharedProps = AriaProps & {
     /**
      * An optional icon displayed before the link label.
      */
-    startIcon?: IconAsset;
+    startIcon?: React.ReactElement<typeof Icon>;
     /**
      * An optional icon displayed after the link label.
      * If `target="_blank"` and `endIcon` is passed in, `endIcon` will override
      * the default `externalIcon`.
      */
-    endIcon?: IconAsset;
+    endIcon?: React.ReactElement<typeof Icon>;
 };
 
 /**


### PR DESCRIPTION
## Summary:
We want the `startIcon` and `endIcon` props on `Link` to accept `Icon`
instead of `IconAsset`.

In this PR:
- Updated `startIcon` and `endIcon` to use type `Icon`
- Updated Icon so it forwards refs while I was here
- Updated tests for Icon so they use RTL convention

Issue: https://khanacademy.atlassian.net/browse/WB-1542

## Test plan:
`yarn jest`

Go to Storybook and confirm that the Links and Icons look
exactly the same as before.