### PR TITLE
Fix AccordionSection outline overlap issue

### DIFF
--- a/.changeset/good-balloons-laugh.md
+++ b/.changeset/good-balloons-laugh.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Give AccordionSection static position to fix outline overlap issue

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -526,19 +526,19 @@ LongSections.parameters = {
 
 // This story can be used to visually check background color overflow behavior.
 /**
- * Accordion is transparent by default. If you want it to look white on
- * a darker background, you can pass in a custom style with a white
- * background color to each individual AccordionSection.
+ * Accordion has a white background color by default. If you want
+ * to change the background color, you can pass in a custom style with
+ * the desired background color into each individual AccordionSection.
  *
  * NOTE: Passing in a background color to the Accordion itself is NOT
  * recommended, beacuse it will cause the color to overflow into the
  * corners of a rounded Accordion and between the individual sections
  * of a rounded-per-section Accordion.
  */
-export const OnDarkBackground: StoryComponentType = {
+export const BackgroundColorExample: StoryComponentType = {
     render: () => {
         const accordionSectionStyle = {
-            backgroundColor: tokens.color.white,
+            backgroundColor: tokens.color.fadedBlue,
         };
 
         const sections = [
@@ -579,7 +579,7 @@ export const OnDarkBackground: StoryComponentType = {
     },
 };
 
-OnDarkBackground.parameters = {
+BackgroundColorExample.parameters = {
     backgrounds: {
         default: "darkBlue",
     },

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -531,7 +531,7 @@ LongSections.parameters = {
  * the desired background color into each individual AccordionSection.
  *
  * NOTE: Passing in a background color to the Accordion itself is NOT
- * recommended, beacuse it will cause the color to overflow into the
+ * recommended, because it will cause the color to overflow into the
  * corners of a rounded Accordion and between the individual sections
  * of a rounded-per-section Accordion.
  */

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -524,6 +524,61 @@ LongSections.parameters = {
     },
 };
 
+// This story can be used to visually check overflow behavior.
+/**
+ * Accordion is transparent by default. If you want it to look white on
+ * a darker background, you can ... (todo)
+ */
+export const OnDarkBackground: StoryComponentType = {
+    render: () => {
+        const accordionSectionStyle = {
+            backgroundColor: tokens.color.white,
+        };
+
+        const sections = [
+            <AccordionSection
+                key="first"
+                header="First section"
+                style={accordionSectionStyle}
+            >
+                This is the information present in the first section
+            </AccordionSection>,
+            <AccordionSection
+                key="second"
+                header="Second section"
+                style={accordionSectionStyle}
+            >
+                This is the information present in the second section
+            </AccordionSection>,
+            <AccordionSection
+                key="third"
+                header="Third section"
+                style={accordionSectionStyle}
+            >
+                This is the information present in the third section
+            </AccordionSection>,
+        ];
+
+        return (
+            <>
+                <Accordion cornerKind="rounded">{sections}</Accordion>
+                <Strut size={tokens.spacing.large_24} />
+                <Accordion cornerKind="square">{sections}</Accordion>
+                <Strut size={tokens.spacing.large_24} />
+                <Accordion cornerKind="rounded-per-section">
+                    {sections}
+                </Accordion>
+            </>
+        );
+    },
+};
+
+OnDarkBackground.parameters = {
+    backgrounds: {
+        default: "darkBlue",
+    },
+};
+
 const mobile = "@media (max-width: 1023px)";
 
 const styles = StyleSheet.create({

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -524,10 +524,16 @@ LongSections.parameters = {
     },
 };
 
-// This story can be used to visually check overflow behavior.
+// This story can be used to visually check background color overflow behavior.
 /**
  * Accordion is transparent by default. If you want it to look white on
- * a darker background, you can ... (todo)
+ * a darker background, you can pass in a custom style with a white
+ * background color to each individual AccordionSection.
+ *
+ * NOTE: Passing in a background color to the Accordion itself is NOT
+ * recommended, beacuse it will cause the color to overflow into the
+ * corners of a rounded Accordion and between the individual sections
+ * of a rounded-per-section Accordion.
  */
 export const OnDarkBackground: StoryComponentType = {
     render: () => {

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -317,6 +317,7 @@ const styles = StyleSheet.create({
         // vertically stacked.
         position: "static",
         boxSizing: "border-box",
+        backgroundColor: tokens.color.white,
     },
     wrapperWithAnimation: {
         transition: "grid-template-rows 300ms",

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -311,6 +311,11 @@ const styles = StyleSheet.create({
     wrapper: {
         // Use grid layout for clean animations.
         display: "grid",
+        // Remove the View's default relative position because it creates
+        // overlap issues with the outline. In this case, it's safe to
+        // remove the stacking context beacuse accordion sections are always
+        // vertically stacked.
+        position: "static",
         boxSizing: "border-box",
     },
     wrapperWithAnimation: {


### PR DESCRIPTION
## Summary:

Use static position in AccordionSection to fix the outline overlap issue.

Issue: none

## Test plan:
- Go to Storybook at ?path=/story/accordion-accordion--on-dark-background
- Make sure that hovering and tabbing causes the outline to show up.
- Confirm that the outline shows up correctly and isn't clipped anywhere.