### PR TITLE
Make `useOnMountEffect` accept functions with void return types

### DIFF
--- a/.changeset/beige-kings-train.md
+++ b/.changeset/beige-kings-train.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Make useOnMountEffect accept functions with void return types

--- a/packages/wonder-blocks-core/src/hooks/use-on-mount-effect.ts
+++ b/packages/wonder-blocks-core/src/hooks/use-on-mount-effect.ts
@@ -28,9 +28,7 @@ import * as React from "react";
  *
  * If you only need to do something on mount, don't return a cleanup function from `callback`.
  */
-export const useOnMountEffect = (
-    callback: () => void | undefined | (() => void),
-): void => {
+export const useOnMountEffect = (callback: () => void | (() => void)): void => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     React.useEffect(callback, []);
 };

--- a/packages/wonder-blocks-core/src/hooks/use-on-mount-effect.ts
+++ b/packages/wonder-blocks-core/src/hooks/use-on-mount-effect.ts
@@ -29,7 +29,7 @@ import * as React from "react";
  * If you only need to do something on mount, don't return a cleanup function from `callback`.
  */
 export const useOnMountEffect = (
-    callback: () => undefined | (() => void),
+    callback: () => void | undefined | (() => void),
 ): void => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     React.useEffect(callback, []);


### PR DESCRIPTION
## Summary:
Previously, `useOnMountEffect` accepted functions that either return a cleanup function or explicitly return undefined. This means that functions with no return value (e.g. `() => {}`) result in errors, even though they're accepted by `useEffect`. This PR updates the argument type so that it accepts functions with void returns. Minor version bump because the API changed, but it is non-breaking.

## Test plan:
N/A