### PR TITLE
Accordion header overflow fix

### DIFF
--- a/.changeset/wild-kangaroos-impress.md
+++ b/.changeset/wild-kangaroos-impress.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-accordion": patch
 ---
 
-Use display: grid in the header to prevent overflow issues
+Use minWidth: 0 in the header to prevent overflow issues

--- a/.changeset/wild-kangaroos-impress.md
+++ b/.changeset/wild-kangaroos-impress.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Use display: grid in the header to prevent overflow issues

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
+import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import {AccordionSection} from "@khanacademy/wonder-blocks-accordion";
 import Button from "@khanacademy/wonder-blocks-button";
@@ -9,7 +10,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {tokens} from "@khanacademy/wonder-blocks-theming";
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {HeadingSmall, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-accordion/package.json";
@@ -194,32 +195,86 @@ Uncontrolled.parameters = {
 /**
  * An AccordionSection can have either a string or a React Element passed
  * in as its header. Passing in a React Element means no built in styling
- * will be applied to the header. In this example, all the header styles are
- * coming from the DetailCell component.
+ * will be applied to the header.
+ *
+ * The first example here shows how a DetailCell can be used as the header.
+ * The second example shows how a custom header can be created - note that
+ * in this example, a smaller window size will cause the header text to
+ * truncate with ellipses.
  */
 export const ReactElementInHeader: StoryComponentType = {
     render: function Render() {
-        const [expanded, setExpanded] = React.useState(false);
-
         return (
-            <AccordionSection
-                header={
-                    <DetailCell
-                        title="Header for article item"
-                        leftAccessory={
-                            <PhosphorIcon
-                                icon={IconMappings.playCircle}
-                                size="medium"
-                            />
-                        }
-                        horizontalRule="none"
-                    />
-                }
-                expanded={expanded}
-                onToggle={setExpanded}
-            >
-                This is the information present in the first section
-            </AccordionSection>
+            <View>
+                <AccordionSection
+                    header={
+                        <DetailCell
+                            title="Header for article item"
+                            leftAccessory={
+                                <PhosphorIcon
+                                    icon={IconMappings.playCircle}
+                                    size="medium"
+                                />
+                            }
+                            horizontalRule="none"
+                        />
+                    }
+                >
+                    This is the information present in the first section
+                </AccordionSection>
+                <Strut size={tokens.spacing.xLarge_32} />
+                {/* The following AccordionSection is implemented
+                the same way as the CourseAccordion in the LearnableNodeSidebar
+                that can be found on Khan Academy. It should truncate the
+                text with ellipses when the window size is small.*/}
+                <AccordionSection
+                    header={
+                        <View
+                            style={{
+                                flexDirection: "row",
+                                margin: tokens.spacing.medium_16,
+                            }}
+                        >
+                            <View
+                                style={{
+                                    backgroundSize: "contain",
+                                    borderRadius: "8px",
+                                    height: 40,
+                                    marginRight: tokens.spacing.small_12,
+                                    minWidth: 40,
+                                    padding: tokens.spacing.xSmall_8,
+                                    width: 40,
+                                }}
+                            >
+                                <PhosphorIcon
+                                    aria-hidden="true"
+                                    icon={magnifyingGlass}
+                                    size="medium"
+                                    style={styles.icon}
+                                />
+                            </View>
+                            <HeadingSmall
+                                // Setting the tag to span here to override
+                                // HeadingSmall's heading level since h2 is already
+                                // set on the AccordionSection's clickable header.
+                                // This way we can avoid redundancy in the a11y tree.
+                                tag="span"
+                                style={{
+                                    whiteSpace: "nowrap",
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    alignSelf: "center",
+                                }}
+                            >
+                                World History Project - Origins to the Present
+                                (Example of a long title)
+                            </HeadingSmall>
+                        </View>
+                    }
+                >
+                    This is the information present in the second section
+                </AccordionSection>
+            </View>
         );
     },
 };
@@ -246,7 +301,7 @@ export const ReactElementInChildren: StoryComponentType = {
                 onToggle={setExpanded}
             >
                 <DetailCell
-                    title="Header for article item"
+                    title="Child article item"
                     leftAccessory={
                         <PhosphorIcon
                             icon={IconMappings.playCircle}

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -159,6 +159,9 @@ const ANIMATION_LENGTH = "300ms";
 
 const styles = StyleSheet.create({
     heading: {
+        // This also needs to have display: grid (matching its container)
+        // so that the header doesn't overflow when the title text is long.
+        display: "grid",
         marginTop: 0,
     },
     headerWrapper: {

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -159,8 +159,11 @@ const ANIMATION_LENGTH = "300ms";
 
 const styles = StyleSheet.create({
     heading: {
-        // minWidth 0 is necessary to stop custom headers from overflowing
-        // when their content is too long.
+        // As this is a grid item, it has a default minWidth of auto,
+        // which means it would grow to fit its content. minWidth 0 is
+        // necessary here to stop a custom header from overflowing out of
+        // it container when its content is too long (See AccordionSection's
+        // "React Element in Header" story).
         minWidth: 0,
         marginTop: 0,
     },

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -159,10 +159,9 @@ const ANIMATION_LENGTH = "300ms";
 
 const styles = StyleSheet.create({
     heading: {
-        // This also needs to have display: grid (matching its container)
-        // so that the header doesn't overflow when the title text is long
-        // within a custom header.
-        display: "grid",
+        // minWidth 0 is necessary to stop custom headers from overflowing
+        // when their content is too long.
+        minWidth: 0,
         marginTop: 0,
     },
     headerWrapper: {

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -160,7 +160,8 @@ const ANIMATION_LENGTH = "300ms";
 const styles = StyleSheet.create({
     heading: {
         // This also needs to have display: grid (matching its container)
-        // so that the header doesn't overflow when the title text is long.
+        // so that the header doesn't overflow when the title text is long
+        // within a custom header.
         display: "grid",
         marginTop: 0,
     },


### PR DESCRIPTION
## Summary:

Currently, there is an issue with a particular accordion section in webapp where long titles in the
custom header cause the accordion contents to overflow. This is fixed by adding `minWidth: 0`
to the styles in Wonder Blocks Accordion Header.

I also included a story in this PR that replicates the issue, which is fixed with the new style.

| Before | After |
| --- | --- |
| <img width="651" alt="Screenshot 2023-12-19 at 3 41 54 PM" src="https://github.com/Khan/wonder-blocks/assets/13231763/a4106bef-9cef-4479-953e-6c5ed307d699"> | <img width="654" alt="Screenshot 2023-12-19 at 3 41 37 PM" src="https://github.com/Khan/wonder-blocks/assets/13231763/5e9a55e4-b886-4a21-aba3-ad886d820bee"> |


Issue: none

## Test plan:
- Go to the following story: /?path=/story/accordion-accordionsection--react-element-in-header
- Confirm that the second accordion header has an ellipsis when the window is small