### PR TITLE
[🔥AUDIT🔥] Include khanmigo background in storybook toolbar

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import wonderBlocksTheme from "./wonder-blocks-theme";
 import {configure} from "@storybook/testing-library";
 
+import {tokens} from "@khanacademy/wonder-blocks-theming";
 import Link from "@khanacademy/wonder-blocks-link";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
 import {Preview} from "@storybook/react";
@@ -51,12 +52,16 @@ export const parameters = {
         values: [
             {
                 name: "light",
-                value: "#ffffff",
+                value: tokens.color.white,
             },
             {
                 name: "darkBlue",
-                value: "#0b2149",
+                value: tokens.color.darkBlue,
             },
+            {
+                name: "khanmigo",
+                value: tokens.color.eggplant,
+            }
         ],
     },
     // https://storybook.js.org/docs/react/configure/story-layout


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Adds a new bg option in the background switcher widget include in the Storybook
toolbar.

Issue: XXX-XXXX

## Test plan:

Verify that the background changes to `eggplant` if you click on `khanmigo` in
the background switcher toolbar option.