### PR TITLE
[fei5147.1.nodata] Add no-data state to useCachedEffect

### DIFF
--- a/.changeset/chilly-steaks-brake.md
+++ b/.changeset/chilly-steaks-brake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": major
+---
+
+Return new no-data state from useCachedEffect when it is not loading and there is no data to return

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-is-mounted.test.ts
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-is-mounted.test.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-unassigned-import
+import "jest-extended";
 import {renderHook} from "@testing-library/react-hooks";
 
 import {useIsMounted} from "../use-is-mounted";
@@ -10,7 +12,6 @@ describe("useIsMounted", () => {
         const {result} = renderHook(useIsMounted);
 
         // Assert
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'toBeTrue' does not exist on type 'JestMatchers<boolean>'.
         expect(result.current()).toBeTrue();
     });
 
@@ -22,7 +23,6 @@ describe("useIsMounted", () => {
         rerender();
 
         // assert
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'toBeTrue' does not exist on type 'JestMatchers<boolean>'.
         expect(result.current()).toBeTrue();
     });
 
@@ -34,7 +34,6 @@ describe("useIsMounted", () => {
         unmount();
 
         // Assert
-        // @ts-expect-error [FEI-5019] - TS2551 - Property 'toBeFalse' does not exist on type 'JestMatchers<boolean>'. Did you mean 'toBeFalsy'?
         expect(result.current()).toBeFalse();
     });
 });

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-online.test.tsx
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-online.test.tsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-unassigned-import
+import "jest-extended";
 import * as React from "react";
 import {render, act as reactAct} from "@testing-library/react";
 import {renderHook} from "@testing-library/react-hooks";
@@ -13,7 +15,6 @@ describe("useOnline", () => {
         const {result} = renderHook(useOnline);
 
         // Assert
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'toBeTrue' does not exist on type 'JestMatchers<boolean>'.
         expect(result.current).toBeTrue();
     });
 
@@ -25,7 +26,6 @@ describe("useOnline", () => {
         const {result} = renderHook(useOnline);
 
         // Assert
-        // @ts-expect-error [FEI-5019] - TS2551 - Property 'toBeFalse' does not exist on type 'JestMatchers<boolean>'. Did you mean 'toBeFalsy'?
         expect(result.current).toBeFalse();
     });
 

