### PR TITLE
Add new xsmall, small, and medium size prop to IconButton

### DIFF
--- a/.changeset/odd-spiders-cry.md
+++ b/.changeset/odd-spiders-cry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": minor
+---
+
+Add size prop to icon button

--- a/__docs__/wonder-blocks-icon-button/icon-button.argtypes.ts
+++ b/__docs__/wonder-blocks-icon-button/icon-button.argtypes.ts
@@ -1,0 +1,38 @@
+import {icons} from "@khanacademy/wonder-blocks-icon";
+
+export default {
+    color: {
+        control: {
+            type: "select",
+        },
+        description: "Color of the icon button.",
+        options: ["default", "destructive"],
+    },
+    disabled: {
+        control: {
+            type: "boolean",
+        },
+        description: "Whether the icon button is disabled.",
+    },
+    icon: {
+        control: {
+            type: "select",
+        },
+        description: "Icon to use.",
+        options: icons,
+    },
+    kind: {
+        control: {
+            type: "select",
+        },
+        description: "The kind of the icon button.",
+        options: ["primary", "secondary", "tertiary"],
+    },
+    size: {
+        control: {
+            type: "select",
+        },
+        description: "The size of the icon button.",
+        options: ["xsmall", "small", "medium"],
+    },
+};

--- a/__docs__/wonder-blocks-icon-button/icon-button.argtypes.ts
+++ b/__docs__/wonder-blocks-icon-button/icon-button.argtypes.ts
@@ -7,6 +7,14 @@ export default {
         },
         description: "Color of the icon button.",
         options: ["default", "destructive"],
