### PR TITLE
WB-1612: `IconButton`: Add PhosphorIcon support

### DIFF
--- a/.changeset/strange-spiders-sing.md
+++ b/.changeset/strange-spiders-sing.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/wonder-blocks-search-field": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-banner": patch
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Switch internal `IconButton` instances to use phosphor.

--- a/.changeset/tasty-deers-listen.md
+++ b/.changeset/tasty-deers-listen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": major
+---
+
+Change `icon` type to use `PhosphorIcon` (instead of `Icon`).

--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -30,10 +30,7 @@ jobs:
   changeset:
     name: Check for .changeset entries for all changed files
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-            os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -34,7 +34,6 @@ jobs:
     strategy:
         matrix:
             os: [ubuntu-latest]
-            node-version: [16.x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -30,7 +30,11 @@ jobs:
   changeset:
     name: Check for .changeset entries for all changed files
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-latest]
+            node-version: [16.x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/__docs__/wonder-blocks-icon-button/icon-button.argtypes.ts
+++ b/__docs__/wonder-blocks-icon-button/icon-button.argtypes.ts
@@ -1,4 +1,4 @@
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
 export default {
     color: {
@@ -26,8 +26,8 @@ export default {
         control: {
             type: "select",
         },
-        description: "Icon to use.",
-        options: icons,
+        description: "A Phosphor icon asset (imported as a static SVG file).",
+        options: IconMappings,
     },
     kind: {
         control: {

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -4,11 +4,15 @@ import {StyleSheet} from "aphrodite";
 import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
+import CaretLeft from "@phosphor-icons/core/regular/caret-left.svg";
+import CaretRight from "@phosphor-icons/core/regular/caret-right.svg";
+import Info from "@phosphor-icons/core/regular/info.svg";
+import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+import MagnifyingGlassBold from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
+
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {icons} from "@khanacademy/wonder-blocks-icon";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
@@ -16,6 +20,45 @@ import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-icon-button/package.json";
 import IconButtonArgtypes from "./icon-button.argtypes";
 
+/**
+ * An `IconButton` is a button whose contents are an SVG image.
+ *
+ * To use, supply an `onClick` function, a Phosphor icon asset (see the
+ * `Icon>PhosphorIcon` section) and an `aria-label` to describe the button
+ * functionality. Optionally specify href (URL), clientSideNav, color (Wonder
+ * Blocks Blue or Red), kind ("primary", "secondary", or "tertiary"), light
+ * (whether the IconButton will be rendered on a dark background), disabled ,
+ * test ID, and custom styling.
+ *
+ * The size of an `IconButton` is based on how the `size` prop is defined (see
+ * `Sizes` below for more details). The focus ring which is displayed on hover
+ * and focus is much larger but does not affect its size. This matches the
+ * behavior of Button.
+ *
+ * IconButtons require a certain amount of space between them to ensure the
+ * focus rings don't overlap. The minimum amount of spacing is 16px, but you
+ * should refer to the mocks provided by design.  Using a Strut in between
+ * IconButtons is the preferred way to for adding this spacing.
+ *
+ * Many layouts require alignment of visual left (or right) side of an
+ * `IconButton`. This requires a little bit of pixel nudging since each icon as
+ * a different amount of internal padding.
+ *
+ * See the Toolbar documentation for examples of `IconButton` use that follow
+ * the best practices described above.
+ *
+ * ```js
+ * import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+ * import IconButton from "@khanacademy/wonder-blocks-icon-button";
+ *
+ * <IconButton
+ *     icon={MagnifyingGlass}
+ *     aria-label="An Icon"
+ *     onClick={(e) => console.log("Hello, world!")}
+ *     size="medium"
+ * />
+ * ```
+ */
 export default {
     title: "IconButton",
     component: IconButton,
@@ -32,9 +75,13 @@ export default {
 
 type StoryComponentType = StoryObj<typeof IconButton>;
 
+/**
+ * Minimal icon button. The only props specified in this example are `icon` and
+ * `onClick`.
+ */
 export const Default: StoryComponentType = {
     args: {
-        icon: icons.search,
+        icon: MagnifyingGlass,
         color: "default",
         disabled: false,
         kind: "primary",
@@ -47,61 +94,41 @@ export const Default: StoryComponentType = {
     },
 };
 
-export const Basic: StoryComponentType = () => {
-    return (
-        <IconButton icon={icons.search} onClick={() => console.log("Click!")} />
-    );
-};
-
-Basic.parameters = {
-    docs: {
-        description: {
-            story: `Minimal icon button. The only props specified in
-            this example are \`icon\` and \`onClick\`.`,
-        },
-    },
-};
-
 /**
- * Icon buttons can be one of three sizes: `xsmall` (16px icon with a 24px touch target),
- * `small` (24px icon with a 32px touch target), and `medium` (24px icon with a 40px touch target).
- * The default size is `medium`.
+ * IconButtons can be used with any icon from the `@phosphor-icons/core`
+ * package. The `icon` prop takes an SVG asset from the package.
+ *
+ * In this example you can see the different sizes of the icon button:
+ * - `xsmall` (16px icon with a 24px touch target).
+ * - `small` (24px icon with a 32px touch target).
+ * - `medium` (24px icon with a 40px touch target).
  */
-export const Sizes: StoryComponentType = (() => {
-    return (
-        <View style={{flexDirection: "column"}}>
+export const Sizes: StoryComponentType = {
+    ...Default,
+    args: {
+        icon: MagnifyingGlass,
+    },
+    render: (args) => (
+        <View style={{gap: Spacing.medium_16}}>
             <View style={styles.row}>
                 <LabelMedium style={styles.label}>xsmall</LabelMedium>
                 <IconButton
-                    icon={icons.search}
+                    {...args}
+                    icon={MagnifyingGlassBold}
                     size="xsmall"
-                    aria-label="search"
-                    onClick={(e) => console.log("Click!")}
                 />
             </View>
-            <Strut size={Spacing.large_24} />
             <View style={styles.row}>
                 <LabelMedium style={styles.label}>small</LabelMedium>
-                <IconButton
-                    icon={icons.search}
-                    size="small"
-                    aria-label="search"
-                    onClick={(e) => console.log("Click!")}
-                />
+                <IconButton {...args} size="small" />
             </View>
-            <Strut size={Spacing.large_24} />
             <View style={styles.row}>
                 <LabelMedium style={styles.label}>medium</LabelMedium>
-                <IconButton
-                    icon={icons.search}
-                    size="medium"
-                    aria-label="search"
-                    onClick={(e) => console.log("Click!")}
-                />
+                <IconButton {...args} size="medium" />
             </View>
         </View>
-    );
-}) as StoryComponentType;
+    ),
+};
 
 /**
  * In this example, we have primary, secondary, tertiary,
@@ -112,25 +139,25 @@ export const Variants: StoryComponentType = {
         return (
             <View style={styles.row}>
                 <IconButton
-                    icon={icons.search}
+                    icon={MagnifyingGlass}
                     aria-label="search"
                     onClick={(e) => console.log("Click!")}
                 />
                 <IconButton
-                    icon={icons.search}
+                    icon={MagnifyingGlass}
                     aria-label="search"
                     kind="secondary"
                     onClick={(e) => console.log("Click!")}
                 />
                 <IconButton
-                    icon={icons.search}
+                    icon={MagnifyingGlass}
                     aria-label="search"
                     kind="tertiary"
                     onClick={(e) => console.log("Click!")}
                 />
                 <IconButton
                     disabled={true}
-                    icon={icons.search}
+                    icon={MagnifyingGlass}
                     aria-label="search"
                     onClick={(e) => console.log("Click!")}
                 />
@@ -148,7 +175,7 @@ export const Light: StoryComponentType = {
         return (
             <View style={styles.dark}>
                 <IconButton
-                    icon={icons.search}
+                    icon={MagnifyingGlass}
                     aria-label="search"
                     light={true}
                     onClick={(e) => console.log("Click!")}
@@ -167,7 +194,7 @@ export const DisabledLight: StoryComponentType = {
             <View style={styles.dark}>
                 <IconButton
                     disabled={true}
-                    icon={icons.search}
+                    icon={MagnifyingGlass}
                     aria-label="search"
                     light={true}
                     onClick={(e) => console.log("Click!")}
@@ -187,7 +214,7 @@ export const UsingHref: StoryComponentType = {
     render: () => {
         return (
             <IconButton
-                icon={icons.info}
+                icon={Info}
                 aria-label="More information"
                 href="/"
                 target="_blank"
@@ -206,12 +233,12 @@ export const WithAriaLabel: StoryComponentType = {
         return (
             <View style={styles.arrowsWrapper}>
                 <IconButton
-                    icon={icons.caretLeft}
+                    icon={CaretLeft}
                     onClick={(e) => console.log("Click!")}
                     aria-label="Previous page"
                 />
                 <IconButton
-                    icon={icons.caretRight}
+                    icon={CaretRight}
                     onClick={(e) => console.log("Click!")}
                     aria-label="Next page"
                 />

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -4,11 +4,11 @@ import {StyleSheet} from "aphrodite";
 import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import CaretLeft from "@phosphor-icons/core/regular/caret-left.svg";
-import CaretRight from "@phosphor-icons/core/regular/caret-right.svg";
-import Info from "@phosphor-icons/core/regular/info.svg";
-import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
-import MagnifyingGlassBold from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
+import caretLeft from "@phosphor-icons/core/regular/caret-left.svg";
+import caretRight from "@phosphor-icons/core/regular/caret-right.svg";
+import info from "@phosphor-icons/core/regular/info.svg";
+import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+import magnifyingGlassBold from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -48,11 +48,11 @@ import IconButtonArgtypes from "./icon-button.argtypes";
  * the best practices described above.
  *
  * ```js
- * import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+ * import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
  * import IconButton from "@khanacademy/wonder-blocks-icon-button";
  *
  * <IconButton
- *     icon={MagnifyingGlass}
+ *     icon={magnifyingGlassIcon}
  *     aria-label="An Icon"
  *     onClick={(e) => console.log("Hello, world!")}
  *     size="medium"
@@ -81,7 +81,7 @@ type StoryComponentType = StoryObj<typeof IconButton>;
  */
 export const Default: StoryComponentType = {
     args: {
-        icon: MagnifyingGlass,
+        icon: magnifyingGlass,
         color: "default",
         disabled: false,
         kind: "primary",
@@ -106,7 +106,7 @@ export const Default: StoryComponentType = {
 export const Sizes: StoryComponentType = {
     ...Default,
     args: {
-        icon: MagnifyingGlass,
+        icon: magnifyingGlass,
     },
     render: (args) => (
         <View style={{gap: Spacing.medium_16}}>
@@ -114,7 +114,7 @@ export const Sizes: StoryComponentType = {
                 <LabelMedium style={styles.label}>xsmall</LabelMedium>
                 <IconButton
                     {...args}
-                    icon={MagnifyingGlassBold}
+                    icon={magnifyingGlassBold}
                     size="xsmall"
                 />
             </View>
@@ -139,25 +139,25 @@ export const Variants: StoryComponentType = {
         return (
             <View style={styles.row}>
                 <IconButton
-                    icon={MagnifyingGlass}
+                    icon={magnifyingGlass}
                     aria-label="search"
                     onClick={(e) => console.log("Click!")}
                 />
                 <IconButton
-                    icon={MagnifyingGlass}
+                    icon={magnifyingGlass}
                     aria-label="search"
                     kind="secondary"
                     onClick={(e) => console.log("Click!")}
                 />
                 <IconButton
-                    icon={MagnifyingGlass}
+                    icon={magnifyingGlass}
                     aria-label="search"
                     kind="tertiary"
                     onClick={(e) => console.log("Click!")}
                 />
                 <IconButton
                     disabled={true}
-                    icon={MagnifyingGlass}
+                    icon={magnifyingGlass}
                     aria-label="search"
                     onClick={(e) => console.log("Click!")}
                 />
@@ -175,7 +175,7 @@ export const Light: StoryComponentType = {
         return (
             <View style={styles.dark}>
                 <IconButton
-                    icon={MagnifyingGlass}
+                    icon={magnifyingGlass}
                     aria-label="search"
                     light={true}
                     onClick={(e) => console.log("Click!")}
@@ -194,7 +194,7 @@ export const DisabledLight: StoryComponentType = {
             <View style={styles.dark}>
                 <IconButton
                     disabled={true}
-                    icon={MagnifyingGlass}
+                    icon={magnifyingGlass}
                     aria-label="search"
                     light={true}
                     onClick={(e) => console.log("Click!")}
@@ -214,7 +214,7 @@ export const UsingHref: StoryComponentType = {
     render: () => {
         return (
             <IconButton
-                icon={Info}
+                icon={info}
                 aria-label="More information"
                 href="/"
                 target="_blank"
@@ -233,12 +233,12 @@ export const WithAriaLabel: StoryComponentType = {
         return (
             <View style={styles.arrowsWrapper}>
                 <IconButton
-                    icon={CaretLeft}
+                    icon={caretLeft}
                     onClick={(e) => console.log("Click!")}
                     aria-label="Previous page"
                 />
                 <IconButton
-                    icon={CaretRight}
+                    icon={caretRight}
                     onClick={(e) => console.log("Click!")}
                     aria-label="Next page"
                 />

--- a/__docs__/wonder-blocks-icon/phosphor-icon.argtypes.ts
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.argtypes.ts
@@ -1,45 +1,45 @@
 import type {InputType} from "@storybook/csf";
 
-import PlusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import PlusCircleBold from "@phosphor-icons/core/bold/plus-circle-bold.svg";
-import XCircle from "@phosphor-icons/core/regular/x-circle.svg";
-import XCircleBold from "@phosphor-icons/core/bold/x-circle-bold.svg";
-import X from "@phosphor-icons/core/regular/x.svg";
-import XBold from "@phosphor-icons/core/bold/x-bold.svg";
-import CheckCircle from "@phosphor-icons/core/regular/check-circle.svg";
-import CheckCircleBold from "@phosphor-icons/core/bold/check-circle-bold.svg";
-import Check from "@phosphor-icons/core/regular/check.svg";
-import CheckBold from "@phosphor-icons/core/bold/check-bold.svg";
-import CaretDown from "@phosphor-icons/core/regular/caret-down.svg";
-import CaretDownBold from "@phosphor-icons/core/bold/caret-down-bold.svg";
-import CaretUp from "@phosphor-icons/core/regular/caret-up.svg";
-import CaretUpBold from "@phosphor-icons/core/bold/caret-up-bold.svg";
-import CaretLeft from "@phosphor-icons/core/regular/caret-left.svg";
-import CaretLeftBold from "@phosphor-icons/core/bold/caret-left-bold.svg";
-import CaretRight from "@phosphor-icons/core/regular/caret-right.svg";
-import CaretRightBold from "@phosphor-icons/core/bold/caret-right-bold.svg";
-import MinusCircle from "@phosphor-icons/core/regular/minus-circle.svg";
-import MinusCircleBold from "@phosphor-icons/core/bold/minus-circle-bold.svg";
-import Lightbulb from "@phosphor-icons/core/regular/lightbulb.svg";
-import LightbulbBold from "@phosphor-icons/core/bold/lightbulb-bold.svg";
-import ArrowUp from "@phosphor-icons/core/regular/arrow-up.svg";
-import ArrowUpBold from "@phosphor-icons/core/bold/arrow-up-bold.svg";
-import ArrowDown from "@phosphor-icons/core/regular/arrow-down.svg";
-import ArrowDownBold from "@phosphor-icons/core/bold/arrow-down-bold.svg";
-import Info from "@phosphor-icons/core/regular/info.svg";
-import InfoBold from "@phosphor-icons/core/bold/info-bold.svg";
-import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
-import MagnifyingGlassBold from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
-import MagnifyingGlassPlus from "@phosphor-icons/core/regular/magnifying-glass-plus.svg";
-import MagnifyingGlassPlusBold from "@phosphor-icons/core/bold/magnifying-glass-plus-bold.svg";
-import MagnifyingGlassMinus from "@phosphor-icons/core/regular/magnifying-glass-minus.svg";
-import MagnifyingGlassMinusBold from "@phosphor-icons/core/bold/magnifying-glass-minus-bold.svg";
-import Article from "@phosphor-icons/core/regular/article.svg";
-import ArticleBold from "@phosphor-icons/core/bold/article-bold.svg";
-import PencilSimple from "@phosphor-icons/core/regular/pencil-simple.svg";
-import PencilSimpleBold from "@phosphor-icons/core/bold/pencil-simple-bold.svg";
-import Play from "@phosphor-icons/core/regular/play.svg";
-import PlayBold from "@phosphor-icons/core/bold/play-bold.svg";
+import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
+import plusCircleBold from "@phosphor-icons/core/bold/plus-circle-bold.svg";
+import xCircle from "@phosphor-icons/core/regular/x-circle.svg";
+import xCircleBold from "@phosphor-icons/core/bold/x-circle-bold.svg";
+import x from "@phosphor-icons/core/regular/x.svg";
+import xBold from "@phosphor-icons/core/bold/x-bold.svg";
+import checkCircle from "@phosphor-icons/core/regular/check-circle.svg";
+import checkCircleBold from "@phosphor-icons/core/bold/check-circle-bold.svg";
+import check from "@phosphor-icons/core/regular/check.svg";
+import checkBold from "@phosphor-icons/core/bold/check-bold.svg";
+import caretDown from "@phosphor-icons/core/regular/caret-down.svg";
+import caretDownBold from "@phosphor-icons/core/bold/caret-down-bold.svg";
+import caretUp from "@phosphor-icons/core/regular/caret-up.svg";
+import caretUpBold from "@phosphor-icons/core/bold/caret-up-bold.svg";
+import caretLeft from "@phosphor-icons/core/regular/caret-left.svg";
+import caretLeftBold from "@phosphor-icons/core/bold/caret-left-bold.svg";
+import caretRight from "@phosphor-icons/core/regular/caret-right.svg";
+import caretRightBold from "@phosphor-icons/core/bold/caret-right-bold.svg";
+import minusCircle from "@phosphor-icons/core/regular/minus-circle.svg";
+import minusCircleBold from "@phosphor-icons/core/bold/minus-circle-bold.svg";
+import lightbulb from "@phosphor-icons/core/regular/lightbulb.svg";
+import lightbulbBold from "@phosphor-icons/core/bold/lightbulb-bold.svg";
+import arrowUp from "@phosphor-icons/core/regular/arrow-up.svg";
+import arrowUpBold from "@phosphor-icons/core/bold/arrow-up-bold.svg";
+import arrowDown from "@phosphor-icons/core/regular/arrow-down.svg";
+import arrowDownBold from "@phosphor-icons/core/bold/arrow-down-bold.svg";
+import info from "@phosphor-icons/core/regular/info.svg";
+import infoBold from "@phosphor-icons/core/bold/info-bold.svg";
+import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+import magnifyingGlassBold from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
+import magnifyingGlassPlus from "@phosphor-icons/core/regular/magnifying-glass-plus.svg";
+import magnifyingGlassPlusBold from "@phosphor-icons/core/bold/magnifying-glass-plus-bold.svg";
+import magnifyingGlassMinus from "@phosphor-icons/core/regular/magnifying-glass-minus.svg";
+import magnifyingGlassMinusBold from "@phosphor-icons/core/bold/magnifying-glass-minus-bold.svg";
+import article from "@phosphor-icons/core/regular/article.svg";
+import articleBold from "@phosphor-icons/core/bold/article-bold.svg";
+import pencilSimple from "@phosphor-icons/core/regular/pencil-simple.svg";
+import pencilSimpleBold from "@phosphor-icons/core/bold/pencil-simple-bold.svg";
+import play from "@phosphor-icons/core/regular/play.svg";
+import playBold from "@phosphor-icons/core/bold/play-bold.svg";
 
 import {tokens} from "@khanacademy/wonder-blocks-theming";
 
@@ -47,46 +47,46 @@ import {tokens} from "@khanacademy/wonder-blocks-theming";
  * Some pre-defined icon examples to use in our stories.
  */
 export const IconMappings = {
-    PlusCircle,
-    PlusCircleBold,
-    CaretDown,
-    CaretDownBold,
-    CaretUp,
-    CaretUpBold,
-    CaretLeft,
-    CaretLeftBold,
-    CaretRight,
-    CaretRightBold,
-    Check,
-    CheckBold,
-    CheckCircle,
-    CheckCircleBold,
-    X,
-    XBold,
-    XCircle,
-    XCircleBold,
-    MinusCircle,
-    MinusCircleBold,
-    Lightbulb,
-    LightbulbBold,
-    ArrowUp,
-    ArrowUpBold,
-    ArrowDown,
-    ArrowDownBold,
-    Info,
-    InfoBold,
-    MagnifyingGlass,
-    MagnifyingGlassBold,
-    MagnifyingGlassPlus,
-    MagnifyingGlassPlusBold,
-    MagnifyingGlassMinus,
-    MagnifyingGlassMinusBold,
-    Article,
-    ArticleBold,
-    PencilSimple,
-    PencilSimpleBold,
-    Play,
-    PlayBold,
+    plusCircle,
+    plusCircleBold,
+    caretDown,
+    caretDownBold,
+    caretUp,
+    caretUpBold,
+    caretLeft,
+    caretLeftBold,
+    caretRight,
+    caretRightBold,
+    check,
+    checkBold,
+    checkCircle,
+    checkCircleBold,
+    x,
+    xBold,
+    xCircle,
+    xCircleBold,
+    minusCircle,
+    minusCircleBold,
+    lightbulb,
+    lightbulbBold,
+    arrowUp,
+    arrowUpBold,
+    arrowDown,
+    arrowDownBold,
+    info,
+    infoBold,
+    magnifyingGlass,
+    magnifyingGlassBold,
+    magnifyingGlassPlus,
+    magnifyingGlassPlusBold,
+    magnifyingGlassMinus,
+    magnifyingGlassMinusBold,
+    article,
+    articleBold,
+    pencilSimple,
+    pencilSimpleBold,
+    play,
+    playBold,
 } as const;
 
 export default {

--- a/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
@@ -23,11 +23,11 @@ import PhosphorIconArgtypes, {IconMappings} from "./phosphor-icon.argtypes";
  * ## Usage
  *
  * ```tsx
+ * import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
  * import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
- * import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
  *
  * <PhosphorIcon
- *     icon={MagnifyingGlass}
+ *     icon={magnifyingGlassIcon}
  *     color={Color.blue}
  *     size="medium"
  *     style={{margin: Spacing.xxxxSmall_2}}
@@ -68,7 +68,7 @@ ${code.replace(iconPropRegex, `{${iconName}}`)}
  */
 export const Default: StoryComponentType = {
     args: {
-        icon: IconMappings.MagnifyingGlassBold,
+        icon: IconMappings.magnifyingGlassBold,
         size: "small",
         "aria-label": "Search",
     },
@@ -80,7 +80,7 @@ export const Default: StoryComponentType = {
                     transformCode(
                         code,
                         "MagnifyingGlassBold",
-                        IconMappings.MagnifyingGlassBold,
+                        IconMappings.magnifyingGlassBold,
                     ),
             },
         },
@@ -103,14 +103,14 @@ export const Sizes: StoryComponentType = {
                 <View style={styles.row}>
                     <LabelMedium>small</LabelMedium>
                     <PhosphorIcon
-                        icon={IconMappings.MagnifyingGlassBold}
+                        icon={IconMappings.magnifyingGlassBold}
                         size="small"
                     />
                 </View>
                 <View style={styles.row}>
                     <LabelMedium>medium</LabelMedium>
                     <PhosphorIcon
-                        icon={IconMappings.MagnifyingGlass}
+                        icon={IconMappings.magnifyingGlass}
                         size="medium"
                     />
                 </View>
@@ -118,7 +118,7 @@ export const Sizes: StoryComponentType = {
                     <LabelMedium>large</LabelMedium>
 
                     <PhosphorIcon
-                        icon={IconMappings.MagnifyingGlass}
+                        icon={IconMappings.magnifyingGlass}
                         size="large"
                     />
                 </View>
@@ -126,7 +126,7 @@ export const Sizes: StoryComponentType = {
                     <LabelMedium>xlarge</LabelMedium>
 
                     <PhosphorIcon
-                        icon={IconMappings.MagnifyingGlass}
+                        icon={IconMappings.magnifyingGlass}
                         size="xlarge"
                     />
                 </View>
@@ -245,7 +245,7 @@ export const Variants: StoryComponentType = {
 export const WithColor: StoryComponentType = {
     args: {
         size: "small",
-        icon: IconMappings.InfoBold,
+        icon: IconMappings.infoBold,
         color: tokens.color.red,
     },
 };
@@ -260,7 +260,7 @@ export const Inline: StoryComponentType = {
                 Here is an icon
                 <PhosphorIcon
                     size="small"
-                    icon={IconMappings.InfoBold}
+                    icon={IconMappings.infoBold}
                     style={{margin: tokens.spacing.xxxxSmall_2}}
                     className="foo"
                 />

--- a/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
@@ -1,8 +1,12 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
+import X from "@phosphor-icons/core/regular/x.svg";
+import Lightbulb from "@phosphor-icons/core/regular/lightbulb.svg";
+import MagnifyingGlassPlus from "@phosphor-icons/core/regular/magnifying-glass-plus.svg";
+import MagnifyingGlassMinus from "@phosphor-icons/core/regular/magnifying-glass-minus.svg";
+
 import Button from "@khanacademy/wonder-blocks-button";
-import {icons} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
@@ -31,14 +35,14 @@ type Mappings = {
 
 export const leftContentMappings: Mappings = {
     none: null,
-    dismissButton: <IconButton icon={icons.dismiss} kind="tertiary" />,
-    lightButton: <IconButton icon={icons.dismiss} light={true} />,
-    hintButton: <IconButton icon={icons.hint} kind="primary" />,
+    dismissButton: <IconButton icon={X} kind="tertiary" />,
+    lightButton: <IconButton icon={X} light={true} />,
+    hintButton: <IconButton icon={Lightbulb} kind="primary" />,
     multipleContent: (
         <>
-            <IconButton icon={icons.zoomOut} kind="primary" />
+            <IconButton icon={MagnifyingGlassMinus} kind="primary" />
             <Strut size={Spacing.medium_16} />
-            <IconButton icon={icons.zoomIn} kind="primary" />
+            <IconButton icon={MagnifyingGlassPlus} kind="primary" />
         </>
     ),
 };

--- a/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import X from "@phosphor-icons/core/regular/x.svg";
-import Lightbulb from "@phosphor-icons/core/regular/lightbulb.svg";
-import MagnifyingGlassPlus from "@phosphor-icons/core/regular/magnifying-glass-plus.svg";
-import MagnifyingGlassMinus from "@phosphor-icons/core/regular/magnifying-glass-minus.svg";
+import xIcon from "@phosphor-icons/core/regular/x.svg";
+import lightbulb from "@phosphor-icons/core/regular/lightbulb.svg";
+import magnifyingGlassPlus from "@phosphor-icons/core/regular/magnifying-glass-plus.svg";
+import magnifyingGlassMinus from "@phosphor-icons/core/regular/magnifying-glass-minus.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
@@ -35,14 +35,14 @@ type Mappings = {
 
 export const leftContentMappings: Mappings = {
     none: null,
-    dismissButton: <IconButton icon={X} kind="tertiary" />,
-    lightButton: <IconButton icon={X} light={true} />,
-    hintButton: <IconButton icon={Lightbulb} kind="primary" />,
+    dismissButton: <IconButton icon={xIcon} kind="tertiary" />,
+    lightButton: <IconButton icon={xIcon} light={true} />,
+    hintButton: <IconButton icon={lightbulb} kind="primary" />,
     multipleContent: (
         <>
-            <IconButton icon={MagnifyingGlassMinus} kind="primary" />
+            <IconButton icon={magnifyingGlassMinus} kind="primary" />
             <Strut size={Spacing.medium_16} />
-            <IconButton icon={MagnifyingGlassPlus} kind="primary" />
+            <IconButton icon={magnifyingGlassPlus} kind="primary" />
         </>
     ),
 };

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -5,12 +5,13 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {within, userEvent} from "@storybook/testing-library";
 import {expect} from "@storybook/jest";
 
+import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+
 import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {icons} from "@khanacademy/wonder-blocks-icon";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {Body} from "@khanacademy/wonder-blocks-typography";
@@ -250,7 +251,7 @@ export const TooltipOnButtons: StoryComponentType = () => {
             </Tooltip>
             <Tooltip content="Short and stout">
                 <IconButton
-                    icon={icons.search}
+                    icon={MagnifyingGlass}
                     aria-label="search"
                     onClick={() => {}}
                 />

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {within, userEvent} from "@storybook/testing-library";
 import {expect} from "@storybook/jest";
 
-import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
@@ -251,7 +251,7 @@ export const TooltipOnButtons: StoryComponentType = () => {
             </Tooltip>
             <Tooltip content="Short and stout">
                 <IconButton
-                    icon={MagnifyingGlass}
+                    icon={magnifyingGlass}
                     aria-label="search"
                     onClick={() => {}}
                 />

--- a/consistency-tests/__tests__/ref-forwarded.test.tsx
+++ b/consistency-tests/__tests__/ref-forwarded.test.tsx
@@ -3,7 +3,7 @@ import {render, waitFor} from "@testing-library/react";
 import {MemoryRouter, Link as ReactRouterLink} from "react-router-dom";
 import * as ReactDOM from "react-dom";
 
-import Plus from "@phosphor-icons/core/regular/plus.svg";
+import plus from "@phosphor-icons/core/regular/plus.svg";
 
 import {icons} from "@khanacademy/wonder-blocks-icon";
 
@@ -252,7 +252,7 @@ describe("IconButton", () => {
         const ref: React.RefObject<HTMLButtonElement> = React.createRef();
 
         // Act
-        render(<IconButton ref={ref} icon={Plus} />);
+        render(<IconButton ref={ref} icon={plus} />);
 
         // Assert
         expect(ref.current).toBeInstanceOf(HTMLButtonElement);
@@ -270,7 +270,7 @@ describe("IconButton", () => {
                 href="/foo"
                 skipClientNav={true}
                 ref={ref}
-                icon={Plus}
+                icon={plus}
             />,
         );
 
@@ -291,7 +291,7 @@ describe("IconButton", () => {
                     href="/foo"
                     skipClientNav={false}
                     ref={ref}
-                    icon={Plus}
+                    icon={plus}
                 />
                 ,
             </MemoryRouter>,

--- a/consistency-tests/__tests__/ref-forwarded.test.tsx
+++ b/consistency-tests/__tests__/ref-forwarded.test.tsx
@@ -3,6 +3,8 @@ import {render, waitFor} from "@testing-library/react";
 import {MemoryRouter, Link as ReactRouterLink} from "react-router-dom";
 import * as ReactDOM from "react-dom";
 
+import Plus from "@phosphor-icons/core/regular/plus.svg";
+
 import {icons} from "@khanacademy/wonder-blocks-icon";
 
 import Breadcrumbs from "../../packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs";
@@ -250,7 +252,7 @@ describe("IconButton", () => {
         const ref: React.RefObject<HTMLButtonElement> = React.createRef();
 
         // Act
-        render(<IconButton ref={ref} icon={icons.add} />);
+        render(<IconButton ref={ref} icon={Plus} />);
 
         // Assert
         expect(ref.current).toBeInstanceOf(HTMLButtonElement);
@@ -268,7 +270,7 @@ describe("IconButton", () => {
                 href="/foo"
                 skipClientNav={true}
                 ref={ref}
-                icon={icons.add}
+                icon={Plus}
             />,
         );
 
@@ -289,7 +291,7 @@ describe("IconButton", () => {
                     href="/foo"
                     skipClientNav={false}
                     ref={ref}
-                    icon={icons.add}
+                    icon={Plus}
                 />
                 ,
             </MemoryRouter>,

--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
   ],
   "resolutions": {
     "@types/react": "16",
-    "@types/react-dom": "16"
+    "@types/react-dom": "16",
+    "strip-ansi": "6.0.1",
+    "strip-ansi-explanation": "There's an issue with strip-ansi v7 which causes conflicts with the Khan/changeset-per-package action"
   }
 }

--- a/packages/wonder-blocks-banner/package.json
+++ b/packages/wonder-blocks-banner/package.json
@@ -26,6 +26,7 @@
     "@khanacademy/wonder-blocks-typography": "^2.1.8"
   },
   "peerDependencies": {
+    "@phosphor-icons/core": "^2.0.2",
     "aphrodite": "^1.2.5",
     "react": "16.14.0"
   },

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import X from "@phosphor-icons/core/regular/x.svg";
+import xIcon from "@phosphor-icons/core/regular/x.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
@@ -263,7 +263,7 @@ const Banner = (props: Props): React.ReactElement => {
                 {onDismiss ? (
                     <View style={styles.dismissContainer}>
                         <IconButton
-                            icon={X}
+                            icon={xIcon}
                             kind="tertiary"
                             onClick={onDismiss}
                             style={styles.dismiss}

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
+import X from "@phosphor-icons/core/regular/x.svg";
+
 import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+import Icon from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import Link from "@khanacademy/wonder-blocks-link";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
@@ -261,8 +263,8 @@ const Banner = (props: Props): React.ReactElement => {
                 {onDismiss ? (
                     <View style={styles.dismissContainer}>
                         <IconButton
-                            icon={icons.dismiss}
-                            kind={"tertiary"}
+                            icon={X}
+                            kind="tertiary"
                             onClick={onDismiss}
                             style={styles.dismiss}
                             aria-label={dismissAriaLabel}

--- a/packages/wonder-blocks-icon-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-icon-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -46,25 +46,24 @@ exports[`IconButtonCore kind:primary color:default size:medium light:false disab
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -118,25 +117,24 @@ exports[`IconButtonCore kind:primary color:default size:medium light:false focus
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -190,25 +188,24 @@ exports[`IconButtonCore kind:primary color:default size:medium light:false hover
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -262,25 +259,24 @@ exports[`IconButtonCore kind:primary color:default size:medium light:false press
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -330,25 +326,24 @@ exports[`IconButtonCore kind:primary color:default size:medium light:true disabl
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -402,25 +397,24 @@ exports[`IconButtonCore kind:primary color:default size:medium light:true focuse
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -474,25 +468,24 @@ exports[`IconButtonCore kind:primary color:default size:medium light:true hovere
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -546,25 +539,24 @@ exports[`IconButtonCore kind:primary color:default size:medium light:true presse
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -614,25 +606,24 @@ exports[`IconButtonCore kind:primary color:default size:small light:false disabl
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -686,25 +677,24 @@ exports[`IconButtonCore kind:primary color:default size:small light:false focuse
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -758,25 +748,24 @@ exports[`IconButtonCore kind:primary color:default size:small light:false hovere
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -830,25 +819,24 @@ exports[`IconButtonCore kind:primary color:default size:small light:false presse
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -898,25 +886,24 @@ exports[`IconButtonCore kind:primary color:default size:small light:true disable
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -970,25 +957,24 @@ exports[`IconButtonCore kind:primary color:default size:small light:true focused
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1042,25 +1028,24 @@ exports[`IconButtonCore kind:primary color:default size:small light:true hovered
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1114,25 +1099,24 @@ exports[`IconButtonCore kind:primary color:default size:small light:true pressed
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1182,25 +1166,24 @@ exports[`IconButtonCore kind:primary color:default size:xsmall light:false disab
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1254,25 +1237,24 @@ exports[`IconButtonCore kind:primary color:default size:xsmall light:false focus
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1326,25 +1308,24 @@ exports[`IconButtonCore kind:primary color:default size:xsmall light:false hover
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1398,25 +1379,24 @@ exports[`IconButtonCore kind:primary color:default size:xsmall light:false press
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1466,25 +1446,24 @@ exports[`IconButtonCore kind:primary color:default size:xsmall light:true disabl
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1538,25 +1517,24 @@ exports[`IconButtonCore kind:primary color:default size:xsmall light:true focuse
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1610,25 +1588,24 @@ exports[`IconButtonCore kind:primary color:default size:xsmall light:true hovere
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1682,25 +1659,24 @@ exports[`IconButtonCore kind:primary color:default size:xsmall light:true presse
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1750,25 +1726,24 @@ exports[`IconButtonCore kind:primary color:destructive size:medium light:false d
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1822,25 +1797,24 @@ exports[`IconButtonCore kind:primary color:destructive size:medium light:false f
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1894,25 +1868,24 @@ exports[`IconButtonCore kind:primary color:destructive size:medium light:false h
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -1966,25 +1939,24 @@ exports[`IconButtonCore kind:primary color:destructive size:medium light:false p
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2034,25 +2006,24 @@ exports[`IconButtonCore kind:primary color:destructive size:medium light:true di
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2106,25 +2077,24 @@ exports[`IconButtonCore kind:primary color:destructive size:medium light:true fo
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2178,25 +2148,24 @@ exports[`IconButtonCore kind:primary color:destructive size:medium light:true ho
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2250,25 +2219,24 @@ exports[`IconButtonCore kind:primary color:destructive size:medium light:true pr
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2318,25 +2286,24 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false di
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2390,25 +2357,24 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false fo
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2462,25 +2428,24 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false ho
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2534,25 +2499,24 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:false pr
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2602,25 +2566,24 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true dis
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2674,25 +2637,24 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true foc
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2746,25 +2708,24 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true hov
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2818,25 +2779,24 @@ exports[`IconButtonCore kind:primary color:destructive size:small light:true pre
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2886,25 +2846,24 @@ exports[`IconButtonCore kind:primary color:destructive size:xsmall light:false d
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -2958,25 +2917,24 @@ exports[`IconButtonCore kind:primary color:destructive size:xsmall light:false f
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3030,25 +2988,24 @@ exports[`IconButtonCore kind:primary color:destructive size:xsmall light:false h
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3102,25 +3059,24 @@ exports[`IconButtonCore kind:primary color:destructive size:xsmall light:false p
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3170,25 +3126,24 @@ exports[`IconButtonCore kind:primary color:destructive size:xsmall light:true di
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3242,25 +3197,24 @@ exports[`IconButtonCore kind:primary color:destructive size:xsmall light:true fo
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3314,25 +3268,24 @@ exports[`IconButtonCore kind:primary color:destructive size:xsmall light:true ho
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3386,25 +3339,24 @@ exports[`IconButtonCore kind:primary color:destructive size:xsmall light:true pr
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3454,25 +3406,24 @@ exports[`IconButtonCore kind:secondary color:default size:medium light:false dis
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3526,25 +3477,24 @@ exports[`IconButtonCore kind:secondary color:default size:medium light:false foc
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3598,25 +3548,24 @@ exports[`IconButtonCore kind:secondary color:default size:medium light:false hov
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3670,25 +3619,24 @@ exports[`IconButtonCore kind:secondary color:default size:medium light:false pre
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3738,25 +3686,24 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false disa
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3810,25 +3757,24 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false focu
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3882,25 +3828,24 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false hove
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -3954,25 +3899,24 @@ exports[`IconButtonCore kind:secondary color:default size:small light:false pres
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4022,25 +3966,24 @@ exports[`IconButtonCore kind:secondary color:default size:xsmall light:false dis
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4094,25 +4037,24 @@ exports[`IconButtonCore kind:secondary color:default size:xsmall light:false foc
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4166,25 +4108,24 @@ exports[`IconButtonCore kind:secondary color:default size:xsmall light:false hov
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4238,25 +4179,24 @@ exports[`IconButtonCore kind:secondary color:default size:xsmall light:false pre
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4306,25 +4246,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:medium light:false
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4378,25 +4317,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:medium light:false
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4450,25 +4388,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:medium light:false
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4522,25 +4459,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:medium light:false
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4590,25 +4526,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4662,25 +4597,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4734,25 +4668,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4806,25 +4739,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:small light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4874,25 +4806,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:xsmall light:false
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -4946,25 +4877,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:xsmall light:false
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5018,25 +4948,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:xsmall light:false
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5090,25 +5019,24 @@ exports[`IconButtonCore kind:secondary color:destructive size:xsmall light:false
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5158,25 +5086,24 @@ exports[`IconButtonCore kind:tertiary color:default size:medium light:false disa
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5230,25 +5157,24 @@ exports[`IconButtonCore kind:tertiary color:default size:medium light:false focu
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5302,25 +5228,24 @@ exports[`IconButtonCore kind:tertiary color:default size:medium light:false hove
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5374,25 +5299,24 @@ exports[`IconButtonCore kind:tertiary color:default size:medium light:false pres
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5442,25 +5366,24 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false disab
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5514,25 +5437,24 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false focus
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5586,25 +5508,24 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false hover
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5658,25 +5579,24 @@ exports[`IconButtonCore kind:tertiary color:default size:small light:false press
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5726,25 +5646,24 @@ exports[`IconButtonCore kind:tertiary color:default size:xsmall light:false disa
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5798,25 +5717,24 @@ exports[`IconButtonCore kind:tertiary color:default size:xsmall light:false focu
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5870,25 +5788,24 @@ exports[`IconButtonCore kind:tertiary color:default size:xsmall light:false hove
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -5942,25 +5859,24 @@ exports[`IconButtonCore kind:tertiary color:default size:xsmall light:false pres
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6010,25 +5926,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:medium light:false 
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6082,25 +5997,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:medium light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6154,25 +6068,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:medium light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6226,25 +6139,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:medium light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6294,25 +6206,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false d
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6366,25 +6277,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false f
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6438,25 +6348,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false h
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6510,25 +6419,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:small light:false p
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={24}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 24,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 24,
       }
     }
-    viewBox="0 0 24 24"
-    width={24}
-  >
-    <path
-      d="M11 17a6 6 0 1 0 0-12 6 6 0 0 0 0 12zm6.32-1.094l3.387 3.387a1 1 0 0 1-1.414 1.414l-3.387-3.387a8 8 0 1 1 1.414-1.414z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6578,25 +6486,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:xsmall light:false 
   tabIndex={-1}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6650,25 +6557,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:xsmall light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6722,25 +6628,24 @@ exports[`IconButtonCore kind:tertiary color:destructive size:xsmall light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;
 
@@ -6794,24 +6699,23 @@ exports[`IconButtonCore kind:tertiary color:destructive size:xsmall light:false 
   tabIndex={0}
   type="button"
 >
-  <svg
+  <span
     className=""
-    height={16}
     style={
       {
+        "backgroundColor": "currentColor",
         "display": "inline-block",
         "flexGrow": 0,
         "flexShrink": 0,
+        "height": 16,
+        "maskImage": "url([object Object])",
+        "maskPosition": "center",
+        "maskRepeat": "no-repeat",
+        "maskSize": "100%",
         "verticalAlign": "text-bottom",
+        "width": 16,
       }
     }
-    viewBox="0 0 16 16"
-    width={16}
-  >
-    <path
-      d="M11.172 9.757l2.535 2.536a1 1 0 0 1-1.414 1.414l-2.536-2.535a5 5 0 1 1 1.414-1.414zM7 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"
-      fill="currentColor"
-    />
-  </svg>
+  />
 </button>
 `;

--- a/packages/wonder-blocks-icon-button/src/__tests__/custom-snapshot.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/__tests__/custom-snapshot.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as renderer from "react-test-renderer";
 
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import IconButtonCore from "../components/icon-button-core";
 import {IconButtonSize} from "../components/icon-button";
@@ -52,7 +52,7 @@ describe("IconButtonCore", () => {
                             const tree = renderer
                                 .create(
                                     <IconButtonCore
-                                        icon={icons.search}
+                                        icon={MagnifyingGlass}
                                         aria-label="search"
                                         kind={kind}
                                         color={color}

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
@@ -3,7 +3,7 @@ import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {MemoryRouter, Route, Switch} from "react-router-dom";
-import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import expectRenderError from "../../../../../utils/testing/expect-render-error";
 import {IconButton} from "../icon-button";
@@ -28,7 +28,7 @@ describe("IconButton", () => {
         // Act
         render(
             <IconButton
-                icon={MagnifyingGlass}
+                icon={magnifyingGlassIcon}
                 aria-label="search"
                 onClick={() => {}}
                 testId="icon-button"
@@ -44,7 +44,7 @@ describe("IconButton", () => {
     test("throw an error for if light and not primary", () => {
         expectRenderError(
             <IconButton
-                icon={MagnifyingGlass}
+                icon={magnifyingGlassIcon}
                 aria-label="search"
                 kind="secondary"
                 light={true}
@@ -60,7 +60,7 @@ describe("IconButton", () => {
             <MemoryRouter>
                 <div>
                     <IconButton
-                        icon={MagnifyingGlass}
+                        icon={magnifyingGlassIcon}
                         aria-label="search"
                         testId="icon-button"
                         href="/foo"
@@ -87,7 +87,7 @@ describe("IconButton", () => {
             <MemoryRouter>
                 <div>
                     <IconButton
-                        icon={MagnifyingGlass}
+                        icon={magnifyingGlassIcon}
                         aria-label="search"
                         testId="icon-button"
                         href="/unknown"
@@ -114,7 +114,7 @@ describe("IconButton", () => {
             <MemoryRouter>
                 <div>
                     <IconButton
-                        icon={MagnifyingGlass}
+                        icon={magnifyingGlassIcon}
                         aria-label="search"
                         testId="icon-button"
                         href="/foo"
@@ -141,7 +141,7 @@ describe("IconButton", () => {
             <MemoryRouter>
                 <div>
                     <IconButton
-                        icon={MagnifyingGlass}
+                        icon={magnifyingGlassIcon}
                         aria-label="search"
                         testId="icon-button"
                         href="/foo"

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
@@ -3,10 +3,10 @@ import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {MemoryRouter, Route, Switch} from "react-router-dom";
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import expectRenderError from "../../../../../utils/testing/expect-render-error";
-import IconButton from "../icon-button";
+import {IconButton} from "../icon-button";
 
 describe("IconButton", () => {
     const {location} = window;
@@ -22,13 +22,13 @@ describe("IconButton", () => {
         window.location = location;
     });
 
-    test("render an icon", () => {
+    test("render a span containing the reference to the icon", () => {
         // Arrange
 
         // Act
         render(
             <IconButton
-                icon={icons.search}
+                icon={MagnifyingGlass}
                 aria-label="search"
                 onClick={() => {}}
                 testId="icon-button"
@@ -38,13 +38,13 @@ describe("IconButton", () => {
         const icon = screen.getByLabelText("search");
 
         // Assert
-        expect(icon.innerHTML).toEqual(expect.stringContaining("<svg"));
+        expect(icon.innerHTML).toEqual(expect.stringContaining("mask-image"));
     });
 
     test("throw an error for if light and not primary", () => {
         expectRenderError(
             <IconButton
-                icon={icons.search}
+                icon={MagnifyingGlass}
                 aria-label="search"
                 kind="secondary"
                 light={true}
@@ -60,7 +60,7 @@ describe("IconButton", () => {
             <MemoryRouter>
                 <div>
                     <IconButton
-                        icon={icons.search}
+                        icon={MagnifyingGlass}
                         aria-label="search"
                         testId="icon-button"
                         href="/foo"
@@ -87,7 +87,7 @@ describe("IconButton", () => {
             <MemoryRouter>
                 <div>
                     <IconButton
-                        icon={icons.search}
+                        icon={MagnifyingGlass}
                         aria-label="search"
                         testId="icon-button"
                         href="/unknown"
@@ -114,7 +114,7 @@ describe("IconButton", () => {
             <MemoryRouter>
                 <div>
                     <IconButton
-                        icon={icons.search}
+                        icon={MagnifyingGlass}
                         aria-label="search"
                         testId="icon-button"
                         href="/foo"
@@ -141,7 +141,7 @@ describe("IconButton", () => {
             <MemoryRouter>
                 <div>
                     <IconButton
-                        icon={icons.search}
+                        icon={MagnifyingGlass}
                         aria-label="search"
                         testId="icon-button"
                         href="/foo"

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -10,7 +10,7 @@ import Color, {
 } from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
-import Icon from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import type {
     ChildrenProps,
@@ -21,6 +21,39 @@ import {
     iconSizeForButtonSize,
     targetPixelsForSize,
 } from "../util/icon-button-util";
+
+/**
+ * Returns the phosphor icon component based on the size. This is necessary
+ * so we can cast the icon to the correct type.
+ */
+function IconChooser({
+    icon,
+    size,
+}: {
+    icon: SharedProps["icon"];
+    size: IconButtonSize;
+}) {
+    const iconSize = iconSizeForButtonSize(size);
+    switch (iconSize) {
+        case "small":
+            return (
+                <PhosphorIcon
+                    size="small"
+                    color="currentColor"
+                    icon={icon as PhosphorBold | PhosphorFill}
+                />
+            );
+        case "medium":
+        default:
+            return (
+                <PhosphorIcon
+                    size="medium"
+                    color="currentColor"
+                    icon={icon as PhosphorRegular | PhosphorFill}
+                />
+            );
+    }
+}
 
 type Props = SharedProps &
     ChildrenProps &
@@ -81,13 +114,7 @@ const IconButtonCore: React.ForwardRefExoticComponent<
                     : (hovered || focused) && buttonStyles.focus),
         ];
 
-        const child = (
-            <Icon
-                size={iconSizeForButtonSize(size)}
-                color="currentColor"
-                icon={icon}
-            />
-        );
+        const child = <IconChooser size={size} icon={icon} />;
 
         const commonProps = {
             "data-test-id": testId,

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {__RouterContext} from "react-router";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
-import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
+import type {PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import {Link} from "react-router-dom";
 import IconButtonCore from "./icon-button-core";
@@ -11,10 +11,9 @@ export type IconButtonSize = "xsmall" | "small" | "medium";
 
 export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
     /**
-     * A Wonder Blocks icon asset, an object specifing paths for one or more of
-     * the following sizes: small, medium, large, xlarge.
+     * A Phosphor icon asset (imported as a static SVG file).
      */
-    icon: IconAsset;
+    icon: PhosphorIconAsset;
     /**
      * The color of the icon button, either blue or red.
      */
@@ -122,43 +121,45 @@ export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
 };
 
 /**
- * An IconButton is a button whose contents are an SVG image.
+ * An `IconButton` is a button whose contents are an SVG image.
  *
- * To use, supply an onClick function, a wonder-blocks icon asset (see
- * the Icon section) and an aria-label to describe the button functionality.
- * Optionally specify href (URL), clientSideNav, color
- * (Wonder Blocks Blue or Red), kind ("primary", "secondary", or "tertiary"),
- * light (whether the IconButton will be rendered on a dark background),
- * disabled , test ID, and custom styling.
+ * To use, supply an `onClick` function, a Phosphor icon asset (see the
+ * `Icon>PhosphorIcon` section) and an `aria-label` to describe the button
+ * functionality. Optionally specify href (URL), clientSideNav, color (Wonder
+ * Blocks Blue or Red), kind ("primary", "secondary", or "tertiary"), light
+ * (whether the IconButton will be rendered on a dark background), disabled ,
+ * test ID, and custom styling.
  *
- * The size of an IconButton matches the size of icon it wraps which is 24x24
- * pixels.  The focus ring which is displayed on hover and focus is much
- * larger but does not affect its size.  This matches the behavior of Button.
+ * The size of an `IconButton` is based on how the `size` prop is defined (see
+ * `Sizes` below for more details). The focus ring which is displayed on hover
+ * and focus is much larger but does not affect its size. This matches the
+ * behavior of Button.
  *
  * IconButtons require a certain amount of space between them to ensure the
- * focus rings don't overlap.  The minimum amount of spacing is 16px, but
- * you should refer to the mocks provided by design.  Using a Strut in between
+ * focus rings don't overlap. The minimum amount of spacing is 16px, but you
+ * should refer to the mocks provided by design.  Using a Strut in between
  * IconButtons is the preferred way to for adding this spacing.
  *
  * Many layouts require alignment of visual left (or right) side of an
- * IconButton.  This requires a little bit of pixel nudging since each icon
- * as a different amount of internal padding.
+ * `IconButton`. This requires a little bit of pixel nudging since each icon as
+ * a different amount of internal padding.
  *
- * See the Toolbar documentation for examples of IconButton use that follow
+ * See the Toolbar documentation for examples of `IconButton` use that follow
  * the best practices described above.
  *
  * ```js
- * import {icons} from "@khanacademy/wonder-blocks-icon";
+ * import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
  * import IconButton from "@khanacademy/wonder-blocks-icon-button";
  *
  * <IconButton
- *     icon={icons.anIcon}
+ *     icon={MagnifyingGlass}
  *     aria-label="An Icon"
  *     onClick={(e) => console.log("Hello, world!")}
+ *     size="medium"
  * />
  * ```
  */
-const IconButton: React.ForwardRefExoticComponent<
+export const IconButton: React.ForwardRefExoticComponent<
     SharedProps &
         React.RefAttributes<typeof Link | HTMLButtonElement | HTMLAnchorElement>
 > = React.forwardRef<
@@ -222,5 +223,3 @@ const IconButton: React.ForwardRefExoticComponent<
         </__RouterContext.Consumer>
     );
 });
-
-export default IconButton;

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -148,11 +148,11 @@ export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
  * the best practices described above.
  *
  * ```js
- * import MagnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
+ * import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
  * import IconButton from "@khanacademy/wonder-blocks-icon-button";
  *
  * <IconButton
- *     icon={MagnifyingGlass}
+ *     icon={magnifyingGlassIcon}
  *     aria-label="An Icon"
  *     onClick={(e) => console.log("Hello, world!")}
  *     size="medium"

--- a/packages/wonder-blocks-icon-button/src/index.ts
+++ b/packages/wonder-blocks-icon-button/src/index.ts
@@ -1,3 +1,1 @@
-import IconButton from "./components/icon-button";
-
-export {IconButton as default};
+export {IconButton as default} from "./components/icon-button";

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -19,7 +19,6 @@
     "@khanacademy/wonder-blocks-breadcrumbs": "^2.1.8",
     "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.2.0",
-    "@khanacademy/wonder-blocks-icon": "^2.1.6",
     "@khanacademy/wonder-blocks-icon-button": "^4.2.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.22",
     "@khanacademy/wonder-blocks-spacing": "^4.0.1",

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -27,6 +27,7 @@
     "@khanacademy/wonder-blocks-typography": "^2.1.8"
   },
   "peerDependencies": {
+    "@phosphor-icons/core": "^2.0.2",
     "aphrodite": "^1.2.5",
     "react": "16.14.0",
     "react-dom": "16.14.0"

--- a/packages/wonder-blocks-modal/src/components/close-button.tsx
+++ b/packages/wonder-blocks-modal/src/components/close-button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import X from "@phosphor-icons/core/regular/x.svg";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
@@ -46,7 +46,7 @@ export default class CloseButton extends React.Component<Props> {
 
                     return (
                         <IconButton
-                            icon={icons.dismiss}
+                            icon={X}
                             // TODO(mdr): Translate this string for i18n.
                             // TODO(kevinb): provide a way to set this label
                             aria-label="Close modal"

--- a/packages/wonder-blocks-modal/src/components/close-button.tsx
+++ b/packages/wonder-blocks-modal/src/components/close-button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import X from "@phosphor-icons/core/regular/x.svg";
+import xIcon from "@phosphor-icons/core/regular/x.svg";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
@@ -46,7 +46,7 @@ export default class CloseButton extends React.Component<Props> {
 
                     return (
                         <IconButton
-                            icon={X}
+                            icon={xIcon}
                             // TODO(mdr): Translate this string for i18n.
                             // TODO(kevinb): provide a way to set this label
                             aria-label="Close modal"

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -26,6 +26,7 @@
     "@khanacademy/wonder-blocks-typography": "^2.1.8"
   },
   "peerDependencies": {
+    "@phosphor-icons/core": "^2.0.2",
     "@popperjs/core": "^2.10.1",
     "aphrodite": "^1.2.5",
     "react": "16.14.0",

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -18,7 +18,6 @@
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.2.0",
-    "@khanacademy/wonder-blocks-icon": "^2.1.6",
     "@khanacademy/wonder-blocks-icon-button": "^4.2.1",
     "@khanacademy/wonder-blocks-modal": "^4.0.28",
     "@khanacademy/wonder-blocks-spacing": "^4.0.1",

--- a/packages/wonder-blocks-popover/src/components/close-button.tsx
+++ b/packages/wonder-blocks-popover/src/components/close-button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import X from "@phosphor-icons/core/regular/x.svg";
+import xIcon from "@phosphor-icons/core/regular/x.svg";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
 import PopoverContext from "./popover-context";
@@ -45,7 +45,7 @@ export default class CloseButton extends React.Component<Props> {
                 {({close}) => {
                     return (
                         <IconButton
-                            icon={X}
+                            icon={xIcon}
                             aria-label={ariaLabel}
                             onClick={close}
                             kind={light ? "primary" : "tertiary"}

--- a/packages/wonder-blocks-popover/src/components/close-button.tsx
+++ b/packages/wonder-blocks-popover/src/components/close-button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import X from "@phosphor-icons/core/regular/x.svg";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
 import PopoverContext from "./popover-context";
@@ -45,7 +45,7 @@ export default class CloseButton extends React.Component<Props> {
                 {({close}) => {
                     return (
                         <IconButton
-                            icon={icons.dismiss}
+                            icon={X}
                             aria-label={ariaLabel}
                             onClick={close}
                             kind={light ? "primary" : "tertiary"}

--- a/packages/wonder-blocks-search-field/package.json
+++ b/packages/wonder-blocks-search-field/package.json
@@ -25,6 +25,7 @@
     "@khanacademy/wonder-blocks-typography": "^2.1.8"
   },
   "peerDependencies": {
+    "@phosphor-icons/core": "^2.0.2",
     "aphrodite": "^1.2.5",
     "react": "16.14.0"
   },

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
+import X from "@phosphor-icons/core/regular/x.svg";
+
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {View, IDProvider} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
@@ -141,7 +143,7 @@ const SearchField: React.ForwardRefExoticComponent<
 
         return (
             <IconButton
-                icon={icons.dismiss}
+                icon={X}
                 kind="tertiary"
                 onClick={handleClear}
                 style={styles.dismissIcon}

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import X from "@phosphor-icons/core/regular/x.svg";
+import xIcon from "@phosphor-icons/core/regular/x.svg";
 
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {View, IDProvider} from "@khanacademy/wonder-blocks-core";
@@ -143,7 +143,7 @@ const SearchField: React.ForwardRefExoticComponent<
 
         return (
             <IconButton
-                icon={X}
+                icon={xIcon}
                 kind="tertiary"
                 onClick={handleClear}
                 style={styles.dismissIcon}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5184,11 +5184,6 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
-
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -13187,19 +13182,12 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
-
-strip-ansi@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
-  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
-  dependencies:
-    ansi-regex "^6.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Summary:
- Changes the `icon` prop to accept a `PhosphorIcon` instead of an
`IconAsset`.
- Updates the `IconButton` stories and unit tests to verify the new
  `PhosphorIcon` support.
- Updates existing WB packages to use the new `IconButton` API (Banner,
  Modal, Popover, SearchField).

**NOTE:** The plan is to replace all `IconButton` instances in webapp after this PR is landed.

Issue: WB-1612

## Test plan:

Verify that the `IconButton` stories and unit tests are passing. Also verify the
visual changes in Chromatic.


https://github.com/Khan/wonder-blocks/assets/843075/5a5c8ba1-3858-42c0-8791-085cf819ffda
