### PR TITLE
WB-1638: Fix tabbing in popover

### DIFF
--- a/.changeset/cyan-oranges-wait.md
+++ b/.changeset/cyan-oranges-wait.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+---
+
+Fix tab navigation order

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -391,7 +391,7 @@ export const CustomPopoverContent: StoryComponentType = {
 export const KeyboardNavigation: StoryComponentType = {
     render: function Render() {
         const [numButtonsAfter, setNumButtonsAfter] = React.useState(0);
-        const [numButtonsInside, setNumButtonsInside] = React.useState(0);
+        const [numButtonsInside, setNumButtonsInside] = React.useState(1);
 
         return (
             <View>

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -360,6 +360,58 @@ export const CustomPopoverContent: StoryComponentType = {
         id: "custom-popover",
     } as PopoverArgs,
 };
+
+/**
+ * This example shows how the focus is managed when a popover is opened. If the
+ * popover is closed, the focus flows naturally. However, if the popover is
+ * opened, the focus is managed internally by the `Popover` component.
+ *
+ * The focus is managed in the following way:
+ * - When the popover is opened, the focus is set on the first focusable element
+ *  inside the popover.
+ * - When the popover is closed, the focus is returned to the element that
+ * triggered the popover.
+ * - If the popover is opened and the focus reaches the last focusable element
+ * inside the popover, the next tab will set focus on the next focusable
+ * element that exists after the PopoverAnchor (or trigger element).
+ * - If the focus is set to the first focusable element inside the popover, the
+ * next shift + tab will set focus on the PopoverAnchor element.
+ */
+export const KeyboardNavigation: StoryComponentType = {
+    render: () => {
+        return (
+            <View style={{flexDirection: "row", gap: 16}}>
+                <Button>First button</Button>
+                <Popover
+                    content={({close}) => (
+                        <PopoverContent
+                            closeButtonVisible
+                            title="Keyboard navigation"
+                            content="This example shows how the focus is managed when a popover is opened."
+                            actions={
+                                <View style={[styles.row, styles.actions]}>
+                                    <Button kind="tertiary">An action</Button>
+                                </View>
+                            }
+                        />
+                    )}
+                    placement="top"
+                >
+                    <Button>Open popover</Button>
+                </Popover>
+                <Button>Button after popover</Button>
+                <Button>Last button</Button>
+            </View>
+        );
+    },
+    parameters: {
+        // This example is behavior based, not visual.
+        chromatic: {
+            disableSnapshot: true,
+        },
+    },
+};
+
 /**
  * Alignment example
  */

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -390,7 +390,8 @@ export const CustomPopoverContent: StoryComponentType = {
  */
 export const KeyboardNavigation: StoryComponentType = {
     render: function Render() {
-        const [numButtons, setNumButtons] = React.useState(0);
+        const [numButtonsAfter, setNumButtonsAfter] = React.useState(0);
+        const [numButtonsInside, setNumButtonsInside] = React.useState(0);
 
         return (
             <View>
@@ -398,7 +399,7 @@ export const KeyboardNavigation: StoryComponentType = {
                     <Button
                         kind="secondary"
                         onClick={() => {
-                            setNumButtons(numButtons + 1);
+                            setNumButtonsAfter(numButtonsAfter + 1);
                         }}
                     >
                         Add button after trigger element
@@ -407,12 +408,31 @@ export const KeyboardNavigation: StoryComponentType = {
                         kind="secondary"
                         color="destructive"
                         onClick={() => {
-                            if (numButtons > 0) {
-                                setNumButtons(numButtons - 1);
+                            if (numButtonsAfter > 0) {
+                                setNumButtonsAfter(numButtonsAfter - 1);
                             }
                         }}
                     >
                         Remove button after trigger element
+                    </Button>
+                    <Button
+                        kind="secondary"
+                        onClick={() => {
+                            setNumButtonsInside(numButtonsInside + 1);
+                        }}
+                    >
+                        Add button inside popover
+                    </Button>
+                    <Button
+                        kind="secondary"
+                        color="destructive"
+                        onClick={() => {
+                            if (numButtonsAfter > 0) {
+                                setNumButtonsInside(numButtonsInside - 1);
+                            }
+                        }}
+                    >
+                        Remove button inside popover
                     </Button>
                 </View>
                 <View style={styles.playground}>
@@ -425,9 +445,18 @@ export const KeyboardNavigation: StoryComponentType = {
                                 content="This example shows how the focus is managed when a popover is opened."
                                 actions={
                                     <View style={[styles.row, styles.actions]}>
-                                        <Button kind="tertiary">
-                                            An action
-                                        </Button>
+                                        {Array.from(
+                                            {length: numButtonsInside},
+                                            (_, index) => (
+                                                <Button
+                                                    onClick={() => {}}
+                                                    key={index}
+                                                    kind="tertiary"
+                                                >
+                                                    {`Button ${index + 1}`}
+                                                </Button>
+                                            ),
+                                        )}
                                     </View>
                                 }
                             />
@@ -436,7 +465,7 @@ export const KeyboardNavigation: StoryComponentType = {
                     >
                         <Button>Open popover (trigger element)</Button>
                     </Popover>
-                    {Array.from({length: numButtons}, (_, index) => (
+                    {Array.from({length: numButtonsAfter}, (_, index) => (
                         <Button onClick={() => {}} key={index}>
                             {`Button ${index + 1}`}
                         </Button>

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -3,6 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
+import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
@@ -79,6 +80,13 @@ const styles = StyleSheet.create({
         alignItems: "center",
         flex: 1,
         justifyContent: "space-between",
+    },
+    playground: {
+        border: `1px dashed ${Color.lightBlue}`,
+        marginTop: Spacing.large_24,
+        padding: Spacing.large_24,
+        flexDirection: "row",
+        gap: Spacing.medium_16,
     },
 });
 
@@ -376,31 +384,64 @@ export const CustomPopoverContent: StoryComponentType = {
  * element that exists after the PopoverAnchor (or trigger element).
  * - If the focus is set to the first focusable element inside the popover, the
  * next shift + tab will set focus on the PopoverAnchor element.
+ *
+ * **NOTE:** You can add/remove buttons after the trigger element by using the
+ * buttons at the top of the example.
  */
 export const KeyboardNavigation: StoryComponentType = {
-    render: () => {
+    render: function Render() {
+        const [numButtons, setNumButtons] = React.useState(0);
+
         return (
-            <View style={{flexDirection: "row", gap: 16}}>
-                <Button>First button</Button>
-                <Popover
-                    content={({close}) => (
-                        <PopoverContent
-                            closeButtonVisible
-                            title="Keyboard navigation"
-                            content="This example shows how the focus is managed when a popover is opened."
-                            actions={
-                                <View style={[styles.row, styles.actions]}>
-                                    <Button kind="tertiary">An action</Button>
-                                </View>
+            <View>
+                <View style={[styles.row, {gap: Spacing.medium_16}]}>
+                    <Button
+                        kind="secondary"
+                        onClick={() => {
+                            setNumButtons(numButtons + 1);
+                        }}
+                    >
+                        Add button after trigger element
+                    </Button>
+                    <Button
+                        kind="secondary"
+                        color="destructive"
+                        onClick={() => {
+                            if (numButtons > 0) {
+                                setNumButtons(numButtons - 1);
                             }
-                        />
-                    )}
-                    placement="top"
-                >
-                    <Button>Open popover</Button>
-                </Popover>
-                <Button>Button after popover</Button>
-                <Button>Last button</Button>
+                        }}
+                    >
+                        Remove button after trigger element
+                    </Button>
+                </View>
+                <View style={styles.playground}>
+                    <Button>First button</Button>
+                    <Popover
+                        content={({close}) => (
+                            <PopoverContent
+                                closeButtonVisible
+                                title="Keyboard navigation"
+                                content="This example shows how the focus is managed when a popover is opened."
+                                actions={
+                                    <View style={[styles.row, styles.actions]}>
+                                        <Button kind="tertiary">
+                                            An action
+                                        </Button>
+                                    </View>
+                                }
+                            />
+                        )}
+                        placement="top"
+                    >
+                        <Button>Open popover (trigger element)</Button>
+                    </Popover>
+                    {Array.from({length: numButtons}, (_, index) => (
+                        <Button onClick={() => {}} key={index}>
+                            {`Button ${index + 1}`}
+                        </Button>
+                    ))}
+                </View>
             </View>
         );
     },

--- a/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.tsx
@@ -1,31 +1,19 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import FocusManager from "../focus-manager";
-import {findFocusableNodes} from "../../util/util";
 
 describe("FocusManager", () => {
     it("should focus on the first focusable element inside the popover", async () => {
         // Arrange
-        const ref = await new Promise((resolve: any) => {
-            const nodes = (
-                <div ref={resolve}>
-                    <button>Open popover</button>
-                    <button>Next focusable element outside</button>
-                </div>
-            );
-            render(nodes);
-        });
-        // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
-        const domNode = ReactDOM.findDOMNode(ref) as HTMLElement;
-
-        // mock focusable elements in document
-        // eslint-disable-next-line testing-library/no-node-access
-        global.document.querySelectorAll = jest
-            .fn()
-            .mockImplementation(() => findFocusableNodes(domNode));
+        const externalNodes = (
+            <div>
+                <button>Open popover</button>
+                <button>Next focusable element outside</button>
+            </div>
+        );
+        render(externalNodes);
 
         // get the anchor reference to be able pass it to the FocusManager
         const anchorElementNode = screen.getByRole("button", {
@@ -58,23 +46,13 @@ describe("FocusManager", () => {
 
     it("should focus on the last focusable element inside the popover", async () => {
         // Arrange
-        const ref = await new Promise((resolve: any) => {
-            const nodes = (
-                <div ref={resolve}>
-                    <button>Open popover</button>
-                    <button>Next focusable element outside</button>
-                </div>
-            );
-            render(nodes);
-        });
-        // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
-        const domNode = ReactDOM.findDOMNode(ref) as HTMLElement;
-
-        // mock focusable elements in document
-        // eslint-disable-next-line testing-library/no-node-access
-        global.document.querySelectorAll = jest
-            .fn()
-            .mockImplementation(() => findFocusableNodes(domNode));
+        const externalNodes = (
+            <div>
+                <button>Open popover</button>
+                <button>Next focusable element outside</button>
+            </div>
+        );
+        render(externalNodes);
 
         // get the anchor reference to be able pass it to the FocusManager
         const anchorElementNode = screen.getByRole("button", {
@@ -108,5 +86,106 @@ describe("FocusManager", () => {
 
         // Assert
         expect(lastFocusableElementInside).toHaveFocus();
+    });
+
+    it("should allow flowing the focus correctly", async () => {
+        // Arrange
+        const externalNodes = (
+            <div>
+                <button>Prev focusable element outside</button>
+                <button>Open popover</button>
+                <button>Next focusable element outside</button>
+            </div>
+        );
+        render(externalNodes);
+
+        // get the anchor reference to be able pass it to the FocusManager
+        const anchorElementNode = screen.getByRole("button", {
+            name: "Open popover",
+        });
+
+        render(
+            <FocusManager anchorElement={anchorElementNode}>
+                <div>
+                    <button>first focusable element inside</button>
+                </div>
+            </FocusManager>,
+        );
+
+        // Act
+        // 1. focus on the previous element before the popover
+        userEvent.tab();
+
+        // 2. focus on the anchor element
+        userEvent.tab();
+
+        // 3. focus on focusable element inside the popover
+        userEvent.tab();
+
+        // 4. focus on the next focusable element outside the popover (this will
+        //    be the first focusable element outside the popover)
+        userEvent.tab();
+
+        // NOTE: At this point, the focus moves to the document body, so we need
+        // to press tab again to move the focus to the next focusable element.
+        userEvent.tab();
+
+        // 5. Finally focus on the first element in the document
+        userEvent.tab();
+
+        // find previous focusable element outside the popover
+        const prevFocusableElementOutside = screen.getByRole("button", {
+            name: "Prev focusable element outside",
+        });
+
+        // Assert
+        expect(prevFocusableElementOutside).toHaveFocus();
+    });
+
+    it("should disallow focusability on internal elements if the user focus out of the focus manager", async () => {
+        // Arrange
+        const externalNodes = (
+            <div>
+                <button>Prev focusable element outside</button>
+                <button>Open popover</button>
+                <button>Next focusable element outside</button>
+            </div>
+        );
+        render(externalNodes);
+
+        // get the anchor reference to be able pass it to the FocusManager
+        const anchorElementNode = screen.getByRole("button", {
+            name: "Open popover",
+        });
+
+        render(
+            <FocusManager anchorElement={anchorElementNode}>
+                <div>
+                    <button>first focusable element inside</button>
+                </div>
+            </FocusManager>,
+        );
+
+        // Act
+        // 1. focus on the previous element before the popover
+        userEvent.tab();
+
+        // 2. focus on the anchor element
+        userEvent.tab();
+
+        // 3. focus on focusable element inside the popover
+        userEvent.tab();
+
+        // 4. focus on the next focusable element outside the popover (this will
+        //    be the first focusable element outside the popover)
+        userEvent.tab();
+
+        // The elements inside the focus manager should not be focusable anymore.
+        const focusableElementInside = screen.getByRole("button", {
+            name: "first focusable element inside",
+        });
+
+        // Assert
+        expect(focusableElementInside).toHaveAttribute("tabIndex", "-1");
     });
 });

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -356,4 +356,191 @@ describe("Popover", () => {
             ).toBeInTheDocument();
         });
     });
+
+    describe("keyboard navigation", () => {
+        it("should move focus to the first focusable element after popover is open", async () => {
+            // Arrange
+            render(
+                <>
+                    <Button>Prev focusable element outside</Button>
+                    <Popover
+                        onClose={jest.fn()}
+                        content={
+                            <PopoverContent
+                                title="Popover title"
+                                content="content"
+                                actions={<Button>Button inside popover</Button>}
+                            />
+                        }
+                    >
+                        <Button>Open default popover</Button>
+                    </Popover>
+                    <Button>Next focusable element outside</Button>
+                </>,
+            );
+
+            // Focus on the first element outside the popover
+            userEvent.tab();
+            // open the popover by focusing on the trigger element
+            userEvent.tab();
+            userEvent.keyboard("{enter}");
+
+            // Act
+            // Wait for the popover to be open.
+            await screen.findByRole("dialog");
+
+            // Assert
+            // Focus should move to the button inside the popover
+            expect(
+                screen.getByRole("button", {
+                    name: "Button inside popover",
+                }),
+            ).toHaveFocus();
+        });
+
+        it("should allow flowing focus correctly even if the popover remains open", async () => {
+            // Arrange
+            render(
+                <>
+                    <Button>Prev focusable element outside</Button>
+                    <Popover
+                        onClose={jest.fn()}
+                        content={
+                            <PopoverContent
+                                title="Popover title"
+                                content="content"
+                                actions={<Button>Button inside popover</Button>}
+                            />
+                        }
+                    >
+                        <Button>Open default popover</Button>
+                    </Popover>
+                    <Button>Next focusable element outside</Button>
+                </>,
+            );
+
+            // Focus on the first element outside the popover
+            userEvent.tab();
+            // open the popover by focusing on the trigger element
+            userEvent.tab();
+            userEvent.keyboard("{enter}");
+
+            // Wait for the popover to be open.
+            await screen.findByRole("dialog");
+
+            // Act
+            // Focus on the next element after the popover
+            userEvent.tab();
+
+            // Assert
+            expect(
+                screen.getByRole("button", {
+                    name: "Next focusable element outside",
+                }),
+            ).toHaveFocus();
+        });
+
+        it("should allow circular navigation when the popover is open", async () => {
+            // Arrange
+            render(
+                <>
+                    <Button>Prev focusable element outside</Button>
+                    <Popover
+                        onClose={jest.fn()}
+                        content={
+                            <PopoverContent
+                                title="Popover title"
+                                content="content"
+                                actions={<Button>Button inside popover</Button>}
+                            />
+                        }
+                    >
+                        <Button>Open default popover</Button>
+                    </Popover>
+                    <Button>Next focusable element outside</Button>
+                </>,
+            );
+
+            // Focus on the first element outside the popover
+            userEvent.tab();
+            // open the popover by focusing on the trigger element
+            userEvent.tab();
+            userEvent.keyboard("{enter}");
+
+            // Wait for the popover to be open.
+            await screen.findByRole("dialog");
+
+            // Focus on the next element after the popover
+            userEvent.tab();
+
+            // Focus on the document body
+            userEvent.tab();
+
+            // Act
+            // Focus again on the first element in the document.
+            userEvent.tab();
+
+            // Assert
+            expect(
+                screen.getByRole("button", {
+                    name: "Prev focusable element outside",
+                }),
+            ).toHaveFocus();
+        });
+
+        it("should allow navigating backwards when the popover is open", async () => {
+            // Arrange
+            render(
+                <>
+                    <Button>Prev focusable element outside</Button>
+                    <Popover
+                        onClose={jest.fn()}
+                        content={
+                            <PopoverContent
+                                title="Popover title"
+                                content="content"
+                                actions={<Button>Button inside popover</Button>}
+                            />
+                        }
+                    >
+                        <Button>Open default popover</Button>
+                    </Popover>
+                    <Button>Next focusable element outside</Button>
+                </>,
+            );
+
+            // Open the popover
+            userEvent.click(
+                screen.getByRole("button", {name: "Open default popover"}),
+            );
+
+            // Wait for the popover to be open.
+            await screen.findByRole("dialog");
+
+            // At this point, the focus moves to the focusable element inside
+            // the popover, so we need to move the focus back to the trigger
+            // element.
+            userEvent.tab({shift: true});
+
+            // Focus on the first element in the document
+            userEvent.tab({shift: true});
+
+            // Focus on the document body
+            userEvent.tab({shift: true});
+
+            // Focus on the last element in the document
+            userEvent.tab({shift: true});
+
+            // Act
+            // Focus again on element inside the popover.
+            userEvent.tab({shift: true});
+
+            // Assert
+            expect(
+                screen.getByRole("button", {
+                    name: "Button inside popover",
+                }),
+            ).toHaveFocus();
+        });
+    });
 });

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -369,7 +369,12 @@ describe("Popover", () => {
                             <PopoverContent
                                 title="Popover title"
                                 content="content"
-                                actions={<Button>Button inside popover</Button>}
+                                actions={
+                                    <>
+                                        <Button>Button 1 inside popover</Button>
+                                        <Button>Button 2 inside popover</Button>
+                                    </>
+                                }
                             />
                         }
                     >
@@ -390,10 +395,10 @@ describe("Popover", () => {
             await screen.findByRole("dialog");
 
             // Assert
-            // Focus should move to the button inside the popover
+            // Focus should move to the first button inside the popover
             expect(
                 screen.getByRole("button", {
-                    name: "Button inside popover",
+                    name: "Button 1 inside popover",
                 }),
             ).toHaveFocus();
         });

--- a/packages/wonder-blocks-popover/src/components/focus-manager.tsx
+++ b/packages/wonder-blocks-popover/src/components/focus-manager.tsx
@@ -51,6 +51,10 @@ export default class FocusManager extends React.Component<Props> {
         this.addEventListeners();
     }
 
+    componentDidUpdate() {
+        this.addEventListeners();
+    }
+
     /**
      * Remove keydown listeners
      */

--- a/packages/wonder-blocks-popover/src/components/focus-manager.tsx
+++ b/packages/wonder-blocks-popover/src/components/focus-manager.tsx
@@ -102,6 +102,21 @@ export default class FocusManager extends React.Component<Props> {
             );
         }
 
+        if (this.rootNode) {
+            // store the list of possible focusable elements inside the popover
+            this.elementsThatCanBeFocusableInsidePopover = findFocusableNodes(
+                this.rootNode,
+            );
+
+            // find the first and last focusable elements inside the popover
+            this.firstFocusableElementInPopover =
+                this.elementsThatCanBeFocusableInsidePopover[0];
+            this.lastFocusableElementInPopover =
+                this.elementsThatCanBeFocusableInsidePopover[
+                    this.elementsThatCanBeFocusableInsidePopover.length - 1
+                ];
+        }
+
         // tries to get the next focusable element outside of the popover
         this.nextElementAfterPopover = this.getNextFocusableElement();
 
@@ -145,6 +160,12 @@ export default class FocusManager extends React.Component<Props> {
                 "keydown",
                 this.handleKeydownPreviousFocusableElement,
             );
+        }
+
+        if (!this.nextElementAfterPopover) {
+            window.removeEventListener("blur", () => {
+                this.changeFocusabilityInsidePopover(true);
+            });
         }
 
         if (this.firstFocusableElementInPopover) {
@@ -243,19 +264,6 @@ export default class FocusManager extends React.Component<Props> {
         }
 
         this.rootNode = rootNode as HTMLElement;
-
-        // store the list of possible focusable elements inside the popover
-        this.elementsThatCanBeFocusableInsidePopover = findFocusableNodes(
-            this.rootNode,
-        );
-
-        // find the first and last focusable elements inside the popover
-        this.firstFocusableElementInPopover =
-            this.elementsThatCanBeFocusableInsidePopover[0];
-        this.lastFocusableElementInPopover =
-            this.elementsThatCanBeFocusableInsidePopover[
-                this.elementsThatCanBeFocusableInsidePopover.length - 1
-            ];
     };
 
     /**

--- a/packages/wonder-blocks-popover/src/components/focus-manager.tsx
+++ b/packages/wonder-blocks-popover/src/components/focus-manager.tsx
@@ -67,7 +67,6 @@ export default class FocusManager extends React.Component<Props> {
             anchorElement.removeEventListener(
                 "keydown",
                 this.handleKeydownPreviousFocusableElement,
-                false,
             );
         }
 
@@ -75,7 +74,6 @@ export default class FocusManager extends React.Component<Props> {
             this.nextElementAfterPopover.removeEventListener(
                 "keydown",
                 this.handleKeydownNextFocusableElement,
-                false,
             );
         }
     }
@@ -100,7 +98,6 @@ export default class FocusManager extends React.Component<Props> {
             anchorElement.addEventListener(
                 "keydown",
                 this.handleKeydownPreviousFocusableElement,
-                // true,
             );
         }
 
@@ -111,7 +108,6 @@ export default class FocusManager extends React.Component<Props> {
             this.nextElementAfterPopover.addEventListener(
                 "keydown",
                 this.handleKeydownNextFocusableElement,
-                // true,
             );
         }
     };


### PR DESCRIPTION
## Summary:
There is a bug in the popover where tabbing out of the popover (while it
is still open) will cause the focus order to be incorrect. More
specifically, the focus will be returned to the trigger element, while
it should be returned to the next element in the tab order.

This is because the popover is not properly handling the case where the
trigger element is the last element in the tab order. This PR fixes that
by making all the focusable elements in the popover non-tabbable, and
then make them tabbable again when the popover gains focus.

For more reference on the actual error, see: https://khanacademy.atlassian.net/browse/CL-1259

https://github.com/Khan/wonder-blocks/assets/843075/ca72e266-9091-409e-9065-3754e4c681c9

Issue: WB-1638

## Test plan:

- Navigate to /?path=/story/popover-popover--keyboard-navigation
- Start tabbing through the elements in the story
- Verify that the focus order is correct
- Open the popover
- Tab through the elements in the popover and verify that the focus
  order is still correct
- Tab backwards through the elements in the popover and verify that the
  focus order is still correct (using shift+tab).
- Close the popover and verify that the focus order is still correct


https://github.com/Khan/wonder-blocks/assets/843075/a8831575-84a8-4bb3-a0f3-11a26d872076

