### PR TITLE
WB-1567: Add tokens to theming package

### DIFF
--- a/.changeset/short-apes-flow.md
+++ b/.changeset/short-apes-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-theming": minor
+---
+
+Add global tokens

--- a/.storybook/components/token-table.tsx
+++ b/.storybook/components/token-table.tsx
@@ -27,7 +27,7 @@ type Props<T> = {
      * NOTE: We use generic types here to ensure that the data passed in is of
      * the same type as the data in the rows.
      */
-    data: Array<T>;
+    tokens: Record<string, string | number | T>;
     /**
      * The columns to include in the table.
      */
@@ -36,8 +36,13 @@ type Props<T> = {
 
 export default function TokenTable<T>({
     columns,
-    data,
+    tokens,
 }: Props<T>): React.ReactElement {
+    // Convert the tokens object into an array of objects.
+    const data = Object.entries(tokens).map(
+        ([key, value]) => ({label: key, value} as T),
+    );
+
     return (
         <StyledTable style={styles.table}>
             <thead>
@@ -54,6 +59,7 @@ export default function TokenTable<T>({
                     <StyledTableRow key={idx} style={styles.row}>
                         {columns.map((column, i) => (
                             <StyledTableCell key={i} style={styles.cell}>
+                                {/* We pass the value directly or via the result of a function call. */}
                                 {typeof column.cell === "string"
                                     ? row[column.cell]
                                     : column.cell(row)}

--- a/.storybook/components/token-table.tsx
+++ b/.storybook/components/token-table.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import Color from "@khanacademy/wonder-blocks-color";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+
+const StyledTable = addStyle("table");
+const StyledTableRow = addStyle("tr");
+const StyledTableHeader = addStyle("th");
+const StyledTableCell = addStyle("td");
+
+type Column<T> = {
+    // The label to display in the table header.
+    label: string | React.ReactNode;
+    // The key to access the data in the row.
+    dataKey?: string;
+    // Custom cell renderer. If not provided, the value at `dataKey` will be
+    // used.
+    cell: string | ((row: T) => React.ReactNode);
+};
+
+type Props<T> = {
+    /**
+     * The data to render in the table.
+     * NOTE: We use generic types here to ensure that the data passed in is of
+     * the same type as the data in the rows.
+     */
+    data: Array<T>;
+    /**
+     * The columns to include in the table.
+     */
+    columns: Array<Column<T>>;
+};
+
+export default function TokenTable<T>({
+    columns,
+    data,
+}: Props<T>): React.ReactElement {
+    return (
+        <StyledTable style={styles.table}>
+            <thead>
+                <StyledTableRow style={styles.header}>
+                    {columns.map((column, i) => (
+                        <StyledTableHeader key={i} style={styles.cell}>
+                            {column.label}
+                        </StyledTableHeader>
+                    ))}
+                </StyledTableRow>
+            </thead>
+            <tbody>
+                {data.map((row, idx) => (
+                    <StyledTableRow key={idx} style={styles.row}>
+                        {columns.map((column, i) => (
+                            <StyledTableCell key={i} style={styles.cell}>
+                                {typeof column.cell === "string"
+                                    ? row[column.cell]
+                                    : column.cell(row)}
+                            </StyledTableCell>
+                        ))}
+                    </StyledTableRow>
+                ))}
+            </tbody>
+        </StyledTable>
+    );
+}
+
+const styles = StyleSheet.create({
+    table: {
+        borderCollapse: "collapse",
+        borderSpacing: 0,
+        margin: `${Spacing.xLarge_32}px 0`,
+        textAlign: "left",
+        width: "100%",
+    },
+    header: {
+        backgroundColor: Color.offWhite,
+    },
+    row: {
+        borderTop: `1px solid ${Color.offBlack8}`,
+        backgroundColor: Color.white,
+    },
+    cell: {
+        padding: Spacing.xSmall_8,
+        verticalAlign: "middle",
+    },
+});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -68,6 +68,7 @@ export const parameters = {
         },
     },
     docs: {
+        toc: true,
         theme: wonderBlocksTheme,
         components: {
             // Override the default link component to use the WB Link component.

--- a/__docs__/wonder-blocks-theming/tokens-border.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-border.mdx
@@ -1,0 +1,96 @@
+import {Meta, Source} from "@storybook/blocks";
+
+import TokenTable from "../../.storybook/components/token-table";
+
+import Banner from "@khanacademy/wonder-blocks-banner";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {tokens} from "@khanacademy/wonder-blocks-theming";
+
+<Meta title="Theming / Tokens / Border" />
+
+export const baseColumns = (kind) => [
+    {
+        label: "Token",
+        cell: (row) => (
+            <code>
+                border.{kind}.{row.label}
+            </code>
+        ),
+    },
+    {
+        label: "Value",
+        cell: "value",
+    },
+];
+
+export const mapFunction = ([key, value]) => ({
+    label: key,
+    value: value,
+});
+
+export const tokensRadiusMap = Object.entries(tokens.border.radius).map(
+    mapFunction,
+);
+
+export const tokensWidthMap = Object.entries(tokens.border.width).map(
+    mapFunction,
+);
+
+# Tokens
+
+## Border
+
+<Banner
+    kind="warning"
+    text="Note that this is intended only internal
+    development purposes. We'll let you know as soon as this is ready for public
+    consumption."
+/>
+
+### Radius
+
+<TokenTable
+    columns={[
+        ...baseColumns("radius"),
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        backgroundColor: tokens.color.purple,
+                        borderRadius: row.value,
+                        width: tokens.spacing.large_24,
+                        height: tokens.spacing.large_24,
+                    }}
+                >
+                    &nbsp;
+                </View>
+            ),
+        },
+    ]}
+    data={tokensRadiusMap}
+/>
+
+### Width
+
+<TokenTable
+    columns={[
+        ...baseColumns("width"),
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        borderColor: tokens.color.purple,
+                        borderWidth: row.value,
+                        width: tokens.spacing.large_24,
+                        height: tokens.spacing.large_24,
+                    }}
+                >
+                    &nbsp;
+                </View>
+            ),
+        },
+    ]}
+    data={tokensWidthMap}
+/>

--- a/__docs__/wonder-blocks-theming/tokens-border.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-border.mdx
@@ -23,25 +23,13 @@ export const baseColumns = (kind) => [
     },
 ];
 
-export const mapFunction = ([key, value]) => ({
-    label: key,
-    value: value,
-});
-
-export const tokensRadiusMap = Object.entries(tokens.border.radius).map(
-    mapFunction,
-);
-
-export const tokensWidthMap = Object.entries(tokens.border.width).map(
-    mapFunction,
-);
-
 # Tokens
 
 ## Border
 
 <Banner
     kind="warning"
+    layout="full-width"
     text="Note that this is intended only internal
     development purposes. We'll let you know as soon as this is ready for public
     consumption."
@@ -68,7 +56,7 @@ export const tokensWidthMap = Object.entries(tokens.border.width).map(
             ),
         },
     ]}
