### PR TITLE
Add alert for failure in publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           SLACK_ICON_EMOJI: ":goose:"
           SLACK_MESSAGE: "Something went wrong with the release of ${{ github.event.repository.name }}. \nPlease check the logs → https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_TITLE: "Oops! I'm the Bad News Goose!"
-          SLACK_FOOTER: Perseus Slack Notification
+          SLACK_FOOTER: Wonder Blocks Slack Notification
           MSG_MINIMAL: true
 
       - name: Build Slack message

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Send a Slack notification if a publish fails
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          SLACK_MSG_AUTHOR: ${{ github.event.pull_request.user.login }}
+          SLACK_USERNAME: GithubGoose
+          SLACK_ICON_EMOJI: ":goose:"
+          SLACK_MESSAGE: "Something went wrong with the release of ${{ github.event.repository.name }}. \nPlease check the logs → https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_TITLE: "Oops! I'm the Bad News Goose!"
+          SLACK_FOOTER: Perseus Slack Notification
+          MSG_MINIMAL: true
+
       - name: Build Slack message
         id: slack_message
         if: steps.changesets.outputs.published == 'true'
@@ -76,7 +90,7 @@ jobs:
           SLACK_MSG_AUTHOR: ${{ github.event.pull_request.user.login }}
           SLACK_USERNAME: GithubGoose
           SLACK_ICON_EMOJI: ":goose:"
-          SLACK_MESSAGE: "A new version of ${{ github.event.repository.name }} was published! 🎉 \n${{ steps.slack_message.outputs.updated_packages }}\nRelease notes → https://github.com/Khan/${{ github.event.repository.name }}/releases/"
+          SLACK_MESSAGE: "A new version of ${{ github.event.repository.name }} was published! 🎉 \n${{ steps.slack_message.outputs.updated_packages }}\nRelease notes → https://github.com/${{ github.repository }}/releases/"
           SLACK_TITLE: "New Wonder Blocks release!"
           SLACK_FOOTER: Wonder Blocks Slack Notification
           MSG_MINIMAL: true


### PR DESCRIPTION
## Summary:

Replicating the changes done in the Perseus repo to able to send an alert to the
#wonder-blocks-dev channel in Slack when the publishing workflow fails.

See https://github.com/Khan/perseus/pull/727 for the original implementation.

Issue: XXX-XXXX

## Test plan:

If the publishing workflow fails, an alert should be sent to the
#wonder-blocks-dev channel in Slack.