### PR TITLE
Remove tests and stories from changesets check

### DIFF
--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -99,6 +99,8 @@ jobs:
         if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
         with:
           exclude: .github/,.storybook/
+          exclude_extensions: .test.ts, .test.tsx, .stories.ts, .stories.tsx, .mdx
+          exclude_globs: "**/__tests__/*, **/__docs__/*"
 
   test:
     name: Test


### PR DESCRIPTION
## Summary:

Removes the need for adding a changeset when only tests and stories are changed.

Issue: XXX-XXXX

## Test plan:

Try to create a separate PR that only includes tests and/or stories changes and
verify that the changeset check is not required.