### PR TITLE
Add `collapsible` prop to AccordionSection

### DIFF
--- a/.changeset/many-kids-raise.md
+++ b/.changeset/many-kids-raise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": minor
+---
+
+Add `collapsible` prop to AccordionSection

--- a/__docs__/wonder-blocks-accordion/accordion-section.argtypes.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.argtypes.tsx
@@ -66,6 +66,17 @@ export default {
             required: false,
         },
     },
+    collapsible: {
+        control: {type: "boolean"},
+        description: `Whether the section is collapsible or not. If false,
+            the header will not be clickable, and the section will always
+            be expanded. Defaults to true.`,
+        defaultValue: true,
+        table: {
+            defaultValue: {summary: "true"},
+            type: {summary: "boolean"},
+        },
+    },
     expanded: {
         control: {type: "boolean"},
         description: `Whether this section should be expanded on initial load.

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -12,7 +12,7 @@ import {tokens} from "@khanacademy/wonder-blocks-theming";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import ComponentInfo from "../../.storybook/components/component-info";
-import packageConfig from "../../packages/wonder-blocks-icon/package.json";
+import packageConfig from "../../packages/wonder-blocks-accordion/package.json";
 
 import AccordionSectionArgtypes from "./accordion-section.argtypes";
 
@@ -94,6 +94,7 @@ export const Default: StoryComponentType = {
         header: "Standalone section",
         caretPosition: "end",
         cornerKind: "rounded",
+        collapsible: true,
         expanded: false,
     },
 };
@@ -412,6 +413,25 @@ export const CornerKinds: StoryComponentType = {
             </View>
         );
     },
+};
+
+/**
+ * An AccordionSection can have its `collapsible` prop set to false.
+ * This means that the section's header will not be clickable, and the
+ * section will always be expanded.
+ *
+ * NOTE: It is recommended to only use this prop when the AccordionSection
+ * is used on its own, not within an Accordion.
+ */
+export const NotCollapsible: StoryComponentType = {
+    render: () => (
+        <AccordionSection
+            header="This section is not collapsible"
+            collapsible={false}
+        >
+            Something
+        </AccordionSection>
+    ),
 };
 
 /**

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -13,7 +13,7 @@ import {tokens} from "@khanacademy/wonder-blocks-theming";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import ComponentInfo from "../../.storybook/components/component-info";
-import packageConfig from "../../packages/wonder-blocks-icon/package.json";
+import packageConfig from "../../packages/wonder-blocks-accordion/package.json";
 
 import AccordionArgtypes from "./accordion.argtypes";
 

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section-header.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section-header.test.tsx
@@ -146,4 +146,58 @@ describe("AccordionSectionHeader", () => {
             transition: "border-radius 300ms",
         });
     });
+
+    test("shows icon when collapsible is true", () => {
+        // Arrange
+        render(
+            <AccordionSectionHeader
+                header="Title"
+                caretPosition="end"
+                cornerKind="square"
+                expanded={false}
+                animated={false}
+                collapsible={true}
+                onClick={() => {}}
+                sectionContentUniqueId="section-content-unique-id"
+                isFirstSection={false}
+                isLastSection={false}
+                testId="accordion-section-header"
+            />,
+        );
+
+        // Act
+        const icon = screen.queryByTestId(
+            "accordion-section-header-caret-icon",
+        );
+
+        // Assert
+        expect(icon).toBeInTheDocument();
+    });
+
+    test("does not show icon when collapsible is false", () => {
+        // Arrange
+        render(
+            <AccordionSectionHeader
+                header="Title"
+                caretPosition="end"
+                cornerKind="square"
+                expanded={false}
+                animated={false}
+                collapsible={false}
+                onClick={() => {}}
+                sectionContentUniqueId="section-content-unique-id"
+                isFirstSection={false}
+                isLastSection={false}
+                testId="accordion-section-header"
+            />,
+        );
+
+        // Act
+        const icon = screen.queryByTestId(
+            "accordion-section-header-caret-icon",
+        );
+
+        // Assert
+        expect(icon).not.toBeInTheDocument();
+    });
 });

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
@@ -175,10 +175,7 @@ describe("AccordionSection", () => {
     test("uses headerTestId as button's data-test-id", () => {
         // Arrange
         render(
-            <AccordionSection
-                header="Title"
-                headerTestId="accordion-section-header"
-            >
+            <AccordionSection header="Title" testId="accordion-section">
                 Section content
             </AccordionSection>,
             {wrapper: RenderStateRoot},
@@ -261,14 +258,62 @@ describe("AccordionSection", () => {
         });
     });
 
+    test("aria-disabled is false by default", () => {
+        // Arrange
+        render(
+            <AccordionSection header="Title">Section content</AccordionSection>,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const button = screen.getByRole("button", {name: "Title"});
+
+        // Assert
+        expect(button).toHaveAttribute("aria-disabled", "false");
+    });
+
+    test("sets aria-disabled to true when collapsible prop is false", () => {
+        // Arrange
+        render(
+            <AccordionSection header="Title" collapsible={false}>
+                Section content
+            </AccordionSection>,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const button = screen.getByRole("button", {name: "Title"});
+
+        // Assert
+        expect(button).toHaveAttribute("aria-disabled", "true");
+    });
+
+    test("does not allow clicking when collapsible prop is false", () => {
+        // Arrange
+        render(
+            <AccordionSection header="Title" collapsible={false}>
+                Section content
+            </AccordionSection>,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const button = screen.getByRole("button", {name: "Title"});
+        button.click();
+
+        // Assert
+        // Confirm the content is still visible even though the
+        // header button was clicked.
+        expect(screen.queryByText("Section content")).toBeVisible();
+    });
+
     test("includes transition when animated is true", () => {
         // Arrange
         render(
             <AccordionSection
                 header="Title"
                 animated={true}
-                testId="accordion-section-test-id"
-                headerTestId="accordion-section-header"
+                testId="accordion-section"
             >
                 Section content
             </AccordionSection>,
@@ -276,7 +321,7 @@ describe("AccordionSection", () => {
         );
 
         // Act
-        const wrapper = screen.getByTestId("accordion-section-test-id");
+        const wrapper = screen.getByTestId("accordion-section");
         const header = screen.getByTestId("accordion-section-header");
 
         // Assert
@@ -294,8 +339,7 @@ describe("AccordionSection", () => {
             <AccordionSection
                 header="Title"
                 animated={false}
-                testId="accordion-section-test-id"
-                headerTestId="accordion-section-header"
+                testId="accordion-section"
             >
                 Section content
             </AccordionSection>,
@@ -303,7 +347,7 @@ describe("AccordionSection", () => {
         );
 
         // Act
-        const wrapper = screen.getByTestId("accordion-section-test-id");
+        const wrapper = screen.getByTestId("accordion-section");
         const header = screen.getByTestId("accordion-section-header");
 
         // Assert

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
@@ -163,16 +163,10 @@ describe("Accordion", () => {
         // Arrange
         render(
             <Accordion>
-                <AccordionSection
-                    header="Section 1"
-                    headerTestId="header-test-id-1"
-                >
+                <AccordionSection header="Section 1" testId="test-id-1">
                     Section 1 content
                 </AccordionSection>
-                <AccordionSection
-                    header="Section 2"
-                    headerTestId="header-test-id-2"
-                >
+                <AccordionSection header="Section 2" testId="test-id-2">
                     Section 2 content
                 </AccordionSection>
             </Accordion>,
@@ -180,8 +174,8 @@ describe("Accordion", () => {
         );
 
         // Act
-        const header1 = screen.getByTestId("header-test-id-1");
-        const header2 = screen.getByTestId("header-test-id-2");
+        const header1 = screen.getByTestId("test-id-1-header");
+        const header2 = screen.getByTestId("test-id-2-header");
 
         // Assert
         expect(header1).toBeVisible();
@@ -288,10 +282,7 @@ describe("Accordion", () => {
         render(
             <Accordion caretPosition="start">
                 {[
-                    <AccordionSection
-                        header="Title"
-                        headerTestId="section-header-test-id"
-                    >
+                    <AccordionSection header="Title" testId="section-test-id">
                         Section content
                     </AccordionSection>,
                 ]}
@@ -300,7 +291,7 @@ describe("Accordion", () => {
         );
 
         // Act
-        const sectionHeader = screen.getByTestId("section-header-test-id");
+        const sectionHeader = screen.getByTestId("section-test-id-header");
 
         // Assert
         expect(sectionHeader).toHaveStyle({
@@ -313,10 +304,7 @@ describe("Accordion", () => {
         render(
             <Accordion caretPosition="end">
                 {[
-                    <AccordionSection
-                        header="Title"
-                        headerTestId="section-header-test-id"
-                    >
+                    <AccordionSection header="Title" testId="section-test-id">
                         Section content
                     </AccordionSection>,
                 ]}
@@ -325,7 +313,7 @@ describe("Accordion", () => {
         );
 
         // Act
-        const sectionHeader = screen.getByTestId("section-header-test-id");
+        const sectionHeader = screen.getByTestId("section-test-id-header");
 
         // Assert
         expect(sectionHeader).toHaveStyle({
@@ -341,7 +329,7 @@ describe("Accordion", () => {
                     <AccordionSection
                         header="Title"
                         caretPosition="end"
-                        headerTestId="section-header-test-id"
+                        testId="section-test-id"
                     >
                         Section content
                     </AccordionSection>,
@@ -351,7 +339,7 @@ describe("Accordion", () => {
         );
 
         // Act
-        const sectionHeader = screen.getByTestId("section-header-test-id");
+        const sectionHeader = screen.getByTestId("section-test-id-header");
 
         // Assert
         expect(sectionHeader).toHaveStyle({
@@ -367,7 +355,7 @@ describe("Accordion", () => {
                     <AccordionSection
                         header="Title"
                         animated={false}
-                        headerTestId="section-header-test-id"
+                        testId="section-test-id"
                     >
                         Section content
                     </AccordionSection>,
@@ -377,7 +365,7 @@ describe("Accordion", () => {
         );
 
         // Act
-        const sectionHeader = screen.getByTestId("section-header-test-id");
+        const sectionHeader = screen.getByTestId("section-test-id-header");
 
         // Assert
         // The parent has animated=true, so the child's animated=false

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -21,7 +21,7 @@ type Props = {
     // Corner roundedness type.
     cornerKind: AccordionCornerKindType;
     // Whether the section is collapsible or not. If false, the header will
-    // not be clickable.
+    // not be clickable, and the section will stay expanded at all times.
     collapsible?: boolean;
     // Whether the section is expanded or not.
     expanded: boolean;

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -20,6 +20,9 @@ type Props = {
     caretPosition: "start" | "end";
     // Corner roundedness type.
     cornerKind: AccordionCornerKindType;
+    // Whether the section is collapsible or not. If false, the header will
+    // not be clickable.
+    collapsible?: boolean;
     // Whether the section is expanded or not.
     expanded: boolean;
     // Whether to include animation on the header. This should be false
@@ -50,6 +53,7 @@ const AccordionSectionHeader = (props: Props) => {
         header,
         caretPosition,
         cornerKind,
+        collapsible = true,
         expanded,
         animated,
         onClick,
@@ -76,7 +80,8 @@ const AccordionSectionHeader = (props: Props) => {
                 aria-expanded={expanded}
                 aria-controls={sectionContentUniqueId}
                 onClick={onClick}
-                testId={testId}
+                disabled={!collapsible}
+                testId={testId ? `${testId}-header` : undefined}
                 style={[
                     styles.headerWrapper,
                     animated && styles.headerWrapperWithAnimation,
@@ -84,6 +89,7 @@ const AccordionSectionHeader = (props: Props) => {
                     roundedTop && styles.roundedTop,
                     roundedBottom && styles.roundedBottom,
                     headerStyle,
+                    !collapsible && styles.disabled,
                 ]}
             >
                 {() => (
@@ -108,18 +114,23 @@ const AccordionSectionHeader = (props: Props) => {
                                 header
                             )}
                         </View>
-                        <PhosphorIcon
-                            icon={caretDown}
-                            color={tokens.color.offBlack64}
-                            size="small"
-                            style={[
-                                animated && styles.iconWithAnimation,
-                                caretPosition === "start"
-                                    ? styles.iconStart
-                                    : styles.iconEnd,
-                                expanded && styles.iconExpanded,
-                            ]}
-                        />
+                        {collapsible && (
+                            <PhosphorIcon
+                                icon={caretDown}
+                                color={tokens.color.offBlack64}
+                                size="small"
+                                style={[
+                                    animated && styles.iconWithAnimation,
+                                    caretPosition === "start"
+                                        ? styles.iconStart
+                                        : styles.iconEnd,
+                                    expanded && styles.iconExpanded,
+                                ]}
+                                testId={
+                                    testId ? `${testId}-caret-icon` : undefined
+                                }
+                            />
+                        )}
                     </>
                 )}
             </Clickable>
@@ -202,6 +213,10 @@ const styles = StyleSheet.create({
     },
     iconEnd: {
         marginInlineEnd: tokens.spacing.medium_16,
+    },
+    disabled: {
+        pointerEvents: "none",
+        color: "inherit",
     },
 });
 

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -54,6 +54,11 @@ type Props = AriaProps & {
      */
     cornerKind?: AccordionCornerKindType;
     /**
+     * Whether this section is collapsible. If false, the header will not be
+     * clickable, and the section will be stay expanded at all times.
+     */
+    collapsible?: boolean;
+    /**
      * Whether this section is expanded or closed.
      *
      * NOTE: This prop is NOT used when this AccordionSection is rendered
@@ -94,12 +99,6 @@ type Props = AriaProps & {
      * The test ID used to locate this component in automated tests.
      */
     testId?: string;
-    /**
-     * The test ID used to locate this component's clickable header in
-     * automated tests.
-     */
-    headerTestId?: string;
-
     /**
      * Whether this section is the first section in the accordion.
      * For internal use only.
@@ -165,6 +164,7 @@ const AccordionSection = React.forwardRef(function AccordionSection(
         children,
         id,
         header,
+        collapsible,
         expanded,
         animated = false,
         onToggle,
@@ -174,7 +174,6 @@ const AccordionSection = React.forwardRef(function AccordionSection(
         headerStyle,
         tag,
         testId,
-        headerTestId,
         // Assume it's the first section and last section by default
         // in case this component is being used standalone. If it's part
         // of an accordion, these will be overridden by the Accordion
@@ -215,11 +214,17 @@ const AccordionSection = React.forwardRef(function AccordionSection(
         }
     };
 
-    // If the expanded prop is undefined, we're in uncontrolled mode and
-    // should use the internal state to determine the expanded state.
-    // Otherwise, we're in controlled mode and should use the expanded prop
-    // that's passed in to determine the expanded state.
-    const expandedState = controlledMode ? expanded : internalExpanded;
+    let expandedState;
+    if (collapsible === false) {
+        // If the section is disabled, it should always be expanded.
+        expandedState = true;
+        // If the expanded prop is undefined, we're in uncontrolled mode and
+        // should use the internal state to determine the expanded state.
+        // Otherwise, we're in controlled mode and should use the expanded prop
+        // that's passed in to determine the expanded state.
+    } else {
+        expandedState = controlledMode ? expanded : internalExpanded;
+    }
 
     return (
         <View
@@ -241,13 +246,14 @@ const AccordionSection = React.forwardRef(function AccordionSection(
                 header={header}
                 caretPosition={caretPosition}
                 cornerKind={cornerKind}
+                collapsible={collapsible}
                 expanded={expandedState}
                 animated={animated}
                 onClick={handleClick}
                 sectionContentUniqueId={sectionContentUniqueId}
                 headerStyle={headerStyle}
                 tag={tag}
-                testId={headerTestId}
+                testId={testId}
                 isFirstSection={isFirstSection}
                 isLastSection={isLastSection}
             />

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -55,7 +55,7 @@ type Props = AriaProps & {
     cornerKind?: AccordionCornerKindType;
     /**
      * Whether this section is collapsible. If false, the header will not be
-     * clickable, and the section will be stay expanded at all times.
+     * clickable, and the section will stay expanded at all times.
      */
     collapsible?: boolean;
     /**


### PR DESCRIPTION
## Summary
In the event that an accordion section needs to stay open at all times, the user can now use `collapsible={false}` to keep it open. This also sets the header button's `aria-disabled` to `true`, as outlined in the [accessibility guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/).

Issue: https://khanacademy.atlassian.net/browse/WB-1585

## Test plan
`yarn jest packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx`
`yarn jest packages/wonder-blocks-accordion/src/components/__tests__/accordion-section-header.test.tsx`

Storybook
- Go to http://localhost:6061/?path=/docs/accordion-accordionsection--docs
- Check that there is no caret icon 
- Confirm that the header button cannot be clicked