### PR TITLE
WB-1652.3: Add theming support to ModalHeader and ModalFooter

### DIFF
--- a/.changeset/tough-waves-juggle.md
+++ b/.changeset/tough-waves-juggle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": minor
+---
+
+Add theming support to ModalHeader and ModalFooter

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -174,8 +174,7 @@ export const Default: StoryComponentType = {
 
 /**
  * This is a `<ModalFooter>` with a `<Button>` as a child. No additional styling
- * is needed, as the footer already has the style `{justifyContent:
- * "flex-end"}`.
+ * is needed, as the footer already has the style `{justifyContent: "flex-end"}`.
  */
 export const WithButton: StoryComponentType = {
     render: () => (

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -89,6 +89,23 @@ est.`}
     </>
 );
 
+/**
+ * Modal footer included after the content.
+ *
+ * ### Implementation notes
+ *
+ * If you are creating a custom Dialog, make sure to follow these guidelines:
+ * - Make sure to include it as part of [ModalPanel](/#modalpanel) by using the `footer` prop.
+ * - The footer is completely flexible. Meaning the developer needs to add its own custom layout to match design specs.
+ *
+ * ### Usage
+ *
+ * ```tsx
+ * <ModalFooter>
+ *     <Button onClick={() => {}}>Submit</Button>
+ * </ModalFooter>
+ * ```
+ */
 export default {
     title: "Modal/Building Blocks/ModalFooter",
     component: ModalFooter,
@@ -109,9 +126,6 @@ export default {
             />
         ),
         docs: {
-            description: {
-                component: null,
-            },
             source: {
                 // See https://github.com/storybookjs/storybook/issues/12596
                 excludeDecorators: true,
@@ -134,7 +148,14 @@ export default {
 
 type StoryComponentType = StoryObj<typeof ModalFooter>;
 
+/**
+ * This is a basic footer. It contains an empty `<View>`, so it is completely
+ * blank.
+ */
 export const Default: StoryComponentType = {
+    args: {
+        children: <View />,
+    },
     render: (args) => (
         <ModalDialog aria-labelledby={"modal-id-0"} style={styles.dialog}>
             <ModalPanel
@@ -151,171 +172,134 @@ export const Default: StoryComponentType = {
     ),
 };
 
-export const Simple: StoryComponentType = () => (
-    <ModalDialog aria-labelledby={"modal-id-1"} style={styles.dialog}>
-        <ModalPanel
-            content={
-                <>
-                    <Title id="modal-id-1">Modal Title</Title>
-                    <Strut size={Spacing.large_24} />
-                    {longBody}
-                </>
-            }
-            footer={
-                <ModalFooter>
-                    <View />
-                </ModalFooter>
-            }
-        />
-    </ModalDialog>
-);
+/**
+ * This is a `<ModalFooter>` with a `<Button>` as a child. No additional styling
+ * is needed, as the footer already has the style `{justifyContent:
+ * "flex-end"}`.
+ */
+export const WithButton: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby={"modal-id-2"} style={styles.dialog}>
+            <ModalPanel
+                content={
+                    <>
+                        <Title id="modal-id-2">Modal Title</Title>
+                        <Strut size={Spacing.large_24} />
+                        {longBody}
+                    </>
+                }
+                footer={
+                    <ModalFooter>
+                        <Button onClick={() => {}}>Submit</Button>
+                    </ModalFooter>
+                }
+            />
+        </ModalDialog>
+    ),
+};
 
-Simple.parameters = {
-    docs: {
-        description: {
-            story: `This is a basic footer. It contains an empty
-            \`<View>\`, so it is completely blank.`,
-        },
+/**
+ * This is an example of a footer with multiple actions. It's fully responsive,
+ * so the buttons are in a column layout when the window is small.
+ */
+export const WithThreeActions: StoryComponentType = {
+    render: () => {
+        const mobile = "@media (max-width: 1023px)";
+        const desktop = "@media (min-width: 1024px)";
+
+        const buttonStyle = {
+            [desktop]: {
+                marginRight: Spacing.medium_16,
+            },
+            [mobile]: {
+                marginBottom: Spacing.medium_16,
+            },
+        } as const;
+
+        const containerStyle = {
+            [desktop]: {
+                flexDirection: "row",
+                justifyContent: "flex-end",
+            },
+            [mobile]: {
+                flexDirection: "column-reverse",
+                width: "100%",
+            },
+        } as const;
+
+        return (
+            <ModalDialog aria-labelledby={"modal-id-3"} style={styles.dialog}>
+                <ModalPanel
+                    content={
+                        <>
+                            <Title id="modal-id-3">Modal Title</Title>
+                            <Strut size={Spacing.large_24} />
+                            {longBody}
+                        </>
+                    }
+                    footer={
+                        <ModalFooter>
+                            <View style={containerStyle}>
+                                <Button style={buttonStyle} kind="tertiary">
+                                    Tertiary action
+                                </Button>
+                                <Button style={buttonStyle} kind="tertiary">
+                                    Secondary action
+                                </Button>
+                                <Button style={buttonStyle}>
+                                    Primary action
+                                </Button>
+                            </View>
+                        </ModalFooter>
+                    }
+                />
+            </ModalDialog>
+        );
     },
 };
 
-export const WithButton: StoryComponentType = () => (
-    <ModalDialog aria-labelledby={"modal-id-2"} style={styles.dialog}>
-        <ModalPanel
-            content={
-                <>
-                    <Title id="modal-id-2">Modal Title</Title>
-                    <Strut size={Spacing.large_24} />
-                    {longBody}
-                </>
-            }
-            footer={
-                <ModalFooter>
-                    <Button onClick={() => {}}>Submit</Button>
-                </ModalFooter>
-            }
-        />
-    </ModalDialog>
-);
+/**
+ * This is an example of a footer that indicates multiple steps in a flow.
+ */
+export const WithMultipleActions: StoryComponentType = {
+    render: () => {
+        const footerStyle = {
+            alignItems: "center",
+            flexDirection: "row",
+            justifyContent: "space-between",
+            width: "100%",
+        } as const;
 
-WithButton.parameters = {
-    docs: {
-        description: {
-            story: `This is a \`<ModalFooter>\` with a \`<Button>\`
-            as a child. No additional styling is needed, as the footer
-            already has the style \`{justifyContent: "flex-end"}\`.`,
-        },
-    },
-};
-
-export const WithThreeActions: StoryComponentType = () => {
-    const mobile = "@media (max-width: 1023px)";
-    const desktop = "@media (min-width: 1024px)";
-
-    const buttonStyle = {
-        [desktop]: {
-            marginRight: Spacing.medium_16,
-        },
-        [mobile]: {
-            marginBottom: Spacing.medium_16,
-        },
-    } as const;
-
-    const containerStyle = {
-        [desktop]: {
+        const rowStyle = {
             flexDirection: "row",
             justifyContent: "flex-end",
-        },
-        [mobile]: {
-            flexDirection: "column-reverse",
-            width: "100%",
-        },
-    } as const;
+        } as const;
 
-    return (
-        <ModalDialog aria-labelledby={"modal-id-3"} style={styles.dialog}>
-            <ModalPanel
-                content={
-                    <>
-                        <Title id="modal-id-3">Modal Title</Title>
-                        <Strut size={Spacing.large_24} />
-                        {longBody}
-                    </>
-                }
-                footer={
-                    <ModalFooter>
-                        <View style={containerStyle}>
-                            <Button style={buttonStyle} kind="tertiary">
-                                Tertiary action
-                            </Button>
-                            <Button style={buttonStyle} kind="tertiary">
-                                Secondary action
-                            </Button>
-                            <Button style={buttonStyle}>Primary action</Button>
-                        </View>
-                    </ModalFooter>
-                }
-            />
-        </ModalDialog>
-    );
-};
-
-WithThreeActions.parameters = {
-    docs: {
-        description: {
-            story: `This is an example of a footer with multiple
-            actions. It's fully responsive, so the buttons are in a
-            column layout when the window is small.`,
-        },
-    },
-};
-
-export const WithMultipleActions: StoryComponentType = () => {
-    const footerStyle = {
-        alignItems: "center",
-        flexDirection: "row",
-        justifyContent: "space-between",
-        width: "100%",
-    } as const;
-
-    const rowStyle = {
-        flexDirection: "row",
-        justifyContent: "flex-end",
-    } as const;
-
-    return (
-        <ModalDialog aria-labelledby={"modal-id-4"} style={styles.dialog}>
-            <ModalPanel
-                content={
-                    <>
-                        <Title id="modal-id-4">Modal Title</Title>
-                        <Strut size={Spacing.large_24} />
-                        {longBody}
-                    </>
-                }
-                footer={
-                    <ModalFooter>
-                        <View style={footerStyle}>
-                            <LabelLarge>Step 1 of 4</LabelLarge>
-                            <View style={rowStyle}>
-                                <Button kind="tertiary">Previous</Button>
-                                <Strut size={16} />
-                                <Button kind="primary">Next</Button>
+        return (
+            <ModalDialog aria-labelledby={"modal-id-4"} style={styles.dialog}>
+                <ModalPanel
+                    content={
+                        <>
+                            <Title id="modal-id-4">Modal Title</Title>
+                            <Strut size={Spacing.large_24} />
+                            {longBody}
+                        </>
+                    }
+                    footer={
+                        <ModalFooter>
+                            <View style={footerStyle}>
+                                <LabelLarge>Step 1 of 4</LabelLarge>
+                                <View style={rowStyle}>
+                                    <Button kind="tertiary">Previous</Button>
+                                    <Strut size={16} />
+                                    <Button kind="primary">Next</Button>
+                                </View>
                             </View>
-                        </View>
-                    </ModalFooter>
-                }
-            />
-        </ModalDialog>
-    );
-};
-
-WithMultipleActions.parameters = {
-    docs: {
-        description: {
-            story: `This is an example of a footer that indicates
-            multiple steps in a flow.`,
-        },
+                        </ModalFooter>
+                    }
+                />
+            </ModalDialog>
+        );
     },
 };
 

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -92,6 +92,49 @@ est.`}
     </>
 );
 
+/**
+ * This is a helper component that is never rendered by itself. It is always
+ * pinned to the top of the dialog, is responsive using the same behavior as its
+ * parent dialog, and has the following properties:
+ * - title
+ * - breadcrumb OR subtitle, but not both.
+ *
+ * ### Accessibility notes
+ *
+ * - By default (e.g. using [OnePaneDialog](/#onepanedialog)), `titleId` is
+ *   populated automatically by the parent container.
+ * - If there is a custom Dialog implementation (e.g. `TwoPaneDialog`), the
+ *   ModalHeader doesn’t have to have the `titleId` prop however this is
+ *   recommended. It should match the `aria-labelledby` prop of the
+ *   [ModalDialog](/#modaldialog) component. If you want to see an example of
+ *   how to generate this ID, check [IDProvider](/#idprovider).
+ *
+ * ### Implementation notes
+ *
+ * If you are creating a custom Dialog, make sure to follow these guidelines:
+ * - Make sure to include it as part of [ModalPanel](/#modalpanel) by using the
+ *   `header` prop.
+ * - Add a title (required).
+ * - Optionally add a subtitle or breadcrumbs.
+ * - We encourage you to add `titleId` (see Accessibility notes).
+ * - If the `ModalPanel` has a dark background, make sure to set `light` to
+ *   `false`.
+ * - If you need to create e2e tests, make sure to pass a `testId` prop and
+ *   add a sufix to scope the testId to this component: e.g.
+ *   `some-random-id-ModalHeader`. This scope will also be passed to the title
+ *   and subtitle elements: e.g. `some-random-id-ModalHeader-title`.
+ *
+ * ### Usage
+ *
+ * ```tsx
+ * <ModalHeader
+ *      title="This is a modal title."
+ *      subtitle="subtitle"
+ *      titleId="uniqueTitleId"
+ *      light={false}
+ *  />
+ * ```
+ */
 export default {
     title: "Modal/Building Blocks/ModalHeader",
     component: ModalHeader,
@@ -112,9 +155,6 @@ export default {
             />
         ),
         docs: {
-            description: {
-                component: null,
-            },
             source: {
                 // See https://github.com/storybookjs/storybook/issues/12596
                 excludeDecorators: true,
@@ -133,6 +173,10 @@ export default {
 
 type StoryComponentType = StoryObj<typeof ModalHeader>;
 
+/**
+ * This is a basic `<ModalHeader>`. It just has a `content` prop that contains a
+ * title and a body.
+ */
 export const Default: StoryComponentType = {
     render: (args) => (
         <ModalDialog aria-labelledby={args.titleId} style={styles.dialog}>
@@ -145,136 +189,104 @@ export const Default: StoryComponentType = {
     },
 };
 
-export const Simple: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-1" style={styles.dialog}>
-        <ModalPanel
-            header={<ModalHeader title="Modal Title" titleId="modal-title-1" />}
-            content={longBody}
-        />
-    </ModalDialog>
-);
-
-Simple.parameters = {
-    docs: {
-        description: {
-            story: `This is a basic \`<ModalHeader>\`. It just has a
-            \`content\` prop that contains a title and a body.`,
-        },
-    },
+/**
+ * This is `<ModalHeader>` when `light` is set to false. This should only be
+ * false if the `light` prop on the encompassing `<ModalPanel>` is also false .
+ * Note that the close button is not visible on the header if the panel is
+ * light.
+ */
+export const Dark: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby="modal-title-2" style={styles.dialog}>
+            <ModalPanel
+                header={
+                    <ModalHeader
+                        title="Modal Title"
+                        titleId="modal-title-2"
+                        light={false}
+                    />
+                }
+                content={longBody}
+                light={false}
+            />
+        </ModalDialog>
+    ),
 };
 
