### PR TITLE
Create new primitive Switch component based on implementation spec

### DIFF
--- a/.changeset/beige-oranges-call.md
+++ b/.changeset/beige-oranges-call.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-switch": major
+"@khanacademy/wonder-blocks-clickable": minor
+---
+
+Create new Switch component and add 'switch' role to ClickableRole

--- a/__docs__/wonder-blocks-form/checkbox-accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-form/checkbox-accessibility.stories.mdx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import {Meta, Story, Canvas} from "@storybook/blocks";
 import {StyleSheet} from "aphrodite";
 

--- a/__docs__/wonder-blocks-switch/switch-best-practices.mdx
+++ b/__docs__/wonder-blocks-switch/switch-best-practices.mdx
@@ -1,0 +1,63 @@
+import {Canvas, Meta} from "@storybook/blocks";
+
+import * as SwitchBestPracticesStories from "./switch-best-practices.stories";
+
+<Meta of={SwitchBestPracticesStories} />
+
+# Switch
+
+## Best Practices
+
+### With Labelling
+
+The switch can be paired with a visible label which should be an html `label` element. The label
+should include the `htmlFor` attribute, and the switch should include the `aria-labelledby`
+attribute.
+
+#### Label
+
+The label text should __not__ change as the state of the switch changes.
+
+<Canvas of={SwitchBestPracticesStories.WithLabel} />
+
+#### Label, Description
+
+If a description is also provided, the switch should include the `aria-describedby` attribute.
+
+<Canvas of={SwitchBestPracticesStories.WithLabelAndDescription} />
+
+#### Label, ON/OFF Labels
+
+If on/off labels are desired, they should include the `aria-hidden` attribute to prevent
+redundant descriptions of the state for screen readers.
+
+<Canvas of={SwitchBestPracticesStories.WithLabelAndOnOff} />
+
+### Inside Cells
+
+The switch can be placed inside a cell as a left/right accessory.
+
+In the following examples, the title is a `label` element with the `htmlFor` attribute set to the
+switch, so that clicking the title also changes the state of the switch. The `onClick` attribute
+is omitted from the cell, and the `onChange` exists on the switch as normal.
+
+#### Compact Cell
+
+<Canvas of={SwitchBestPracticesStories.InsideCell} />
+
+#### Detailed Cell
+
+In the detailed cell, the title should change the state of the switch, and the description should
+not.
+
+<Canvas of={SwitchBestPracticesStories.InsideDetailCell} />
+
+### With a Tooltip
+
+The switch can be wrapped with a tooltip that describes the purpose and state of the switch.
+
+<Canvas of={SwitchBestPracticesStories.WithTooltip} />
+
+### References
+
+For more details, see the [Accessibility section](https://www.w3.org/WAI/ARIA/apg/patterns/switch/#wai-ariaroles,states,andproperties) in w3.org.

--- a/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
@@ -1,0 +1,217 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react";
+
+import Switch from "@khanacademy/wonder-blocks-switch";
+import {CompactCell, DetailCell} from "@khanacademy/wonder-blocks-cell";
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
+import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {View} from "@khanacademy/wonder-blocks-core";
+import Color from "@khanacademy/wonder-blocks-color";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+
+import packageConfig from "../../packages/wonder-blocks-switch/package.json";
+import ComponentInfo from "../../.storybook/components/component-info";
+
+import SwitchArgtypes from "./switch.argtypes";
+import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+
+type StoryComponentType = StoryObj<typeof Switch>;
+
+export default {
+    title: "Switch / Best Practices",
+    component: Switch,
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+        chromatic: {
+            disableSnapshot: true,
+        },
+    },
+    argTypes: SwitchArgtypes,
+} as Meta<typeof Switch>;
+
+export const WithLabel: StoryComponentType = (() => {
+    const [checked, setChecked] = React.useState(false);
+
+    return (
+        <View
+            style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+            }}
+        >
+            <Switch
+                id="switch-with-label"
+                checked={checked}
+                onChange={setChecked}
+                aria-labelledby="label-for-switch-with-label"
+            />
+            <LabelMedium
+                id="label-for-switch-with-label"
+                htmlFor="switch-with-label"
+                style={{marginLeft: Spacing.xSmall_8}}
+                tag="label"
+            >
+                Superpowers
+            </LabelMedium>
+        </View>
+    );
+}) as StoryComponentType;
+
+export const WithLabelAndDescription: StoryComponentType = (() => {
+    const [checked, setChecked] = React.useState(false);
+
+    return (
+        <View
+            style={{
+                display: "flex",
+                flexDirection: "row",
+            }}
+        >
+            <Switch
+                id="switch-with-desc"
+                checked={checked}
+                onChange={setChecked}
+                aria-labelledby="label-for-switch-with-desc"
+                aria-describedby="desc-for-switch-with-desc"
+            />
+            <View style={{marginLeft: Spacing.xSmall_8}}>
+                <LabelMedium
+                    id="label-for-switch-with-desc"
+                    htmlFor="switch-with-desc"
+                    tag="label"
+                >
+                    Getting a Healthy Amount of Sleep
+                </LabelMedium>
+                <LabelSmall
+                    id="desc-for-switch-with-desc"
+                    style={{color: Color.offBlack64}}
+                >
+                    Sleep is important for your health. The benefits of a good
+                    night sleep include improved memory, longer life, and
+                    increased creativity.
+                </LabelSmall>
+            </View>
+        </View>
+    );
+}) as StoryComponentType;
+
+export const WithLabelAndOnOff: StoryComponentType = (() => {
+    const [checked, setChecked] = React.useState(false);
+
+    return (
+        <View
+            style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+            }}
+        >
+            <LabelMedium
+                id="label-for-switch-with-on-off"
+                htmlFor="switch-with-on-off"
+                style={{marginRight: Spacing.xSmall_8}}
+                tag="label"
+            >
+                Gravity
+            </LabelMedium>
+            <Switch
+                id="switch-with-on-off"
+                checked={checked}
+                onChange={setChecked}
+                aria-labelledby="label-for-switch-with-on-off"
+            />
+            <LabelSmall
+                style={{marginLeft: Spacing.xSmall_8, color: Color.offBlack64}}
+                aria-hidden={true}
+            >
+                {checked ? "ON" : "OFF"}
+            </LabelSmall>
+        </View>
+    );
+}) as StoryComponentType;
+
+export const WithTooltip: StoryComponentType = (() => {
+    const [checked, setChecked] = React.useState(false);
+    const tooltipContent = `Hints turned ${checked ? "ON" : "OFF"}`;
+
+    return (
+        <View>
+            <Tooltip content={tooltipContent} placement="right">
+                <Switch
+                    checked={checked}
+                    onChange={setChecked}
+                    icon={<Icon icon={icons.hint} />}
+                />
+            </Tooltip>
+        </View>
+    );
+}) as StoryComponentType;
+
+export const InsideCell: StoryComponentType = (() => {
+    const [checked, setChecked] = React.useState(false);
+
+    return (
+        <CompactCell
+            title={
+                <LabelMedium
+                    id="label-for-switch-inside-cell"
+                    htmlFor="switch-inside-cell"
+                    tag="label"
+                >
+                    Click me!
+                </LabelMedium>
+            }
+            rightAccessory={
+                <Switch
+                    id="switch-inside-cell"
+                    aria-labelledby="label-for-switch-inside-cell"
+                    checked={checked}
+                    onChange={setChecked}
+                />
+            }
+        />
+    );
+}) as StoryComponentType;
+
+export const InsideDetailCell: StoryComponentType = (() => {
+    const [checked, setChecked] = React.useState(false);
+
+    return (
+        <DetailCell
+            title={
+                <LabelMedium
+                    id="label-for-switch-inside-detail-cell"
+                    htmlFor="switch-inside-detail-cell"
+                    tag="label"
+                >
+                    Click me! I will change the state of the switch.
+                </LabelMedium>
+            }
+            subtitle2={
+                <LabelSmall
+                    id="desc-for-switch-inside-detail-cell"
+                    style={{color: Color.offBlack64}}
+                >
+                    I am a long description that does not change the state of
+                    the switch. Click me all you want and nothing will change.
+                </LabelSmall>
+            }
+            leftAccessory={<Icon icon={icons.info} />}
+            rightAccessory={
+                <Switch
+                    id="switch-inside-detail-cell"
+                    aria-labelledby="label-for-switch-inside-detail-cell"
+                    aria-describedby="desc-for-switch-inside-detail-cell"
+                    checked={checked}
+                    onChange={setChecked}
+                />
+            }
+        />
+    );
+}) as StoryComponentType;

