### PR TITLE
[propsfor] Add PropsFor type

### DIFF
--- a/.changeset/strange-suns-kick.md
+++ b/.changeset/strange-suns-kick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Add `PropsFor` type to simplify `JSX.LibraryManagedAttributes` usage

--- a/packages/wonder-blocks-clickable/src/util/get-clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/util/get-clickable-behavior.ts
@@ -11,6 +11,8 @@
 import * as React from "react";
 import {withRouter} from "react-router-dom";
 
+import {PropsFor} from "@khanacademy/wonder-blocks-core";
+
 import ClickableBehavior from "../components/clickable-behavior";
 import {isClientSideUrl} from "./is-client-side-url";
 
@@ -30,12 +32,7 @@ export default function getClickableBehavior(
      * router object added to the React context object by react-router-dom.
      */
     router?: any,
-): React.ComponentType<
-    JSX.LibraryManagedAttributes<
-        typeof ClickableBehavior,
-        React.ComponentProps<typeof ClickableBehavior>
-    >
-> {
+): React.ComponentType<PropsFor<typeof ClickableBehavior>> {
     if (router && skipClientNav !== true && href && isClientSideUrl(href)) {
         // We cast to `any` here since the type of ClickableBehaviorWithRouter
         // is slightly different from the return type of this function.

--- a/packages/wonder-blocks-core/src/index.ts
+++ b/packages/wonder-blocks-core/src/index.ts
@@ -1,4 +1,9 @@
-import type {AriaProps, IIdentifierFactory, StyleType} from "./util/types";
+import type {
+    AriaProps,
+    IIdentifierFactory,
+    StyleType,
+    PropsFor,
+} from "./util/types";
 
 export {default as Text} from "./components/text";
 export {default as View} from "./components/view";
@@ -20,4 +25,4 @@ export {useRenderState} from "./hooks/use-render-state";
 export {RenderStateRoot} from "./components/render-state-root";
 export {RenderState} from "./components/render-state-context";
 
-export type {AriaProps, IIdentifierFactory, StyleType};
+export type {AriaProps, IIdentifierFactory, StyleType, PropsFor};

--- a/packages/wonder-blocks-core/src/util/types.propsfor.js.flow
+++ b/packages/wonder-blocks-core/src/util/types.propsfor.js.flow
@@ -1,0 +1,9 @@
+import * as React from "react";
+/**
+ * Get the props for a component, accounting for default props.
+ *
+ * This is equivalent to `React.ElementConfig`.
+ */
+export type PropsFor<
+  T: React.AbstractComponent<any> | React.ComponentType<any>,
+> = React.ElementConfig<T>;

--- a/packages/wonder-blocks-core/src/util/types.propsfor.ts
+++ b/packages/wonder-blocks-core/src/util/types.propsfor.ts
@@ -1,0 +1,14 @@
+// Separate file to simplify the flow type override while we're still
+// exporting flow types.
+import * as React from "react";
+
+/**
+ * Get the props for a component, accounting for default props.
+ *
+ * This is equivalent to using `JSX.LibraryManagedAttributes`, but with a
+ * simpler type signature. For those familiar with Flow types, this is
+ * equivalent to `React.ElementConfig`.
+ */
+export type PropsFor<
+    T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>,
+> = JSX.LibraryManagedAttributes<T, React.ComponentProps<T>>;

--- a/packages/wonder-blocks-core/src/util/types.ts
+++ b/packages/wonder-blocks-core/src/util/types.ts
@@ -108,13 +108,4 @@ export interface IIdentifierFactory {
     get(id: string): string;
 }
 
-/**
- * Get the props for a component, accounting for default props.
- *
- * This is equivalent to using `JSX.LibraryManagedAttributes`, but with a
- * simpler type signature. For those familiar with Flow types, this is
- * equivalent to `React.ElementConfig`.
- */
-export type PropsFor<
-    T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>,
-> = JSX.LibraryManagedAttributes<T, React.ComponentProps<T>>;
+export * from "./types.propsfor";

--- a/packages/wonder-blocks-core/src/util/types.ts
+++ b/packages/wonder-blocks-core/src/util/types.ts
@@ -107,3 +107,14 @@ export type TextViewSharedProps = {
 export interface IIdentifierFactory {
     get(id: string): string;
 }
+
+/**
+ * Get the props for a component, accounting for default props.
+ *
+ * This is equivalent to using `JSX.LibraryManagedAttributes`, but with a
+ * simpler type signature. For those familiar with Flow types, this is
+ * equivalent to `React.ElementConfig`.
+ */
+export type PropsFor<
+    T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>,
+> = JSX.LibraryManagedAttributes<T, React.ComponentProps<T>>;

--- a/packages/wonder-blocks-typography/src/components/body-monospace.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-monospace.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const BodyMonospace = React.forwardRef(function BodyMonospace(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/body-serif-block.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-serif-block.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const BodySerifBlock = React.forwardRef(function BodySerifBlock(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/body-serif.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-serif.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const BodySerif = React.forwardRef(function BodySerif(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/body.tsx
+++ b/packages/wonder-blocks-typography/src/components/body.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const Body = React.forwardRef(function Body(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/caption.tsx
+++ b/packages/wonder-blocks-typography/src/components/caption.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const Caption = React.forwardRef(function Caption(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/footnote.tsx
+++ b/packages/wonder-blocks-typography/src/components/footnote.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const Footnote = React.forwardRef(function Footnote(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/heading-large.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-large.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const HeadingLarge = React.forwardRef(function HeadingLarge(
     {style, children, tag = "h2", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/heading-medium.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-medium.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const HeadingMedium = React.forwardRef(function HeadingMedium(
     {style, children, tag = "h3", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/heading-small.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-small.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const HeadingSmall = React.forwardRef(function HeadingSmall(
     {style, children, tag = "h4", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/heading-xsmall.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading-xsmall.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const HeadingXSmall = React.forwardRef(function HeadingXSmall(
     {style, children, tag = "h4", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/label-large.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-large.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const LabelLarge = React.forwardRef(function LabelLarge(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/label-medium.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-medium.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const LabelMedium = React.forwardRef(function LabelMedium(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/label-small.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-small.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const LabelSmall = React.forwardRef(function LabelSmall(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/label-xsmall.tsx
+++ b/packages/wonder-blocks-typography/src/components/label-xsmall.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const LabelXSmall = React.forwardRef(function LabelXSmall(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/tagline.tsx
+++ b/packages/wonder-blocks-typography/src/components/tagline.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const Tagline = React.forwardRef(function Tagline(
     {style, children, tag = "span", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/components/title.tsx
+++ b/packages/wonder-blocks-typography/src/components/title.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
 import styles from "../util/styles";
 
-import type {Props} from "../util/types";
+type Props = PropsFor<typeof Text>;
 
 const Title = React.forwardRef(function Title(
     {style, children, tag = "h1", ...otherProps}: Props,

--- a/packages/wonder-blocks-typography/src/util/types.ts
+++ b/packages/wonder-blocks-typography/src/util/types.ts
@@ -1,8 +1,0 @@
-import * as React from "react";
-
-import {Text} from "@khanacademy/wonder-blocks-core";
-
-export type Props = JSX.LibraryManagedAttributes<
-    typeof Text,
-    React.ComponentProps<typeof Text>
->;


### PR DESCRIPTION
## Summary:
This adds a new type, `PropsFor` that is like `React.ElementConfig` in flow, simplifying the interface of `JSX.LibraryManagedAttributes`.

Issue: XXX-XXXX

## Test plan:
I updated code that used `JSX.ManagedAttributes` to use `PropsFor` instead, so this change is dog-fooding the type.

I verified the flow equivalent that we output here:
https://flow.org/try/#1N4Igxg9gdgZglgcxALlAJwKYEMwBcD6aArlLnALYYrgA2WAzvXGCADQgYAeOBARgJ74AJhhhYiNXClzEM7DFCLl602QF92kEdQD0AKgAEAARg0IAdwN6dAHSgUADhDS4rBhgYBK2PAZhoIcgMbEEweEIBuOztcfgcMAwAFAId6AwBeA2AAHzsDd2QDRXJeDDRWO2y1aKhIKHpXAFl+AGFApygFV0yACgcU+kLkiFSASgyAPmCQAAkAUQAZBYB5AEJImtj4pIGAMWcAHgAVQu8eADoAQV4GtB428g6ug6wofinsrx9cc4en0iOcQwLzeEymmTOeHOcxoGEopDasEQxwmUSgMSBOxG9F2AXIw1S+zQGSxhMOWwwEBgBmaf2gXVRNTqDQMnCGezxBJxzhJwDyBQMAGYKlA1Gi7MzXPx2djcYEuUTefysIUQoKQiKxWwQAA3MpMaDUHUABnOACYAIwAFnOxpAaiAA

Also, ran `yarn build:types && yarn build:flowtypes` to verify the output.