### PR TITLE
Dropdown: Fix focus state for custom openers

### DIFF
--- a/.changeset/eighty-radios-trade.md
+++ b/.changeset/eighty-radios-trade.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fix focus state on custom openers

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -6,7 +6,7 @@ import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color, {mix} from "@khanacademy/wonder-blocks-color";
+import Color, {fade} from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -126,8 +126,7 @@ const styles = StyleSheet.create({
         padding: Spacing.medium_16,
     },
     focused: {
-        backgroundColor: mix(Color.lightBlue, Color.offWhite),
-        color: Color.offWhite,
+        backgroundColor: fade(Color.lightBlue, 0.8),
     },
     hovered: {
         textDecoration: "underline",

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -2,10 +2,11 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import planetIcon from "@phosphor-icons/core/regular/planet.svg";
 
+import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
+import Color, {mix} from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -125,6 +126,7 @@ const styles = StyleSheet.create({
         padding: Spacing.medium_16,
     },
     focused: {
+        backgroundColor: mix(Color.lightBlue, Color.offWhite),
         color: Color.offWhite,
     },
     hovered: {
@@ -133,7 +135,7 @@ const styles = StyleSheet.create({
         cursor: "pointer",
     },
     pressed: {
-        color: Color.blue,
+        backgroundColor: Color.blue,
     },
 
     fullBleed: {
@@ -628,22 +630,28 @@ export const CustomOpener: StoryComponentType = {
     render: Template,
     args: {
         selectedValue: "",
-        opener: ({focused, hovered, pressed, text}: any) => (
-            <HeadingLarge
-                onClick={() => {
-                    // eslint-disable-next-line no-console
-                    console.log("custom click!!!!!");
-                }}
-                style={[
-                    styles.customOpener,
-                    focused && styles.focused,
-                    hovered && styles.hovered,
-                    pressed && styles.pressed,
-                ]}
-            >
-                {text}
-            </HeadingLarge>
-        ),
+        opener: ({focused, hovered, pressed, text}: any) => {
+            action(JSON.stringify({focused, hovered, pressed}))(
+                "state changed!",
+            );
+
+            return (
+                <HeadingLarge
+                    onClick={() => {
+                        // eslint-disable-next-line no-console
+                        console.log("custom click!!!!!");
+                    }}
+                    style={[
+                        styles.customOpener,
+                        focused && styles.focused,
+                        hovered && styles.hovered,
+                        pressed && styles.pressed,
+                    ]}
+                >
+                    {text}
+                </HeadingLarge>
+            );
+        },
     } as SingleSelectArgs,
     name: "With custom opener",
 };

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
@@ -82,6 +82,10 @@ class DropdownOpener extends React.Component<Props> {
             <ClickableBehavior
                 onClick={this.props.onClick}
                 disabled={this.props.disabled}
+                // Allows the opener to be focused with the keyboard, which ends
+                // up triggering onFocus/onBlur events needed to re-render the
+                // dropdown opener.
+                tabIndex={0}
             >
                 {(eventState, handlers) =>
                     this.renderAnchorChildren(eventState, handlers)


### PR DESCRIPTION
## Summary:

There's a bug in the dropdown component where the focus state is not applied to
custom openers. This PR solves that by adding `tabIndex` to the custom opener so
`ClickableBehavior` can apply the focus state as the element can trigger its
`onFocus`/`onBlur` handlers.

Issue: XXX-XXXX

## Test plan:

Verify that the SingleSelect > Custom opener example displays the focus state
when tabbing to the opener.

https://github.com/Khan/wonder-blocks/assets/843075/f30cfeea-b6b0-427f-a0bd-22a04ff149ef