-    data={tokensRadiusMap}
+    tokens={tokens.border.radius}
 />
 
 ### Width
@@ -92,5 +80,5 @@ export const tokensWidthMap = Object.entries(tokens.border.width).map(
             ),
         },
     ]}
-    data={tokensWidthMap}
+    tokens={tokens.border.width}
 />

--- a/__docs__/wonder-blocks-theming/tokens-color.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-color.mdx
@@ -1,0 +1,61 @@
+import {Meta, Source} from "@storybook/blocks";
+
+import TokenTable from "../../.storybook/components/token-table";
+
+import Banner from "@khanacademy/wonder-blocks-banner";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {tokens} from "@khanacademy/wonder-blocks-theming";
+
+<Meta title="Theming / Tokens / Color" />
+
+export const tokensMap = Object.entries(tokens.color).map(([key, value]) => {
+    return {
+        label: key,
+        value: value,
+    };
+});
+
+# Tokens
+
+## Color
+
+<Banner
+    kind="warning"
+    text="Note that this is intended only internal
+    development purposes. We'll let you know as soon as this is ready for public
+    consumption."
+/>
+
+<TokenTable
+    columns={[
+        {
+            label: "Token",
+            cell: (row) => <code>color.{row.label}</code>,
+        },
+        {
+            label: "Value",
+            cell: "value",
+        },
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        background: tokens.color.offBlack8,
+                        padding: tokens.spacing.xxSmall_6,
+                    }}
+                >
+                    <View
+                        style={{
+                            backgroundColor: row.value,
+                            boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.1)",
+                        }}
+                    >
+                        &nbsp;
+                    </View>
+                </View>
+            ),
+        },
+    ]}
+    data={tokensMap}
+/>

