### PR TITLE
WB-1607: Allow displaying the listbox based on the viewport size

### DIFF
--- a/.changeset/friendly-taxis-drive.md
+++ b/.changeset/friendly-taxis-drive.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Allow changing the popper's height to accomodate for the viewport size

--- a/__docs__/wonder-blocks-dropdown/action-menu.argtypes.ts
+++ b/__docs__/wonder-blocks-dropdown/action-menu.argtypes.ts
@@ -1,52 +1,30 @@
-import type {InputType} from "@storybook/csf";
+import {ArgTypes} from "@storybook/react";
+import baseSelectArgTypes from "./base-select.argtypes";
 
-export default {
-    alignment: {
+const argTypes: ArgTypes = {
+    ...baseSelectArgTypes,
+    children: {
+        control: {type: null},
+        description: "The items in this dropdown.",
         table: {
-            category: "Layout",
+            type: {
+                summary: `Array<Item> | Item`,
+            },
         },
     },
-
-    disabled: {
+    menuText: {
+        control: {type: "text"},
+        description: "Text for the opener of this menu.",
         table: {
-            category: "States",
+            type: {summary: "string"},
         },
     },
-
-    opened: {
-        control: "boolean",
+    selectedValues: {
+        description: "The values of the items that are currently selected.",
         table: {
-            category: "States",
+            type: {summary: "Array<string>"},
         },
     },
+};
 
-    onToggle: {
-        table: {
-            category: "Events",
-        },
-    },
-
-    onChange: {
-        table: {
-            category: "Events",
-        },
-    },
-
-    dropdownStyle: {
-        table: {
-            category: "Styling",
-        },
-    },
-
-    style: {
-        table: {
-            category: "Styling",
-        },
-    },
-
-    className: {
-        table: {
-            category: "Styling",
-        },
-    },
-} satisfies Record<string, InputType>;
+export default argTypes;

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -84,6 +84,20 @@ const defaultArgs = {
     children: actionItems.map((actionItem, index) => actionItem),
 };
 
+/**
+ * A menu that consists of various types of items.
+ *
+ * ### Usage
+ *
+ * ```tsx
+ * import {ActionMenu, ActionItem} from "@khanacademy/wonder-blocks-dropdown";
+ *
+ * <ActionMenu menuText="Menu">
+ *  <ActionItem href="/profile" label="Profile" />
+ *  <ActionItem label="Settings" onClick={() => {}} />
+ * </ActionMenu>
+ * ```
+ */
 export default {
     title: "Dropdown / ActionMenu",
     // TODO(FEI-5000): Fix this type.
@@ -153,54 +167,48 @@ const styles = StyleSheet.create({
 
 type StoryComponentType = StoryObj<typeof ActionMenu>;
 
-export const Default: StoryComponentType = {};
-
-Default.parameters = {
-    chromatic: {
-        // Disabling because this doesn't test visuals, its only showing the
-        // dropdown opener closed.
-        disableSnapshot: true,
+export const Default: StoryComponentType = {
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test visuals, its only showing the
+            // dropdown opener closed.
+            disableSnapshot: true,
+        },
     },
 };
 
 /**
- * Right-aligned action menu.
+ * This menu shows different type of possible items in this type of menu:
+ *  1. leads to a different page (the profile).
+ *  2. leads to the teacher dashboard.
+ *  3. has an onClick callback, which could be used for conversion logging.
+ *  4. is a disabled item.
+ *  5. is a separator.
+ *  6. leads to the logout link.
+ *
+ * This menu is also left-aligned.
  */
 export const RightAligned: StoryComponentType = {
     args: {
         alignment: "right",
     } as Partial<typeof ActionMenu>,
-};
-
-RightAligned.decorators = [
-    (Story: any): React.ReactElement<React.ComponentProps<typeof View>> => (
-        <View style={styles.rowRight}>{Story()}</View>
-    ),
-];
-
-RightAligned.parameters = {
-    docs: {
-        description: {
-            story:
-                "This menu shows different type of possible items in this type of menu:\n" +
-                "1. leads to a different page (the profile).\n" +
-                "2. leads to the teacher dashboard.\n" +
-                "3. has an onClick callback, which could be used for conversion logging.\n" +
-                "4. is a disabled item.\n" +
-                "5. is a separator.\n" +
-                "6. leads to the logout link.\n\n" +
-                "This menu is also right-aligned.",
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test visuals, its only showing the
+            // dropdown opener closed.
+            disableSnapshot: true,
         },
     },
-    chromatic: {
-        // Disabling because this doesn't test visuals, its only showing the
-        // dropdown opener closed.
-        disableSnapshot: true,
-    },
+    decorators: [
+        (Story: any): React.ReactElement<React.ComponentProps<typeof View>> => (
+            <View style={styles.rowRight}>{Story()}</View>
+        ),
+    ],
 };
 
 /**
- * Menu with truncated text.
+ * The text in the menu opener should be truncated with ellipsis at the end and
+ * the down caret should be the same size as it is for the other examples.
  */
 export const TruncatedOpener: StoryComponentType = {
     args: {
@@ -208,163 +216,153 @@ export const TruncatedOpener: StoryComponentType = {
     } as Partial<typeof ActionMenu>,
 };
 
-TruncatedOpener.parameters = {
-    docs: {
-        description: {
-            story: "The text in the menu opener should be truncated with ellipsis at the end and the down caret should be the same size as it is for the other examples.",
-        },
-    },
-};
-
 /**
- * With option items
+ * The following menu demonstrates a hybrid menu with both action items and
+ * items that can toggle to change the state of the application. The user of
+ * this menu must keep track of the state of the selected items.
  */
-export const WithOptionItems: StoryComponentType = () => {
-    const [selectedValues, setSelectedValues] = React.useState<Array<string>>(
-        [],
-    );
-    const [showHiddenOption, setShowHiddenOption] = React.useState(false);
+export const WithOptionItems: StoryComponentType = {
+    render: function Render() {
+        const [selectedValues, setSelectedValues] = React.useState<
+            Array<string>
+        >([]);
+        const [showHiddenOption, setShowHiddenOption] = React.useState(false);
 
-    const handleChange = (selectedItems: Array<string>) => {
-        setSelectedValues(selectedItems);
-        setShowHiddenOption(selectedItems.includes("in-class"));
-    };
+        const handleChange = (selectedItems: Array<string>) => {
+            setSelectedValues(selectedItems);
+            setShowHiddenOption(selectedItems.includes("in-class"));
+        };
 
-    return (
-        <ActionMenu
-            menuText="Assignments"
-            onChange={handleChange}
-            selectedValues={selectedValues}
-        >
-            <ActionItem
-                label="Create..."
-                onClick={() => console.log("create action")}
-            />
-            <ActionItem
-                label="Edit..."
-                disabled={true}
-                onClick={() => console.log("edit action")}
-            />
-            <ActionItem
-                label="Delete"
-                disabled={true}
-                onClick={() => console.log("delete action")}
-            />
-            {showHiddenOption && (
+        return (
+            <ActionMenu
+                menuText="Assignments"
+                onChange={handleChange}
+                selectedValues={selectedValues}
+            >
                 <ActionItem
-                    label="Hidden menu for class"
-                    disabled={!showHiddenOption}
-                    onClick={() => console.log("hidden menu is clicked!")}
+                    label="Create..."
+                    onClick={() => console.log("create action")}
                 />
-            )}
-            <SeparatorItem />
-            <OptionItem
-                label="Show homework assignments"
-                value="homework"
-                onClick={() => console.log(`Show homework assignments toggled`)}
-            />
-            <OptionItem
-                label="Show in-class assignments"
-                value="in-class"
-                onClick={() => console.log(`Show in-class assignments toggled`)}
-            />
-        </ActionMenu>
-    );
-};
-
-WithOptionItems.parameters = {
-    docs: {
-        description: {
-            story: "The following menu demonstrates a hybrid menu with both action items and items that can toggle to change the state of the application. The user of this menu must keep track of the state of the selected items.",
-        },
+                <ActionItem
+                    label="Edit..."
+                    disabled={true}
+                    onClick={() => console.log("edit action")}
+                />
+                <ActionItem
+                    label="Delete"
+                    disabled={true}
+                    onClick={() => console.log("delete action")}
+                />
+                {showHiddenOption && (
+                    <ActionItem
+                        label="Hidden menu for class"
+                        disabled={!showHiddenOption}
+                        onClick={() => console.log("hidden menu is clicked!")}
+                    />
+                )}
+                <SeparatorItem />
+                <OptionItem
+                    label="Show homework assignments"
+                    value="homework"
+                    onClick={() =>
+                        console.log(`Show homework assignments toggled`)
+                    }
+                />
+                <OptionItem
+                    label="Show in-class assignments"
+                    value="in-class"
+                    onClick={() =>
+                        console.log(`Show in-class assignments toggled`)
+                    }
+                />
+            </ActionMenu>
+        );
     },
-    chromatic: {
-        // Disabling because this doesn't test visuals, its only showing the
-        // dropdown opener closed.
-        disableSnapshot: true,
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test visuals, its only showing the
+            // dropdown opener closed.
+            disableSnapshot: true,
+        },
     },
 };
 
 /**
- * Empty menu
+ * Empty menus are disabled automatically.
  */
-export const EmptyMenu: StoryComponentType = () => (
-    <ActionMenu menuText="Empty" />
-);
-
-EmptyMenu.parameters = {
-    docs: {
-        description: {
-            story: "Empty menus are disabled automatically.",
-        },
-    },
+export const EmptyMenu: StoryComponentType = {
+    render: () => <ActionMenu menuText="Empty" />,
 };
 
 /**
- * Custom dropdownStyle
+ * This example shows how we can add custom styles to the dropdown menu.
  */
 export const CustomDropdownStyle: StoryComponentType = {
     name: "Custom dropdownStyle",
     args: {
         dropdownStyle: styles.dropdown,
     } as Partial<typeof ActionMenu>,
-};
-
-CustomDropdownStyle.parameters = {
-    docs: {
-        description: {
-            story: "This example shows how we can add custom styles to the dropdown menu.",
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test visuals.
+            disableSnapshot: true,
         },
-    },
-    chromatic: {
-        // Disabling because this doesn't test visuals.
-        disableSnapshot: true,
     },
 };
 
 /**
- * Controlled ActionMenu
+ * Sometimes you'll want to trigger a dropdown programmatically. This can be
+ * done by setting a value to the opened prop (true or false). In this situation
+ * the ActionMenu is a controlled component. The parent is responsible for
+ * managing the opening/closing of the dropdown when using this prop.
+ *
+ * This means that you'll also have to update opened to the value triggered by
+ * the onToggle prop.
  */
-export const Controlled: StoryComponentType = () => {
-    const [opened, setOpened] = React.useState(false);
+export const Controlled: StoryComponentType = {
+    render: function Render() {
+        const [opened, setOpened] = React.useState(false);
 
-    return (
-        <View style={styles.row}>
-            <Checkbox
-                label="Click to toggle"
-                onChange={setOpened}
-                checked={opened}
-            />
-            <ActionMenu
-                menuText="Betsy Appleseed"
-                opened={opened}
-                onToggle={setOpened}
-            >
-                {actionItems.map((actionItem, index) => actionItem)}
-            </ActionMenu>
-        </View>
-    );
-};
-
-Controlled.parameters = {
-    docs: {
-        description: {
-            story:
-                "Sometimes you'll want to trigger a dropdown programmatically. This can be done by setting a value to the opened prop (true or false). In this situation the ActionMenu is a controlled component. The parent is responsible for managing the opening/closing of the dropdown when using this prop.\n" +
-                "This means that you'll also have to update opened to the value triggered by the onToggle prop.",
-        },
+        return (
+            <View style={styles.row}>
+                <Checkbox
+                    label="Click to toggle"
+                    onChange={setOpened}
+                    checked={opened}
+                />
+                <ActionMenu
+                    menuText="Betsy Appleseed"
+                    opened={opened}
+                    onToggle={setOpened}
+                >
+                    {actionItems.map((actionItem, index) => actionItem)}
+                </ActionMenu>
+            </View>
+        );
     },
-    chromatic: {
-        // Disabling because this doesn't test visuals.
-        disableSnapshot: true,
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test visuals.
+            disableSnapshot: true,
+        },
     },
 };
 
 /**
- * With custom opener
+ * In case you need to use a custom opener, you can use the opener property to
+ * achieve this. In this example, the opener prop accepts a function with the
+ * following arguments:
+ *  - `eventState`: lets you customize the style for different states, such as
+ *    pressed, hovered and focused.
+ *  - `text`: Passes the menu label defined in the parent component. This value
+ *    is passed using the placeholder prop set in the ActionMenu component.
+ *
+ * **Note:** If you need to use a custom ID for testing the opener, make sure to
+ * pass the testId prop inside the opener component/element.
  */
 
 export const CustomOpener: StoryComponentType = {
+    name: "With custom opener",
     args: {
         opener: ({focused, hovered, pressed, text}: any) => (
             <LabelLarge
@@ -385,45 +383,29 @@ export const CustomOpener: StoryComponentType = {
     } as Partial<typeof ActionMenu>,
 };
 
-CustomOpener.storyName = "With custom opener";
-
-CustomOpener.parameters = {
-    docs: {
-        description: {
-            story:
-                "In case you need to use a custom opener, you can use the opener property to achieve this. In this example, the opener prop accepts a function with the following arguments:\n" +
-                "- `eventState`: lets you customize the style for different states, such as pressed, hovered and focused.\n" +
-                "- `text`: Passes the menu label defined in the parent component. This value is passed using the placeholder prop set in the ActionMenu component.\n\n" +
-                "**Note:** If you need to use a custom ID for testing the opener, make sure to pass the testId prop inside the opener component/element.",
-        },
-    },
-};
-
 /**
- * Action menu items with lang attribute.
+ * You can use the `lang` attribute to specify the language of the action
+ * item(s). This is useful if you want to avoid issues with Screen Readers
+ * trying to read the proper language for the rendered text.
  */
-export const ActionMenuWithLang: StoryComponentType = () => (
-    <ActionMenu menuText="Locales">
-        {locales.map((locale) => (
-            <ActionItem
-                key={locale.locale}
-                label={locale.localName}
-                lang={locale.locale}
-                testId={"language_picker_" + locale.locale}
-            />
-        ))}
-    </ActionMenu>
-);
-
-ActionMenuWithLang.storyName = "Using the lang attribute";
-
-ActionMenuWithLang.parameters = {
-    docs: {
-        storyDescription:
-            "You can use the `lang` attribute to specify the language of the action item(s). This is useful if you want to avoid issues with Screen Readers trying to read the proper language for the rendered text.",
-    },
-    chromatic: {
-        disableSnapshot: true,
+export const ActionMenuWithLang: StoryComponentType = {
+    name: "Using the lang attribute",
+    render: () => (
+        <ActionMenu menuText="Locales">
+            {locales.map((locale) => (
+                <ActionItem
+                    key={locale.locale}
+                    label={locale.localName}
+                    lang={locale.locale}
+                    testId={"language_picker_" + locale.locale}
+                />
+            ))}
+        </ActionMenu>
+    ),
+    parameters: {
+        chromatic: {
+            disableSnapshot: true,
+        },
     },
 };
 

--- a/__docs__/wonder-blocks-dropdown/base-select.argtypes.ts
+++ b/__docs__/wonder-blocks-dropdown/base-select.argtypes.ts
@@ -1,68 +1,139 @@
-export default {
+import {ArgTypes} from "@storybook/react";
+
+const argTypes: ArgTypes = {
     alignment: {
+        control: {type: "select"},
+        defaultValue: "info",
+        description: `Whether this dropdown should be left-aligned or
+            right-aligned with the opener component.`,
+        options: ["left", "right"],
         table: {
             category: "Layout",
+            type: {summary: `"left" | "right"`},
+            defaultValue: {summary: `"left"`},
+        },
+        type: {
+            name: "enum",
+            value: ["left", "right"],
+            required: false,
         },
     },
 
     disabled: {
+        defaultValue: false,
+        description: `Whether the dropdown is disabled. A disabled dropdown may
+            not be opened and does not support interaction.`,
         table: {
             category: "States",
+            defaultValue: {summary: false},
         },
     },
 
     error: {
+        description: "Whether this component is in an error state.",
         table: {
             category: "States",
+            defaultValue: {summary: false},
         },
     },
 
     isFilterable: {
+        description: `When this is true, the dropdown body shows a search text
+            input top. The items will be filtered by the input. Selected items
+            will be moved to the top when the dropdown is re-opened.`,
         table: {
             category: "States",
         },
     },
 
     light: {
+        description: `Whether to display the "light" version of this component
+            instead, for use when the component is used on a dark background.`,
         table: {
             category: "States",
+            defaultValue: {summary: false},
         },
     },
 
     opened: {
         control: "boolean",
+        description:
+            "Can be used to override the state of the ActionMenu by parent elements",
         table: {
             category: "States",
         },
     },
 
     onToggle: {
+        description: `In controlled mode, use this prop in case the parent
+            needs to be notified when the menu opens/closes.`,
         table: {
             category: "Events",
+            type: {summary: "(opened: boolean) => unknown"},
         },
     },
 
     onChange: {
+        description: `Callback for when the selection changes. Parameter is an
+            updated array of selected values.`,
         table: {
             category: "Events",
+            type: {summary: "(selectedValues: Array<string>) => unknown"},
         },
     },
 
     dropdownStyle: {
+        control: {type: "object"},
+        description:
+            `Optional custom styles applied to the dropdown container.
+            This is useful for setting a custom width or a custom height.\n\n` +
+            `**NOTE:** we don't recommend setting a custom height, as the
+            dropdown should be able to grow to fit its contents.`,
         table: {
             category: "Styling",
+            type: {summary: "StyleType"},
         },
     },
 
     style: {
+        control: {type: "object"},
+        description: "Optional styling to add to the opener component wrapper.",
         table: {
             category: "Styling",
+            type: {summary: "StyleType"},
         },
     },
 
     className: {
+        control: {type: "text"},
+        description: "Adds CSS classes to the opener component wrapper.",
         table: {
             category: "Styling",
+            type: {summary: "string"},
         },
     },
+
+    id: {
+        control: {type: "text"},
+        description: `Unique identifier attached to the field control. If used,
+            we need to guarantee that the ID is unique within everything
+            rendered on a page. Used to match \`<label>\` with \`<button>\`
+            elements for screenreaders.`,
+        table: {
+            type: {summary: "string"},
+        },
+        type: {name: "string", required: false},
+    },
+
+    testId: {
+        control: {type: "text"},
+        description:
+            "The test ID used to locate this component in automated tests.",
+        table: {
+            type: {summary: "string"},
+        },
+        type: {name: "string", required: false},
+    },
 };
+
+export default argTypes;

--- a/__docs__/wonder-blocks-dropdown/multi-select.argtypes.ts
+++ b/__docs__/wonder-blocks-dropdown/multi-select.argtypes.ts
@@ -1,0 +1,26 @@
+import {ArgTypes} from "@storybook/react";
+import baseSelectArgTypes from "./base-select.argtypes";
+
+const argTypes: ArgTypes = {
+    ...baseSelectArgTypes,
+    implicitAllEnabled: {
+        description: `When this is true, the menu text shows either "All items"
+            or the value set in \`labels.allSelected\` when no item is selected.`,
+    },
+    selectedValues: {
+        description: "The values of the items that are currently selected.",
+        table: {
+            type: {summary: "Array<string>"},
+        },
+    },
+    labels: {
+        control: {type: "object"},
+        description:
+            "The object containing the custom labels used inside this component.",
+        table: {
+            type: {summary: "Labels"},
+        },
+    },
+};
+
+export default argTypes;

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -22,6 +22,25 @@ type StoryComponentType = StoryObj<typeof MultiSelect>;
 
 type MultiSelectArgs = Partial<typeof MultiSelect>;
 
+/**
+ * A dropdown that consists of multiple selection items. This select allows
+ * multiple options to be selected. Clients are responsible for keeping track of
+ * the selected items.
+ *
+ * The multi select stays open until closed by the user. The onChange callback
+ * happens every time there is a change in the selection of the items.
+ *
+ * ### Usage
+ *
+ * ```tsx
+ * import {OptionItem, MultiSelect} from "@khanacademy/wonder-blocks-dropdown";
+ *
+ * <MultiSelect onChange={setSelectedValues} selectedValues={selectedValues}>
+ *  <OptionItem value="pear">Pear</OptionItem>
+ *  <OptionItem value="mango">Mango</OptionItem>
+ * </MultiSelect>
+ * ```
+ */
 export default {
     title: "Dropdown / MultiSelect",
     component: MultiSelect as unknown as React.ComponentType<any>,
@@ -51,15 +70,6 @@ export default {
                 version={packageConfig.version}
             />
         ) as any,
-        docs: {
-            description: {
-                component: null,
-            },
-            source: {
-                // See https://github.com/storybookjs/storybook/issues/12596
-                excludeDecorators: true,
-            },
-        },
     },
 } as Meta<typeof MultiSelect>;
 
@@ -76,7 +86,7 @@ const styles = StyleSheet.create({
         maxHeight: 200,
     },
     wrapper: {
-        height: "400px",
+        height: "600px",
         width: "600px",
     },
     centered: {
@@ -140,22 +150,26 @@ const Template = (args: any) => {
     }, [args.opened]);
 
     return (
-        <View style={styles.wrapper}>
-            <MultiSelect
-                {...args}
-                onChange={setSelectedValues}
-                selectedValues={selectedValues}
-                opened={opened}
-                onToggle={setOpened}
-            >
-                {items}
-            </MultiSelect>
-        </View>
+        <MultiSelect
+            {...args}
+            onChange={setSelectedValues}
+            selectedValues={selectedValues}
+            opened={opened}
+            onToggle={setOpened}
+        >
+            {items}
+        </MultiSelect>
     );
 };
 
 export const Default: StoryComponentType = {
     render: Template,
+    parameters: {
+        chromatic: {
+            // We don't need screenshots b/c the dropdown is initially closed.
+            disableSnapshot: true,
+        },
+    },
 };
 
 const ControlledWrapper = (args: any) => {
@@ -185,25 +199,24 @@ const ControlledWrapper = (args: any) => {
     );
 };
 
+/**
+ * Sometimes you'll want to trigger a dropdown programmatically. This can be
+ * done by `MultiSelect` is a controlled component. The parent is responsible
+ * for managing the opening/closing of the dropdown when using this prop.
+ *
+ * This means that you'll also have to update `opened` to the value triggered by
+ * the `onToggle` prop.
+ */
 export const ControlledOpened: StoryComponentType = {
+    name: "Controlled (opened)",
     render: (args) => <ControlledWrapper {...args} />,
     args: {
         opened: true,
     } as MultiSelectArgs,
-};
-
-ControlledOpened.storyName = "Controlled (opened)";
-
-ControlledOpened.parameters = {
-    docs: {
-        description: {
-            story:
-                "Sometimes you'll want to trigger a dropdown programmatically. This can be done by `MultiSelect` is a controlled component. The parent is responsible for managing the opening/closing of the dropdown when using this prop.\n\n" +
-                "This means that you'll also have to update `opened` to the value triggered by the `onToggle` prop.",
-        },
+    parameters: {
+        // Added to ensure that the dropdown menu is rendered using PopperJS.
+        chromatic: {delay: 500},
     },
-    // Added to ensure that the dropdown menu is rendered using PopperJS.
-    chromatic: {delay: 500},
 };
 
 // Custom MultiSelect labels
@@ -213,6 +226,14 @@ const dropdownLabels: Labels = {
     someSelected: (numSelectedValues) => `${numSelectedValues} planets`,
 };
 
+/**
+ * Sometimes, we may want to customize the dropdown style (for example, to limit
+ * the height of the list). For this purpose, we have the `dropdownStyle` prop.
+ *
+ * **NOTE:** We are overriding the max height of the dropdown in this example
+ * but we recommend letting the dropdown calculate its own height, as we already
+ * have a max height set for the dropdown internally.
+ */
 export const CustomStyles: StoryComponentType = {
     render: Template,
     args: {
@@ -220,20 +241,17 @@ export const CustomStyles: StoryComponentType = {
         dropdownStyle: styles.customDropdown,
         style: styles.setWidth,
     } as MultiSelectArgs,
-};
-
-CustomStyles.parameters = {
-    docs: {
-        description: {
-            story: "Sometimes, we may want to customize the dropdown style (for example, to limit the height of the list). For this purpose, we have the `dropdownStyle` prop.",
+    parameters: {
+        chromatic: {
+            // we don't need screenshots because this story only tests behavior.
+            disableSnapshot: true,
         },
     },
-    chromatic: {
-        // we don't need screenshots because this story only tests behavior.
-        disableSnapshot: true,
-    },
 };
 
+/**
+ * Here you can see an example of the previous dropdown opened.
+ */
 export const CustomStylesOpened: StoryComponentType = {
     render: Template,
     args: {
@@ -243,14 +261,13 @@ export const CustomStylesOpened: StoryComponentType = {
         opened: true,
     } as MultiSelectArgs,
     name: "Custom styles (opened)",
-};
-
-CustomStylesOpened.parameters = {
-    docs: {
-        description: {
-            story: "Here you can see an example of the previous dropdown opened",
-        },
-    },
+    decorators: [
+        (Story): React.ReactElement<React.ComponentProps<typeof View>> => (
+            <View style={styles.wrapper}>
+                <Story />
+            </View>
+        ),
+    ],
 };
 
 const ErrorWrapper = (args: any) => {
@@ -281,8 +298,8 @@ const ErrorWrapper = (args: any) => {
 };
 
 /**
- * Here is an example of a dropdown that is in an error state.
- * Selecting two or more options will clear the error by setting the `error` prop to `false`.
+ * Here is an example of a dropdown that is in an error state. Selecting two or
+ * more options will clear the error by setting the `error` prop to `false`.
  */
 export const Error: StoryComponentType = {
     render: ErrorWrapper,
@@ -292,7 +309,8 @@ export const Error: StoryComponentType = {
 };
 
 /**
- * With shortcuts
+ * This example starts with one item selected and has selection shortcuts for
+ * select all and select none. This one does not have a predefined placeholder.
  */
 export const Shortcuts: StoryComponentType = {
     render: Template,
@@ -300,14 +318,13 @@ export const Shortcuts: StoryComponentType = {
         shortcuts: true,
         opened: true,
     } as MultiSelectArgs,
-};
-
-Shortcuts.parameters = {
-    docs: {
-        description: {
-            story: "This example starts with one item selected and has selection shortcuts for select all and select none. This one does not have a predefined placeholder.",
-        },
-    },
+    decorators: [
+        (Story): React.ReactElement<React.ComponentProps<typeof View>> => (
+            <View style={styles.wrapper}>
+                <Story />
+            </View>
+        ),
+    ],
 };
 
 /**
@@ -353,43 +370,40 @@ const DropdownInModalWrapper = (args: MultiSelectArgs) => {
     );
 };
 
+/**
+ * Sometimes we want to include Dropdowns inside a Modal, and these controls can
+ * be accessed only by scrolling down. This example help us to demonstrate that
+ * `MultiSelect` components can correctly be displayed within the visible
+ * scrolling area.
+ */
 export const DropdownInModal: StoryComponentType = {
     render: (args) => <DropdownInModalWrapper {...args} />,
     name: "Dropdown in a modal",
-};
-
-DropdownInModal.parameters = {
-    docs: {
-        description: {
-            story: "Sometimes we want to include Dropdowns inside a Modal, and these controls can be accessed only by scrolling down. This example help us to demonstrate that `MultiSelect` components can correctly be displayed within the visible scrolling area.",
+    parameters: {
+        chromatic: {
+            // We don't need screenshots because this story can be tested after
+            // the modal is opened.
+            disableSnapshot: true,
         },
     },
-    chromatic: {
-        // We don't need screenshots because this story can be tested after
-        // the modal is opened.
-        disableSnapshot: true,
-    },
 };
 
 /**
- * Disabled
+ * `MultiSelect` can be disabled by passing `disabled={true}`. This can be
+ * useful when you want to disable a control temporarily.
  */
-export const Disabled: StoryComponentType = () => (
-    <MultiSelect disabled={true} onChange={() => {}}>
-        <OptionItem label="Mercury" value="1" />
-        <OptionItem label="Venus" value="2" />
-    </MultiSelect>
-);
-
-Disabled.parameters = {
-    docs: {
-        storyDescription:
-            "`MultiSelect` can be disabled by passing `disabled={true}`. This can be useful when you want to disable a control temporarily.",
-    },
+export const Disabled: StoryComponentType = {
+    render: () => (
+        <MultiSelect disabled={true} onChange={() => {}}>
+            <OptionItem label="Mercury" value="1" />
+            <OptionItem label="Venus" value="2" />
+        </MultiSelect>
+    ),
 };
 
 /**
- * ImplicitAll enabled
+ * When nothing is selected, show the menu text as "All selected". Note that the
+ * actual selection logic doesn't change. (Only the menu text)
  */
 export const ImplicitAllEnabled: StoryComponentType = {
     render: Template,
@@ -402,17 +416,11 @@ export const ImplicitAllEnabled: StoryComponentType = {
             allSelected: "All planets selected",
         },
     } as MultiSelectArgs,
-};
-
-ImplicitAllEnabled.parameters = {
-    docs: {
-        description: {
-            story: `When nothing is selected, show the menu text as "All selected". Note that the actual selection logic doesn't change. (Only the menu text)`,
+    parameters: {
+        chromatic: {
+            // We don't need screenshots b/c the dropdown is initially closed.
+            disableSnapshot: true,
         },
-    },
-    chromatic: {
-        // We don't need screenshots b/c the dropdown is initially closed.
-        disableSnapshot: true,
     },
 };
 
@@ -458,24 +466,27 @@ const VirtualizedMultiSelect = function (props: Props): React.ReactElement {
 };
 
 /**
- * Virtualized MultiSelect
+ * When there are many options, you could use a search filter in the
+ * `MultiSelect`. The search filter will be performed toward the labels of the
+ * option items. Note that this example shows how we can add custom styles to
+ * the dropdown as well.
  */
-export const VirtualizedFilterable: StoryComponentType = () => (
-    <VirtualizedMultiSelect opened={true} />
-);
-
-VirtualizedFilterable.storyName = "Virtualized (isFilterable)";
-
-VirtualizedFilterable.parameters = {
-    docs: {
-        description: {
-            story: "When there are many options, you could use a search filter in the `MultiSelect`. The search filter will be performed toward the labels of the option items. Note that this example shows how we can add custom styles to the dropdown as well.",
-        },
-    },
+export const VirtualizedFilterable: StoryComponentType = {
+    name: "Virtualized (isFilterable)",
+    render: () => <VirtualizedMultiSelect opened={true} />,
 };
 
 /**
- * Custom opener
+ * In case you need to use a custom opener with the `MultiSelect`, you can use
+ * the opener property to achieve this. In this example, the opener prop accepts
+ * a function with the following arguments:
+ *  - `eventState`: lets you customize the style for different states, such as
+ *    pressed, hovered and focused.
+ *  - `text`: Passes the menu label defined in the parent component. This value
+ *  is passed using the placeholder prop set in the `MultiSelect` component.
+ *
+ * **Note:** If you need to use a custom ID for testing the opener, make sure to
+ * pass the testId prop inside the opener component/element.
  */
 export const CustomOpener: StoryComponentType = {
     render: Template,
@@ -501,18 +512,6 @@ export const CustomOpener: StoryComponentType = {
     name: "With custom opener",
 };
 
-CustomOpener.parameters = {
-    docs: {
-        description: {
-            story:
-                "In case you need to use a custom opener with the `MultiSelect`, you can use the opener property to achieve this. In this example, the opener prop accepts a function with the following arguments:\n" +
-                "- `eventState`: lets you customize the style for different states, such as pressed, hovered and focused.\n" +
-                "- `text`: Passes the menu label defined in the parent component. This value is passed using the placeholder prop set in the `MultiSelect` component.\n\n" +
-                "**Note:** If you need to use a custom ID for testing the opener, make sure to pass the testId prop inside the opener component/element.",
-        },
-    },
-};
-
 /**
  * Custom labels
  */
@@ -526,45 +525,43 @@ const translatedItems = new Array(10)
         />
     ));
 
-export const CustomLabels: StoryComponentType = () => {
-    const [selectedValues, setSelectedValues] = React.useState<Array<string>>(
-        [],
-    );
-    const [opened, setOpened] = React.useState(true);
+/**
+ * This example illustrates how you can pass custom labels to the MultiSelect
+ * component.
+ */
+export const CustomLabels: StoryComponentType = {
+    render: function Render() {
+        const [selectedValues, setSelectedValues] = React.useState<
+            Array<string>
+        >([]);
+        const [opened, setOpened] = React.useState(true);
 
-    const labels: Labels = {
-        clearSearch: "Limpiar busqueda",
-        filter: "Filtrar",
-        noResults: "Sin resultados",
-        selectAllLabel: (numOptions) => `Seleccionar todas (${numOptions})`,
-        selectNoneLabel: "No seleccionar ninguno",
-        noneSelected: "0 escuelas seleccionadas",
-        allSelected: "Todas las escuelas",
-        someSelected: (numSelectedValues) =>
-            `${numSelectedValues} escuelas seleccionadas`,
-    };
+        const labels: Labels = {
+            clearSearch: "Limpiar busqueda",
+            filter: "Filtrar",
+            noResults: "Sin resultados",
+            selectAllLabel: (numOptions) => `Seleccionar todas (${numOptions})`,
+            selectNoneLabel: "No seleccionar ninguno",
+            noneSelected: "0 escuelas seleccionadas",
+            allSelected: "Todas las escuelas",
+            someSelected: (numSelectedValues) =>
+                `${numSelectedValues} escuelas seleccionadas`,
+        };
 
-    return (
-        <View style={styles.wrapper}>
-            <MultiSelect
-                shortcuts={true}
-                isFilterable={true}
-                onChange={setSelectedValues}
-                selectedValues={selectedValues}
-                labels={labels}
-                opened={opened}
-                onToggle={setOpened}
-            >
-                {translatedItems}
-            </MultiSelect>
-        </View>
-    );
-};
-
-CustomLabels.parameters = {
-    docs: {
-        description: {
-            story: "This example illustrates how you can pass custom labels to the MultiSelect component.",
-        },
+        return (
+            <View style={styles.wrapper}>
+                <MultiSelect
+                    shortcuts={true}
+                    isFilterable={true}
+                    onChange={setSelectedValues}
+                    selectedValues={selectedValues}
+                    labels={labels}
+                    opened={opened}
+                    onToggle={setOpened}
+                >
+                    {translatedItems}
+                </MultiSelect>
+            </View>
+        );
     },
 };

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -15,7 +15,7 @@ import type {Labels} from "@khanacademy/wonder-blocks-dropdown";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
-import multiSelectArgtypes from "./base-select.argtypes";
+import multiSelectArgtypes from "./multi-select.argtypes";
 import {defaultLabels} from "../../packages/wonder-blocks-dropdown/src/util/constants";
 
 type StoryComponentType = StoryObj<typeof MultiSelect>;

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -276,7 +276,7 @@ const ErrorWrapper = (args: any) => {
     const [error, setError] = React.useState(true);
 
     return (
-        <View style={styles.wrapper}>
+        <>
             <LabelMedium style={{marginBottom: Spacing.xSmall_8}}>
                 Select at least 2 options to clear the error!
             </LabelMedium>
@@ -293,7 +293,7 @@ const ErrorWrapper = (args: any) => {
             >
                 {items}
             </MultiSelect>
-        </View>
+        </>
     );
 };
 

--- a/__docs__/wonder-blocks-dropdown/single-select.argtypes.ts
+++ b/__docs__/wonder-blocks-dropdown/single-select.argtypes.ts
@@ -1,0 +1,26 @@
+import {ArgTypes} from "@storybook/react";
+import baseSelectArgTypes from "./base-select.argtypes";
+
+const argTypes: ArgTypes = {
+    ...baseSelectArgTypes,
+    placeholder: {
+        description:
+            "Placeholder for the opening component when there are no items selected.",
+    },
+    selectedValue: {
+        description: "The value of the currently selected item.",
+        table: {
+            type: {summary: "string"},
+        },
+    },
+    labels: {
+        control: {type: "object"},
+        description:
+            "The object containing the custom labels used inside this component.",
+        table: {
+            type: {summary: "Labels"},
+        },
+    },
+};
+
+export default argTypes;

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -25,13 +25,40 @@ import type {SingleSelectLabels} from "@khanacademy/wonder-blocks-dropdown";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
-import singleSelectArgtypes from "./base-select.argtypes";
+import singleSelectArgtypes from "./single-select.argtypes";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {defaultLabels} from "../../packages/wonder-blocks-dropdown/src/util/constants";
 
 type StoryComponentType = StoryObj<typeof SingleSelect>;
 type SingleSelectArgs = Partial<typeof SingleSelect>;
 
+/**
+ * The single select allows the selection of one item. Clients are responsible
+ * for keeping track of the selected item in the select.
+ *
+ * The single select dropdown closes after the selection of an item. If the same
+ * item is selected, there is no callback.
+ *
+ * **NOTE:** If there are more than 125 items, the component automatically uses
+ * [react-window](https://github.com/bvaughn/react-window) to improve
+ * performance when rendering these elements and is capable of handling many
+ * hundreds of items without performance problems.
+ *
+ * ### Usage
+ *
+ * #### General usage
+ *
+ * ```tsx
+ * import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+ *
+ * const [selectedValue, setSelectedValue] = React.useState("");
+ *
+ * <SingleSelect placeholder="Choose a fruit" onChange={setSelectedValue} selectedValue={selectedValue}>
+ *     <OptionItem label="Pear" value="pear" />
+ *     <OptionItem label="Mango" value="mango" />
+ * </SingleSelect>
+ * ```
+ */
 export default {
     title: "Dropdown / SingleSelect",
     component: SingleSelect as unknown as React.ComponentType<any>,
@@ -63,15 +90,6 @@ export default {
                 version={packageConfig.version}
             />
         ),
-        docs: {
-            description: {
-                component: null,
-            },
-            source: {
-                // See https://github.com/storybookjs/storybook/issues/12596
-                excludeDecorators: true,
-            },
-        },
     },
 } as Meta<typeof SingleSelect>;
 
@@ -215,112 +233,110 @@ const ControlledOpenedWrapper = (args: any) => {
     );
 };
 
+/**
+ * Sometimes you'll want to trigger a dropdown programmatically. This can be
+ * done by setting a value to the `opened` prop (`true` or `false`). In this
+ * situation the `SingleSelect` is a controlled component. The parent is
+ * responsible for managing the opening/closing of the dropdown when using this
+ * prop.
+ *
+ * This means that you'll also have to update `opened` to the value triggered by
+ * the `onToggle` prop.
+ */
 export const ControlledOpened: StoryComponentType = {
     render: (args) => <ControlledOpenedWrapper {...args} />,
     args: {
         opened: true,
     } as SingleSelectArgs,
     name: "Controlled (opened)",
-};
-
-ControlledOpened.parameters = {
-    docs: {
-        description: {
-            story:
-                "Sometimes you'll want to trigger a dropdown programmatically. This can be done by setting a value to the `opened` prop (`true` or `false`). In this situation the `SingleSelect` is a controlled component. The parent is responsible for managing the opening/closing of the dropdown when using this prop.\n\n" +
-                "This means that you'll also have to update `opened` to the value triggered by the `onToggle` prop.",
-        },
-    },
-    // Added to ensure that the dropdown menu is rendered using PopperJS.
-    chromatic: {delay: 500},
-};
-
-export const LongOptionLabels: StoryComponentType = () => {
-    const [selectedValue, setSelectedValue] = React.useState("");
-    const [opened, setOpened] = React.useState(false);
-
-    const smallWidthStyle = {width: 200};
-
-    return (
-        <SingleSelect
-            onChange={setSelectedValue}
-            selectedValue={selectedValue}
-            opened={opened}
-            onToggle={setOpened}
-            placeholder="Fruit placeholder is also long"
-            style={smallWidthStyle}
-        >
-            <OptionItem
-                label="Bananas are the most amazing fruit I've ever had in my entire life."
-                value="banana"
-                key={0}
-                style={smallWidthStyle}
-            />
-            <OptionItem
-                label="Strawberries are the most amazing fruit I've ever had in my entire life."
-                value="strawberry"
-                disabled
-                key={1}
-                style={smallWidthStyle}
-            />
-            <OptionItem
-                label="Pears are the most amazing fruit I've ever had in my entire life."
-                value="pear"
-                key={2}
-                style={smallWidthStyle}
-            />
-            <OptionItem
-                label="Oranges are the most amazing fruit I've ever had in my entire life."
-                value="orange"
-                key={3}
-                style={smallWidthStyle}
-            />
-            <OptionItem
-                label="Watermelons are the most amazing fruit I've ever had in my entire life."
-                value="watermelon"
-                key={4}
-                style={smallWidthStyle}
-            />
-            <OptionItem
-                label="Apples are the most amazing fruit I've ever had in my entire life."
-                value="apple"
-                key={5}
-                style={smallWidthStyle}
-            />
-            <OptionItem
-                label="Grapes are the most amazing fruit I've ever had in my entire life."
-                value="grape"
-                key={6}
-                style={smallWidthStyle}
-            />
-            <OptionItem
-                label="Lemons are the most amazing fruit I've ever had in my entire life."
-                value="lemon"
-                key={7}
-                style={smallWidthStyle}
-            />
-            <OptionItem
-                label="Mangos are the most amazing fruit I've ever had in my entire life."
-                value="mango"
-                key={8}
-                style={smallWidthStyle}
-            />
-        </SingleSelect>
-    );
-};
-
-LongOptionLabels.parameters = {
-    docs: {
-        description: {
-            story: `If the label for the opener or the OptionItem(s)
-            is longer than its bounding box, it will be truncated with
-            an ellipsis at the end.`,
-        },
+    parameters: {
+        // Added to ensure that the dropdown menu is rendered using PopperJS.
+        chromatic: {delay: 500},
     },
 };
 
 /**
- * Disabled
+ * If the label for the opener or the OptionItem(s) is longer than its bounding
+ * box, it will be truncated with an ellipsis at the end.
+ */
+export const LongOptionLabels: StoryComponentType = {
+    render: function Render() {
+        const [selectedValue, setSelectedValue] = React.useState("");
+        const [opened, setOpened] = React.useState(false);
+
+        const smallWidthStyle = {width: 200};
+
+        return (
+            <SingleSelect
+                onChange={setSelectedValue}
+                selectedValue={selectedValue}
+                opened={opened}
+                onToggle={setOpened}
+                placeholder="Fruit placeholder is also long"
+                style={smallWidthStyle}
+            >
+                <OptionItem
+                    label="Bananas are the most amazing fruit I've ever had in my entire life."
+                    value="banana"
+                    key={0}
+                    style={smallWidthStyle}
+                />
+                <OptionItem
+                    label="Strawberries are the most amazing fruit I've ever had in my entire life."
+                    value="strawberry"
+                    disabled
+                    key={1}
+                    style={smallWidthStyle}
+                />
+                <OptionItem
+                    label="Pears are the most amazing fruit I've ever had in my entire life."
+                    value="pear"
+                    key={2}
+                    style={smallWidthStyle}
+                />
+                <OptionItem
+                    label="Oranges are the most amazing fruit I've ever had in my entire life."
+                    value="orange"
+                    key={3}
+                    style={smallWidthStyle}
+                />
+                <OptionItem
+                    label="Watermelons are the most amazing fruit I've ever had in my entire life."
+                    value="watermelon"
+                    key={4}
+                    style={smallWidthStyle}
+                />
+                <OptionItem
+                    label="Apples are the most amazing fruit I've ever had in my entire life."
+                    value="apple"
+                    key={5}
+                    style={smallWidthStyle}
+                />
+                <OptionItem
+                    label="Grapes are the most amazing fruit I've ever had in my entire life."
+                    value="grape"
+                    key={6}
+                    style={smallWidthStyle}
+                />
+                <OptionItem
+                    label="Lemons are the most amazing fruit I've ever had in my entire life."
+                    value="lemon"
+                    key={7}
+                    style={smallWidthStyle}
+                />
+                <OptionItem
+                    label="Mangos are the most amazing fruit I've ever had in my entire life."
+                    value="mango"
+                    key={8}
+                    style={smallWidthStyle}
+                />
+            </SingleSelect>
+        );
+    },
+};
+
+/**
+ * This select is disabled and cannot be interacted with.
  */
 export const Disabled: StoryComponentType = {
     render: (args) => (
@@ -334,14 +350,6 @@ export const Disabled: StoryComponentType = {
             {items}
         </SingleSelect>
     ),
-};
-
-Disabled.parameters = {
-    docs: {
-        description: {
-            story: "This select is disabled and cannot be interacted with.",
-        },
-    },
 };
 
 const ErrorWrapper = () => {
@@ -372,106 +380,94 @@ const ErrorWrapper = () => {
 };
 
 /**
- * This select is in an error state.
- * Selecting any option other than lemon will clear the error state by updating the `error` prop to `false`.
+ * This select is in an error state. Selecting any option other than lemon will
+ * clear the error state by updating the `error` prop to `false`.
  */
 export const Error: StoryComponentType = {
     render: ErrorWrapper,
 };
 
 /**
- * TwoWithText
+ * This story has two selects nested inline within text.
  */
-export const TwoWithText: StoryComponentType = (args: any) => {
-    const [selectedValue, setSelectedValue] = React.useState(
-        args.selectedValue,
-    );
-    const [secondSelectedValue, setSecondSelectedValue] = React.useState(
-        args.selectedValue,
-    );
-    const [opened, setOpened] = React.useState(args.opened);
-    const [secondOpened, setSecondOpened] = React.useState(args.opened);
-    React.useEffect(() => {
-        // Only update opened if the args.opened prop changes (using the
-        // controls panel).
-        setOpened(args.opened);
-    }, [args.opened]);
+export const TwoWithText: StoryComponentType = {
+    render: function Render(args: any) {
+        const [selectedValue, setSelectedValue] = React.useState(
+            args.selectedValue,
+        );
+        const [secondSelectedValue, setSecondSelectedValue] = React.useState(
+            args.selectedValue,
+        );
+        const [opened, setOpened] = React.useState(args.opened);
+        const [secondOpened, setSecondOpened] = React.useState(args.opened);
+        React.useEffect(() => {
+            // Only update opened if the args.opened prop changes (using the
+            // controls panel).
+            setOpened(args.opened);
+        }, [args.opened]);
 
-    return (
-        <div>
-            Here is some text to nest the dropdown
-            <SingleSelect
-                {...args}
-                onChange={setSelectedValue}
-                selectedValue={selectedValue}
-                opened={opened}
-                onToggle={setOpened}
-                style={{display: "inline-block"}}
-            >
-                {[...items, <OptionItem label="" value="" key={9} />]}
-            </SingleSelect>
-            . And here is more text to compare!
-            <SingleSelect
-                {...args}
-                onChange={setSecondSelectedValue}
-                selectedValue={secondSelectedValue}
-                opened={secondOpened}
-                onToggle={setSecondOpened}
-                style={{display: "inline-block"}}
-            >
-                {[...items, <OptionItem label="" value="" key={9} />]}
-            </SingleSelect>
-        </div>
-    );
-};
-
-TwoWithText.parameters = {
-    docs: {
-        description: {
-            story: "This story has two selects nested inline within text.",
-        },
+        return (
+            <div>
+                Here is some text to nest the dropdown
+                <SingleSelect
+                    {...args}
+                    onChange={setSelectedValue}
+                    selectedValue={selectedValue}
+                    opened={opened}
+                    onToggle={setOpened}
+                    style={{display: "inline-block"}}
+                >
+                    {[...items, <OptionItem label="" value="" key={9} />]}
+                </SingleSelect>
+                . And here is more text to compare!
+                <SingleSelect
+                    {...args}
+                    onChange={setSecondSelectedValue}
+                    selectedValue={secondSelectedValue}
+                    opened={secondOpened}
+                    onToggle={setSecondOpened}
+                    style={{display: "inline-block"}}
+                >
+                    {[...items, <OptionItem label="" value="" key={9} />]}
+                </SingleSelect>
+            </div>
+        );
     },
 };
 
 /**
- * On dark background, right-aligned
+ * "This single select is on a dark background and is also right-aligned.
  */
-export const Light: StoryComponentType = (args: any) => {
-    const [selectedValue, setSelectedValue] = React.useState("pear");
+export const Light: StoryComponentType = {
+    render: function Render(args: any) {
+        const [selectedValue, setSelectedValue] = React.useState("pear");
 
-    return (
-        <View style={styles.row}>
-            <View style={styles.darkBackgroundWrapper}>
-                <SingleSelect
-                    alignment="right"
-                    light={true}
-                    onChange={setSelectedValue}
-                    placeholder="Choose a drink"
-                    selectedValue={selectedValue}
-                >
-                    <OptionItem
-                        label="Regular milk tea with boba"
-                        value="regular"
-                    />
-                    <OptionItem
-                        label="Wintermelon milk tea with boba"
-                        value="wintermelon"
-                    />
-                    <OptionItem
-                        label="Taro milk tea, half sugar"
-                        value="taro"
-                    />
-                </SingleSelect>
+        return (
+            <View style={styles.row}>
+                <View style={styles.darkBackgroundWrapper}>
+                    <SingleSelect
+                        alignment="right"
+                        light={true}
+                        onChange={setSelectedValue}
+                        placeholder="Choose a drink"
+                        selectedValue={selectedValue}
+                    >
+                        <OptionItem
+                            label="Regular milk tea with boba"
+                            value="regular"
+                        />
+                        <OptionItem
+                            label="Wintermelon milk tea with boba"
+                            value="wintermelon"
+                        />
+                        <OptionItem
+                            label="Taro milk tea, half sugar"
+                            value="taro"
+                        />
+                    </SingleSelect>
+                </View>
             </View>
-        </View>
-    );
-};
-
-Light.parameters = {
-    docs: {
-        description: {
-            story: "This single select is on a dark background and is also right-aligned.",
-        },
+        );
     },
 };
 
@@ -517,39 +513,34 @@ const VirtualizedSingleSelect = function (props: Props): React.ReactElement {
 };
 
 /**
- * Virtualized SingleSelect
+ * When there are many options, you could use a search filter in the
+ * SingleSelect. The search filter will be performed toward the labels of the
+ * option items. Note that this example shows how we can add custom styles to
+ * the dropdown as well.
  */
-export const VirtualizedFilterable: StoryComponentType = () => (
-    <VirtualizedSingleSelect />
-);
-
-VirtualizedFilterable.storyName = "Virtualized (isFilterable)";
-
-VirtualizedFilterable.parameters = {
-    docs: {
-        description: {
-            story: "When there are many options, you could use a search filter in the SingleSelect. The search filter will be performed toward the labels of the option items. Note that this example shows how we can add custom styles to the dropdown as well.",
+export const VirtualizedFilterable: StoryComponentType = {
+    name: "Virtualized (isFilterable)",
+    render: () => <VirtualizedSingleSelect />,
+    parameters: {
+        chromatic: {
+            // we don't need screenshots because this story only tests behavior.
+            disableSnapshot: true,
         },
-    },
-    chromatic: {
-        // we don't need screenshots because this story only tests behavior.
-        disableSnapshot: true,
     },
 };
 
+/**
+ * This example shows how to use the `opened` prop to open the dropdown.
+ */
 export const VirtualizedOpened: StoryComponentType = {
     render: () => <VirtualizedSingleSelect opened={true} />,
     name: "Virtualized (opened)",
 };
 
-VirtualizedOpened.parameters = {
-    docs: {
-        description: {
-            story: "This example shows how to use the `opened` prop to open the dropdown.",
-        },
-    },
-};
-
+/**
+ * This example shows how the focus is set to the search field if there's no
+ * current selection.
+ */
 export const VirtualizedOpenedNoSelection: StoryComponentType = {
     render: () => (
         <VirtualizedSingleSelect opened={true} selectedValue={null} />
@@ -557,78 +548,77 @@ export const VirtualizedOpenedNoSelection: StoryComponentType = {
     name: "Virtualized (opened, no selection)",
 };
 
-VirtualizedOpenedNoSelection.parameters = {
-    docs: {
-        description: {
-            story: "This example shows how the focus is set to the search field if there's no current selection.",
-        },
-    },
-};
-
 /**
- * Inside a modal
+ * Sometimes we want to include Dropdowns inside a Modal, and these controls can
+ * be accessed only by scrolling down. This example help us to demonstrate that
+ * `SingleSelect` components can correctly be displayed within the visible
+ * scrolling area.
  */
-export const DropdownInModal: StoryComponentType = () => {
-    const [value, setValue] = React.useState<any>(null);
-    const [opened, setOpened] = React.useState(true);
+export const DropdownInModal: StoryComponentType = {
+    name: "Dropdown in a modal",
+    render: function Render() {
+        const [value, setValue] = React.useState<any>(null);
+        const [opened, setOpened] = React.useState(true);
 
-    const modalContent = (
-        <View style={styles.scrollableArea}>
-            <View>
-                <Body>
-                    Sometimes we want to include Dropdowns inside a Modal, and
-                    these controls can be accessed only by scrolling down. This
-                    example help us to demonstrate that SingleSelect components
-                    can correctly be displayed within the visible scrolling
-                    area.
-                </Body>
-                <Strut size={Spacing.large_24} />
-                <SingleSelect
-                    onChange={(selected) => setValue(selected)}
-                    isFilterable={true}
-                    opened={opened}
-                    onToggle={(opened) => setOpened(opened)}
-                    placeholder="Select a fruit"
-                    selectedValue={value}
-                >
-                    {optionItems}
-                </SingleSelect>
+        const modalContent = (
+            <View style={styles.scrollableArea}>
+                <View>
+                    <Body>
+                        Sometimes we want to include Dropdowns inside a Modal,
+                        and these controls can be accessed only by scrolling
+                        down. This example help us to demonstrate that
+                        SingleSelect components can correctly be displayed
+                        within the visible scrolling area.
+                    </Body>
+                    <Strut size={Spacing.large_24} />
+                    <SingleSelect
+                        onChange={(selected) => setValue(selected)}
+                        isFilterable={true}
+                        opened={opened}
+                        onToggle={(opened) => setOpened(opened)}
+                        placeholder="Select a fruit"
+                        selectedValue={value}
+                    >
+                        {optionItems}
+                    </SingleSelect>
+                </View>
             </View>
-        </View>
-    );
+        );
 
-    const modal = (
-        <OnePaneDialog title="Dropdown in a Modal" content={modalContent} />
-    );
+        const modal = (
+            <OnePaneDialog title="Dropdown in a Modal" content={modalContent} />
+        );
 
-    return (
-        <View style={styles.centered}>
-            <ModalLauncher modal={modal}>
-                {({openModal}) => (
-                    <Button onClick={openModal}>Click here!</Button>
-                )}
-            </ModalLauncher>
-        </View>
-    );
-};
-
-DropdownInModal.storyName = "Dropdown in a modal";
-
-DropdownInModal.parameters = {
-    docs: {
-        description: {
-            story: "Sometimes we want to include Dropdowns inside a Modal, and these controls can be accessed only by scrolling down. This example help us to demonstrate that `SingleSelect` components can correctly be displayed within the visible scrolling area.",
-        },
+        return (
+            <View style={styles.centered}>
+                <ModalLauncher modal={modal}>
+                    {({openModal}) => (
+                        <Button onClick={openModal}>Click here!</Button>
+                    )}
+                </ModalLauncher>
+            </View>
+        );
     },
-    chromatic: {
-        // We don't need screenshots because this story can be tested after
-        // the modal is opened.
-        disableSnapshot: true,
+    parameters: {
+        chromatic: {
+            // We don't need screenshots because this story can be tested after
+            // the modal is opened.
+            disableSnapshot: true,
+        },
     },
 };
 
 /**
- * Custom opener
+ * In case you need to use a custom opener with the `SingleSelect`, you can use
+ * the opener property to achieve this. In this example, the opener prop accepts
+ * a function with the following arguments:
+ *  - `eventState`: lets you customize the style for different states, such as
+ *    pressed, hovered and focused.
+ *  - `text`: Passes the menu label defined in the parent component. This value
+ *   is passed using the placeholder prop set in the `SingleSelect` component.
+ *
+ * **Note:** If you need to use a custom ID for testing the opener, make sure to
+ * pass the testId prop inside the opener component/element.
  */
 export const CustomOpener: StoryComponentType = {
     render: Template,
@@ -654,18 +644,6 @@ export const CustomOpener: StoryComponentType = {
     name: "With custom opener",
 };
 
-CustomOpener.parameters = {
-    docs: {
-        description: {
-            story:
-                "In case you need to use a custom opener with the `SingleSelect`, you can use the opener property to achieve this. In this example, the opener prop accepts a function with the following arguments:\n" +
-                "- `eventState`: lets you customize the style for different states, such as pressed, hovered and focused.\n" +
-                "- `text`: Passes the menu label defined in the parent component. This value is passed using the placeholder prop set in the `SingleSelect` component.\n\n" +
-                "**Note:** If you need to use a custom ID for testing the opener, make sure to pass the testId prop inside the opener component/element.",
-        },
-    },
-};
-
 /**
  * Custom labels
  */
@@ -681,39 +659,37 @@ const translatedItems = [
     <OptionItem label="Mango" value="mango" />,
 ];
 
-export const CustomLabels: StoryComponentType = () => {
-    const [value, setValue] = React.useState<any>(null);
-    const [opened, setOpened] = React.useState(true);
+/**
+ * This example illustrates how you can pass custom labels to the `SingleSelect`
+ * component.
+ */
+export const CustomLabels: StoryComponentType = {
+    render: function Render() {
+        const [value, setValue] = React.useState<any>(null);
+        const [opened, setOpened] = React.useState(true);
 
-    const translatedLabels: SingleSelectLabels = {
-        clearSearch: "Limpiar busqueda",
-        filter: "Filtrar",
-        noResults: "Sin resultados",
-        someResults: (numResults) => `${numResults} frutas`,
-    };
+        const translatedLabels: SingleSelectLabels = {
+            clearSearch: "Limpiar busqueda",
+            filter: "Filtrar",
+            noResults: "Sin resultados",
+            someResults: (numResults) => `${numResults} frutas`,
+        };
 
-    return (
-        <View style={styles.wrapper}>
-            <SingleSelect
-                isFilterable={true}
-                onChange={setValue}
-                selectedValue={value}
-                labels={translatedLabels}
-                opened={opened}
-                onToggle={setOpened}
-                placeholder="Selecciona una fruta"
-            >
-                {translatedItems}
-            </SingleSelect>
-        </View>
-    );
-};
-
-CustomLabels.parameters = {
-    docs: {
-        description: {
-            story: "This example illustrates how you can pass custom labels to the `SingleSelect` component.",
-        },
+        return (
+            <View style={styles.wrapper}>
+                <SingleSelect
+                    isFilterable={true}
+                    onChange={setValue}
+                    selectedValue={value}
+                    labels={translatedLabels}
+                    opened={opened}
+                    onToggle={setOpened}
+                    placeholder="Selecciona una fruta"
+                >
+                    {translatedItems}
+                </SingleSelect>
+            </View>
+        );
     },
 };
 
@@ -740,62 +716,61 @@ const timeSlotOptions = timeSlots.map((timeSlot) => (
     <OptionItem label={timeSlot} value={timeSlot} />
 ));
 
-export const AutoFocusDisabled: StoryComponentType = () => {
-    const textFieldRef = React.useRef(null);
-    const [value, setValue] = React.useState<any>(null);
-    const [opened, setOpened] = React.useState(false);
+/**
+ * This example illustrates how you can disable the auto focus of the
+ * `SingleSelect` component. Note that for this example, we are using a
+ * `TextField` component as a custom opener to ilustrate how the focus remains
+ * on the opener.
+ *
+ * **Note:** We also disabled the `enableTypeAhead` prop to be able to use the
+ * textbox properly.
+ */
+export const AutoFocusDisabled: StoryComponentType = {
+    render: function Render() {
+        const textFieldRef = React.useRef(null);
+        const [value, setValue] = React.useState<any>(null);
+        const [opened, setOpened] = React.useState(false);
 
-    return (
-        <View style={styles.wrapper}>
-            <SingleSelect
-                autoFocus={false}
-                enableTypeAhead={false}
-                onChange={setValue}
-                selectedValue={value}
-                opened={opened}
-                onToggle={setOpened}
-                placeholder="Choose a time"
-                opener={({focused, hovered, pressed, text}) => (
-                    <View style={styles.row}>
-                        <TextField
-                            placeholder="Choose a time"
-                            id="single-select-opener"
-                            onChange={setValue}
-                            value={value ?? ""}
-                            ref={textFieldRef}
-                            autoComplete="off"
-                            style={styles.fullBleed}
-                        />
-                        <PhosphorIcon
-                            color={Color.blue}
-                            icon={IconMappings.clockBold}
-                            size="small"
-                            style={styles.icon}
-                        />
-                    </View>
-                )}
-            >
-                {timeSlotOptions}
-            </SingleSelect>
-        </View>
-    );
-};
-
-AutoFocusDisabled.parameters = {
-    docs: {
-        description: {
-            story:
-                `This example illustrates how you can disable the auto focus
-                of the \`SingleSelect\` component. Note that for this example,
-                we are using a \`TextField\` component as a custom opener to
-                ilustrate how the focus remains on the opener.\n\n` +
-                `**Note:** We also disabled the \`enableTypeAhead\` prop to be
-                able to use the textbox properly.`,
-        },
+        return (
+            <View style={styles.wrapper}>
+                <SingleSelect
+                    autoFocus={false}
+                    enableTypeAhead={false}
+                    onChange={setValue}
+                    selectedValue={value}
+                    opened={opened}
+                    onToggle={setOpened}
+                    placeholder="Choose a time"
+                    opener={({focused, hovered, pressed, text}) => (
+                        <View style={styles.row}>
+                            <TextField
+                                placeholder="Choose a time"
+                                id="single-select-opener"
+                                onChange={setValue}
+                                value={value ?? ""}
+                                ref={textFieldRef}
+                                autoComplete="off"
+                                style={styles.fullBleed}
+                            />
+                            <PhosphorIcon
+                                color={Color.blue}
+                                icon={IconMappings.clockBold}
+                                size="small"
+                                style={styles.icon}
+                            />
+                        </View>
+                    )}
+                >
+                    {timeSlotOptions}
+                </SingleSelect>
+            </View>
+        );
     },
-    chromatic: {
-        // we don't need screenshots because this story only tests focus +
-        // keyboard behavior.
-        disableSnapshot: true,
+    parameters: {
+        chromatic: {
+            // we don't need screenshots because this story only tests focus +
+            // keyboard behavior.
+            disableSnapshot: true,
+        },
     },
 };

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.tsx
@@ -702,7 +702,7 @@ describe("DropdownCore", () => {
             await screen.findByRole("listbox");
 
             // Act
-            const item = await screen.findByTestId("item-1");
+            const item = await screen.findByRole("option", {name: "Fruit # 2"});
             userEvent.click(item);
 
             // Assert

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-popper.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-popper.test.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import {render, screen} from "@testing-library/react";
+import {render, screen, waitFor} from "@testing-library/react";
 
 import DropdownPopper from "../dropdown-popper";
+import {maxHeightModifier} from "../../util/popper-max-height-modifier";
 
 describe("DropdownPopper", () => {
     it("renders the children if valid props are passed in", () => {
@@ -11,7 +12,7 @@ describe("DropdownPopper", () => {
         // Act
         render(
             <DropdownPopper referenceElement={referenceElement}>
-                {(shouldHide: any) => (
+                {() => (
                     <div data-test-id="dropdown-container">
                         dropdown container
                     </div>
@@ -33,7 +34,7 @@ describe("DropdownPopper", () => {
                 referenceElement={referenceElement}
                 alignment="right"
             >
-                {(shouldHide: any) => (
+                {() => (
                     <div data-test-id="dropdown-container">
                         dropdown container
                     </div>
@@ -45,6 +46,35 @@ describe("DropdownPopper", () => {
         expect(screen.getByTestId("dropdown-popper")).toHaveAttribute(
             "data-placement",
             "bottom-end",
+        );
+    });
+
+    it("applies a max-height style", async () => {
+        // Arrange
+        const referenceElement = document.createElement("button");
+        jest.spyOn(maxHeightModifier, "fn").mockImplementation(({state}) => {
+            state.styles.popper = {
+                ...state.styles.popper,
+                maxHeight: "500px",
+            };
+        });
+
+        // Act
+        render(
+            <DropdownPopper referenceElement={referenceElement}>
+                {() => (
+                    <div data-test-id="dropdown-container">
+                        dropdown container
+                    </div>
+                )}
+            </DropdownPopper>,
+        );
+
+        // Assert
+        await waitFor(() =>
+            expect(screen.getByTestId("dropdown-popper")).toHaveStyle(
+                "max-height: 500px",
+            ),
         );
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -663,7 +663,7 @@ describe("SingleSelect", () => {
     });
 
     describe("Custom listbox styles", () => {
-        it("should apply the default maxHeight to the listbox", () => {
+        it("should apply the default maxHeight to the listbox wrapper", () => {
             // Arrange
 
             // Act
@@ -681,11 +681,15 @@ describe("SingleSelect", () => {
             );
 
             // Assert
-            const dropdownMenu = screen.getByRole("listbox");
-            expect(dropdownMenu).toHaveStyle("max-height: 120px");
+            const dropdownMenuWrapper = screen.getByTestId(
+                "dropdown-core-container",
+            );
+            expect(dropdownMenuWrapper).toHaveStyle(
+                "max-height: var(--popper-max-height)",
+            );
         });
 
-        it("should apply the default maxHeight to a virtualized listbox", () => {
+        it("should apply the default maxHeight to a virtualized listbox wrapper", () => {
             // Arrange
             const optionItems = new Array(1000)
                 .fill(null)
@@ -711,9 +715,13 @@ describe("SingleSelect", () => {
             );
 
             // Assert
-            const dropdownMenu = screen.getByRole("listbox");
+            const dropdownMenuWrapper = screen.getByTestId(
+                "dropdown-core-container",
+            );
             // Max allowed height
-            expect(dropdownMenu).toHaveStyle("max-height: 360px");
+            expect(dropdownMenuWrapper).toHaveStyle(
+                "max-height: var(--popper-max-height)",
+            );
         });
 
         it("should override the default maxHeight to the listbox if a custom dropdownStyle is set", () => {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -955,9 +955,6 @@ class DropdownCore extends React.Component<Props, State> {
                     styles.dropdown,
                     light && styles.light,
                     isReferenceHidden && styles.hidden,
-                    {
-                        maxHeight: "var(--popper-max-height)",
-                    },
                     dropdownStyle,
                 ]}
                 testId="dropdown-core-container"
@@ -1060,6 +1057,10 @@ const styles = StyleSheet.create({
         paddingBottom: Spacing.xxxSmall_4,
         border: `solid 1px ${Color.offBlack16}`,
         boxShadow: `0px 8px 8px 0px ${fade(Color.offBlack, 0.1)}`,
+        // We use a custom property to set the max height of the dropdown.
+        // This comes from the maxHeight custom modifier.
+        // @see ../util/popper-max-height-modifier.ts
+        maxHeight: "var(--popper-max-height)",
     },
 
     light: {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -10,7 +10,7 @@ import {VariableSizeList as List} from "react-window";
 import Color, {fade} from "@khanacademy/wonder-blocks-color";
 
 import Spacing from "@khanacademy/wonder-blocks-spacing";
-import {addStyle, PropsFor, View} from "@khanacademy/wonder-blocks-core";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
@@ -22,8 +22,7 @@ import SeparatorItem from "./separator-item";
 import {defaultLabels, keyCodes} from "../util/constants";
 import type {DropdownItem} from "../util/types";
 import DropdownPopper from "./dropdown-popper";
-import {debounce, getLabel, getStringForKey} from "../util/helpers";
-import OptionItem from "./option-item";
+import {debounce, getStringForKey} from "../util/helpers";
 
 /**
  * The number of options to apply the virtualized list to.

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -10,7 +10,7 @@ import {VariableSizeList as List} from "react-window";
 import Color, {fade} from "@khanacademy/wonder-blocks-color";
 
 import Spacing from "@khanacademy/wonder-blocks-spacing";
-import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {addStyle, PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
@@ -22,11 +22,8 @@ import SeparatorItem from "./separator-item";
 import {defaultLabels, keyCodes} from "../util/constants";
 import type {DropdownItem} from "../util/types";
 import DropdownPopper from "./dropdown-popper";
-import {debounce, getStringForKey} from "../util/helpers";
-import {
-    generateDropdownMenuStyles,
-    getDropdownMenuHeight,
-} from "../util/dropdown-menu-styles";
+import {debounce, getLabel, getStringForKey} from "../util/helpers";
+import OptionItem from "./option-item";
 
 /**
  * The number of options to apply the virtualized list to.
@@ -950,8 +947,6 @@ class DropdownCore extends React.Component<Props, State> {
             ? openerStyle.getPropertyValue("width")
             : 0;
 
-        const maxDropdownHeight = getDropdownMenuHeight(this.props.items);
-
         return (
             <View
                 // Stop propagation to prevent the mouseup listener on the
@@ -961,6 +956,9 @@ class DropdownCore extends React.Component<Props, State> {
                     styles.dropdown,
                     light && styles.light,
                     isReferenceHidden && styles.hidden,
+                    {
+                        maxHeight: "var(--popper-max-height)",
+                    },
                     dropdownStyle,
                 ]}
                 testId="dropdown-core-container"
@@ -970,11 +968,9 @@ class DropdownCore extends React.Component<Props, State> {
                     role={role}
                     style={[
                         styles.listboxOrMenu,
-                        generateDropdownMenuStyles(
-                            // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'string | 0' is not assignable to parameter of type 'number'.
-                            minDropdownWidth,
-                            maxDropdownHeight,
-                        ),
+                        {
+                            minWidth: minDropdownWidth,
+                        },
                     ]}
                     // Only the `listbox` role supports aria-invalid and aria-required because
                     // the `menu` role is not a form control.
@@ -1093,6 +1089,7 @@ const styles = StyleSheet.create({
         // Set `minHeight` to "auto" to stop the search field from having
         // a height of 0 and being cut off.
         minHeight: "auto",
+        position: "sticky",
     },
 
     srOnly: {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
@@ -5,6 +5,7 @@ import {Popper} from "react-popper";
 import {maybeGetPortalMountedModalHostElement} from "@khanacademy/wonder-blocks-modal";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import {maxHeightModifier} from "../util/popper-max-height-modifier";
 
 const modifiers = [
     {
@@ -19,6 +20,7 @@ const modifiers = [
             tether: false,
         },
     },
+    maxHeightModifier,
 ];
 
 type Props = {

--- a/packages/wonder-blocks-dropdown/src/util/dropdown-menu-styles.ts
+++ b/packages/wonder-blocks-dropdown/src/util/dropdown-menu-styles.ts
@@ -1,7 +1,3 @@
-import {StyleSheet} from "aphrodite";
-
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
-
 import {
     DROPDOWN_ITEM_HEIGHT,
     MAX_VISIBLE_ITEMS,
@@ -34,26 +30,4 @@ export function getDropdownMenuHeight(
             return sum + DROPDOWN_ITEM_HEIGHT;
         }
     }, initialHeight);
-}
-
-/**
- * Wraps the dynamic styles in an Aphrodite style sheet so we can properly apply
- * the styles to a merged stylesheet (instead of inlining the styles).
- *
- * @param {StyleType} customStyles - The custom styles to apply to the dropdown
- * menu.
- * @returns The Aphrodite stylesheet for the dropdown menu.
- */
-export function generateDropdownMenuStyles(
-    minWidth: number,
-    maxHeight: number,
-): StyleType {
-    const styles = StyleSheet.create({
-        dropdownMenu: {
-            minWidth,
-            maxHeight,
-        },
-    });
-
-    return styles.dropdownMenu;
 }

--- a/packages/wonder-blocks-dropdown/src/util/popper-max-height-modifier.ts
+++ b/packages/wonder-blocks-dropdown/src/util/popper-max-height-modifier.ts
@@ -1,0 +1,57 @@
+/**
+ * NOTE: This modifier is adapted from the PopperJS source code. We don't use
+ * the original modifier because it is not exported as part of the public API.
+ *
+ * @see
+ * https://github.com/atomiks/popper.js/blob/master/src/modifiers/maxSize.js
+ */
+
+import {detectOverflow, ModifierArguments} from "@popperjs/core";
+import {Modifier} from "react-popper";
+import {DROPDOWN_ITEM_HEIGHT} from "./constants";
+
+type MaxHeightOptions = {
+    /**
+     * The offset of the popper relative to its reference.
+     */
+    padding?: number;
+};
+
+function modifyMaxHeight({
+    state,
+    options,
+}: ModifierArguments<MaxHeightOptions>): void {
+    // Calculates the available space for the popper based on the placement
+    // relative to the viewport.
+    const overflow = detectOverflow(state, options);
+    const {y} = state.modifiersData.preventOverflow || {x: 0, y: 0};
+    const {height} = state.rects.popper;
+    const [basePlacement] = state.placement.split("-");
+
+    const heightProp = basePlacement === "top" ? "top" : "bottom";
+
+    const maxHeight = height - overflow[heightProp] - y;
+
+    // Apply the maxHeight to the popper element
+    state.styles.popper = {
+        ...state.styles.popper,
+        maxHeight: `${maxHeight}px`,
+        // Also propagate the maxHeight to its children via CSS variables.
+        // This is useful for adding scrollbars to the dropdown list.
+        ["--popper-max-height" as any]: `${maxHeight}px`,
+    };
+}
+
+type MaxHeightModifier = Modifier<"maxHeight", MaxHeightOptions>;
+
+export const maxHeightModifier: MaxHeightModifier = {
+    name: "maxHeight",
+    enabled: true,
+    phase: "main",
+    options: {
+        // Default padding to 40px to account for the input's height.
+        padding: DROPDOWN_ITEM_HEIGHT,
+    },
+    requiresIfExists: ["offset", "preventOverflow", "flip"],
+    fn: modifyMaxHeight,
+};


### PR DESCRIPTION
## Summary:

This PR changes the logic to display the listbox based on the viewport size.
Before this, we were calculating a fixed height for the listbox based on the
number of items in the listbox. This was causing the listbox to be displayed
partially and the scrollbar was not visible by default.

I'm changing that logic to display the listbox based on the viewport size. This
is done using a PopperJS modifier so we can detect the viewport size and
calculate the height of the listbox accordingly. By implementing this change, we
no longer display a fixed height and instead we display as many items as we can.

Issue: WB-1607

## Test plan:

Navigate to any of the `SingleSelect/MultiSelect` stories and verify that the
listbox is displayed based on the viewport size (resize the screen to see how
the listbox changes its height).


https://github.com/Khan/wonder-blocks/assets/843075/fee493a6-619b-4a16-b5bf-f59a40a6c467

