### PR TITLE
WB-1657: Add support to `closedFocusId` prop in Popover

### DIFF
--- a/.changeset/strong-lemons-crash.md
+++ b/.changeset/strong-lemons-crash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-popover": minor
+---
+
+Add `closedFocusId` prop to manually return focus to a specific element

--- a/__docs__/wonder-blocks-popover/popover.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover.argtypes.tsx
@@ -85,6 +85,15 @@ export default {
             `title will have the ID \`"my-popover-title"\` and the popover ` +
             `content will have the ID \`"my-popover-content"\`.`,
     },
+    closedFocusId: {
+        description:
+            `The selector for the element that will be focused after the ` +
+            `popover dialog closes. When not set, the element that triggered ` +
+            `the popover will be used.`,
+        control: {
+            type: "text",
+        },
+    },
     initialFocusId: {
         description:
             `The selector for the element that will be focused when the ` +

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -352,6 +352,42 @@ WithInitialFocusId.parameters = {
 };
 
 /**
+ * You can use the `closedFocusId` prop on the `Popover` component to specify
+ * where to set the focus after the popover dialog has been closed. This is
+ * useful for cases when you need to return the focus to a specific element.
+ *
+ * In this example, `closedFocusId` is set to the ID of the button labeled
+ * "Focus here after close.", and it means that the focus will be set on that
+ * button after the popover dialog has been closed/dismissed.
+ */
+export const WithClosedFocusId: StoryComponentType = {
+    name: "With closedFocusId",
+    render: () => (
+        <View style={{gap: 20}}>
+            <Button id="button-to-focus-on">Focus here after close</Button>
+            <Popover
+                dismissEnabled={true}
+                closedFocusId="button-to-focus-on"
+                content={
+                    <PopoverContent
+                        closeButtonVisible={true}
+                        title="Returning focus to a specific element"
+                        content='After dismissing the popover, the focus will be set on the button labeled "Focus here after close."'
+                    />
+                }
+            >
+                <Button>Open popover</Button>
+            </Popover>
+        </View>
+    ),
+    parameters: {
+        chromatic: {
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
  * Popovers can have custom layouts. This is done by using the
  * `PopoverContentCore` component.
  *

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -263,6 +263,87 @@ describe("Popover", () => {
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
+    describe("return focus", () => {
+        it("should return focus to the trigger element by default", async () => {
+            // Arrange
+            render(
+                <Popover
+                    dismissEnabled={true}
+                    content={
+                        <PopoverContent
+                            closeButtonVisible={true}
+                            title="Returning focus to a specific element"
+                            content='After dismissing the popover, the focus will be set on the button labeled "Focus here after close."'
+                        />
+                    }
+                >
+                    <Button>Open popover</Button>
+                </Popover>,
+            );
+
+            const anchorButton = screen.getByRole("button", {
+                name: "Open popover",
+            });
+
+            // open the popover
+            userEvent.click(anchorButton);
+            await screen.findByRole("dialog");
+
+            // Act
+            const closeButton = screen.getByRole("button", {
+                name: "Close Popover",
+            });
+            closeButton.click();
+
+            // Assert
+            expect(anchorButton).toHaveFocus();
+        });
+
+        it("should return focus to a specific element if closedFocusId is set", async () => {
+            // Arrange
+            render(
+                <View>
+                    <Button id="button-to-focus-on">
+                        Focus here after close
+                    </Button>
+                    <Popover
+                        closedFocusId="button-to-focus-on"
+                        dismissEnabled={true}
+                        content={
+                            <PopoverContent
+                                closeButtonVisible={true}
+                                title="Returning focus to a specific element"
+                                content='After dismissing the popover, the focus will be set on the button labeled "Focus here after close."'
+                            />
+                        }
+                    >
+                        <Button>Open popover</Button>
+                    </Popover>
+                </View>,
+            );
+
+            const anchorButton = screen.getByRole("button", {
+                name: "Open popover",
+            });
+
+            // open the popover
+            userEvent.click(anchorButton);
+            await screen.findByRole("dialog");
+
+            // Act
+            const closeButton = screen.getByRole("button", {
+                name: "Close Popover",
+            });
+            closeButton.click();
+
+            // Assert
+            const buttonToFocusOn = screen.getByRole("button", {
+                name: "Focus here after close",
+            });
+            expect(buttonToFocusOn).toHaveFocus();
+        });
+    });
+
     describe("dismissEnabled", () => {
         it("should close the Popover if dismissEnabled is set", async () => {
             // Arrange

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -70,6 +70,12 @@ type Props = AriaProps &
          */
         id?: string;
         /**
+         * The selector for the element that will be focused after the popover
+         * dialog closes. When not set, the element that triggered the popover
+         * will be used.
+         */
+        closedFocusId?: string;
+        /**
          * The selector for the element that will be focused when the popover
          * content shows. When not set, the first focusable element within the
          * popover content will be used.
@@ -172,17 +178,40 @@ export default class Popover extends React.Component<Props, State> {
         React.createRef();
 
     /**
+     * Returns focus to a given element.
+     */
+    maybeReturnFocus = () => {
+        const {anchorElement} = this.state;
+        const {closedFocusId} = this.props;
+
+        // Focus on the specified element after dismissing the popover.
+        if (closedFocusId) {
+            const focusElement = ReactDOM.findDOMNode(
+                document.getElementById(closedFocusId),
+            ) as any;
+
+            focusElement?.focus();
+            return;
+        }
+
+        // If no element is specified, focus on the element that triggered the
+        // popover.
+        if (anchorElement) {
+            anchorElement.focus();
+        }
+    };
+
+    /**
      * Popover dialog closed
      */
     handleClose: (shouldReturnFocus?: boolean) => void = (
         shouldReturnFocus = true,
     ) => {
-        const {anchorElement} = this.state;
         this.setState({opened: false}, () => {
             this.props.onClose?.();
 
             if (shouldReturnFocus) {
-                anchorElement?.focus();
+                this.maybeReturnFocus();
             }
         });
     };


### PR DESCRIPTION
## Summary:

Allows manually redirecting the focus after the popover is closed/hidden. This
feature already exists in the WB Modal package, and this commit adds support to
the popover package.

The `closedFocusId` prop is a string that represents the id of the element that
should receive focus after the popover is closed. If the element is not found,
the focus will be set to the element that triggered the popover.

This feature has been requested by the Perseus team.

Issue: https://khanacademy.atlassian.net/browse/WB-1657

## Test plan:

- Navigate to /?path=/docs/popover-popover--docs#with-closedfocusid
- Verify that the popover returns focus to the first button after it is closed.


https://github.com/Khan/wonder-blocks/assets/843075/a6ab6c20-2abe-4eec-b6b0-513c2392cc52

