### PR TITLE
WB-1606: Re-enable snapshots release job

### DIFF
--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -188,86 +188,85 @@ jobs:
           # Always ignore SourceMaps and node_modules:
           exclude: "{**/*.map,**/node_modules/**}"
 
-# TODO(WB-1606): re-enable snapshots once release bug is fixed
-  # publish_snapshot:
-  #   name: Publish npm snapshot
-  #   # We don't publish snapshots on draft PRs or
-  #   # on the main Changeset "Version Packages" PR
-  #   if: |
-  #     github.event.pull_request.draft == false
-  #     && !startsWith(github.head_ref, 'changeset-release/')
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest]
-  #       node-version: [16.x]
-  #   steps:
-  #     # We need to checkout all history, so that the changeset tool can diff it
-  #     - name: Checkout current commit
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: "0"
-  #     - name: Ensure main branch is avaialble
-  #       run: |
-  #         REF=$(git rev-parse HEAD)
-  #         git checkout main
-  #         git checkout $REF
-  #     - name: Use Node.js ${{ matrix.node-version }} & Install & cache node_modules
-  #       uses: Khan/actions@shared-node-cache-v0
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
+  publish_snapshot:
+    name: Publish npm snapshot
+    # We don't publish snapshots on draft PRs or
+    # on the main Changeset "Version Packages" PR
+    if: |
+      github.event.pull_request.draft == false
+      && !startsWith(github.head_ref, 'changeset-release/')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16.x]
+    steps:
+      # We need to checkout all history, so that the changeset tool can diff it
+      - name: Checkout current commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+      - name: Ensure main branch is avaialble
+        run: |
+          REF=$(git rev-parse HEAD)
+          git checkout main
+          git checkout $REF
+      - name: Use Node.js ${{ matrix.node-version }} & Install & cache node_modules
+        uses: Khan/actions@shared-node-cache-v0
+        with:
+          node-version: ${{ matrix.node-version }}
 
-  #     - name: Publish snapshot release to npm
-  #       id: publish-snapshot
-  #       run: ./utils/publish/publish-snapshot.sh # All config is via Github env vars
-  #       env:
-  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish snapshot release to npm
+        id: publish-snapshot
+        run: ./utils/publish/publish-snapshot.sh # All config is via Github env vars
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  #     - name: Calculate short SHA for this commit
-  #       id: short-sha
-  #       run: echo "short_sha=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
+      - name: Calculate short SHA for this commit
+        id: short-sha
+        run: echo "short_sha=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
 
-  #     # Note: these two actions are locked to the latest version that were
-  #     # published when @jeremy (Jeremy Wiebe) created the original job in Perseus.
-  #     - name: Find existing comment
-  #       uses: peter-evans/find-comment@034abe94d3191f9c89d870519735beae326f2bdb
-  #       id: find-comment
-  #       with:
-  #         issue-number: ${{ github.event.pull_request.number }}
-  #         comment-author: "github-actions[bot]"
-  #         body-includes: "npm Snapshot:"
+      # Note: these two actions are locked to the latest version that were
+      # published when @jeremy (Jeremy Wiebe) created the original job in Perseus.
+      - name: Find existing comment
+        uses: peter-evans/find-comment@034abe94d3191f9c89d870519735beae326f2bdb
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "npm Snapshot:"
 
-  #     - name: Create or update npm snapshot comment - Success
-  #       if: steps.publish-snapshot.outputs.npm_snapshot_tag != ''
-  #       uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
-  #       with:
-  #         issue-number: ${{ github.event.pull_request.number }}
-  #         comment-id: ${{ steps.find-comment.outputs.comment-id }}
-  #         edit-mode: replace
-  #         body: |
-  #           ## npm Snapshot: Published
-  #           🎉 Good news!! We've packaged up the latest commit from this PR (${{
-  #           steps.short-sha.outputs.short_sha }}) and published all packages with changesets to npm.
+      - name: Create or update npm snapshot comment - Success
+        if: steps.publish-snapshot.outputs.npm_snapshot_tag != ''
+        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            ## npm Snapshot: Published
+            🎉 Good news!! We've packaged up the latest commit from this PR (${{
+            steps.short-sha.outputs.short_sha }}) and published all packages with changesets to npm.
 
