### PR TITLE
Provide better debug component name for withActionScheduler HoC

### DIFF
--- a/.changeset/curly-zoos-guess.md
+++ b/.changeset/curly-zoos-guess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-timing": patch
+---
+
+Provide a friendly name (for dev tools) for withActionScheduler

--- a/packages/wonder-blocks-timing/src/components/with-action-scheduler.tsx
+++ b/packages/wonder-blocks-timing/src/components/with-action-scheduler.tsx
@@ -18,11 +18,20 @@ type WithoutActionScheduler<T> = Omit<T, "schedule">;
 export default function withActionScheduler<
     Props extends WithActionSchedulerProps,
 >(WrappedComponent: React.ComponentType<Props>) {
-    return (props: WithoutActionScheduler<Props>) => (
+    const displayName = `withActionScheduler(${
+        WrappedComponent.displayName || WrappedComponent.name
+    })`;
+
+    const C = (props: WithoutActionScheduler<Props>) => (
         <ActionSchedulerProvider>
             {(schedule: IScheduleActions) => (
                 <WrappedComponent {...(props as Props)} schedule={schedule} />
             )}
         </ActionSchedulerProvider>
     );
+
+    C.displayName = displayName;
+    C.WrappedComponent = WrappedComponent;
+
+    return C;
 }

--- a/packages/wonder-blocks-timing/src/components/with-action-scheduler.tsx
+++ b/packages/wonder-blocks-timing/src/components/with-action-scheduler.tsx
@@ -31,7 +31,6 @@ export default function withActionScheduler<
     );
 
     C.displayName = displayName;
-    C.WrappedComponent = WrappedComponent;
 
     return C;
 }


### PR DESCRIPTION
## Summary:

When a component is wrapped with `withActionScheduler`, the React dev tools aren't able to derive a meaningful name for the wrapping component. This PR uses a [trick](https://github.com/remix-run/react-router/blob/7a891467987b164b64f39eaf72415b609ed2d4a7/packages/react-router/modules/withRouter.js) I learned from `react-router` to provide a friendly name for the wrapping component. 

Issue: "none"

## Test plan:

Run an app that uses `withActionScheduler`
Inspect a page using the React dev tools and note that the component created by `withActionScheduler` is named `withActionSchedule(SomeComponent)`.