### PR TITLE
Make Accordion fully accessible

### DIFF
--- a/.changeset/smart-flowers-wave.md
+++ b/.changeset/smart-flowers-wave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Add region and aria-labelledby to accordion

--- a/__docs__/wonder-blocks-accordion/accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-accordion/accessibility.stories.mdx
@@ -1,0 +1,69 @@
+import {Meta, Story, Canvas} from "@storybook/blocks";
+
+import {Accordion, AccordionSection} from "@khanacademy/wonder-blocks-accordion";
+
+<Meta
+    title="Accordion / Accessibility"
+    component={Accordion}
+    parameters={{
+        previewTabs: {
+            canvas: {hidden: true},
+        },
+        viewMode: "docs",
+        chromatic: {
+            // Disables chromatic testing for these stories.
+            disableSnapshot: true,
+        },
+    }}
+/>
+
+## Accordion Accessibility
+
+### Built in Accessibility Features
+
+Wonder Blocks Accordion already has some built in accessibility features
+as [advised by W3](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/).
+
+- The headers of each section are button components. The user can click on
+  the header to expand the section. The user can also use the enter or
+  space keys when focused on the header to expand the section.
+- The headers are keyboard navigable:
+  - The "tab" key and "arrow down" keys will focus on the next header
+    in the sequence. ("Arrow down" only works if the focus is already
+    within the accordion, and will cycle to the top if the focus is
+    currently on the last element.)
+  - The "shift + tab" and "arrow up" keys will focus on the previous
+    header in the sequence. ("Arrow up" only works if the focus is
+    already within the accordion, and will cycle to the bottom if
+    the focus is currently on the first element.)
+  - The "home" key will focus on the first header in the accordion.
+  - The "end" key will focus on the last header in the accordion.
+- The roles and structures are set as advised:
+  - The title of each header is contained within a button.
+  - The title button is wrapped in a heading.
+      - It is currently `<h2>` by default, but the user is advised to
+        set it to the appropriate heading level via the `tag` prop on
+        each accordion section.
+  - The header button has the `aria-expanded` attribute, which is
+    true when the accordion section is expanded and false when not.
+  - The header button has the `aria-controls` attribute pointing to
+    the ID of that section's content panel container.
+  - If the section is not collapsible, the header button has the
+    `aria-disabled` attribute set to true.
+  - Each section's content panel has its `aria-labelledby` pointing To
+    its header button.
+  - If there are six or fewer sections, each section's content panel
+    has the `role` attribute set to "region".
+
+### Considerations for the User
+
+- The accordion can be animated using the `animated` prop. However,
+  PLEASE set this according to the users' "prefers reduced motion"
+  setting (this can be in the application or in their operating system).
+- PLEASE use AccordionSection's `tag` prop to appropriately set the
+  section's heading level! It defaults to `<h2>`, but it needs to be
+  set appropriately based on the page's heading structure.
+
+### References
+
+[W3 Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section-header.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section-header.test.tsx
@@ -8,6 +8,7 @@ describe("AccordionSectionHeader", () => {
         // Arrange
         render(
             <AccordionSectionHeader
+                id="accordion-section-header"
                 header="Title"
                 caretPosition="end"
                 cornerKind="square"
@@ -31,6 +32,7 @@ describe("AccordionSectionHeader", () => {
         // Arrange
         render(
             <AccordionSectionHeader
+                id="accordion-section-header"
                 header="Title"
                 caretPosition="end"
                 cornerKind="square"
@@ -57,6 +59,7 @@ describe("AccordionSectionHeader", () => {
         // Act
         render(
             <AccordionSectionHeader
+                id="accordion-section-header"
                 header={<div>Section content</div>}
                 caretPosition="end"
                 cornerKind="square"
@@ -80,6 +83,7 @@ describe("AccordionSectionHeader", () => {
         // Act
         render(
             <AccordionSectionHeader
+                id="accordion-section-header"
                 header="Title"
                 caretPosition="end"
                 cornerKind="square"
@@ -101,6 +105,7 @@ describe("AccordionSectionHeader", () => {
         // Arrange
         render(
             <AccordionSectionHeader
+                id="accordion-section-header"
                 header="Title"
                 caretPosition="end"
                 cornerKind="square"
@@ -126,6 +131,7 @@ describe("AccordionSectionHeader", () => {
         // Arrange
         render(
             <AccordionSectionHeader
+                id="accordion-section-header"
                 header="Title"
                 caretPosition="end"
                 cornerKind="square"
@@ -151,6 +157,7 @@ describe("AccordionSectionHeader", () => {
         // Arrange
         render(
             <AccordionSectionHeader
+                id="accordion-section-header"
                 header="Title"
                 caretPosition="end"
                 cornerKind="square"
@@ -178,6 +185,7 @@ describe("AccordionSectionHeader", () => {
         // Arrange
         render(
             <AccordionSectionHeader
+                id="accordion-section-header"
                 header="Title"
                 caretPosition="end"
                 cornerKind="square"

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
@@ -399,6 +399,104 @@ describe("Accordion", () => {
         expect(wrapper).toHaveStyle({color: "red"});
     });
 
+    test("applies region role to sections when there are 6 or fewer", () => {
+        // Arrange
+        render(
+            <Accordion>
+                <AccordionSection header="Section 1" testId="section-1">
+                    Section 1 content
+                </AccordionSection>
+                <AccordionSection header="Section 2">
+                    Section 2 content
+                </AccordionSection>
+                <AccordionSection header="Section 3">
+                    Section 3 content
+                </AccordionSection>
+                <AccordionSection header="Section 4">
+                    Section 4 content
+                </AccordionSection>
+                <AccordionSection header="Section 5">
+                    Section 5 content
+                </AccordionSection>
+                <AccordionSection header="Section 6">
+                    Section 6 content
+                </AccordionSection>
+            </Accordion>,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const section1ContentPanel = screen.getByTestId(
+            "section-1-content-panel",
+        );
+
+        // Assert
+        expect(section1ContentPanel).toHaveAttribute("role", "region");
+    });
+
+    test("does not apply region role to sections when there are more than 6", () => {
+        // Arrange
+        render(
+            <Accordion>
+                <AccordionSection header="Section 1" testId="section-1">
+                    Section 1 content
+                </AccordionSection>
+                <AccordionSection header="Section 2">
+                    Section 2 content
+                </AccordionSection>
+                <AccordionSection header="Section 3">
+                    Section 3 content
+                </AccordionSection>
+                <AccordionSection header="Section 4">
+                    Section 4 content
+                </AccordionSection>
+                <AccordionSection header="Section 5">
+                    Section 5 content
+                </AccordionSection>
+                <AccordionSection header="Section 6">
+                    Section 6 content
+                </AccordionSection>
+                <AccordionSection header="Section 7">
+                    Section 7 content
+                </AccordionSection>
+            </Accordion>,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const section1ContentPanel = screen.getByTestId(
+            "section-1-content-panel",
+        );
+
+        // Assert
+        expect(section1ContentPanel).not.toHaveAttribute("role", "region");
+    });
+
+    test("appropriately sets aria-labelledby on the content panel", () => {
+        // Arrange
+        render(
+            <Accordion>
+                <AccordionSection header="Section 1" testId="section-1">
+                    Section 1 content
+                </AccordionSection>
+                <AccordionSection header="Section 2">
+                    Section 2 content
+                </AccordionSection>
+            </Accordion>,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const section1ContentPanel = screen.getByTestId(
+            "section-1-content-panel",
+        );
+
+        // Assert
+        // Not testing the actual value of the aria-labelledby attribute
+        // because it comes from the unique ID generator.
+        expect(section1ContentPanel).toHaveAttribute("aria-labelledby");
+    });
+
     describe("keyboard navigation", () => {
         test("can open a section with the enter key", () => {
             // Arrange

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
@@ -476,7 +476,11 @@ describe("Accordion", () => {
         // Arrange
         render(
             <Accordion>
-                <AccordionSection header="Section 1" testId="section-1">
+                <AccordionSection
+                    id="accordion-section-id-for-test"
+                    header="Section 1"
+                    testId="section-1"
+                >
                     Section 1 content
                 </AccordionSection>
                 <AccordionSection header="Section 2">
@@ -492,9 +496,10 @@ describe("Accordion", () => {
         );
 
         // Assert
-        // Not testing the actual value of the aria-labelledby attribute
-        // because it comes from the unique ID generator.
-        expect(section1ContentPanel).toHaveAttribute("aria-labelledby");
+        expect(section1ContentPanel).toHaveAttribute(
+            "aria-labelledby",
+            "accordion-section-id-for-test-header",
+        );
     });
 
     describe("keyboard navigation", () => {

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -14,6 +14,8 @@ import type {TagType} from "./accordion-section";
 import {getRoundedValuesForHeader} from "../utils";
 
 type Props = {
+    // Unique ID for this section's button.
+    id: string;
     // Header content.
     header: string | React.ReactElement;
     // Whether the caret shows up at the start or end of the header block.
@@ -55,6 +57,7 @@ const AccordionSectionHeader = React.forwardRef(function AccordionSectionHeader(
     ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
     const {
+        id,
         header,
         caretPosition,
         cornerKind,
@@ -83,6 +86,7 @@ const AccordionSectionHeader = React.forwardRef(function AccordionSectionHeader(
     return (
         <HeadingSmall tag={tag} style={styles.heading}>
             <Clickable
+                id={id}
                 aria-expanded={expanded}
                 aria-controls={sectionContentUniqueId}
                 onClick={onClick}

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -112,6 +112,15 @@ type Props = AriaProps & {
      */
     isLastSection?: boolean;
     /**
+     * Whether this section should have role="region". True by default.
+     * According to W3, the panel container should have role region except
+     * when there are more than six panels in an accordion, in which case
+     * we should set this prop to false.
+     * For internal use only.
+     * @ignore
+     */
+    isRegion?: boolean;
+    /**
      * Called when the header is focused.
      * For internal use only.
      * @ignore
@@ -189,6 +198,9 @@ const AccordionSection = React.forwardRef(function AccordionSection(
         // parent component.
         isFirstSection = true,
         isLastSection = true,
+        // Assume it's a region by default. Override this to be false
+        // if we know there are more than six panels in an accordion.
+        isRegion = true,
         ...ariaProps
     } = props;
 
@@ -200,6 +212,9 @@ const AccordionSection = React.forwardRef(function AccordionSection(
 
     const ids = useUniqueIdWithMock();
     const sectionId = id ?? ids.get("accordion-section");
+    // We need an ID for the header so that the content section's
+    // aria-labelledby attribute can point to it.
+    const headerId = ids.get("accordion-section-header");
     // We need an ID for the content section so that the opener's
     // aria-controls attribute can point to it.
     const sectionContentUniqueId = ids.get("accordion-section-content");
@@ -252,6 +267,7 @@ const AccordionSection = React.forwardRef(function AccordionSection(
             {...ariaProps}
         >
             <AccordionSectionHeader
+                id={headerId}
                 header={header}
                 caretPosition={caretPosition}
                 cornerKind={cornerKind}
@@ -270,6 +286,8 @@ const AccordionSection = React.forwardRef(function AccordionSection(
             />
             <View
                 id={sectionContentUniqueId}
+                role={isRegion ? "region" : undefined}
+                aria-labelledby={headerId}
                 style={[
                     styles.contentWrapper,
                     expandedState
@@ -277,6 +295,7 @@ const AccordionSection = React.forwardRef(function AccordionSection(
                         : styles.conentWrapperCollapsed,
                     sectionStyles.contentWrapper,
                 ]}
+                testId={testId ? `${testId}-content-panel` : undefined}
             >
                 {typeof children === "string" ? (
                     <Body style={styles.stringContent}>{children}</Body>

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -214,7 +214,7 @@ const AccordionSection = React.forwardRef(function AccordionSection(
     const sectionId = id ?? ids.get("accordion-section");
     // We need an ID for the header so that the content section's
     // aria-labelledby attribute can point to it.
-    const headerId = ids.get("accordion-section-header");
+    const headerId = id ? `${id}-header` : ids.get("accordion-section-header");
     // We need an ID for the content section so that the opener's
     // aria-controls attribute can point to it.
     const sectionContentUniqueId = ids.get("accordion-section-content");

--- a/packages/wonder-blocks-accordion/src/components/accordion.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion.tsx
@@ -75,6 +75,8 @@ type Props = AriaProps & {
     style?: StyleType;
 };
 
+const LANDMARK_PROLIFERATION_THRESHOLD = 6;
+
 /**
  * An accordion displays a vertically stacked list of sections, each of which
  * contains content that can be shown or hidden by clicking its header.
@@ -138,6 +140,13 @@ const Accordion = React.forwardRef(function Accordion(
     //  they are there. Screenreaders will read them out as disabled, the
     //  status will still be clear to users.
     const childRefs = Array(children.length).fill(null);
+
+    // If the number of sections is greater than the threshold,
+    // we don't want to use the `region` role on the AccordionSection
+    // components because it will cause too many landmarks to be created.
+    // (See https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)
+    const sectionsAreRegions =
+        children.length <= LANDMARK_PROLIFERATION_THRESHOLD;
 
     const handleSectionClick = (
         index: number,
@@ -250,6 +259,7 @@ const Accordion = React.forwardRef(function Accordion(
                             onFocus: () => handleSectionFocus(index),
                             isFirstSection: isFirstChild,
                             isLastSection: isLastChild,
+                            isRegion: sectionsAreRegions,
                             ref: childRef,
                         })}
                     </li>


### PR DESCRIPTION
## Summary:
This PR includes
- a11y mdx docs
- the addition of `region` as advised by w3
- the addition of `aria-labelledby` as advised by w3
- tests

Issue: https://khanacademy.atlassian.net/browse/WB-1585

## Test plan:
`yarn jest packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx`

Go to the storybook page and check the accessibility tool to confirm
that `region` and `aria-labelledby` are set appropriately.

Turn on Voiceover and confirm that the new region(s) are available in the landmarks menu.

https://github.com/Khan/wonder-blocks/assets/13231763/3c66bb8a-9598-4bb4-9fc5-f2c91422fff2