-  #           You can install the packages in webapp by running:
-  #           ```sh
-  #           ./services/static/dev/tools/deploy_wonder_blocks.js --tag="${{
-  #           steps.publish-snapshot.outputs.npm_snapshot_tag }}"
-  #           ```
+            You can install the packages in webapp by running:
+            ```sh
+            ./services/static/dev/tools/deploy_wonder_blocks.js --tag="${{
+            steps.publish-snapshot.outputs.npm_snapshot_tag }}"
+            ```
 
-  #           Packages can also be installed manually by running:
-  #           ```sh
-  #           yarn add @khanacademy/wonder-blocks-<package-name>@${{
-  #           steps.publish-snapshot.outputs.npm_snapshot_tag }}
-  #           ```
-  #     - name: Create or update npm snapshot comment - Failure
-  #       if: steps.publish-snapshot.outputs.npm_snapshot_tag == ''
-  #       uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
-  #       with:
-  #         issue-number: ${{ github.event.pull_request.number }}
-  #         comment-id: ${{ steps.find-comment.outputs.comment-id }}
-  #         edit-mode: replace
-  #         body: |
-  #             ## npm Snapshot: **NOT** Published
-  #             🤕 Oh noes!! We couldn't find any changesets in this PR (${{
-  #             steps.short-sha.outputs.short_sha }}). As a result, we did **not** publish an npm snapshot for you.
+            Packages can also be installed manually by running:
+            ```sh
+            yarn add @khanacademy/wonder-blocks-<package-name>@${{
+            steps.publish-snapshot.outputs.npm_snapshot_tag }}
+            ```
+      - name: Create or update npm snapshot comment - Failure
+        if: steps.publish-snapshot.outputs.npm_snapshot_tag == ''
+        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+              ## npm Snapshot: **NOT** Published
+              🤕 Oh noes!! We couldn't find any changesets in this PR (${{
+              steps.short-sha.outputs.short_sha }}). As a result, we did **not** publish an npm snapshot for you.

--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -27,6 +27,37 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+  changeset:
+    name: Check for .changeset entries for all changed files
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-latest]
+            node-version: [16.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        uses: Khan/actions@get-changed-files-v1
+        id: changed
+
+      - name: Filter out files that don't need a changeset
+        uses: Khan/actions@filter-files-v0
+        id: match
+        with:
+            changed-files: ${{ steps.changed.outputs.files }}
+            files: packages/ # Only look for changes in packages
+            globs: "!(**/__tests__/*), !(**/dist/*)" # Ignore test files
+
+      - name: Verify changeset entries
+        uses: Khan/changeset-per-package@v1.0.1
+        with:
+            changed_files: ${{ steps.match.outputs.filtered }}
+
   lint:
     name: Lint
     needs: prime_cache_primary
@@ -94,15 +125,6 @@ jobs:
 
       - name: Check package.json files
         run: node utils/publish/pre-publish-check-ci.js
-
-      # We don't need changesets for infrastructure-type files (tests, stories,
-      # etc).
-      - uses: Khan/actions@check-for-changeset-v0
-        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-        with:
-          exclude: .github/,.storybook/
-          exclude_extensions: .test.ts, .test.tsx, .stories.ts, .stories.tsx, .mdx
-          exclude_globs: "**/__tests__/*, **/__docs__/*"
 
   test:
     name: Test


### PR DESCRIPTION
## Summary:

Now that we have a better path to release the packages in a safer way (#2070 and
#2071), we can re-enable the snapshots release job. re-enable the snapshots
release job to run on every non-draft PR.

Issue: WB-1606

## Test plan:

Verify that the snapshots release job is running on every non-draft PR.