### PR TITLE
Fix glob match issue in `filter-files` action

### DIFF
--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -52,6 +52,7 @@ jobs:
             changed-files: ${{ steps.changed.outputs.files }}
             files: packages/ # Only look for changes in packages
             globs: "!(**/__tests__/*), !(**/dist/*)" # Ignore test files
+            matchAllGlobs: true # All globs must match (disjunction is the default)
             conjunctive: true # Only return files that match all of the above
 
       - name: Verify changeset entries


### PR DESCRIPTION
Corrects an issue where we unexpectedly match all files except those with both `tests` and `dist` in the path.