### PR TITLE
WB-1577: Add khanmigo theme to Button

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import * as React from "react";
 import wonderBlocksTheme from "./wonder-blocks-theme";
 import {configure} from "@storybook/testing-library";
 
 import Link from "@khanacademy/wonder-blocks-link";
+import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
+import {Preview} from "@storybook/react";
 
 configure({
     testIdAttribute: "data-test-id",
@@ -79,3 +81,45 @@ export const parameters = {
         viewports: wbViewports,
     },
 };
+
+export const decorators = [
+    (Story, context) => {
+        const theme = context.globals.theme;
+        return (
+            <ThemeSwitcherContext.Provider value={theme}>
+                <Story />
+            </ThemeSwitcherContext.Provider>
+        );
+    },
+];
+
+const preview: Preview = {
+    globalTypes: {
+        // Allow the user to select a theme from the toolbar.
+        theme: {
+            description: "Global theme for components",
+            toolbar: {
+                // The label to show for this toolbar item
+                title: "Theme",
+                icon: "switchalt",
+                // Array of plain string values or MenuItem shape (see below)
+                items: [
+                    {
+                        value: "default",
+                        icon: "circlehollow",
+                        title: "Wonder Blocks (default)",
+                    },
+                    {
+                        value: "khanmigo",
+                        icon: "circle",
+                        title: "Khanmigo",
+                    },
+                ],
+                // Change title based on selected value
+                dynamicTitle: true,
+            },
+        },
+    },
+};
+
+export default preview;

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -19,6 +19,7 @@ import packageConfig from "../../packages/wonder-blocks-button/package.json";
 import ComponentInfo from "../../.storybook/components/component-info";
 
 import ButtonArgTypes from "./button.argtypes";
+import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
 
 export default {
     title: "Button",
@@ -32,6 +33,7 @@ export default {
         ),
     },
     argTypes: ButtonArgTypes,
+    decorators: [(Story): React.ReactElement => <>{Story()}</>],
     excludeStories: ["styles"],
 } as Meta<typeof Button>;
 
@@ -120,51 +122,49 @@ export const styles: StyleDeclaration = StyleSheet.create({
     },
 });
 
-export const Variants: StoryComponentType = {
-    render: () => (
-        <View>
-            <View style={{flexDirection: "row"}}>
-                <Button onClick={() => {}}>Hello, world!</Button>
-                <Strut size={16} />
-                <Button onClick={() => {}} kind="secondary">
-                    Hello, world!
-                </Button>
-                <Strut size={16} />
-                <Button onClick={() => {}} kind="tertiary">
-                    Hello, world!
-                </Button>
-            </View>
+export const Variants: StoryComponentType = () => (
+    <View style={{padding: Spacing.medium_16}}>
+        <View style={{flexDirection: "row"}}>
+            <Button onClick={() => {}}>Hello, world!</Button>
             <Strut size={16} />
-            <View style={{flexDirection: "row"}}>
-                <Button onClick={() => {}} disabled={true}>
-                    Hello, world!
-                </Button>
-                <Strut size={16} />
-                <Button onClick={() => {}} disabled={true} kind="secondary">
-                    Hello, world!
-                </Button>
-                <Strut size={16} />
-                <Button onClick={() => {}} disabled={true} kind="tertiary">
-                    Hello, world!
-                </Button>
-            </View>
+            <Button onClick={() => {}} kind="secondary">
+                Hello, world!
+            </Button>
             <Strut size={16} />
-            <View style={{flexDirection: "row"}}>
-                <Button onClick={() => {}} color="destructive">
-                    Hello, world!
-                </Button>
-                <Strut size={16} />
-                <Button onClick={() => {}} kind="secondary" color="destructive">
-                    Hello, world!
-                </Button>
-                <Strut size={16} />
-                <Button onClick={() => {}} kind="tertiary" color="destructive">
-                    Hello, world!
-                </Button>
-            </View>
+            <Button onClick={() => {}} kind="tertiary">
+                Hello, world!
+            </Button>
         </View>
-    ),
-};
+        <Strut size={16} />
+        <View style={{flexDirection: "row"}}>
+            <Button onClick={() => {}} disabled={true}>
+                Hello, world!
+            </Button>
+            <Strut size={16} />
+            <Button onClick={() => {}} disabled={true} kind="secondary">
+                Hello, world!
+            </Button>
+            <Strut size={16} />
+            <Button onClick={() => {}} disabled={true} kind="tertiary">
+                Hello, world!
+            </Button>
+        </View>
+        <Strut size={16} />
+        <View style={{flexDirection: "row"}}>
+            <Button onClick={() => {}} color="destructive">
+                Hello, world!
+            </Button>
+            <Strut size={16} />
+            <Button onClick={() => {}} kind="secondary" color="destructive">
+                Hello, world!
+            </Button>
+            <Strut size={16} />
+            <Button onClick={() => {}} kind="tertiary" color="destructive">
+                Hello, world!
+            </Button>
+        </View>
+    </View>
+);
 
 Variants.parameters = {
     docs: {
@@ -211,10 +211,15 @@ WithColor.parameters = {
             story: "Buttons have a `color` that is either `default` (the default, as shown above) or `destructive` (as can seen below):",
         },
     },
+    chromatic: {
+        // NOTE: We already have screenshots of other stories that cover more of
+        // the button states (see Variants).
+        disableSnapshot: true,
+    },
 };
 
 export const Dark: StoryComponentType = () => (
-    <View style={{backgroundColor: Color.darkBlue}}>
+    <View style={{backgroundColor: Color.darkBlue, padding: Spacing.medium_16}}>
         <View style={{flexDirection: "row"}}>
             <Button onClick={() => {}} light={true}>
                 Hello, world!
@@ -568,5 +573,32 @@ WithRouter.parameters = {
     },
     chromatic: {
         disableSnapshot: true,
+    },
+};
+
+/**
+ * Button supports theming via the `ThemeSwitcherContext`. This story shows the
+ * button in the `khanmigo` theme using all the variants.
+ *
+ * **Note:** You can also use the "Theme" addon in the toolbar to switch themes.
+ */
+export const KhanmigoTheme: StoryComponentType = {
+    render: () => {
+        const stories = [
+            Variants,
+            Dark,
+            Size,
+            Icon,
+        ] as Array<React.ElementType>;
+
+        return (
+            <ThemeSwitcherContext.Provider value="khanmigo">
+                <View style={{gap: Spacing.medium_16}}>
+                    {stories.map((Story, i) => (
+                        <Story key={i} />
+                    ))}
+                </View>
+            </ThemeSwitcherContext.Provider>
+        );
     },
 };

