### PR TITLE
WB-1643.1: Add transform to migrate spacing to tokens

### DIFF
--- a/.changeset/eight-timers-sneeze.md
+++ b/.changeset/eight-timers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wb-codemod": minor
+---
+
+Add transform to migrate spacing to tokens

--- a/wb-codemod/bin/cli.js
+++ b/wb-codemod/bin/cli.js
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable import/no-commonjs */
 const {parseArgs} = require("node:util");
-const {run} = require("../src/wb-codemodd");
+const {run} = require("../src/wb-codemod");
 
 const HELP_TEXT = `
 Usage: wb-codemod [options] <files>

--- a/wb-codemod/transforms/__tests__/migrate-spacing-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-spacing-to-tokens.test.ts
@@ -1,0 +1,31 @@
+import transform from "../migrate-spacing-to-tokens";
+
+// eslint-disable-next-line import/no-commonjs, @typescript-eslint/no-var-requires
+const defineInlineTest = require("jscodeshift/dist/testUtils").defineInlineTest;
+
+const transformOptions = {
+    printOptions: {
+        objectCurlySpacing: false,
+    },
+};
+
+describe("migrate-spacing-to-tokens", () => {
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `import Spacing from "@khanacademy/wonder-blocks-spacing";`,
+        `import {spacing} from "@khanacademy/wonder-blocks-tokens";`,
+        "should replace default import with named import",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `import {color, spacing} from "@khanacademy/wonder-blocks-tokens";`,
+        "should add a named import to the existing import declaration",
+    );
+});

--- a/wb-codemod/transforms/__tests__/migrate-spacing-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-spacing-to-tokens.test.ts
@@ -28,4 +28,15 @@ import {color} from "@khanacademy/wonder-blocks-tokens";
         `import {color, spacing} from "@khanacademy/wonder-blocks-tokens";`,
         "should add a named import to the existing import declaration",
     );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `import {spacing} from "@khanacademy/wonder-blocks-tokens";`,
+        "should delete the import declaration if the tokens.spacing named import is already used",
+    );
 });

--- a/wb-codemod/transforms/migrate-spacing-to-tokens.ts
+++ b/wb-codemod/transforms/migrate-spacing-to-tokens.ts
@@ -1,0 +1,69 @@
+import {API, FileInfo, Options} from "jscodeshift";
+
+// From
+const SOURCE_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-spacing";
+const SOURCE_SPECIFIER = "Spacing";
+// To
+const TARGET_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-tokens";
+const TARGET_SPECIFIER = "spacing";
+
+/**
+ * Transforms:
+ * import Spacing from "@khanacademy/wonder-blocks-spacing"
+ * const padding = Spacing.xxx;
+ *
+ * to:
+ * import {spacing} from "@khanacademy/wonder-blocks-tokens"
+ * const padding = spacing.xxx;
+ */
+export default function transform(file: FileInfo, api: API, options: Options) {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+
+    // Step 1: Verify if the import exists
+    const sourceImport = root.find(j.ImportDeclaration, {
+        source: {value: SOURCE_IMPORT_DECLARATION},
+    });
+
+    // If the import doesn't exist, we don't need to do anything.
+    if (sourceImport.size() === 0) {
+        return;
+    }
+
+    // Step 2: Replace the import
+    const targetImport = root.find(j.ImportDeclaration, {
+        source: {value: TARGET_IMPORT_DECLARATION},
+    });
+
+    sourceImport.forEach((path) => {
+        // Replace default import with named import
+        const targetSpecifier = j.importSpecifier(
+            j.identifier(TARGET_SPECIFIER),
+        );
+
+        // If the import is already used, we add a named import to the existing
+        // import declaration.
+        if (targetImport.size() > 0) {
+            targetImport.get().node.specifiers.push(targetSpecifier);
+            // Remove the import declaration
+            j(path).remove();
+            return;
+        }
+
+        // Create a new import declaration.
+        const newTargetImport = j.importDeclaration(
+            [targetSpecifier],
+            j.literal(TARGET_IMPORT_DECLARATION),
+        );
+
+        // Replace the existing import declaration with the new one.
+        j(path).replaceWith(newTargetImport);
+    });
+
+    // Step 3: Replace the usage
+    root.find(j.Identifier, {name: SOURCE_SPECIFIER}).forEach((path) => {
+        path.node.name = TARGET_SPECIFIER;
+    });
+
+    return root.toSource(options.printOptions);
+}

--- a/wb-codemod/transforms/migrate-spacing-to-tokens.ts
+++ b/wb-codemod/transforms/migrate-spacing-to-tokens.ts
@@ -1,4 +1,4 @@
-import {API, FileInfo, Options} from "jscodeshift";
+import {API, FileInfo, ModuleSpecifier, Options} from "jscodeshift";
 
 // From
 const SOURCE_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-spacing";
@@ -44,7 +44,17 @@ export default function transform(file: FileInfo, api: API, options: Options) {
         // If the import is already used, we add a named import to the existing
         // import declaration.
         if (targetImport.size() > 0) {
-            targetImport.get().node.specifiers.push(targetSpecifier);
+            // NOTE: We only add the specifier if it doesn't exist already.
+            const specifierExists = targetImport
+                .get()
+                .node.specifiers.some(
+                    (specifier: ModuleSpecifier) =>
+                        specifier.local?.name === TARGET_SPECIFIER,
+                );
+
+            if (!specifierExists) {
+                targetImport.get().node.specifiers.push(targetSpecifier);
+            }
             // Remove the import declaration
             j(path).remove();
             return;


### PR DESCRIPTION
## Summary:

Creates a codemod to migrate the Spacing package to wb-tokens. This will allow
us to have a consistent spacing across the repo(s) and make it easier to change
in the future.

Issue: WB-1643

## Test plan:

- Run the codemod on the repo (next PR).
- Run unit tests for the codemod.