### PR TITLE
[🔥AUDIT🔥] Clickable: Fix focused/onFocus handling for buttons

### DIFF
--- a/.changeset/violet-clocks-switch.md
+++ b/.changeset/violet-clocks-switch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Fix onFocus handler on Clickable

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -55,19 +55,18 @@ type StoryComponentType = StoryObj<typeof Clickable>;
 
 export const Default: StoryComponentType = (args: any) => (
     <Clickable {...args}>
-        {({hovered, pressed}) => {
-            return (
-                <View
-                    style={[
-                        styles.clickable,
-                        hovered && styles.hovered,
-                        pressed && styles.pressed,
-                    ]}
-                >
-                    <Body>This text is clickable!</Body>
-                </View>
-            );
-        }}
+        {({hovered, pressed, focused}) => (
+            <View
+                style={[
+                    styles.clickable,
+                    hovered && styles.hovered,
+                    pressed && styles.pressed,
+                    focused && styles.focused,
+                ]}
+            >
+                <Body>This text is clickable!</Body>
+            </View>
+        )}
     </Clickable>
 );
 

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -112,6 +112,10 @@ type CommonProps = Readonly<{
      */
     role?: ClickableRole;
     /**
+     * Respond to raw "onfocus" event.
+     */
+    onFocus?: (e: React.FocusEvent) => unknown;
+    /**
      * Respond to raw "keydown" event.
      */
     onKeyDown?: (e: React.KeyboardEvent) => unknown;
@@ -580,7 +584,12 @@ export default class ClickableBehavior extends React.Component<
     };
 
     handleFocus: (e: React.FocusEvent) => void = (e) => {
-        this.setState({focused: true});
+        const {onFocus} = this.props;
+        this.setState({focused: true}, () => {
+            if (onFocus) {
+                onFocus(e);
+            }
+        });
     };
 
     handleBlur: (e: React.FocusEvent) => void = (e) => {

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -270,6 +270,7 @@ const Clickable = React.forwardRef(function Clickable(
             style,
             target = undefined,
             testId,
+            onFocus,
             onKeyDown,
             onKeyUp,
             hideDefaultFocusRing,
@@ -301,6 +302,7 @@ const Clickable = React.forwardRef(function Clickable(
                     onClick={onClick}
                     beforeNav={beforeNav}
                     safeWithNav={safeWithNav}
+                    onFocus={onFocus}
                     onKeyDown={onKeyDown}
                     onKeyUp={onKeyUp}
                     disabled={disabled}
@@ -322,6 +324,7 @@ const Clickable = React.forwardRef(function Clickable(
                     href={href}
                     onClick={onClick}
                     safeWithNav={safeWithNav}
+                    onFocus={onFocus}
                     onKeyDown={onKeyDown}
                     onKeyUp={onKeyUp}
                     target={target}

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -250,11 +250,6 @@ const Clickable = React.forwardRef(function Clickable(
                     {...commonProps}
                     type="button"
                     aria-disabled={props.disabled}
-                    onFocus={(e) => {
-                        if (props.onFocus) {
-                            props.onFocus(e);
-                        }
-                    }}
                     ref={ref as React.Ref<HTMLButtonElement>}
                 >
                     {props.children(clickableState)}


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Recently, Clickable was updated to include a `onFocus` handler to be able to use
that event in consumers. One of the changes caused clickable from not reporting
the focused state correctly. This PR fixes that, but removing the custom handler
and leaving to `ClickableBehavior` to resolve that directly (via `commonProps`).

Issue: XXX-XXXX

## Test plan:

Verify that the `focused` state is now correctly displayed.

/?path=/story/clickable-clickable--default

BEFORE:

https://github.com/Khan/wonder-blocks/assets/843075/042128a3-fc72-4521-be22-e8ac7627f5a0

AFTER:

https://github.com/Khan/wonder-blocks/assets/843075/c5dbb8a1-6b00-4bed-b6c6-6254104ec01f

