### PR TITLE
WB-1609: Add support to disabled + focus state to Switch

### DIFF
--- a/.changeset/fast-jokes-hammer.md
+++ b/.changeset/fast-jokes-hammer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-switch": patch
+---
+
+Use `aria-disabled` instead of `disabled` for enabling focus on Screen Readers.

--- a/__docs__/wonder-blocks-switch/switch.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch.stories.tsx
@@ -5,7 +5,7 @@ import {expect} from "@storybook/jest";
 import {userEvent, within} from "@storybook/testing-library";
 
 import Switch from "@khanacademy/wonder-blocks-switch";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
 import {ThemeSwitcherContext, tokens} from "@khanacademy/wonder-blocks-theming";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
@@ -18,19 +18,19 @@ import SwitchArgtypes from "./switch.argtypes";
 type StoryComponentType = StoryObj<typeof Switch>;
 
 /**
- * A Switch is an input that allows users to toggle between two states, typically `on` and `off`.
- * It is a controlled component, meaning that the state of the switch is controlled by the
- * `checked` prop.
- * See the Best Practices tab for more information on how to use this component with labels,
+ * A Switch is an input that allows users to toggle between two states,
+ * typically `on` and `off`. It is a controlled component, meaning that the
+ * state of the switch is controlled by the `checked` prop. See the Best
+ * Practices tab for more information on how to use this component with labels,
  * descriptions, tooltips, and more.
  *
  * ### Usage
  * ```jsx
  *
- * import Switch from "@khanacademy/wonder-blocks-switch";
+ *import Switch from "@khanacademy/wonder-blocks-switch";
  *
- * <Switch checked={false} onChange={() => {}} />
- * ```
+ *<Switch checked={false} onChange={() => {}} />
+ *```
  */
 export default {
     title: "Switch",
@@ -46,11 +46,26 @@ export default {
     argTypes: SwitchArgtypes,
 } as Meta<typeof Switch>;
 
+function ControlledDefaultSwitch(args: PropsFor<typeof Switch>) {
+    const [checked, setChecked] = React.useState(args.checked);
+
+    // Update the checked state when the args change.
+    React.useEffect(() => {
+        setChecked(args.checked);
+    }, [args.checked]);
+
+    return <Switch {...args} checked={checked} onChange={setChecked} />;
+}
+
+/**
+ * The switch has a default state that can be controlled by the `checked` prop.
+ */
 export const Default: StoryComponentType = {
     args: {
         checked: false,
         onChange: () => {},
     },
+    render: ControlledDefaultSwitch,
     decorators: [
         (Story) => (
             <View>
@@ -66,7 +81,6 @@ export const Default: StoryComponentType = {
  * The `onChange` prop is optional in case the toggle will
  * be wrapped in a larger clickable component.
  */
-
 export const Controlled: StoryComponentType = () => {
     const [checkedOne, setCheckedOne] = React.useState(false);
     const [checkedTwo, setCheckedTwo] = React.useState(false);

--- a/__docs__/wonder-blocks-switch/switch.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch.stories.tsx
@@ -110,7 +110,9 @@ Controlled.play = async ({canvasElement}) => {
 };
 
 /**
- * The switch can be disabled.
+ * The switch can be disabled. Note that we use `aria-disabled` to allow the
+ * switch to receive focus even when disabled. This helps Screen Readers to
+ * announce the state of the switch.
  */
 export const Disabled: StoryComponentType = {
     render: () => (

--- a/packages/wonder-blocks-switch/src/components/__tests__/switch.test.tsx
+++ b/packages/wonder-blocks-switch/src/components/__tests__/switch.test.tsx
@@ -125,5 +125,44 @@ describe("Switch", () => {
             // Assert
             expect(icon).toBeInTheDocument();
         });
+
+        it("should have set aria-disabled if disabled is set", () => {
+            // Arrange
+            render(
+                <RenderStateRoot>
+                    <Switch
+                        aria-label="Gravity"
+                        checked={true}
+                        disabled={true}
+                    />
+                </RenderStateRoot>,
+            );
+
+            // Act
+            const switchComponent = screen.getByRole("switch");
+
+            // Assert
+            expect(switchComponent).toHaveAttribute("aria-disabled", "true");
+        });
+
+        it("should receive focus even if disabled is set", () => {
+            // Arrange
+            render(
+                <RenderStateRoot>
+                    <Switch
+                        aria-label="Gravity"
+                        checked={true}
+                        disabled={true}
+                    />
+                </RenderStateRoot>,
+            );
+
+            // Act
+            userEvent.tab();
+
+            // Assert
+            const switchComponent = screen.getByRole("switch");
+            expect(switchComponent).toHaveFocus();
+        });
     });
 });

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -114,7 +114,7 @@ const SwitchCore = React.forwardRef(function SwitchCore(
                 aria-label={ariaLabel}
                 aria-labelledby={ariaLabelledBy}
                 checked={checked}
-                disabled={disabled}
+                aria-disabled={disabled}
                 id={uniqueId}
                 // Need to specify because this is a controlled React component, but we
                 // handle the clicks on the outer View


### PR DESCRIPTION
## Summary:

We are not currently allowing to focus a disabled switch component. This PR adds
support to that via the `aria-disabled` attribute.

Also made the default story fully interactive so users can play/interact with
it.

Issue: WB-1609

## Test plan:

1. Verify that the switch elements in the `Disabled` state can be focused via
keyboard.

/?path=/story/switch--disabled


https://github.com/Khan/wonder-blocks/assets/843075/7f6c4f2f-424b-4fed-8695-33e4399b2c2c



2. Verify that the `Default` story is fully interactive (switch can be
checked/unchecked).

/?path=/story/switch--default