### PR TITLE
Enforce TData type in MockResponse

### DIFF
--- a/.changeset/honest-shoes-remain.md
+++ b/.changeset/honest-shoes-remain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": major
+---
+
+Make sure that `MockResponse<TData>` properly enforces `TData` type. This is a breaking change as it affects the usage of the various mocking frameworks, and may result in new type errors in consuming code.

--- a/packages/wonder-blocks-testing/src/gql/__tests__/types.typestest.ts
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/types.typestest.ts
@@ -1,0 +1,97 @@
+import {GqlOperation} from "@khanacademy/wonder-blocks-data";
+import type {GqlFetchMockFn} from "../types";
+import {RespondWith} from "../../respond-with";
+
+type SomeGqlData = {
+    a: string;
+    b: number;
+};
+
+type SomeGqlVariables = {
+    a: string;
+    b: number;
+};
+
+const fakeOperation: GqlOperation<SomeGqlData, SomeGqlVariables> = {} as any;
+
+const mockFetch: GqlFetchMockFn = (() => {}) as any;
+
+// should be ok, no variables
+mockFetch.mockOperation(
+    {
+        operation: fakeOperation,
+    },
+    RespondWith.graphQLData({
+        a: "string",
+        b: 42,
+    }),
+);
+
+// should be ok, with variables
+mockFetch.mockOperation(
+    {
+        operation: fakeOperation,
+        variables: {
+            a: "string",
+            b: 42,
+        },
+    },
+    RespondWith.graphQLData({
+        a: "string",
+        b: 42,
+    }),
+);
+
+// should error; incorrect variable values and keys
+mockFetch.mockOperation(
+    {
+        operation: fakeOperation,
+        variables: {
+            // @ts-expect-error Type 'number' is not assignable to type 'string'
+            a: 42,
+            // @ts-expect-error Type 'string' is not assignable to type 'number'
+            b: "not a number",
+        },
+    },
+    RespondWith.graphQLData({
+        a: "string",
+        b: 42,
+    }),
+);
+
+// should error; incorrect variable keys
+mockFetch.mockOperation(
+    {
+        operation: fakeOperation,
+        variables: {
+            // @ts-expect-error Type '{ notAValidKey: number; }' is not assignable to type 'SomeGqlVariables'.
+            // Object literal may only specify known properties, and 'notAValidKey' does not exist in type 'SomeGqlVariables'.
+            notAValidKey: 42,
+        },
+    },
+    RespondWith.graphQLData({
+        a: "string",
+        b: 42,
+    }),
+);
+
+// should error; wrong mock response type
+mockFetch.mockOperation(
+    {
+        operation: fakeOperation,
+    },
+    // @ts-expect-error Argument of type 'MockResponse<string>' is not assignable to parameter of type 'MockResponse<GraphQLJson<SomeGqlData>>'.
+    RespondWith.text("Hello, I'm not a GraphQL response at all!"),
+);
+
+// should error; invalid graphQL data
+mockFetch.mockOperation(
+    {
+        operation: fakeOperation,
+    },
+    // @ts-expect-error Argument of type 'MockResponse<GraphQLJson<{ a: number; b: string; }>>' is not assignable to parameter of type 'MockResponse<GraphQLJson<SomeGqlData>>'.
+    RespondWith.graphQLData({
+        a: 42,
+        b: "string",
+    }),
+);


### PR DESCRIPTION
## Summary:
This change makes sure that the `TData` type parameter of `MockResponse<TData>` has an effect on the generated type.

Before this change, the value of `TData` did not affect the resultant type. For example, `MockResponse<{a: number}>` and `MockResponse<{b: string}>` would both be equivalent to the type looked like `{readonly toPromise: () => Promise<Response>}`. Since they both look the same, TypeScript accepts them as the same.

After this change, we have a hidden property on `MockResponse` that cannot be accessed that expects data of shape `TData`. We never assign it (we use casting to pretend we are honoring that contract), but by having it present, TypeScript now sees the types as different as `MockResponse<{a: number}>` is now a type like `{[inaccessible]: {a: number}; readonly toPromise: () => Promise<Response>;}` and `MockResponse<{b: string}>` is now a type like `{[inaccessible]: {b: string}; readonly toPromise: () => Promise<Response>;}`; and, since the inaccessible property is different, TypeScript now sees them as different types.

Issue: FEI-5352

## Test plan:
`yarn test`
`yarn typecheck`

I have added a typestest file for this. You can verify the difference between before and after by commenting out the symbolic opaque property in the `MockResponse` type definition. In doing so, the two error cases that should fail because the `MockResponse` type is bad will instead pass (i.e. the error suppressions will be marked as redundant).