--- a/__docs__/wonder-blocks-theming/tokens-color.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-color.mdx
@@ -19,6 +19,8 @@ export const tokensMap = Object.entries(tokens.color).map(([key, value]) => {
 
 ## Color
 
+The color palette containing all the global WB colors.
+
 <Banner
     kind="warning"
     text="Note that this is intended only internal

--- a/__docs__/wonder-blocks-theming/tokens-color.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-color.mdx
@@ -8,13 +8,6 @@ import {tokens} from "@khanacademy/wonder-blocks-theming";
 
 <Meta title="Theming / Tokens / Color" />
 
-export const tokensMap = Object.entries(tokens.color).map(([key, value]) => {
-    return {
-        label: key,
-        value: value,
-    };
-});
-
 # Tokens
 
 ## Color
@@ -23,6 +16,7 @@ The color palette containing all the global WB colors.
 
 <Banner
     kind="warning"
+    layout="full-width"
     text="Note that this is intended only internal
     development purposes. We'll let you know as soon as this is ready for public
     consumption."
@@ -59,5 +53,5 @@ The color palette containing all the global WB colors.
             ),
         },
     ]}
-    data={tokensMap}
+    tokens={tokens.color}
 />

--- a/__docs__/wonder-blocks-theming/tokens-font.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-font.mdx
@@ -46,6 +46,8 @@ export const tokensLineHeightMap = Object.entries(tokens.font.lineHeight).map(
 
 ## Typography
 
+Text sizes, weights and font families used across Wonder Blocks.
+
 <Banner
     kind="warning"
     text="Note that this is intended only internal
@@ -54,6 +56,8 @@ export const tokensLineHeightMap = Object.entries(tokens.font.lineHeight).map(
 />
 
 ### Family
+
+The available font families in our system.
 
 <TokenTable
     columns={[
@@ -76,6 +80,8 @@ export const tokensLineHeightMap = Object.entries(tokens.font.lineHeight).map(
 />
 
 ### Size
+
+The list of possible font sizes that can be used with our components.
 
 <TokenTable
     columns={[
@@ -100,6 +106,8 @@ export const tokensLineHeightMap = Object.entries(tokens.font.lineHeight).map(
 
 ### LineHeight
 
+The vertical space associated to a given font size.
+
 <TokenTable
     columns={[
         ...baseColumns("lineHeight"),
@@ -122,6 +130,8 @@ export const tokensLineHeightMap = Object.entries(tokens.font.lineHeight).map(
 />
 
 ### Weight
+
+Font weight options include regular, bold and black.
 
 <TokenTable
     columns={[

--- a/__docs__/wonder-blocks-theming/tokens-font.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-font.mdx
@@ -1,0 +1,144 @@
+import {Meta} from "@storybook/blocks";
+
+import Banner from "@khanacademy/wonder-blocks-banner";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {tokens} from "@khanacademy/wonder-blocks-theming";
+
+import TokenTable from "../../.storybook/components/token-table";
+
+<Meta title="Theming / Tokens / Typography" />
+
+export const sampleTextUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+export const sampleTextLower = "abcdefghijklmnopqrstuvwxyz";
+
+export const baseColumns = (kind) => [
+    {
+        label: "Token",
+        cell: (row) => (
+            <code>
+                font.{kind}.{row.label}
+            </code>
+        ),
+    },
+    {
+        label: "Value",
+        cell: "value",
+    },
+];
+
+export const mapFunction = ([key, value]) => ({
+    label: key,
+    value: value,
+});
+
+export const tokensFamilyMap = Object.entries(tokens.font.family).map(
+    mapFunction,
+);
+export const tokensWeightMap = Object.entries(tokens.font.weight).map(
+    mapFunction,
+);
+export const tokensSizeMap = Object.entries(tokens.font.size).map(mapFunction);
+export const tokensLineHeightMap = Object.entries(tokens.font.lineHeight).map(
+    mapFunction,
+);
+
+# Tokens
+
+## Typography
+
+<Banner
+    kind="warning"
+    text="Note that this is intended only internal
+    development purposes. We'll let you know as soon as this is ready for public
+    consumption."
+/>
+
+### Family
+
+<TokenTable
+    columns={[
+        ...baseColumns("family"),
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        fontFamily: row.value,
+                    }}
+                >
+                    <span>{sampleTextUpper}</span>
+                    <span>{sampleTextLower}</span>
+                </View>
+            ),
+        },
+    ]}
+    data={tokensFamilyMap}
+/>
+
+### Size
+
+<TokenTable
+    columns={[
+        ...baseColumns("size"),
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        fontSize: row.value,
+                        lineHeight: 1,
+                    }}
+                >
+                    <span>{sampleTextUpper}</span>
+                    <span>{sampleTextLower}</span>
+                </View>
+            ),
+        },
+    ]}
+    data={tokensSizeMap}
+/>
+
+### LineHeight
+
+<TokenTable
+    columns={[
+        ...baseColumns("lineHeight"),
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        backgroundColor: tokens.color.offBlack8,
+                        lineHeight: `${row.value}px`,
+                    }}
+                >
+                    <span>{sampleTextUpper}</span>
+                    <span>{sampleTextLower}</span>
+                </View>
+            ),
+        },
+    ]}
+    data={tokensSizeMap}
+/>
+
+### Weight
+
+<TokenTable
+    columns={[
+        ...baseColumns("weight"),
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        fontWeight: row.value,
+                    }}
+                >
+                    <span>{sampleTextUpper}</span>
+                    <span>{sampleTextLower}</span>
+                </View>
+            ),
+        },
+    ]}
+    data={tokensWeightMap}
+/>

