### PR TITLE
Allow 'title' to be used on typography components and View

### DIFF
--- a/.changeset/sixty-moons-promise.md
+++ b/.changeset/sixty-moons-promise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Allow 'title' on View and typography components

--- a/packages/wonder-blocks-core/src/util/types.ts
+++ b/packages/wonder-blocks-core/src/util/types.ts
@@ -93,6 +93,7 @@ export type TextViewSharedProps = {
     htmlFor?: string;
     tabIndex?: number;
     id?: string;
+    title?: string;
 
     // TODO(kevinb) remove the need for this
     "data-modal-launcher-portal"?: boolean;


### PR DESCRIPTION
## Summary:
There are a number of places where we use 'title' on a View or typography component in webapp.  Our types should allow this.

Issue: None

## Test plan:
- let CI run TypeScript