### PR TITLE
Experiment: try using CSS Modules

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,7 @@ const config: StorybookConfig = {
         getAbsolutePath("@storybook/addon-interactions"),
         getAbsolutePath("@storybook/addon-mdx-gfm"),
         getAbsolutePath("storybook-addon-pseudo-states"),
+        getAbsolutePath("storybook-css-modules"),
     ],
     staticDirs: ["../static"],
     core: {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "rollup-plugin-babel": "^4.0.0-beta.2",
     "storybook": "^7.5.1",
     "storybook-addon-pseudo-states": "^2.1.2",
+    "storybook-css-modules": "^1.0.8",
     "typescript": "^4.9.5",
     "typescript-coverage-report": "^0.7.0",
     "vite": "^4.4.8",

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.module.css
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.module.css
@@ -1,0 +1,87 @@
+@value tokens: "./tokens.module.css";
+@value white, offBlack, offBlack8, offBlack16, blue, cellMinHeight, cellPaddingVertical, cellPaddingHorizontal from tokens;
+
+.wrapper {
+    background: white;
+    color: offBlack;
+    display: flex;
+    min-height: cellMinHeight;
+    text-align: left;
+}
+
+.innerWrapper {
+    min-height: cellMinHeight;
+    padding: cellPaddingVertical cellPaddingHorizontal;
+    flex-direction: row;
+    flex: 1;
+
+    /* Reduce the padding of the innerWrapper when the focus ring is */
+    /* visible. */
+    &:focus-visible {
+        padding: calc(cellPaddingVertical - 2px) calc(cellPaddingHorizontal - 2px);
+    }
+}
+
+.clickable {
+    outline: none;
+    /**
+     * States
+     */
+    /* disabled */
+    /* NOTE: We use `aria-disabled` instead of `disabled` because we want */
+    /* to allow the cell to be focusable even when it's disabled. */
+    &:hover[aria-disabled=true] {
+        cursor: not-allowed;
+    }
+
+    /* focus (only visible when using keyboard navigation) */
+    &:focus-visible {
+        border-radius: 4px;
+        /* To hide the internal corners of the cell. */
+        overflow: hidden;
+        /* To display the focus ring based on the cell's border. */
+        position: relative;
+    }
+    /* NOTE: We use a pseudo element to draw the focus ring because we can't */
+    /* use `outline` since it conflicts with different layout contexts (e.g. */
+    /* `View` elements add their own z-index). */
+    &:focus-visible:after {
+        content: '';
+        /* Since we are using a pseudo element, we need to manually */
+        /* calculate the width/height and use absolute position to */
+        /* prevent other elements from being shifted around. */
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 1;
+        /* We remove the border width from the width/height to ensure */
+        /* that the focus ring is drawn inside the cell. */
+        width: calc(100% - 4px);
+        height: calc(100% - 4px);
+        border: 2px solid blue;
+        border-radius: 4px,
+    }
+
+    /* hover + enabled */
+    &:hover[aria-disabled=false] {
+        background: offBlack8;
+    }
+
+    /* pressed + enabled */
+    &:active[aria-disabled=false] {
+        background: offBlack16;
+    }
+}
+
+.active {
+    background: color-mix(in srgb, blue, transparent 8%);
+    color: blue;
+
+    &:hover[aria-disabled=false] {
+        background-color: color-mix(in srgb, blue, transparent 16%);
+    }
+
+    &:active[aria-disabled=false] {
+        background-color: color-mix(in srgb, blue, transparent 24%);
+    }
+}

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -13,6 +13,8 @@ import {CellMeasurements, getHorizontalRuleStyles} from "./common";
 
 import type {CellProps} from "../../util/types";
 
+import cssStyles from "./cell-core.module.css";
+
 type LeftAccessoryProps = {
     leftAccessory?: CellProps["leftAccessory"];
     leftAccessoryStyle?: CellProps["leftAccessoryStyle"];
@@ -110,15 +112,18 @@ function CellInner(props: CellCoreProps): React.ReactElement {
     } = props;
     const horizontalRuleStyles = getHorizontalRuleStyles(horizontalRule);
 
+    const className = cssStyles.innerWrapper;
+
     return (
         <View
-            style={[
-                styles.innerWrapper,
-                innerStyle,
-                // custom styles
-                style,
-                horizontalRuleStyles,
-            ]}
+            // style={[
+            //     styles.innerWrapper,
+            //     innerStyle,
+            //     // custom styles
+            //     style,
+            //     horizontalRuleStyles,
+            // ]}
+            className={className}
         >
             {/* Left accessory */}
             <LeftAccessory
@@ -177,6 +182,13 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
 
     // Pressable cell.
     if (onClick || href) {
+        let className = `${cssStyles.wrapper} ${cssStyles.clickable}`;
+        if (active) {
+            className += ` ${cssStyles.active}`;
+        }
+        if (disabled) {
+            className += ` ${cssStyles.disabled}`;
+        }
         return (
             // @ts-expect-error - TypeScript doesn't know that `target` can only be defined when `href` is.
             <Clickable
@@ -186,12 +198,13 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
                 hideDefaultFocusRing={true}
                 aria-label={ariaLabel ? ariaLabel : undefined}
                 target={target}
-                style={[
-                    styles.wrapper,
-                    styles.clickable,
-                    active && styles.active,
-                    disabled && styles.disabled,
-                ]}
+                // style={[
+                //     styles.wrapper,
+                //     styles.clickable,
+                //     active && styles.active,
+                //     disabled && styles.disabled,
+                // ]}
+                className={className}
                 aria-current={active ? "true" : undefined}
             >
                 {() => <CellInner {...props} />}
@@ -201,9 +214,14 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
 
     // No click event attached, so just render the cell without a Clickable
     // wrapper.
+    let className = cssStyles.wrapper;
+    if (active) {
+        className += ` ${cssStyles.active}`;
+    }
     return (
         <View
-            style={[styles.wrapper, active && styles.active]}
+            // style={[styles.wrapper, active && styles.active]}
+            className={className}
             aria-current={active ? "true" : undefined}
         >
             <CellInner {...props} />

--- a/packages/wonder-blocks-cell/src/components/internal/tokens.module.css
+++ b/packages/wonder-blocks-cell/src/components/internal/tokens.module.css
@@ -1,0 +1,14 @@
+@value white: #ffffff;
+@value offWhite: #f7f8fa;
+@value offBlack: #21242c;
+@value blue: #1865f2;
+
+@value offBlack8: color-mix(in srgb, offBlack 8%, transparent);
+@value offBlack16: color-mix(in srgb, offBlack 16%, transparent);
+
+@value cellMinHeight: 48px;
+@value cellPaddingVertical: 12px;
+@value cellPaddingHorizontal: 16px;
+@value detailCellPaddingHorizontal: 16px;
+@value detailCellPaddingVertical: 16px;
+@value accessoryPaddingHorizontal: 16px;

--- a/packages/wonder-blocks-clickable/src/components/clickable.module.css
+++ b/packages/wonder-blocks-clickable/src/components/clickable.module.css
@@ -1,0 +1,28 @@
+.reset {
+    border: none;
+    margin: 0;
+    padding: 0;
+    width: auto;
+    overflow: visible;
+
+    background: transparent;
+    text-decoration: none;
+
+    color: inherit;
+    font: inherit;
+
+    box-sizing: border-box;
+    touch-action: manipulation;
+    user-select: none;
+
+    outline: none;
+
+    line-height: normal;
+
+    -webkit-font-smoothing: inherit;
+    -moz-osx-font-smoothing: inherit;
+}
+
+.link {
+    cursor: pointer;
+}

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -11,6 +11,8 @@ import getClickableBehavior from "../util/get-clickable-behavior";
 import type {ClickableRole, ClickableState} from "./clickable-behavior";
 import {isClientSideUrl} from "../util/is-client-side-url";
 
+import cssStyles from "./clickable.module.css";
+
 type CommonProps =
     /**
      * aria-label should be used when `spinner={true}` to let people using screen
@@ -208,6 +210,8 @@ const Clickable = React.forwardRef(function Clickable(
             [key: string]: any;
         },
     ) => React.ReactElement = (clickableState, router, commonProps) => {
+        console.log(commonProps);
+
         const activeHref = props.href && !props.disabled;
         const useClient =
             router && !props.skipClientNav && isClientSideUrl(props.href || "");
@@ -241,6 +245,7 @@ const Clickable = React.forwardRef(function Clickable(
                 </StyledAnchor>
             );
         } else {
+            console.log(`className = ${commonProps.className}`);
             return (
                 <StyledButton
                     {...commonProps}
@@ -272,6 +277,7 @@ const Clickable = React.forwardRef(function Clickable(
             light,
             disabled,
             tabIndex,
+            className,
             ...restProps
         } = props;
         const ClickableBehavior = getClickableBehavior(
@@ -290,6 +296,9 @@ const Clickable = React.forwardRef(function Clickable(
             style,
         ];
 
+        const finalClassName = `${cssStyles.reset} ${cssStyles.link} ${className}`;
+        console.log(`finalClassName = ${finalClassName}`);
+
         if (beforeNav) {
             return (
                 <ClickableBehavior
@@ -306,7 +315,8 @@ const Clickable = React.forwardRef(function Clickable(
                         getCorrectTag(state, router, {
                             ...restProps,
                             "data-test-id": testId,
-                            style: getStyle(state),
+                            // style: getStyle(state),
+                            className: finalClassName,
                             ...childrenProps,
                         })
                     }
@@ -328,7 +338,8 @@ const Clickable = React.forwardRef(function Clickable(
                         getCorrectTag(state, router, {
                             ...restProps,
                             "data-test-id": testId,
-                            style: getStyle(state),
+                            // style: getStyle(state),
+                            className: finalClassName,
                             ...childrenProps,
                         })
                     }

--- a/packages/wonder-blocks-core/src/components/view.module.css
+++ b/packages/wonder-blocks-core/src/components/view.module.css
@@ -1,0 +1,15 @@
+.default {
+    align-items: stretch;
+    border-width: 0;
+    border-style: solid;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    z-index: 0;
+    /* fix flexbox bugs */
+    min-height: 0;
+    min-width: 0;
+}

--- a/packages/wonder-blocks-core/src/components/view.tsx
+++ b/packages/wonder-blocks-core/src/components/view.tsx
@@ -1,29 +1,31 @@
 // WARNING: If you modify this file you must update view.js.flow.
 import * as React from "react";
-import {StyleSheet} from "aphrodite";
+// import {StyleSheet} from "aphrodite";
 
 import addStyle from "../util/add-style";
 
 import type {TextViewSharedProps} from "../util/types";
 
-const styles = StyleSheet.create({
-    // https://github.com/facebook/css-layout#default-values
-    default: {
-        alignItems: "stretch",
-        borderWidth: 0,
-        borderStyle: "solid",
-        boxSizing: "border-box",
-        display: "flex",
-        flexDirection: "column",
-        margin: 0,
-        padding: 0,
-        position: "relative",
-        zIndex: 0,
-        // fix flexbox bugs
-        minHeight: 0,
-        minWidth: 0,
-    },
-});
+import styles from "./view.module.css";
+
+// const styles = StyleSheet.create({
+//     // https://github.com/facebook/css-layout#default-values
+//     default: {
+//         alignItems: "stretch",
+//         borderWidth: 0,
+//         borderStyle: "solid",
+//         boxSizing: "border-box",
+//         display: "flex",
+//         flexDirection: "column",
+//         margin: 0,
+//         padding: 0,
+//         position: "relative",
+//         zIndex: 0,
+//         // fix flexbox bugs
+//         minHeight: 0,
+//         minWidth: 0,
+//     },
+// });
 
 type ValidViewTags = "div" | "article" | "aside" | "nav" | "section";
 type Props = TextViewSharedProps & {
@@ -33,11 +35,11 @@ type Props = TextViewSharedProps & {
     tag?: ValidViewTags;
 };
 
-const StyledDiv = addStyle("div", styles.default);
-const StyledArticle = addStyle("article", styles.default);
-const StyledAside = addStyle("aside", styles.default);
-const StyledNav = addStyle("nav", styles.default);
-const StyledSection = addStyle("section", styles.default);
+const StyledDiv = addStyle("div", undefined, styles.default);
+const StyledArticle = addStyle("article", undefined, styles.default);
+const StyledAside = addStyle("aside", undefined, styles.default);
+const StyledNav = addStyle("nav", undefined, styles.default);
+const StyledSection = addStyle("section", undefined, styles.default);
 
 /**
  * View is a building block for constructing other components. `View` roughly

--- a/packages/wonder-blocks-core/src/util/add-style.tsx
+++ b/packages/wonder-blocks-core/src/util/add-style.tsx
@@ -16,7 +16,9 @@ export default function addStyle<
     } & Omit<React.ComponentProps<T>, "style">, // Removes the 'style' prop from the original component
 >(
     Component: T,
+    // TODO: only allow one of these to be set
     defaultStyle?: StyleType,
+    defaultClassName?: string,
 ): React.ForwardRefExoticComponent<
     React.PropsWithoutRef<Props> &
         React.RefAttributes<
@@ -33,11 +35,13 @@ export default function addStyle<
     >((props, ref) => {
         // eslint-disable-next-line react/prop-types
         const {className, style, ...otherProps} = props;
-        const reset =
-            typeof Component === "string" ? overrides[Component] : null;
+
+        // TODO(kevinb): add this back in later
+        // const reset =
+        //     typeof Component === "string" ? overrides[Component] : null;
 
         const {className: aphroditeClassName, style: inlineStyles} =
-            processStyleList([reset, defaultStyle, style]);
+            processStyleList([defaultStyle, style]);
 
         return (
             // @ts-expect-error: TS says this is not assignable to the return forwardRef()'s return type.
@@ -46,7 +50,7 @@ export default function addStyle<
             <Component
                 {...otherProps}
                 ref={ref}
-                className={[aphroditeClassName, className]
+                className={[defaultClassName, aphroditeClassName, className]
                     .filter(Boolean)
                     .join(" ")}
                 style={inlineStyles}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,14 @@
         "paths": {
             "@khanacademy/*": ["./packages/*/src"]
         },
+
+        "plugins": [
+            {
+                "name": "typescript-plugin-css-modules",
+                "options": {
+                    "goToDefinition": true,
+                }
+            }
+        ]
     }
 }

--- a/types/assets.d.ts
+++ b/types/assets.d.ts
@@ -24,3 +24,8 @@ declare module "@phosphor-icons/core/fill/*-fill.svg" {
     const icon: PhosphorFill;
     export default icon;
 }
+
+declare module "*.module.css" {
+    const classes: {[key: string]: string};
+    export default classes;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13206,6 +13206,11 @@ storybook-addon-pseudo-states@^2.1.2:
   resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-2.1.2.tgz#9a04b8b97abecba69a47eca37966e297d15f924f"
   integrity sha512-AHv6q1JiQEUnMyZE3729iV6cNmBW7bueeytc4Lga4+8W1En8YNea5VjqAdrDNJhXVU0QEEIGtxkD3EoC9aVWLw==
 
+storybook-css-modules@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/storybook-css-modules/-/storybook-css-modules-1.0.8.tgz#19392c07a31849dbcd2753ae6331e7f8c0f2ec69"
+  integrity sha512-anITwllH6nLw0quPElVBLRrE8QDbcRv0Dgl8sKLOc4uiqw+g1GE2l21Stjx3Wyv2O6ZKJScbyOpOuuz3SmeaOQ==
+
 storybook@^7.5.1:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.5.1.tgz#e7554aa674355fedb1f49f9651f0650b8f9ee13b"


### PR DESCRIPTION
## Summary:
The purpose of this PR is figure out what the issues would be adopting CSS Modules in wonder-blocks.  This PR updates cell-core.tsx and its dependencies (View, Clickable, and addStyle) to use CSS Modules for styles.

TODO:
- [ ] fix the rollup config to that we can get pass the build step on CI
- [ ] get all of the Cell stories behaving as expected
- [ ] figure out how to get these components to work with styles from either CSS Modules or an Aphrodite stylesheet
- [ ] make sure that the changes to View and Clickable don't break any other components that depend on them

Issue: None

## Test plan:
- TBD