-export const Dark: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-2" style={styles.dialog}>
-        <ModalPanel
-            header={
-                <ModalHeader
-                    title="Modal Title"
-                    titleId="modal-title-2"
-                    light={false}
-                />
-            }
-            content={longBody}
-            light={false}
-        />
-    </ModalDialog>
-);
-
-Dark.parameters = {
-    docs: {
-        description: {
-            story: `This is \`<ModalHeader>\` when \`light\` is
-            set to false. This should only be false if the \`light\` prop
-            on the encompassing \`<ModalPanel>\` is also false . Note that
-            the close button is not visible on the header if the panel is
-            light.`,
-        },
-    },
+/**
+ * This is `<ModalHeader>` with a subtitle, which can be done by passing a
+ * string into the `subtitle` prop.
+ */
+export const WithSubtitle: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby="modal-title-3" style={styles.dialog}>
+            <ModalPanel
+                header={
+                    <ModalHeader
+                        title="Modal Title"
+                        titleId="modal-title-3"
+                        subtitle="This is what a subtitle looks like."
+                    />
+                }
+                content={longBody}
+            />
+        </ModalDialog>
+    ),
 };
 
-export const WithSubtitle: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-3" style={styles.dialog}>
-        <ModalPanel
-            header={
-                <ModalHeader
-                    title="Modal Title"
-                    titleId="modal-title-3"
-                    subtitle="This is what a subtitle looks like."
-                />
-            }
-            content={longBody}
-        />
-    </ModalDialog>
-);
-
-WithSubtitle.parameters = {
-    docs: {
-        description: {
-            story: `This is \`<ModalHeader>\` with a subtitle, which
-            can be done by passing a string into the \`subtitle\` prop.`,
-        },
-    },
+/**
+ * This is `<ModalHeader>` with a subtitle when it also has `light` set to
+ * false.
+ */
+export const WithSubtitleDark: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby="modal-title-4" style={styles.dialog}>
+            <ModalPanel
+                header={
+                    <ModalHeader
+                        title="Modal Title"
+                        titleId="modal-title-4"
+                        subtitle="This is what a subtitle looks like."
+                        light={false}
+                    />
+                }
+                content={longBody}
+                light={false}
+            />
+        </ModalDialog>
+    ),
 };
 
