### PR TITLE
Accordion keyboard nav: stop nav keys from causing page scroll

### DIFF
--- a/.changeset/fifty-countries-fry.md
+++ b/.changeset/fifty-countries-fry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Prevent default in home, end, and arrow keys

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -508,6 +508,10 @@ export const NotCollapsible: StoryComponentType = {
  * If `animated` is specified both here in the AccordionSection
  * and within a parent Accordion component, the AccordionSection's
  * `animated` value is prioritized.
+ *
+ * **NOTE: HEIGHT ANIMATIONS ARE INHERENTLY NOT PERFORMANT.** USING ANIMATIONS
+ * *WILL* DECREASE PERFORMANCE. It is recommended that animations be used
+ * sparingly for this reason, and only on lighter accordions.
  */
 export const WithAnimation: StoryComponentType = {
     render: () => {

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -296,6 +296,10 @@ export const WithInitialExpandedIndex: StoryComponentType = {
  * If `animated` is specified both here in the Accordion
  * and within a child AccordionSection component, the AccordionSection's
  * `animated` value is prioritized.
+ *
+ * **NOTE: HEIGHT ANIMATIONS ARE INHERENTLY NOT PERFORMANT.** USING ANIMATIONS
+ * *WILL* DECREASE PERFORMANCE. It is recommended that animations be used
+ * sparingly for this reason, and only on lighter accordions.
  */
 export const WithAnimation: StoryComponentType = {
     render: () => {

--- a/packages/wonder-blocks-accordion/src/components/accordion.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion.tsx
@@ -188,6 +188,8 @@ const Accordion = React.forwardRef(function Accordion(
         switch (event.key) {
             // ArrowUp focuses on the previous section.
             case "ArrowUp":
+                // Stop the page from scrolling when the up arrow is pressed.
+                event.preventDefault();
                 // Get the previous section, or cycle to last section if
                 // the first section is currently focused.
                 const previousSectionIndex =
@@ -199,6 +201,8 @@ const Accordion = React.forwardRef(function Accordion(
                 break;
             // ArrowDown focuses on the next section.
             case "ArrowDown":
+                // Stop the page from scrolling when the down arrow is pressed.
+                event.preventDefault();
                 // Get the next section, or cycle to first section if
                 // the last section is currently focused.
                 const nextSectionIndex =
@@ -209,12 +213,16 @@ const Accordion = React.forwardRef(function Accordion(
                 break;
             // Home focuses on the first section.
             case "Home":
+                // Stop the page from jumping up when the home key is pressed.
+                event.preventDefault();
                 const firstChildRef = childRefs[0];
                 firstChildRef.current?.focus();
 
                 break;
             // End focuses on the last section.
             case "End":
+                // Stop the page from jumping down when the end key is pressed.
+                event.preventDefault();
                 const lastChildRef = childRefs[children.length - 1];
                 lastChildRef.current?.focus();
 


### PR DESCRIPTION
Currently, pressing the home, end, and arrow keys causes
scrolling on the page (the default behavior of those keys).

To fix this, I added `preventDefault()` for all the keys.

While I'm updating accordion, I also added a comment to the
`WithAnimation` stories warning people about the performance
impact of using height animations.

Issue: none

## Test plan:
- Go to local accordion stories docs tab.
- Click just before the "Default" story accordion.
- Press tab so that the focus shifts to the first section header.
- Press the end key and confirm that the page does not jump
  to the bottom. Confirm that it focuses on the last section header.
- Press the home key and confirm that the page does not jump
  to the top. Confirm that it focuses on the first section header.
- Press the up arrow key repeatedly. Confirm that it cycles through
  the accordion sections and does not slowly scroll up the page.
- Press the down key repeatedly. Confirm that it cycles through
  the accordion sections and does not slowly scroll down the page.


### Demo: Before and after

https://github.com/Khan/wonder-blocks/assets/13231763/829993a2-a484-4987-8d71-54bdd0cc338c
