### PR TITLE
Fix the return type of useLatestRef

### DIFF
--- a/.changeset/wild-guests-protect.md
+++ b/.changeset/wild-guests-protect.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Change the return type of `useLatestRef` from `RefObject<T>` to
+`{readonly current: T}`, so the `current` property is not nullable.
+
+This fixes a bug introduced by the migration to TypeScript.

--- a/__docs__/wonder-blocks-core/exports.use-latest-ref.stories.mdx
+++ b/__docs__/wonder-blocks-core/exports.use-latest-ref.stories.mdx
@@ -19,7 +19,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 # useLatestRef()
 
 ```ts
-function useLatestRef<T>(value: T): React.RefObject<T>;
+function useLatestRef<T>(value: T): {readonly current: T};
 ```
 
 The `useLatestRef` hook returns a ref that always contains the `value` passed

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.test.ts
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.test.ts
@@ -37,4 +37,15 @@ describe("useLatestRef", () => {
         // Assert
         expect(result.current).toBe(refFromFirstRender);
     });
+
+    // Type tests
+    const _ = () => {
+        // The correct, non-nullable type should be inferred for `current`.
+        useLatestRef(123) satisfies {current: number};
+        // The return value should be assignable to React's ref types.
+        useLatestRef(123) satisfies React.RefObject<number>;
+        useLatestRef(123) satisfies React.MutableRefObject<number>;
+        // @ts-expect-error the result should not be assignable to the wrong type
+        useLatestRef(123) satisfies {current: string};
+    };
 });

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.test.ts
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.test.ts
@@ -37,15 +37,4 @@ describe("useLatestRef", () => {
         // Assert
         expect(result.current).toBe(refFromFirstRender);
     });
-
-    // Type tests
-    const _ = () => {
-        // The correct, non-nullable type should be inferred for `current`.
-        useLatestRef(123) satisfies {current: number};
-        // The return value should be assignable to React's ref types.
-        useLatestRef(123) satisfies React.RefObject<number>;
-        useLatestRef(123) satisfies React.MutableRefObject<number>;
-        // @ts-expect-error the result should not be assignable to the wrong type
-        useLatestRef(123) satisfies {current: string};
-    };
 });

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.typestest.ts
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.typestest.ts
@@ -1,21 +1,21 @@
+// Suppress the linter so we can call hooks at the top level.
+/* eslint-disable react-hooks/rules-of-hooks */
 import * as React from "react";
 import {useLatestRef} from "../use-latest-ref";
 
-const _ = () => {
-    // The correct, non-nullable type should be inferred for `current`.
-    useLatestRef(123) satisfies {current: number};
+// The correct, non-nullable type should be inferred for `current`.
+useLatestRef(123) satisfies {current: number};
 
-    // The return value should be assignable to React's ref types.
-    useLatestRef(123) satisfies React.RefObject<number>;
-    useLatestRef(123) satisfies React.MutableRefObject<number>;
+// The return value should be assignable to React's ref types.
+useLatestRef(123) satisfies React.RefObject<number>;
+useLatestRef(123) satisfies React.MutableRefObject<number>;
 
-    // @ts-expect-error the result should not be assignable to the wrong type
-    useLatestRef(123) satisfies {current: string};
+// @ts-expect-error the result should not be assignable to the wrong type
+useLatestRef(123) satisfies {current: string};
 
-    {
-        // The `current` property of the returned object should be readonly
-        const ref = useLatestRef("");
-        // @ts-expect-error the current property should be readonly
-        ref.current = "changed";
-    }
-};
+{
+    // The `current` property of the returned object should be readonly
+    const ref = useLatestRef("");
+    // @ts-expect-error the current property should be readonly
+    ref.current = "changed";
+}

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.typestest.ts
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.typestest.ts
@@ -1,18 +1,21 @@
+import * as React from "react";
 import {useLatestRef} from "../use-latest-ref";
 
-// The correct, non-nullable type should be inferred for `current`.
-useLatestRef(123) satisfies {current: number};
+const _ = () => {
+    // The correct, non-nullable type should be inferred for `current`.
+    useLatestRef(123) satisfies {current: number};
 
-// The return value should be assignable to React's ref types.
-useLatestRef(123) satisfies React.RefObject<number>;
-useLatestRef(123) satisfies React.MutableRefObject<number>;
+    // The return value should be assignable to React's ref types.
+    useLatestRef(123) satisfies React.RefObject<number>;
+    useLatestRef(123) satisfies React.MutableRefObject<number>;
 
-// @ts-expect-error the result should not be assignable to the wrong type
-useLatestRef(123) satisfies {current: string};
+    // @ts-expect-error the result should not be assignable to the wrong type
+    useLatestRef(123) satisfies {current: string};
 
-{
-    // The `current` property of the returned object should be readonly
-    const ref = useLatestRef("")
-    // @ts-expect-error the current property should be readonly
-    ref.current = "changed"
-}
+    {
+        // The `current` property of the returned object should be readonly
+        const ref = useLatestRef("");
+        // @ts-expect-error the current property should be readonly
+        ref.current = "changed";
+    }
+};

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.typestest.ts
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-latest-ref.typestest.ts
@@ -1,0 +1,18 @@
+import {useLatestRef} from "../use-latest-ref";
+
+// The correct, non-nullable type should be inferred for `current`.
+useLatestRef(123) satisfies {current: number};
+
+// The return value should be assignable to React's ref types.
+useLatestRef(123) satisfies React.RefObject<number>;
+useLatestRef(123) satisfies React.MutableRefObject<number>;
+
+// @ts-expect-error the result should not be assignable to the wrong type
+useLatestRef(123) satisfies {current: string};
+
+{
+    // The `current` property of the returned object should be readonly
+    const ref = useLatestRef("")
+    // @ts-expect-error the current property should be readonly
+    ref.current = "changed"
+}

--- a/packages/wonder-blocks-core/src/hooks/use-latest-ref.ts
+++ b/packages/wonder-blocks-core/src/hooks/use-latest-ref.ts
@@ -10,7 +10,7 @@ import * as React from "react";
  * be passed to useEffect without causing unnecessary re-renders. See the
  * Storybook docs for a usage example.
  */
-export function useLatestRef<T>(value: T): React.RefObject<T> {
+export function useLatestRef<T>(value: T): {readonly current: T} {
     const ref = React.useRef(value);
     ref.current = value;
     return ref;


### PR DESCRIPTION
## Summary:
React defines the RefObject type as:

```
interface RefObject<T> {
  readonly current: T | null;
}
```

Previously, the `useLatestRef` hook was typed to return `RefObject<T>`,
but that wasn't really correct. The `current` value returned by
`useLatestRef` cannot be null if `T` is not nullable.

This commit changes the return type to `{readonly current: T}`.

Issue: none

## Test plan:

Run `yarn start` to launch Storybook.

View the documentation for `useLatestRef`. The return type should be `React.MutableRefObject<T>`.

`yarn lint`, `yarn test`, and `yarn typecheck` should pass.