-export const WithSubtitleDark: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-4" style={styles.dialog}>
-        <ModalPanel
-            header={
-                <ModalHeader
-                    title="Modal Title"
-                    titleId="modal-title-4"
-                    subtitle="This is what a subtitle looks like."
-                    light={false}
-                />
-            }
-            content={longBody}
-            light={false}
-        />
-    </ModalDialog>
-);
-
-WithSubtitleDark.parameters = {
-    docs: {
-        description: {
-            story: `This is \`<ModalHeader>\` with a subtitle
-            when it also has \`light\` set to false.`,
-        },
-    },
-};
-
-export const WithBreadcrumbs: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-5" style={styles.dialog}>
-        <ModalPanel
-            header={
-                <ModalHeader
-                    title="Modal Title"
-                    titleId="modal-title-5"
-                    breadcrumbs={
-                        <Breadcrumbs>
-                            <BreadcrumbsItem>
-                                <Link href="">Course</Link>
-                            </BreadcrumbsItem>
-                            <BreadcrumbsItem>
-                                <Link href="">Unit</Link>
-                            </BreadcrumbsItem>
-                            <BreadcrumbsItem>Lesson</BreadcrumbsItem>
-                        </Breadcrumbs>
-                    }
-                />
-            }
-            content={longBody}
-        />
-    </ModalDialog>
-);
-
-WithBreadcrumbs.parameters = {
-    docs: {
-        description: {
-            story: `This is \`<ModalHeader>\` with breadcrumbs, which
-            can be done by passing a Wonder Blocks \`<Breadcrumbs>\`
-            element into the \`breadcrumbs\` prop. Note that \`breadcrumbs\`
-            currently do not work when \`light\` is false.`,
-        },
-    },
+/**
+ * This is `<ModalHeader>` with breadcrumbs, which can be done by passing a
+ * Wonder Blocks `<Breadcrumbs>` element into the `breadcrumbs` prop. Note that
+ * `breadcrumbs` currently do not work when `light` is false.
+ */
+export const WithBreadcrumbs: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby="modal-title-5" style={styles.dialog}>
+            <ModalPanel
+                header={
+                    <ModalHeader
+                        title="Modal Title"
+                        titleId="modal-title-5"
+                        breadcrumbs={
+                            <Breadcrumbs>
+                                <BreadcrumbsItem>
+                                    <Link href="">Course</Link>
+                                </BreadcrumbsItem>
+                                <BreadcrumbsItem>
+                                    <Link href="">Unit</Link>
+                                </BreadcrumbsItem>
+                                <BreadcrumbsItem>Lesson</BreadcrumbsItem>
+                            </Breadcrumbs>
+                        }
+                    />
+                }
+                content={longBody}
+            />
+        </ModalDialog>
+    ),
 };
 
 const styles = StyleSheet.create({

--- a/__docs__/wonder-blocks-modal/modal-panel.argtypes.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.argtypes.tsx
@@ -1,0 +1,99 @@
+import {ArgTypes} from "@storybook/react";
+
+const argTypes: ArgTypes = {
+    content: {
+        control: {type: null},
+        description: `The main contents of the ModalPanel. All other parts of
+            the panel are positioned around it.`,
+        table: {
+            category: "Layout",
+            type: {summary: "React.Node"},
+        },
+        type: {
+            name: "other",
+            value: "React.Node",
+            required: true,
+        },
+    },
+    header: {
+        control: {type: null},
+        description: "The modal header to show at the top of the panel.",
+        table: {
+            category: "Layout",
+            type: {summary: "React.Node"},
+        },
+    },
+    footer: {
+        control: {type: null},
+        description: "A footer to show beneath the contents.",
+        table: {
+            category: "Layout",
+            type: {summary: "React.Node"},
+        },
+    },
+    closeButtonVisible: {
+        control: {type: "boolean"},
+        description: `When true, the close button is shown; otherwise, the
+            close button is not shown.`,
+        table: {
+            category: "Layout",
+            defaultValue: true,
+            type: {summary: "boolean"},
+        },
+    },
+    light: {
+        control: {type: "boolean"},
+        description: `Whether to display the "light" version of this component
+            instead, for  use when the item is used on a dark background.`,
+        table: {
+            category: "Styling",
+            defaultValue: true,
+            type: {summary: "boolean"},
+        },
+    },
+    scrollOverflow: {
+        control: {type: "boolean"},
+        description: `Should the contents of the panel become scrollable should
+            they become too tall?`,
+        table: {
+            category: "Styling",
+            defaultValue: true,
+            type: {summary: "boolean"},
+        },
+    },
+    style: {
+        control: {type: "object"},
+        description: "Any optional styling to apply to the panel.",
+        table: {
+            category: "Styling",
+            type: {summary: "StyleType"},
+        },
+    },
+    testId: {
+        control: {type: "text"},
+        description:
+            `Test ID used for e2e testing.\n\n` +
+            `Normally, this \`testId\` comes from the \`testId\` prop defined
+            in the Dialog variant (e.g. OnePaneDialog).`,
+        table: {
+            category: "Other",
+            type: {summary: "string"},
+        },
+    },
+    onClose: {
+        control: {type: null},
+        description:
+            `Called when the close button is clicked.\n\n` +
+            `If you're using \`ModalLauncher\`, you should not use this prop!
+            Instead, to listen for when the modal closes, add an \`onClose\`
+            handler to the \`ModalLauncher\`. Doing so will throw an error.`,
+        table: {
+            category: "Other",
+            type: {
+                summary: "() => unknown",
+            },
+        },
+    },
+};
+
+export default argTypes;

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -16,8 +16,8 @@ import {
     ModalFooter,
 } from "@khanacademy/wonder-blocks-modal";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
-
 import ComponentInfo from "../../.storybook/components/component-info";
+import modalPanelArgtypes from "./modal-panel.argtypes";
 
 const customViewports = {
     phone: {
@@ -91,6 +91,30 @@ est.`}
     </>
 );
 
+/**
+ * ModalPanel is the content container.
+ *
+ * ### Implementation notes
+ *
+ * If you are creating a custom Dialog, make sure to follow these guidelines:
+ * - Make sure to add this component inside the
+ *   [ModalDialog](../?path=/docs/modal-building-blocks-modaldialog--docs).
+ * - If needed, you can also add a
+ *   [ModalHeader](../?path=/docs/modal-building-blocks-modalheader--docs) using
+ *   the `header` prop. Same goes for
+ *   [ModalFooter](../?path=/docs/modal-building-blocks-modalfooter--docs).
+ * - If you need to create e2e tests, make sure to pass a `testId` prop. This
+ *   will be passed down to this component using a sufix: e.g.
+ *   `some-random-id-ModalPanel`. This scope will be propagated to the
+ *   CloseButton element as well: e.g. `some-random-id-CloseButton`.
+ *
+ * ### Usage
+ * ```tsx
+ * <ModalDialog>
+ *      <ModalPanel content={"custom content goes here"} />
+ * </ModalDialog>
+ * ```
+ */
 export default {
     title: "Modal/Building Blocks/ModalPanel",
     component: ModalPanel,
@@ -111,9 +135,6 @@ export default {
             />
         ),
         docs: {
-            description: {
-                component: null,
-            },
             source: {
                 // See https://github.com/storybookjs/storybook/issues/12596
                 excludeDecorators: true,
@@ -127,26 +148,15 @@ export default {
             viewports: [320, 640, 1024],
         },
     },
-    // Make the following props null in the control panel
-    // because setting an object for a React node is
-    // not practical to do manually, and adding a React Element
-    // as one of the default args just results in an incoherent
-    // json object in the control panel.
-    argTypes: {
-        content: {
-            control: {type: null},
-        },
-        header: {
-            control: {type: null},
-        },
-        footer: {
-            control: {type: null},
-        },
-    },
+    argTypes: modalPanelArgtypes,
 } as Meta<typeof ModalPanel>;
 
 type StoryComponentType = StoryObj<typeof ModalPanel>;
 
+/**
+ * This is a basic `<ModalPanel>`. It just has a `content` prop that contains a
+ * title and a body.
+ */
 export const Default: StoryComponentType = {
     render: (args) => (
         <ModalDialog aria-labelledby="modal-title-0" style={styles.dialog}>
@@ -164,240 +174,201 @@ export const Default: StoryComponentType = {
     ),
 };
 
-export const Simple: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-1" style={styles.dialog}>
-        <ModalPanel
-            content={
-                <>
-                    <Title id="modal-title-1">Modal Title</Title>
-                    <Strut size={Spacing.large_24} />
-                    {longBody}
-                </>
-            }
-        />
-    </ModalDialog>
-);
-
-Simple.parameters = {
-    docs: {
-        description: {
-            story: `This is a basic \`<ModalPanel>\`. It just has a
-            \`content\` prop that contains a title and a body.`,
-        },
-    },
-};
-
-export const Dark: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-a" style={styles.dialog}>
-        <ModalPanel
-            content={
-                <>
-                    <Title id="modal-title-a">Modal Title</Title>
-                    <Strut size={Spacing.large_24} />
-                    {longBody}
-                </>
-            }
-            light={false}
-        />
-    </ModalDialog>
-);
-
-Dark.parameters = {
-    docs: {
-        description: {
-            story: "This is what a modal panel looks like when its `light` prop is set to false.",
-        },
-    },
-};
-
-export const WithHeader: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-2" style={styles.dialog}>
-        <ModalPanel
-            header={<ModalHeader titleId="modal-title-2" title="Modal Title" />}
-            content={longBody}
-        />
-    </ModalDialog>
-);
-
-WithHeader.parameters = {
-    docs: {
-        description: {
-            story: `This is a \`<ModalPanel>\` with a \`header\`
-            prop. Note that the header that renders here as part of the
-            \`header\` prop is sticky, so it remains even if you scroll
-            down in the modal.`,
-        },
-    },
-};
-
-export const WithFooter: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-3" style={styles.dialog}>
-        <ModalPanel
-            content={
-                <>
-                    <Title id="modal-title-3">Modal Title</Title>
-                    <Strut size={Spacing.large_24} />
-                    {longBody}
-                </>
-            }
-            footer={
-                <ModalFooter>
-                    <Button onClick={() => {}}>Continue</Button>
-                </ModalFooter>
-            }
-        />
-    </ModalDialog>
-);
-
-WithFooter.parameters = {
-    docs: {
-        description: {
-            story: `A modal panel can have a footer with the \`footer\`
-            prop. In this example, the footer just contains a button. Note
-            that the footer is sticky.`,
-        },
-    },
-};
-
-export const DarkWithHeaderAndFooter: StoryComponentType = () => (
-    <ModalDialog aria-labelledby="modal-title-3" style={styles.dialog}>
-        <ModalPanel
-            header={<ModalHeader titleId="modal-title-2" title="Modal Title" />}
-            content={longBody}
-            footer={
-                <ModalFooter>
-                    <Button onClick={() => {}} light={true}>
-                        Continue
-                    </Button>
-                </ModalFooter>
-            }
-            light={false}
-        />
-    </ModalDialog>
-);
-
-DarkWithHeaderAndFooter.parameters = {
-    docs: {
-        description: {
-            story: `Here is a dark \`<ModalPanel>\` with a header
-            and a footer. The \`<Button>\` in the footer must have the
-            \`light\` prop set to true in order to be visible on the dark
-            background.`,
-        },
-    },
-};
-
-export const TwoPanels: StoryComponentType = () => {
-    const mobile = "@media (max-width: 1023px)";
-    const desktop = "@media (min-width: 1024px)";
-
-    const twoPaneDialogStyle = {
-        [desktop]: {
-            width: "86.72%",
-            maxWidth: 888,
-            height: "60.42%",
-            minHeight: 308,
-        },
-        [mobile]: {
-            width: "100%",
-            height: "100%",
-            overflow: "hidden",
-        },
-    } as const;
-
-    const panelGroupStyle = {
-        flex: 1,
-
-        [desktop]: {
-            flexDirection: "row",
-        },
-        [mobile]: {
-            flexDirection: "column",
-        },
-    } as const;
-
-    return (
-        <ModalDialog style={twoPaneDialogStyle}>
-            <View style={panelGroupStyle}>
-                <ModalPanel
-                    content={
-                        <View>
-                            <Title>Sidebar</Title>
-                            <Strut size={Spacing.large_24} />
-                            <Body>
-                                Lorem ipsum dolor sit amet, consectetur
-                                adipiscing elit, sed do eiusmod tempor
-                                incididunt ut labore et dolore magna aliqua. Ut
-                                enim ad minim veniam, quis nostrud exercitation
-                                ullamco laboris.
-                            </Body>
-                        </View>
-                    }
-                    light={false}
-                    closeButtonVisible={false}
-                />
-                <ModalPanel
-                    content={
-                        <View>
-                            <Title>Contents</Title>
-                            <Strut size={Spacing.large_24} />
-                            <Body>
-                                Lorem ipsum dolor sit amet, consectetur
-                                adipiscing elit, sed do eiusmod tempor
-                                incididunt ut labore et dolore magna aliqua.
-                            </Body>
-                            <Strut size={Spacing.large_24} />
-                            <Button>Primary action</Button>
-                        </View>
-                    }
-                    closeButtonVisible={false}
-                />
-            </View>
-        </ModalDialog>
-    );
-};
-
-TwoPanels.parameters = {
-    docs: {
-        description: {
-            story: `Here is an example of how you can have a modal
-            with two panels. Observe that it is responsive, so it uses a
-            row layout with a larger window size and a column layout on
-            a smaller window size. The "X" close button has been disabled
-            for both panels since the top right spot would change depending
-            on which layout is being used.`,
-        },
-    },
-};
-
-export const WithStyle: StoryComponentType = () => {
-    const modalStyles = {
-        color: Color.blue,
-        border: `2px solid ${Color.darkBlue}`,
-        borderRadius: 20,
-    } as const;
-
-    return (
-        <ModalDialog aria-labelledby="modal-title-1" style={styles.dialog}>
+/**
+ * This is what a modal panel looks like when its `light` prop is set to false.
+ */
+export const Dark: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby="modal-title-a" style={styles.dialog}>
             <ModalPanel
-                header={
-                    <ModalHeader titleId="modal-title-1" title="Modal Title" />
+                content={
+                    <>
+                        <Title id="modal-title-a">Modal Title</Title>
+                        <Strut size={Spacing.large_24} />
+                        {longBody}
+                    </>
                 }
-                content={longBody}
-                style={modalStyles}
+                light={false}
             />
         </ModalDialog>
-    );
+    ),
 };
 
