### PR TITLE
[🔥AUDIT🔥] Run snapshots job when the PR is ready for review

### DIFF
--- a/.github/workflows/node-ci-pr.yml
+++ b/.github/workflows/node-ci-pr.yml
@@ -2,7 +2,9 @@ name: Node CI (PR)
 
 on:
   pull_request:
-    types: [edited, opened, synchronize, reopened]
+    # ready_for_review is useful for when a PR is converted from "draft" to "not
+    # draft".
+    types: [edited, opened, synchronize, ready_for_review, reopened]
 
 # Our jobs run like this to minimize wasting resource cycles:
 #   1. Prime caches for primary configuration (ubuntu on node 16).


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

The snapshot releases job only runs when the PR is not a draft. There was an
issue that prevented from creating a snapshot release when a PR was moved from
`draft` to `ready for review`.

This PR fixes that by including the `ready_for_review` activity type in the
workflow.

Issue: XXX-XXXX

## Test plan:

N/A