--- a/__docs__/wonder-blocks-theming/tokens-font.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-font.mdx
@@ -11,12 +11,12 @@ import TokenTable from "../../.storybook/components/token-table";
 export const sampleTextUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 export const sampleTextLower = "abcdefghijklmnopqrstuvwxyz";
 
-export const baseColumns = (kind) => [
+export const baseColumns = (property) => [
     {
         label: "Token",
         cell: (row) => (
             <code>
-                font.{kind}.{row.label}
+                font.{property}.{row.label}
             </code>
         ),
     },
@@ -26,22 +26,6 @@ export const baseColumns = (kind) => [
     },
 ];
 
-export const mapFunction = ([key, value]) => ({
-    label: key,
-    value: value,
-});
-
-export const tokensFamilyMap = Object.entries(tokens.font.family).map(
-    mapFunction,
-);
-export const tokensWeightMap = Object.entries(tokens.font.weight).map(
-    mapFunction,
-);
-export const tokensSizeMap = Object.entries(tokens.font.size).map(mapFunction);
-export const tokensLineHeightMap = Object.entries(tokens.font.lineHeight).map(
-    mapFunction,
-);
-
 # Tokens
 
 ## Typography
@@ -50,6 +34,7 @@ Text sizes, weights and font families used across Wonder Blocks.
 
 <Banner
     kind="warning"
+    layout="full-width"
     text="Note that this is intended only internal
     development purposes. We'll let you know as soon as this is ready for public
     consumption."
@@ -70,13 +55,13 @@ The available font families in our system.
                         fontFamily: row.value,
                     }}
                 >
-                    <span>{sampleTextUpper}</span>
-                    <span>{sampleTextLower}</span>
+                    <View className="sb-unstyled">{sampleTextUpper}</View>
+                    <View className="sb-unstyled">{sampleTextLower}</View>
                 </View>
             ),
         },
     ]}
-    data={tokensFamilyMap}
+    tokens={tokens.font.family}
 />
 
 ### Size