-WithStyle.parameters = {
-    docs: {
-        description: {
-            story: `A \`<ModalPanel>\` can have custom styles.
-            In this example, the styles for the modal panel include blue
-            text color, a 2px solid dark blue border, and a border
-            radius of 20px.`,
-        },
+/**
+ * This is a `<ModalPanel>` with a `header` prop. Note that the header that
+ * renders here as part of the `header` prop is sticky, so it remains even if
+ * you scroll down in the modal.
+ */
+export const WithHeader: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby="modal-title-2" style={styles.dialog}>
+            <ModalPanel
+                header={
+                    <ModalHeader titleId="modal-title-2" title="Modal Title" />
+                }
+                content={longBody}
+            />
+        </ModalDialog>
+    ),
+};
+
+/**
+ * A modal panel can have a footer with the `footer` prop. In this example, the
+ * footer just contains a button. Note that the footer is sticky.
+ */
+export const WithFooter: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby="modal-title-3" style={styles.dialog}>
+            <ModalPanel
+                content={
+                    <>
+                        <Title id="modal-title-3">Modal Title</Title>
+                        <Strut size={Spacing.large_24} />
+                        {longBody}
+                    </>
+                }
+                footer={
+                    <ModalFooter>
+                        <Button onClick={() => {}}>Continue</Button>
+                    </ModalFooter>
+                }
+            />
+        </ModalDialog>
+    ),
+};
+
+/**
+ * Here is a dark `<ModalPanel>` with a header and a footer. The `<Button>` in
+ * the footer must have the `light` prop set to true in order to be visible on
+ * the dark background.
+ */
+export const DarkWithHeaderAndFooter: StoryComponentType = {
+    render: () => (
+        <ModalDialog aria-labelledby="modal-title-3" style={styles.dialog}>
+            <ModalPanel
+                header={
+                    <ModalHeader titleId="modal-title-2" title="Modal Title" />
+                }
+                content={longBody}
+                footer={
+                    <ModalFooter>
+                        <Button onClick={() => {}} light={true}>
+                            Continue
+                        </Button>
+                    </ModalFooter>
+                }
+                light={false}
+            />
+        </ModalDialog>
+    ),
+};
+
+/**
+ * Here is an example of how you can have a modal with two panels. Observe that
+ * it is responsive, so it uses a row layout with a larger window size and a
+ * column layout on a smaller window size. The "X" close button has been
+ * disabled for both panels since the top right spot would change depending on
+ * which layout is being used.
+ */
+export const TwoPanels: StoryComponentType = {
+    render: () => {
+        const mobile = "@media (max-width: 1023px)";
+        const desktop = "@media (min-width: 1024px)";
+
+        const twoPaneDialogStyle = {
+            [desktop]: {
+                width: "86.72%",
+                maxWidth: 888,
+                height: "60.42%",
+                minHeight: 308,
+            },
+            [mobile]: {
+                width: "100%",
+                height: "100%",
+                overflow: "hidden",
+            },
+        } as const;
+
+        const panelGroupStyle = {
+            flex: 1,
+
+            [desktop]: {
+                flexDirection: "row",
+            },
+            [mobile]: {
+                flexDirection: "column",
+            },
+        } as const;
+
+        return (
+            <ModalDialog style={twoPaneDialogStyle}>
+                <View style={panelGroupStyle}>
+                    <ModalPanel
+                        content={
+                            <View>
+                                <Title>Sidebar</Title>
+                                <Strut size={Spacing.large_24} />
+                                <Body>
+                                    Lorem ipsum dolor sit amet, consectetur
+                                    adipiscing elit, sed do eiusmod tempor
+                                    incididunt ut labore et dolore magna aliqua.
+                                    Ut enim ad minim veniam, quis nostrud
+                                    exercitation ullamco laboris.
+                                </Body>
+                            </View>
+                        }
+                        light={false}
+                        closeButtonVisible={false}
+                    />
+                    <ModalPanel
+                        content={
+                            <View>
+                                <Title>Contents</Title>
+                                <Strut size={Spacing.large_24} />
+                                <Body>
+                                    Lorem ipsum dolor sit amet, consectetur
+                                    adipiscing elit, sed do eiusmod tempor
+                                    incididunt ut labore et dolore magna aliqua.
+                                </Body>
+                                <Strut size={Spacing.large_24} />
+                                <Button>Primary action</Button>
+                            </View>
+                        }
+                        closeButtonVisible={false}
+                    />
+                </View>
+            </ModalDialog>
+        );
+    },
+};
+
+/**
+ * A `<ModalPanel>` can have custom styles. In this example, the styles for the
+ * modal panel include blue text color, a 2px solid dark blue border, and a
+ * border radius of 20px.
+ */
+export const WithStyle: StoryComponentType = {
+    render: () => {
+        const modalStyles = {
+            color: Color.blue,
+            border: `2px solid ${Color.darkBlue}`,
+            borderRadius: 20,
+        } as const;
+
+        return (
+            <ModalDialog aria-labelledby="modal-title-1" style={styles.dialog}>
+                <ModalPanel
+                    header={
+                        <ModalHeader
+                            titleId="modal-title-1"
+                            title="Modal Title"
+                        />
+                    }
+                    content={longBody}
+                    style={modalStyles}
+                />
+            </ModalDialog>
+        );
     },
 };
 

