### PR TITLE
[fei5275.3.removedepsfromprehydrationeffect] Remove deps arg from usePreHydrationEffect

### DIFF
--- a/.changeset/thin-feet-shave.md
+++ b/.changeset/thin-feet-shave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Remove deps argument from `usePreHydrationEffect`

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -183,12 +183,7 @@ module.exports = {
          * react-hooks rules
          */
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": [
-            "error",
-            {
-                additionalHooks: "(usePreHydrationEffect)",
-            },
-        ],
+        "react-hooks/exhaustive-deps": "error",
 
         /**
          * testing-library rules

--- a/__docs__/wonder-blocks-core/exports.use-pre-hydration-effect.stories.mdx
+++ b/__docs__/wonder-blocks-core/exports.use-pre-hydration-effect.stories.mdx
@@ -14,12 +14,11 @@ import {Meta} from "@storybook/blocks";
 ```ts
 function usePreHydrationEffect(
     effect: EffectCallback,
-    deps?: DependencyList,
 ): void);
 ```
 
 The `usePreHydrationEffect` hook provides means to run some code during the
-initial render cycle. It is a drop-in replacement for the `useLayoutEffect` hook except that it does not cause an error during server-side rendering.
+initial render cycle. It is a drop-in replacement for the `useLayoutEffect` hook except that it does not cause an error during server-side rendering and it only runs once - there are no dependencies to specify.
 
 It is highly recommended that you use `useLayoutEffect` in your components unless you are certain that you need the functionality provided here, you have reliable testing for hydration errors, and you understand the implications of using this hook.
 
@@ -27,19 +26,3 @@ Because it runs pre-hydration, it should never be used for anything that might
 change the rendered output or the DOM as that will cause hydration errors. It
 should only be used for things like setting up event listeners or other
 side-effects that do not affect the rendered output.
-
-When using `eslint`, you can get exhaustive dependency checks for this hook by updating your configuration for the `react-hooks/exhaustive-deps` rule:
-
-For example:
-```json
-{
-    "rules": {
-        "react-hooks/exhaustive-deps": [
-            "error",
-            {
-                "additionalHooks": "(usePreHydrationEffect)"
-            }
-        ]
-    }
-}
-```

--- a/packages/wonder-blocks-core/src/hooks/__tests__/use-pre-hydration-effect.test.tsx
+++ b/packages/wonder-blocks-core/src/hooks/__tests__/use-pre-hydration-effect.test.tsx
@@ -27,13 +27,12 @@ describe("usePreHydrationEffect", () => {
             // Arrange
             const useLayoutEffectSpy = jest.spyOn(React, "useLayoutEffect");
             const effect = () => {};
-            const deps = ["foo", "bar"];
 
             // Act
-            renderHook(() => usePreHydrationEffect(effect, deps));
+            renderHook(() => usePreHydrationEffect(effect));
 
             // assert
-            expect(useLayoutEffectSpy).toHaveBeenCalledWith(effect, deps);
+            expect(useLayoutEffectSpy).toHaveBeenCalledWith(effect, []);
         });
 
         it("should cause an error if statically rendered (i.e. rendered server-side)", () => {
@@ -47,7 +46,7 @@ describe("usePreHydrationEffect", () => {
                     /* no-op */
                 });
             const Component = () => {
-                usePreHydrationEffect(() => {}, []);
+                usePreHydrationEffect(() => {});
                 return null;
             };
 
@@ -75,7 +74,7 @@ describe("usePreHydrationEffect", () => {
                     /* no-op */
                 });
             const Component = () => {
-                usePreHydrationEffect(() => {}, []);
+                usePreHydrationEffect(() => {});
                 return null;
             };
 

--- a/packages/wonder-blocks-core/src/hooks/use-pre-hydration-effect.ts
+++ b/packages/wonder-blocks-core/src/hooks/use-pre-hydration-effect.ts
@@ -17,10 +17,12 @@ import Server from "../util/server";
  * that won't affect the current render. In those cases, rather than erroring,
  * we want the server side to just silently no-op like `useEffect` calls do.
  * This hook allows that but should be used with extreme care.
+ *
+ * @param effect The effect to run.
  */
-export const usePreHydrationEffect: typeof React.useLayoutEffect = (
-    ...args
-): void => {
+export const usePreHydrationEffect: (effect: React.EffectCallback) => void = (
+    effect,
+) => {
     // We are breaking the rules of hooks here by calling a hook conditionally,
     // but that's OK since effects don't run on the server anyway. If we don't
     // do this, `useLayoutEffect` will give an error when rendered on the
@@ -39,5 +41,7 @@ export const usePreHydrationEffect: typeof React.useLayoutEffect = (
             : React.useLayoutEffect,
     );
 
-    effectCallRef.current(...args);
+    effectCallRef.current(effect, [
+        /* no-deps: this only runs the very first time */
+    ]);
 };


### PR DESCRIPTION
## Summary:
With the very specific naming and purpose of this hook, we don't want any dependencies, so this removes them.

I made this a minor update to the package; it's a breaking change to typing but not functionality, and nothing should be using this yet outside my code. I could've added some typing to allow an empty deps array only but that seemed pointless.

Issue: FEI-5275

## Test plan:
`yarn typecheck`