### PR TITLE
WB-1654: Popover trigger element is stealing focus from other focusable elements [FIX]

### DIFF
--- a/.changeset/clever-trees-confess.md
+++ b/.changeset/clever-trees-confess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+---
+
+Don't return focus to trigger element if the focus has to go to a different interactive element

--- a/packages/wonder-blocks-popover/src/components/focus-manager.tsx
+++ b/packages/wonder-blocks-popover/src/components/focus-manager.tsx
@@ -61,15 +61,8 @@ export default class FocusManager extends React.Component<Props> {
      * Remove keydown listeners
      */
     componentWillUnmount() {
-        const {anchorElement} = this.props;
-
         // Reset focusability
         this.changeFocusabilityInsidePopover(true);
-
-        if (anchorElement) {
-            // wait for styles to applied, then return the focus to the anchor
-            setTimeout(() => anchorElement.focus(), 0);
-        }
 
         this.removeEventListeners();
     }

--- a/packages/wonder-blocks-popover/src/components/popover-event-listener.ts
+++ b/packages/wonder-blocks-popover/src/components/popover-event-listener.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import {isFocusable} from "../util/util";
 
 import PopoverContent from "./popover-content";
 import PopoverContentCore from "./popover-content-core";
@@ -8,7 +9,7 @@ type Props = {
     /**
      * Called when `esc` is pressed
      */
-    onClose: () => unknown;
+    onClose: (shouldReturnFocus: boolean) => unknown;
     /**
      * Popover Content ref.
      * Will close the popover when clicking outside this element.
@@ -59,7 +60,9 @@ export default class PopoverEventListener extends React.Component<
             // unexpectedly cancels multiple things.
             e.preventDefault();
             e.stopPropagation();
-            this.props.onClose();
+            // In the case of the Escape key, we should return focus to the
+            // trigger button.
+            this.props.onClose(true);
         }
     };
 
@@ -77,7 +80,13 @@ export default class PopoverEventListener extends React.Component<
             // Only allow click to cancel one thing at a time.
             e.preventDefault();
             e.stopPropagation();
-            this.props.onClose();
+
+            // Determine if the focus must go to a focusable/interactive
+            // element.
+            const shouldReturnFocus = !isFocusable(e.target as any);
+            // If that's the case, we need to prevent the default behavior of
+            // returning the focus to the trigger button.
+            this.props.onClose(shouldReturnFocus);
         }
     };
 

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -174,9 +174,16 @@ export default class Popover extends React.Component<Props, State> {
     /**
      * Popover dialog closed
      */
-    handleClose: () => void = () => {
+    handleClose: (shouldReturnFocus?: boolean) => void = (
+        shouldReturnFocus = true,
+    ) => {
+        const {anchorElement} = this.state;
         this.setState({opened: false}, () => {
             this.props.onClose?.();
+
+            if (shouldReturnFocus) {
+                anchorElement?.focus();
+            }
         });
     };
 
@@ -185,7 +192,7 @@ export default class Popover extends React.Component<Props, State> {
      */
     handleOpen: () => void = () => {
         if (this.props.dismissEnabled && this.state.opened) {
-            this.setState({opened: false});
+            this.handleClose(true);
         } else {
             this.setState({opened: true});
         }

--- a/packages/wonder-blocks-popover/src/util/__tests__/util.test.tsx
+++ b/packages/wonder-blocks-popover/src/util/__tests__/util.test.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import {isFocusable} from "../util";
+
+describe("isFocusable", () => {
+    it("should mark a button as focusable", () => {
+        // Arrange
+        render(<button>Open popover</button>);
+
+        // Act
+        const result = isFocusable(screen.getByRole("button"));
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("should mark a div as non-focusable", () => {
+        // Arrange
+        render(<div>placeholder</div>);
+
+        // Act
+        const result = isFocusable(screen.getByText("placeholder"));
+
+        // Assert
+        expect(result).toBe(false);
+    });
+
+    it("should mark a div with tabIndex greater than -1 as focusable", () => {
+        // Arrange
+        render(<div tabIndex={0}>placeholder</div>);
+
+        // Act
+        const result = isFocusable(screen.getByText("placeholder"));
+
+        // Assert
+        expect(result).toBe(true);
+    });
+});

--- a/packages/wonder-blocks-popover/src/util/util.ts
+++ b/packages/wonder-blocks-popover/src/util/util.ts
@@ -10,3 +10,11 @@ export function findFocusableNodes(
 ): Array<HTMLElement> {
     return Array.from(root.querySelectorAll(FOCUSABLE_ELEMENTS));
 }
+
+/**
+ * Checks if an element is focusable
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
+ */
+export function isFocusable(element: HTMLElement): boolean {
+    return element.matches(FOCUSABLE_ELEMENTS);
+}


### PR DESCRIPTION
## Summary:

As soon as a popover is closed, we return focus to its trigger element (or
element that caused the popover to open). This works fine in most cases, but
there are situations where we don’t want to do that.

For example, when there are multiple Popovers within the same context and the
user opens a separate popover, the previous opened popover closes, but in this
case the focus is being moved from the new popover to the trigger element of the
previous popover.

This PR fixes this by detecting if the element that caused the popover to be
dismissed is an element that can be focused, and if so, we let the focus flow
naturally to that element. If not, we return focus to the trigger element.

Issue: https://khanacademy.atlassian.net/browse/WB-1654

## Test plan:

- Open the popover docs page.
- Scroll down to the first story.
- Click on the popover trigger button and verify that the popover opens.
- Now click on the popover trigger button of the second story and wait until
  the first popover closes and the second popover opens.
- Verify that the focus is not being moved to the trigger element of the
  first popover.

| BEFORE | AFTER |
|--------|--------|
| https://github.com/Khan/wonder-blocks/assets/843075/3024ed9c-491e-4963-9b1c-53ae3034870e | https://github.com/Khan/wonder-blocks/assets/843075/a0a2fc3a-9656-4505-a20e-6ee2e795ec83 | 