### PR TITLE
Export `ModalContent` building block from modal package

### DIFF
--- a/.changeset/lucky-jokes-stare.md
+++ b/.changeset/lucky-jokes-stare.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Exports `ModalContent` component

--- a/packages/wonder-blocks-modal/src/index.ts
+++ b/packages/wonder-blocks-modal/src/index.ts
@@ -1,3 +1,4 @@
+import ModalContent from "./components/modal-content";
 import ModalDialog from "./components/modal-dialog";
 import ModalFooter from "./components/modal-footer";
 import ModalHeader from "./components/modal-header";
@@ -7,11 +8,12 @@ import OnePaneDialog from "./components/one-pane-dialog";
 import maybeGetPortalMountedModalHostElement from "./util/maybe-get-portal-mounted-modal-host-element";
 
 export {
-    ModalHeader,
-    ModalFooter,
+    ModalContent,
     ModalDialog,
-    ModalPanel,
+    ModalFooter,
+    ModalHeader,
     ModalLauncher,
+    ModalPanel,
     OnePaneDialog,
     maybeGetPortalMountedModalHostElement,
 };


### PR DESCRIPTION
## Summary:
There is a desire to export the `ModalContent` component to give consumers more control when constructing Modals using the building blocks. 

Currently, we always wrap the `ModalPanel`'s `content` prop in a `ModelContent` component if it isn't already wrapped in one (which is typically the case); the `ModelContent` component has pre-defined styles and there is currently no way to customize it, so we export the `ModelContent` component to allow for this as part of the Modal building blocks.

Issue: "none"

Test plan:

None (there is no functionality change)