### PR TITLE
WB-1613: Add PhosphorIcon support to Button

### DIFF
--- a/.changeset/nervous-ladybugs-search.md
+++ b/.changeset/nervous-ladybugs-search.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-button": major
+---
+
+Change `icon` type to use `PhosphorIcon` (instead of `Icon`).

--- a/.storybook/components/component-info.tsx
+++ b/.storybook/components/component-info.tsx
@@ -3,10 +3,7 @@ import * as React from "react";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Caption} from "@khanacademy/wonder-blocks-typography";
-
-const githubIconAsset = {
-    small: `M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z`,
-} as const;
+import githubLogo from "@phosphor-icons/core/fill/github-logo-fill.svg";
 
 type Props = {
     /**
@@ -47,7 +44,7 @@ const ComponentInfo: React.FC<Props> = (
                 href={`https://github.com/Khan/wonder-blocks/tree/main/packages/${packageFolder}`}
                 target="_blank"
                 style={{color: "black"}}
-                icon={githubIconAsset}
+                icon={githubLogo}
             >
                 Source code
             </Button>

--- a/__docs__/wonder-blocks-button/button.argtypes.ts
+++ b/__docs__/wonder-blocks-button/button.argtypes.ts
@@ -1,6 +1,6 @@
 import type {InputType} from "@storybook/csf";
 
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
 export default {
     children: {
@@ -8,14 +8,13 @@ export default {
         type: {name: "string", required: true},
     },
     icon: {
-        description: "An icon, displayed to the left of the title.",
-        type: {name: "other", value: "IconAsset", required: false},
+        description: "A Phosphor icon asset (imported as a static SVG file).",
+        type: {name: "other", value: "PhosphorIconAsset", required: false},
         control: {type: "select"},
-        options: Object.keys(icons) as Array<string>,
-        mapping: icons,
+        options: IconMappings,
         table: {
             category: "Layout",
-            type: {summary: "IconAsset"},
+            type: {summary: "PhosphorIconAsset"},
         },
     },
     spinner: {

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -25,6 +25,26 @@ import ComponentInfo from "../../.storybook/components/component-info";
 import ButtonArgTypes from "./button.argtypes";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
 
+/**
+ * Reusable button component.
+ *
+ * Consisting of a [`ClickableBehavior`](#clickablebehavior) surrounding a
+ * `ButtonCore`. `ClickableBehavior` handles interactions and state changes.
+ * `ButtonCore` is a stateless component which displays the different states the
+ * `Button` can take.
+ *
+ * ### Usage
+ *
+ * ```tsx
+ * import Button from "@khanacademy/wonder-blocks-button";
+ *
+ * <Button
+ *     onClick={(e) => console.log("Hello, world!")}
+ * >
+ *     Hello, world!
+ * </Button>
+ * ```
+ */
 export default {
     title: "Button",
     component: Button,
@@ -292,40 +312,49 @@ Dark.parameters = {
 
 const kinds = ["primary", "secondary", "tertiary"] as const;
 
-export const Icon: StoryComponentType = () => (
-    <View>
-        <View style={styles.row}>
-            {kinds.map((kind, idx) => (
-                <Button
-                    kind={kind}
-                    icon={pencilSimple}
-                    style={styles.button}
-                    key={idx}
-                >
-                    {kind}
-                </Button>
-            ))}
+/**
+ * Buttons can have an icon on it's left side.
+ *
+ * __NOTE:__ Icons are available from the [Phosphor
+ * Icons](https://phosphoricons.com/) library.
+ *
+ * To import an icon, you can use the following syntax:
+ *
+ * e.g.
+ * ```
+ * import pencilSimple from "@phosphor-icons/core/regular/pencil-simple.svg";
+ * ```
+ */
+export const Icon: StoryComponentType = {
+    render: () => (
+        <View>
+            <View style={styles.row}>
+                {kinds.map((kind, idx) => (
+                    <Button
+                        kind={kind}
+                        icon={pencilSimple}
+                        style={styles.button}
+                        key={idx}
+                    >
+                        {kind}
+                    </Button>
+                ))}
+            </View>
+            <View style={styles.row}>
+                {kinds.map((kind, idx) => (
+                    <Button
+                        kind={kind}
+                        icon={pencilSimpleBold}
+                        style={styles.button}
+                        key={idx}
+                        size="small"
+                    >
+                        {`${kind} small`}
+                    </Button>
+                ))}
+            </View>
         </View>
-        <View style={styles.row}>
-            {kinds.map((kind, idx) => (
-                <Button
-                    kind={kind}
-                    icon={pencilSimpleBold}
-                    style={styles.button}
-                    key={idx}
-                    size="small"
-                >
-                    {`${kind} small`}
-                </Button>
-            ))}
-        </View>
-    </View>
-);
-
-Icon.parameters = {
-    docs: {
-        description: {story: "Buttons can have an icon on it's left side."},
-    },
+    ),
 };
 
 export const Size: StoryComponentType = () => (

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -6,10 +6,14 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 
 import type {StyleDeclaration} from "aphrodite";
+
+import pencilSimple from "@phosphor-icons/core/regular/pencil-simple.svg";
+import pencilSimpleBold from "@phosphor-icons/core/bold/pencil-simple-bold.svg";
+import plus from "@phosphor-icons/core/regular/plus.svg";
+
 import {fireEvent, userEvent, within} from "@storybook/testing-library";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {icons} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
@@ -294,7 +298,7 @@ export const Icon: StoryComponentType = () => (
             {kinds.map((kind, idx) => (
                 <Button
                     kind={kind}
-                    icon={icons.contentExercise}
+                    icon={pencilSimple}
                     style={styles.button}
                     key={idx}
                 >
@@ -306,7 +310,7 @@ export const Icon: StoryComponentType = () => (
             {kinds.map((kind, idx) => (
                 <Button
                     kind={kind}
-                    icon={icons.contentExercise}
+                    icon={pencilSimpleBold}
                     style={styles.button}
                     key={idx}
                     size="small"
@@ -452,7 +456,7 @@ export const TruncatingLabels: StoryComponentType = {
                 label too long for the parent container
             </Button>
             <Strut size={16} />
-            <Button onClick={() => {}} style={{maxWidth: 200}} icon={icons.add}>
+            <Button onClick={() => {}} style={{maxWidth: 200}} icon={plus}>
                 label too long for the parent container
             </Button>
         </View>

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -312,6 +312,36 @@ Dark.parameters = {
 
 const kinds = ["primary", "secondary", "tertiary"] as const;
 
+const IconExample = () => (
+    <View>
+        <View style={styles.row}>
+            {kinds.map((kind, idx) => (
+                <Button
+                    kind={kind}
+                    icon={pencilSimple}
+                    style={styles.button}
+                    key={idx}
+                >
+                    {kind}
+                </Button>
+            ))}
+        </View>
+        <View style={styles.row}>
+            {kinds.map((kind, idx) => (
+                <Button
+                    kind={kind}
+                    icon={pencilSimpleBold}
+                    style={styles.button}
+                    key={idx}
+                    size="small"
+                >
+                    {`${kind} small`}
+                </Button>
+            ))}
+        </View>
+    </View>
+);
+
 /**
  * Buttons can have an icon on it's left side.
  *
@@ -326,35 +356,7 @@ const kinds = ["primary", "secondary", "tertiary"] as const;
  * ```
  */
 export const Icon: StoryComponentType = {
-    render: () => (
-        <View>
-            <View style={styles.row}>
-                {kinds.map((kind, idx) => (
-                    <Button
-                        kind={kind}
-                        icon={pencilSimple}
-                        style={styles.button}
-                        key={idx}
-                    >
-                        {kind}
-                    </Button>
-                ))}
-            </View>
-            <View style={styles.row}>
-                {kinds.map((kind, idx) => (
-                    <Button
-                        kind={kind}
-                        icon={pencilSimpleBold}
-                        style={styles.button}
-                        key={idx}
-                        size="small"
-                    >
-                        {`${kind} small`}
-                    </Button>
-                ))}
-            </View>
-        </View>
-    ),
+    render: () => <IconExample />,
 };
 
 export const Size: StoryComponentType = () => (
@@ -612,7 +614,7 @@ export const KhanmigoTheme: StoryComponentType = {
             Variants,
             Dark,
             Size,
-            Icon,
+            IconExample,
         ] as Array<React.ElementType>;
 
         return (

--- a/packages/wonder-blocks-button/src/components/__tests__/button.test.tsx
+++ b/packages/wonder-blocks-button/src/components/__tests__/button.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {icons} from "@khanacademy/wonder-blocks-icon";
+import plus from "@phosphor-icons/core/regular/plus.svg";
 
 import Button from "../button";
 
@@ -833,7 +833,7 @@ describe("Button", () => {
         test("icon is displayed when button contains icon", () => {
             // Arrange
             render(
-                <Button testId={"button-focus-test"} icon={icons.add}>
+                <Button testId={"button-focus-test"} icon={plus}>
                     Label
                 </Button>,
             );
@@ -842,7 +842,22 @@ describe("Button", () => {
             const icon = screen.getByTestId("button-focus-test-icon");
 
             // Assert
-            expect(icon).toBeDefined();
+            expect(icon).toBeInTheDocument();
+            expect(icon).toHaveAttribute("aria-hidden", "true");
+        });
+
+        test("icon should be hidden from Screen Readers", () => {
+            // Arrange
+            render(
+                <Button testId={"button-focus-test"} icon={plus}>
+                    Label
+                </Button>,
+            );
+
+            // Act
+            const icon = screen.getByTestId("button-focus-test-icon");
+
+            // Assert
             expect(icon).toHaveAttribute("aria-hidden", "true");
         });
     });

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -4,9 +4,8 @@ import {Link} from "react-router-dom";
 import {__RouterContext} from "react-router";
 
 import {LabelLarge, LabelSmall} from "@khanacademy/wonder-blocks-typography";
-import {addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {CircularSpinner} from "@khanacademy/wonder-blocks-progress-spinner";
-import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
 import {
     ThemedStylesFn,
@@ -20,56 +19,13 @@ import type {
 } from "@khanacademy/wonder-blocks-clickable";
 import type {SharedProps} from "./button";
 import {ButtonThemeContext, ButtonThemeContract} from "../themes/themed-button";
+import {ButtonIcon} from "./button-icon";
 
 type Props = SharedProps & ChildrenProps & ClickableState;
 
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");
 const StyledLink = addStyle(Link);
-
-/**
- * Returns the phosphor icon component based on the size. This is necessary
- * so we can cast the icon to the correct type.
- */
-function IconChooser({
-    icon,
-    size,
-    style,
-    testId,
-}: {
-    icon: SharedProps["icon"];
-    size: "small" | "medium";
-    style?: StyleType;
-    testId?: string;
-}) {
-    const commonProps = {
-        "aria-hidden": true,
-        color: "currentColor",
-        style: style,
-        testId,
-    };
-
-    switch (size) {
-        case "small":
-            return (
-                <PhosphorIcon
-                    {...commonProps}
-                    size="small"
-                    icon={icon as PhosphorBold | PhosphorFill}
-                />
-            );
-
-        case "medium":
-        default:
-            return (
-                <PhosphorIcon
-                    {...commonProps}
-                    size="medium"
-                    icon={icon as PhosphorRegular | PhosphorFill}
-                />
-            );
-    }
-}
 
 const ButtonCore: React.ForwardRefExoticComponent<
     Props &
@@ -186,7 +142,7 @@ const ButtonCore: React.ForwardRefExoticComponent<
         const contents = (
             <React.Fragment>
                 {icon && (
-                    <IconChooser
+                    <ButtonIcon
                         size={iconSize}
                         icon={icon}
                         style={sharedStyles.icon}

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -4,9 +4,9 @@ import {Link} from "react-router-dom";
 import {__RouterContext} from "react-router";
 
 import {LabelLarge, LabelSmall} from "@khanacademy/wonder-blocks-typography";
-import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
 import {CircularSpinner} from "@khanacademy/wonder-blocks-progress-spinner";
-import Icon from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
 import {
     ThemedStylesFn,
@@ -26,6 +26,50 @@ type Props = SharedProps & ChildrenProps & ClickableState;
 const StyledAnchor = addStyle("a");
 const StyledButton = addStyle("button");
 const StyledLink = addStyle(Link);
+
+/**
+ * Returns the phosphor icon component based on the size. This is necessary
+ * so we can cast the icon to the correct type.
+ */
+function IconChooser({
+    icon,
+    size,
+    style,
+    testId,
+}: {
+    icon: SharedProps["icon"];
+    size: "small" | "medium";
+    style?: StyleType;
+    testId?: string;
+}) {
+    const commonProps = {
+        "aria-hidden": true,
+        color: "currentColor",
+        style: style,
+        testId,
+    };
+
+    switch (size) {
+        case "small":
+            return (
+                <PhosphorIcon
+                    {...commonProps}
+                    size="small"
+                    icon={icon as PhosphorBold | PhosphorFill}
+                />
+            );
+
+        case "medium":
+        default:
+            return (
+                <PhosphorIcon
+                    {...commonProps}
+                    size="medium"
+                    icon={icon as PhosphorRegular | PhosphorFill}
+                />
+            );
+    }
+}
 
 const ButtonCore: React.ForwardRefExoticComponent<
     Props &
@@ -109,10 +153,6 @@ const ButtonCore: React.ForwardRefExoticComponent<
 
         const Label = size === "small" ? LabelSmall : LabelLarge;
 
-        // We have to use `medium` for both md and lg buttons so we can fit the
-        // icons in large buttons.
-        const iconSize = size === "small" ? "small" : "medium";
-
         const label = (
             <Label
                 style={[
@@ -139,15 +179,17 @@ const ButtonCore: React.ForwardRefExoticComponent<
             large: "medium",
         } as const;
 
+        // We have to use `medium` for both md and lg buttons so we can fit the
+        // icons in large buttons.
+        const iconSize = size === "small" ? "small" : "medium";
+
         const contents = (
             <React.Fragment>
                 {icon && (
-                    <Icon
+                    <IconChooser
                         size={iconSize}
-                        color="currentColor"
                         icon={icon}
                         style={sharedStyles.icon}
-                        aria-hidden="true"
                         testId={testId ? `${testId}-icon` : undefined}
                     />
                 )}
@@ -268,7 +310,7 @@ const themedSharedStyles: ThemedStylesFn<ButtonThemeContract> = (theme) => ({
         position: "absolute",
     },
     icon: {
-        paddingRight: theme.padding.small,
+        marginRight: theme.padding.small,
     },
 });
 

--- a/packages/wonder-blocks-button/src/components/button-icon.tsx
+++ b/packages/wonder-blocks-button/src/components/button-icon.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import {StyleType} from "@khanacademy/wonder-blocks-core";
+import {PhosphorIcon, PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
+
+/**
+ * Returns the phosphor icon component based on the size. This is necessary
+ * so we can cast the icon to the correct type.
+ */
+export function ButtonIcon({
+    icon,
+    size,
+    style,
+    testId,
+}: {
+    icon: PhosphorIconAsset;
+    size: "small" | "medium";
+    style?: StyleType;
+    testId?: string;
+}) {
+    const commonProps = {
+        "aria-hidden": true,
+        color: "currentColor",
+        style: style,
+        testId,
+    };
+
+    switch (size) {
+        case "small":
+            return (
+                <PhosphorIcon
+                    {...commonProps}
+                    size="small"
+                    icon={icon as PhosphorBold | PhosphorFill}
+                />
+            );
+
+        case "medium":
+        default:
+            return (
+                <PhosphorIcon
+                    {...commonProps}
+                    size="medium"
+                    icon={icon as PhosphorRegular | PhosphorFill}
+                />
+            );
+    }
+}

--- a/packages/wonder-blocks-button/src/components/button.tsx
+++ b/packages/wonder-blocks-button/src/components/button.tsx
@@ -7,7 +7,7 @@ import type {
     ChildrenProps,
 } from "@khanacademy/wonder-blocks-clickable";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
+import type {PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
 import {Link} from "react-router-dom";
 import ButtonCore from "./button-core";
 import ThemedButton from "../themes/themed-button";
@@ -24,9 +24,9 @@ export type SharedProps =
          */
         children: string;
         /**
-         * An icon, displayed to the left of the title.
+         * A Phosphor icon asset (imported as a static SVG file).
          */
-        icon?: IconAsset;
+        icon?: PhosphorIconAsset;
         /**
          * If true, replaces the contents with a spinner.
          *


### PR DESCRIPTION
## Summary:

- Changes the `icon` prop to accept a `PhosphorIconAsset` instead of an
`IconAsset`.
- Updates the `Button` stories and unit tests to verify the new `PhosphorIcon` support.

Issue: WB-1613

## Test plan:

Verify that the `Button` stories and unit tests are passing. Also verify the
visual changes in Chromatic.