### PR TITLE
Fix how `mix` from `wonder-blocks-color` formats single-digit color components

### DIFF
--- a/.changeset/afraid-rings-knock.md
+++ b/.changeset/afraid-rings-knock.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/wonder-blocks-color": patch
+"@khanacademy/wonder-blocks-color": major
 ---
 
 Fix how mix formats single-digit color components

--- a/.changeset/afraid-rings-knock.md
+++ b/.changeset/afraid-rings-knock.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-color": patch
+---
+
+Fix how mix formats single-digit color components

--- a/packages/wonder-blocks-color/src/util/__tests__/utils.test.ts
+++ b/packages/wonder-blocks-color/src/util/__tests__/utils.test.ts
@@ -76,6 +76,7 @@ describe("mix", () => {
             ["rgba(0,0,0,0.25)", "#fFfFfF", "#bfbfbf"],
             ["rgba(0,0,0,0.25)", "rgb(255,255,0)", "#bfbf00"],
             ["rgba(100,200,100,0.25)", "rgb(255,255,0)", "#d8f119"],
+            ["rgba(33,36,44,0.32)", "#00a60e", "#0b7c18"],
         ];
 
         for (const [color, background, expectation] of testpoints) {

--- a/packages/wonder-blocks-color/src/util/utils.ts
+++ b/packages/wonder-blocks-color/src/util/utils.ts
@@ -61,10 +61,9 @@ const format = (color: Color): string => {
     const b = Math.round(color.b);
 
     if (color.a === 1) {
-        // @ts-expect-error [FEI-5019] - TS7006 - Parameter 'c' implicitly has an 'any' type.
-        const _s = (c) => {
+        const _s = (c: number) => {
             const asString = c.toString(16);
-            return asString.length === 1 ? asString + asString : asString;
+            return asString.length === 1 ? `0${asString}` : asString;
         };
         return `#${_s(r)}${_s(g)}${_s(b)}`;
     } else {


### PR DESCRIPTION
## Summary:
Previously, if the red, green, or blue component was less than 16, its hex digit would be repeated (e.g. `f` would become `ff`). With this change, we preserve the real value of the number by prepending a `0` instead (e.g. `f` becomes `0f`).

## Test plan:
`yarn run jest packages/wonder-blocks-color/src/util/__tests__/utils.test.ts`