### PR TITLE
Allow 'beforeNav' and 'safeWithNav' to be used without an 'href'

### DIFF
--- a/.changeset/great-planes-vanish.md
+++ b/.changeset/great-planes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Allow 'beforeNav' and 'safeWithNav' to be used without an 'href'

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable.typestest.tsx
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable.typestest.tsx
@@ -47,3 +47,18 @@ import Clickable from "../clickable";
 >
     {(_) => "Hello, world!"}
 </Clickable>;
+
+<Clickable beforeNav={() => Promise.resolve()}>
+    {(_) => "Hello, world!"}
+</Clickable>;
+
+<Clickable safeWithNav={() => Promise.resolve()}>
+    {(_) => "Hello, world!"}
+</Clickable>;
+
+<Clickable
+    beforeNav={() => Promise.resolve()}
+    safeWithNav={() => Promise.resolve()}
+>
+    {(_) => "Hello, world!"}
+</Clickable>;

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -113,11 +113,6 @@ type CommonProps =
 
 type Props =
     | (CommonProps & {
-          target?: never;
-          beforeNav?: never;
-          safeWithNav?: never;
-      })
-    | (CommonProps & {
           href: string;
 
           /**
@@ -136,7 +131,7 @@ type Props =
           beforeNav?: never;
       })
     | (CommonProps & {
-          href: string;
+          href?: string;
 
           /**
            * Run async code before navigating. If the promise returned rejects then


### PR DESCRIPTION
## Summary:
Looking at the implementation of ClickableBehavior, 'beforeNav' and 'safeWithNav' can be used without an 'href'.  This change to the types allows us to use 'Clicakble' in accordion-item.tsx in webapp without splitting its existing use in two.

Issue: None

## Test plan:
- yarn tsc
- let CI run tests
- copy the types over to webapp and check that we can collapse the uses of `Clickable` in https://github.com/Khan/webapp/pull/16140