--- a/__docs__/wonder-blocks-switch/switch.argtypes.tsx
+++ b/__docs__/wonder-blocks-switch/switch.argtypes.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+
+import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+
+const iconsMap: Record<string, React.ReactElement<typeof Icon>> = {};
+
+Object.entries(icons).forEach(([iconLabel, iconValue]) => {
+    iconsMap[iconLabel] = <Icon icon={iconValue} />;
+});
+
+export default {
+    "aria-describedby": {
+        description: "The id of an element that describes the switch.",
+        table: {
+            category: "Accessibility",
+            type: {
+                summary: "string",
+            },
+        },
+    },
+    "aria-label": {
+        description:
+            "An accessible label for the switch. If a visible label is not provided, aria-label should be used to describe the purpose of the switch.",
+        table: {
+            category: "Accessibility",
+            type: {
+                summary: "string",
+            },
+        },
+    },
+    "aria-labelledby": {
+        description:
+            "The id of an element that is a label for the switch. Aria-labelledby takes precedence over all other methods of providing an accessible name.",
+        table: {
+            category: "Accessibility",
+            type: {
+                summary: "string",
+            },
+        },
+    },
+    checked: {
+        description: "Whether this component is checked.",
+        control: {
+            type: "boolean",
+        },
+    },
+    disabled: {
+        description: "Whether the switch is disabled. Defaults to `false`.",
+        control: {
+            type: "boolean",
+        },
+        table: {
+            type: {
+                summary: "boolean",
+            },
+        },
+    },
+    icon: {
+        description: "Optional icon to display on the slider.",
+        control: {
+            type: "select",
+            labels: {
+                null: "none",
+            },
+        },
+        options: [null, ...Object.keys(iconsMap)],
+        mapping: iconsMap,
+        table: {
+            type: {
+                summary: "Icon",
+            },
+        },
+    },
+    id: {
+        description:
+            "The unique identifier for the switch. If not provided, a unique id will be generated.",
+        control: {
+            type: "text",
+        },
+        table: {
+            type: {
+                summary: "string",
+            },
+        },
+    },
+    onChange: {
+        description: "Function to call when the switch is clicked.",
+        table: {
+            type: {
+                summary: "(newCheckedState: boolean) => unknown",
+            },
+        },
+    },
+    testId: {
+        description: "Optional test ID used for e2e testing.",
+        control: {
+            type: "text",
+        },
+        table: {
+            type: {
+                summary: "string",
+            },
+        },
+    },
+};

