### PR TITLE
Fix destructured props in Choice Internal

### DIFF
--- a/.changeset/khaki-pianos-brush.md
+++ b/.changeset/khaki-pianos-brush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Fix props so `variants` doesn't show up in underlying input attributes

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -66,13 +66,11 @@ type Props = AriaProps & {
         error = false,
         id,
         label,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         onChange,
         style,
         className,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         variant,
-        // ...coreProps
+        ...coreProps
     } = props;
 
     const handleClick: () => void = () => {
@@ -140,8 +138,9 @@ type Props = AriaProps & {
                             tabIndex={-1}
                         >
                             <ChoiceCore
-                                {...props}
+                                {...coreProps}
                                 id={uniqueId}
+                                checked={checked}
                                 aria-describedby={descriptionId}
                                 onClick={handleClick}
                                 disabled={disabled}


### PR DESCRIPTION
After forwarding refs, the snapshots showed that the checkbox and
radio `input` elements had a random `variant` attribute that isn't
supposed to be there. This was an oversight on my part when I updated
these to be functional components and shifted around their props in #1956.

I'm fixing that here by making sure I don't pass in all the props when it should
just be a subset.

Issue: none

Test plan:
- Go to the Checkbox and Radio (Internal) stories in storybook.
- Use the dev tools to confirm that they don't have `variant` in their attributes.

### Before

<img width="496" alt="image" src="https://github.com/Khan/wonder-blocks/assets/13231763/9a0938ac-95c1-42c4-a903-0b22c3674433">

### After

<img width="435" alt="image" src="https://github.com/Khan/wonder-blocks/assets/13231763/a5081d1f-603e-49d9-ae7f-b52085c0dd06">
