### PR TITLE
Fix typo in switch style check

### DIFF
--- a/.changeset/gorgeous-books-hunt.md
+++ b/.changeset/gorgeous-books-hunt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-switch": patch
+---
+
+Fix style generation

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -180,8 +180,8 @@ const _generateStyles = (
 ) => {
     const checkedStyle = `${checked}-${disabled}-${clickable}`;
     // The styles are cached to avoid creating a new object on every render.
-    if (sharedStyles[checkedStyle]) {
-        return sharedStyles[checkedStyle];
+    if (styles[checkedStyle]) {
+        return styles[checkedStyle];
     }
 
     let newStyles: Record<string, any> = {};


### PR DESCRIPTION
## Summary:
I realized that the styles check in switch was checking the wrong object. Corrected the typo

Issue: XXX-XXXX

## Test plan:
- Add console logs and make sure the styles are not being regenerated every render