@@ -95,13 +80,13 @@ The list of possible font sizes that can be used with our components.
                         lineHeight: 1,
                     }}
                 >
-                    <span>{sampleTextUpper}</span>
-                    <span>{sampleTextLower}</span>
+                    <View className="sb-unstyled">{sampleTextUpper}</View>
+                    <View className="sb-unstyled">{sampleTextLower}</View>
                 </View>
             ),
         },
     ]}
-    data={tokensSizeMap}
+    tokens={tokens.font.size}
 />
 
 ### LineHeight
@@ -120,18 +105,18 @@ The vertical space associated to a given font size.
                         lineHeight: `${row.value}px`,
                     }}
                 >
-                    <span>{sampleTextUpper}</span>
-                    <span>{sampleTextLower}</span>
+                    <View className="sb-unstyled">{sampleTextUpper}</View>
+                    <View className="sb-unstyled">{sampleTextLower}</View>
                 </View>
             ),
         },
     ]}
-    data={tokensSizeMap}
+    tokens={tokens.font.lineHeight}
 />
 
 ### Weight
 
-Font weight options include regular, bold and black.
+Font weight options include `light`, `regular` and `bold`.
 
 <TokenTable
     columns={[
@@ -144,11 +129,11 @@ Font weight options include regular, bold and black.
                         fontWeight: row.value,
                     }}
                 >
-                    <span>{sampleTextUpper}</span>
-                    <span>{sampleTextLower}</span>
+                    <View className="sb-unstyled">{sampleTextUpper}</View>
+                    <View className="sb-unstyled">{sampleTextLower}</View>
                 </View>
             ),
         },
     ]}
-    data={tokensWeightMap}
+    tokens={tokens.font.weight}
 />

--- a/__docs__/wonder-blocks-theming/tokens-spacing.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-spacing.mdx
@@ -8,13 +8,6 @@ import {tokens} from "@khanacademy/wonder-blocks-theming";
 
 <Meta title="Theming / Tokens / Spacing" />
 
-export const tokensMap = Object.entries(tokens.spacing).map(([key, value]) => {
-    return {
-        label: key,
-        value: value,
-    };
-});
-
 # Tokens
 
 ## Spacing
@@ -24,6 +17,7 @@ height, border-width, etc.
 
 <Banner
     kind="warning"
+    layout="full-width"
     text="Note that this is intended only internal
     development purposes. We'll let you know as soon as this is ready for public
     consumption."
@@ -53,5 +47,5 @@ height, border-width, etc.
             ),
         },
     ]}
-    data={tokensMap}
+    tokens={tokens.spacing}
 />

--- a/__docs__/wonder-blocks-theming/tokens-spacing.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-spacing.mdx
@@ -19,6 +19,9 @@ export const tokensMap = Object.entries(tokens.spacing).map(([key, value]) => {
 
 ## Spacing
 
+All the available spacing values that can be used for margin, padding, width,
+height, border-width, etc.
+
 <Banner
     kind="warning"
     text="Note that this is intended only internal

--- a/__docs__/wonder-blocks-theming/tokens-spacing.mdx
+++ b/__docs__/wonder-blocks-theming/tokens-spacing.mdx
@@ -1,0 +1,54 @@
+import {Meta, Source} from "@storybook/blocks";
+
+import TokenTable from "../../.storybook/components/token-table";
+
+import Banner from "@khanacademy/wonder-blocks-banner";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {tokens} from "@khanacademy/wonder-blocks-theming";
+
+<Meta title="Theming / Tokens / Spacing" />
+
+export const tokensMap = Object.entries(tokens.spacing).map(([key, value]) => {
+    return {
+        label: key,
+        value: value,
+    };
+});
+
+# Tokens
+
+## Spacing
+
+<Banner
+    kind="warning"
+    text="Note that this is intended only internal
+    development purposes. We'll let you know as soon as this is ready for public
+    consumption."
+/>
+
+<TokenTable
+    columns={[
+        {
+            label: "Token",
+            cell: (row) => <code>spacing.{row.label}</code>,
+        },
+        {
+            label: "Value",
+            cell: "value",
+        },
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        backgroundColor: tokens.color.purple,
+                        height: row.value,
+                    }}
+                >
+                    &nbsp;
+                </View>
+            ),
+        },
+    ]}
+    data={tokensMap}
+/>

