### PR TITLE
[🔥AUDIT🔥] [fei5275.3.actuallyexporthook] Actually export the new hook

### DIFF
--- a/.changeset/flat-sloths-sit.md
+++ b/.changeset/flat-sloths-sit.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Add new usePreHydrationEffect hook to module exports

--- a/packages/wonder-blocks-core/src/index.ts
+++ b/packages/wonder-blocks-core/src/index.ts
@@ -21,6 +21,7 @@ export {useIsMounted} from "./hooks/use-is-mounted";
 export {useLatestRef} from "./hooks/use-latest-ref";
 export {useOnMountEffect} from "./hooks/use-on-mount-effect";
 export {useOnline} from "./hooks/use-online";
+export {usePreHydrationEffect} from "./hooks/use-pre-hydration-effect";
 export {useRenderState} from "./hooks/use-render-state";
 export {RenderStateRoot} from "./components/render-state-root";
 export {RenderState} from "./components/render-state-context";


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This exports the new `usePreHydrationEffect` hook from Wonder Blocks Core, which I forgot to do in the last PR. 🤦🏻‍♂️

Issue: FEI-5275

## Test plan:
`yarn build` and check the output.