### PR TITLE
Fix search/filter logic on SingleSelect

### DIFF
--- a/.changeset/tough-rabbits-cough.md
+++ b/.changeset/tough-rabbits-cough.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fix filter functionality (SingleSelect)

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -19,7 +19,7 @@ import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 import multiSelectArgtypes from "./multi-select.argtypes";
 import {defaultLabels} from "../../packages/wonder-blocks-dropdown/src/util/constants";
-import {allProfilesWithPictures} from "./option-item-examples";
+import {allCountries, allProfilesWithPictures} from "./option-item-examples";
 import {OpenerProps} from "../../packages/wonder-blocks-dropdown/src/util/types";
 
 type StoryComponentType = StoryObj<typeof MultiSelect>;
@@ -431,17 +431,9 @@ export const ImplicitAllEnabled: StoryComponentType = {
 /**
  * Virtualized with search filter
  */
-const fruits = ["banana", "strawberry", "pear", "orange"];
-
-const optionItems = new Array(1000)
-    .fill(null)
-    .map((_, i) => (
-        <OptionItem
-            key={i}
-            value={(i + 1).toString()}
-            label={`Fruit # ${i + 1} ${fruits[i % fruits.length]}`}
-        />
-    ));
+const optionItems = allCountries.map(([code, translatedName]) => (
+    <OptionItem key={code} value={code} label={translatedName} />
+));
 
 type Props = {
     opened?: boolean;

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -477,17 +477,9 @@ export const Light: StoryComponentType = {
     },
 };
 
-const fruits = ["banana", "strawberry", "pear", "orange"];
-
-const optionItems = new Array(1000)
-    .fill(null)
-    .map((_, i) => (
-        <OptionItem
-            key={i}
-            value={(i + 1).toString()}
-            label={`Fruit # ${i + 1} ${fruits[i % fruits.length]}`}
-        />
-    ));
+const optionItems = allCountries.map(([code, translatedName]) => (
+    <OptionItem key={code} value={code} label={translatedName} />
+));
 
 type Props = {
     selectedValue?: string | null | undefined;
@@ -507,7 +499,7 @@ const VirtualizedSingleSelect = function (props: Props): React.ReactElement {
                 isFilterable={true}
                 opened={opened}
                 onToggle={setOpened}
-                placeholder="Select a fruit"
+                placeholder="Select a country"
                 selectedValue={selectedValue}
                 dropdownStyle={styles.fullBleed}
                 style={styles.fullBleed}
@@ -582,7 +574,7 @@ export const DropdownInModal: StoryComponentType = {
                         isFilterable={true}
                         opened={opened}
                         onToggle={(opened) => setOpened(opened)}
-                        placeholder="Select a fruit"
+                        placeholder="Select a country"
                         selectedValue={value}
                     >
                         {optionItems}

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -720,6 +720,70 @@ describe("MultiSelect", () => {
             // Assert
             expect(screen.getByPlaceholderText("Filter")).toHaveValue("");
         });
+
+        it("should find an option after using the search filter", async () => {
+            // Arrange
+            const labels: Labels = {
+                ...builtinLabels,
+                someSelected: (numOptions: number): string =>
+                    ngettext("%(num)s planet", "%(num)s planets", numOptions),
+            };
+
+            render(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    isFilterable={true}
+                    shortcuts={true}
+                    labels={labels}
+                    opened={true}
+                >
+                    <OptionItem label="Earth" value="earth" />
+                    <OptionItem label="Venus" value="venus" />
+                    <OptionItem label="Mars" value="mars" />
+                </MultiSelect>,
+            );
+
+            // Act
+            userEvent.paste(screen.getByRole("textbox"), "ear");
+
+            // Assert
+            const filteredOption = screen.getByRole("option", {
+                name: "Earth",
+            });
+            expect(filteredOption).toBeInTheDocument();
+        });
+
+        it("should filter out an option if it's not part of the results", async () => {
+            // Arrange
+            const labels: Labels = {
+                ...builtinLabels,
+                someSelected: (numOptions: number): string =>
+                    ngettext("%(num)s planet", "%(num)s planets", numOptions),
+            };
+
+            render(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    isFilterable={true}
+                    shortcuts={true}
+                    labels={labels}
+                    opened={true}
+                >
+                    <OptionItem label="Earth" value="earth" />
+                    <OptionItem label="Venus" value="venus" />
+                    <OptionItem label="Mars" value="mars" />
+                </MultiSelect>,
+            );
+
+            // Act
+            userEvent.paste(screen.getByRole("textbox"), "ear");
+
+            // Assert
+            const filteredOption = screen.queryByRole("option", {
+                name: "Venus",
+            });
+            expect(filteredOption).not.toBeInTheDocument();
+        });
     });
 
     describe("Custom Opener", () => {
@@ -1341,7 +1405,7 @@ describe("MultiSelect", () => {
             );
 
             // Act
-            userEvent.paste(screen.getByRole("textbox"), "Ear");
+            userEvent.paste(screen.getByRole("textbox"), "ear");
 
             // Assert
             expect(container).toHaveTextContent("1 planet");

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -751,6 +751,56 @@ describe("SingleSelect", () => {
             const dismissBtn = screen.getByLabelText("Clear search");
             expect(dismissBtn).toHaveFocus();
         });
+
+        it("should filter an option", () => {
+            // Arrange
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    isFilterable={true}
+                    opened={true}
+                >
+                    <OptionItem label="Canada" value="ca" />
+                    <OptionItem label="Colombia" value="co" />
+                </SingleSelect>,
+            );
+
+            // Act
+            // NOTE: We search using the lowercased version of the label.
+            userEvent.paste(screen.getByRole("textbox"), "col");
+
+            // Assert
+            const filteredOption = screen.getByRole("option", {
+                name: "Colombia",
+            });
+            expect(filteredOption).toBeInTheDocument();
+        });
+
+        it("should filter out an option if it's not part of the results", () => {
+            // Arrange
+            render(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    isFilterable={true}
+                    opened={true}
+                >
+                    <OptionItem label="Canada" value="ca" />
+                    <OptionItem label="Colombia" value="co" />
+                </SingleSelect>,
+            );
+
+            // Act
+            // NOTE: We search using the lowercased version of the label.
+            userEvent.paste(screen.getByRole("textbox"), "col");
+
+            // Assert
+            const filteredOutOption = screen.queryByRole("option", {
+                name: "Canada",
+            });
+            expect(filteredOutOption).not.toBeInTheDocument();
+        });
     });
 
     describe("Custom listbox styles", () => {
@@ -850,13 +900,14 @@ describe("SingleSelect", () => {
                     isFilterable={true}
                     opened={true}
                 >
-                    <OptionItem label="item 0" value="0" />
-                    <OptionItem label="item 1" value="1" />
-                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="ITEM 0" value="0" />
+                    <OptionItem label="ITEM 1" value="1" />
+                    <OptionItem label="ITEM 2" value="2" />
                 </SingleSelect>,
             );
 
             // Act
+            // NOTE: We search using the lowercased version of the label.
             userEvent.paste(screen.getByRole("textbox"), "item 0");
 
             // Assert

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -331,7 +331,8 @@ export default class SingleSelect extends React.Component<Props, State> {
         return children.filter(
             ({props}) =>
                 !searchText ||
-                getLabel(props).indexOf(lowercasedSearchText) > -1,
+                getLabel(props).toLowerCase().indexOf(lowercasedSearchText) >
+                    -1,
         );
     }
 


### PR DESCRIPTION
## Summary:

After introducing the custom option items, the search/filter logic was broken.
This PR fixes that by using the correct lookup value for the search/filter.

Also added some unit tests and modified some stories to ensure that this
scenario is fully covered for both `SingleSelect` and `MultiSelect`.


Issue: XXX-XXXX

## Test plan:

Verify that the search/filter logic works as expected in the following stories:

- /?path=/story/dropdown-singleselect--virtualized-filterable
- /?path=/story/dropdown-singleselect--custom-option-items-virtualized

https://github.com/Khan/wonder-blocks/assets/843075/0f8fbed5-aaff-4ce2-b5be-cea449d41248