--- a/packages/wonder-blocks-data/src/components/__tests__/data.test.tsx
+++ b/packages/wonder-blocks-data/src/components/__tests__/data.test.tsx
@@ -47,7 +47,7 @@ describe("Data", () => {
 
             it("should make request for data on construction", async () => {
                 // Arrange
-                const response = Promise.resolve("data");
+                const response: any = Promise.resolve("data");
                 const fakeHandler = jest.fn().mockReturnValue(response);
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -57,7 +57,6 @@ describe("Data", () => {
                         {fakeChildrenFn}
                     </Data>,
                 );
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                 await act(() => response);
 
                 // Assert
@@ -66,7 +65,7 @@ describe("Data", () => {
 
             it("should initially render children with loading", async () => {
                 // Arrange
-                const response = Promise.resolve("data");
+                const response: any = Promise.resolve("data");
                 const fakeHandler = jest.fn().mockReturnValue(response);
                 const fakeChildrenFn = jest.fn(() => null);
 
@@ -76,7 +75,6 @@ describe("Data", () => {
                         {fakeChildrenFn}
                     </Data>,
                 );
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                 await act(() => response);
 
                 // Assert
@@ -272,7 +270,7 @@ describe("Data", () => {
 
             it("should ignore resolution of pending handler fulfillment when id changes", async () => {
                 // Arrange
-                const oldRequest = Promise.resolve("OLD DATA");
+                const oldRequest: any = Promise.resolve("OLD DATA");
                 const oldHandler = jest
                     .fn()
                     .mockReturnValueOnce(oldRequest)
@@ -294,7 +292,6 @@ describe("Data", () => {
                         {fakeChildrenFn}
                     </Data>,
                 );
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                 await act(() => oldRequest);
 
                 // Assert
@@ -343,14 +340,13 @@ describe("Data", () => {
 
             it("should ignore catastrophic request fulfillment when id changes", async () => {
                 // Arrange
-                const catastrophe = Promise.resolve({
+                const catastrophe: any = Promise.resolve({
                     status: "error",
                     error: new Error("CATASTROPHE!"),
                 });
                 jest.spyOn(
                     RequestFulfillment.Default,
                     "fulfill",
-                    // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'Promise<{ status: string; error: Error; }>' is not assignable to parameter of type 'Promise<Result<ValidCacheData>>'.
                 ).mockReturnValueOnce(catastrophe);
                 const oldHandler = jest.fn().mockResolvedValue("OLD DATA");
 
@@ -367,7 +363,6 @@ describe("Data", () => {
                     </Data>,
                 );
                 await act(() =>
-                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                     catastrophe.catch(() => {
                         /* ignore */
                     }),
@@ -428,8 +423,8 @@ describe("Data", () => {
 
             it("should retain old data while reloading if retainResultOnChange is true", async () => {
                 // Arrange
-                const response1 = Promise.resolve("data1");
-                const response2 = Promise.resolve("data2");
+                const response1: any = Promise.resolve("data1");
+                const response2: any = Promise.resolve("data2");
                 const fakeHandler1 = () => response1;
                 const fakeHandler2 = () => response2;
                 const fakeChildrenFn = jest.fn(() => null);
@@ -445,7 +440,6 @@ describe("Data", () => {
                     </Data>,
                 );
                 fakeChildrenFn.mockClear();
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                 await act(() => response1);
                 wrapper.rerender(
                     <Data
@@ -456,7 +450,6 @@ describe("Data", () => {
                         {fakeChildrenFn}
                     </Data>,
                 );
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
                 await act(() => response2);
 
                 // Assert

--- a/packages/wonder-blocks-data/src/components/data.ts
+++ b/packages/wonder-blocks-data/src/components/data.ts
@@ -48,7 +48,7 @@ type Props<
      * loading state and data or error that gets retrieved from cache or loaded
      * via the request if no cached value is available.
      */
-    children: (result: Result<TData>) => React.ReactNode;
+    children: (result: Result<TData>) => React.ReactElement | null;
 };
 
 /**
@@ -62,13 +62,11 @@ const Data = <TData extends ValidCacheData>({
     children,
     retainResultOnChange = false,
     clientBehavior = WhenClientSide.ExecuteWhenNoSuccessResult,
-}: Props<TData>): React.ReactElement => {
+}: Props<TData>): React.ReactElement | null => {
     const result = useHydratableEffect(requestId, handler, {
         retainResultOnChange,
         clientBehavior,
     });
-    // @ts-expect-error: React TS types don't allow functional components to return
-    // ReactNodes even though React itself does.
     return children(result);
 };
 

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-gql-router-context.test.tsx
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-gql-router-context.test.tsx
@@ -123,8 +123,7 @@ describe("#useGqlRouterContext", () => {
             },
         );
         const result1 = wrapper.result.current;
-        // @ts-expect-error [FEI-5019] - TS2741 - Property 'fiz' is missing in type '{}' but required in type '{ fiz: string; }'.
-        wrapper.rerender({overrides: {}});
+        wrapper.rerender({overrides: {} as any});
         const result2 = wrapper.result.current;
 
         // Assert

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.ts
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-hydratable-effect.test.ts
@@ -562,10 +562,9 @@ describe("#useHydratableEffect", () => {
                 },
             );
             rerender({
-                // @ts-expect-error [FEI-5019] - TS2322 - Type '{ scope: string; }' is not assignable to type 'undefined'.
                 options: {
                     scope: "BLAH!",
-                },
+                } as any,
             });
 
             await act((): Promise<any> => response1);

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-request-interception.test.tsx
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-request-interception.test.tsx
@@ -68,7 +68,7 @@ describe("#useRequestInterception", () => {
         const handler = jest.fn();
         const interceptor1 = jest.fn();
         const interceptor2 = jest.fn();
-        const Wrapper = ({children, interceptor}: any) => (
+        const Wrapper = ({children, interceptor}: any): React.ReactElement => (
             <InterceptRequests interceptor={interceptor}>
                 {children}
             </InterceptRequests>
@@ -80,8 +80,7 @@ describe("#useRequestInterception", () => {
             {wrapper: Wrapper, initialProps: {interceptor: interceptor1}},
         );
         const result1 = wrapper.result.current;
-        // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '{ wrapper: ({ children, interceptor, }: any) => JSX.Element; interceptor: jest.Mock<any, any, any>; }' is not assignable to parameter of type '{ interceptor: jest.Mock<any, any, any>; }'.
-        wrapper.rerender({wrapper: Wrapper, interceptor: interceptor2});
+        wrapper.rerender({interceptor: interceptor2});
         const result2 = wrapper.result.current;
 
         // Assert
@@ -126,7 +125,6 @@ describe("#useRequestInterception", () => {
             interceptedHandler();
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'toHaveBeenCalledBefore' does not exist on type 'JestMatchers<Mock<null, [], any>>'.
             expect(interceptorNearest).toHaveBeenCalledBefore(
                 interceptorFurthest,
             );
@@ -154,7 +152,6 @@ describe("#useRequestInterception", () => {
             interceptedHandler();
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'toHaveBeenCalledBefore' does not exist on type 'JestMatchers<Mock<null, [], any>>'.
             expect(interceptorFurthest).toHaveBeenCalledBefore(handler);
         });
 

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.ts
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-server-effect.test.ts
@@ -139,8 +139,7 @@ describe("#useServerEffect", () => {
             const interceptedHandler = jest.fn();
             jest.spyOn(SsrCache.Default, "getEntry").mockReturnValueOnce({
                 data: "DATA",
-                // @ts-expect-error [FEI-5019] - TS2322 - Type 'null' is not assignable to type 'undefined'.
-                error: null,
+                error: undefined,
             });
             jest.spyOn(
                 UseRequestInterception,
@@ -165,8 +164,7 @@ describe("#useServerEffect", () => {
             const fakeHandler = jest.fn();
             jest.spyOn(SsrCache.Default, "getEntry").mockReturnValueOnce({
                 data: "DATA",
-                // @ts-expect-error [FEI-5019] - TS2322 - Type 'null' is not assignable to type 'undefined'.
-                error: null,
+                error: undefined,
             });
 
             // Act
@@ -221,8 +219,7 @@ describe("#useServerEffect", () => {
             const fakeHandler = jest.fn();
             jest.spyOn(SsrCache.Default, "getEntry").mockReturnValueOnce({
                 data: "DATA",
-                // @ts-expect-error [FEI-5019] - TS2322 - Type 'null' is not assignable to type 'undefined'.
-                error: null,
+                error: undefined,
             });
 
             // Act

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-shared-cache.test.ts
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-shared-cache.test.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-unassigned-import
+import "jest-extended";
 import {renderHook as clientRenderHook} from "@testing-library/react-hooks";
 
 import {useSharedCache, SharedCache} from "../use-shared-cache";
@@ -48,7 +50,6 @@ describe("#useSharedCache", () => {
         } = clientRenderHook(() => useSharedCache("id", "scope"));
 
         // Assert
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'toBeArrayOfSize' does not exist on type 'JestMatchers<[ValidCacheData | null | undefined, CacheValueFn<ValidCacheData>]>'.
         expect(result).toBeArrayOfSize(2);
     });
 
@@ -119,12 +120,13 @@ describe("#useSharedCache", () => {
                 id: "id",
                 scope: "scope",
             });
-            const result1 = wrapper.result.all[wrapper.result.all.length - 2];
-            const result2 = wrapper.result.current;
+            const value1 = wrapper.result.all[wrapper.result.all.length - 2];
+            const value2 = wrapper.result.current;
+            const result1 = Array.isArray(value1) ? value1[1] : "BAD1";
+            const result2 = Array.isArray(value2) ? value2[1] : "BAD2";
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS7053 - Element implicitly has an 'any' type because expression of type '1' can't be used to index type 'Error | [ValidCacheData | null | undefined, CacheValueFn<ValidCacheData>]'.
-            expect(result1[1]).toBe(result2[1]);
+            expect(result1).toBe(result2);
         });
 
         it("should be a new function if the id changes", () => {
@@ -138,12 +140,13 @@ describe("#useSharedCache", () => {
 
             // Act
             wrapper.rerender({id: "new-id"});
-            const result1 = wrapper.result.all[wrapper.result.all.length - 2];
-            const result2 = wrapper.result.current;
+            const value1 = wrapper.result.all[wrapper.result.all.length - 2];
+            const value2 = wrapper.result.current;
+            const result1 = Array.isArray(value1) ? value1[1] : "BAD1";
+            const result2 = Array.isArray(value2) ? value2[1] : "BAD2";
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS7053 - Element implicitly has an 'any' type because expression of type '1' can't be used to index type 'Error | [ValidCacheData | null | undefined, CacheValueFn<ValidCacheData>]'.
-            expect(result1[1]).not.toBe(result2[1]);
+            expect(result1).not.toBe(result2);
         });
 
         it("should be a new function if the scope changes", () => {
@@ -157,12 +160,13 @@ describe("#useSharedCache", () => {
 
             // Act
             wrapper.rerender({scope: "new-scope"});
-            const result1 = wrapper.result.all[wrapper.result.all.length - 2];
-            const result2 = wrapper.result.current;
+            const value1 = wrapper.result.all[wrapper.result.all.length - 2];
+            const value2 = wrapper.result.current;
+            const result1 = Array.isArray(value1) ? value1[1] : "BAD1";
+            const result2 = Array.isArray(value2) ? value2[1] : "BAD2";
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS7053 - Element implicitly has an 'any' type because expression of type '1' can't be used to index type 'Error | [ValidCacheData | null | undefined, CacheValueFn<ValidCacheData>]'.
-            expect(result1[1]).not.toBe(result2[1]);
+            expect(result1).not.toBe(result2);
         });
 
         it("should set the value in the cache", () => {

--- a/packages/wonder-blocks-data/src/hooks/use-request-interception.ts
+++ b/packages/wonder-blocks-data/src/hooks/use-request-interception.ts
@@ -31,8 +31,13 @@ export const useRequestInterception = <TData extends ValidCacheData>(
         // Call the interceptors from closest to furthest.
         // If one returns a non-null result, then we keep that.
         const interceptResponse = interceptors.reduceRight(
-            // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
-            (prev, interceptor) => {
+            (
+                prev:
+                    | Promise<ValidCacheData | null | undefined>
+                    | null
+                    | undefined,
+                interceptor,
+            ) => {
                 if (prev != null) {
                     return prev;
                 }

--- a/packages/wonder-blocks-data/src/hooks/use-request-interception.ts
+++ b/packages/wonder-blocks-data/src/hooks/use-request-interception.ts
@@ -30,25 +30,22 @@ export const useRequestInterception = <TData extends ValidCacheData>(
     const interceptedHandler = React.useCallback((): Promise<TData> => {
         // Call the interceptors from closest to furthest.
         // If one returns a non-null result, then we keep that.
-        const interceptResponse = interceptors.reduceRight(
-            (
-                prev:
-                    | Promise<ValidCacheData | null | undefined>
-                    | null
-                    | undefined,
-                interceptor,
-            ) => {
-                if (prev != null) {
-                    return prev;
-                }
-                return interceptor(requestId);
-            },
-            null,
-        );
+        const interceptResponse: Promise<TData> | null | undefined =
+            interceptors.reduceRight(
+                (prev: Promise<TData> | null | undefined, interceptor) => {
+                    if (prev != null) {
+                        return prev;
+                    }
+                    return interceptor(requestId) as
+                        | Promise<TData>
+                        | null
+                        | undefined;
+                },
+                null,
+            );
         // If nothing intercepted this request, invoke the original handler.
         // NOTE: We can't guarantee all interceptors return the same type
         // as our handler, so how can TypeScript know? Let's just suppress that.
-        // @ts-expect-error [FEI-5019] - TS2739 - Type '(requestId: string) => Promise<ValidCacheData | null | undefined> | null | undefined' is missing the following properties from type 'Promise<TData>': then, catch, finally, [Symbol.toStringTag]
         return interceptResponse ?? handler();
     }, [handler, interceptors, requestId]);
 

--- a/packages/wonder-blocks-data/src/hooks/use-shared-cache.ts
+++ b/packages/wonder-blocks-data/src/hooks/use-shared-cache.ts
@@ -81,8 +81,10 @@ export const useSharedCache = <TValue extends ValidCacheData>(
     // since our last run through. Also, our cache does not know what type it
     // stores, so we have to cast it to the type we're exporting. This is a
     // dev time courtesy, rather than a runtime thing.
-    // @ts-expect-error [FEI-5019] - TS2322 - Type 'ValidCacheData | null | undefined' is not assignable to type 'TValue | null | undefined'.
-    let currentValue: TValue | null | undefined = cache.get(scope, id);
+    let currentValue: TValue | null | undefined = cache.get(scope, id) as
+        | TValue
+        | null
+        | undefined;
 
     // If we have an initial value, we need to add it to the cache
     // and use it as our current value.

--- a/packages/wonder-blocks-data/src/util/__tests__/request-api.test.ts
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-api.test.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-unassigned-import
+import "jest-extended";
 import {Server} from "@khanacademy/wonder-blocks-core";
 import {RequestFulfillment} from "../request-fulfillment";
 import {RequestTracker} from "../request-tracking";
@@ -123,7 +125,6 @@ describe("#hasTrackedRequestsToBeFetched", () => {
             const result = hasTrackedRequestsToBeFetched();
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'toBeTrue' does not exist on type 'JestMatchers<boolean>'.
             expect(result).toBeTrue();
         });
     });

--- a/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.tsx
+++ b/packages/wonder-blocks-data/src/util/__tests__/request-tracking.test.tsx
@@ -162,13 +162,12 @@ describe("../request-tracking.js", () => {
             it("should cache errors occurring in promises", async () => {
                 // Arrange
                 const requestTracker = createRequestTracker();
-                const fakeBadRequestHandler = () =>
+                const fakeBadRequestHandler = (): Promise<any> =>
                     new Promise((resolve: any, reject: any) =>
                         reject("OH NO!"),
                     );
                 requestTracker.trackDataRequest(
                     "ID",
-                    // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '() => Promise<unknown>' is not assignable to parameter of type '() => Promise<ValidCacheData>'.
                     fakeBadRequestHandler,
                     true,
                 );
@@ -192,23 +191,22 @@ describe("../request-tracking.js", () => {
                  * - Handlers that reject the promise
                  * - Handlers that resolve
                  */
-                const fakeBadRequestHandler = () =>
+                const fakeBadRequestHandler = (): Promise<any> =>
                     new Promise((resolve: any, reject: any) =>
                         reject("OH NO!"),
                     );
-                const fakeBadHandler = () => {
+                const fakeBadHandler = (): Promise<any> => {
                     throw new Error("OH NO!");
                 };
-                const fakeValidHandler = (() => {
+                const fakeValidHandler = ((): (() => Promise<any>) => {
                     let counter = 0;
-                    return (o: any) => {
+                    return () => {
                         counter++;
                         return Promise.resolve(`DATA:${counter}`);
                     };
                 })();
                 requestTracker.trackDataRequest(
                     "BAD_REQUEST",
-                    // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '() => Promise<unknown>' is not assignable to parameter of type '() => Promise<ValidCacheData>'.
                     fakeBadRequestHandler,
                     true,
                 );
@@ -219,13 +217,11 @@ describe("../request-tracking.js", () => {
                 );
                 requestTracker.trackDataRequest(
                     "VALID_HANDLER1",
-                    // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '(o: any) => Promise<string>' is not assignable to parameter of type '() => Promise<string>'.
                     fakeValidHandler,
                     true,
                 );
                 requestTracker.trackDataRequest(
                     "VALID_HANDLER2",
-                    // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '(o: any) => Promise<string>' is not assignable to parameter of type '() => Promise<string>'.
                     fakeValidHandler,
                     true,
                 );

--- a/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.ts
+++ b/packages/wonder-blocks-data/src/util/__tests__/result-from-cache-response.test.ts
@@ -70,8 +70,8 @@ describe("#resultFromCachedResponse", () => {
         };
 
         // Act
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'error' does not exist on type 'Result<ValidCacheData> | null | undefined'.
-        const {error} = resultFromCachedResponse(cacheEntry);
+        const cacheResult = resultFromCachedResponse(cacheEntry);
+        const error = cacheResult?.status === "error" && cacheResult.error;
 
         // Assert
         expect(error).toMatchInlineSnapshot(`[HydratedDataError: ERROR]`);

--- a/packages/wonder-blocks-data/src/util/__tests__/serializable-in-memory-cache.test.ts
+++ b/packages/wonder-blocks-data/src/util/__tests__/serializable-in-memory-cache.test.ts
@@ -9,12 +9,11 @@ describe("SerializableInMemoryCache", () => {
                 scope: {
                     key: "value",
                 },
-            } as const;
+            };
 
             // Act
             const cache = new SerializableInMemoryCache(sourceData);
             // Try to mutate the cache.
-            // @ts-expect-error [FEI-5019] - TS2540 - Cannot assign to 'scope' because it is a read-only property.
             sourceData["scope"] = {key: "SOME_NEW_DATA"};
             const result = cache.get("scope", "key");
 

--- a/packages/wonder-blocks-data/src/util/__tests__/ssr-cache.test.ts
+++ b/packages/wonder-blocks-data/src/util/__tests__/ssr-cache.test.ts
@@ -125,12 +125,11 @@ describe("../ssr-cache.js", () => {
             const cache = new SsrCache();
             const sourceData = {
                 MY_KEY: {data: "THE_DATA"},
-            } as const;
+            };
 
             // Act
             cache.initialize(sourceData);
             // Try to mutate the cache.
-            // @ts-expect-error [FEI-5019] - TS2540 - Cannot assign to 'MY_KEY' because it is a read-only property.
             sourceData["MY_KEY"] = {data: "SOME_NEW_DATA"};
             const result = cache.getEntry("MY_KEY");
 
@@ -448,8 +447,7 @@ describe("../ssr-cache.js", () => {
             const cloneSpy = jest
                 .spyOn(hydrationCache, "clone")
                 .mockReturnValue({
-                    // @ts-expect-error [FEI-5019] - TS2322 - Type 'string' is not assignable to type '{ [id: string]: ValidCacheData; }'.
-                    default: "CLONE!",
+                    default: "CLONE!" as any,
                 });
             const cache = new SsrCache(hydrationCache);
             // Let's add to the initialized state to check that everything

--- a/packages/wonder-blocks-data/src/util/__tests__/to-gql-operation.test.ts
+++ b/packages/wonder-blocks-data/src/util/__tests__/to-gql-operation.test.ts
@@ -9,11 +9,10 @@ describe("#toGqlOperation", () => {
         const documentNode: any = {};
         const parserSpy = jest
             .spyOn(GDNP, "graphQLDocumentNodeParser")
-            // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '{ name: string; type: string; }' is not assignable to parameter of type 'IDocumentDefinition'.
             .mockReturnValue({
                 name: "operationName",
                 type: "query",
-            });
+            } as any);
 
         // Act
         toGqlOperation(documentNode);
@@ -25,11 +24,10 @@ describe("#toGqlOperation", () => {
     it("should return the Wonder Blocks Data representation of the given document node", () => {
         // Arrange
         const documentNode: any = {};
-        // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '{ name: string; type: string; }' is not assignable to parameter of type 'IDocumentDefinition'.
         jest.spyOn(GDNP, "graphQLDocumentNodeParser").mockReturnValue({
             name: "operationName",
             type: "mutation",
-        });
+        } as any);
 
         // Act
         const result = toGqlOperation(documentNode);

--- a/packages/wonder-blocks-data/src/util/graphql-document-node-parser.ts
+++ b/packages/wonder-blocks-data/src/util/graphql-document-node-parser.ts
@@ -59,20 +59,20 @@ export function graphQLDocumentNodeParser(
 
     const queries = document.definitions.filter(
         (x: DefinitionNode) =>
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'operation' does not exist on type 'DefinitionNode'.
-            x.kind === "OperationDefinition" && x.operation === "query",
+            x.kind === "OperationDefinition" &&
+            (x as OperationDefinitionNode).operation === "query",
     );
 
     const mutations = document.definitions.filter(
         (x: DefinitionNode) =>
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'operation' does not exist on type 'DefinitionNode'.
-            x.kind === "OperationDefinition" && x.operation === "mutation",
+            x.kind === "OperationDefinition" &&
+            (x as OperationDefinitionNode).operation === "mutation",
     );
 
     const subscriptions = document.definitions.filter(
         (x: DefinitionNode) =>
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'operation' does not exist on type 'DefinitionNode'.
-            x.kind === "OperationDefinition" && x.operation === "subscription",
+            x.kind === "OperationDefinition" &&
+            (x as OperationDefinitionNode).operation === "subscription",
     );
 
     if (fragments.length && !queries.length && !mutations.length) {

--- a/packages/wonder-blocks-data/src/util/merge-gql-context.ts
+++ b/packages/wonder-blocks-data/src/util/merge-gql-context.ts
@@ -23,7 +23,8 @@ export const mergeGqlContext = <TContext extends GqlContext>(
                     delete acc[key];
                 } else {
                     // Otherwise, we set it.
-                    // @ts-expect-error [FEI-5019] - TS2536 - Type 'string' cannot be used to index type 'TContext'.
+                    // @ts-expect-error TypeScript doesn't seem to see that
+                    // TContext can have string keys.
                     acc[key] = overrides[key];
                 }
             }

--- a/packages/wonder-blocks-data/src/util/request-tracking.ts
+++ b/packages/wonder-blocks-data/src/util/request-tracking.ts
@@ -53,8 +53,7 @@ export class RequestTracker {
     _responseCache: SsrCache;
     _requestFulfillment: RequestFulfillment;
 
-    // @ts-expect-error [FEI-5019] - TS2322 - Type 'undefined' is not assignable to type 'SsrCache | null'.
-    constructor(responseCache: SsrCache | null = undefined) {
+    constructor(responseCache?: SsrCache | null) {
         this._responseCache = responseCache || SsrCache.Default;
         this._requestFulfillment = new RequestFulfillment();
     }
@@ -156,6 +155,11 @@ export class RequestTracker {
                                 }
 
                                 // For status === "loading":
+                                // Could never get here unless we wrote
+                                // the code wrong. Rather than bloat
+                                // code with useless error, just ignore.
+
+                                // For status === "no-data":
                                 // Could never get here unless we wrote
                                 // the code wrong. Rather than bloat
                                 // code with useless error, just ignore.

--- a/packages/wonder-blocks-data/src/util/ssr-cache.ts
+++ b/packages/wonder-blocks-data/src/util/ssr-cache.ts
@@ -124,7 +124,7 @@ export class SsrCache {
             : null;
 
         // Now we defer to the SSR value, and fallback to the hydration cache.
-        const internalEntry =
+        const internalEntry: ValidCacheData | null | undefined =
             ssrEntry ?? this._hydrationCache.get(DefaultScope, id);
 
         // If we are not server-side and we hydrated something, let's clear
@@ -140,8 +140,10 @@ export class SsrCache {
         }
         // Getting the typing right between the in-memory cache and this
         // is hard. Just telling TypeScript it's OK.
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'string | number | boolean | Record<any, any> | null | undefined' is not assignable to type 'Readonly<CachedResponse<TData>> | null | undefined'.
-        return internalEntry;
+        return internalEntry as
+            | Readonly<CachedResponse<TData>>
+            | null
+            | undefined;
     };
 
     /**
@@ -161,9 +163,11 @@ export class SsrCache {
         const realPredicate = predicate
             ? // We know what we're putting into the cache so let's assume it
               // conforms.
-              // @ts-expect-error [FEI-5019] - TS7006 - Parameter 'cachedEntry' implicitly has an 'any' type.
-              (_: string, key: string, cachedEntry) =>
-                  predicate(key, cachedEntry)
+              (_: string, key: string, cachedEntry: ValidCacheData) =>
+                  predicate(
+                      key,
+                      cachedEntry as Readonly<CachedResponse<ValidCacheData>>,
+                  )
             : undefined;
 
         // Apply the predicate to what we have in our caches.
@@ -184,7 +188,6 @@ export class SsrCache {
         // to an empty object.
         // We only need the default scope out of our scoped in-memory cache.
         // We know that it conforms to our expectations.
-        // @ts-expect-error [FEI-5019] - TS2322 - Type '{ [id: string]: ValidCacheData; }' is not assignable to type 'ResponseCache'.
-        return cache[DefaultScope] ?? {};
+        return (cache[DefaultScope] as ResponseCache) ?? {};
     };
 }

--- a/packages/wonder-blocks-data/src/util/status.ts
+++ b/packages/wonder-blocks-data/src/util/status.ts
@@ -4,6 +4,10 @@ const loadingStatus = Object.freeze({
     status: "loading",
 });
 
+const noDataStatus = Object.freeze({
+    status: "no-data",
+});
+
 const abortedStatus = Object.freeze({
     status: "aborted",
 });
@@ -14,6 +18,8 @@ const abortedStatus = Object.freeze({
 export const Status = Object.freeze({
     loading: <TData extends ValidCacheData = ValidCacheData>(): Result<TData> =>
         loadingStatus,
+    noData: <TData extends ValidCacheData = ValidCacheData>(): Result<TData> =>
+        noDataStatus,
     aborted: <TData extends ValidCacheData = ValidCacheData>(): Result<TData> =>
         abortedStatus,
     success: <TData extends ValidCacheData>(data: TData): Result<TData> => ({

--- a/packages/wonder-blocks-data/src/util/types.ts
+++ b/packages/wonder-blocks-data/src/util/types.ts
@@ -49,6 +49,9 @@ export type Result<TData extends ValidCacheData> =
           status: "loading";
       }
     | {
+          status: "no-data";
+      }
+    | {
           status: "success";
           data: TData;
       }


### PR DESCRIPTION
## Summary:
This introduces a new status to the `Result<TData>` type; `no-data`. This new result is returned when the effect is not waiting on a pending fetch, and there is no data in the cache.

I also addressed the suppressed ts errors in WB Data while I was doing this - most of them were very simple.

Issue: FEI-5147

## Test plan:
`yarn test`
`yarn typecheck`