### PR TITLE
Allow 'title' as a prop on Clickable

### DIFF
--- a/.changeset/thick-frogs-warn.md
+++ b/.changeset/thick-frogs-warn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Allow 'title' as a prop on Clickable

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -91,6 +91,7 @@ type CommonProps =
          * Set the tabindex attribute on the rendered element.
          */
         tabIndex?: number;
+        title?: string;
         /**
          * Run async code before navigating. If the promise returned rejects then
          * navigation will not occur.

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -91,6 +91,9 @@ type CommonProps =
          * Set the tabindex attribute on the rendered element.
          */
         tabIndex?: number;
+        /**
+         * An optional title attribute.
+         */
         title?: string;
         /**
          * Run async code before navigating. If the promise returned rejects then


### PR DESCRIPTION
## Summary:
We're passing 'title' to Clickable in a number of places in webapp.  When I havemore time I'll fix this in a comprehensive way so that we aren't playing whack-a-mole.

Issue: None

## Test plan:
- n/a, yolo