### PR TITLE
[🔥AUDIT🔥] Re-enable chromatic snapshots on draft PRs

### DIFF
--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -23,12 +23,11 @@ jobs:
 
   # ------- Regular PRs --------
   chromatic_review:
-    # (if) Run this step on non-draft regular PRs.
+    # (if) Run this step on regular PRs.
     if: |
       github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' &&
-      !startsWith(github.head_ref, 'changeset-release/') &&
-      github.event.pull_request.draft == false
-    name: Chromatic - Build on non-draft regular PRs
+      !startsWith(github.head_ref, 'changeset-release/')
+    name: Chromatic - Build on regular PRs
     uses: ./.github/workflows/chromatic-build.yml
     with:
       target: 'review'
@@ -39,9 +38,8 @@ jobs:
     # (if) Run this step on regular PRs.
     if: |
       github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' &&
-      !startsWith(github.head_ref, 'changeset-release/') &&
-      github.event.pull_request.draft == false
-    name: Chromatic - Get results on non-draft regular PRs
+      !startsWith(github.head_ref, 'changeset-release/')
+    name: Chromatic - Get results on regular PRs
     needs: chromatic_review
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

After optimizing our chromatic workflow, we can now re-enable chromatic
snapshots on draft PRs.

Some data collected from the past 3 months:

- July 14 / Aug 13 => 9,524 skipped snapshots (21.4%) - 35,000 snapshots (78.6%)…  :red: reached the quota limit on Aug 2.
- Aug 14 / Sept 13 => 13,193 skipped snapshots  (27.4%) - 35,000 (72.6%) snapshots…  :red: reached the quota limit on Aug 23.
- [Optimized the chromatic workflow at this point]
- Sept 14 / Oct 13 => 17,449 skipped snapshots (46.5%) - 20,104 snapshots (53.5%) :white_check_mark: we still have ~15000 snapshots available.

This data shows that we can re-enable chromatic snapshots on draft PRs without
reaching the quota limit. If that happens, we can always disable them again.

Issue: XXX-XXXX

## Test plan:

Verify that chromatic snapshots are enabled on draft PRs.