### PR TITLE
Add keyboard nav support to Accordion (arrow keys, home, end)

### DIFF
--- a/.changeset/clever-rice-protect.md
+++ b/.changeset/clever-rice-protect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Get onFocus to work for buttons

--- a/.changeset/forty-tomatoes-wink.md
+++ b/.changeset/forty-tomatoes-wink.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Add support for up arrow, down arrow, home, and end keys

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -63,13 +63,13 @@ export default {
 type StoryComponentType = StoryObj<typeof Accordion>;
 
 const exampleSections = [
-    <AccordionSection header="First section">
+    <AccordionSection key="first" header="First section">
         This is the information present in the first section
     </AccordionSection>,
-    <AccordionSection header="Second section">
+    <AccordionSection key="second" header="Second section">
         This is the information present in the second section
     </AccordionSection>,
-    <AccordionSection header="Third section">
+    <AccordionSection key="third" header="Third section">
         This is the information present in the third section
     </AccordionSection>,
 ];

--- a/consistency-tests/__tests__/ref-forwarded.test.tsx
+++ b/consistency-tests/__tests__/ref-forwarded.test.tsx
@@ -105,7 +105,7 @@ describe("Accordion elements", () => {
 
     test("AccordionSection forwards ref", () => {
         // Arrange
-        const ref: React.RefObject<HTMLDivElement> = React.createRef();
+        const ref: React.RefObject<HTMLButtonElement> = React.createRef();
 
         // Act
         render(
@@ -116,7 +116,7 @@ describe("Accordion elements", () => {
         );
 
         // Assert
-        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
     });
 });
 

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 
@@ -396,5 +397,283 @@ describe("Accordion", () => {
 
         // Assert
         expect(wrapper).toHaveStyle({color: "red"});
+    });
+
+    describe("keyboard navigation", () => {
+        test("can open a section with the enter key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+
+            // Act
+            // Confirm that the section is closed.
+            expect(screen.queryByText("Section 1 content")).not.toBeVisible();
+
+            button1.focus();
+            userEvent.keyboard("{enter}");
+
+            // Assert
+            // Confirm that the section is now open.
+            expect(screen.getByText("Section 1 content")).toBeVisible();
+        });
+
+        test("can open a section with the space key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+
+            // Act
+            // Confirm that the section is closed.
+            expect(screen.queryByText("Section 1 content")).not.toBeVisible();
+
+            button1.focus();
+            userEvent.keyboard("{space}");
+
+            // Assert
+            // Confirm that the section is now open.
+            expect(screen.getByText("Section 1 content")).toBeVisible();
+        });
+
+        test("can close a section with the enter key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+
+            // Act
+            // Confirm that the section is open.
+            button1.click();
+            expect(screen.getByText("Section 1 content")).toBeVisible();
+
+            button1.focus();
+            userEvent.keyboard("{enter}");
+
+            // Assert
+            // Confirm that the section is now closed.
+            expect(screen.queryByText("Section 1 content")).not.toBeVisible();
+        });
+
+        test("can close a section with the space key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+
+            // Act
+            // Confirm that the section is open.
+            button1.click();
+            expect(screen.getByText("Section 1 content")).toBeVisible();
+
+            button1.focus();
+            userEvent.keyboard("{space}");
+
+            // Assert
+            // Confirm that the section is now closed.
+            expect(screen.queryByText("Section 1 content")).not.toBeVisible();
+        });
+
+        test("can navigate to the next section with the tab key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+            const button2 = screen.getByRole("button", {name: "Section 2"});
+
+            // Act
+            button1.focus();
+            userEvent.tab();
+
+            // Assert
+            expect(button2).toHaveFocus();
+        });
+
+        test("can navigate to the previous section with the shift+tab key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+            const button2 = screen.getByRole("button", {name: "Section 2"});
+
+            // Act
+            button2.focus();
+            userEvent.tab({shift: true});
+
+            // Assert
+            expect(button1).toHaveFocus();
+        });
+
+        test("can navigate to the next section with the arrow down key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+            const button2 = screen.getByRole("button", {name: "Section 2"});
+
+            // Act
+            button1.focus();
+            userEvent.keyboard("{arrowdown}");
+
+            // Assert
+            expect(button2).toHaveFocus();
+        });
+
+        test("can navigate to the previous section with the arrow up key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+            const button2 = screen.getByRole("button", {name: "Section 2"});
+
+            // Act
+            button2.focus();
+            userEvent.keyboard("{arrowup}");
+
+            // Assert
+            expect(button1).toHaveFocus();
+        });
+
+        test("can navigate to the first section with the home key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 3">
+                        Section 3 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+            const button2 = screen.getByRole("button", {name: "Section 2"});
+            const button3 = screen.getByRole("button", {name: "Section 3"});
+
+            // Act
+            button3.focus();
+            userEvent.keyboard("{home}");
+
+            // Assert
+            expect(button1).toHaveFocus();
+            expect(button2).not.toHaveFocus();
+            expect(button3).not.toHaveFocus();
+        });
+
+        test("can navigate to the last section with the end key", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 3">
+                        Section 3 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+            const button2 = screen.getByRole("button", {name: "Section 2"});
+            const button3 = screen.getByRole("button", {name: "Section 3"});
+
+            // Act
+            button1.focus();
+            userEvent.keyboard("{end}");
+
+            // Assert
+            expect(button1).not.toHaveFocus();
+            expect(button2).not.toHaveFocus();
+            expect(button3).toHaveFocus();
+        });
     });
 });

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
@@ -589,6 +589,35 @@ describe("Accordion", () => {
             expect(button2).toHaveFocus();
         });
 
