### PR TITLE
[fixpilldeps] Changesets was noting that the pill package had dependencies that were older than what it should be depending on - so I updated things

### DIFF
--- a/.changeset/shy-singers-report.md
+++ b/.changeset/shy-singers-report.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-pill": patch
+---
+
+Fix up dependency versions

--- a/packages/wonder-blocks-pill/package.json
+++ b/packages/wonder-blocks-pill/package.json
@@ -16,10 +16,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@khanacademy/wonder-blocks-clickable": "^3.1.2",
+    "@khanacademy/wonder-blocks-clickable": "^4.0.2",
     "@khanacademy/wonder-blocks-color": "^2.0.1",
-    "@khanacademy/wonder-blocks-core": "^5.3.1",
-    "@khanacademy/wonder-blocks-link": "^4.3.1",
+    "@khanacademy/wonder-blocks-core": "^6.0.1",
+    "@khanacademy/wonder-blocks-link": "^5.0.2",
     "@khanacademy/wonder-blocks-spacing": "^4.0.1",
     "@khanacademy/wonder-blocks-typography": "^2.1.1"
   },


### PR DESCRIPTION
## Summary:
When running `yarn changeset` it noted:

```
Package "@khanacademy/wonder-blocks-pill" must depend on the current version of "@khanacademy/wonder-blocks-clickable": "4.0.2" vs "^3.1.2"
Package "@khanacademy/wonder-blocks-pill" must depend on the current version of "@khanacademy/wonder-blocks-core": "6.0.1" vs "^5.3.1"
Package "@khanacademy/wonder-blocks-pill" must depend on the current version of "@khanacademy/wonder-blocks-link": "5.0.2" vs "^4.3.1"
```

I am assuming these are the versions of these packages when pill was first created and as such, they should be the minimum version it depends on. So I've updated the package.json accordingly.

Issue: XXX-XXXX

## Test plan:
`yarn changeset` and see that the warnings no longer appear.