### PR TITLE
Add `opened` state to Dropdown opener function

### DIFF
--- a/.changeset/red-foxes-thank.md
+++ b/.changeset/red-foxes-thank.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Add `opened` state to OpenerProps on Dropdown custom opener function.

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -356,6 +356,7 @@ export const Controlled: StoryComponentType = {
  *    pressed, hovered and focused.
  *  - `text`: Passes the menu label defined in the parent component. This value
  *    is passed using the placeholder prop set in the ActionMenu component.
+ *  - `opened`: Whether the dropdown is opened.
  *
  * **Note:** If you need to use a custom ID for testing the opener, make sure to
  * pass the testId prop inside the opener component/element.

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
+import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 
@@ -19,6 +20,7 @@ import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 import multiSelectArgtypes from "./multi-select.argtypes";
 import {defaultLabels} from "../../packages/wonder-blocks-dropdown/src/util/constants";
 import {allProfilesWithPictures} from "./option-item-examples";
+import {OpenerProps} from "../../packages/wonder-blocks-dropdown/src/util/types";
 
 type StoryComponentType = StoryObj<typeof MultiSelect>;
 
@@ -495,22 +497,29 @@ export const CustomOpener: StoryComponentType = {
     render: Template,
     args: {
         selectedValues: [],
-        opener: ({focused, hovered, pressed, text}: any) => (
-            <HeadingLarge
-                onClick={() => {
-                    // eslint-disable-next-line no-console
-                    console.log("custom click!!!!!");
-                }}
-                style={[
-                    styles.customOpener,
-                    focused && styles.focused,
-                    hovered && styles.hovered,
-                    pressed && styles.pressed,
-                ]}
-            >
-                {text}
-            </HeadingLarge>
-        ),
+        opener: ({focused, hovered, pressed, text, opened}: OpenerProps) => {
+            action(JSON.stringify({focused, hovered, pressed, opened}))(
+                "state changed!",
+            );
+
+            return (
+                <HeadingLarge
+                    onClick={() => {
+                        // eslint-disable-next-line no-console
+                        console.log("custom click!!!!!");
+                    }}
+                    style={[
+                        styles.customOpener,
+                        focused && styles.focused,
+                        hovered && styles.hovered,
+                        pressed && styles.pressed,
+                    ]}
+                >
+                    {text}
+                    {opened ? ": opened" : ""}
+                </HeadingLarge>
+            );
+        },
     } as MultiSelectArgs,
     name: "With custom opener",
 };

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -486,6 +486,7 @@ export const VirtualizedFilterable: StoryComponentType = {
  *    pressed, hovered and focused.
  *  - `text`: Passes the menu label defined in the parent component. This value
  *  is passed using the placeholder prop set in the `MultiSelect` component.
+ *  - `opened`: Whether the dropdown is opened.
  *
  * **Note:** If you need to use a custom ID for testing the opener, make sure to
  * pass the testId prop inside the opener component/element.

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -621,6 +621,7 @@ export const DropdownInModal: StoryComponentType = {
  *    pressed, hovered and focused.
  *  - `text`: Passes the menu label defined in the parent component. This value
  *   is passed using the placeholder prop set in the `SingleSelect` component.
+ *  - `opened`: Whether the dropdown is opened.
  *
  * **Note:** If you need to use a custom ID for testing the opener, make sure to
  * pass the testId prop inside the opener component/element.

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -33,6 +33,7 @@ import singleSelectArgtypes from "./single-select.argtypes";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {defaultLabels} from "../../packages/wonder-blocks-dropdown/src/util/constants";
 import {allCountries, allProfilesWithPictures} from "./option-item-examples";
+import {OpenerProps} from "../../packages/wonder-blocks-dropdown/src/util/types";
 
 type StoryComponentType = StoryObj<typeof SingleSelect>;
 type SingleSelectArgs = Partial<typeof SingleSelect>;
@@ -630,8 +631,8 @@ export const CustomOpener: StoryComponentType = {
     render: Template,
     args: {
         selectedValue: "",
-        opener: ({focused, hovered, pressed, text}: any) => {
-            action(JSON.stringify({focused, hovered, pressed}))(
+        opener: ({focused, hovered, pressed, text, opened}: OpenerProps) => {
+            action(JSON.stringify({focused, hovered, pressed, opened}))(
                 "state changed!",
             );
 
@@ -646,9 +647,11 @@ export const CustomOpener: StoryComponentType = {
                         focused && styles.focused,
                         hovered && styles.hovered,
                         pressed && styles.pressed,
+                        opened && styles.focused,
                     ]}
                 >
                     {text}
+                    {opened ? ": opened" : ""}
                 </HeadingLarge>
             );
         },

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
@@ -231,7 +231,6 @@ export default class ActionMenu extends React.Component<Props, State> {
         numItems: number,
     ): React.ReactElement<React.ComponentProps<typeof DropdownOpener>> {
         const {disabled, menuText, opener, testId} = this.props;
-        const {opened} = this.state;
 
         return (
             <DropdownOpener
@@ -240,6 +239,7 @@ export default class ActionMenu extends React.Component<Props, State> {
                 text={menuText}
                 ref={this.handleOpenerRef}
                 testId={opener ? undefined : testId}
+                opened={this.state.opened}
             >
                 {opener
                     ? opener
@@ -247,6 +247,7 @@ export default class ActionMenu extends React.Component<Props, State> {
                           const {
                               // eslint-disable-next-line @typescript-eslint/no-unused-vars
                               text,
+                              opened,
                               ...eventState
                           } = openerProps;
                           return (

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
@@ -35,6 +35,10 @@ type Props = Partial<Omit<AriaProps, "aria-disabled">> & {
      * Text for the opener that can be passed to the child as an argument.
      */
     text: OptionLabel;
+    /**
+     * Whether the dropdown is opened.
+     */
+    opened: boolean;
 };
 
 type DefaultProps = {
@@ -54,8 +58,12 @@ class DropdownOpener extends React.Component<Props> {
         eventState: ClickableState,
         clickableChildrenProps: ChildrenProps,
     ): React.ReactElement {
-        const {disabled, testId, text} = this.props;
-        const renderedChildren = this.props.children({...eventState, text});
+        const {disabled, testId, text, opened} = this.props;
+        const renderedChildren = this.props.children({
+            ...eventState,
+            text,
+            opened,
+        });
         const childrenProps = renderedChildren.props;
         const childrenTestId = this.getTestIdFromProps(childrenProps);
 

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -513,6 +513,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 disabled={numOptions === 0 || disabled}
                 ref={this.handleOpenerRef}
                 text={menuText}
+                opened={this.state.open}
             >
                 {opener}
             </DropdownOpener>

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -410,6 +410,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                 disabled={numItems === 0 || disabled}
                 ref={this.handleOpenerRef}
                 text={menuText}
+                opened={this.state.open}
             >
                 {opener}
             </DropdownOpener>

--- a/packages/wonder-blocks-dropdown/src/util/types.ts
+++ b/packages/wonder-blocks-dropdown/src/util/types.ts
@@ -43,6 +43,7 @@ export type OptionLabel = string | CellProps["title"];
 // Custom opener arguments
 export type OpenerProps = ClickableState & {
     text: OptionLabel;
+    opened: boolean;
 };
 
 export type OptionItemComponentArray = React.ReactElement<


### PR DESCRIPTION
## Summary:
Pass opened state down to custom opener in order to control styles without additional dom manipulation.

Issue: N/A

## Test plan:
Verify that custom opener story displays opened state when clicking on the opener.

https://github.com/Khan/wonder-blocks/assets/23404711/0c8e3ff9-3692-4fb3-8dd1-065875641193