### PR TITLE
[fei5235.4.cacheadaptercomponents] Cache adapter components so we reuse the same one rather than causing remounting by auto-generating them

### DIFF
--- a/.changeset/chatty-chicken-listen.md
+++ b/.changeset/chatty-chicken-listen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": minor
+---
+
+Fix bug where the test harness was causing the component under test to be remounted when rerendering instead of reusing the existing instance

--- a/packages/wonder-blocks-testing/src/harness/adapt.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapt.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import {getNamedAdapterComponent} from "./get-named-adapter-component";
+
 import type {TestHarnessConfigs, TestHarnessAdapters} from "./types";
 
 type Props<TAdapters extends TestHarnessAdapters> = {
@@ -20,17 +22,20 @@ export const Adapt = <TAdapters extends TestHarnessAdapters>({
     children,
     adapters,
     configs,
-}: Props<TAdapters>): React.ReactElement =>
+}: Props<TAdapters>): React.ReactElement => {
     // Here we reduce the adapters in order, such that each one becomes the
     // child of the next, that way the first adapter in the list is the
     // innermost and the last is the outermost.
-    Object.entries(adapters).reduce((newChildren, [name, adapter]) => {
-        const config = configs[name];
-        if (config == null) {
+    return Object.entries(adapters).reduce((newChildren, [name, adapter]) => {
+        const theConfig = configs[name];
+        if (theConfig == null) {
             return newChildren;
         }
-        const Adapter: React.FunctionComponent = ({children}) =>
-            adapter(children, config);
-        Adapter.displayName = `Adapter(${name})`;
-        return <Adapter>{newChildren}</Adapter>;
+        const Adapter = getNamedAdapterComponent(name);
+        return (
+            <Adapter key={name} adapter={adapter} config={theConfig}>
+                {newChildren}
+            </Adapter>
+        );
     }, <>{children}</>);
+};

--- a/packages/wonder-blocks-testing/src/harness/get-named-adapter-component.tsx
+++ b/packages/wonder-blocks-testing/src/harness/get-named-adapter-component.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import type {TestHarnessAdapter} from "./types";
+
+type Props<TConfig = any> = {
+    children: React.ReactNode;
+    config: TConfig;
+    adapter: TestHarnessAdapter<TConfig>;
+};
+
+const componentCache = new Map<string, React.FunctionComponent<Props>>();
+
+/**
+ * Get a component tagged with the given name for rendering an adapter.
+ *
+ * We can share these across invocations because only the name is used.
+ * The rest is configured at render time. This way we don't recreate new
+ * components on the fly and cause remounting to occur.
+ */
+export const getNamedAdapterComponent = (name: string) => {
+    // If we already have this component, just return it.
+    const existing = componentCache.get(name);
+    if (existing != null) {
+        return existing;
+    }
+
+    // Otherwise, create a new component, name it, cache it, and return it.
+    const newComponent: React.FunctionComponent<Props> = ({
+        children,
+        config,
+        adapter,
+    }: any) => adapter(children, config);
+    newComponent.displayName = `Adapter(${name})`;
+    componentCache.set(name, newComponent);
+    return newComponent;
+};


### PR DESCRIPTION
## Summary:
My change to add a name to each adapter component broke our testing because it meant that every render of the harness would cause things to remount unnecessarily.

This works around that problem by caching the named components so they can be reused across renders. This works great since only the name changes; everything else is done at render time, allowing even different adapters with the same name to share a cached component.

I also added a test case to capture the non-cached situation to show that things are not remounting in this new implementation (comment out the cache retrieval step in `getNamedAdapterComponent` to see the test fail).

Issue: FEI-5235

## Test plan:
`yarn test`
`yarn typecheck`

Putting this into my PR for adding the new `ssr` test harness adapter to webapp will show that it works. Currently, with the old "remounting" bug, there were a number of test failures. Now, with this change, they should just pass.