### PR TITLE
[🔥AUDIT🔥] WB-1609: Switch - Add `not-allowed` cursor for disabled + hover state

### DIFF
--- a/.changeset/hot-bikes-approve.md
+++ b/.changeset/hot-bikes-approve.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-switch": patch
+---
+
+Add `not-allowed` cursor to disabled+hover

--- a/__docs__/wonder-blocks-switch/switch-best-practices.mdx
+++ b/__docs__/wonder-blocks-switch/switch-best-practices.mdx
@@ -10,13 +10,17 @@ import * as SwitchBestPracticesStories from "./switch-best-practices.stories";
 
 ### With Labelling
 
-The switch can be paired with a visible label which should be an html `label` element. The label
-should include the `htmlFor` attribute, and the switch should include the `aria-labelledby`
-attribute.
+The switch can be paired with a visible label which should be an html `label`
+element. The label should include the `htmlFor` attribute, and the switch should
+include the `aria-labelledby` attribute.
+
+**Note:** If you are already using a label to describe the switch, we encourage
+you not to use the `aria-label` attribute because it could override the
+`label`'s text.
 
 #### Label
 
-The label text should __not__ change as the state of the switch changes.
+The label text should **not** change as the state of the switch changes.
 
 <Canvas of={SwitchBestPracticesStories.WithLabel} />
 

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -153,7 +153,7 @@ const themedSharedStyles: ThemedStylesFn<SwitchThemeContract> = (theme) => ({
         },
     },
     disabled: {
-        cursor: "auto",
+        cursor: "not-allowed",
         ":hover": {
             outline: "none",
         },


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Based on feedback from SarahB:

- Adds a `not-allowed` cursor for disabled + hover state.
- Includes a note in the best practices section about not using `label` + `aria-label` at the same time.

Issue: WB-1609

## Test plan:

Verify that the cursor is `not-allowed` when hovering over a disabled switch.