### PR TITLE
WB-1623: Cell states don't work with anchor tags correctly [fix]

### DIFF
--- a/.changeset/hot-starfishes-sleep.md
+++ b/.changeset/hot-starfishes-sleep.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+Add display:flex to top node to ensure that cells render correctly

--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -54,7 +54,7 @@ jobs:
             globs: "!(**/__tests__/*), !(**/dist/*)" # Ignore test files
 
       - name: Verify changeset entries
-        uses: Khan/changeset-per-package@v1.0.1
+        uses: Khan/changeset-per-package@v1.0.2-pre
         with:
             changed_files: ${{ steps.match.outputs.filtered }}
 

--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
   ],
   "resolutions": {
     "@types/react": "16",
-    "@types/react-dom": "16"
+    "@types/react-dom": "16",
+    "strip-ansi": "6.0.1",
+    "strip-ansi-explanation": "There's an issue with strip-ansi v7 which causes conflicts with the Khan/changeset-per-package action"
   }
 }

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -215,6 +215,7 @@ const styles = StyleSheet.create({
     wrapper: {
         background: Color.white,
         color: Color.offBlack,
+        display: "flex",
         minHeight: CellMeasurements.cellMinHeight,
         textAlign: "left",
     },


### PR DESCRIPTION
## Summary:

There’s an issue with wb-cell that was introduced after making some layout/css
changes to the components.

Turns out that Cell states won’t be displayed as expected when the cell top node
is `display: inline`. As cells are meant to use the full-width of it’s parent
container, this PR fixes that by making the top node to always use `display: flex`.

Issue: https://khanacademy.atlassian.net/browse/WB-1623

## Test plan:

Verify that cell states are displayed as expected (hover, active change the bg
color).