### PR TITLE
Accordion only handles keydown when header focused

### DIFF
--- a/.changeset/grumpy-meals-sleep.md
+++ b/.changeset/grumpy-meals-sleep.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Fix focus handling for Accordion headers

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -563,7 +563,7 @@ export const WithDropdown: StoryComponentType = {
                     </View>
                 </AccordionSection>
                 <AccordionSection header={`Multi Select`}>
-                    <View style={singleOpened && {height: 200}}>
+                    <View style={multiOpened && {height: 200}}>
                         <MultiSelect
                             selectedValues={values}
                             onChange={setValues}

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -527,11 +527,6 @@ export const LongSections: StoryComponentType = {
  * This demonstrates how the accordion keyboard interactions do not interfere
  * with the dropdown's keyboard interactions.
  */
-const items = [
-    <OptionItem label="Banana" value="banana" key={0} />,
-    <OptionItem label="Strawberry" value="strawberry" disabled key={1} />,
-    <OptionItem label="Pear" value="pear" key={2} />,
-];
 export const WithDropdown: StoryComponentType = {
     render: function Render() {
         const [value, setValue] = React.useState<any>(null);
@@ -539,6 +534,17 @@ export const WithDropdown: StoryComponentType = {
 
         const [values, setValues] = React.useState<any>([]);
         const [multiOpened, setMultiOpened] = React.useState(false);
+
+        const items = [
+            <OptionItem label="Banana" value="banana" key={0} />,
+            <OptionItem
+                label="Strawberry"
+                value="strawberry"
+                disabled
+                key={1}
+            />,
+            <OptionItem label="Pear" value="pear" key={2} />,
+        ];
 
         return (
             <Accordion animated={true}>
@@ -576,7 +582,7 @@ export const WithDropdown: StoryComponentType = {
             // Disabling because this doesn't test anything visual.
             disableSnapshot: true,
         },
-    }
+    },
 };
 
 LongSections.parameters = {

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -571,6 +571,12 @@ export const WithDropdown: StoryComponentType = {
             </Accordion>
         );
     },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    }
 };
 
 LongSections.parameters = {

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -543,6 +543,7 @@ export const WithDropdown: StoryComponentType = {
         return (
             <Accordion animated={true}>
                 <AccordionSection header={`Single Select`}>
+                    {/* Adding height because overflow hidden in sections. */}
                     <View style={singleOpened && {height: 200}}>
                         <SingleSelect
                             placeholder="Select an option"
@@ -556,7 +557,7 @@ export const WithDropdown: StoryComponentType = {
                     </View>
                 </AccordionSection>
                 <AccordionSection header={`Multi Select`}>
-                    <View>
+                    <View style={singleOpened && {height: 200}}>
                         <MultiSelect
                             selectedValues={values}
                             onChange={setValues}

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -11,6 +11,11 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {tokens} from "@khanacademy/wonder-blocks-theming";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {
+    MultiSelect,
+    OptionItem,
+    SingleSelect,
+} from "@khanacademy/wonder-blocks-dropdown";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-accordion/package.json";
@@ -513,6 +518,56 @@ export const LongSections: StoryComponentType = {
                     </Accordion>
                 )}
             </View>
+        );
+    },
+};
+
+/**
+ * This is an example of an Accordion with a dropdown within each section.
+ * This demonstrates how the accordion keyboard interactions do not interfere
+ * with the dropdown's keyboard interactions.
+ */
+const items = [
+    <OptionItem label="Banana" value="banana" key={0} />,
+    <OptionItem label="Strawberry" value="strawberry" disabled key={1} />,
+    <OptionItem label="Pear" value="pear" key={2} />,
+];
+export const WithDropdown: StoryComponentType = {
+    render: function Render() {
+        const [value, setValue] = React.useState<any>(null);
+        const [singleOpened, setSingleOpened] = React.useState(false);
+
+        const [values, setValues] = React.useState<any>([]);
+        const [multiOpened, setMultiOpened] = React.useState(false);
+
+        return (
+            <Accordion animated={true}>
+                <AccordionSection header={`Single Select`}>
+                    <View style={singleOpened && {height: 200}}>
+                        <SingleSelect
+                            placeholder="Select an option"
+                            selectedValue={value}
+                            onChange={setValue}
+                            opened={singleOpened}
+                            onToggle={setSingleOpened}
+                        >
+                            {items}
+                        </SingleSelect>
+                    </View>
+                </AccordionSection>
+                <AccordionSection header={`Multi Select`}>
+                    <View>
+                        <MultiSelect
+                            selectedValues={values}
+                            onChange={setValues}
+                            opened={multiOpened}
+                            onToggle={setMultiOpened}
+                        >
+                            {items}
+                        </MultiSelect>
+                    </View>
+                </AccordionSection>
+            </Accordion>
         );
     },
 };

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
@@ -836,5 +836,38 @@ describe("Accordion", () => {
             expect(button2).not.toHaveFocus();
             expect(button3).toHaveFocus();
         });
+
+        test.each(["{end}", "{home}", "{arrowup}", "{arrowdown}"])(
+            "cannot navigate when header not currently focused",
+            async (key) => {
+                // Arrange
+                render(
+                    <Accordion initialExpandedIndex={0}>
+                        <AccordionSection header="Section 1">
+                            <label>
+                                Focus on this textbox!
+                                <input />
+                            </label>
+                        </AccordionSection>
+                        <AccordionSection header="Section 2">
+                            Section 2 content
+                        </AccordionSection>
+                    </Accordion>,
+                    {wrapper: RenderStateRoot},
+                );
+
+                const button1 = screen.getByRole("button", {name: "Section 1"});
+                const button2 = screen.getByRole("button", {name: "Section 2"});
+
+                // Act
+                const button = screen.getByRole("textbox");
+                button.focus();
+                userEvent.keyboard(key);
+
+                // Assert
+                expect(button1).not.toHaveFocus();
+                expect(button2).not.toHaveFocus();
+            },
+        );
     });
 });

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -32,8 +32,6 @@ type Props = {
     animated: boolean;
     // Called on header click.
     onClick?: () => void;
-    // Called on header focus.
-    onFocus?: () => void;
     // The ID for the content that the header's `aria-controls` should
     // point to.
     sectionContentUniqueId: string;
@@ -65,7 +63,6 @@ const AccordionSectionHeader = React.forwardRef(function AccordionSectionHeader(
         expanded,
         animated,
         onClick,
-        onFocus,
         sectionContentUniqueId,
         headerStyle,
         tag = "h2",
@@ -90,7 +87,6 @@ const AccordionSectionHeader = React.forwardRef(function AccordionSectionHeader(
                 aria-expanded={expanded}
                 aria-controls={sectionContentUniqueId}
                 onClick={onClick}
-                onFocus={onFocus}
                 disabled={!collapsible}
                 testId={testId ? `${testId}-header` : undefined}
                 style={[

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -320,6 +320,9 @@ const styles = StyleSheet.create({
     wrapperExpanded: {
         gridTemplateRows: "min-content 1fr",
     },
+    contentWrapper: {
+        overflow: "hidden",
+    },
     conentWrapperCollapsed: {
         // Make sure screen readers don't read the content when it's
         // collapsed.

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -120,12 +120,6 @@ type Props = AriaProps & {
      * @ignore
      */
     isRegion?: boolean;
-    /**
-     * Called when the header is focused.
-     * For internal use only.
-     * @ignore
-     */
-    onFocus?: () => void;
 };
 
 /**
@@ -185,7 +179,6 @@ const AccordionSection = React.forwardRef(function AccordionSection(
         expanded,
         animated = false,
         onToggle,
-        onFocus,
         caretPosition = "end",
         cornerKind = "rounded",
         style,
@@ -275,7 +268,6 @@ const AccordionSection = React.forwardRef(function AccordionSection(
                 expanded={expandedState}
                 animated={animated}
                 onClick={handleClick}
-                onFocus={onFocus}
                 sectionContentUniqueId={sectionContentUniqueId}
                 headerStyle={headerStyle}
                 tag={tag}
@@ -327,9 +319,6 @@ const styles = StyleSheet.create({
     },
     wrapperExpanded: {
         gridTemplateRows: "min-content 1fr",
-    },
-    contentWrapper: {
-        overflow: "hidden",
     },
     conentWrapperCollapsed: {
         // Make sure screen readers don't read the content when it's


### PR DESCRIPTION
Summary:
Adjusts Accordion element to only handle keydown events when an Accordion header is focused. Previously, an "active header" index would be set, but not unset when the header was blurred. Rather than adding `onBlur` handlers throughout `Clickable`, instead remove active index state and check the `activeElement` from the document at the time a keydown event is fired.

Issue: WB-1656

Test:
Added a story, "With Dropdown" to Accordion docs.