### PR TITLE
Accordion: Use z-index instead of adding a 2px margin to bring the header outline in front of the content panel

### DIFF
--- a/.changeset/itchy-penguins-dress.md
+++ b/.changeset/itchy-penguins-dress.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Use z-index to put the header outline in front of the content panel instead of adding a 2px margin that can cause weird spacing issues

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -168,6 +168,10 @@ const styles = StyleSheet.create({
         overflow: "hidden",
         minWidth: "auto",
         width: "100%",
+        // Always make the header's outline show up in front of
+        // the content panel.
+        position: "relative",
+        zIndex: 1,
 
         ":active": {
             outline: `2px solid ${tokens.color.activeBlue}`,

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -338,10 +338,6 @@ const styles = StyleSheet.create({
     },
     contentWrapperExpanded: {
         visibility: "visible",
-        // Add a small margin to the top of the content block so that the
-        // header outline doesn't overlap with the content (and the content
-        // doesn't overlap with the header outline).
-        marginTop: tokens.spacing.xxxxSmall_2,
     },
     stringContent: {
         padding: tokens.spacing.medium_16,


### PR DESCRIPTION
## Summary:
Currently, there is a 2px added to expanded accordions in order to account for
the outline and stop it from being cut off by the content panel. This is causing
an issue in webapp where these 2px is causing a weird visible gap, so we
want to remove it.

While using z-index here is unfortunate, this is still an appropriate use
for z-index, and it will remove spacing issues.

Example of the gap this 2px margin was causing:

![image](https://github.com/Khan/wonder-blocks/assets/13231763/862a912a-66d6-4388-8eaf-f2cce64aed5a)

Outline cutoff issue that is making the use of z-index necessary:

![image](https://github.com/Khan/wonder-blocks/assets/13231763/e35e24e4-9e6e-4725-90a1-499f0feacccc)


Issue: none

## Test plan:
- Make sure the outline shows up on hover and via keyboard nav in Accordion storybook
- Specifically this story is a good test:
  http://localhost:6061/?path=/story/accordion-accordionsection--react-element-in-header