### PR TITLE
[fei5242.2.wbsettings] Move build settings package to Khan namespace

### DIFF
--- a/.changeset/early-squids-retire.md
+++ b/.changeset/early-squids-retire.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wb-dev-build-settings": major
+---
+
+Move build settings to Khan Academy namespace

--- a/build-settings/package.json
+++ b/build-settings/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wb-dev-build-settings",
+  "name": "@khanacademy/wb-dev-build-settings",
   "version": "0.9.7",
   "main": "index.js",
   "license": "MIT",

--- a/packages/wonder-blocks-banner/package.json
+++ b/packages/wonder-blocks-banner/package.json
@@ -30,6 +30,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-birthday-picker/package.json
+++ b/packages/wonder-blocks-birthday-picker/package.json
@@ -28,7 +28,7 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-breadcrumbs/package.json
+++ b/packages/wonder-blocks-breadcrumbs/package.json
@@ -24,6 +24,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -31,6 +31,6 @@
     "react-router-dom": "5.3.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-cell/package.json
+++ b/packages/wonder-blocks-cell/package.json
@@ -26,7 +26,7 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -27,6 +27,6 @@
     "react-router-dom": "5.3.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-color/package.json
+++ b/packages/wonder-blocks-color/package.json
@@ -13,7 +13,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -23,7 +23,7 @@
     "react-router-dom": "5.3.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-data/package.json
+++ b/packages/wonder-blocks-data/package.json
@@ -21,7 +21,7 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -39,6 +39,6 @@
   },
   "devDependencies": {
     "@khanacademy/wonder-blocks-button": "^4.1.2",
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -29,6 +29,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-grid/package.json
+++ b/packages/wonder-blocks-grid/package.json
@@ -26,6 +26,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-i18n/package.json
+++ b/packages/wonder-blocks-i18n/package.json
@@ -21,6 +21,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -28,6 +28,6 @@
     "react-router-dom": "5.3.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-icon/package.json
+++ b/packages/wonder-blocks-icon/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@khanacademy/wonder-stuff-core": "^1.4.2",
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-layout/package.json
+++ b/packages/wonder-blocks-layout/package.json
@@ -18,7 +18,7 @@
     "@khanacademy/wonder-blocks-spacing": "^4.0.1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -29,6 +29,6 @@
     "react-router-dom": "5.3.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -33,6 +33,6 @@
   },
   "devDependencies": {
     "@khanacademy/wonder-blocks-breadcrumbs": "^2.1.2",
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -33,6 +33,6 @@
     "react-popper": "^2.0.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-progress-spinner/package.json
+++ b/packages/wonder-blocks-progress-spinner/package.json
@@ -24,6 +24,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-search-field/package.json
+++ b/packages/wonder-blocks-search-field/package.json
@@ -29,6 +29,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-spacing/package.json
+++ b/packages/wonder-blocks-spacing/package.json
@@ -13,7 +13,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-switch/package.json
+++ b/packages/wonder-blocks-switch/package.json
@@ -26,6 +26,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-testing/package.json
+++ b/packages/wonder-blocks-testing/package.json
@@ -26,7 +26,7 @@
         "react-router-dom": "5.3.0"
     },
     "devDependencies": {
-        "wb-dev-build-settings": "^0.9.7"
+        "@khanacademy/wb-dev-build-settings": "^0.9.7"
     },
     "author": "",
     "license": "MIT"

--- a/packages/wonder-blocks-theming/package.json
+++ b/packages/wonder-blocks-theming/package.json
@@ -22,7 +22,7 @@
         "react-dom": "16.14.0"
     },
     "devDependencies": {
-        "wb-dev-build-settings": "^0.9.7"
+        "@khanacademy/wb-dev-build-settings": "^0.9.7"
     },
     "author": "",
     "license": "MIT"

--- a/packages/wonder-blocks-timing/package.json
+++ b/packages/wonder-blocks-timing/package.json
@@ -17,7 +17,7 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-toolbar/package.json
+++ b/packages/wonder-blocks-toolbar/package.json
@@ -26,6 +26,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -31,6 +31,6 @@
     "react-popper": "^2.0.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }

--- a/packages/wonder-blocks-typography/package.json
+++ b/packages/wonder-blocks-typography/package.json
@@ -23,6 +23,6 @@
     "react": "16.14.0"
   },
   "devDependencies": {
-    "wb-dev-build-settings": "^0.9.7"
+    "@khanacademy/wb-dev-build-settings": "^0.9.7"
   }
 }


### PR DESCRIPTION
## Summary:
This renames the build settings package so that it sits in the Khan Academy namespace. This should prevent folks squatting the package on NPM, since it would require being able to publish to the Khan Academy NPM org.

Issue: FEI-5242

## Test plan:
Not much to test here but I did run `yarn build` to make sure it still works.