--- a/packages/wonder-blocks-theming/src/index.ts
+++ b/packages/wonder-blocks-theming/src/index.ts
@@ -1,2 +1,1 @@
-// Just a temporary export to include some code.
-export const NOTHING = "NOTHING";
+export {default as tokens} from "./tokens";

--- a/packages/wonder-blocks-theming/src/tokens.ts
+++ b/packages/wonder-blocks-theming/src/tokens.ts
@@ -1,0 +1,70 @@
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import Color, {fade, mix} from "@khanacademy/wonder-blocks-color";
+
+/**
+ * Core tokens for the Wonder Blocks design system.
+ * @private
+ *
+ * NOTE: This file is private for WB usage only. It's not recommended to use
+ * this file in consumer apps at the moment.
+ */
+const tokens = {
+    color: {
+        // Wonder Blocks base colors
+        ...Color,
+        // New colors
+        activeBlue: mix(Color.offBlack32, Color.blue),
+        fadedBlue: mix(fade(Color.blue, 0.32), Color.white),
+        activeRed: mix(Color.offBlack32, Color.red),
+        fadedRed: mix(fade(Color.red, 0.32), Color.white),
+        // Additional colors (e.g. for use in other themes)
+    },
+    spacing: Spacing,
+    border: {
+        radius: {
+            xSmall_2: 2,
+            small_3: 3,
+            medium_4: 4,
+            large_6: 6,
+            full: "50%",
+        },
+        width: {
+            none: 0,
+            hairline: 1,
+            thin: 2,
+            thick: 4,
+        },
+    },
+    font: {
+        family: {
+            sans: 'Lato,"Noto Sans" sans-serif',
+            serif: '"Noto Serif", serif',
+            mono: "Inconsolata, monospace",
+        },
+        size: {
+            xxxLarge: 36,
+            xxLarge: 28,
+            xLarge: 24,
+            large: 20,
+            medium: 16,
+            small: 14,
+            xSmall: 12,
+        },
+        lineHeight: {
+            xxxLarge: 40,
+            xxLarge: 32,
+            xLarge: 28,
+            large: 24,
+            medium: 20,
+            small: 18,
+            xSmall: 16,
+        },
+        weight: {
+            light: 300,
+            regular: 400,
+            bold: 700,
+        },
+    },
+};
+
+export default tokens;


### PR DESCRIPTION
## Summary:
Adds global tokens to the theming package. This includes border, color,
font, and spacing tokens.

This also adds a token table component to storybook.

### Implementation plan:

1. **WB-1567: Add tokens to theming package [CURRENT]**
2. #1977
3. #1978
4. #1979 
5. #1981
6. #1982
7. Create Storybook example for adding theming support to a custom component (WIP)

Issue: WB-1567

## Test plan:

Verify that the new tokens stories are in storybook.

https://5e1bf4b385e3fb0020b7073c-ywcimklozr.chromatic.com/?path=/docs/theming-tokens-border--docs

<img width="1213" alt="Screenshot 2023-08-10 at 5 58 40 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/5dccd8ad-082b-47f8-b0a2-af45c7027d03">

https://5e1bf4b385e3fb0020b7073c-ywcimklozr.chromatic.com/?path=/docs/theming-tokens-color--docs

<img width="1044" alt="Screenshot 2023-08-10 at 5 59 08 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/e6be4791-3824-44ba-a5bf-ebac88b214fb">

https://5e1bf4b385e3fb0020b7073c-ywcimklozr.chromatic.com/?path=/docs/theming-tokens-typography--docs
<img width="1242" alt="Screenshot 2023-08-10 at 5 59 29 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/7e92db3d-7306-4546-88cb-3187038c6095">

https://5e1bf4b385e3fb0020b7073c-ywcimklozr.chromatic.com/?path=/docs/theming-tokens-spacing--docs
<img width="1086" alt="Screenshot 2023-08-10 at 5 59 54 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/afefda97-f2be-4560-b5fa-3de217f6bc95">

