### PR TITLE
[fei5235.1.ssradapter] Add SSR adapter for test harness

### DIFF
--- a/.changeset/blue-ways-cough.md
+++ b/.changeset/blue-ways-cough.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": major
+---
+
+Added new SSR adapter for test harnesses to support `RenderStateRoot` in tests and stories

--- a/.changeset/large-paws-wonder.md
+++ b/.changeset/large-paws-wonder.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": patch
+---
+
+`RenderStateRoot` now wraps children in a React fragment

--- a/__docs__/wonder-blocks-testing/exports.harness-adapters.stories.mdx
+++ b/__docs__/wonder-blocks-testing/exports.harness-adapters.stories.mdx
@@ -20,6 +20,7 @@ const DefaultAdapters = {
     data: data.adapter,
     portal: portal.adapter,
     router: router.adapter,
+    ssr: ssr.adapter,
 };
 
 /**
@@ -30,6 +31,7 @@ const DefaultConfigs: Configs<typeof DefaultAdapters> = {
     data: data.defaultConfig,
     portal: portal.defaultConfig,
     router: router.defaultConfig,
+    ssr: ssr.defaultConfig,
 };
 ```
 
@@ -43,6 +45,7 @@ There are four build-in adapters:
 -   [`data`](#data)
 -   [`portal`](#portal)
 -   [`router`](#router)
+-   [`ssr`](#ssr)
 
 ## css
 
@@ -186,3 +189,15 @@ There are four distinct shapes to the configuration:
 The first of these provides the most flexibility, basically supporting full configuration of a `MemoryRouter`, which supports history and navigation. The second configuration type is for scenarios where we absolutely do not want navigation, such as server-side rendering scenarios; it forces the use of a `StaticRouter` instance. The third type is for when you just need to render a single location with a matched route path. The fourth and final type allows you to just provide the location as a string.
 
 By default, the router adapter is configured with `{location: "/"}`.
+
+## ssr
+
+The `ssr` adapter ensures that the render state is being managed by rendering a `RenderStateRoot` component around the harnessed component.
+
+```ts
+type Config = "Default";
+```
+
+By default, this adapter is on.
+
+NOTE: If you are updating existing tests with this version of Wonder Blocks Testing, you may see failures in tests that already use `RenderStateRoot` as it will throw when nested. Just remove the `RenderStateRoot` you are rendering in your tests and use this adapter instead.

--- a/__docs__/wonder-blocks-testing/exports.harness-adapters.stories.mdx
+++ b/__docs__/wonder-blocks-testing/exports.harness-adapters.stories.mdx
@@ -195,9 +195,7 @@ By default, the router adapter is configured with `{location: "/"}`.
 The `ssr` adapter ensures that the render state is being managed by rendering a `RenderStateRoot` component around the harnessed component.
 
 ```ts
-type Config = "Default";
+type Config =  true | null;
 ```
 
-By default, this adapter is on.
-
-NOTE: If you are updating existing tests with this version of Wonder Blocks Testing, you may see failures in tests that already use `RenderStateRoot` as it will throw when nested. Just remove the `RenderStateRoot` you are rendering in your tests and use this adapter instead.
+By default, this adapter is off since state changes occur when `RenderStateRoot` is used that may require tests to make accommodations, such as adding appropriate `act` or `waitFor` calls when using Testing Library.

--- a/__docs__/wonder-blocks-testing/types.test-harness-adapters.stories.mdx
+++ b/__docs__/wonder-blocks-testing/types.test-harness-adapters.stories.mdx
@@ -29,6 +29,7 @@ const DefaultAdapters = {
     data: data.adapter,
     portal: portal.adapter,
     router: router.adapter,
+    ssr: ssr.adapter,
 };
 ```
 
@@ -40,6 +41,7 @@ type DefaultAdaptersType = {|
    data: typeof data.adapter,
    portal: typeof portal.adapter,
    router: typeof router.adapter,
+   ssr: typeof ssr.adapter,
 |};
 ```
 

--- a/__docs__/wonder-blocks-testing/types.test-harness-configs.stories.mdx
+++ b/__docs__/wonder-blocks-testing/types.test-harness-configs.stories.mdx
@@ -27,6 +27,7 @@ const DefaultAdapters = {
     data: data.adapter,
     portal: portal.adapter,
     router: router.adapter,
+    ssr: ssr.adapter,
 };
 ```
 
@@ -34,10 +35,11 @@ const DefaultAdapters = {
 
 ```ts
 type DefaultAdaptersType = {|
-   css: typeof css.adapter,
-   data: typeof data.adapter,
-   portal: typeof portal.adapter,
-   router: typeof router.adapter,
+    css: typeof css.adapter,
+    data: typeof data.adapter,
+    portal: typeof portal.adapter,
+    router: typeof router.adapter,
+    ssr: typeof ssr.adapter,
 |};
 ```
 
@@ -49,6 +51,7 @@ const DefaultConfigs: TestHarnessConfigs<typeof DefaultAdapters> = {
     data: data.defaultConfig,
     portal: portal.defaultConfig,
     router: router.defaultConfig,
+    ssr: ssr.defaultConfig,
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:coverage": "yarn run test:common && yarn run jest --coverage",
     "test": "yarn run test:common && yarn run jest",
     "typecheck": "tsc",
+    "typewatch": "tsc --noEmit --watch --incremental",
     "add:devdepbysha": "bash -c 'yarn add -W --dev \"git+https://git@github.com/Khan/$0.git#$1\"'"
   },
   "author": "",

--- a/packages/wonder-blocks-core/src/components/render-state-root.tsx
+++ b/packages/wonder-blocks-core/src/components/render-state-root.tsx
@@ -32,8 +32,7 @@ const RenderStateRoot = ({
         }
         // Avoid rendering multiple providers if this RenderStateRoot
         // is nested inside another one.
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
-        return children;
+        return <>{children}</>;
     }
 
     const value = firstRender ? RenderState.Initial : RenderState.Standard;

--- a/packages/wonder-blocks-testing/src/fetch/fetch-request-matches-mock.ts
+++ b/packages/wonder-blocks-testing/src/fetch/fetch-request-matches-mock.ts
@@ -12,10 +12,8 @@ const getHref = (input: RequestInfo): string => {
         return input;
     } else if (typeof input.url === "string") {
         return input.url;
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'href' does not exist on type 'Request'.
-    } else if (typeof input.href === "string") {
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'href' does not exist on type 'Request'.
-        return input.href;
+    } else if (typeof (input as any).href === "string") {
+        return (input as any).href;
     } else {
         throw new Error(`Unsupported input type`);
     }

--- a/packages/wonder-blocks-testing/src/fetch/mock-fetch.ts
+++ b/packages/wonder-blocks-testing/src/fetch/mock-fetch.ts
@@ -6,7 +6,7 @@ import type {FetchMockFn, FetchMockOperation} from "./types";
  * A mock for the fetch function passed to GqlRouter.
  */
 export const mockFetch = (): FetchMockFn =>
