### PR TITLE
[🔥AUDIT🔥] WB-1645.fix Dropdown: Fix regression in SingleSelect

### DIFF
--- a/.changeset/warm-hats-walk.md
+++ b/.changeset/warm-hats-walk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fix issue with empty option items

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import * as React from "react";
 import {fireEvent, render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -32,6 +33,96 @@ describe("SingleSelect", () => {
                 <OptionItem label="item 3" value="3" />
             </SingleSelect>
         );
+
+        describe("opener", () => {
+            it("should render the placeholder if no selections are made", () => {
+                // Arrange
+                render(
+                    <SingleSelect
+                        placeholder="Default placeholder"
+                        onChange={jest.fn()}
+                    >
+                        <OptionItem label="Toggle A" value="toggle_a" />
+                        <OptionItem label="Toggle B" value="toggle_b" />
+                    </SingleSelect>,
+                );
+
+                // Act
+                const opener = screen.getByRole("button");
+
+                // Assert
+                expect(opener).toHaveTextContent("Default placeholder");
+            });
+
+            it("should render empty if the selected option has an empty value", () => {
+                // Arrange
+                render(
+                    <SingleSelect
+                        placeholder="Default placeholder"
+                        onChange={jest.fn()}
+                        selectedValue=""
+                    >
+                        <OptionItem label="" value="" />
+                        <OptionItem label="Toggle A" value="toggle_a" />
+                        <OptionItem label="Toggle B" value="toggle_b" />
+                    </SingleSelect>,
+                );
+
+                // Act
+                const opener = screen.getByRole("button");
+
+                // Assert
+                expect(opener).toHaveTextContent("");
+            });
+
+            it("should render the label of the selected option", () => {
+                // Arrange
+                render(
+                    <SingleSelect
+                        placeholder="Default placeholder"
+                        onChange={jest.fn()}
+                        selectedValue="toggle_a"
+                    >
+                        <OptionItem label="Toggle A" value="toggle_a" />
+                        <OptionItem label="Toggle B" value="toggle_b" />
+                    </SingleSelect>,
+                );
+
+                // Act
+                const opener = screen.getByRole("button");
+
+                // Assert
+                expect(opener).toHaveTextContent("Toggle A");
+            });
+
+            it("should render labelAsText of the selected option", () => {
+                // Arrange
+                render(
+                    <SingleSelect
+                        placeholder="Default placeholder"
+                        onChange={jest.fn()}
+                        selectedValue="toggle_a"
+                    >
+                        <OptionItem
+                            label={<div>custom item A</div>}
+                            value="toggle_a"
+                            labelAsText="Plain Toggle A"
+                        />
+                        <OptionItem
+                            label={<div>custom item B</div>}
+                            value="toggle_b"
+                            labelAsText="Plain Toggle B"
+                        />
+                    </SingleSelect>,
+                );
+
+                // Act
+                const opener = screen.getByRole("button");
+
+                // Assert
+                expect(opener).toHaveTextContent("Plain Toggle A");
+            });
+        });
 
         describe("mouse", () => {
             it("should open when clicking on the default opener", () => {

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -401,7 +401,7 @@ export default class SingleSelect extends React.Component<Props, State> {
         // If nothing is selected, or if the selectedValue doesn't match any
         // item in the menu, use the placeholder.
         const menuText = selectedItem
-            ? getLabel(selectedItem.props) || defaultLabels.someSelected(1)
+            ? getLabel(selectedItem.props)
             : placeholder;
 
         const dropdownOpener = opener ? (


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Fixes a regression in `SingleSelect` where the opener is not able to use an
empty string as a label.

In #2139, I changed the logic to use `1 item` for those cases, but turns out
that this "empty" value feature is required by Perseus.

Issue: WB-1645

## Test plan:

Verify that the "Two with Text" example in the `SingleSelect` storybook page
shows empty string as the label for both openers:

http://localhost:6061/?path=/story/dropdown-singleselect--two-with-text

<img width="1584" alt="Screenshot 2023-12-15 at 1 52 16 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/5a65edeb-334b-43db-9a72-ce2fe2058139">

