### PR TITLE
[🔥AUDIT🔥] [fixtimingstories] The examples use React but that isn't a globally available thing, we have to import it

### DIFF
--- a/__docs__/wonder-blocks-timing/use-interval.stories.mdx
+++ b/__docs__/wonder-blocks-timing/use-interval.stories.mdx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import {Meta, Story, Source, Canvas} from "@storybook/blocks";
 
 import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
@@ -59,7 +60,7 @@ export const BasicUsage = () => {
     </Story>
 </Canvas>
 
-```jsx
+```tsx
 export const BasicUsage = () => {
     const [callCount, setCallCount] = React.useState(0);
     const [active, setActive] = React.useState(false);

--- a/__docs__/wonder-blocks-timing/use-scheduled-interval.stories.mdx
+++ b/__docs__/wonder-blocks-timing/use-scheduled-interval.stories.mdx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 import {Meta, Story, Source, Canvas} from "@storybook/blocks";
 
 import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-timing/use-scheduled-timeout.stories.mdx
+++ b/__docs__/wonder-blocks-timing/use-scheduled-timeout.stories.mdx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 import {Meta, Story, Source, Canvas} from "@storybook/blocks";
 
 import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-timing/use-timeout.stories.mdx
+++ b/__docs__/wonder-blocks-timing/use-timeout.stories.mdx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 import {Meta, Story, Source, Canvas} from "@storybook/blocks";
 
 import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We were seeing errors in the docs for these examples. It turns out they were trying to use React without importing it.

Issue: XXX-XXXX

## Test plan:
`yarn start` and view the various timing hooks docs to see they work rather than showing a stacktrace.