--- a/__docs__/wonder-blocks-switch/switch.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch.stories.tsx
@@ -1,0 +1,144 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react";
+import {StyleSheet} from "aphrodite";
+import {expect} from "@storybook/jest";
+import {userEvent, within} from "@storybook/testing-library";
+
+import Switch from "@khanacademy/wonder-blocks-switch";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+
+import packageConfig from "../../packages/wonder-blocks-switch/package.json";
+import ComponentInfo from "../../.storybook/components/component-info";
+
+import SwitchArgtypes from "./switch.argtypes";
+
+type StoryComponentType = StoryObj<typeof Switch>;
+
+export default {
+    title: "Switch",
+    component: Switch,
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+    },
+    argTypes: SwitchArgtypes,
+} as Meta<typeof Switch>;
+
+export const Default: StoryComponentType = {
+    args: {
+        checked: false,
+        onChange: () => {},
+    },
+};
+
+export const Controlled: StoryComponentType = () => {
+    const [checkedOne, setCheckedOne] = React.useState(false);
+    const [checkedTwo, setCheckedTwo] = React.useState(false);
+
+    return (
+        <View style={styles.column}>
+            <Switch checked={checkedOne} onChange={setCheckedOne} />
+            <Strut size={Spacing.xSmall_8} />
+            <Switch
+                testId="test-switch"
+                aria-label="test switch"
+                checked={checkedTwo}
+                onChange={setCheckedTwo}
+                icon={<Icon icon={icons.search} />}
+            />
+        </View>
+    );
+};
+
+Controlled.play = async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const switchWithIcon = canvas.getByTestId("test-switch");
+    const switchInput = canvas.getByRole("switch", {name: "test switch"});
+
+    await userEvent.tab();
+    await userEvent.tab();
+
+    expect(switchWithIcon).toHaveStyle(
+        "background-color: rgba(33, 36, 44, 0.5)",
+    );
+    expect(switchWithIcon).toHaveStyle("outline: 2px solid rgb(24, 101, 242)");
+    expect(switchInput).toHaveProperty("checked", false);
+
+    await userEvent.click(switchWithIcon);
+    // Wait for animations to finish
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(switchInput).toHaveProperty("checked", true);
+    expect(switchWithIcon).toHaveStyle("background-color: rgb(24, 101, 242)");
+};
+
+Controlled.parameters = {
+    docs: {
+        description: {
+            story: `The switch is a controlled component, so state should be used to keep track of
+            whether it is checked or not. The \`onChange\` prop is optional in case the toggle
+            will be wrapped in a larger clickable component.`,
+        },
+    },
+};
+
+export const Disabled: StoryComponentType = () => (
+    <View style={styles.column}>
+        <Switch checked={false} disabled={true} />
+        <Strut size={Spacing.xSmall_8} />
+        <Switch checked={true} disabled={true} />
+        <Strut size={Spacing.xSmall_8} />
+        <Switch
+            checked={false}
+            disabled={true}
+            icon={<Icon icon={icons.search} />}
+        />
+        <Strut size={Spacing.xSmall_8} />
+        <Switch
+            checked={true}
+            disabled={true}
+            icon={<Icon icon={icons.search} />}
+        />
+    </View>
+);
+
+Disabled.parameters = {
+    docs: {
+        description: {
+            story: `The switch can be disabled.`,
+        },
+    },
+};
+
+export const WithIcon: StoryComponentType = () => {
+    return (
+        <View style={styles.column}>
+            <Switch checked={false} icon={<Icon icon={icons.search} />} />
+            <Strut size={Spacing.xSmall_8} />
+            <Switch checked={true} icon={<Icon icon={icons.search} />} />
+        </View>
+    );
+};
+
+WithIcon.parameters = {
+    docs: {
+        description: {
+            story: `The switch can take an \`Icon\` element which will be rendered inside the slider.`,
+        },
+    },
+};
+
+const styles = StyleSheet.create({
+    column: {
+        flexDirection: "column",
+        alignItems: "start",
+    },
+});