--- a/packages/wonder-blocks-button/src/components/button.tsx
+++ b/packages/wonder-blocks-button/src/components/button.tsx
@@ -10,6 +10,7 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 import {Link} from "react-router-dom";
 import ButtonCore from "./button-core";
+import ThemedButton from "../themes/themed-button";
 
 export type SharedProps =
     /**
@@ -287,9 +288,11 @@ const Button: React.ForwardRefExoticComponent<
     };
 
     return (
-        <__RouterContext.Consumer>
-            {(router) => renderClickableBehavior(router)}
-        </__RouterContext.Consumer>
+        <ThemedButton>
+            <__RouterContext.Consumer>
+                {(router) => renderClickableBehavior(router)}
+            </__RouterContext.Consumer>
+        </ThemedButton>
     );
 });
 

--- a/packages/wonder-blocks-button/src/themes/default.ts
+++ b/packages/wonder-blocks-button/src/themes/default.ts
@@ -1,0 +1,98 @@
+import {tokens} from "@khanacademy/wonder-blocks-theming";
+
+const theme = {
+    color: {
+        bg: {
+            // color="destructive"
+            critical: tokens.color.red,
+            criticalActive: tokens.color.activeRed,
+            criticalInverse: tokens.color.fadedRed,
+            // color="default"
+            action: tokens.color.blue,
+            actionActive: tokens.color.activeBlue,
+            actionInverse: tokens.color.fadedBlue,
+            // kind="primary", light=true | kind="secondary", light=false
+            primary: tokens.color.white,
+            // kind="secondary", light=false
+            secondary: "none",
+            // kind="secondary", light=true
+            secondaryInverse: "none",
+            secondaryFocus: tokens.color.white,
+            // kind="secondary", light=false, active=true
+            secondaryActive: tokens.color.fadedBlue,
+            // disabled=true
+            disabled: tokens.color.offBlack32,
+            // SHADOW kind="primary", state="focus, active"
+            inverse: tokens.color.darkBlue,
+        },
+        text: {
+            // kind="primary", disabled=true
+            primaryDisabled: tokens.color.white64,
+            // kind="primary, secondary", light=false | kind="tertiary", light=true
+            inverse: tokens.color.white,
+            // kind="secondary", disabled=true, light=true
+            secondaryInverse: tokens.color.white50,
+            // kind="secondary, tertiary", disabled=true, light=false
+            disabled: tokens.color.offBlack32,
+        },
+        border: {
+            primaryInverse: tokens.color.white,
+            secondaryAction: tokens.color.offBlack50,
+            secondaryCritical: tokens.color.offBlack50,
+            secondaryInverse: tokens.color.white50,
+            // kind="tertiary", state="hover", light=true
+            tertiaryInverse: tokens.color.white,
+            disabled: tokens.color.offBlack32,
+        },
+    },
+    border: {
+        width: {
+            // secondary (resting)
+            secondary: tokens.border.width.hairline,
+            // secondary (resting, focus, active), tertiary (focus)
+            focused: tokens.border.width.thin,
+            // secondary (disabled)
+            disabled: tokens.border.width.thin,
+        },
+        radius: {
+            // default
+            default: tokens.border.radius.small_3,
+            // tertiary
+            tertiary: tokens.border.radius.xSmall_2,
+            // small button
+            small: tokens.border.radius.small_3,
+            // large button
+            large: tokens.border.radius.large_6,
+        },
+    },
+    size: {
+        width: {
+            medium: tokens.spacing.large_24,
+            large: tokens.spacing.xLarge_32,
+        },
+        height: {
+            tertiaryHover: tokens.spacing.xxxxSmall_2,
+            small: tokens.spacing.xLarge_32,
+            // NOTE: These height tokens are specific to this component.
+            medium: 40,
+            large: 56,
+        },
+    },
+    padding: {
+        small: tokens.spacing.xSmall_8,
+        medium: tokens.spacing.small_12,
+        large: tokens.spacing.medium_16,
+        xLarge: tokens.spacing.xLarge_32,
+    },
+    font: {
+        size: {
+            // NOTE: This token is specific to this button size.
+            large: 18,
+        },
+        lineHeight: {
+            large: tokens.font.lineHeight.medium,
+        },
+    },
+};
+
+export default theme;

--- a/packages/wonder-blocks-button/src/themes/khanmigo.ts
+++ b/packages/wonder-blocks-button/src/themes/khanmigo.ts
@@ -1,0 +1,31 @@
+import {mergeTheme, tokens} from "@khanacademy/wonder-blocks-theming";
+import defaultTheme from "./default";
+
+/**
+ * The overrides for the Khanmigo theme.
+ */
+const theme = mergeTheme(defaultTheme, {
+    color: {
+        bg: {
+            secondary: tokens.color.offWhite,
+            secondaryActive: tokens.color.fadedBlue8,
+            secondaryFocus: tokens.color.offWhite,
+        },
+        border: {
+            secondaryAction: tokens.color.fadedBlue,
+            secondaryCritical: tokens.color.fadedRed,
+        },
+    },
+    border: {
+        radius: {
+            default: tokens.border.radius.xLarge_12,
+            small: tokens.border.radius.large_6,
+            large: tokens.border.radius.xLarge_12,
+        },
+        width: {
+            focused: tokens.border.width.hairline,
+        },
+    },
+});
+
+export default theme;

