### PR TITLE
WB-1614: Add PhosphorIcon support to Link

### DIFF
--- a/.changeset/shiny-pugs-shout.md
+++ b/.changeset/shiny-pugs-shout.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-link": major
+---
+
+Add support to PhosphorIcon in Link

--- a/__docs__/wonder-blocks-link/link.argtypes.tsx
+++ b/__docs__/wonder-blocks-link/link.argtypes.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 
 import type {InputType} from "@storybook/csf";
-import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
-const iconsMap: Record<string, React.ReactElement<typeof Icon>> = {};
+const iconsMap: Record<string, React.ReactElement<typeof PhosphorIcon>> = {};
 
-Object.entries(icons).forEach(([iconLabel, iconValue]) => {
-    iconsMap[iconLabel] = <Icon icon={iconValue} />;
+Object.entries(IconMappings).forEach(([iconLabel, iconValue]) => {
+    iconsMap[iconLabel] = <PhosphorIcon icon={iconValue} />;
 });
 
 export default {
@@ -27,7 +28,7 @@ export default {
         mapping: iconsMap,
         table: {
             category: "Icons",
-            type: {summary: "Icon"},
+            type: {summary: "PhosphorIcon"},
         },
     },
 
@@ -127,7 +128,7 @@ export default {
         mapping: iconsMap,
         table: {
             category: "Icons",
-            type: {summary: "Icon"},
+            type: {summary: "PhosphorIcon"},
         },
     },
 

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 // We need to use fireEvent for mouseDown in these tests, none of the userEvent
 // alternatives work. Click includes mouseUp, which removes the pressed style.
 /* eslint-disable testing-library/prefer-user-event */
@@ -10,7 +11,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {
@@ -23,6 +24,7 @@ import packageConfig from "../../packages/wonder-blocks-link/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import LinkArgTypes from "./link.argtypes";
+import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
 export default {
     title: "Link",
@@ -257,14 +259,16 @@ export const StartAndEndIcons: StoryComponentType = () => (
         <View style={{padding: Spacing.large_24}}>
             <Link
                 href="#"
-                startIcon={<Icon icon={icons.add} />}
+                startIcon={<PhosphorIcon icon={IconMappings.plusCircleBold} />}
                 style={styles.standaloneLinkWrapper}
             >
                 This link has a start icon
             </Link>
             <Link
                 href="#"
-                endIcon={<Icon icon={icons.search} />}
+                endIcon={
+                    <PhosphorIcon icon={IconMappings.magnifyingGlassBold} />
+                }
                 kind="secondary"
                 style={styles.standaloneLinkWrapper}
             >
@@ -272,7 +276,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="https://stuffonmycat.com/"
-                endIcon={<Icon icon={icons.info} />}
+                endIcon={<PhosphorIcon icon={IconMappings.infoBold} />}
                 target="_blank"
                 style={styles.standaloneLinkWrapper}
             >
@@ -281,8 +285,8 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                startIcon={<Icon icon={icons.caretLeft} />}
-                endIcon={<Icon icon={icons.caretRight} />}
+                startIcon={<PhosphorIcon icon={IconMappings.caretLeftBold} />}
+                endIcon={<PhosphorIcon icon={IconMappings.caretRightBold} />}
                 kind="secondary"
                 style={styles.standaloneLinkWrapper}
             >
@@ -290,8 +294,8 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                startIcon={<Icon icon={icons.caretLeft} />}
-                endIcon={<Icon icon={icons.caretRight} />}
+                startIcon={<PhosphorIcon icon={IconMappings.caretLeftBold} />}
+                endIcon={<PhosphorIcon icon={IconMappings.caretRightBold} />}
                 style={styles.multiLine}
             >
                 This is a multi-line link with start and end icons
@@ -301,7 +305,9 @@ export const StartAndEndIcons: StoryComponentType = () => (
                 <Link
                     href="#"
                     inline={true}
-                    startIcon={<Icon icon={icons.caretLeft} />}
+                    startIcon={
+                        <PhosphorIcon icon={IconMappings.caretLeftBold} />
+                    }
                 >
                     link with a start icon
                 </Link>{" "}
@@ -310,7 +316,9 @@ export const StartAndEndIcons: StoryComponentType = () => (
                     href="#"
                     inline={true}
                     target="_blank"
-                    endIcon={<Icon icon={icons.caretRight} />}
+                    endIcon={
+                        <PhosphorIcon icon={IconMappings.caretRightBold} />
+                    }
                 >
                     link with an end icon
                 </Link>
@@ -326,7 +334,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
         >
             <Link
                 href="#"
-                startIcon={<Icon icon={icons.add} />}
+                startIcon={<PhosphorIcon icon={IconMappings.plusCircleBold} />}
                 light={true}
                 style={styles.standaloneLinkWrapper}
             >
@@ -334,7 +342,9 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                endIcon={<Icon icon={icons.search} />}
+                endIcon={
+                    <PhosphorIcon icon={IconMappings.magnifyingGlassBold} />
+                }
                 light={true}
                 style={styles.standaloneLinkWrapper}
             >
@@ -342,7 +352,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="https://stuffonmycat.com/"
-                endIcon={<Icon icon={icons.info} />}
+                endIcon={<PhosphorIcon icon={IconMappings.infoBold} />}
                 target="_blank"
                 light={true}
                 style={styles.standaloneLinkWrapper}
@@ -352,8 +362,8 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                startIcon={<Icon icon={icons.caretLeft} />}
-                endIcon={<Icon icon={icons.caretRight} />}
+                startIcon={<PhosphorIcon icon={IconMappings.caretLeftBold} />}
+                endIcon={<PhosphorIcon icon={IconMappings.caretRightBold} />}
                 light={true}
                 style={styles.standaloneLinkWrapper}
             >
@@ -361,8 +371,8 @@ export const StartAndEndIcons: StoryComponentType = () => (
             </Link>
             <Link
                 href="#"
-                startIcon={<Icon icon={icons.caretLeft} />}
-                endIcon={<Icon icon={icons.caretRight} />}
+                startIcon={<PhosphorIcon icon={IconMappings.caretLeftBold} />}
+                endIcon={<PhosphorIcon icon={IconMappings.caretRightBold} />}
                 light={true}
                 style={styles.multiLine}
             >
@@ -372,7 +382,9 @@ export const StartAndEndIcons: StoryComponentType = () => (
                 This is an inline{" "}
                 <Link
                     href="#"
-                    startIcon={<Icon icon={icons.caretLeft} />}
+                    startIcon={
+                        <PhosphorIcon icon={IconMappings.caretLeftBold} />
+                    }
                     inline={true}
                     light={true}
                 >
@@ -381,7 +393,9 @@ export const StartAndEndIcons: StoryComponentType = () => (
                 and an inline{" "}
                 <Link
                     href="#"
-                    endIcon={<Icon icon={icons.caretRight} />}
+                    endIcon={
+                        <PhosphorIcon icon={IconMappings.caretRightBold} />
+                    }
                     inline={true}
                     light={true}
                     target="_blank"
@@ -914,18 +928,24 @@ WithTitle.play = async ({canvasElement}) => {
 export const RightToLeftWithIcons: StoryComponentType = () => (
     <View style={{padding: Spacing.medium_16}}>
         <View style={styles.rightToLeft}>
-            <Link href="/" startIcon={<Icon icon={icons.caretRight} />}>
-                هذا الرابط مكتوب باللغة العربية
-            </Link>
-            <Strut size={Spacing.medium_16} />
-            <Link href="/" endIcon={<Icon icon={icons.caretLeft} />}>
+            <Link
+                href="/"
+                startIcon={<PhosphorIcon icon={IconMappings.caretRightBold} />}
+            >
                 هذا الرابط مكتوب باللغة العربية
             </Link>
             <Strut size={Spacing.medium_16} />
             <Link
                 href="/"
-                startIcon={<Icon icon={icons.caretRight} />}
-                endIcon={<Icon icon={icons.caretLeft} />}
+                endIcon={<PhosphorIcon icon={IconMappings.caretLeftBold} />}
+            >
+                هذا الرابط مكتوب باللغة العربية
+            </Link>
+            <Strut size={Spacing.medium_16} />
+            <Link
+                href="/"
+                startIcon={<PhosphorIcon icon={IconMappings.caretRightBold} />}
+                endIcon={<PhosphorIcon icon={IconMappings.caretLeftBold} />}
             >
                 هذا الرابط مكتوب باللغة العربية
             </Link>

--- a/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
@@ -3,7 +3,8 @@ import {MemoryRouter, Route, Switch} from "react-router-dom";
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import plusIcon from "@phosphor-icons/core/bold/plus-bold.svg";
 
 import Link from "../link";
 
@@ -362,12 +363,12 @@ describe("Link", () => {
             );
 
             // Act
-            const link = screen.getByRole("link");
             const icon = screen.getByTestId("external-icon");
 
             // Assert
-            expect(link.innerHTML).toEqual(expect.stringContaining("<svg"));
-            expect(icon).toBeInTheDocument();
+            expect(icon).toHaveStyle({
+                maskImage: "url(arrow-square-out-bold.svg)",
+            });
         });
 
         test("does not render external icon when `target=_blank` and link is relative", () => {
@@ -414,19 +415,17 @@ describe("Link", () => {
             render(
                 <Link
                     href="https://www.khanacademy.org/"
-                    startIcon={<Icon icon={icons.add} />}
+                    startIcon={<PhosphorIcon icon={plusIcon} />}
                 >
                     Add new item
                 </Link>,
             );
 
             // Act
-            const link = screen.getByRole("link");
             const icon = screen.getByTestId("start-icon");
 
             // Assert
-            expect(link.innerHTML).toEqual(expect.stringContaining("<svg"));
-            expect(icon).toBeInTheDocument();
+            expect(icon).toHaveStyle({maskImage: "url(plus-bold.svg)"});
         });
 
         test("does not render icon when startIcon prop is not passed in", () => {
@@ -445,7 +444,7 @@ describe("Link", () => {
             render(
                 <Link
                     href="https://www.khanacademy.org/"
-                    startIcon={<Icon icon={icons.add} />}
+                    startIcon={<PhosphorIcon icon={plusIcon} />}
                 >
                     Add new item
                 </Link>,
@@ -453,13 +452,9 @@ describe("Link", () => {
 
             // Act
             const icon = screen.getByTestId("start-icon");
-            const iconToExpect =
-                "M11 11V7a1 1 0 0 1 2 0v4h4a1 1 0 0 1 0 2h-4v4a1 1 0 0 1-2 0v-4H7a1 1 0 0 1 0-2h4zm1 13C5.373 24 0 18.627 0 12S5.373 0 12 0s12 5.373 12 12-5.373 12-12 12zm0-2c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z";
 
             // Assert
-            expect(icon.innerHTML).toEqual(
-                expect.stringContaining(iconToExpect),
-            );
+            expect(icon).toHaveStyle({maskImage: "url(plus-bold.svg)"});
         });
 
         test("render icon with link when endIcon prop is passed in", () => {
@@ -467,19 +462,17 @@ describe("Link", () => {
             render(
                 <Link
                     href="https://www.khanacademy.org/"
-                    endIcon={<Icon icon={icons.caretRight} />}
+                    endIcon={<PhosphorIcon icon={plusIcon} />}
                 >
                     Click to go back
                 </Link>,
             );
 
             // Act
-            const link = screen.getByRole("link");
             const icon = screen.getByTestId("end-icon");
 
             // Assert
-            expect(link.innerHTML).toEqual(expect.stringContaining("<svg"));
-            expect(icon).toBeInTheDocument();
+            expect(icon).toHaveStyle({maskImage: "url(plus-bold.svg)"});
         });
 
         test("does not render icon when endIcon prop is not passed in", () => {
@@ -498,7 +491,7 @@ describe("Link", () => {
             render(
                 <Link
                     href="https://www.google.com/"
-                    endIcon={<Icon icon={icons.caretRight} />}
+                    endIcon={<PhosphorIcon icon={plusIcon} />}
                     target="_blank"
                 >
                     Open a new tab
@@ -517,7 +510,7 @@ describe("Link", () => {
             render(
                 <Link
                     href="https://www.google.com/"
-                    endIcon={<Icon icon={icons.caretRight} />}
+                    endIcon={<PhosphorIcon icon={plusIcon} />}
                     target="_blank"
                 >
                     Open a new tab
@@ -525,31 +518,25 @@ describe("Link", () => {
             );
 
             // Act
-            const link = screen.getByRole("link");
-            const endIcon = screen.getByTestId("end-icon");
+            const icon = screen.getByTestId("end-icon");
 
             // Assert
-            expect(link.innerHTML).toEqual(expect.stringContaining("<svg"));
-            expect(endIcon).toBeInTheDocument();
+            expect(icon).toHaveStyle({maskImage: "url(plus-bold.svg)"});
         });
 
         test("endIcon prop passed down correctly", () => {
             // Arrange
             render(
-                <Link href="/" endIcon={<Icon icon={icons.caretRight} />}>
+                <Link href="/" endIcon={<PhosphorIcon icon={plusIcon} />}>
                     Click to go back
                 </Link>,
             );
 
             // Act
             const icon = screen.getByTestId("end-icon");
-            const iconToExpect =
-                "M8.586 8L5.293 4.707a1 1 0 0 1 1.414-1.414l4 4a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414-1.414L8.586 8z";
 
             // Assert
-            expect(icon.innerHTML).toEqual(
-                expect.stringContaining(iconToExpect),
-            );
+            expect(icon).toHaveStyle({maskImage: "url(plus-bold.svg)"});
         });
     });
 });

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -6,15 +6,15 @@ import {__RouterContext} from "react-router";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
-import Icon from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
+import externalLinkIcon from "@phosphor-icons/core/bold/arrow-square-out-bold.svg";
 
 import type {
     ChildrenProps,
     ClickableState,
 } from "@khanacademy/wonder-blocks-clickable";
 import type {StyleDeclaration} from "aphrodite";
-import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
 import type {SharedProps} from "./link";
 
 type Props = SharedProps &
@@ -80,13 +80,9 @@ const LinkCore = React.forwardRef(function LinkCore(
 
         const isExternalLink = linkUrl.origin !== window.location.origin;
 
-        const externalIconPath: IconAsset = {
-            small: "M14 6.5C14 6.63261 13.9473 6.75979 13.8536 6.85355C13.7598 6.94732 13.6326 7 13.5 7C13.3674 7 13.2402 6.94732 13.1464 6.85355C13.0527 6.75979 13 6.63261 13 6.5V3.7075L8.85437 7.85375C8.76055 7.94757 8.63331 8.00028 8.50062 8.00028C8.36794 8.00028 8.2407 7.94757 8.14688 7.85375C8.05306 7.75993 8.00035 7.63268 8.00035 7.5C8.00035 7.36732 8.05306 7.24007 8.14688 7.14625L12.2925 3H9.5C9.36739 3 9.24021 2.94732 9.14645 2.85355C9.05268 2.75979 9 2.63261 9 2.5C9 2.36739 9.05268 2.24021 9.14645 2.14645C9.24021 2.05268 9.36739 2 9.5 2H13.5C13.6326 2 13.7598 2.05268 13.8536 2.14645C13.9473 2.24021 14 2.36739 14 2.5V6.5ZM11.5 8C11.3674 8 11.2402 8.05268 11.1464 8.14645C11.0527 8.24021 11 8.36739 11 8.5V13H3V5H7.5C7.63261 5 7.75979 4.94732 7.85355 4.85355C7.94732 4.75979 8 4.63261 8 4.5C8 4.36739 7.94732 4.24021 7.85355 4.14645C7.75979 4.05268 7.63261 4 7.5 4H3C2.73478 4 2.48043 4.10536 2.29289 4.29289C2.10536 4.48043 2 4.73478 2 5V13C2 13.2652 2.10536 13.5196 2.29289 13.7071C2.48043 13.8946 2.73478 14 3 14H11C11.2652 14 11.5196 13.8946 11.7071 13.7071C11.8946 13.5196 12 13.2652 12 13V8.5C12 8.36739 11.9473 8.24021 11.8536 8.14645C11.7598 8.05268 11.6326 8 11.5 8Z",
-        };
-
         const externalIcon = (
-            <Icon
-                icon={externalIconPath}
+            <PhosphorIcon
+                icon={externalLinkIcon}
                 size="small"
                 style={[linkContentStyles.endIcon, linkContentStyles.centered]}
                 testId="external-icon"
@@ -105,7 +101,7 @@ const LinkCore = React.forwardRef(function LinkCore(
                 testId: "start-icon",
                 "aria-hidden": "true",
                 ...startIcon.props,
-            } as Partial<React.ComponentProps<typeof Icon>>);
+            } as Partial<React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>>);
         }
 
         if (endIcon) {
@@ -114,7 +110,7 @@ const LinkCore = React.forwardRef(function LinkCore(
                 testId: "end-icon",
                 "aria-hidden": "true",
                 ...endIcon.props,
-            } as Partial<React.ComponentProps<typeof Icon>>);
+            } as Partial<React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>>);
         }
 
         const linkContent = (

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -4,7 +4,7 @@ import {Link as ReactRouterLink} from "react-router-dom";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import Icon from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 import LinkCore from "./link-core";
 
@@ -123,13 +123,13 @@ type CommonProps = AriaProps & {
     /**
      * An optional icon displayed before the link label.
      */
-    startIcon?: React.ReactElement<typeof Icon>;
+    startIcon?: React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>;
     /**
      * An optional icon displayed after the link label.
      * If `target="_blank"` and `endIcon` is passed in, `endIcon` will override
      * the default `externalIcon`.
      */
-    endIcon?: React.ReactElement<typeof Icon>;
+    endIcon?: React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>;
 };
 
 export type SharedProps =


### PR DESCRIPTION
## Summary:

Replaces `Icon` with the new `PhosphorIcon` component in `Link`. Now `Link` only
should accept PhosphorIcon instances in the `startIcon` and `endIcon` props.

Issue: https://khanacademy.atlassian.net/browse/WB-1614

## Test plan:
In Storybook, verify that the `Link` icon stories look correct.

- `startIcon` and `endIcon`: /?path=/story/link--start-and-end-icons
- External link: /?path=/story/link--opens-in-a-new-tab

Also compare the changes in Chromatic.