--- a/consistency-tests/__tests__/ref-forwarded.test.tsx
+++ b/consistency-tests/__tests__/ref-forwarded.test.tsx
@@ -11,6 +11,7 @@ import Button from "../../packages/wonder-blocks-button/src/components/button";
 import Icon from "../../packages/wonder-blocks-icon/src/components/icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import Link from "../../packages/wonder-blocks-link/src/components/link";
+import Switch from "../../packages/wonder-blocks-switch/src/components/switch";
 import Text from "../../packages/wonder-blocks-core/src/components/text";
 import View from "../../packages/wonder-blocks-core/src/components/view";
 
@@ -354,6 +355,19 @@ describe("Form elements", () => {
 
         // Assert
         expect(ref.current).toBeInstanceOf(HTMLFieldSetElement);
+    });
+
+    describe("Switch", () => {
+        test("forwards ref to an HTMLInputElement", () => {
+            // Arrange
+            const ref: React.RefObject<HTMLInputElement> = React.createRef();
+
+            // Act
+            render(<Switch checked={false} ref={ref} />);
+
+            // Assert
+            expect(ref.current).toBeInstanceOf(HTMLInputElement);
+        });
     });
 });
 

--- a/consistency-tests/tsconfig.json
+++ b/consistency-tests/tsconfig.json
@@ -10,6 +10,7 @@
         {"path": "../packages/wonder-blocks-clickable/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-color/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-core/tsconfig-build.json"},
+        {"path": "../packages/wonder-blocks-dropdown/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-form/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-i18n/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-icon/tsconfig-build.json"},
@@ -18,6 +19,7 @@
         {"path": "../packages/wonder-blocks-modal/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-search-field/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../packages/wonder-blocks-switch/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-timing/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-typography/tsconfig-build.json"},
     ]

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -3,13 +3,14 @@ import * as React from "react";
 // NOTE: Potentially add to this as more cases come up.
 export type ClickableRole =
     | "button"