--- a/packages/wonder-blocks-button/src/themes/themed-button.tsx
+++ b/packages/wonder-blocks-button/src/themes/themed-button.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import {
+    createThemeContext,
+    ThemeSwitcherContext,
+} from "@khanacademy/wonder-blocks-theming";
+
+import defaultTheme from "./default";
+import khanmigoTheme from "./khanmigo";
+
+type Props = {
+    children: React.ReactNode;
+};
+
+/**
+ * The themes available to the Button component.
+ */
+const themes = {
+    default: defaultTheme,
+    khanmigo: khanmigoTheme,
+};
+
+export type ButtonThemeContract = typeof defaultTheme;
+
+/**
+ * The context that provides the theme to the Button component.
+ * This is generally consumed via the `useScopedTheme` hook.
+ */
+export const ButtonThemeContext = createThemeContext(defaultTheme);
+
+/**
+ * ThemedButton is a component that provides a theme to the <Button/> component.
+ */
+export default function ThemedButton(props: Props) {
+    const currentTheme = React.useContext(ThemeSwitcherContext);
+
+    const theme = themes[currentTheme as keyof typeof themes] || defaultTheme;
+    return (
+        <ButtonThemeContext.Provider value={theme}>
+            {props.children}
+        </ButtonThemeContext.Provider>
+    );
+}

--- a/packages/wonder-blocks-button/tsconfig-build.json
+++ b/packages/wonder-blocks-button/tsconfig-build.json
@@ -12,6 +12,7 @@
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-progress-spinner/tsconfig-build.json"},
         {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-theming/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-theming/src/tokens.ts
+++ b/packages/wonder-blocks-theming/src/tokens.ts
@@ -15,8 +15,12 @@ const tokens = {
         // New colors
         activeBlue: mix(Color.offBlack32, Color.blue),
         fadedBlue: mix(fade(Color.blue, 0.32), Color.white),
+        fadedBlue16: fade(Color.blue, 0.16),
+        fadedBlue8: fade(Color.blue, 0.08),
         activeRed: mix(Color.offBlack32, Color.red),
         fadedRed: mix(fade(Color.red, 0.32), Color.white),
+        fadedRed16: fade(Color.red, 0.16),
+        fadedRed8: fade(Color.red, 0.08),
         // Additional colors (e.g. for use in other themes)
     },
     spacing: Spacing,
@@ -26,6 +30,7 @@ const tokens = {
             small_3: 3,
             medium_4: 4,
             large_6: 6,
+            xLarge_12: 12,
             full: "50%",
         },
         width: {


### PR DESCRIPTION
## Summary:

This PR adds theming support to the Button component via the
`wonder-blocks-theming` package. It also creates a new `khanmigo` theme for the
Button component so it can be used within the Khanmigo widget.

Another change is that we include a new "Theme" toolbar option in the Storybook
UI to be able to switch between the default and khanmigo themes for any
story/component that supports theming.


Issue: WB-1577

## Test plan:

Verify that the new theme story works as expected in Storybook: `/?path=/story/button--khanmigo-theme`.

Also verify that the "Theme" toolbar option switches between themes.