### PR TITLE
WB-1641.1: Create wonder-blocks-tokens package

### DIFF
--- a/.changeset/metal-boxes-turn.md
+++ b/.changeset/metal-boxes-turn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add skeleton for tokens package

--- a/packages/wonder-blocks-tokens/package.json
+++ b/packages/wonder-blocks-tokens/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@khanacademy/wonder-blocks-tokens",
+    "version": "0.0.1",
+    "description": "Core primitive design tokens for Web Wonder Blocks",
+    "main": "dist/index.js",
+    "module": "dist/es/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "",
+    "license": "MIT",
+    "publishConfig": {
+        "access": "restricted"
+    },
+    "private": true,
+    "dependencies": {
+        "@khanacademy/wonder-blocks-color": "^3.0.0",
+        "@khanacademy/wonder-blocks-spacing": "^4.0.1"
+    },
+    "devDependencies": {
+        "@khanacademy/wb-dev-build-settings": "^1.0.0"
+    }
+}

--- a/packages/wonder-blocks-tokens/src/index.ts
+++ b/packages/wonder-blocks-tokens/src/index.ts
@@ -1,0 +1,2 @@
+// Just a temporary export to include some code.
+export const NOTHING = "NOTHING";

--- a/packages/wonder-blocks-tokens/tsbuild-config.json
+++ b/packages/wonder-blocks-tokens/tsbuild-config.json
@@ -1,0 +1,18 @@
+{
+    "exclude": [
+        "dist"
+    ],
+    "extends": "../tsconfig-shared.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "src"
+    },
+    "references": [
+        {
+            "path": "../wonder-blocks-color/tsconfig-build.json"
+        },
+        {
+            "path": "../wonder-blocks-spacing/tsconfig-build.json"
+        }
+    ]
+}

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -34,6 +34,7 @@
         {"path": "./packages/wonder-blocks-testing/tsconfig-build.json"},
         {"path": "./packages/wonder-blocks-theming/tsconfig-build.json"},
         {"path": "./packages/wonder-blocks-timing/tsconfig-build.json"},
+        {"path": "./packages/wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "./packages/wonder-blocks-toolbar/tsconfig-build.json"},
         {"path": "./packages/wonder-blocks-tooltip/tsconfig-build.json"},
         {"path": "./packages/wonder-blocks-typography/tsconfig-build.json"},


### PR DESCRIPTION
## Summary:

Adds a new package `wonder-blocks-tokens` that will contain the design tokens
for Web Wonder Blocks.

**NOTE:** The next PR will include the migration of the existing tokens from
`@khanacademy/wonder-blocks-theming` to `wonder-blocks-tokens`. (Other PRs will
move color and spacing here as well.)

Issue: WB-1641

## Test plan:

N/A