### PR TITLE
WB-1619: Add PhosphorIcon support to Dropdown

### DIFF
--- a/.changeset/fast-snails-love.md
+++ b/.changeset/fast-snails-love.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Add PhosphorIcon support to Dropdown

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -29,6 +29,7 @@
     "@khanacademy/wonder-blocks-typography": "^2.1.9"
   },
   "peerDependencies": {
+    "@phosphor-icons/core": "^2.0.2",
     "@popperjs/core": "^2.10.1",
     "aphrodite": "^1.2.5",
     "react": "16.14.0",

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -4,11 +4,12 @@ import {StyleSheet} from "aphrodite";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import Color, {SemanticColor, mix} from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
-import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import type {ClickableState} from "@khanacademy/wonder-blocks-clickable";
+import caretDownIcon from "@phosphor-icons/core/bold/caret-down-bold.svg";
 
 import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 
@@ -90,10 +91,11 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
                     {label}
                 </View>
                 <Strut size={Spacing.xxxSmall_4} />
-                <Icon
+                <PhosphorIcon
                     size="small"
                     color="currentColor"
-                    icon={icons.caretDown}
+                    icon={caretDownIcon}
+                    aria-hidden="true"
                 />
             </StyledButton>
         );

--- a/packages/wonder-blocks-dropdown/src/components/check.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/check.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
-import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 
 const {offBlack, offBlack32, white} = Color;
 
@@ -29,8 +30,8 @@ type CheckProps = {
 const Check = function (props: CheckProps): React.ReactElement {
     const {disabled, selected, pressed, hovered, focused} = props;
     return (
-        <Icon
-            icon={icons.check}
+        <PhosphorIcon
+            icon={checkIcon}
             size="small"
             color={
                 disabled

--- a/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
@@ -3,17 +3,10 @@ import {StyleSheet} from "aphrodite";
 
 import Color, {mix} from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Icon from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 
-import type {IconAsset} from "@khanacademy/wonder-blocks-icon";
-
-// NOTE(sophie): This is a smaller check specifically for use in checkboxes.
-// Please don't copy it automatically and check with designers before using.
-// If the intended icon is a check without a checkbox, you should be using
-// icons.check from the Wonder Blocks Icon package.
-const checkboxCheck: IconAsset = {
-    small: "M11.263 4.324a1 1 0 1 1 1.474 1.352l-5.5 6a1 1 0 0 1-1.505-.036l-2.5-3a1 1 0 1 1 1.536-1.28L6.536 9.48l4.727-5.157z",
-};
 const {blue, white, offBlack16, offBlack32, offBlack50, offWhite} = Color;
 
 /**
@@ -65,11 +58,20 @@ const Checkbox = function (props: CheckProps): React.ReactElement {
             ]}
         >
             {selected && (
-                <Icon
-                    icon={checkboxCheck}
+                <PhosphorIcon
+                    icon={checkIcon}
                     size="small"
                     color={checkColor}
                     style={[
+                        {
+                            // The check icon is smaller than the checkbox, as
+                            // per design.
+                            width: Spacing.small_12,
+                            height: Spacing.small_12,
+                            // This margin is to center the check icon in the
+                            // checkbox.
+                            margin: Spacing.xxxxSmall_2,
+                        },
                         disabled && selected && styles.disabledCheckFormatting,
                     ]}
                 />

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -7,9 +7,10 @@ import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import {mix} from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
-import Icon, {icons} from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {tokens} from "@khanacademy/wonder-blocks-theming";
+import caretDownIcon from "@phosphor-icons/core/bold/caret-down-bold.svg";
 import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 
 const StyledButton = addStyle("button");
@@ -144,8 +145,8 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                                 shift for empty selection */}
                                 {children || "\u00A0"}
                             </LabelMedium>
-                            <Icon
-                                icon={icons.caretDown}
+                            <PhosphorIcon
+                                icon={caretDownIcon}
                                 color={iconColor}
                                 size="small"
                                 style={styles.caret}


### PR DESCRIPTION
## Summary:

Replaces all the existing `Icon` instances in `wb-dropdown` with `PhosphorIcon`
instances.

Issue: WB-1619

## Test plan:

Verify that the icons in the dropdowns are still there and look the same.

- Caret Down icon in all the openers.

- Checkmark icon in the checkbox (MultiSelect).

- Checkbox icon in Select.