### PR TITLE
Fix filters for changeset workflow step

### DIFF
--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -52,6 +52,7 @@ jobs:
             changed-files: ${{ steps.changed.outputs.files }}
             files: packages/ # Only look for changes in packages
             globs: "!(**/__tests__/*), !(**/dist/*)" # Ignore test files
+            conjunctive: true # Only return files that match all of the above
 
       - name: Verify changeset entries
         uses: Khan/changeset-per-package@v1.0.2-pre


### PR DESCRIPTION
By default, filters are inclusive disjunctions (OR). This makes the `packages/` filter useless, since the glob filter will match anything that does not include `__tests__` and `dist` in the path.

This field that I added to the `filter-files` action will ensure that file pathnames match EVERY provided filter. This prevents accidental inclusions of packages outside of `packages/`.