### PR TITLE
Minor tweaks to Clickable's prop types

### DIFF
--- a/.changeset/polite-adults-fix.md
+++ b/.changeset/polite-adults-fix.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Allow 'safeWithNav()' to be used on its own without 'beforeNav()' in prop types

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable.typestest.tsx
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable.typestest.tsx
@@ -17,6 +17,10 @@ import Clickable from "../clickable";
     {(_) => "Hello, world!"}
 </Clickable>;
 
+<Clickable href="/foo" safeWithNav={() => Promise.resolve()}>
+    {(_) => "Hello, world!"}
+</Clickable>;
+
 <Clickable href="/foo" target="_blank" safeWithNav={() => Promise.resolve()}>
     {(_) => "Hello, world!"}
 </Clickable>;

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -121,38 +121,12 @@ type Props =
           href: string;
 
           /**
-           * A target destination window for a link to open in.
-           */
-          target?: "_blank";
-
-          beforeNav?: never;
-          safeWithNav?: never;
-      })
-    | (CommonProps & {
-          href: string;
-
-          /**
-           * Run async code before navigating. If the promise returned rejects then
-           * navigation will not occur.
-           *
-           * If both safeWithNav and beforeNav are provided, beforeNav will be run
-           * first and safeWithNav will only be run if beforeNav does not reject.
-           */
-          beforeNav: () => Promise<unknown>;
-
-          safeWithNav?: never;
-          target?: never;
-      })
-    | (CommonProps & {
-          href: string;
-
-          /**
            * Run async code in the background while client-side navigating. If the
            * browser does a full page load navigation, the callback promise must be
            * settled before the navigation will occur. Errors are ignored so that
            * navigation is guaranteed to succeed.
            */
-          safeWithNav: () => Promise<unknown>;
+          safeWithNav?: () => Promise<unknown>;
 
           /**
            * A target destination window for a link to open in.
@@ -171,7 +145,7 @@ type Props =
            * If both safeWithNav and beforeNav are provided, beforeNav will be run
            * first and safeWithNav will only be run if beforeNav does not reject.
            */
-          beforeNav: () => Promise<unknown>;
+          beforeNav?: () => Promise<unknown>;
 
           /**
            * Run async code in the background while client-side navigating. If the
@@ -179,7 +153,7 @@ type Props =
            * settled before the navigation will occur. Errors are ignored so that
            * navigation is guaranteed to succeed.
            */
-          safeWithNav: () => Promise<unknown>;
+          safeWithNav?: () => Promise<unknown>;
 
           target?: never;
       });


### PR DESCRIPTION
## Summary:
TypeScript was complaining about Clickables in webapp that were only using 'safeWithNav()' without 'beforeNav()'.

Issue: None

## Test plan:
- yarn tsc
- copy prop types for Clickable into .d.ts in services/static/node_modules/@khanacademy/wonder-blocks-clickable/dist/components/clickable.d.ts
- run 'yarn tsc' in services/static/