### PR TITLE
[🔥AUDIT🔥] [ssradaptertweak] Don't throw when the ssr adapter is nested

### DIFF
--- a/.changeset/lucky-zoos-heal.md
+++ b/.changeset/lucky-zoos-heal.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": patch
+---
+
+Make sure ssr adapter doesn't throw if it gets nested

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/__snapshots__/ssr.test.tsx.snap
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/__snapshots__/ssr.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SSR.adapter should throw on bad configuration ({"thisConfig": "isNotValid"}) 1`] = `"Unexpected configuration: set config to null to turn this adapter off"`;
+
+exports[`SSR.adapter should throw on bad configuration (false) 1`] = `"Unexpected configuration: set config to null to turn this adapter off"`;
+
+exports[`SSR.adapter should throw on bad configuration (string) 1`] = `"Unexpected configuration: set config to null to turn this adapter off"`;

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/ssr.test.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/ssr.test.tsx
@@ -16,7 +16,7 @@ jest.mock("@khanacademy/wonder-stuff-core", () => {
 });
 
 describe("SSR.adapter", () => {
-    it("should render the RenderStateRoot", () => {
+    it("should render the RenderStateRoot with throwIfNested set to false", () => {
         // Arrange
         const children = <div>CHILDREN!</div>;
         const renderStateRootSpy = jest.spyOn(WBCore, "RenderStateRoot");
@@ -28,6 +28,7 @@ describe("SSR.adapter", () => {
         expect(renderStateRootSpy).toHaveBeenCalledWith(
             {
                 children,
+                throwIfNested: false,
             },
             {},
         );
@@ -67,16 +68,19 @@ describe("SSR.adapter", () => {
         expect(underTest).not.toThrowError();
     });
 
-    it("should throw on bad configuration", () => {
+    it.each`
+        config
+        ${false}
+        ${"string"}
+        ${{thisConfig: "isNotValid"}}
+    `("should throw on bad configuration ($config)", ({config}) => {
         // Arrange
         const children = <div>CHILDREN!</div>;
 
         // Act
-        const underTest = () => render(SSR.adapter(children, false as any));
+        const underTest = () => render(SSR.adapter(children, config));
 
         // Assert
-        expect(underTest).toThrowErrorMatchingInlineSnapshot(
-            `"Unexpected configuration: set config to null to turn this adapter off"`,
-        );
+        expect(underTest).toThrowErrorMatchingSnapshot();
     });
 });

--- a/packages/wonder-blocks-testing/src/harness/adapters/ssr.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/ssr.tsx
@@ -4,14 +4,13 @@ import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 
 import type {TestHarnessAdapter} from "../types";
 
-// We only support one configuration for this adapter; the default
-// behavior - it's either on or off.
-type Config = true | null;
+//
+type Config = true;
 
 // The default configuration is off since this will likely cause state changes
 // and add Testing Library act/waitFor calls in tests using the harness when
 // its enabled.
-export const defaultConfig: Config = null;
+export const defaultConfig: Config | null = null;
 
 /**
  * Test harness adapter for supporting portals.
@@ -33,5 +32,6 @@ export const adapter: TestHarnessAdapter<Config> = (
             },
         );
     }
-    return <RenderStateRoot>{children}</RenderStateRoot>;
+    // We never want to throw if the test harness is nested.
+    return <RenderStateRoot throwIfNested={false}>{children}</RenderStateRoot>;
 };


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
There are times, like in our storybook stories, where we may nest harnessed components. We should be passive when doing that, which means not throwing just because we're nested.

Issue: XXX-XXXX

## Test plan:
`yarn test`
`yarn typecheck`