-    | "link"
     | "checkbox"
-    | "radio"
+    | "link"
     | "listbox"
-    | "option"
-    | "menuitem"
     | "menu"
+    | "menuitem"
+    | "option"
+    | "radio"
+    | "switch"
     | "tab";
 
 const getAppropriateTriggersForRole = (role?: ClickableRole | null) => {

--- a/packages/wonder-blocks-switch/package.json
+++ b/packages/wonder-blocks-switch/package.json
@@ -17,10 +17,10 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-clickable": "^3.1.3",
     "@khanacademy/wonder-blocks-color": "^2.0.1",
     "@khanacademy/wonder-blocks-core": "^5.4.0",
-    "@khanacademy/wonder-blocks-typography": "^2.1.2"
+    "@khanacademy/wonder-blocks-icon": "^2.1.0",
+    "@khanacademy/wonder-blocks-spacing": "^4.0.1"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-switch/src/components/__tests__/switch.test.tsx
+++ b/packages/wonder-blocks-switch/src/components/__tests__/switch.test.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+
+import userEvent from "@testing-library/user-event";
+import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+import Switch from "../switch";
+
+describe("Switch", () => {
+    describe("trigger switch callback", () => {
+        test("clicking the switch should call onChange", () => {
+            // Arrange
+            const onChangeSpy = jest.fn();
+            render(<Switch checked={false} onChange={onChangeSpy} />);
+
+            // Act
+            const switchComponent = screen.getByRole("switch");
+            switchComponent.click();
+
+            // Assert
+            expect(onChangeSpy).toHaveBeenCalled();
+        });
+
+        test("clicking a disabled switch should not call onChange", () => {
+            // Arrange
+            const onChangeSpy = jest.fn();
+            render(
+                <Switch
+                    checked={false}
+                    onChange={onChangeSpy}
+                    disabled={true}
+                />,
+            );
+
+            // Act
+            const switchComponent = screen.getByRole("switch");
+            switchComponent.click();
+
+            // Assert
+            expect(onChangeSpy).not.toHaveBeenCalled();
+        });
+
+        test("pressing the space key should call onChange", () => {
+            // Arrange
+            const onChangeSpy = jest.fn();
+            render(<Switch checked={false} onChange={onChangeSpy} />);
+
+            // Act
+            const switchComponent = screen.getByRole("switch");
+            userEvent.tab();
+            userEvent.type(switchComponent, " ");
+
+            // Assert
+            expect(onChangeSpy).toHaveBeenCalled();
+        });
+
+        test("clicking a label for the switch should call onChange", () => {
+            // Arrange
+            const onChangeSpy = jest.fn();
+            render(
+                <>
+                    <Switch
+                        id="switch-id"
+                        checked={false}
+                        onChange={onChangeSpy}
+                    />
+                    <label htmlFor="switch-id">Switch</label>
+                </>,
+            );
+
+            // Act
+            const label = screen.getByText("Switch");
+            label.click();
+
+            // Assert
+            expect(onChangeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("setting attributes", () => {
+        it("should set the accessibility attributes accordingly", () => {
+            // Arrange
+            render(
+                <Switch aria-label="Gravity" checked={true} disabled={true} />,
+            );
+
+            // Act
+            const switchComponent = screen.getByRole("switch");
+
+            // Assert
+            expect(switchComponent).toHaveAttribute("aria-label", "Gravity");
+            expect(switchComponent).toHaveProperty("checked", true);
+        });
+
+        it("should render an icon if one is provided", () => {
+            // Arrange
+            render(
+                <Switch
+                    checked={false}
+                    icon={<Icon icon={icons.add} testId="test-icon" />}
+                />,
+            );
+
+            // Act
+            const icon = screen.getByTestId("test-icon");
+
+            // Assert
+            expect(icon).toBeInTheDocument();
+        });
+    });
+});

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -1,0 +1,246 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {
+    AriaProps,
+    UniqueIDProvider,
+    View,
+    addStyle,
+} from "@khanacademy/wonder-blocks-core";
+import Color, {mix} from "@khanacademy/wonder-blocks-color";
+import Icon from "@khanacademy/wonder-blocks-icon";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+
+type Props = Pick<
+    AriaProps,
+    "aria-labelledby" | "aria-label" | "aria-describedby"
+> & {
+    /**
+     * Whether this compoonent is checked.
+     */
+    checked: boolean;
+    /**
+     * Whether the switch is disabled. Defaults to `false`.
+     */
+    disabled?: boolean;
+    /**
+     * Optional icon to display on the slider.
+     */
+    icon?: React.ReactElement<typeof Icon>;
+    /**
+     * The unique identifier for the switch.
+     */
+    id?: string;
+    /**
+     * Function to call when the switch is clicked.
+     * @param newCheckedValue
+     * @returns {unknown}
+     */
+    onChange?: (newCheckedState: boolean) => unknown;
+    /**
+     * Test ID used for e2e testing.
+     */
+    testId?: string;
+};
+
+const StyledSpan = addStyle("span");
+const StyledInput = addStyle("input");
+
+const Switch = React.forwardRef(function Switch(
+    props: Props,
+    ref: React.ForwardedRef<HTMLInputElement>,
+) {
+    const {
+        "aria-label": ariaLabel,
+        "aria-labelledby": ariaLabelledBy,
+        "aria-describedby": ariaDescribedBy,
+        checked,
+        disabled = false,
+        icon,
+        id,
+        onChange,
+        testId,
+    } = props;
+
+    const handleClick = () => {
+        if (!disabled && onChange) {
+            onChange(!checked);
+        }
+    };
+    const handleChange = () => {};
+
+    const stateStyles = _generateStyles(
+        checked,
+        disabled,
+        onChange !== undefined,
+    );
+
+    let styledIcon: React.ReactElement<typeof Icon> | undefined;
+    if (icon) {
+        styledIcon = React.cloneElement(icon, {
+            size: "small",
+            style: [sharedStyles.icon, stateStyles.icon],
+            "aria-hidden": true,
+            ...icon.props,
+        } as Partial<React.ComponentProps<typeof Icon>>);
+    }
+
+    return (
+        <UniqueIDProvider mockOnFirstRender={true} scope="switch">
+            {(ids) => {
+                const uniqueId = id || ids.get("switch");
+
+                return (
+                    <View
+                        onClick={handleClick}
+                        style={[
+                            sharedStyles.switch,
+                            stateStyles.switch,
+                            disabled && sharedStyles.disabled,
+                        ]}
+                        testId={testId}
+                    >
+                        <StyledInput
+                            aria-describedby={ariaDescribedBy}
+                            aria-label={ariaLabel}
+                            aria-labelledby={ariaLabelledBy}
+                            checked={checked}
+                            disabled={disabled}
+                            id={uniqueId}
+                            // Need to specify because this is a controlled React component, but we
+                            // handle the clicks on the outer View
+                            onChange={handleChange}
+                            ref={ref}
+                            role="switch"
+                            // Input is visually hidden because we use a view and span to render
+                            // the actual switch. The input is used for accessibility.
+                            style={sharedStyles.hidden}
+                            type="checkbox"
+                        />
+                        {icon && styledIcon}
+                        <StyledSpan
+                            style={[sharedStyles.slider, stateStyles.slider]}
+                        />
+                    </View>
+                );
+            }}
+        </UniqueIDProvider>
+    );
+});
+
+const sharedStyles = StyleSheet.create({
+    hidden: {
+        opacity: 0,
+        height: 0,
+        width: 0,
+    },
+    switch: {
+        display: "inline-flex",
+        height: Spacing.large_24,
+        width: `calc(${Spacing.xLarge_32}px + ${Spacing.xSmall_8}px)`,
+        borderRadius: Spacing.small_12,
+        flexShrink: 0,
+        cursor: "pointer",
+        ":hover": {
+            outlineOffset: 1,
+        },
+        transition: "background-color 0.15s ease-in-out",
+    },
+    disabled: {
+        cursor: "auto",
+        ":hover": {
+            outline: "none",
+        },
+    },
+    slider: {
+        position: "absolute",
+        top: Spacing.xxxxSmall_2,
+        left: Spacing.xxxxSmall_2,
+        height: `calc(${Spacing.medium_16}px + ${Spacing.xxxSmall_4}px)`,
+        width: `calc(${Spacing.medium_16}px + ${Spacing.xxxSmall_4}px)`,
+        borderRadius: "50%",
+        backgroundColor: Color.white,
+        transition: "transform 0.15s ease-in-out",
+    },
+    icon: {
+        position: "absolute",
+        top: Spacing.xxxSmall_4,
+        left: Spacing.xxxSmall_4,
+        zIndex: 1,
+        transition: "0.15s ease-in-out",
+        transitionProperty: "transform, color",
+    },
+});
+
+const styles: Record<string, any> = {};
+const _generateStyles = (
+    checked: boolean,
+    disabled: boolean,
+    clickable: boolean,
+) => {
+    const checkedStyle = `${checked}-${disabled}-${clickable}`;
+    // The styles are cached to avoid creating a new object on every render.
+    if (sharedStyles[checkedStyle]) {
+        return sharedStyles[checkedStyle];
+    }
+
+    let newStyles: Record<string, any> = {};
+
+    const disabledBlue = mix(Color.blue, Color.offBlack50);
+    const activeBlue = mix(Color.offBlack32, Color.blue);
+
+    if (checked) {
+        newStyles = {
+            switch: {
+                backgroundColor: disabled ? disabledBlue : Color.blue,
+                ":active": {
+                    backgroundColor: !disabled && clickable && activeBlue,
+                },
+                ":focus-within": {
+                    outline: `solid ${Spacing.xxxxSmall_2}px ${Color.blue}`,
+                    outlineOffset: 1,
+                },
+                ":hover": {
+                    outline: clickable
+                        ? `solid ${Spacing.xxxxSmall_2}px ${Color.blue}`
+                        : "none",
+                },
+            },
+            slider: {
+                transform: `translateX(${Spacing.medium_16}px)`,
+            },
+            icon: {
+                color: disabled ? disabledBlue : Color.blue,
+                transform: `translateX(${Spacing.medium_16}px)`,
+            },
+        };
+    } else {
+        newStyles = {
+            switch: {
+                backgroundColor: disabled ? Color.offBlack32 : Color.offBlack50,
+                ":active": {
+                    backgroundColor: !disabled && clickable && Color.offBlack64,
+                },
+                ":focus-within": {
+                    outline: `solid ${Spacing.xxxxSmall_2}px ${Color.blue}`,
+                    outlineOffset: 1,
+                },
+                ":hover": {
+                    outline: clickable
+                        ? `solid ${Spacing.xxxxSmall_2}px ${Color.blue}`
+                        : "none",
+                },
+            },
+            icon: {
+                color: disabled ? Color.offBlack32 : Color.offBlack50,
+            },
+        };
+    }
+
+    styles[checkedStyle] = StyleSheet.create(newStyles);
+    return styles[checkedStyle];
+};
+
+Switch.displayName = "Switch";
+
+export default Switch;

--- a/packages/wonder-blocks-switch/src/index.ts
+++ b/packages/wonder-blocks-switch/src/index.ts
@@ -1,2 +1,3 @@
-// Just a temporary export to include some code.
-export const NOTHING = "NOTHING";
+import Switch from "./components/switch";
+
+export default Switch;

--- a/packages/wonder-blocks-switch/tsconfig-build.json
+++ b/packages/wonder-blocks-switch/tsconfig-build.json
@@ -6,9 +6,9 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
         {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
-        {"path": "../wonder-blocks-typography/tsconfig-build.json"},
+        {"path": "../wonder-blocks-icon/tsconfig-build.json"},
+        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
     ]
 }


### PR DESCRIPTION
## Summary:
- Add 'switch' role to ClickableBehavior
- Create new Switch component
- Add unit tests for Switch
- Add stories for Switch
- Add ref forwarding test for Switch

<img width="81" alt="image" src="https://github.com/Khan/wonder-blocks/assets/77523470/3a427e14-5c82-41e6-a4ab-18e63ee0f3ee"> 
<img width="74" alt="image" src="https://github.com/Khan/wonder-blocks/assets/77523470/71fa3246-97d0-4ac7-8526-af9c322814af">

Issue: WB-1581

## Test plan:
- Write new unit tests and run `yarn test packages/wonder-blocks-switch`
- Create new stories for use cases