### PR TITLE
Add missing 'types' field to package.json, add pre-publish check to PR CI workflow

### DIFF
--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Build .d.ts types
         run: yarn build:types
 
+      - name: Check package.json files
+        run: node utils/publish/pre-publish-check-ci.js
+
       - uses: Khan/actions@check-for-changeset-v0
         if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
         with:

--- a/packages/wonder-blocks-pill/package.json
+++ b/packages/wonder-blocks-pill/package.json
@@ -6,6 +6,7 @@
     "main": "dist/index.js",
     "module": "dist/es/index.js",
     "source": "src/index.js",
+    "types": "dist/index.d.ts",
     "scripts": {
       "test": "echo \"Error: no test specified\" && exit 1"
     },


### PR DESCRIPTION
## Summary:
This will allow us to publish.  I've also add a check to the PR CI workflow so that we get notified about issues in package.json files sooner in the process.

Issue: None

## Test plan:
- let CI run