+        test("can cycle to the first section with the arrow down key from the last section", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2" testId="section-2">
+                        Section 2 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 3">
+                        Section 3 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+            const button3 = screen.getByRole("button", {name: "Section 3"});
+
+            // Act
+            button3.focus();
+            userEvent.keyboard("{arrowdown}");
+
+            // Assert
+            expect(button1).toHaveFocus();
+            expect(button3).not.toHaveFocus();
+        });
+
         test("can navigate to the previous section with the arrow up key", () => {
             // Arrange
             render(
@@ -612,6 +641,35 @@ describe("Accordion", () => {
 
             // Assert
             expect(button1).toHaveFocus();
+        });
+
+        test("can cycle to the last section with the arrow up key from the first section", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2" testId="section-2">
+                        Section 2 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 3">
+                        Section 3 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            const button1 = screen.getByRole("button", {name: "Section 1"});
+            const button3 = screen.getByRole("button", {name: "Section 3"});
+
+            // Act
+            button1.focus();
+            userEvent.keyboard("{arrowup}");
+
+            // Assert
+            expect(button3).toHaveFocus();
+            expect(button1).not.toHaveFocus();
         });
 
         test("can navigate to the first section with the home key", () => {

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -225,6 +225,10 @@ const styles = StyleSheet.create({
     disabled: {
         pointerEvents: "none",
         color: "inherit",
+
+        ":focus-visible": {
+            outline: `2px solid ${tokens.color.offBlack32}`,
+        },
     },
 });
 

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -30,6 +30,8 @@ type Props = {
     animated: boolean;
     // Called on header click.
     onClick?: () => void;
+    // Called on header focus.
+    onFocus?: () => void;
     // The ID for the content that the header's `aria-controls` should
     // point to.
     sectionContentUniqueId: string;
@@ -48,7 +50,10 @@ type Props = {
     isLastSection: boolean;
 };
 
-const AccordionSectionHeader = (props: Props) => {
+const AccordionSectionHeader = React.forwardRef(function AccordionSectionHeader(
+    props: Props,
+    ref: React.ForwardedRef<HTMLButtonElement>,
+) {
     const {
         header,
         caretPosition,
@@ -57,6 +62,7 @@ const AccordionSectionHeader = (props: Props) => {
         expanded,
         animated,
         onClick,
+        onFocus,
         sectionContentUniqueId,
         headerStyle,
         tag = "h2",
@@ -80,6 +86,7 @@ const AccordionSectionHeader = (props: Props) => {
                 aria-expanded={expanded}
                 aria-controls={sectionContentUniqueId}
                 onClick={onClick}
+                onFocus={onFocus}
                 disabled={!collapsible}
                 testId={testId ? `${testId}-header` : undefined}
                 style={[
@@ -91,6 +98,7 @@ const AccordionSectionHeader = (props: Props) => {
                     headerStyle,
                     !collapsible && styles.disabled,
                 ]}
+                ref={ref}
             >
                 {() => (
                     <>
@@ -136,7 +144,7 @@ const AccordionSectionHeader = (props: Props) => {
             </Clickable>
         </HeadingSmall>
     );
-};
+});
 
 // The AccordionSection border radius for rounded corners is 12px.
 // If we set the inner radius to the same value, there ends up being

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -168,10 +168,24 @@ const styles = StyleSheet.create({
         ":active": {
             outline: `2px solid ${tokens.color.activeBlue}`,
         },
-        ":focus-visible": {
+
+        ":hover": {
             outline: `2px solid ${tokens.color.blue}`,
         },
-        ":hover": {
+
+        // Provide basic, default focus styles on older browsers (e.g.
+        // Safari 14)
+        ":focus": {
+            boxShadow: `0 0 0 2px ${tokens.color.blue}`,
+        },
+
+        // Remove default focus styles for mouse users ONLY if
+        // :focus-visible is supported on this platform.
+        ":focus:not(:focus-visible)": {
+            boxShadow: "none",
+        },
+
+        ":focus-visible": {
             outline: `2px solid ${tokens.color.blue}`,
         },
     },
@@ -225,6 +239,18 @@ const styles = StyleSheet.create({
     disabled: {
         pointerEvents: "none",
         color: "inherit",
+
+        // Provide basic, default focus styles on older browsers (e.g.
+        // Safari 14)
+        ":focus": {
+            boxShadow: `0 0 0 2px ${tokens.color.offBlack32}`,
+        },
+
+        // Remove default focus styles for mouse users ONLY if
+        // :focus-visible is supported on this platform.
+        ":focus:not(:focus-visible)": {
+            boxShadow: "none",
+        },
 
         ":focus-visible": {
             outline: `2px solid ${tokens.color.offBlack32}`,

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -111,6 +111,12 @@ type Props = AriaProps & {
      * @ignore
      */
     isLastSection?: boolean;
+    /**
+     * Called when the header is focused.
+     * For internal use only.
+     * @ignore
+     */
+    onFocus?: () => void;
 };
 
 /**
@@ -158,7 +164,9 @@ type Props = AriaProps & {
  */
 const AccordionSection = React.forwardRef(function AccordionSection(
     props: Props,
-    ref: React.ForwardedRef<HTMLDivElement>,
+    // Using a button ref here beacuse the ref is pointing to the
+    // section header, which is a button.
+    ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
     const {
         children,
@@ -168,6 +176,7 @@ const AccordionSection = React.forwardRef(function AccordionSection(
         expanded,
         animated = false,
         onToggle,
+        onFocus,
         caretPosition = "end",
         cornerKind = "rounded",
         style,
@@ -240,7 +249,6 @@ const AccordionSection = React.forwardRef(function AccordionSection(
             ]}
             testId={testId}
             {...ariaProps}
-            ref={ref}
         >
             <AccordionSectionHeader
                 header={header}
@@ -250,12 +258,14 @@ const AccordionSection = React.forwardRef(function AccordionSection(
                 expanded={expandedState}
                 animated={animated}
                 onClick={handleClick}
+                onFocus={onFocus}
                 sectionContentUniqueId={sectionContentUniqueId}
                 headerStyle={headerStyle}
                 tag={tag}
                 testId={testId}
                 isFirstSection={isFirstSection}
                 isLastSection={isLastSection}
+                ref={ref}
             />
             <View
                 id={sectionContentUniqueId}

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -225,7 +225,8 @@ const AccordionSection = React.forwardRef(function AccordionSection(
 
     let expandedState;
     if (collapsible === false) {
-        // If the section is disabled, it should always be expanded.
+        // If the section is disabled (not collapsible), it should
+        // always be expanded.
         expandedState = true;
         // If the expanded prop is undefined, we're in uncontrolled mode and
         // should use the internal state to determine the expanded state.

--- a/packages/wonder-blocks-accordion/src/components/accordion.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion.tsx
@@ -155,6 +155,16 @@ const Accordion = React.forwardRef(function Accordion(
         }
     };
 
+    /**
+     * Set focus on the section that was selected.
+     *
+     * NOTE: It may seem like we should filter out non-collapsible sections
+     * here as they are effectively disabled. However, we should keep these
+     * disabled sections in the focus order as they'd receive focus anyway
+     * with `aria-disabled` and visually impaired users should still know
+     * they are there. Screenreaders will read them out as disabled, the
+     * status will still be clear to users.
+     */
     const handleSectionFocus = (index: number) => {
         setCurrentlyFocusedSection(index);
     };

--- a/packages/wonder-blocks-accordion/src/components/accordion.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion.tsx
@@ -120,12 +120,18 @@ const Accordion = React.forwardRef(function Accordion(
         ...ariaProps
     } = props;
 
+    // Starting array for the initial expanded state of each section.
     const startingArray = Array(children.length).fill(false);
+    // If initialExpandedIndex is specified, we want to open that section.
     if (initialExpandedIndex !== undefined) {
         startingArray[initialExpandedIndex] = true;
     }
-
     const [sectionsOpened, setSectionsOpened] = React.useState(startingArray);
+
+    // Setting up focus state and refs for keyboard navigation.
+    const [currentlyFocusedSection, setCurrentlyFocusedSection] =
+        React.useState(0);
+    const childRefs = Array(children.length).fill(null);
 
     const handleSectionClick = (
         index: number,
@@ -141,14 +147,59 @@ const Accordion = React.forwardRef(function Accordion(
         newSectionsOpened[index] = newOpenedValueAtIndex;
         setSectionsOpened(newSectionsOpened);
 
+        // Keep track of the currently focused section for keyboard navigation.
+        setCurrentlyFocusedSection(index);
+
         if (childOnToggle) {
             childOnToggle(newOpenedValueAtIndex);
+        }
+    };
+
+    const handleSectionFocus = (index: number) => {
+        setCurrentlyFocusedSection(index);
+    };
+
+    /** Keyboard navigation for keys: ArrowUp, ArrowDown, Home, and End.
+     *
+     * Note that we don't have to use `setCurrentlyFocusedSection` in this
+     * function because the focus is handled by the browser + the
+     * section's onFocus handler (the `handleSectionFocus` function above).
+     */
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        switch (event.key) {
+            // ArrowUp focuses on the previous section.
+            case "ArrowUp":
+                const previousSectionIndex = currentlyFocusedSection - 1;
+                if (previousSectionIndex >= 0) {
+                    const previousChildRef = childRefs[previousSectionIndex];
+                    previousChildRef.current.focus();
+                }
+                break;
+            // ArrowDown focuses on the next section.
+            case "ArrowDown":
+                const nextSectionIndex = currentlyFocusedSection + 1;
+                if (nextSectionIndex < children.length) {
+                    const nextChildRef = childRefs[nextSectionIndex];
+                    nextChildRef.current.focus();
+                }
+                break;
+            // Home focuses on the first section.
+            case "Home":
+                const firstChildRef = childRefs[0];
+                firstChildRef.current.focus();
+                break;
+            // End focuses on the last section.
+            case "End":
+                const lastChildRef = childRefs[children.length - 1];
+                lastChildRef.current.focus();
+                break;
         }
     };
 
     return (
         <StyledUnorderedList
             style={[styles.wrapper, style]}
+            onKeyDown={handleKeyDown}
             {...ariaProps}
             ref={ref}
         >
@@ -159,6 +210,11 @@ const Accordion = React.forwardRef(function Accordion(
                     onToggle: childOnToggle,
                     animated: childanimated,
                 } = child.props;
+
+                // Create a ref for each child AccordionSection to
+                // be able to focus on them with keyboard navigation.
+                const childRef = React.createRef<HTMLButtonElement>();
+                childRefs[index] = childRef;
 
                 const isFirstChild = index === 0;
                 const isLastChild = index === children.length - 1;
@@ -180,8 +236,10 @@ const Accordion = React.forwardRef(function Accordion(
                             animated: animated ?? childanimated,
                             onToggle: () =>
                                 handleSectionClick(index, childOnToggle),
+                            onFocus: () => handleSectionFocus(index),
                             isFirstSection: isFirstChild,
                             isLastSection: isLastChild,
+                            ref: childRef,
                         })}
                     </li>
                 );

--- a/packages/wonder-blocks-accordion/src/components/accordion.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion.tsx
@@ -169,19 +169,24 @@ const Accordion = React.forwardRef(function Accordion(
         switch (event.key) {
             // ArrowUp focuses on the previous section.
             case "ArrowUp":
-                const previousSectionIndex = currentlyFocusedSection - 1;
-                if (previousSectionIndex >= 0) {
-                    const previousChildRef = childRefs[previousSectionIndex];
-                    previousChildRef.current.focus();
-                }
+                // Get the previous section, or cycle to last section if
+                // the first section is currently focused.
+                const previousSectionIndex =
+                    (currentlyFocusedSection + children.length - 1) %
+                    children.length;
+                const previousChildRef = childRefs[previousSectionIndex];
+                previousChildRef.current.focus();
+
                 break;
             // ArrowDown focuses on the next section.
             case "ArrowDown":
-                const nextSectionIndex = currentlyFocusedSection + 1;
-                if (nextSectionIndex < children.length) {
-                    const nextChildRef = childRefs[nextSectionIndex];
-                    nextChildRef.current.focus();
-                }
+                // Get the next section, or cycle to first section if
+                // the last section is currently focused.
+                const nextSectionIndex =
+                    (currentlyFocusedSection + 1) % children.length;
+                const nextChildRef = childRefs[nextSectionIndex];
+                nextChildRef.current.focus();
+
                 break;
             // Home focuses on the first section.
             case "Home":

--- a/packages/wonder-blocks-accordion/src/components/accordion.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion.tsx
@@ -131,6 +131,12 @@ const Accordion = React.forwardRef(function Accordion(
     // Setting up focus state and refs for keyboard navigation.
     const [currentlyFocusedSection, setCurrentlyFocusedSection] =
         React.useState(0);
+    //  NOTE: It may seem like we should filter out non-collapsible sections
+    //  here as they are effectively disabled. However, we should keep these
+    //  disabled sections in the focus order as they'd receive focus anyway
+    //  with `aria-disabled` and visually impaired users should still know
+    //  they are there. Screenreaders will read them out as disabled, the
+    //  status will still be clear to users.
     const childRefs = Array(children.length).fill(null);
 
     const handleSectionClick = (
@@ -155,16 +161,6 @@ const Accordion = React.forwardRef(function Accordion(
         }
     };
 
-    /**
-     * Set focus on the section that was selected.
-     *
-     * NOTE: It may seem like we should filter out non-collapsible sections
-     * here as they are effectively disabled. However, we should keep these
-     * disabled sections in the focus order as they'd receive focus anyway
-     * with `aria-disabled` and visually impaired users should still know
-     * they are there. Screenreaders will read them out as disabled, the
-     * status will still be clear to users.
-     */
     const handleSectionFocus = (index: number) => {
         setCurrentlyFocusedSection(index);
     };

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -29,6 +29,10 @@ type CommonProps =
          */
         onClick?: (e: React.SyntheticEvent) => unknown;
         /**
+         * An onFocus function which Clickable can execute when focused
+         */
+        onFocus?: (e: React.FocusEvent) => unknown;
+        /**
          * Optional href which Clickable should direct to, uses client-side routing
          * by default if react-router is present
          */
@@ -246,6 +250,11 @@ const Clickable = React.forwardRef(function Clickable(
                     {...commonProps}
                     type="button"
                     aria-disabled={props.disabled}
+                    onFocus={(e) => {
+                        if (props.onFocus) {
+                            props.onFocus(e);
+                        }
+                    }}
                     ref={ref as React.Ref<HTMLButtonElement>}
                 >
                     {props.children(clickableState)}

--- a/types/aphrodite.d.ts
+++ b/types/aphrodite.d.ts
@@ -31,6 +31,7 @@ declare module "aphrodite" {
         ":after"?: _CSSProperties;
         ":first-child"?: _CSSProperties;
         ":focus-visible"?: _CSSProperties;
+        ":focus:not(:focus-visible)"?: _CSSProperties;
         ":focus"?: _CSSProperties;
         ":hover"?: _CSSProperties;
         ":last-child"?: _CSSProperties;


### PR DESCRIPTION
## Summary:
As per the [w3 guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/) for accordion, 
it is recommended (but optional... but we're doing it anyway!) to have keyboard nav support for
arrow up, arrow down, home, and end.

I've added that keyboard support here using the `onKeyDown` listener on `ul` and
`onFocus` on AccordionSection. To get this to work, I changed the ref for AccordionSection
from its container View/div to its header button. I also had to update Clickable because its
`onFocus` prop wasn't working on buttons for some reason.

Issue: https://khanacademy.atlassian.net/browse/WB-1585

## Test plan:
Manual testing on Accordion stories
- Go to a story with multiple accordions, such as http://localhost:6061/?path=/story/accordion-accordion--caret-positions
- try keyboard nav in all sort of order + clicking across multiple accordions
- make sure to include tabbing in from elsewhere and then switching to arrow keys, both to the start and the end of the accordion

`yarn jest packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx`