### PR TITLE
Verify changeset for every changed package

### DIFF
--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -27,6 +27,37 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+  changeset:
+    name: Check for .changeset entries for all changed files
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-latest]
+            node-version: [16.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        uses: Khan/actions@get-changed-files-v1
+        id: changed
+
+      - name: Filter out files that don't need a changeset
+        uses: Khan/actions@filter-files-v0
+        id: match
+        with:
+            changed-files: ${{ steps.changed.outputs.files }}
+            files: packages/ # Only look for changes in packages
+            globs: "!(**/__tests__/*), !(**/dist/*)" # Ignore test files
+
+      - name: Verify changeset entries
+        uses: Khan/changeset-per-package@v1.0.1
+        with:
+            changed_files: ${{ steps.match.outputs.filtered }}
+
   lint:
     name: Lint
     needs: prime_cache_primary
@@ -94,15 +125,6 @@ jobs:
 
       - name: Check package.json files
         run: node utils/publish/pre-publish-check-ci.js
-
-      # We don't need changesets for infrastructure-type files (tests, stories,
-      # etc).
-      - uses: Khan/actions@check-for-changeset-v0
-        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-        with:
-          exclude: .github/,.storybook/
-          exclude_extensions: .test.ts, .test.tsx, .stories.ts, .stories.tsx, .mdx
-          exclude_globs: "**/__tests__/*, **/__docs__/*"
 
   test:
     name: Test


### PR DESCRIPTION
## Summary:

Another implementation borrowed from the Perseus repo, that help us to verify
that there's a changeset for every changed package.

Previously, we were using `check-for-changeset` to verify the existence of a
changeset file, but now we switch to `changeset-per-package` to make sure that
there's a changeset for every changed package. This is useful in monorepos like
this one.

See original PR: https://github.com/Khan/perseus/pull/735 (thanks @nedredmond!)

Issue: XXX-XXXX

## Test plan:

Verify that the CI passes and that in other PRs with actual changes, the
changeset workflow works as expected.