-    mockRequester<FetchMockOperation, any>(
+    mockRequester<FetchMockOperation>(
         fetchRequestMatchesMock,
         // NOTE(somewhatabstract): The indentation is expected on the lines
         // here.

--- a/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.tsx
+++ b/packages/wonder-blocks-testing/src/fixtures/__tests__/fixtures.test.tsx
@@ -114,10 +114,9 @@ describe("fixtures", () => {
 
         it("should render the component", () => {
             // Arrange
-            const fixture = fixtures(
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '(props: any) => string' is not assignable to parameter of type 'ComponentType<any>'.
-                (props: any) => `I rendered ${JSON.stringify(props)}`,
-            );
+            const fixture = fixtures((props: any) => (
+                <>{`I rendered ${JSON.stringify(props)}`}</>
+            ));
             const Fixture: any = fixture("A simple story", {});
 
             // Act
@@ -131,16 +130,12 @@ describe("fixtures", () => {
 
         it("should render the wrapper", () => {
             // Arrange
-            const fixture = fixtures(
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '(props: any) => string' is not assignable to parameter of type 'ComponentType<any>'.
-                (props: any) => `I rendered ${JSON.stringify(props)}`,
-            );
-            const Fixture: any = fixture(
-                "A simple story",
-                {},
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '() => string' is not assignable to parameter of type 'ComponentType<any> | undefined'.
-                () => "I am a wrapper",
-            );
+            const fixture = fixtures((props: any) => (
+                <>{`I rendered ${JSON.stringify(props)}`}</>
+            ));
+            const Fixture: any = fixture("A simple story", {}, () => (
+                <>I am a wrapper</>
+            ));
 
             // Act
             render(<Fixture aProp="aValue" />);

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.basic.stories.tsx
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.basic.stories.tsx
@@ -7,9 +7,15 @@ type Props = {
     propB?: string;
 };
 
-const MyComponent = (props: Props): React.ReactElement =>
-    // @ts-expect-error: `string` is not a valid `ReactElement`.
-    `I am a component. Here are my props: ${JSON.stringify(props, null, 2)}`;
+const MyComponent = (props: Props): React.ReactElement => (
+    <>
+        {`I am a component. Here are my props: ${JSON.stringify(
+            props,
+            null,
+            2,
+        )}`}
+    </>
+);
 
 const Wrapper = (props: any) => (
     <>

--- a/packages/wonder-blocks-testing/src/fixtures/fixtures.tsx
+++ b/packages/wonder-blocks-testing/src/fixtures/fixtures.tsx
@@ -27,8 +27,7 @@ export const fixtures = <
     let storyNumber = 1;
 
     const getPropsOptions = {
-        // @ts-expect-error [FEI-5019] - TS7006 - Parameter 'message' implicitly has an 'any' type. | TS7019 - Rest parameter 'args' implicitly has an 'any[]' type.
-        log: (message, ...args) => action(message)(...args),
+        log: (message: string, ...args: Array<any>) => action(message)(...args),
         logHandler: action,
     } as const;
 

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.ts
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.ts
@@ -6,7 +6,7 @@ import type {GqlFetchMockFn, GqlMockOperation} from "./types";
  * A mock for the fetch function passed to GqlRouter.
  */
 export const mockGqlFetch = (): GqlFetchMockFn =>
-    mockRequester<GqlMockOperation<any, any, any>, any>(
+    mockRequester<GqlMockOperation<any, any, any>>(
         gqlRequestMatchesMock,
         // Note that the identation at the start of each line is important.
         // TODO(somewhatabstract): Make a stringify that indents each line of

--- a/packages/wonder-blocks-testing/src/harness/__tests__/hook-harness.test.ts
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/hook-harness.test.ts
@@ -34,7 +34,8 @@ describe("#hookHarness", () => {
         const config = {
             router: "/boo",
         } as const;
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'harnessFake' does not exist on type 'typeof import("/Users/kevinbarabash/khan/wonder-blocks/packages/wonder-blocks-testing/src/harness/make-hook-harness")'.
+        // @ts-expect-error We know harnessFake isn't real, we add it in the
+        // mocks at the top of this file.
         const [{harnessFake}, {hookHarness}] = await ws.isolateModules(() =>
             Promise.all([
                 import("../make-hook-harness"),
@@ -54,7 +55,8 @@ describe("#hookHarness", () => {
         const config = {
             router: "/boo",
         } as const;
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'returnValueFake' does not exist on type 'typeof import("/Users/kevinbarabash/khan/wonder-blocks/packages/wonder-blocks-testing/src/harness/make-hook-harness")'.
+        // @ts-expect-error We know harnessFake isn't real, we add it in the
+        // mocks at the top of this file.
         const [{returnValueFake}, {hookHarness}] = await ws.isolateModules(() =>
             Promise.all([
                 import("../make-hook-harness"),

--- a/packages/wonder-blocks-testing/src/harness/__tests__/render-adapters.test.tsx
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/render-adapters.test.tsx
@@ -4,7 +4,7 @@ import {renderAdapters} from "../render-adapters";
 import type {TestHarnessAdapter, TestHarnessConfigs} from "../types";
 
 describe("#renderAdapters", () => {
-    it("should return children if no adapters", () => {
+    it("should render children if no adapters", () => {
         // Arrange
         const children = <div>Adapt me!</div>;
 
@@ -12,7 +12,13 @@ describe("#renderAdapters", () => {
         const result = renderAdapters({}, {}, children);
 
         // Assert
-        expect(result).toBe(children);
+        expect(result).toMatchInlineSnapshot(`
+            <React.Fragment>
+              <div>
+                Adapt me!
+              </div>
+            </React.Fragment>
+        `);
     });
 
     it("should invoke the adapter with its corresponding config", () => {
@@ -38,10 +44,8 @@ describe("#renderAdapters", () => {
     it("should render each adapter and the children", () => {
         // Arrange
         const children = "Adapt me!";
-        // @ts-expect-error: `string` is not a valid `ReactElement`.
-        const adapter: TestHarnessAdapter<string> = (c: any, conf: any) => {
-            return `${conf}:${c}`;
-        };
+        const adapter: TestHarnessAdapter<string> = (c: any, conf: any) =>
+            `${conf}:${c}` as any;
         const adapters = {
             adapterA: adapter,
             adapterB: adapter,
@@ -57,16 +61,18 @@ describe("#renderAdapters", () => {
         const result = renderAdapters(adapters, configs, children);
 
         // Assert
-        expect(result).toMatchInlineSnapshot(`"C:B:A:Adapt me!"`);
+        expect(result).toMatchInlineSnapshot(`
+            <React.Fragment>
+              C:B:A:Adapt me!
+            </React.Fragment>
+        `);
     });
 
     it("should skip adapters where the corresponding config is null", () => {
         // Arrange
         const children = "Adapt me!";
-        // @ts-expect-error: `string` is not a valid `ReactElement`.
-        const adapter: TestHarnessAdapter<string> = (c: any, conf: any) => {
-            return `${conf}:${c}`;
-        };
+        const adapter: TestHarnessAdapter<string> = (c: any, conf: any) =>
+            `${conf}:${c}` as any;
         const adapters = {
             adapterA: adapter,
             adapterB: adapter,
@@ -82,6 +88,10 @@ describe("#renderAdapters", () => {
         const result = renderAdapters(adapters, configs, children);
 
         // Assert
-        expect(result).toMatchInlineSnapshot(`"C:A:Adapt me!"`);
+        expect(result).toMatchInlineSnapshot(`
+            <React.Fragment>
+              C:A:Adapt me!
+            </React.Fragment>
+        `);
     });
 });

--- a/packages/wonder-blocks-testing/src/harness/__tests__/test-harness.test.ts
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/test-harness.test.ts
@@ -35,7 +35,8 @@ describe("#testHarness", () => {
         const config = {
             router: "/boo",
         } as const;
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'harnessFake' does not exist on type 'typeof import("/Users/kevinbarabash/khan/wonder-blocks/packages/wonder-blocks-testing/src/harness/make-test-harness")'.
+        // @ts-expect-error We know harnessFake isn't real, we add it in the
+        // mocks at the top of this file.
         const [{harnessFake}, {testHarness}] = await ws.isolateModules(() =>
             Promise.all([
                 import("../make-test-harness"),
@@ -56,7 +57,8 @@ describe("#testHarness", () => {
         const config = {
             router: "/boo",
         } as const;
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'returnValueFake' does not exist on type 'typeof import("/Users/kevinbarabash/khan/wonder-blocks/packages/wonder-blocks-testing/src/harness/make-test-harness")'.
+        // @ts-expect-error We know harnessFake isn't real, we add it in the
+        // mocks at the top of this file.
         const [{returnValueFake}, {testHarness}] = await ws.isolateModules(() =>
             Promise.all([
                 import("../make-test-harness"),

--- a/packages/wonder-blocks-testing/src/harness/__tests__/types.typestest.tsx
+++ b/packages/wonder-blocks-testing/src/harness/__tests__/types.typestest.tsx
@@ -12,13 +12,10 @@ import type {
  */
 
 //>  should assert type of config.
-// @ts-expect-error [FEI-5019] - TS2352 - Conversion of type '(children: React.ReactNode, config: number) => React.ReactElement<any>' to type 'TestHarnessAdapter<string>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
-((
-    children: React.ReactNode,
-    // TConfig is string, but we typed this arg as a number
-    // $FlowExpectedError[incompatible-cast]
-    config: number,
-): React.ReactElement<any> => <div />) as TestHarnessAdapter<string>;
+// @ts-expect-error TConfig is string, but we typed config as a number
+((children: React.ReactNode, config: number): React.ReactElement<any> => (
+    <div />
+)) as TestHarnessAdapter<string>;
 //<
 
 //>  should work for correct definition
@@ -36,10 +33,8 @@ import type {
 //<
 
 //>  should assert if adapter is not Adapter<TConfig>
-// @ts-expect-error [FEI-5019] - TS2352 - Conversion of type '{ adapterString: string; }' to type 'TestHarnessAdapters' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+// @ts-expect-error  String is not a adapter function
 ({
-    // String is not a adapter function
-    // $FlowExpectedError[incompatible-cast]
     adapterString: "string",
 } as TestHarnessAdapters);
 //<
@@ -100,11 +95,9 @@ const adapters = {
 //<
 
 //>  should assert if config does not match adapter config
-// @ts-expect-error: Conversion of type '{ adapterA: string; adapterB: string; }' to type 'TestHarnessConfigs<{ readonly adapterA: TestHarnessAdapter<string>; readonly adapterB: TestHarnessAdapter<number>; }>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first. Types of property 'adapterB' are incompatible. Type 'string' is not comparable to type 'number'.
+// @ts-expect-error: the config type here is a number, not a string
 ({
     adapterA: "a string, this is correct",
-    // the config type here is a number, not a string
-    // $FlowExpectedError[incompatible-cast]
     adapterB: "a string, but it should be a number",
 } as TestHarnessConfigs<typeof adapters>);
 //<

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/data.test.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/data.test.tsx
@@ -21,8 +21,12 @@ describe("WonderBlocksData.adapter", () => {
         const TestFixture = () => {
             const [result] = useCachedEffect("ID", jest.fn());
 
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'data' does not exist on type 'Result<ValidCacheData>'.
-            return <div>CONTENT: {result?.data}</div>;
+            return (
+                <div>
+                    CONTENT:{" "}
+                    {result.status === "success" ? result.data : undefined}
+                </div>
+            );
         };
 
         // Act
@@ -43,8 +47,12 @@ describe("WonderBlocksData.adapter", () => {
         const TestFixture = () => {
             const [result] = useCachedEffect("ID", jest.fn());
 
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'data' does not exist on type 'Result<ValidCacheData>'.
-            return <div>CONTENT:{result?.data}</div>;
+            return (
+                <div>
+                    CONTENT:
+                    {result.status === "success" ? result.data : undefined}
+                </div>
+            );
         };
 
         // Act

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/ssr.test.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/ssr.test.tsx
@@ -17,7 +17,7 @@ describe("SSR.adapter", () => {
         const renderStateRootSpy = jest.spyOn(WBCore, "RenderStateRoot");
 
         // Act
-        render(SSR.adapter(children, "Default"));
+        render(SSR.adapter(children, true));
 
         // Assert
         expect(renderStateRootSpy).toHaveBeenCalledWith(
@@ -33,7 +33,7 @@ describe("SSR.adapter", () => {
         const children = <div>CHILDREN!</div>;
 
         // Act
-        render(SSR.adapter(children, "Default"));
+        render(SSR.adapter(children, true));
 
         // Assert
         expect(screen.getByText("CHILDREN!")).toBeInTheDocument();

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/ssr.test.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/ssr.test.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+
+import * as WBCore from "@khanacademy/wonder-blocks-core";
+
+import * as SSR from "../ssr";
+
+jest.mock("@khanacademy/wonder-stuff-core", () => ({
+    ...jest.requireActual("@khanacademy/wonder-stuff-core"),
+    RenderStateRoot: (props: any) => <div {...props} />,
+}));
+
+describe("SSR.adapter", () => {
+    it("should render the RenderStateRoot", () => {
+        // Arrange
+        const children = <div>CHILDREN!</div>;
+        const renderStateRootSpy = jest.spyOn(WBCore, "RenderStateRoot");
+
+        // Act
+        render(SSR.adapter(children, "Default"));
+
+        // Assert
+        expect(renderStateRootSpy).toHaveBeenCalledWith(
+            {
+                children,
+            },
+            {},
+        );
+    });
+
+    it("should render the children correctly", () => {
+        // Arrange
+        const children = <div>CHILDREN!</div>;
+
+        // Act
+        render(SSR.adapter(children, "Default"));
+
+        // Assert
+        expect(screen.getByText("CHILDREN!")).toBeInTheDocument();
+    });
+});

--- a/packages/wonder-blocks-testing/src/harness/adapters/adapters.ts
+++ b/packages/wonder-blocks-testing/src/harness/adapters/adapters.ts
@@ -2,6 +2,7 @@ import * as css from "./css";
 import * as data from "./data";
 import * as portal from "./portal";
 import * as router from "./router";
+import * as ssr from "./ssr";
 
 import type {TestHarnessConfigs} from "../types";
 
@@ -19,6 +20,7 @@ export const DefaultAdapters = {
     data: data.adapter,
     portal: portal.adapter,
     router: router.adapter,
+    ssr: ssr.adapter,
 } as const;
 
 /**
@@ -29,4 +31,5 @@ export const DefaultConfigs: TestHarnessConfigs<typeof DefaultAdapters> = {
     data: data.defaultConfig,
     portal: portal.defaultConfig,
     router: router.defaultConfig,
+    ssr: ssr.defaultConfig,
 } as const;

--- a/packages/wonder-blocks-testing/src/harness/adapters/css.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/css.tsx
@@ -40,9 +40,7 @@ const normalizeConfig = (
             return config;
         }
 
-        // @ts-expect-error: at this point, `CSSProperties` is the only thing
-        // that `config` can be.
-        return {classes: [], style: config};
+        return {classes: [], style: config as CSSProperties};
     }
 
     throw new Error(`Invalid config: ${config}`);

--- a/packages/wonder-blocks-testing/src/harness/adapters/router.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/router.tsx
@@ -98,8 +98,7 @@ const maybeWithRoute = (
     path?: string | null,
 ): React.ReactElement => {
     if (path == null) {
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
-        return children;
+        return <>{children}</>;
     }
 
     return (
@@ -142,14 +141,12 @@ export const adapter: TestHarnessAdapter<Config> = (
 
     // Wrap children with the various contexts and routes, as per the config.
     const wrappedWithRoute = maybeWithRoute(children, config.path);
-    // @ts-expect-error [FEI-5019] - TS2339 - Property 'forceStatic' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
-    if (config.forceStatic) {
+    if ("forceStatic" in config && config.forceStatic) {
         /**
          * There may be times (SSR testing comes to mind) where we will be
          * really strict about not permitting client-side navigation events.
          */
         return (
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'location' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
             <StaticRouter location={config.location} context={{}}>
                 {wrappedWithRoute}
             </StaticRouter>
@@ -164,10 +161,8 @@ export const adapter: TestHarnessAdapter<Config> = (
      *
      * First, the easy one.
      */
-    // @ts-expect-error [FEI-5019] - TS2339 - Property 'location' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
-    if (typeof config.location !== "undefined") {
+    if ("location" in config && config.location !== undefined) {
         return (
-            // @ts-expect-error [FEI-5019] - TS2339 - Property 'location' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
             <MemoryRouter initialEntries={[config.location]}>
                 {wrappedWithRoute}
             </MemoryRouter>
@@ -178,8 +173,7 @@ export const adapter: TestHarnessAdapter<Config> = (
      * If it's not the easy one, it should be the complex one.
      * Let's make sure we have good data (also keeps TypeScript happy).
      */
-    // @ts-expect-error [FEI-5019] - TS2339 - Property 'initialEntries' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
-    if (typeof config.initialEntries === "undefined") {
+    if (!("initialEntries" in config) || config.initialEntries === undefined) {
         throw new Error(
             "A location or initial history entries must be provided.",
         );
@@ -191,25 +185,19 @@ export const adapter: TestHarnessAdapter<Config> = (
      * we want, so let's ensure we always have our default location at least.
      */
     const entries =
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'initialEntries' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
         config.initialEntries.length === 0
             ? [defaultConfig.location]
-            : // @ts-expect-error [FEI-5019] - TS2339 - Property 'initialEntries' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
-              config.initialEntries;
+            : config.initialEntries;
 
     // Memory router doesn't allow us to pass maybe types in its TypeScript types.
     // So let's build props then spread them.
     const routerProps: MemoryRouterProps = {
         initialEntries: entries,
     };
-    // @ts-expect-error [FEI-5019] - TS2339 - Property 'initialIndex' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
     if (config.initialIndex != null) {
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'initialIndex' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
         routerProps.initialIndex = config.initialIndex;
     }
-    // @ts-expect-error [FEI-5019] - TS2339 - Property 'getUserConfirmation' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
     if (config.getUserConfirmation != null) {
-        // @ts-expect-error [FEI-5019] - TS2339 - Property 'getUserConfirmation' does not exist on type 'Readonly<{ initialEntries: LocationDescriptor<unknown>[] | undefined; initialIndex?: number | undefined; getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined; path?: string | undefined; } | { ...; } | { ...; }>'.
         routerProps.getUserConfirmation = config.getUserConfirmation;
     }
 

--- a/packages/wonder-blocks-testing/src/harness/adapters/ssr.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/ssr.tsx
@@ -6,10 +6,12 @@ import type {TestHarnessAdapter} from "../types";
 
 // We only support one configuration for this adapter; the default
 // behavior - it's either on or off.
-type Config = "Default";
+type Config = true | null;
 
-// The default configuration is to do the default behavior.
-export const defaultConfig: Config = "Default";
+// The default configuration is off since this will likely cause state changes
+// and add Testing Library act/waitFor calls in tests using the harness when
+// its enabled.
+export const defaultConfig: Config = null;
 
 /**
  * Test harness adapter for supporting portals.
@@ -22,7 +24,7 @@ export const adapter: TestHarnessAdapter<Config> = (
     children: React.ReactNode,
     config: Config,
 ): React.ReactElement<any> => {
-    if (config !== "Default") {
+    if (config !== true) {
         throw new KindError("Unexpected configuraiton", Errors.InvalidInput, {
             metadata: {config},
         });

--- a/packages/wonder-blocks-testing/src/harness/adapters/ssr.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/ssr.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import {KindError, Errors} from "@khanacademy/wonder-stuff-core";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+
+import type {TestHarnessAdapter} from "../types";
+
+// We only support one configuration for this adapter; the default
+// behavior - it's either on or off.
+type Config = "Default";
+
+// The default configuration is to do the default behavior.
+export const defaultConfig: Config = "Default";
+
+/**
+ * Test harness adapter for supporting portals.
+ *
+ * Some components rely on rendering with a React Portal. This adapter ensures
+ * that the DOM contains a mounting point for the portal with the expected
+ * identifier.
+ */
+export const adapter: TestHarnessAdapter<Config> = (
+    children: React.ReactNode,
+    config: Config,
+): React.ReactElement<any> => {
+    if (config !== "Default") {
+        throw new KindError("Unexpected configuraiton", Errors.InvalidInput, {
+            metadata: {config},
+        });
+    }
+    return <RenderStateRoot>{children}</RenderStateRoot>;
+};

--- a/packages/wonder-blocks-testing/src/harness/make-hook-harness.tsx
+++ b/packages/wonder-blocks-testing/src/harness/make-hook-harness.tsx
@@ -4,8 +4,9 @@ import {makeTestHarness} from "./make-test-harness";
 
 import type {TestHarnessAdapters, TestHarnessConfigs} from "./types";
 
-// @ts-expect-error [FEI-5019] - TS7031 - Binding element 'children' implicitly has an 'any' type.
-const HookHarness = ({children}) => children;
+const HookHarness = ({
+    children,
+}: React.PropsWithChildren<unknown>): React.ReactElement => <>{children}</>;
 
 /**
  * Create a test harness method for use with React hooks.

--- a/packages/wonder-blocks-testing/src/harness/render-adapters.tsx
+++ b/packages/wonder-blocks-testing/src/harness/render-adapters.tsx
@@ -22,6 +22,5 @@ export const renderAdapters = <TAdapters extends TestHarnessAdapters>(
             currentChildren = adapter(currentChildren, config);
         }
     }
-    // @ts-expect-error [FEI-5019] - TS2322 - Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
-    return currentChildren;
+    return <>{currentChildren}</>;
 };

--- a/packages/wonder-blocks-testing/src/harness/types.ts
+++ b/packages/wonder-blocks-testing/src/harness/types.ts
@@ -6,7 +6,7 @@ import * as React from "react";
 export type TestHarnessAdapter<TConfig> = (
     children: React.ReactNode,
     config: TConfig,
-) => React.ReactElement<any>;
+) => React.ReactElement;
 
 /**
  * A general map of adapters by their identifiers.

--- a/packages/wonder-blocks-testing/src/mock-requester.ts
+++ b/packages/wonder-blocks-testing/src/mock-requester.ts
@@ -4,23 +4,17 @@ import type {OperationMock, OperationMatcher, MockFn} from "./types";
 /**
  * A generic mock request function for using when mocking fetch or gqlFetch.
  */
-export const mockRequester = <
-    TOperationType,
-    TOperationMock extends OperationMock<TOperationType> = OperationMock<TOperationType>,
->(
+export const mockRequester = <TOperationType>(
     operationMatcher: OperationMatcher<any>,
-    operationToString: (
-        operationMock: TOperationMock,
-        ...args: Array<any>
-    ) => string,
+    operationToString: (...args: Array<any>) => string,
 ): MockFn<TOperationType> => {
     // We want this to work in jest and in fixtures to make life easy for folks.
     // This is the array of mocked operations that we will traverse and
     // manipulate.
     const mocks: Array<OperationMock<any>> = [];
 
-    // What we return has to be a drop in for the fetch function that is
-    // provided to `GqlRouter` which is how folks will then use this mock.
+    // What we return has to be a drop in replacement for the mocked function
+    // which is how folks will then use this mock.
     const mockFn: MockFn<TOperationType> = (
         ...args: Array<any>
     ): Promise<Response> => {
@@ -38,7 +32,6 @@ export const mockRequester = <
 
         // Default is to reject with some helpful info on what request
         // we rejected.
-        // @ts-expect-error [FEI-5019] - TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
         const operation = operationToString(...args);
         return Promise.reject(
             new Error(`No matching mock response found for request:

--- a/packages/wonder-blocks-testing/src/respond-with.ts
+++ b/packages/wonder-blocks-testing/src/respond-with.ts
@@ -228,7 +228,8 @@ const makeMockResponse = (
             if (process.env.NODE_ENV !== "production") {
                 // If we're not in production, give an immediate signal that the
                 // dev forgot to support this new type.
-                // @ts-expect-error [FEI-5019] - TS2339 - Property 'type' does not exist on type 'never'.
+                // @ts-expect-error TS knows we can't get here and so sees
+                // `response` as `never`.
                 throw new Error(`Unknown response type: ${response.type}`);
             }
             // Production; assume a rejection.

--- a/packages/wonder-blocks-testing/src/settle-controller.ts
+++ b/packages/wonder-blocks-testing/src/settle-controller.ts
@@ -4,8 +4,7 @@ import {SettleSignal} from "./settle-signal";
  * A controller for the `RespondWith` API to control response settlement.
  */
 export class SettleController {
-    // @ts-expect-error [FEI-5019] - TS2564 - Property '#settleFn' has no initializer and is not definitely assigned in the constructor.
-    private _settleFn: () => void;
+    private _settleFn: undefined | (() => void);
     private _signal: SettleSignal;
 
     constructor() {
@@ -30,6 +29,6 @@ export class SettleController {
      * @throws {Error} if the signal has already been settled.
      */
     settle(): void {
-        this._settleFn();
+        this._settleFn?.();
     }
 }


### PR DESCRIPTION
## Summary:
This adds a new `ssr` adapter to the Wonder Blocks Testing package. It ensures a `RenderStateRoot` component is rendered around the component under test.

This adapter is default off since it may add the need for additional `act` or `waitFor` calls when using Testing Library due to the state changes that `RenderStateRoot` will perform.

In addition, default off ensures that updating to this new version won't break tests that were rendering their own `RenderStateRoot` component; nested `RenderStateRoot` components throw an error by default.

This change also addresses the TypeScript error suppressions in Wonder Blocks Testing as well as one in Wonder Blocks Core.

I also added a `yarn typewatch` command to package.json. This is a useful command to run in a separate terminal while developing to ensure that your changes don't break the type definitions, saves a few keystrokes, and is easier to remember/discover.

Issue: FEI-5235

## Test plan:
`yarn jest`
`yarn typecheck`