+        table: {
+            type: {
+                summary: `"default" | "destructive"`,
+            },
+            defaultValue: {
+                summary: `"default"`,
+            },
+        },
     },
     disabled: {
         control: {
@@ -27,6 +35,14 @@ export default {
         },
         description: "The kind of the icon button.",
         options: ["primary", "secondary", "tertiary"],
+        table: {
+            type: {
+                summary: `"primary" | "secondary" | "tertiary"`,
+            },
+            defaultValue: {
+                summary: `"primary"`,
+            },
+        },
     },
     size: {
         control: {
@@ -34,5 +50,13 @@ export default {
         },
         description: "The size of the icon button.",
         options: ["xsmall", "small", "medium"],
+        table: {
+            type: {
+                summary: `"xsmall" | "small" | "medium"`,
+            },
+            defaultValue: {
+                summary: `"medium"`,
+            },
+        },
     },
 };

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -7,15 +7,17 @@ import type {Meta, StoryObj} from "@storybook/react";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {icons} from "@khanacademy/wonder-blocks-icon";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-icon-button/package.json";
+import IconButtonArgtypes from "./icon-button.argtypes";
 
 export default {
-    title: "IconButton / IconButton",
+    title: "IconButton",
     component: IconButton,
     parameters: {
         componentSubtitle: (
@@ -25,11 +27,7 @@ export default {
             />
         ),
     },
-    argTypes: {
-        icon: {
-            options: icons,
-        },
-    },
+    argTypes: IconButtonArgtypes,
 } as Meta<typeof IconButton>;
 
 type StoryComponentType = StoryObj<typeof IconButton>;
@@ -38,7 +36,9 @@ export const Default: StoryComponentType = {
     args: {
         icon: icons.search,
         color: "default",
+        disabled: false,
         kind: "primary",
+        size: "medium",
 
         onClick: (e: React.SyntheticEvent) => {
             console.log("Click!");
@@ -62,143 +62,161 @@ Basic.parameters = {
     },
 };
 
-export const Variants: StoryComponentType = () => {
+/**
+ * Icon buttons can be one of three sizes: `xsmall` (16px icon with a 24px touch target),
+ * `small` (24px icon with a 32px touch target), and `medium` (24px icon with a 40px touch target).
+ * The default size is `medium`.
+ */
+export const Sizes: StoryComponentType = (() => {
     return (
-        <View style={{flexDirection: "row"}}>
-            <IconButton
-                icon={icons.search}
-                aria-label="search"
-                onClick={(e) => console.log("Click!")}
-            />
-            <Strut size={Spacing.medium_16} />
-            <IconButton
-                icon={icons.search}
-                aria-label="search"
-                kind="secondary"
-                onClick={(e) => console.log("Click!")}
-            />
-            <Strut size={Spacing.medium_16} />
-            <IconButton
-                icon={icons.search}
-                aria-label="search"
-                kind="tertiary"
-                onClick={(e) => console.log("Click!")}
-            />
-            <Strut size={Spacing.medium_16} />
-            <IconButton
-                disabled={true}
-                icon={icons.search}
-                aria-label="search"
-                onClick={(e) => console.log("Click!")}
-            />
+        <View style={{flexDirection: "column"}}>
+            <View style={styles.row}>
+                <LabelMedium style={styles.label}>xsmall</LabelMedium>
+                <IconButton
+                    icon={icons.search}
+                    size="xsmall"
+                    aria-label="search"
+                    onClick={(e) => console.log("Click!")}
+                />
+            </View>
+            <Strut size={Spacing.large_24} />
+            <View style={styles.row}>
+                <LabelMedium style={styles.label}>small</LabelMedium>
+                <IconButton
+                    icon={icons.search}
+                    size="small"
+                    aria-label="search"
+                    onClick={(e) => console.log("Click!")}
+                />
+            </View>
+            <Strut size={Spacing.large_24} />
+            <View style={styles.row}>
+                <LabelMedium style={styles.label}>medium</LabelMedium>
+                <IconButton
+                    icon={icons.search}
+                    size="medium"
+                    aria-label="search"
+                    onClick={(e) => console.log("Click!")}
+                />
+            </View>
         </View>
     );
-};
+}) as StoryComponentType;
 
-Variants.parameters = {
-    docs: {
-        description: {
-            story: `In this example, we have primary, secondary,
-            tertiary, and disabled \`IconButton\`s from left to right.`,
-        },
+/**
+ * In this example, we have primary, secondary, tertiary,
+ * and disabled `IconButton`s from left to right.
+ */
+export const Variants: StoryComponentType = {
+    render: () => {
+        return (
+            <View style={styles.row}>
+                <IconButton
+                    icon={icons.search}
+                    aria-label="search"
+                    onClick={(e) => console.log("Click!")}
+                />
+                <IconButton
+                    icon={icons.search}
+                    aria-label="search"
+                    kind="secondary"
+                    onClick={(e) => console.log("Click!")}
+                />
+                <IconButton
+                    icon={icons.search}
+                    aria-label="search"
+                    kind="tertiary"
+                    onClick={(e) => console.log("Click!")}
+                />
+                <IconButton
+                    disabled={true}
+                    icon={icons.search}
+                    aria-label="search"
+                    onClick={(e) => console.log("Click!")}
+                />
+            </View>
+        );
     },
 };
 
-export const Light: StoryComponentType = () => {
-    return (
-        <View style={styles.dark}>
-            <IconButton
-                icon={icons.search}
-                aria-label="search"
-                light={true}
-                onClick={(e) => console.log("Click!")}
-            />
-        </View>
-    );
-};
-
-Light.parameters = {
-    docs: {
-        description: {
-            story: `An IconButton on a dark background.
-            Only the primary kind is allowed to have the \`light\`
-            prop set to true.`,
-        },
+/**
+ * An IconButton on a dark background.
+ * Only the primary kind is allowed to have the `light` prop set to true.
+ */
+export const Light: StoryComponentType = {
+    render: () => {
+        return (
+            <View style={styles.dark}>
+                <IconButton
+                    icon={icons.search}
+                    aria-label="search"
+                    light={true}
+                    onClick={(e) => console.log("Click!")}
+                />
+            </View>
+        );
     },
 };
 
-export const DisabledLight: StoryComponentType = () => {
-    return (
-        <View style={styles.dark}>
-            <IconButton
-                disabled={true}
-                icon={icons.search}
-                aria-label="search"
-                light={true}
-                onClick={(e) => console.log("Click!")}
-            />
-        </View>
-    );
-};
-
-DisabledLight.parameters = {
-    docs: {
-        description: {
-            story: "This is a disabled icon button with the `light` prop set to true.",
-        },
+/**
+ * This is a disabled icon button with the `light` prop set to true.
+ */
+export const DisabledLight: StoryComponentType = {
+    render: () => {
+        return (
+            <View style={styles.dark}>
+                <IconButton
+                    disabled={true}
+                    icon={icons.search}
+                    aria-label="search"
+                    light={true}
+                    onClick={(e) => console.log("Click!")}
+                />
+            </View>
+        );
     },
 };
 
-export const UsingHref: StoryComponentType = () => {
-    return (
-        <IconButton
-            icon={icons.info}
-            aria-label="More information"
-            href="/"
-            target="_blank"
-            onClick={(e) => console.log("Click!")}
-        />
-    );
-};
-
-UsingHref.parameters = {
-    docs: {
-        description: {
-            story: `This example has an \`href\` prop in addition to the
-            \`onClick\` prop. \`href\` takes a URL or path, and clicking the
-            icon button will result in a navigation to the specified page.
-            Note that \`onClick\` is not required if \`href\` is defined.
-            The \`target="_blank"\` prop will cause the href page to open in
-            a new tab.`,
-        },
+/**
+ * This example has an `href` prop in addition to the `onClick` prop. `href` takes a URL or path,
+ * and clicking the icon button will result in a navigation to the specified page. Note that
+ * `onClick` is not required if `href` is defined. The `target="_blank"` prop will cause the href
+ *  page to open in a new tab.
+ */
+export const UsingHref: StoryComponentType = {
+    render: () => {
+        return (
+            <IconButton
+                icon={icons.info}
+                aria-label="More information"
+                href="/"
+                target="_blank"
+                onClick={(e) => console.log("Click!")}
+            />
+        );
     },
 };
 
-export const WithAriaLabel: StoryComponentType = () => {
-    return (
-        <View style={styles.arrowsWrapper}>
-            <IconButton
-                icon={icons.caretLeft}
-                onClick={(e) => console.log("Click!")}
-                aria-label="Previous page"
-            />
-            <IconButton
-                icon={icons.caretRight}
-                onClick={(e) => console.log("Click!")}
-                aria-label="Next page"
-            />
-        </View>
-    );
-};
-
-WithAriaLabel.parameters = {
-    docs: {
-        description: {
-            story: `By default, the icon buttons do not have
-            accessible names. The \`aria-label\` prop must be used to explain
-            the function of the button. Remember to keep the description
-            concise but understandable.`,
-        },
+/**
+ * By default, the icon buttons do not have accessible names. The `aria-label` prop must be used
+ * to explain the function of the button. Remember to keep the description concise but understandable.
+ */
+export const WithAriaLabel: StoryComponentType = {
+    render: () => {
+        return (
+            <View style={styles.arrowsWrapper}>
+                <IconButton
+                    icon={icons.caretLeft}
+                    onClick={(e) => console.log("Click!")}
+                    aria-label="Previous page"
+                />
+                <IconButton
+                    icon={icons.caretRight}
+                    onClick={(e) => console.log("Click!")}
+                    aria-label="Next page"
+                />
+            </View>
+        );
     },
 };
 
@@ -210,6 +228,14 @@ const styles = StyleSheet.create({
     arrowsWrapper: {
         flexDirection: "row",
         justifyContent: "space-between",
+        width: Spacing.xxxLarge_64,
+    },
+    row: {
+        flexDirection: "row",
+        gap: Spacing.medium_16,
+        alignItems: "center",
+    },
+    label: {
         width: Spacing.xxxLarge_64,
     },
 });

--- a/packages/wonder-blocks-icon-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-icon-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IconButtonCore kind:primary color:default size:default light:false disabled 1`] = `
+exports[`IconButtonCore kind:primary color:default size:medium light:false disabled 1`] = `
 <button
   aria-label="search"
   className=""
@@ -68,7 +68,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false disa
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:default size:default light:false focused 1`] = `
+exports[`IconButtonCore kind:primary color:default size:medium light:false focused 1`] = `
 <button
   aria-label="search"
   className=""
@@ -140,7 +140,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false focu
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:default size:default light:false hovered 1`] = `
+exports[`IconButtonCore kind:primary color:default size:medium light:false hovered 1`] = `
 <button
   aria-label="search"
   className=""
@@ -212,7 +212,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false hove
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:default size:default light:false pressed 1`] = `
+exports[`IconButtonCore kind:primary color:default size:medium light:false pressed 1`] = `
 <button
   aria-label="search"
   className=""
@@ -284,7 +284,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:false pres
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:default size:default light:true disabled 1`] = `
+exports[`IconButtonCore kind:primary color:default size:medium light:true disabled 1`] = `
 <button
   aria-label="search"
   className=""
@@ -352,7 +352,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:true disab
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:default size:default light:true focused 1`] = `
+exports[`IconButtonCore kind:primary color:default size:medium light:true focused 1`] = `
 <button
   aria-label="search"
   className=""
@@ -424,7 +424,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:true focus
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:default size:default light:true hovered 1`] = `
+exports[`IconButtonCore kind:primary color:default size:medium light:true hovered 1`] = `
 <button
   aria-label="search"
   className=""
@@ -496,7 +496,7 @@ exports[`IconButtonCore kind:primary color:default size:default light:true hover
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:default size:default light:true pressed 1`] = `
+exports[`IconButtonCore kind:primary color:default size:medium light:true pressed 1`] = `
 <button
   aria-label="search"
   className=""
@@ -600,7 +600,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
       "color": "rgba(33,36,44,0.32)",
       "cursor": "default",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -608,7 +608,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={-1}
@@ -672,7 +672,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -680,7 +680,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -744,7 +744,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -752,7 +752,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -816,7 +816,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -824,7 +824,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -884,7 +884,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
       "color": "#6296f6",
       "cursor": "default",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -892,7 +892,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={-1}
@@ -956,7 +956,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -964,7 +964,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -1028,7 +1028,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -1036,7 +1036,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -1100,7 +1100,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
       "color": "#b5cefb",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -1108,7 +1108,7 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -1136,7 +1136,575 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:destructive size:default light:false disabled 1`] = `
+exports[`IconButtonCore kind:primary color:default size:xsmall light:false disabled 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "boxSizing": "border-box",
+      "color": "rgba(33,36,44,0.32)",
+      "cursor": "default",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={-1}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:default size:xsmall light:false focused 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1865f2",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1865f2",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:default size:xsmall light:false hovered 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1865f2",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1865f2",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:default size:xsmall light:false pressed 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1b50b3",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1b50b3",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:default size:xsmall light:true disabled 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "boxSizing": "border-box",
+      "color": "#6296f6",
+      "cursor": "default",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={-1}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:default size:xsmall light:true focused 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#ffffff",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#ffffff",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:default size:xsmall light:true hovered 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#ffffff",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#ffffff",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:default size:xsmall light:true pressed 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#b5cefb",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#b5cefb",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:destructive size:medium light:false disabled 1`] = `
 <button
   aria-label="search"
   className=""
@@ -1204,7 +1772,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:destructive size:default light:false focused 1`] = `
+exports[`IconButtonCore kind:primary color:destructive size:medium light:false focused 1`] = `
 <button
   aria-label="search"
   className=""
@@ -1276,7 +1844,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:destructive size:default light:false hovered 1`] = `
+exports[`IconButtonCore kind:primary color:destructive size:medium light:false hovered 1`] = `
 <button
   aria-label="search"
   className=""
@@ -1348,7 +1916,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:destructive size:default light:false pressed 1`] = `
+exports[`IconButtonCore kind:primary color:destructive size:medium light:false pressed 1`] = `
 <button
   aria-label="search"
   className=""
@@ -1420,7 +1988,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:false 
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:destructive size:default light:true disabled 1`] = `
+exports[`IconButtonCore kind:primary color:destructive size:medium light:true disabled 1`] = `
 <button
   aria-label="search"
   className=""
@@ -1488,7 +2056,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true d
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:destructive size:default light:true focused 1`] = `
+exports[`IconButtonCore kind:primary color:destructive size:medium light:true focused 1`] = `
 <button
   aria-label="search"
   className=""
@@ -1560,7 +2128,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true f
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:destructive size:default light:true hovered 1`] = `
+exports[`IconButtonCore kind:primary color:destructive size:medium light:true hovered 1`] = `
 <button
   aria-label="search"
   className=""
@@ -1632,7 +2200,7 @@ exports[`IconButtonCore kind:primary color:destructive size:default light:true h
 </button>
 `;
 
-exports[`IconButtonCore kind:primary color:destructive size:default light:true pressed 1`] = `
+exports[`IconButtonCore kind:primary color:destructive size:medium light:true pressed 1`] = `
 <button
   aria-label="search"
   className=""
@@ -1736,7 +2304,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
       "color": "rgba(33,36,44,0.32)",
       "cursor": "default",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -1744,7 +2312,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={-1}
@@ -1808,7 +2376,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
       "color": "#d92916",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -1816,7 +2384,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -1880,7 +2448,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
       "color": "#d92916",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -1888,7 +2456,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -1952,7 +2520,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
       "color": "#9e271d",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -1960,7 +2528,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -2020,7 +2588,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
       "color": "#e56d61",
       "cursor": "default",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -2028,7 +2596,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={-1}
@@ -2092,7 +2660,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -2100,7 +2668,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -2164,7 +2732,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
       "color": "#ffffff",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -2172,7 +2740,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -2236,7 +2804,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
       "color": "#f3bbb4",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -2244,7 +2812,7 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -2272,7 +2840,575 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
 </button>
 `;
 
-exports[`IconButtonCore kind:secondary color:default size:default light:false disabled 1`] = `
+exports[`IconButtonCore kind:primary color:destructive size:xsmall light:false disabled 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "boxSizing": "border-box",
+      "color": "rgba(33,36,44,0.32)",
+      "cursor": "default",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={-1}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:destructive size:xsmall light:false focused 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#d92916",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#d92916",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:destructive size:xsmall light:false hovered 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#d92916",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#d92916",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:destructive size:xsmall light:false pressed 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#9e271d",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#9e271d",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:destructive size:xsmall light:true disabled 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "boxSizing": "border-box",
+      "color": "#e56d61",
+      "cursor": "default",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={-1}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:destructive size:xsmall light:true focused 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#ffffff",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#ffffff",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:destructive size:xsmall light:true hovered 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#ffffff",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#ffffff",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:primary color:destructive size:xsmall light:true pressed 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#f3bbb4",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#f3bbb4",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:secondary color:default size:medium light:false disabled 1`] = `
 <button
   aria-label="search"
   className=""
@@ -2340,7 +3476,7 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false di
 </button>
 `;
 
-exports[`IconButtonCore kind:secondary color:default size:default light:false focused 1`] = `
+exports[`IconButtonCore kind:secondary color:default size:medium light:false focused 1`] = `
 <button
   aria-label="search"
   className=""
@@ -2412,7 +3548,7 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false fo
 </button>
 `;
 
-exports[`IconButtonCore kind:secondary color:default size:default light:false hovered 1`] = `
+exports[`IconButtonCore kind:secondary color:default size:medium light:false hovered 1`] = `
 <button
   aria-label="search"
   className=""
@@ -2484,7 +3620,7 @@ exports[`IconButtonCore kind:secondary color:default size:default light:false ho
 </button>
 `;
 
-exports[`IconButtonCore kind:secondary color:default size:default light:false pressed 1`] = `
+exports[`IconButtonCore kind:secondary color:default size:medium light:false pressed 1`] = `
 <button
   aria-label="search"
   className=""
@@ -2588,7 +3724,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
       "color": "rgba(33,36,44,0.32)",
       "cursor": "default",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -2596,7 +3732,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={-1}
@@ -2660,7 +3796,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -2668,7 +3804,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -2732,7 +3868,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -2740,7 +3876,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -2804,7 +3940,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -2812,7 +3948,7 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -2840,7 +3976,291 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
 </button>
 `;
 
-exports[`IconButtonCore kind:secondary color:destructive size:default light:false disabled 1`] = `
+exports[`IconButtonCore kind:secondary color:default size:xsmall light:false disabled 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "boxSizing": "border-box",
+      "color": "rgba(33,36,44,0.32)",
+      "cursor": "default",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={-1}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:secondary color:default size:xsmall light:false focused 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1865f2",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1865f2",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:secondary color:default size:xsmall light:false hovered 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1865f2",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1865f2",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:secondary color:default size:xsmall light:false pressed 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1b50b3",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1b50b3",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:secondary color:destructive size:medium light:false disabled 1`] = `
 <button
   aria-label="search"
   className=""
@@ -2908,7 +4328,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
 </button>
 `;
 
-exports[`IconButtonCore kind:secondary color:destructive size:default light:false focused 1`] = `
+exports[`IconButtonCore kind:secondary color:destructive size:medium light:false focused 1`] = `
 <button
   aria-label="search"
   className=""
@@ -2980,7 +4400,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
 </button>
 `;
 
-exports[`IconButtonCore kind:secondary color:destructive size:default light:false hovered 1`] = `
+exports[`IconButtonCore kind:secondary color:destructive size:medium light:false hovered 1`] = `
 <button
   aria-label="search"
   className=""
@@ -3052,7 +4472,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:default light:fals
 </button>
 `;
 
-exports[`IconButtonCore kind:secondary color:destructive size:default light:false pressed 1`] = `
+exports[`IconButtonCore kind:secondary color:destructive size:medium light:false pressed 1`] = `
 <button
   aria-label="search"
   className=""
@@ -3156,7 +4576,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "color": "rgba(33,36,44,0.32)",
       "cursor": "default",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -3164,7 +4584,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={-1}
@@ -3228,7 +4648,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "color": "#d92916",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -3236,7 +4656,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -3300,7 +4720,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "color": "#d92916",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -3308,7 +4728,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -3372,7 +4792,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "color": "#9e271d",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -3380,7 +4800,7 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -3408,7 +4828,291 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
 </button>
 `;
 
-exports[`IconButtonCore kind:tertiary color:default size:default light:false disabled 1`] = `
+exports[`IconButtonCore kind:secondary color:destructive size:xsmall light:false disabled 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "boxSizing": "border-box",
+      "color": "rgba(33,36,44,0.32)",
+      "cursor": "default",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={-1}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:secondary color:destructive size:xsmall light:false focused 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#d92916",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#d92916",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:secondary color:destructive size:xsmall light:false hovered 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#d92916",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#d92916",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:secondary color:destructive size:xsmall light:false pressed 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#9e271d",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#9e271d",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:default size:medium light:false disabled 1`] = `
 <button
   aria-label="search"
   className=""
@@ -3476,7 +5180,7 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false dis
 </button>
 `;
 
-exports[`IconButtonCore kind:tertiary color:default size:default light:false focused 1`] = `
+exports[`IconButtonCore kind:tertiary color:default size:medium light:false focused 1`] = `
 <button
   aria-label="search"
   className=""
@@ -3548,7 +5252,7 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false foc
 </button>
 `;
 
-exports[`IconButtonCore kind:tertiary color:default size:default light:false hovered 1`] = `
+exports[`IconButtonCore kind:tertiary color:default size:medium light:false hovered 1`] = `
 <button
   aria-label="search"
   className=""
@@ -3620,7 +5324,7 @@ exports[`IconButtonCore kind:tertiary color:default size:default light:false hov
 </button>
 `;
 
-exports[`IconButtonCore kind:tertiary color:default size:default light:false pressed 1`] = `
+exports[`IconButtonCore kind:tertiary color:default size:medium light:false pressed 1`] = `
 <button
   aria-label="search"
   className=""
@@ -3724,7 +5428,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
       "color": "rgba(33,36,44,0.32)",
       "cursor": "default",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -3732,7 +5436,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={-1}
@@ -3796,7 +5500,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -3804,7 +5508,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -3868,7 +5572,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
       "color": "#1865f2",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -3876,7 +5580,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -3940,7 +5644,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
       "color": "#1b50b3",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -3948,7 +5652,7 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -3976,7 +5680,291 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
 </button>
 `;
 
-exports[`IconButtonCore kind:tertiary color:destructive size:default light:false disabled 1`] = `
+exports[`IconButtonCore kind:tertiary color:default size:xsmall light:false disabled 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "boxSizing": "border-box",
+      "color": "rgba(33,36,44,0.32)",
+      "cursor": "default",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={-1}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:default size:xsmall light:false focused 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1865f2",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1865f2",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:default size:xsmall light:false hovered 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1865f2",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1865f2",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:default size:xsmall light:false pressed 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#1b50b3",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#1b50b3",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:destructive size:medium light:false disabled 1`] = `
 <button
   aria-label="search"
   className=""
@@ -4044,7 +6032,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
 </button>
 `;
 
-exports[`IconButtonCore kind:tertiary color:destructive size:default light:false focused 1`] = `
+exports[`IconButtonCore kind:tertiary color:destructive size:medium light:false focused 1`] = `
 <button
   aria-label="search"
   className=""
@@ -4116,7 +6104,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
 </button>
 `;
 
-exports[`IconButtonCore kind:tertiary color:destructive size:default light:false hovered 1`] = `
+exports[`IconButtonCore kind:tertiary color:destructive size:medium light:false hovered 1`] = `
 <button
   aria-label="search"
   className=""
@@ -4188,7 +6176,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:default light:false
 </button>
 `;
 
-exports[`IconButtonCore kind:tertiary color:destructive size:default light:false pressed 1`] = `
+exports[`IconButtonCore kind:tertiary color:destructive size:medium light:false pressed 1`] = `
 <button
   aria-label="search"
   className=""
@@ -4292,7 +6280,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
       "color": "rgba(33,36,44,0.32)",
       "cursor": "default",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -4300,7 +6288,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={-1}
@@ -4364,7 +6352,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
       "color": "#d92916",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -4372,7 +6360,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -4436,7 +6424,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
       "color": "#d92916",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -4444,7 +6432,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -4508,7 +6496,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
       "color": "#9e271d",
       "cursor": "pointer",
       "display": "inline-flex",
-      "height": 40,
+      "height": 32,
       "justifyContent": "center",
       "margin": -8,
       "outline": "none",
@@ -4516,7 +6504,7 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
       "position": "relative",
       "textDecoration": "none",
       "touchAction": "manipulation",
-      "width": 40,
+      "width": 32,
     }
   }
   tabIndex={0}
@@ -4538,6 +6526,290 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
   >
     <path
       d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:destructive size:xsmall light:false disabled 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "boxSizing": "border-box",
+      "color": "rgba(33,36,44,0.32)",
+      "cursor": "default",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={-1}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:destructive size:xsmall light:false focused 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#d92916",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#d92916",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:destructive size:xsmall light:false hovered 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#d92916",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#d92916",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
+      fill="currentColor"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButtonCore kind:tertiary color:destructive size:xsmall light:false pressed 1`] = `
+<button
+  aria-label="search"
+  className=""
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  style={
+    {
+      "::MozFocusInner": {
+        "border": 0,
+      },
+      ":focus": {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      },
+      "alignItems": "center",
+      "background": "none",
+      "border": "none",
+      "borderColor": "#9e271d",
+      "borderRadius": 4,
+      "borderStyle": "solid",
+      "borderWidth": 2,
+      "boxSizing": "border-box",
+      "color": "#9e271d",
+      "cursor": "pointer",
+      "display": "inline-flex",
+      "height": 24,
+      "justifyContent": "center",
+      "margin": -8,
+      "outline": "none",
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+      "touchAction": "manipulation",
+      "width": 24,
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <svg
+    className=""
+    height={16}
+    style={
+      {
+        "display": "inline-block",
+        "flexGrow": 0,
+        "flexShrink": 0,
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  >
+    <path
+      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
       fill="currentColor"
     />
   </svg>

--- a/packages/wonder-blocks-icon-button/src/__tests__/custom-snapshot.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/__tests__/custom-snapshot.test.tsx
@@ -4,6 +4,7 @@ import * as renderer from "react-test-renderer";
 import {icons} from "@khanacademy/wonder-blocks-icon";
 
 import IconButtonCore from "../components/icon-button-core";
+import {IconButtonSize} from "../components/icon-button";
 
 const defaultHandlers = {
     onClick: () => void 0,
@@ -23,7 +24,11 @@ const defaultHandlers = {
 describe("IconButtonCore", () => {
     for (const kind of ["primary", "secondary", "tertiary"] as const) {
         for (const color of ["default", "destructive"] as const) {
-            for (const size of ["default", "small"] as const) {
+            for (const size of [
+                "xsmall",
+                "small",
+                "medium",
+            ] as IconButtonSize[]) {
                 for (const light of kind === "primary"
                     ? [true, false]
                     : [false]) {
@@ -52,6 +57,7 @@ describe("IconButtonCore", () => {
                                         kind={kind}
                                         color={color}
                                         light={light}
+                                        size={size}
                                         tabIndex={disabled ? -1 : 0}
                                         {...stateProps}
                                         {...defaultHandlers}

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -74,7 +74,7 @@ const IconButtonCore: React.ForwardRefExoticComponent<
         const defaultStyle = [
             sharedStyles.shared,
             buttonStyles.default,
-            disabled && [sharedStyles.disabled, buttonStyles.disabled],
+            disabled && buttonStyles.disabled,
             !disabled &&
                 (pressed
                     ? buttonStyles.active
@@ -158,9 +158,6 @@ const sharedStyles = StyleSheet.create({
             WebkitTapHighlightColor: "rgba(0,0,0,0)",
         },
     },
-    disabled: {
-        cursor: "default",
-    },
 });
 
 const styles: Record<string, any> = {};
@@ -193,11 +190,12 @@ const _generateStyles = (
                 throw new Error("IconButton kind not recognized");
         }
     })();
+    const pixelsForSize = targetPixelsForSize(size);
 
     const newStyles = {
         default: {
-            height: targetPixelsForSize(size),
-            width: targetPixelsForSize(size),
+            height: pixelsForSize,
+            width: pixelsForSize,
             color: defaultColor,
         },
         focus: {

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -7,6 +7,8 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import {Link} from "react-router-dom";
 import IconButtonCore from "./icon-button-core";
 
+export type IconButtonSize = "xsmall" | "small" | "medium";
+
 export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
     /**
      * A Wonder Blocks icon asset, an object specifing paths for one or more of
@@ -40,6 +42,12 @@ export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
      * Test ID used for e2e testing.
      */
     testId?: string;
+    /**
+     * Size of the icon button.
+     * One of `xsmall` (16 icon, 20 target), `small` (24, 32), or `medium (24, 40).
+     * Defaults to `medium`.
+     */
+    size?: IconButtonSize;
     /**
      * Optional custom styles.
      */
@@ -158,15 +166,16 @@ const IconButton: React.ForwardRefExoticComponent<
     SharedProps
 >(function IconButton(props: SharedProps, ref) {
     const {
-        onClick,
+        color = "default",
+        disabled = false,
         href,
+        kind = "primary",
+        light = false,
+        onClick,
+        size = "medium",
         skipClientNav,
         tabIndex,
         target,
-        color = "default",
-        kind = "primary",
-        light = false,
-        disabled = false,
         ...sharedProps
     } = props;
     const renderClickableBehavior = (router: any): React.ReactNode => {
@@ -191,14 +200,15 @@ const IconButton: React.ForwardRefExoticComponent<
                             {...state}
                             {...childrenProps}
                             color={color}
+                            disabled={disabled}
+                            href={href}
                             kind={kind}
                             light={light}
-                            disabled={disabled}
+                            ref={ref}
                             skipClientNav={skipClientNav}
-                            href={href}
+                            size={size}
                             target={target}
                             tabIndex={tabIndex}
-                            ref={ref}
                         />
                     );
                 }}

--- a/packages/wonder-blocks-icon-button/src/util/icon-button-util.test.ts
+++ b/packages/wonder-blocks-icon-button/src/util/icon-button-util.test.ts
@@ -1,0 +1,17 @@
+import {iconSizeForButtonSize, targetPixelsForSize} from "./icon-button-util";
+
+describe("iconSizeForButtonSize", () => {
+    test("should return the correct icon size for a given icon button size", () => {
+        expect(iconSizeForButtonSize("xsmall")).toBe("small");
+        expect(iconSizeForButtonSize("small")).toBe("medium");
+        expect(iconSizeForButtonSize("medium")).toBe("medium");
+    });
+});
+
+describe("targetPixelsForSize", () => {
+    test("should return the correct target size for a given icon button size", () => {
+        expect(targetPixelsForSize("xsmall")).toBe(24);
+        expect(targetPixelsForSize("small")).toBe(32);
+        expect(targetPixelsForSize("medium")).toBe(40);
+    });
+});

--- a/packages/wonder-blocks-icon-button/src/util/icon-button-util.test.ts
+++ b/packages/wonder-blocks-icon-button/src/util/icon-button-util.test.ts
@@ -1,17 +1,29 @@
 import {iconSizeForButtonSize, targetPixelsForSize} from "./icon-button-util";
 
 describe("iconSizeForButtonSize", () => {
-    test("should return the correct icon size for a given icon button size", () => {
-        expect(iconSizeForButtonSize("xsmall")).toBe("small");
-        expect(iconSizeForButtonSize("small")).toBe("medium");
-        expect(iconSizeForButtonSize("medium")).toBe("medium");
-    });
+    test.each`
+        buttonSize  | expectedIconSize
+        ${"xsmall"} | ${"small"}
+        ${"small"}  | ${"medium"}
+        ${"medium"} | ${"medium"}
+    `(
+        "should return $expectedIconSize icon for $buttonSize icon button",
+        ({buttonSize, expectedIconSize}) => {
+            expect(iconSizeForButtonSize(buttonSize)).toBe(expectedIconSize);
+        },
+    );
 });
 
 describe("targetPixelsForSize", () => {
-    test("should return the correct target size for a given icon button size", () => {
-        expect(targetPixelsForSize("xsmall")).toBe(24);
-        expect(targetPixelsForSize("small")).toBe(32);
-        expect(targetPixelsForSize("medium")).toBe(40);
-    });
+    test.each`
+        size        | expectedTargetPixels
+        ${"xsmall"} | ${24}
+        ${"small"}  | ${32}
+        ${"medium"} | ${40}
+    `(
+        "should return $expectedTargetPixels for $size icon button",
+        ({size, expectedTargetPixels}) => {
+            expect(targetPixelsForSize(size)).toBe(expectedTargetPixels);
+        },
+    );
 });

--- a/packages/wonder-blocks-icon-button/src/util/icon-button-util.ts
+++ b/packages/wonder-blocks-icon-button/src/util/icon-button-util.ts
@@ -1,0 +1,22 @@
+import {IconSize} from "@khanacademy/wonder-blocks-icon";
+import {IconButtonSize} from "../components/icon-button";
+
+/**
+ * A function that returns the icon size for a given icon button size.
+ */
+export const iconSizeForButtonSize = (size: IconButtonSize): IconSize => {
+    switch (size) {
+        case "xsmall":
+            return "small";
+        case "small":
+            return "medium";
+        case "medium":
+            return "medium";
+    }
+};
+
+/**
+ * A function that returns the size of the touch target in pixels for a given icon button size.
+ */
+export const targetPixelsForSize = (size: IconButtonSize): number =>
+    ({xsmall: 24, small: 32, medium: 40}[size]);


### PR DESCRIPTION
## Summary:
- Added new size prop with 3 options based on designs found in Figma
  - Created new icon button util file with 2 simple functions
- Refactored icon button stories file by using comments as descriptions
- Factored out icon button stories argtypes
<img width="136" alt="Screen Shot 2023-09-05 at 2 22 37 PM" src="https://github.com/Khan/wonder-blocks/assets/77523470/880fb63d-c8d9-471d-bd4c-d00484981207">

Issue: WB-1528

## Test plan:
- New test file was created for icon util functions
- New snapshot generated for sizes