--- a/packages/wonder-blocks-modal/src/components/modal-content.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-content.tsx
@@ -1,10 +1,17 @@
 import * as React from "react";
-import {StyleSheet} from "aphrodite";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {MediaLayout} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import {
+    ThemedStylesFn,
+    useScopedTheme,
+    useStyles,
+} from "@khanacademy/wonder-blocks-theming";
+import {
+    ModalDialogThemeContext,
+    ModalDialogThemeContract,
+} from "../themes/themed-modal-dialog";
 
 type Props = {
     /** Should the content scroll on overflow, or just expand. */
@@ -15,68 +22,60 @@ type Props = {
     style?: StyleType;
 };
 
-type DefaultProps = {
-    scrollOverflow: Props["scrollOverflow"];
-};
-
 /**
  * The Modal content included after the header
  */
-export default class ModalContent extends React.Component<Props> {
-    static isClassOf(instance: any): boolean {
-        return instance && instance.type && instance.type.__IS_MODAL_CONTENT__;
-    }
-    static defaultProps: DefaultProps = {
-        scrollOverflow: true,
-    };
+function ModalContent(props: Props) {
+    const {scrollOverflow, style, children} = props;
+    const {theme} = useScopedTheme(ModalDialogThemeContext);
+    const styles = useStyles(themedStylesFn, theme);
 
-    static __IS_MODAL_CONTENT__ = true;
-
-    render(): React.ReactNode {
-        const {scrollOverflow, style, children} = this.props;
-
-        return (
-            <MediaLayout styleSheets={styleSheets}>
-                {({styles}) => (
-                    <View
-                        style={[
-                            styles.wrapper,
-                            scrollOverflow && styles.scrollOverflow,
-                        ]}
-                    >
-                        <View style={[styles.content, style]}>{children}</View>
-                    </View>
-                )}
-            </MediaLayout>
-        );
-    }
+    return (
+        <View style={[styles.wrapper, scrollOverflow && styles.scrollOverflow]}>
+            <View style={[styles.content, style]}>{children}</View>
+        </View>
+    );
 }
 
-const styleSheets = {
-    all: StyleSheet.create({
-        wrapper: {
-            flex: 1,
+ModalContent.__IS_MODAL_CONTENT__ = true;
 
-            // This helps to ensure that the paddingBottom is preserved when
-            // the contents start to overflow, this goes away on display: flex
-            display: "block",
-        },
+ModalContent.isComponentOf = (instance: any): boolean => {
+    return instance && instance.type && instance.type.__IS_MODAL_CONTENT__;
+};
 
-        scrollOverflow: {
-            overflow: "auto",
-        },
+/**
+ * Media query for small screens.
+ * TODO(WB-1655): Change this to use the theme instead (inside themedStylesFn).
+ * e.g. `[theme.breakpoints.small]: {...}`
+ */
+const small = "@media (max-width: 767px)";
 
-        content: {
-            flex: 1,
-            minHeight: "100%",
-            padding: Spacing.xLarge_32,
-            boxSizing: "border-box",
-        },
-    }),
+const themedStylesFn: ThemedStylesFn<ModalDialogThemeContract> = (theme) => ({
+    wrapper: {
+        flex: 1,
 
-    small: StyleSheet.create({
-        content: {
+        // This helps to ensure that the paddingBottom is preserved when
+        // the contents start to overflow, this goes away on display: flex
+        display: "block",
+    },
+
+    scrollOverflow: {
+        overflow: "auto",
+    },
+
+    content: {
+        flex: 1,
+        minHeight: "100%",
+        padding: Spacing.xLarge_32,
+        boxSizing: "border-box",
+        [small]: {
             padding: `${Spacing.xLarge_32}px ${Spacing.medium_16}px`,
         },
-    }),
-} as const;
+    },
+});
+
+ModalContent.defaultProps = {
+    scrollOverflow: true,
+};
+
+export default ModalContent;

--- a/packages/wonder-blocks-modal/src/components/modal-footer.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-footer.tsx
@@ -25,17 +25,15 @@ type Props = {
  * </ModalFooter>
  * ```
  */
-export default class ModalFooter extends React.Component<Props> {
-    static isClassOf(instance: any): boolean {
-        return instance && instance.type && instance.type.__IS_MODAL_FOOTER__;
-    }
-    static __IS_MODAL_FOOTER__ = true;
-
-    render(): React.ReactNode {
-        const {children} = this.props;
-        return <View style={styles.footer}>{children}</View>;
-    }
+export default function ModalFooter({children}: Props) {
+    return <View style={styles.footer}>{children}</View>;
 }
+
+ModalFooter.__IS_MODAL_FOOTER__ = true;
+
+ModalFooter.isComponentOf = (instance: any): boolean => {
+    return instance && instance.type && instance.type.__IS_MODAL_FOOTER__;
+};
 
 const styles = StyleSheet.create({
     footer: {

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import {
@@ -22,20 +22,16 @@ type Props = {
      * are positioned around it.
      */
     content:
-        | React.ReactElement<React.ComponentProps<typeof ModalContent>>
+        | React.ReactElement<PropsFor<typeof ModalContent>>
         | React.ReactNode;
     /**
      * The modal header to show at the top of the panel.
      */
-    header?:
-        | React.ReactElement<React.ComponentProps<typeof ModalHeader>>
-        | React.ReactNode;
+    header?: React.ReactElement<PropsFor<typeof ModalHeader>> | React.ReactNode;
     /**
      * A footer to show beneath the contents.
      */
-    footer?:
-        | React.ReactElement<React.ComponentProps<typeof ModalFooter>>
-        | React.ReactNode;
+    footer?: React.ReactElement<PropsFor<typeof ModalFooter>> | React.ReactNode;
     /**
      * When true, the close button is shown; otherwise, the close button is not shown.
      */
@@ -72,7 +68,7 @@ type Props = {
 };
 
 /**
- * ModalPanel is  the content container.
+ * ModalPanel is the content container.
  *
  * **Implementation notes:**
  *
@@ -105,11 +101,9 @@ export default function ModalPanel({
     const {theme} = useScopedTheme(ModalDialogThemeContext);
     const styles = useStyles(themedStylesFn, theme);
 
-    const renderMainContent = (): React.ReactNode => {
-        const mainContent = ModalContent.isClassOf(content) ? (
-            (content as React.ReactElement<
-                React.ComponentProps<typeof ModalContent>
-            >)
+    const renderMainContent = React.useCallback((): React.ReactNode => {
+        const mainContent = ModalContent.isComponentOf(content) ? (
+            (content as React.ReactElement<PropsFor<typeof ModalContent>>)
         ) : (
             <ModalContent>{content}</ModalContent>
         );
@@ -127,7 +121,7 @@ export default function ModalPanel({
             // know about things being positioned around it.
             style: [!!footer && styles.hasFooter, mainContent.props.style],
         });
-    };
+    }, [content, footer, scrollOverflow, styles.hasFooter]);
 
     const mainContent = renderMainContent();
 
@@ -146,7 +140,7 @@ export default function ModalPanel({
             )}
             {header}
             {mainContent}
-            {!footer || ModalFooter.isClassOf(footer) ? (
+            {!footer || ModalFooter.isComponentOf(footer) ? (
                 footer
             ) : (
                 <ModalFooter>{footer}</ModalFooter>

--- a/packages/wonder-blocks-modal/src/themes/default.ts
+++ b/packages/wonder-blocks-modal/src/themes/default.ts
@@ -7,6 +7,10 @@ const theme = {
         },
         text: {
             inverse: tokens.color.white,
+            secondary: tokens.color.offBlack64,
+        },
+        shadow: {
+            default: tokens.color.offBlack16,
         },
     },
     border: {
@@ -19,6 +23,12 @@ const theme = {
         panel: {
             closeButton: tokens.spacing.medium_16,
             footer: tokens.spacing.xLarge_32,
+        },
+        header: {
+            xsmall: tokens.spacing.xSmall_8,
+            small: tokens.spacing.medium_16,
+            medium: tokens.spacing.large_24,
+            large: tokens.spacing.xLarge_32,
         },
     },
 };


### PR DESCRIPTION
## Summary:

Following up on #2141, this PR focuses on adding theming support to the
remaining modal building blocks: ModalHeader and ModalFooter.

The main change is to add the "eggplant" bg color to ModalHeader and to refactor
these components to use media queries instead of `MediaLayout`.

Also added better docs for ModalPanel and ModalFooter.

Issue: WB-1652

## Test plan:

1. Verify that the `ModalHeader` component is now using the `eggplant` bg color.

2. Verify that the `ModalHeader` and `ModalFooter` docs look correct.