### PR TITLE
[🔥AUDIT🔥] Change wb-codemod to use JS directly

### DIFF
--- a/.changeset/clean-carrots-give.md
+++ b/.changeset/clean-carrots-give.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wb-codemod": patch
+---
+
+Change script to use Node/JS directly instead of TS

--- a/wb-codemod/bin/cli.js
+++ b/wb-codemod/bin/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable import/no-commonjs */
 const {parseArgs} = require("node:util");
@@ -19,14 +19,23 @@ const {
     positionals: [files],
 } = parseArgs({
     options: {
+        /**
+         * The path to the transform file to use.
+         */
         transformFile: {
             type: "string",
             short: "t",
         },
+        /**
+         * Whether to run the codemod without making any changes.
+         */
         dryRun: {
             type: "boolean",
             short: "d",
         },
+        /**
+         * Whether to print the transformed code to stdout.
+         */
         print: {
             type: "boolean",
             short: "p",

--- a/wb-codemod/bin/cli.js
+++ b/wb-codemod/bin/cli.js
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable import/no-commonjs */
 const {parseArgs} = require("node:util");
-const {run} = require("../src/wb-codemod");
+const {run} = require("../src/wb-codemodd");
 
 const HELP_TEXT = `
 Usage: wb-codemod [options] <files>

--- a/wb-codemod/package.json
+++ b/wb-codemod/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@swc-node/register": "^1.6.5",
     "jscodeshift": "^0.15.1"
   },
   "devDependencies": {

--- a/wb-codemod/src/wb-codemod.js
+++ b/wb-codemod/src/wb-codemod.js
@@ -1,30 +1,21 @@
 /* eslint-disable no-console */
-import path from "path";
-import chalk from "chalk";
-import jscodeshift from "jscodeshift/src/Runner";
-
-type RunOptions = {
-    /**
-     * Whether to dry run the codemod.
-     *
-     * If true, the codemod will not be applied in the files, but the
-     * transformed code will be printed.
-     */
-    dryRun?: boolean;
-    /**
-     * Whether to print the output of the codemod.
-     */
-    print?: boolean;
-};
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable import/no-commonjs */
+const path = require("path");
+const chalk = require("chalk");
+const jscodeshift = require("jscodeshift/src/Runner");
 
 /**
  * Runs jscodeshift on the given transform file (codemod) and file paths.
+ *
+ * @param {string} transformFileName The name of the transform file to use.
+ * @param {string[]} filePaths The file paths to transform.
+ * @param {object} options The options to pass to jscodeshift.
+ *
+ * @returns {Promise<void>} A promise that resolves when the transformation is
+ * complete.
  */
-export async function run(
-    transformFileName: string,
-    filePaths: Array<string>,
-    options: RunOptions,
-) {
+async function run(transformFileName, filePaths, options) {
     const jsCodemodsDir = path.resolve(__dirname, "../transforms");
     // Transform path
     const transformFile = path.join(jsCodemodsDir, transformFileName + ".ts");
@@ -41,14 +32,12 @@ export async function run(
             babel: true,
             extensions: "js,jsx,ts,tsx",
             parser: "tsx",
-            runInBand: !!options.dryRun,
+            runInBand: true,
             silent: false,
             ignorePattern: ["**/node_modules/**", "**/dist/**"],
             // Allows to format the transformed code.
             printOptions: {
                 objectCurlySpacing: false,
-                quote: "double",
-                trailingComma: true,
             },
         });
 
@@ -58,3 +47,7 @@ export async function run(
         process.exit(1);
     }
 }
+
+module.exports = {
+    run,
+};

--- a/wb-codemod/src/wb-codemod.js
+++ b/wb-codemod/src/wb-codemod.js
@@ -32,12 +32,14 @@ async function run(transformFileName, filePaths, options) {
             babel: true,
             extensions: "js,jsx,ts,tsx",
             parser: "tsx",
-            runInBand: true,
+            runInBand: !!options.dryRun,
             silent: false,
             ignorePattern: ["**/node_modules/**", "**/dist/**"],
             // Allows to format the transformed code.
             printOptions: {
                 objectCurlySpacing: false,
+                quote: "double",
+                trailingComma: true,
             },
         });
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

This change updates the wb-codemod package to use JS directly instead of TS.
This simplifies the build process and makes it easier to maintain.

The transform files will still be written in TypeScript, but the package will be
built to JS.

Issue: XXX-XXXX

## Test plan:

```
npx @khanacademy/wb-codemod -t template -d -p path/to/files/
```