### PR TITLE
WB-1643.2: Migrate spacing from wb-spacing to wb-tokens

### DIFF
--- a/.changeset/eight-timers-sneeze.md
+++ b/.changeset/eight-timers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wb-codemod": minor
+---
+
+Add transform to migrate spacing to tokens

--- a/.changeset/little-windows-build.md
+++ b/.changeset/little-windows-build.md
@@ -1,0 +1,23 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-labeled-field": patch
+"@khanacademy/wonder-blocks-search-field": patch
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-theming": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-banner": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-layout": patch
+"@khanacademy/wonder-blocks-switch": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-pill": patch
+---
+
+Update internal spacing references (from wb-spacing to wb-tokens)

--- a/.storybook/components/token-table.tsx
+++ b/.storybook/components/token-table.tsx
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
     table: {
         borderCollapse: "collapse",
         borderSpacing: 0,
-        margin: `${Spacing.xLarge_32}px 0`,
+        margin: `${spacing.xLarge_32}px 0`,
         textAlign: "left",
         width: "100%",
     },
@@ -88,7 +88,7 @@ const styles = StyleSheet.create({
         backgroundColor: Color.white,
     },
     cell: {
-        padding: Spacing.xSmall_8,
+        padding: spacing.xSmall_8,
         verticalAlign: "middle",
     },
 });

--- a/.storybook/components/token-table.tsx
+++ b/.storybook/components/token-table.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const StyledTable = addStyle("table");
 const StyledTableRow = addStyle("tr");

--- a/__docs__/_overview_.mdx
+++ b/__docs__/_overview_.mdx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Caption} from "@khanacademy/wonder-blocks-typography";
 
 import ComponentGallery from "./components/gallery/component-gallery";
@@ -25,17 +25,17 @@ export const styles = StyleSheet.create({
     heroWrapper: {
         flexDirection: "row",
         minHeight: "50vh",
-        marginBottom: Spacing.large_24,
+        marginBottom: spacing.large_24,
         [mobile]: {
             flexDirection: "column",
             minHeight: "auto",
-            marginTop: Spacing.large_24,
+            marginTop: spacing.large_24,
         },
     },
     heroBody: {
         alignSelf: "center",
-        gap: Spacing.medium_16,
-        padding: `0 ${Spacing.xxxLarge_64}px 0 0`,
+        gap: spacing.medium_16,
+        padding: `0 ${spacing.xxxLarge_64}px 0 0`,
         [mobile]: {
             padding: 0,
         },
@@ -63,7 +63,7 @@ export const styles = StyleSheet.create({
             <strong>Note:</strong> These components are only available for use
             on the web (including mobile web).
         </Caption>
-        <Strut size={Spacing.large_24} />
+        <Strut size={spacing.large_24} />
     </View>
     <StyledImage
         alt="A illustration that shows multiple components."

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -7,7 +7,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Banner from "@khanacademy/wonder-blocks-banner";
 
@@ -94,19 +94,19 @@ export const Kinds: StoryComponentType = {
                 kind="info"
                 layout="floating"
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Banner
                 text="kind: success - This is a message about something positive or successful!"
                 kind="success"
                 layout="floating"
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Banner
                 text="kind: warning - This is a message warning the user about a potential issue."
                 kind="warning"
                 layout="floating"
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Banner
                 text="kind: critical - This is a message about something critical or an error."
                 kind="critical"
@@ -128,7 +128,7 @@ export const Kinds: StoryComponentType = {
  */
 export const Layouts: StoryComponentType = () => {
     const borderStyle = {border: `2px solid ${Color.pink}`} as const;
-    const floatingContainerStyle = {padding: Spacing.xSmall_8} as const;
+    const floatingContainerStyle = {padding: spacing.xSmall_8} as const;
 
     return (
         <View style={styles.container}>
@@ -137,13 +137,13 @@ export const Layouts: StoryComponentType = () => {
                 layout="full-width"
                 kind="success"
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Banner
                 text="This banner has floating layout."
                 layout="floating"
                 kind="success"
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <View style={borderStyle}>
                 <Banner
                     text="This banner has full-width layout. There is no space around it."
@@ -151,7 +151,7 @@ export const Layouts: StoryComponentType = () => {
                     kind="success"
                 />
             </View>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <View style={[borderStyle, floatingContainerStyle]}>
                 <Banner
                     text={`This banner has floating layout. Padding has been
@@ -198,11 +198,11 @@ export const LongText: StoryComponentType = {
 export const DarkBackground: StoryComponentType = () => (
     <View style={styles.container}>
         <Banner text="kind: info" kind="info" layout="full-width" />
-        <Strut size={Spacing.medium_16} />
+        <Strut size={spacing.medium_16} />
         <Banner text="kind: success" kind="success" layout="full-width" />
-        <Strut size={Spacing.medium_16} />
+        <Strut size={spacing.medium_16} />
         <Banner text="kind: warning" kind="warning" layout="full-width" />
-        <Strut size={Spacing.medium_16} />
+        <Strut size={spacing.medium_16} />
         <Banner text="kind: critical" kind="critical" layout="full-width" />
     </View>
 );
@@ -267,7 +267,7 @@ export const WithInlineLinks: StoryComponentType = {
                     {type: "button", title: "Button", onClick: () => {}},
                 ]}
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Banner
                 text={
                     <LabelSmall>
@@ -484,7 +484,7 @@ export const RightToLeft: StoryComponentType = {
                 ]}
                 layout="full-width"
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Banner
                 text="یہ اردو میں لکھا ہے۔"
                 actions={[

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -15,7 +15,7 @@ import {fireEvent, userEvent, within} from "@storybook/testing-library";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     LabelMedium,
     LabelLarge,
@@ -138,31 +138,31 @@ export const styles: StyleDeclaration = StyleSheet.create({
     row: {
         flexDirection: "row",
         alignItems: "center",
-        marginBottom: Spacing.xSmall_8,
+        marginBottom: spacing.xSmall_8,
     },
     button: {
-        marginRight: Spacing.xSmall_8,
+        marginRight: spacing.xSmall_8,
     },
     truncatedButton: {
         maxWidth: 200,
-        marginBottom: Spacing.medium_16,
+        marginBottom: spacing.medium_16,
     },
     fillSpace: {
         minWidth: 140,
     },
     example: {
         background: Color.offWhite,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     label: {
-        marginTop: Spacing.large_24,
-        marginBottom: Spacing.xSmall_8,
+        marginTop: spacing.large_24,
+        marginBottom: spacing.xSmall_8,
     },
 });
 
 export const Variants: StoryComponentType = () => (
-    <View style={{padding: Spacing.medium_16, gap: Spacing.medium_16}}>
-        <View style={{flexDirection: "row", gap: Spacing.medium_16}}>
+    <View style={{padding: spacing.medium_16, gap: spacing.medium_16}}>
+        <View style={{flexDirection: "row", gap: spacing.medium_16}}>
             <Button onClick={() => {}}>Hello, world!</Button>
             <Button onClick={() => {}} kind="secondary">
                 Hello, world!
@@ -171,7 +171,7 @@ export const Variants: StoryComponentType = () => (
                 Hello, world!
             </Button>
         </View>
-        <View style={{flexDirection: "row", gap: Spacing.medium_16}}>
+        <View style={{flexDirection: "row", gap: spacing.medium_16}}>
             <Button onClick={() => {}} disabled={true}>
                 Hello, world!
             </Button>
@@ -182,7 +182,7 @@ export const Variants: StoryComponentType = () => (
                 Hello, world!
             </Button>
         </View>
-        <View style={{flexDirection: "row", gap: Spacing.medium_16}}>
+        <View style={{flexDirection: "row", gap: spacing.medium_16}}>
             <Button onClick={() => {}} color="destructive">
                 Hello, world!
             </Button>
@@ -249,7 +249,7 @@ WithColor.parameters = {
 };
 
 export const Dark: StoryComponentType = () => (
-    <View style={{backgroundColor: Color.darkBlue, padding: Spacing.medium_16}}>
+    <View style={{backgroundColor: Color.darkBlue, padding: spacing.medium_16}}>
         <View style={{flexDirection: "row"}}>
             <Button onClick={() => {}} light={true}>
                 Hello, world!
@@ -561,7 +561,7 @@ export const TruncatingLabels: StoryComponentType = {
             <Button onClick={() => {}} style={styles.truncatedButton}>
                 label too long for the parent container
             </Button>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button
                 onClick={() => {}}
                 style={styles.truncatedButton}
@@ -569,7 +569,7 @@ export const TruncatingLabels: StoryComponentType = {
             >
                 label too long for the parent container
             </Button>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button
                 size="small"
                 onClick={() => {}}
@@ -577,7 +577,7 @@ export const TruncatingLabels: StoryComponentType = {
             >
                 label too long for the parent container
             </Button>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button
                 size="small"
                 onClick={() => {}}
@@ -624,15 +624,15 @@ export const CustomStyles = {
         },
     },
     render: (args: any) => (
-        <View style={{gap: Spacing.medium_16}}>
+        <View style={{gap: spacing.medium_16}}>
             <HeadingSmall>Wonder Blocks theme (default)</HeadingSmall>
-            <View style={{flexDirection: "row", gap: Spacing.medium_16}}>
+            <View style={{flexDirection: "row", gap: spacing.medium_16}}>
                 <Button {...args} kind="primary" />
                 <Button {...args} kind="secondary" />
                 <Button {...args} kind="tertiary" />
             </View>
             <HeadingSmall>Khanmigo theme</HeadingSmall>
-            <View style={{flexDirection: "row", gap: Spacing.medium_16}}>
+            <View style={{flexDirection: "row", gap: spacing.medium_16}}>
                 <ThemeSwitcherContext.Provider value="khanmigo">
                     <Button {...args} kind="primary" />
                     <Button {...args} kind="secondary" />
@@ -760,7 +760,7 @@ export const KhanmigoTheme: StoryComponentType = {
 
         return (
             <ThemeSwitcherContext.Provider value="khanmigo">
-                <View style={{gap: Spacing.medium_16}}>
+                <View style={{gap: spacing.medium_16}}>
                     {stories.map((Story, i) => (
                         <Story key={i} />
                     ))}

--- a/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import packageConfig from "../../packages/wonder-blocks-cell/package.json";
@@ -117,12 +117,12 @@ export const CompactCellWithDifferentHeights: StoryComponentType = () => (
             title="Single line with short accessory."
             rightAccessory={AccessoryMappings.withCaret}
         />
-        <Strut size={Spacing.xSmall_8} />
+        <Strut size={spacing.xSmall_8} />
         <CompactCell
             title="Single line with tall accessory."
             rightAccessory={AccessoryMappings.withIconText}
         />
-        <Strut size={Spacing.xSmall_8} />
+        <Strut size={spacing.xSmall_8} />
         <CompactCell
             title="Multi line title with tall accessory. Content should fit within the container and the cell height should be consistent no matter the content length."
             rightAccessory={AccessoryMappings.withIconText}
@@ -177,7 +177,7 @@ export const CompactCellAccessoryStyles: StoryComponentType = {
                 <PhosphorIcon icon={IconMappings.article} size="medium" />
             }
             leftAccessoryStyle={{
-                minWidth: Spacing.xxLarge_48,
+                minWidth: spacing.xxLarge_48,
                 alignSelf: "flex-start",
                 alignItems: "flex-start",
             }}
@@ -185,7 +185,7 @@ export const CompactCellAccessoryStyles: StoryComponentType = {
                 <PhosphorIcon icon={IconMappings.caretRightBold} size="small" />
             }
             rightAccessoryStyle={{
-                minWidth: Spacing.large_24,
+                minWidth: spacing.large_24,
                 alignSelf: "flex-end",
                 alignItems: "flex-end",
             }}
@@ -426,7 +426,7 @@ export const CompactCellsAsListItems: StoryComponentType = {
 const styles = StyleSheet.create({
     example: {
         backgroundColor: Color.offWhite,
-        padding: Spacing.large_24,
-        width: 320 + Spacing.xxLarge_48,
+        padding: spacing.large_24,
+        width: 320 + spacing.xxLarge_48,
     },
 });

--- a/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
@@ -346,12 +346,12 @@ export const DetailCellsAsListItems: StoryComponentType = {
 const styles = StyleSheet.create({
     example: {
         backgroundColor: Color.offWhite,
-        padding: Spacing.large_24,
+        padding: spacing.large_24,
         width: 376,
     },
     navigation: {
         border: `1px dashed ${Color.lightBlue}`,
-        marginTop: Spacing.large_24,
-        padding: Spacing.large_24,
+        marginTop: spacing.large_24,
+        padding: spacing.large_24,
     },
 });

--- a/__docs__/wonder-blocks-clickable/accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-clickable/accessibility.stories.mdx
@@ -5,7 +5,7 @@ import Clickable from "@khanacademy/wonder-blocks-clickable";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
@@ -136,7 +136,7 @@ make sure to use `href` and `skipClientNav={true}.
 export const styles = StyleSheet.create({
     resting: {
         boxShadow: `inset 0px 0px 1px 1px ${Color.lightBlue}`,
-        padding: Spacing.xSmall_8,
+        padding: spacing.xSmall_8,
     },
     hovered: {
         textDecoration: "underline",
@@ -150,7 +150,7 @@ export const styles = StyleSheet.create({
         outline: `solid 4px ${Color.lightBlue}`,
     },
     panel: {
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
         boxShadow: `inset 0px 0px 0 1px ${Color.offBlack8}`,
     },
 });

--- a/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import packageConfig from "../../packages/wonder-blocks-clickable/package.json";
@@ -160,7 +160,7 @@ WithTabIndex.parameters = {
 const styles = StyleSheet.create({
     clickable: {
         cursor: "pointer",
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
         textAlign: "center",
     },
     newButton: {

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
@@ -309,7 +309,7 @@ Ref.parameters = {
 const styles = StyleSheet.create({
     clickable: {
         borderWidth: 1,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     hovered: {
         textDecoration: "underline",
@@ -322,25 +322,25 @@ const styles = StyleSheet.create({
         outline: `solid 4px ${Color.lightBlue}`,
     },
     centerText: {
-        gap: Spacing.medium_16,
+        gap: spacing.medium_16,
         textAlign: "center",
     },
     dark: {
         backgroundColor: Color.darkBlue,
         color: Color.white,
-        padding: Spacing.xSmall_8,
+        padding: spacing.xSmall_8,
     },
     row: {
         flexDirection: "row",
         alignItems: "center",
     },
     heading: {
-        marginRight: Spacing.large_24,
+        marginRight: spacing.large_24,
     },
     navigation: {
         border: `1px dashed ${Color.lightBlue}`,
-        marginTop: Spacing.large_24,
-        padding: Spacing.large_24,
+        marginTop: spacing.large_24,
+        padding: spacing.large_24,
     },
     disabled: {
         color: Color.white,

--- a/__docs__/wonder-blocks-color/swatch.tsx
+++ b/__docs__/wonder-blocks-color/swatch.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Caption,
     LabelLarge,
@@ -132,7 +132,7 @@ const styles = StyleSheet.create({
     container: {
         color: Color.offBlack,
         flexDirection: "row",
-        marginBottom: Spacing.xLarge_32,
+        marginBottom: spacing.xLarge_32,
     },
     info: {
         alignItems: "flex-start",
@@ -141,9 +141,9 @@ const styles = StyleSheet.create({
     tag: {
         background: Color.offWhite,
         border: `solid 1px ${Color.offBlack8}`,
-        borderRadius: Spacing.xxxxSmall_2,
-        margin: `${Spacing.xxxSmall_4}px 0`,
-        padding: `0 ${Spacing.xxxSmall_4}px`,
+        borderRadius: spacing.xxxxSmall_2,
+        margin: `${spacing.xxxSmall_4}px 0`,
+        padding: `0 ${spacing.xxxSmall_4}px`,
     },
     usage: {
         color: Color.offBlack64,
@@ -151,18 +151,18 @@ const styles = StyleSheet.create({
     swatch: {
         flexDirection: "row",
         flexBasis: "70%",
-        borderRadius: Spacing.xxxSmall_4,
+        borderRadius: spacing.xxxSmall_4,
         background: Color.white,
-        boxShadow: `0 1px ${Spacing.xxxSmall_4}px 0 ${Color.offBlack8}`,
+        boxShadow: `0 1px ${spacing.xxxSmall_4}px 0 ${Color.offBlack8}`,
         border: `1px solid ${Color.offBlack16}`,
         overflow: "hidden",
-        height: Spacing.xxxLarge_64,
+        height: spacing.xxxLarge_64,
     },
     swatchItem: {
-        gap: Spacing.medium_16,
+        gap: spacing.medium_16,
         flex: 1,
         justifyContent: "center",
         alignItems: "center",
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
 });

--- a/__docs__/wonder-blocks-core/add-style.stories.mdx
+++ b/__docs__/wonder-blocks-core/add-style.stories.mdx
@@ -5,7 +5,7 @@ import {StyleSheet} from "aphrodite";
 import Color, {fade} from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 <Meta title="Core / addStyle" />
 
@@ -14,9 +14,9 @@ export const styles = StyleSheet.create({
         // default style for all instances of StyledInput
         background: Color.white,
         border: `1px solid ${Color.offBlack16}`,
-        borderRadius: Spacing.xxxSmall_4,
-        fontSize: Spacing.medium_16,
-        padding: Spacing.xSmall_8,
+        borderRadius: spacing.xxxSmall_4,
+        fontSize: spacing.medium_16,
+        padding: spacing.xSmall_8,
     },
     error: {
         background: fade(Color.red, 0.16),
@@ -86,7 +86,7 @@ component so we don't have to create a new instance on every render.
 ```js
 import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 
 const StyledInput = addStyle("input", styles.input);
@@ -96,9 +96,9 @@ const styles = StyleSheet.create({
     input: {
         background: Color.white,
         borderColor: Color.offBlack16,
-        borderRadius: Spacing.xxxSmall_4,
-        fontSize: Spacing.medium_16,
-        padding: Spacing.xSmall_8,
+        borderRadius: spacing.xxxSmall_4,
+        fontSize: spacing.medium_16,
+        padding: spacing.xSmall_8,
     },
     error: {
         background: fade(Color.red, 0.16),

--- a/__docs__/wonder-blocks-core/exports.use-latest-ref.stories.mdx
+++ b/__docs__/wonder-blocks-core/exports.use-latest-ref.stories.mdx
@@ -4,7 +4,7 @@ import {useLatestRef, View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import Color from "@khanacademy/wonder-blocks-color";
 
 <Meta
@@ -73,12 +73,12 @@ export function Example1() {
                 value={message}
                 onChange={setMessage}
             />
-            <Strut size={Spacing.medium_16} />
-            <View style={{flexDirection: "row", gap: Spacing.xSmall_8}}>
+            <Strut size={spacing.medium_16} />
+            <View style={{flexDirection: "row", gap: spacing.xSmall_8}}>
                 {isMounted && <Button onClick={unmount}>Unmount</Button>}
                 {!isMounted && <Button onClick={mount}>Mount</Button>}
             </View>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Context>
                 {isMounted && (
                     <ComponentThatAlertsOnUnmount message={message} />
@@ -95,7 +95,7 @@ export function Context({children}) {
                 borderRadius: 5,
                 border: "1px solid #ccc",
                 boxShadow: "inset 1px 1px 6px #0001",
-                padding: Spacing.medium_16,
+                padding: spacing.medium_16,
                 background: Color.offWhite,
             }}
         >

--- a/__docs__/wonder-blocks-core/view.stories.tsx
+++ b/__docs__/wonder-blocks-core/view.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     HeadingMedium,
     LabelMedium,
@@ -55,7 +55,7 @@ export const InlineStyles: StoryComponentType = () => (
                 {
                     background: Color.lightBlue,
                     border: `1px solid ${Color.blue}`,
-                    padding: Spacing.xxxSmall_4,
+                    padding: spacing.xxxSmall_4,
                 },
             ]}
         >
@@ -137,18 +137,18 @@ DefiningLayout.parameters = {
 const styles = StyleSheet.create({
     container: {
         background: Color.offBlack8,
-        gap: Spacing.medium_16,
-        padding: Spacing.xLarge_32,
+        gap: spacing.medium_16,
+        padding: spacing.xLarge_32,
     },
 
     view: {
         border: `1px dashed ${Color.lightBlue}`,
-        gap: Spacing.medium_16,
-        padding: Spacing.medium_16,
+        gap: spacing.medium_16,
+        padding: spacing.medium_16,
     },
 
     item: {
         background: Color.offBlack32,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
 });

--- a/__docs__/wonder-blocks-data/exports.data.stories.mdx
+++ b/__docs__/wonder-blocks-data/exports.data.stories.mdx
@@ -57,7 +57,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Data} from "@khanacademy/wonder-blocks-data";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const myValidHandler = () =>
     new Promise((resolve, reject) =>
@@ -82,7 +82,7 @@ const myInvalidHandler = () =>
             }}
         </Data>
     </View>
-    <Strut size={Spacing.small_12} />
+    <Strut size={spacing.small_12} />
     <View>
         <Body>This request will go boom and give us an error!</Body>
         <Data handler={myInvalidHandler} requestId="INVALID">
@@ -114,7 +114,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Data, initializeHydrationCache} from "@khanacademy/wonder-blocks-data";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const myHandler = () => {
     throw new Error(

--- a/__docs__/wonder-blocks-data/exports.intercept-requests.stories.mdx
+++ b/__docs__/wonder-blocks-data/exports.intercept-requests.stories.mdx
@@ -44,7 +44,6 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {InterceptRequests, Data} from "@khanacademy/wonder-blocks-data";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 const myHandler = () => Promise.reject(new Error("You should not see this!"));
 

--- a/__docs__/wonder-blocks-data/exports.track-data.stories.mdx
+++ b/__docs__/wonder-blocks-data/exports.track-data.stories.mdx
@@ -76,7 +76,7 @@ additional render cycle to render with that data.
 ```jsx
 import {Body, BodyMonospace} from "@khanacademy/wonder-blocks-typography";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import Button from "@khanacademy/wonder-blocks-button";
 import {Server, View} from "@khanacademy/wonder-blocks-core";
 import {
@@ -132,7 +132,7 @@ class Example extends React.Component {
         if (this.state.error) {
             return (
                 <React.Fragment>
-                    <Strut size={Spacing.small_12} />
+                    <Strut size={spacing.small_12} />
                     <Body>
                         We can't show you anything useful in client-side mode
                     </Body>
@@ -146,7 +146,7 @@ class Example extends React.Component {
 
         return (
             <React.Fragment>
-                <Strut size={Spacing.small_12} />
+                <Strut size={spacing.small_12} />
                 <TrackData>
                     <Data
                         handler={myPretendHandler}
@@ -164,7 +164,7 @@ class Example extends React.Component {
                         )}
                     </Data>
                 </TrackData>
-                <Strut size={Spacing.small_12} />
+                <Strut size={spacing.small_12} />
                 <View>
                     <Body>
                         The above components requested data, but we're
@@ -172,14 +172,14 @@ class Example extends React.Component {
                         request. In this example, we've also called
                         `fetchTrackedRequests` to fetch that tracked data.
                     </Body>
-                    <Strut size={Spacing.small_12} />
+                    <Strut size={spacing.small_12} />
                     <Body>
                         In about 3 seconds, it will appear below. Notice that
                         when it does, the above still doesn't update. That's
                         because during SSR, the data is not updated in the
                         rendered tree.
                     </Body>
-                    <Strut size={Spacing.small_12} />
+                    <Strut size={spacing.small_12} />
                     <BodyMonospace>{data}</BodyMonospace>
                 </View>
             </React.Fragment>
@@ -198,7 +198,7 @@ class Example extends React.Component {
                             >
                                 Back to Client-side Mode (reloads page)
                             </Button>
-                            <Strut size={Spacing.small_12} />
+                            <Strut size={spacing.small_12} />
                             <Button
                                 kind={"secondary"}
                                 onClick={() => this.setServerMode()}

--- a/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
@@ -5,7 +5,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {ActionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
@@ -28,7 +28,7 @@ const defaultArgs = {
 const styles = StyleSheet.create({
     example: {
         background: Color.offWhite,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
         width: 300,
     },
     items: {

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -12,7 +12,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Pill from "@khanacademy/wonder-blocks-pill";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {
     ActionItem,
@@ -125,7 +125,7 @@ export default {
 const styles = StyleSheet.create({
     example: {
         background: Color.offWhite,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     exampleExtended: {
         height: 300,
@@ -147,10 +147,10 @@ const styles = StyleSheet.create({
      */
     customOpener: {
         borderLeft: `5px solid ${Color.blue}`,
-        borderRadius: Spacing.xxxSmall_4,
+        borderRadius: spacing.xxxSmall_4,
         background: Color.lightBlue,
         color: Color.white,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     focused: {
         color: Color.offWhite,

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -9,7 +9,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import Pill from "@khanacademy/wonder-blocks-pill";
@@ -80,7 +80,7 @@ export default {
 const styles = StyleSheet.create({
     example: {
         background: Color.offWhite,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     setWidth: {
         minWidth: 170,
@@ -101,9 +101,9 @@ const styles = StyleSheet.create({
         height: 200,
         overflow: "auto",
         border: "1px solid grey",
-        borderRadius: Spacing.xxxSmall_4,
-        margin: Spacing.xSmall_8,
-        padding: Spacing.medium_16,
+        borderRadius: spacing.xxxSmall_4,
+        margin: spacing.xSmall_8,
+        padding: spacing.medium_16,
     },
     scrollableArea: {
         height: "200vh",
@@ -113,10 +113,10 @@ const styles = StyleSheet.create({
      */
     customOpener: {
         borderLeft: `5px solid ${Color.blue}`,
-        borderRadius: Spacing.xxxSmall_4,
+        borderRadius: spacing.xxxSmall_4,
         background: Color.lightBlue,
         color: Color.white,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     focused: {
         color: Color.offWhite,
@@ -281,7 +281,7 @@ const ErrorWrapper = (args: any) => {
 
     return (
         <>
-            <LabelMedium style={{marginBottom: Spacing.xSmall_8}}>
+            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
                 Select at least 2 options to clear the error!
             </LabelMedium>
             <MultiSelect

--- a/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
@@ -5,7 +5,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
@@ -25,7 +25,7 @@ const defaultArgs = {
 const styles = StyleSheet.create({
     example: {
         background: Color.offWhite,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
         width: 300,
     },
     items: {

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -13,7 +13,7 @@ import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import Pill from "@khanacademy/wonder-blocks-pill";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingLarge,
@@ -102,7 +102,7 @@ export default {
 const styles = StyleSheet.create({
     example: {
         background: Color.offWhite,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     rowRight: {
         flexDirection: "row",
@@ -121,10 +121,10 @@ const styles = StyleSheet.create({
      */
     customOpener: {
         borderLeft: `5px solid ${Color.blue}`,
-        borderRadius: Spacing.xxxSmall_4,
+        borderRadius: spacing.xxxSmall_4,
         background: Color.lightBlue,
         color: Color.white,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     focused: {
         backgroundColor: fade(Color.lightBlue, 0.8),
@@ -162,13 +162,13 @@ const styles = StyleSheet.create({
         backgroundColor: Color.darkBlue,
         width: "100%",
         height: 200,
-        paddingRight: Spacing.medium_16,
-        paddingTop: Spacing.medium_16,
+        paddingRight: spacing.medium_16,
+        paddingTop: spacing.medium_16,
     },
     // AutoFocus
     icon: {
         position: "absolute",
-        right: Spacing.medium_16,
+        right: spacing.medium_16,
     },
 });
 
@@ -365,7 +365,7 @@ const ErrorWrapper = () => {
 
     return (
         <>
-            <LabelMedium style={{marginBottom: Spacing.xSmall_8}}>
+            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
                 Select any fruit other than lemon to clear the error!
             </LabelMedium>
             <SingleSelect
@@ -568,7 +568,7 @@ export const DropdownInModal: StoryComponentType = {
                         SingleSelect components can correctly be displayed
                         within the visible scrolling area.
                     </Body>
-                    <Strut size={Spacing.large_24} />
+                    <Strut size={spacing.large_24} />
                     <SingleSelect
                         onChange={(selected) => setValue(selected)}
                         isFilterable={true}

--- a/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge, LabelXSmall} from "@khanacademy/wonder-blocks-typography";
 
 import {Choice, CheckboxGroup} from "@khanacademy/wonder-blocks-form";
@@ -316,11 +316,11 @@ const styles = StyleSheet.create({
         flexWrap: "wrap",
     },
     choice: {
-        marginTop: Spacing.xSmall_8,
+        marginTop: spacing.xSmall_8,
         width: 200,
     },
     title: {
-        paddingBottom: Spacing.xSmall_8,
+        paddingBottom: spacing.xSmall_8,
         borderBottom: `1px solid ${Color.offBlack64}`,
     },
     // Multiple choice styling

--- a/__docs__/wonder-blocks-form/checkbox.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {Checkbox, CheckboxGroup, Choice} from "@khanacademy/wonder-blocks-form";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 import ComponentInfo from "../../.storybook/components/component-info";
@@ -149,8 +149,8 @@ export const IndeterminateWithGroup: StoryComponentType = () => {
                 label={"Topping(s)"}
                 onChange={handleSelectAll}
             />
-            <Strut size={Spacing.small_12} />
-            <View style={{marginInlineStart: Spacing.large_24}}>
+            <Strut size={spacing.small_12} />
+            <View style={{marginInlineStart: spacing.large_24}}>
                 <CheckboxGroup
                     groupName="toppings"
                     onChange={handleCheckboxGroupSelect}

--- a/__docs__/wonder-blocks-form/choice.stories.tsx
+++ b/__docs__/wonder-blocks-form/choice.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {
     Choice,
@@ -56,7 +56,7 @@ const ChoiceWrapper = (args: any) => {
                 <Choice label="Mushroom" value="mushroom-checkbox" />
                 <Choice {...args} />
             </CheckboxGroup>
-            <Strut size={Spacing.xLarge_32} />
+            <Strut size={spacing.xLarge_32} />
             <RadioGroup
                 label="Pizza order"
                 description="Choose only one topping."

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Button from "@khanacademy/wonder-blocks-button";
 import Link from "@khanacademy/wonder-blocks-link";
@@ -541,7 +541,7 @@ export const CustomStyle: StoryComponentType = () => {
                 style={styles.grow}
                 onKeyDown={handleKeyDown}
             />
-            <Strut size={Spacing.xLarge_32} />
+            <Strut size={spacing.xLarge_32} />
             <LabeledTextField
                 label="Last name"
                 description="Please enter your last name"
@@ -620,7 +620,7 @@ export const Ref: StoryComponentType = () => {
                 onKeyDown={handleKeyDown}
                 ref={inputRef}
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button style={styles.button} onClick={handleSubmit}>
                 Focus Input
             </Button>
@@ -732,7 +732,7 @@ AutoComplete.parameters = {
 const styles = StyleSheet.create({
     darkBackground: {
         background: Color.darkBlue,
-        padding: `${Spacing.medium_16}px`,
+        padding: `${spacing.medium_16}px`,
     },
     whiteColor: {
         color: Color.white,
@@ -750,6 +750,6 @@ const styles = StyleSheet.create({
         flexGrow: 1,
     },
     fieldWithButton: {
-        marginBottom: Spacing.medium_16,
+        marginBottom: spacing.medium_16,
     },
 });

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View, Text as _Text} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import Button from "@khanacademy/wonder-blocks-button";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
@@ -209,7 +209,7 @@ export const Password: StoryComponentType = () => {
             />
             {!focused && errorMessage && (
                 <View>
-                    <Strut size={Spacing.xSmall_8} />
+                    <Strut size={spacing.xSmall_8} />
                     <_Text style={styles.errorMessage}>{errorMessage}</_Text>
                 </View>
             )}
@@ -278,7 +278,7 @@ export const Email: StoryComponentType = () => {
             />
             {!focused && errorMessage && (
                 <View>
-                    <Strut size={Spacing.xSmall_8} />
+                    <Strut size={spacing.xSmall_8} />
                     <_Text style={styles.errorMessage}>{errorMessage}</_Text>
                 </View>
             )}
@@ -347,7 +347,7 @@ export const Telephone: StoryComponentType = () => {
             />
             {!focused && errorMessage && (
                 <View>
-                    <Strut size={Spacing.xSmall_8} />
+                    <Strut size={spacing.xSmall_8} />
                     <_Text style={styles.errorMessage}>{errorMessage}</_Text>
                 </View>
             )}
@@ -416,7 +416,7 @@ export const Error: StoryComponentType = () => {
             />
             {!focused && errorMessage && (
                 <View>
-                    <Strut size={Spacing.xSmall_8} />
+                    <Strut size={spacing.xSmall_8} />
                     <_Text style={styles.errorMessage}>{errorMessage}</_Text>
                 </View>
             )}
@@ -484,7 +484,7 @@ export const Light: StoryComponentType = () => {
             />
             {!focused && errorMessage && (
                 <View>
-                    <Strut size={Spacing.xSmall_8} />
+                    <Strut size={spacing.xSmall_8} />
                     <_Text style={styles.errorMessageLight}>
                         {errorMessage}
                     </_Text>
@@ -556,7 +556,7 @@ export const ErrorLight: StoryComponentType = () => {
             />
             {!focused && errorMessage && (
                 <View>
-                    <Strut size={Spacing.xSmall_8} />
+                    <Strut size={spacing.xSmall_8} />
                     <_Text style={styles.errorMessage}>{errorMessage}</_Text>
                 </View>
             )}
@@ -660,7 +660,7 @@ export const Ref: StoryComponentType = () => {
                 onKeyDown={handleKeyDown}
                 ref={inputRef}
             />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button style={styles.button} onClick={handleSubmit}>
                 Focus Input
             </Button>
@@ -757,19 +757,19 @@ export const WithAutofocus: StoryComponentType = () => {
                 autoFocus={true}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
-                style={{flexGrow: 1, marginLeft: Spacing.small_12}}
+                style={{flexGrow: 1, marginLeft: spacing.small_12}}
             />
         </View>
     );
 
     return (
         <View>
-            <LabelLarge style={{marginBottom: Spacing.small_12}}>
+            <LabelLarge style={{marginBottom: spacing.small_12}}>
                 Press the button to view the text field with autofocus.
             </LabelLarge>
             <Button
                 onClick={handleShowDemo}
-                style={{width: 300, marginBottom: Spacing.large_24}}
+                style={{width: 300, marginBottom: spacing.large_24}}
             >
                 Toggle autoFocus demo
             </Button>
@@ -844,15 +844,15 @@ AutoComplete.parameters = {
 const styles = StyleSheet.create({
     errorMessage: {
         color: Color.red,
-        paddingLeft: Spacing.xxxSmall_4,
+        paddingLeft: spacing.xxxSmall_4,
     },
     errorMessageLight: {
         color: Color.white,
-        paddingLeft: Spacing.xxxSmall_4,
+        paddingLeft: spacing.xxxSmall_4,
     },
     darkBackground: {
         backgroundColor: Color.darkBlue,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     customField: {
         backgroundColor: Color.darkBlue,
@@ -867,6 +867,6 @@ const styles = StyleSheet.create({
         maxWidth: 150,
     },
     fieldWithButton: {
-        marginBottom: Spacing.medium_16,
+        marginBottom: spacing.medium_16,
     },
 });

--- a/__docs__/wonder-blocks-icon-button/icon-button-variants.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button-variants.stories.tsx
@@ -5,9 +5,8 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
-import * as tokens from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
@@ -46,9 +45,7 @@ const KindVariants = ({
                                     : styles.darkDefault),
                         ]}
                     >
-                        <LabelMedium
-                            style={light && {color: tokens.color.white}}
-                        >
+                        <LabelMedium style={light && {color: color.white}}>
                             {kind}-default
                         </LabelMedium>
                         <IconButton
@@ -68,9 +65,7 @@ const KindVariants = ({
                                     : styles.darkDefault),
                         ]}
                     >
-                        <LabelMedium
-                            style={light && {color: tokens.color.white}}
-                        >
+                        <LabelMedium style={light && {color: color.white}}>
                             {kind}-destructive
                         </LabelMedium>
                         <IconButton
@@ -90,9 +85,7 @@ const KindVariants = ({
                                     : styles.darkDefault),
                         ]}
                     >
-                        <LabelMedium
-                            style={light && {color: tokens.color.white}}
-                        >
+                        <LabelMedium style={light && {color: color.white}}>
                             {kind}-disabled
                         </LabelMedium>
                         <IconButton
@@ -110,7 +103,7 @@ const KindVariants = ({
 };
 
 const VariantsByTheme = ({themeName = "Default"}: {themeName?: string}) => (
-    <View style={{marginBottom: Spacing.large_24}}>
+    <View style={{marginBottom: spacing.large_24}}>
         <HeadingLarge>{themeName} theme</HeadingLarge>
         <View style={styles.grid}>
             <KindVariants kind="primary" light={false} />
@@ -157,21 +150,21 @@ export const Active: StoryComponentType = {
 
 const styles = StyleSheet.create({
     darkDefault: {
-        backgroundColor: tokens.color.darkBlue,
+        backgroundColor: color.darkBlue,
     },
     darkKhanmigo: {
-        backgroundColor: tokens.color.eggplant,
+        backgroundColor: color.eggplant,
     },
     grid: {
         display: "grid",
         gridTemplateColumns: "repeat(3, 250px)",
-        gap: Spacing.large_24,
+        gap: spacing.large_24,
     },
     gridRow: {
         flexDirection: "row",
         alignItems: "center",
-        gap: Spacing.medium_16,
+        gap: spacing.medium_16,
         justifyContent: "space-between",
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
 });

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -15,9 +15,8 @@ import minusCircle from "@phosphor-icons/core/regular/minus-circle.svg";
 import {MemoryRouter, Route, Switch} from "react-router";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {color} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-icon-button/package.json";
@@ -123,7 +122,7 @@ export const Sizes: StoryComponentType = {
         icon: magnifyingGlass,
     },
     render: (args) => (
-        <View style={{gap: Spacing.medium_16}}>
+        <View style={{gap: spacing.medium_16}}>
             <View style={styles.row}>
                 <LabelMedium style={styles.label}>xsmall</LabelMedium>
                 <IconButton
@@ -347,19 +346,19 @@ export const WithRouter: StoryComponentType = {
 const styles = StyleSheet.create({
     dark: {
         backgroundColor: color.darkBlue,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
     arrowsWrapper: {
         flexDirection: "row",
         justifyContent: "space-between",
-        width: Spacing.xxxLarge_64,
+        width: spacing.xxxLarge_64,
     },
     row: {
         flexDirection: "row",
-        gap: Spacing.medium_16,
+        gap: spacing.medium_16,
         alignItems: "center",
     },
     label: {
-        width: Spacing.xxxLarge_64,
+        width: spacing.xxxLarge_64,
     },
 });

--- a/__docs__/wonder-blocks-icon/accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-icon/accessibility.stories.mdx
@@ -3,7 +3,7 @@ import {Meta, Story, Canvas} from "@storybook/blocks";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "./phosphor-icon.argtypes";
@@ -54,11 +54,11 @@ More information about all these points can be found in the
 
 <Canvas>
     <Story name="Icon contrast">
-        <View style={{flexDirection: "row", marginBottom: Spacing.xSmall_8}}>
+        <View style={{flexDirection: "row", marginBottom: spacing.xSmall_8}}>
             <LabelMedium>High contrast icon (GOOD):</LabelMedium>
             <PhosphorIcon
                 icon={IconMappings.checkCircle}
-                style={{color: Color.blue, marginInlineStart: Spacing.xSmall_8}}
+                style={{color: Color.blue, marginInlineStart: spacing.xSmall_8}}
             />
         </View>
         <View style={{flexDirection: "row"}}>
@@ -67,7 +67,7 @@ More information about all these points can be found in the
                 icon={IconMappings.xCircle}
                 style={{
                     color: Color.lightBlue,
-                    marginInlineStart: Spacing.xSmall_8,
+                    marginInlineStart: spacing.xSmall_8,
                 }}
             />
         </View>
@@ -80,13 +80,13 @@ More information about all these points can be found in the
     <Story name="Right to left icons">
         <View style={{flexDirection: "row", direction: "ltr"}}>
             <PhosphorIcon icon={IconMappings.caretRight} />
-            <LabelMedium style={{marginInlineStart: Spacing.xSmall_8}}>
+            <LabelMedium style={{marginInlineStart: spacing.xSmall_8}}>
                 {"Left to right"}
             </LabelMedium>
         </View>
         <View style={{flexDirection: "row", direction: "rtl"}}>
             <PhosphorIcon icon={IconMappings.caretLeft} />
-            <LabelMedium style={{marginInlineStart: Spacing.xSmall_8}}>
+            <LabelMedium style={{marginInlineStart: spacing.xSmall_8}}>
                 {"دائیں سے بائیں"}
             </LabelMedium>
         </View>

--- a/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
@@ -40,7 +40,7 @@ import PhosphorIconArgtypes, {IconMappings} from "./phosphor-icon.argtypes";
  *     icon={magnifyingGlassIcon}
  *     color={Color.blue}
  *     size="medium"
- *     style={{margin: Spacing.xxxxSmall_2}}
+ *     style={{margin: spacing.xxxxSmall_2}}
  * />
  * ```
  *

--- a/__docs__/wonder-blocks-layout/media-layout.stories.tsx
+++ b/__docs__/wonder-blocks-layout/media-layout.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingSmall,
@@ -130,7 +130,7 @@ export const AllStyles: StoryComponentType = () => {
             // use shared styles for all sizes
             test: {
                 color: Color.white,
-                padding: Spacing.medium_16,
+                padding: spacing.medium_16,
             },
         }),
 
@@ -138,7 +138,7 @@ export const AllStyles: StoryComponentType = () => {
             // override the `padding` prop` here
             test: {
                 backgroundColor: Color.darkBlue,
-                padding: Spacing.xxLarge_48,
+                padding: spacing.xxLarge_48,
             },
         }),
 
@@ -188,14 +188,14 @@ export const CustomSpec: StoryComponentType = () => {
                 alignItems: "center",
                 backgroundColor: Color.darkBlue,
                 color: Color.white,
-                padding: Spacing.xxxLarge_64,
+                padding: spacing.xxxLarge_64,
             },
         }),
 
         small: StyleSheet.create({
             example: {
                 backgroundColor: Color.lightBlue,
-                padding: Spacing.small_12,
+                padding: spacing.small_12,
             },
         }),
     } as const;
@@ -205,14 +205,14 @@ export const CustomSpec: StoryComponentType = () => {
         small: {
             query: "(max-width: 767px)",
             totalColumns: 4,
-            gutterWidth: Spacing.medium_16,
-            marginWidth: Spacing.medium_16,
+            gutterWidth: spacing.medium_16,
+            marginWidth: spacing.medium_16,
         },
         large: {
             query: "(min-width: 768px)",
             totalColumns: 12,
-            gutterWidth: Spacing.xLarge_32,
-            marginWidth: Spacing.xxLarge_48,
+            gutterWidth: spacing.xLarge_32,
+            marginWidth: spacing.xxLarge_48,
         },
     };
 

--- a/__docs__/wonder-blocks-layout/strut.stories.tsx
+++ b/__docs__/wonder-blocks-layout/strut.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import Button from "@khanacademy/wonder-blocks-button";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import packageConfig from "../../packages/wonder-blocks-layout/package.json";
@@ -43,13 +43,13 @@ export const Default: StoryComponentType = {
         </View>
     ),
     args: {
-        size: Spacing.xxxLarge_64,
+        size: spacing.xxxLarge_64,
         style: {},
     },
 };
 
-const smallSize = Spacing.medium_16;
-const largeSize = Spacing.xxxLarge_64;
+const smallSize = spacing.medium_16;
+const largeSize = spacing.xxxLarge_64;
 
 export const Simple: StoryComponentType = {
     render: (args) => (

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -13,7 +13,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingSmall,
@@ -256,7 +256,7 @@ OpensInANewTab.parameters = {
 export const StartAndEndIcons: StoryComponentType = () => (
     <View>
         {/* Default (dark) */}
-        <View style={{padding: Spacing.large_24}}>
+        <View style={{padding: spacing.large_24}}>
             <Link
                 href="#"
                 startIcon={<PhosphorIcon icon={IconMappings.plusCircleBold} />}
@@ -329,7 +329,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
         <View
             style={{
                 backgroundColor: Color.darkBlue,
-                padding: Spacing.large_24,
+                padding: spacing.large_24,
             }}
         >
             <Link
@@ -628,7 +628,7 @@ InlineLight.play = async ({canvasElement}) => {
 export const Variants: StoryComponentType = () => (
     <View>
         {/* Default (dark) */}
-        <View style={{padding: Spacing.large_24}}>
+        <View style={{padding: spacing.large_24}}>
             {/* Standalone */}
             <View>
                 <View style={styles.standaloneLinkWrapper}>
@@ -670,7 +670,7 @@ export const Variants: StoryComponentType = () => (
                     </Link>
                 </View>
             </View>
-            <Strut size={Spacing.xSmall_8} />
+            <Strut size={spacing.xSmall_8} />
             {/* Inline */}
             <Body>
                 This is an{" "}
@@ -718,7 +718,7 @@ export const Variants: StoryComponentType = () => (
         <View
             style={{
                 backgroundColor: Color.darkBlue,
-                padding: Spacing.large_24,
+                padding: spacing.large_24,
             }}
         >
             {/* Standalone */}
@@ -753,7 +753,7 @@ export const Variants: StoryComponentType = () => (
                     </Link>
                 </View>
             </View>
-            <Strut size={Spacing.xSmall_8} />
+            <Strut size={spacing.xSmall_8} />
             {/* Inline */}
             <Body style={{color: Color.white}}>
                 This is an{" "}
@@ -926,7 +926,7 @@ WithTitle.play = async ({canvasElement}) => {
 };
 
 export const RightToLeftWithIcons: StoryComponentType = () => (
-    <View style={{padding: Spacing.medium_16}}>
+    <View style={{padding: spacing.medium_16}}>
         <View style={styles.rightToLeft}>
             <Link
                 href="/"
@@ -934,14 +934,14 @@ export const RightToLeftWithIcons: StoryComponentType = () => (
             >
                 هذا الرابط مكتوب باللغة العربية
             </Link>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Link
                 href="/"
                 endIcon={<PhosphorIcon icon={IconMappings.caretLeftBold} />}
             >
                 هذا الرابط مكتوب باللغة العربية
             </Link>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Link
                 href="/"
                 startIcon={<PhosphorIcon icon={IconMappings.caretRightBold} />}
@@ -970,12 +970,12 @@ const styles = StyleSheet.create({
         padding: 10,
     },
     heading: {
-        marginRight: Spacing.large_24,
+        marginRight: spacing.large_24,
     },
     navigation: {
         border: `1px dashed ${Color.lightBlue}`,
-        marginTop: Spacing.large_24,
-        padding: Spacing.large_24,
+        marginTop: spacing.large_24,
+        padding: spacing.large_24,
     },
     pinkLink: {
         color: Color.pink,
@@ -989,7 +989,7 @@ const styles = StyleSheet.create({
         // instead of taking the full width of the parent
         // container.
         display: "inline-block",
-        marginBottom: Spacing.xSmall_8,
+        marginBottom: spacing.xSmall_8,
     },
     rightToLeft: {
         width: "100%",
@@ -997,7 +997,7 @@ const styles = StyleSheet.create({
     },
     multiLine: {
         display: "inline-block",
-        marginBottom: Spacing.xSmall_8,
+        marginBottom: spacing.xSmall_8,
         maxWidth: "15%",
     },
 });

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -6,7 +6,6 @@ import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {Body, Title} from "@khanacademy/wonder-blocks-typography";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -126,7 +125,7 @@ export const Default: StoryComponentType = {
                         content={
                             <>
                                 <Title id="modal-title-0">Modal Title</Title>
-                                <Strut size={Spacing.large_24} />
+                                <Strut size={spacing.large_24} />
                                 <Body id="modal-desc-0">
                                     Here is some text in the modal.
                                 </Body>
@@ -191,7 +190,7 @@ export const WithAboveAndBelow: StoryComponentType = {
                                     <Title id="modal-title-2">
                                         Modal Title
                                     </Title>
-                                    <Strut size={Spacing.large_24} />
+                                    <Strut size={spacing.large_24} />
                                     <Body>Here is some text in the modal.</Body>
                                 </>
                             }
@@ -225,7 +224,7 @@ export const WithLauncher: StoryComponentType = {
                     content={
                         <>
                             <Title id="modal-title-3">Modal Title</Title>
-                            <Strut size={Spacing.large_24} />
+                            <Strut size={spacing.large_24} />
                             <Body>Here is some text in the modal.</Body>
                         </>
                     }
@@ -286,7 +285,7 @@ export const WithDarkPanel: StoryComponentType = {
                                     <Title id="modal-title-0">
                                         Modal Title
                                     </Title>
-                                    <Strut size={Spacing.large_24} />
+                                    <Strut size={spacing.large_24} />
                                     <Body id="modal-desc-0">
                                         Here is some text in the modal.
                                     </Body>

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge, Title} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -162,7 +162,7 @@ export const Default: StoryComponentType = {
                 content={
                     <>
                         <Title id="modal-id-0">Modal Title</Title>
-                        <Strut size={Spacing.large_24} />
+                        <Strut size={spacing.large_24} />
                         {longBody}
                     </>
                 }
@@ -183,7 +183,7 @@ export const WithButton: StoryComponentType = {
                 content={
                     <>
                         <Title id="modal-id-2">Modal Title</Title>
-                        <Strut size={Spacing.large_24} />
+                        <Strut size={spacing.large_24} />
                         {longBody}
                     </>
                 }
@@ -208,10 +208,10 @@ export const WithThreeActions: StoryComponentType = {
 
         const buttonStyle = {
             [desktop]: {
-                marginRight: Spacing.medium_16,
+                marginRight: spacing.medium_16,
             },
             [mobile]: {
-                marginBottom: Spacing.medium_16,
+                marginBottom: spacing.medium_16,
             },
         } as const;
 
@@ -232,7 +232,7 @@ export const WithThreeActions: StoryComponentType = {
                     content={
                         <>
                             <Title id="modal-id-3">Modal Title</Title>
-                            <Strut size={Spacing.large_24} />
+                            <Strut size={spacing.large_24} />
                             {longBody}
                         </>
                     }
@@ -280,7 +280,7 @@ export const WithMultipleActions: StoryComponentType = {
                     content={
                         <>
                             <Title id="modal-id-4">Modal Title</Title>
-                            <Strut size={Spacing.large_24} />
+                            <Strut size={spacing.large_24} />
                             {longBody}
                         </>
                     }

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -11,7 +11,7 @@ import {
     Choice,
 } from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, Title} from "@khanacademy/wonder-blocks-typography";
 
 import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
@@ -367,7 +367,7 @@ export const WithInitialFocusId: StoryComponentType = () => {
                         value={value}
                         onChange={setValue}
                     />
-                    <Strut size={Spacing.large_24} />
+                    <Strut size={spacing.large_24} />
                     <LabeledTextField
                         label="Label 2"
                         value={value2}
@@ -381,7 +381,7 @@ export const WithInitialFocusId: StoryComponentType = () => {
                     <Button kind="tertiary" onClick={closeModal}>
                         Cancel
                     </Button>
-                    <Strut size={Spacing.medium_16} />
+                    <Strut size={spacing.medium_16} />
                     <Button onClick={closeModal}>Submit</Button>
                 </>
             }
@@ -428,7 +428,7 @@ const SubModal = () => (
     <OnePaneDialog
         title="Submodal"
         content={
-            <View style={{gap: Spacing.medium_16}}>
+            <View style={{gap: spacing.medium_16}}>
                 <Body>
                     This modal demonstrates how the focus trap works when a
                     modal is opened from another modal.
@@ -461,7 +461,7 @@ export const FocusTrap: StoryComponentType = () => {
                         how the focus trap is moved to the next modal when it is
                         opened (focus/tap on the `Open another modal` button).
                     </Body>
-                    <Strut size={Spacing.large_24} />
+                    <Strut size={spacing.large_24} />
                     <RadioGroup
                         label="A RadioGroup component inside a modal"
                         description="Some description"
@@ -483,7 +483,7 @@ export const FocusTrap: StoryComponentType = () => {
                             </Button>
                         )}
                     </ModalLauncher>
-                    <Strut size={Spacing.medium_16} />
+                    <Strut size={spacing.medium_16} />
                     <Button onClick={closeModal} disabled={!selectedValue}>
                         Next
                     </Button>

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -6,7 +6,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, Title} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -165,7 +165,7 @@ export const Default: StoryComponentType = {
                 content={
                     <>
                         <Title id="modal-title-0">Modal Title</Title>
-                        <Strut size={Spacing.large_24} />
+                        <Strut size={spacing.large_24} />
                         {longBody}
                     </>
                 }
@@ -184,7 +184,7 @@ export const Dark: StoryComponentType = {
                 content={
                     <>
                         <Title id="modal-title-a">Modal Title</Title>
-                        <Strut size={Spacing.large_24} />
+                        <Strut size={spacing.large_24} />
                         {longBody}
                     </>
                 }
@@ -223,7 +223,7 @@ export const WithFooter: StoryComponentType = {
                 content={
                     <>
                         <Title id="modal-title-3">Modal Title</Title>
-                        <Strut size={Spacing.large_24} />
+                        <Strut size={spacing.large_24} />
                         {longBody}
                     </>
                 }
@@ -307,7 +307,7 @@ export const TwoPanels: StoryComponentType = {
                         content={
                             <View>
                                 <Title>Sidebar</Title>
-                                <Strut size={Spacing.large_24} />
+                                <Strut size={spacing.large_24} />
                                 <Body>
                                     Lorem ipsum dolor sit amet, consectetur
                                     adipiscing elit, sed do eiusmod tempor
@@ -324,13 +324,13 @@ export const TwoPanels: StoryComponentType = {
                         content={
                             <View>
                                 <Title>Contents</Title>
-                                <Strut size={Spacing.large_24} />
+                                <Strut size={spacing.large_24} />
                                 <Body>
                                     Lorem ipsum dolor sit amet, consectetur
                                     adipiscing elit, sed do eiusmod tempor
                                     incididunt ut labore et dolore magna aliqua.
                                 </Body>
-                                <Strut size={Spacing.large_24} />
+                                <Strut size={spacing.large_24} />
                                 <Button>Primary action</Button>
                             </View>
                         }

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -12,7 +12,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
@@ -385,7 +385,7 @@ WithStyle.parameters = {
 export const FlexibleModal: StoryComponentType = () => {
     const styles = StyleSheet.create({
         example: {
-            padding: Spacing.xLarge_32,
+            padding: spacing.xLarge_32,
             alignItems: "center",
         },
         row: {

--- a/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
@@ -6,7 +6,7 @@ import Color from "@khanacademy/wonder-blocks-color";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingSmall,
@@ -50,28 +50,28 @@ const styles = StyleSheet.create({
     popoverWithIcon: {
         alignItems: "center",
         flexDirection: "row",
-        gap: Spacing.medium_16,
+        gap: spacing.medium_16,
     },
     popoverWithCell: {
         padding: 0,
     },
     customPopover: {
-        maxWidth: Spacing.medium_16 * 25,
-        width: Spacing.medium_16 * 25,
+        maxWidth: spacing.medium_16 * 25,
+        width: spacing.medium_16 * 25,
         textAlign: "center",
     },
     row: {
         flexDirection: "row",
         justifyContent: "center",
-        padding: `${Spacing.small_12}px 0`,
+        padding: `${spacing.small_12}px 0`,
     },
     action: {
         backgroundColor: "transparent",
         border: "none",
         color: Color.white,
         cursor: "pointer",
-        margin: Spacing.small_12,
-        padding: Spacing.xxSmall_6,
+        margin: spacing.small_12,
+        padding: spacing.xxSmall_6,
         alignItems: "center",
         justifyContent: "center",
     },

--- a/__docs__/wonder-blocks-popover/popover-content.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.argtypes.tsx
@@ -3,7 +3,7 @@ import type {InputType} from "@storybook/csf";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {Spring, Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 type Mappings = Record<string, React.ReactNode>;
@@ -19,7 +19,7 @@ const ActionsMappings: Mappings = {
     pagination: (
         <>
             <Button kind="tertiary">Previous</Button>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button kind="primary">Next</Button>
         </>
     ),
@@ -28,7 +28,7 @@ const ActionsMappings: Mappings = {
             <Button kind="tertiary" light={true}>
                 Previous
             </Button>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button kind="primary" light={true}>
                 Next
             </Button>

--- a/__docs__/wonder-blocks-popover/popover-content.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {PopoverContent} from "@khanacademy/wonder-blocks-popover";
 import packageConfig from "../../packages/wonder-blocks-popover/package.json";
@@ -83,7 +83,7 @@ export const Emphasized: StoryComponentType = {
                 <Button light={true} kind="secondary">
                     Previous
                 </Button>
-                <Strut size={Spacing.medium_16} />
+                <Strut size={spacing.medium_16} />
                 <Button light={true} kind="primary">
                     Next
                 </Button>

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -6,7 +6,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import type {Placement} from "@khanacademy/wonder-blocks-tooltip";
 
@@ -83,10 +83,10 @@ const styles = StyleSheet.create({
     },
     playground: {
         border: `1px dashed ${Color.lightBlue}`,
-        marginTop: Spacing.large_24,
-        padding: Spacing.large_24,
+        marginTop: spacing.large_24,
+        padding: spacing.large_24,
         flexDirection: "row",
-        gap: Spacing.medium_16,
+        gap: spacing.medium_16,
     },
 });
 
@@ -217,7 +217,7 @@ export const Controlled: StoryComponentType = () => {
                     Anchor element (it does not open the popover)
                 </Button>
             </Popover>
-            <Strut size={Spacing.xLarge_32} />
+            <Strut size={spacing.xLarge_32} />
             <Button onClick={() => setOpened(true)}>
                 Outside button (click here to re-open the popover)
             </Button>
@@ -262,7 +262,7 @@ export const WithActions: StoryComponentType = () => {
                             <LabelLarge>
                                 Step {step} of {totalSteps}
                             </LabelLarge>
-                            <Strut size={Spacing.medium_16} />
+                            <Strut size={spacing.medium_16} />
                             <Button
                                 kind="tertiary"
                                 onClick={() => {
@@ -315,7 +315,7 @@ export const WithInitialFocusId: StoryComponentType = {
                         <Button kind="tertiary" id="popover-button-1">
                             No focus
                         </Button>
-                        <Strut size={Spacing.medium_16} />
+                        <Strut size={spacing.medium_16} />
                         <Button kind="tertiary" id="popover-button-2">
                             It is focused!
                         </Button>
@@ -431,7 +431,7 @@ export const KeyboardNavigation: StoryComponentType = {
 
         return (
             <View>
-                <View style={[styles.row, {gap: Spacing.medium_16}]}>
+                <View style={[styles.row, {gap: spacing.medium_16}]}>
                     <Button
                         kind="secondary"
                         onClick={() => {

--- a/__docs__/wonder-blocks-progress-spinner/circular-spinner.stories.tsx
+++ b/__docs__/wonder-blocks-progress-spinner/circular-spinner.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {CircularSpinner} from "@khanacademy/wonder-blocks-progress-spinner";
 
@@ -171,13 +171,13 @@ WithStyle.parameters = {
 const styles = StyleSheet.create({
     darkBackground: {
         background: Color.darkBlue,
-        padding: Spacing.xLarge_32,
+        padding: spacing.xLarge_32,
         width: "100%",
         alignItems: "center",
         justifyContent: "center",
     },
     distanced: {
-        margin: Spacing.large_24,
+        margin: spacing.large_24,
     },
     example: {
         alignItems: "center",
@@ -185,6 +185,6 @@ const styles = StyleSheet.create({
     },
     row: {
         flexDirection: "row",
-        marginBottom: Spacing.xLarge_32,
+        marginBottom: spacing.xLarge_32,
     },
 });

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -6,7 +6,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import SearchField from "@khanacademy/wonder-blocks-search-field";
@@ -154,19 +154,19 @@ export const WithAutofocus: StoryComponentType = () => {
                 autoFocus={true}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
-                style={{flexGrow: 1, marginLeft: Spacing.small_12}}
+                style={{flexGrow: 1, marginLeft: spacing.small_12}}
             />
         </View>
     );
 
     return (
         <View>
-            <LabelLarge style={{marginBottom: Spacing.small_12}}>
+            <LabelLarge style={{marginBottom: spacing.small_12}}>
                 Press the button to view the search field with autofocus.
             </LabelLarge>
             <Button
                 onClick={handleShowDemo}
-                style={{width: 300, marginBottom: Spacing.large_24}}
+                style={{width: 300, marginBottom: spacing.large_24}}
             >
                 Toggle autoFocus demo
             </Button>
@@ -193,6 +193,6 @@ WithAutofocus.parameters = {
 const styles = StyleSheet.create({
     darkBackground: {
         background: Color.darkBlue,
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
 });

--- a/__docs__/wonder-blocks-spacing/spacing-table.tsx
+++ b/__docs__/wonder-blocks-spacing/spacing-table.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const StyledTable = addStyle("table");
 const StyledTableRow = addStyle("tr");
@@ -31,7 +31,7 @@ export default function SpacingTable(): React.ReactElement {
                 </StyledTableRow>
             </thead>
             <tbody>
-                {Object.keys(Spacing).map((spaceName, idx) => (
+                {Object.keys(spacing).map((spaceName, idx) => (
                     <StyledTableRow key={idx} style={styles.row}>
                         <StyledTableCell style={styles.cell}>
                             <LabelMedium style={styles.tag}>
@@ -40,15 +40,15 @@ export default function SpacingTable(): React.ReactElement {
                         </StyledTableCell>
                         <StyledTableCell style={styles.cell}>
                             {/* @ts-expect-error [FEI-5019] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ readonly xxxxSmall_2: 2; readonly xxxSmall_4: 4; readonly xxSmall_6: 6; readonly xSmall_8: 8; readonly small_12: 12; readonly medium_16: 16; readonly large_24: 24; readonly xLarge_32: 32; readonly xxLarge_48: 48; readonly xxxLarge_64: 64; }'. */}
-                            <LabelMedium>{Spacing[spaceName]}px</LabelMedium>
+                            <LabelMedium>{spacing[spaceName]}px</LabelMedium>
                         </StyledTableCell>
                         <StyledTableCell style={styles.cell}>
                             <View
                                 style={{
                                     backgroundColor: Color.purple,
                                     // @ts-expect-error [FEI-5019] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ readonly xxxxSmall_2: 2; readonly xxxSmall_4: 4; readonly xxSmall_6: 6; readonly xSmall_8: 8; readonly small_12: 12; readonly medium_16: 16; readonly large_24: 24; readonly xLarge_32: 32; readonly xxLarge_48: 48; readonly xxxLarge_64: 64; }'.
-                                    width: Spacing[spaceName],
-                                    height: Spacing.medium_16,
+                                    width: spacing[spaceName],
+                                    height: spacing.medium_16,
                                 }}
                             />
                         </StyledTableCell>
@@ -56,9 +56,9 @@ export default function SpacingTable(): React.ReactElement {
                             <View
                                 style={{
                                     backgroundColor: Color.purple,
-                                    width: Spacing.medium_16,
+                                    width: spacing.medium_16,
                                     // @ts-expect-error [FEI-5019] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ readonly xxxxSmall_2: 2; readonly xxxSmall_4: 4; readonly xxSmall_6: 6; readonly xSmall_8: 8; readonly small_12: 12; readonly medium_16: 16; readonly large_24: 24; readonly xLarge_32: 32; readonly xxLarge_48: 48; readonly xxxLarge_64: 64; }'.
-                                    height: Spacing[spaceName],
+                                    height: spacing[spaceName],
                                 }}
                             />
                         </StyledTableCell>
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
     table: {
         borderCollapse: "collapse",
         borderSpacing: 0,
-        margin: `${Spacing.xLarge_32}px 0`,
+        margin: `${spacing.xLarge_32}px 0`,
         textAlign: "left",
         width: "100%",
     },
@@ -84,15 +84,15 @@ const styles = StyleSheet.create({
         borderTop: `1px solid ${Color.offBlack8}`,
     },
     cell: {
-        padding: Spacing.xSmall_8,
+        padding: spacing.xSmall_8,
         verticalAlign: "middle",
     },
     tag: {
         background: Color.offWhite,
         border: `solid 1px ${Color.offBlack8}`,
-        borderRadius: Spacing.xxxxSmall_2,
+        borderRadius: spacing.xxxxSmall_2,
         display: "inline-block",
-        margin: `${Spacing.xxxSmall_4}px 0`,
-        padding: `0 ${Spacing.xxxSmall_4}px`,
+        margin: `${spacing.xxxSmall_4}px 0`,
+        padding: `0 ${spacing.xxxSmall_4}px`,
     },
 });

--- a/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
@@ -7,7 +7,7 @@ import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import packageConfig from "../../packages/wonder-blocks-switch/package.json";
@@ -55,7 +55,7 @@ export const WithLabel: StoryComponentType = (() => {
             <LabelMedium
                 id="label-for-switch-with-label"
                 htmlFor="switch-with-label"
-                style={{marginLeft: Spacing.xSmall_8}}
+                style={{marginLeft: spacing.xSmall_8}}
                 tag="label"
             >
                 Superpowers
@@ -81,7 +81,7 @@ export const WithLabelAndDescription: StoryComponentType = (() => {
                 aria-labelledby="label-for-switch-with-desc"
                 aria-describedby="desc-for-switch-with-desc"
             />
-            <View style={{marginLeft: Spacing.xSmall_8}}>
+            <View style={{marginLeft: spacing.xSmall_8}}>
                 <LabelMedium
                     id="label-for-switch-with-desc"
                     htmlFor="switch-with-desc"
@@ -116,7 +116,7 @@ export const WithLabelAndOnOff: StoryComponentType = (() => {
             <LabelMedium
                 id="label-for-switch-with-on-off"
                 htmlFor="switch-with-on-off"
-                style={{marginRight: Spacing.xSmall_8}}
+                style={{marginRight: spacing.xSmall_8}}
                 tag="label"
             >
                 Gravity
@@ -128,7 +128,7 @@ export const WithLabelAndOnOff: StoryComponentType = (() => {
                 aria-labelledby="label-for-switch-with-on-off"
             />
             <LabelSmall
-                style={{marginLeft: Spacing.xSmall_8, color: Color.offBlack64}}
+                style={{marginLeft: spacing.xSmall_8, color: Color.offBlack64}}
                 aria-hidden={true}
             >
                 {checked ? "ON" : "OFF"}

--- a/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
@@ -10,14 +10,14 @@ import Button from "@khanacademy/wonder-blocks-button";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 const mobile = "@media (max-width: 1023px)";
 
 const styles = StyleSheet.create({
     fillContent: {
-        marginLeft: Spacing.small_12,
+        marginLeft: spacing.small_12,
         [mobile]: {
             width: "100vw",
         },
@@ -41,7 +41,7 @@ export const leftContentMappings: Mappings = {
     multipleContent: (
         <>
             <IconButton icon={magnifyingGlassMinus} kind="primary" />
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <IconButton icon={magnifyingGlassPlus} kind="primary" />
         </>
     ),
@@ -67,11 +67,11 @@ export const rightContentMappings: Mappings = {
     multipleContent: (
         <>
             <LabelLarge>7 questions</LabelLarge>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button style={buttonStyle} kind="secondary">
                 Try again
             </Button>
-            <Strut size={Spacing.medium_16} />
+            <Strut size={spacing.medium_16} />
             <Button style={buttonStyle}>Next exercise</Button>
         </>
     ),

--- a/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import Toolbar from "@khanacademy/wonder-blocks-toolbar";
 import packageConfig from "../../packages/wonder-blocks-toolbar/package.json";
@@ -46,7 +46,7 @@ export default {
 
 const styles = StyleSheet.create({
     example: {
-        padding: Spacing.large_24,
+        padding: spacing.large_24,
         alignItems: "center",
         justifyContent: "center",
     },

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -13,7 +13,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
@@ -311,7 +311,7 @@ export const WithStyle: StoryComponentType = () => {
             <Tooltip
                 contentStyle={{
                     color: Color.white,
-                    padding: Spacing.xLarge_32,
+                    padding: spacing.xLarge_32,
                 }}
                 content={`This is a styled tooltip.`}
                 backgroundColor="darkBlue"
@@ -357,7 +357,7 @@ const styles = StyleSheet.create({
     storyCanvas: {
         // NOTE: This is needed for Chromatic to include the tooltip bubble.
         minHeight: 280,
-        padding: Spacing.xxxLarge_64,
+        padding: spacing.xxxLarge_64,
         justifyContent: "center",
         textAlign: "center",
     },
@@ -367,14 +367,14 @@ const styles = StyleSheet.create({
     centered: {
         alignItems: "center",
         justifyContent: "center",
-        gap: Spacing.medium_16,
-        padding: Spacing.xxLarge_48,
+        gap: spacing.medium_16,
+        padding: spacing.xxLarge_48,
     },
     scrollbox: {
         height: 100,
         overflow: "auto",
         border: "1px solid black",
-        margin: Spacing.small_12,
+        margin: spacing.small_12,
     },
     hostbox: {
         minHeight: "200vh",
@@ -384,8 +384,8 @@ const styles = StyleSheet.create({
     },
     block: {
         border: `solid 1px ${Color.lightBlue}`,
-        width: Spacing.xLarge_32,
-        height: Spacing.xLarge_32,
+        width: spacing.xLarge_32,
+        height: spacing.xLarge_32,
         alignItems: "center",
         justifyContent: "center",
     },

--- a/__docs__/wonder-blocks-typography/accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-typography/accessibility.stories.mdx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
@@ -136,16 +136,16 @@ export const styles = StyleSheet.create({
     explanation: {
         fontWeight: 700,
         flexDirection: "row",
-        marginTop: Spacing.xSmall_8,
+        marginTop: spacing.xSmall_8,
     },
     correct: {
         color: Color.green,
-        marginRight: Spacing.xxxSmall_4,
-        paddingTop: Spacing.xxxxSmall_2,
+        marginRight: spacing.xxxSmall_4,
+        paddingTop: spacing.xxxxSmall_2,
     },
     incorrect: {
         color: Color.red,
-        marginRight: Spacing.xxxSmall_4,
-        paddingTop: Spacing.xxxxSmall_2,
+        marginRight: spacing.xxxSmall_4,
+        paddingTop: spacing.xxxxSmall_2,
     },
 });

--- a/__docs__/wonder-blocks-typography/typography.stories.tsx
+++ b/__docs__/wonder-blocks-typography/typography.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Title,
     HeadingLarge,
@@ -368,7 +368,7 @@ Paragraph.parameters = {
 export const LineHeight: StoryObj<any> = () => {
     const style = {
         outline: `1px solid ${Color.offBlack}`,
-        marginBottom: Spacing.small_12,
+        marginBottom: spacing.small_12,
     } as const;
 
     return (

--- a/consistency-tests/tsconfig.json
+++ b/consistency-tests/tsconfig.json
@@ -20,9 +20,9 @@
         {"path": "../packages/wonder-blocks-modal/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-pill/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-search-field/tsconfig-build.json"},
-        {"path": "../packages/wonder-blocks-spacing/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-switch/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-timing/tsconfig-build.json"},
+        {"path": "../packages/wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../packages/wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-banner/package.json
+++ b/packages/wonder-blocks-banner/package.json
@@ -22,7 +22,7 @@
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
     "@khanacademy/wonder-blocks-icon-button": "^5.1.8",
     "@khanacademy/wonder-blocks-link": "^6.0.5",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -9,7 +9,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon, PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import Link from "@khanacademy/wonder-blocks-link";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 import infoIcon from "@phosphor-icons/core/regular/info.svg";
@@ -297,7 +297,7 @@ const styles = StyleSheet.create({
         opacity: 0.08,
     },
     containerOuter: {
-        borderInlineStartWidth: Spacing.xxSmall_6,
+        borderInlineStartWidth: spacing.xxSmall_6,
         width: "100%",
         // Because of the background color's opacity value,
         // the base color needs to be hard-coded as white for the
@@ -307,16 +307,16 @@ const styles = StyleSheet.create({
     },
     containerInner: {
         flexDirection: "row",
-        padding: Spacing.xSmall_8,
+        padding: spacing.xSmall_8,
     },
     icon: {
-        marginTop: Spacing.xSmall_8,
-        marginBottom: Spacing.xSmall_8,
+        marginTop: spacing.xSmall_8,
+        marginBottom: spacing.xSmall_8,
         // The total distance from the icon to the edge is 16px. The
         // vertical identifier is already 6px, and the padding on inner
         // conatiner is 8px. So that leaves 2px.
-        marginInlineStart: Spacing.xxxxSmall_2,
-        marginInlineEnd: Spacing.xSmall_8,
+        marginInlineStart: spacing.xxxxSmall_2,
+        marginInlineEnd: spacing.xSmall_8,
         alignSelf: "flex-start",
         color: Color.offBlack64,
     },
@@ -330,19 +330,19 @@ const styles = StyleSheet.create({
     },
     labelContainer: {
         flexShrink: 1,
-        margin: Spacing.xSmall_8,
+        margin: spacing.xSmall_8,
         textAlign: "start",
         overflowWrap: "break-word",
     },
     actionsContainer: {
         flexDirection: "row",
         justifyContent: "flex-start",
-        marginTop: Spacing.xSmall_8,
-        marginBottom: Spacing.xSmall_8,
+        marginTop: spacing.xSmall_8,
+        marginBottom: spacing.xSmall_8,
     },
     action: {
-        marginLeft: Spacing.xSmall_8,
-        marginRight: Spacing.xSmall_8,
+        marginLeft: spacing.xSmall_8,
+        marginRight: spacing.xSmall_8,
         justifyContent: "center",
         // Set the height to remove the padding from buttons
         height: 18,
@@ -358,8 +358,8 @@ const styles = StyleSheet.create({
         width: 40,
         justifyContent: "center",
         alignItems: "center",
-        marginLeft: Spacing.xSmall_8,
-        marginRight: Spacing.xSmall_8,
+        marginLeft: spacing.xSmall_8,
+        marginRight: spacing.xSmall_8,
     },
     floatingBorder: {
         borderRadius: 4,

--- a/packages/wonder-blocks-banner/tsconfig-build.json
+++ b/packages/wonder-blocks-banner/tsconfig-build.json
@@ -12,7 +12,7 @@
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-link/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-birthday-picker/package.json
+++ b/packages/wonder-blocks-birthday-picker/package.json
@@ -19,7 +19,7 @@
     "@khanacademy/wonder-blocks-dropdown": "^5.1.3",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -2,7 +2,7 @@ import moment from "moment"; // NOTE: DO NOT use named imports; 'moment' does no
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Color from "@khanacademy/wonder-blocks-color";
@@ -245,7 +245,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
 
         return (
             <>
-                <Strut size={Spacing.xxxSmall_4} />
+                <Strut size={spacing.xxxSmall_4} />
                 <View
                     style={{flexDirection: "row", placeItems: "center"}}
                     role="alert"
@@ -256,7 +256,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                         color={Color.red}
                         aria-hidden="true"
                     />
-                    <Strut size={Spacing.xxxSmall_4} />
+                    <Strut size={spacing.xxxSmall_4} />
                     <Body style={{color: Color.red}}>{error}</Body>
                 </View>
             </>
@@ -300,7 +300,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
 
         return (
             <>
-                <Strut size={Spacing.xSmall_8} />
+                <Strut size={spacing.xSmall_8} />
                 <SingleSelect
                     aria-invalid={!!this.state.error}
                     error={!!this.state.error}
@@ -360,7 +360,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
 
                     {this.maybeRenderDay()}
 
-                    <Strut size={Spacing.xSmall_8} />
+                    <Strut size={spacing.xSmall_8} />
 
                     {this.renderYear()}
                 </View>

--- a/packages/wonder-blocks-birthday-picker/tsconfig-build.json
+++ b/packages/wonder-blocks-birthday-picker/tsconfig-build.json
@@ -11,7 +11,7 @@
         {"path": "../wonder-blocks-dropdown/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-breadcrumbs/package.json
+++ b/packages/wonder-blocks-breadcrumbs/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1"
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 type Props = AriaProps & {
     /**
@@ -71,11 +71,11 @@ const styles = StyleSheet.create({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        marginRight: Spacing.xxxSmall_4,
+        marginRight: spacing.xxxSmall_4,
     },
 
     separator: {
-        marginLeft: Spacing.xxxSmall_4,
+        marginLeft: spacing.xxxSmall_4,
     },
 });
 

--- a/packages/wonder-blocks-breadcrumbs/tsconfig-build.json
+++ b/packages/wonder-blocks-breadcrumbs/tsconfig-build.json
@@ -9,7 +9,7 @@
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
         {"path": "../wonder-blocks-link/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -21,7 +21,6 @@
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
     "@khanacademy/wonder-blocks-progress-spinner": "^2.0.25",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
     "@khanacademy/wonder-blocks-theming": "^1.3.0",
     "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"

--- a/packages/wonder-blocks-button/tsconfig-build.json
+++ b/packages/wonder-blocks-button/tsconfig-build.json
@@ -11,7 +11,6 @@
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-progress-spinner/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
         {"path": "../wonder-blocks-theming/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},

--- a/packages/wonder-blocks-cell/package.json
+++ b/packages/wonder-blocks-cell/package.json
@@ -18,7 +18,7 @@
     "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-cell/src/components/detail-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import CellCore from "./internal/cell-core";
@@ -80,14 +80,14 @@ const DetailCell = function (props: DetailCellProps): React.ReactElement {
     return (
         <CellCore {...coreProps} innerStyle={styles.innerWrapper}>
             <Subtitle subtitle={subtitle1} disabled={coreProps.disabled} />
-            {subtitle1 && <Strut size={Spacing.xxxxSmall_2} />}
+            {subtitle1 && <Strut size={spacing.xxxxSmall_2} />}
             {typeof title === "string" ? (
                 <LabelMedium>{title}</LabelMedium>
             ) : (
                 title
             )}
             {/* Add a vertical spacing between the title and the subtitle */}
-            {subtitle2 && <Strut size={Spacing.xxxxSmall_2} />}
+            {subtitle2 && <Strut size={spacing.xxxxSmall_2} />}
             <Subtitle subtitle={subtitle2} disabled={coreProps.disabled} />
         </CellCore>
     );

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -7,7 +7,7 @@ import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Color, {fade} from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {CellMeasurements, getHorizontalRuleStyles} from "./common";
 
@@ -282,7 +282,7 @@ const styles = StyleSheet.create({
 
         // focus (only visible when using keyboard navigation)
         ":focus-visible": {
-            borderRadius: Spacing.xxxSmall_4,
+            borderRadius: spacing.xxxSmall_4,
             // To hide the internal corners of the cell.
             overflow: "hidden",
             // To display the focus ring based on the cell's border.
@@ -302,10 +302,10 @@ const styles = StyleSheet.create({
             zIndex: 1,
             // We remove the border width from the width/height to ensure
             // that the focus ring is drawn inside the cell.
-            width: `calc(100% - ${Spacing.xxxSmall_4}px)`,
-            height: `calc(100% - ${Spacing.xxxSmall_4}px)`,
-            border: `${Spacing.xxxxSmall_2}px solid ${Color.blue}`,
-            borderRadius: Spacing.xxxSmall_4,
+            width: `calc(100% - ${spacing.xxxSmall_4}px)`,
+            height: `calc(100% - ${spacing.xxxSmall_4}px)`,
+            border: `${spacing.xxxxSmall_2}px solid ${Color.blue}`,
+            borderRadius: spacing.xxxSmall_4,
         },
 
         // hover + enabled

--- a/packages/wonder-blocks-cell/src/components/internal/common.ts
+++ b/packages/wonder-blocks-cell/src/components/internal/common.ts
@@ -1,34 +1,34 @@
 import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import type {HorizontalRuleVariant} from "../../util/types";
 
 export const CellMeasurements = {
-    cellMinHeight: Spacing.xxLarge_48,
+    cellMinHeight: spacing.xxLarge_48,
 
     /**
      * The cell wrapper's gap.
      */
     cellPadding: {
-        paddingVertical: Spacing.small_12,
-        paddingHorizontal: Spacing.medium_16,
+        paddingVertical: spacing.small_12,
+        paddingHorizontal: spacing.medium_16,
     },
 
     /**
      * The DetailCell wrapper's gap.
      */
     detailCellPadding: {
-        paddingVertical: Spacing.medium_16,
-        paddingHorizontal: Spacing.medium_16,
+        paddingVertical: spacing.medium_16,
+        paddingHorizontal: spacing.medium_16,
     },
 
     /**
      * The horizontal spacing between the left and right accessory.
      */
-    accessoryHorizontalSpacing: Spacing.medium_16,
+    accessoryHorizontalSpacing: spacing.medium_16,
 } as const;
 
 /**
@@ -61,7 +61,7 @@ const styles = StyleSheet.create({
             bottom: 0,
             // align border to the right of the cell
             right: 0,
-            height: Spacing.xxxxSmall_2,
+            height: spacing.xxxxSmall_2,
             boxShadow: `inset 0px -1px 0px ${Color.offBlack8}`,
         },
     },

--- a/packages/wonder-blocks-cell/tsconfig-build.json
+++ b/packages/wonder-blocks-cell/tsconfig-build.json
@@ -11,7 +11,7 @@
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {CompactCell} from "@khanacademy/wonder-blocks-cell";
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import type {PropsFor, StyleType} from "@khanacademy/wonder-blocks-core";
@@ -189,9 +189,9 @@ const styles = StyleSheet.create({
         ":focus": {
             // Override the default focus state for the cell element, so that it
             // can be added programmatically to the button element.
-            borderRadius: Spacing.xxxSmall_4,
-            outline: `${Spacing.xxxxSmall_2}px solid ${Color.blue}`,
-            outlineOffset: -Spacing.xxxxSmall_2,
+            borderRadius: spacing.xxxSmall_4,
+            outline: `${spacing.xxxxSmall_2}px solid ${Color.blue}`,
+            outlineOffset: -spacing.xxxxSmall_2,
         },
 
         // Overrides the default cell state for the button element.
@@ -228,6 +228,6 @@ const styles = StyleSheet.create({
 
     indent: {
         // Cell's internal padding + checkbox width + checkbox margin
-        paddingLeft: Spacing.medium_16 * 2,
+        paddingLeft: spacing.medium_16 * 2,
     },
 });

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -5,7 +5,7 @@ import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import Color, {SemanticColor, mix} from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import type {ClickableState} from "@khanacademy/wonder-blocks-clickable";
@@ -90,7 +90,7 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
                 >
                     {label}
                 </View>
-                <Strut size={Spacing.xxxSmall_4} />
+                <Strut size={spacing.xxxSmall_4} />
                 <PhosphorIcon
                     size="small"
                     color="currentColor"
@@ -110,7 +110,7 @@ const sharedStyles = StyleSheet.create({
         justifyContent: "center",
         height: DROPDOWN_ITEM_HEIGHT,
         border: "none",
-        borderRadius: Spacing.xxxSmall_4,
+        borderRadius: spacing.xxxSmall_4,
         cursor: "pointer",
         outline: "none",
         textDecoration: "none",
@@ -127,7 +127,7 @@ const sharedStyles = StyleSheet.create({
         cursor: "auto",
     },
     small: {
-        height: Spacing.xLarge_32,
+        height: spacing.xLarge_32,
     },
     text: {
         textAlign: "left",

--- a/packages/wonder-blocks-dropdown/src/components/check.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/check.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 
 /**
@@ -35,10 +35,10 @@ export default Check;
 const styles = StyleSheet.create({
     bounds: {
         alignSelf: "center",
-        height: Spacing.medium_16,
+        height: spacing.medium_16,
         // Semantically, this are the constants for a small-sized icon
-        minHeight: Spacing.medium_16,
-        minWidth: Spacing.medium_16,
+        minHeight: spacing.medium_16,
+        minWidth: spacing.medium_16,
     },
 
     hide: {

--- a/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 
 const {offBlack16, offBlack50, offWhite} = Color;
@@ -44,11 +44,11 @@ const Checkbox = function (props: CheckProps): React.ReactElement {
                         {
                             // The check icon is smaller than the checkbox, as
                             // per design.
-                            width: Spacing.small_12,
-                            height: Spacing.small_12,
+                            width: spacing.small_12,
+                            height: spacing.small_12,
                             // This margin is to center the check icon in the
                             // checkbox.
-                            margin: Spacing.xxxxSmall_2,
+                            margin: spacing.xxxxSmall_2,
                         },
                         disabled && selected && styles.disabledCheckFormatting,
                     ]}
@@ -64,9 +64,9 @@ const styles = StyleSheet.create({
     checkbox: {
         alignSelf: "center",
         // Semantically, this are the constants for a small-sized icon
-        minHeight: Spacing.medium_16,
-        minWidth: Spacing.medium_16,
-        height: Spacing.medium_16,
+        minHeight: spacing.medium_16,
+        minWidth: spacing.medium_16,
+        height: spacing.medium_16,
         borderRadius: 3,
         borderWidth: 1,
         borderStyle: "solid",

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -9,7 +9,7 @@ import {VariableSizeList as List} from "react-window";
 
 import Color, {fade} from "@khanacademy/wonder-blocks-color";
 
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle, PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
@@ -1060,8 +1060,8 @@ const styles = StyleSheet.create({
     dropdown: {
         backgroundColor: Color.white,
         borderRadius: 4,
-        paddingTop: Spacing.xxxSmall_4,
-        paddingBottom: Spacing.xxxSmall_4,
+        paddingTop: spacing.xxxSmall_4,
+        paddingBottom: spacing.xxxSmall_4,
         border: `solid 1px ${Color.offBlack16}`,
         boxShadow: `0px 8px 8px 0px ${fade(Color.offBlack, 0.1)}`,
         // We use a custom property to set the max height of the dropdown.
@@ -1087,12 +1087,12 @@ const styles = StyleSheet.create({
     noResult: {
         color: Color.offBlack64,
         alignSelf: "center",
-        marginTop: Spacing.xxSmall_6,
+        marginTop: spacing.xxSmall_6,
     },
 
     searchInputStyle: {
-        margin: Spacing.xSmall_8,
-        marginTop: Spacing.xxxSmall_4,
+        margin: spacing.xSmall_8,
+        marginTop: spacing.xxxSmall_4,
         // Set `minHeight` to "auto" to stop the search field from having
         // a height of 0 and being cut off.
         minHeight: "auto",

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 import {AriaProps, StyleType, View} from "@khanacademy/wonder-blocks-core";
@@ -194,7 +194,7 @@ export default class OptionItem extends React.Component<OptionProps> {
                                     disabled={disabled}
                                     selected={selected}
                                 />
-                                <Strut size={Spacing.xSmall_8} />
+                                <Strut size={spacing.xSmall_8} />
                                 {leftAccessory}
                             </View>
                         ) : (
@@ -238,7 +238,7 @@ const styles = StyleSheet.create({
         // vertically.
         minHeight: "unset",
         // Make sure that the item is always at least as tall as 40px.
-        paddingBlock: Spacing.xxxxSmall_2,
+        paddingBlock: spacing.xxxxSmall_2,
 
         /**
          * States
@@ -246,9 +246,9 @@ const styles = StyleSheet.create({
         ":focus": {
             // Override the default focus state for the cell element, so that it
             // can be added programmatically to the button element.
-            borderRadius: Spacing.xxxSmall_4,
-            outline: `${Spacing.xxxxSmall_2}px solid ${Color.blue}`,
-            outlineOffset: -Spacing.xxxxSmall_2,
+            borderRadius: spacing.xxxSmall_4,
+            outline: `${spacing.xxxxSmall_2}px solid ${Color.blue}`,
+            outlineOffset: -spacing.xxxxSmall_2,
         },
 
         ":focus-visible": {
@@ -316,8 +316,8 @@ const styles = StyleSheet.create({
     },
     itemContainer: {
         minHeight: "unset",
-        padding: Spacing.xSmall_8,
-        paddingRight: Spacing.medium_16,
+        padding: spacing.xSmall_8,
+        paddingRight: spacing.medium_16,
         whiteSpace: "nowrap",
     },
 

--- a/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {View} from "@khanacademy/wonder-blocks-core";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
         boxShadow: `0 -1px ${Color.offBlack16}`,
         height: 1,
         minHeight: 1,
-        marginTop: Spacing.xxxSmall_4,
-        marginBottom: Spacing.xxxSmall_4,
+        marginTop: spacing.xxxSmall_4,
+        marginBottom: spacing.xxxSmall_4,
     },
 });

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -21,7 +21,7 @@
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 import minusIcon from "@phosphor-icons/core/bold/minus-bold.svg";
 
@@ -29,9 +29,9 @@ function mapCheckedToAriaChecked(value: Checked): AriaChecked {
 const {blue, red, white, offWhite, offBlack16, offBlack32, offBlack50} = Color;
 
 // The checkbox size
-const size = Spacing.medium_16;
+const size = spacing.medium_16;
 // The check icon size
-const checkSize = Spacing.small_12;
+const checkSize = spacing.small_12;
 
 const StyledInput = addStyle("input");
 

--- a/packages/wonder-blocks-form/src/components/checkbox-group.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
@@ -147,7 +147,7 @@ const CheckboxGroup = React.forwardRef(function CheckboxGroup(
                     <LabelSmall style={styles.error}>{errorMessage}</LabelSmall>
                 )}
                 {(label || description || errorMessage) && (
-                    <Strut size={Spacing.small_12} />
+                    <Strut size={spacing.small_12} />
                 )}
 
                 {allChildren.map((child, index) => {

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View, UniqueIDProvider} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import CheckboxCore from "./checkbox-core";
@@ -147,7 +147,7 @@ type Props = AriaProps & {
                                 error={error}
                                 ref={ref}
                             />
-                            <Strut size={Spacing.xSmall_8} />
+                            <Strut size={spacing.xSmall_8} />
                             {label && getLabel(uniqueId)}
                         </View>
                         {description && getDescription(descriptionId)}
@@ -176,8 +176,8 @@ const styles = StyleSheet.create({
     },
     description: {
         // 16 for icon + 8 for spacing strut
-        marginLeft: Spacing.medium_16 + Spacing.xSmall_8,
-        marginTop: Spacing.xxxSmall_4,
+        marginLeft: spacing.medium_16 + spacing.xSmall_8,
+        marginTop: spacing.xxxSmall_4,
         color: Color.offBlack64,
     },
 });

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import {View, addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 type Props = {
@@ -73,7 +73,7 @@ export default class FieldHeading extends React.Component<Props> {
                     {label}
                     {required && requiredIcon}
                 </LabelMedium>
-                <Strut size={Spacing.xxxSmall_4} />
+                <Strut size={spacing.xxxSmall_4} />
             </React.Fragment>
         );
     }
@@ -93,7 +93,7 @@ export default class FieldHeading extends React.Component<Props> {
                 >
                     {description}
                 </LabelSmall>
-                <Strut size={Spacing.xxxSmall_4} />
+                <Strut size={spacing.xxxSmall_4} />
             </React.Fragment>
         );
     }
@@ -107,7 +107,7 @@ export default class FieldHeading extends React.Component<Props> {
 
         return (
             <React.Fragment>
-                <Strut size={Spacing.small_12} />
+                <Strut size={spacing.small_12} />
                 <LabelSmall
                     style={styles.error}
                     role="alert"
@@ -127,7 +127,7 @@ export default class FieldHeading extends React.Component<Props> {
             <View style={style}>
                 {this.renderLabel()}
                 {this.maybeRenderDescription()}
-                <Strut size={Spacing.xSmall_8} />
+                <Strut size={spacing.xSmall_8} />
                 {field}
                 {this.maybeRenderError()}
             </View>

--- a/packages/wonder-blocks-form/src/components/group-styles.ts
+++ b/packages/wonder-blocks-form/src/components/group-styles.ts
@@ -1,7 +1,7 @@
 import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleDeclaration} from "aphrodite";
 
@@ -17,17 +17,17 @@ const styles: StyleDeclaration = StyleSheet.create({
     },
 
     description: {
-        marginTop: Spacing.xxxSmall_4,
+        marginTop: spacing.xxxSmall_4,
         color: Color.offBlack64,
     },
 
     error: {
-        marginTop: Spacing.xxxSmall_4,
+        marginTop: spacing.xxxSmall_4,
         color: Color.red,
     },
 
     defaultLineGap: {
-        marginTop: Spacing.xSmall_8,
+        marginTop: spacing.xSmall_8,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
@@ -132,7 +132,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(
                     <LabelSmall style={styles.error}>{errorMessage}</LabelSmall>
                 )}
                 {(label || description || errorMessage) && (
-                    <Strut size={Spacing.small_12} />
+                    <Strut size={spacing.small_12} />
                 )}
 
                 {allChildren.map((child, index) => {

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
@@ -296,7 +296,7 @@ const styles = StyleSheet.create({
         height: 40,
         borderRadius: 4,
         boxSizing: "border-box",
-        paddingLeft: Spacing.medium_16,
+        paddingLeft: spacing.medium_16,
         margin: 0,
         outline: "none",
         boxShadow: "none",

--- a/packages/wonder-blocks-form/tsconfig-build.json
+++ b/packages/wonder-blocks-form/tsconfig-build.json
@@ -14,7 +14,7 @@
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
         {"path": "../wonder-blocks-link/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-grid/package.json
+++ b/packages/wonder-blocks-grid/package.json
@@ -19,7 +19,7 @@
     "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1"
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-grid/tsconfig-build.json
+++ b/packages/wonder-blocks-grid/tsconfig-build.json
@@ -9,6 +9,6 @@
         {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-labeled-field/package.json
+++ b/packages/wonder-blocks-labeled-field/package.json
@@ -20,7 +20,7 @@
     "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-labeled-field/tsconfig-build.json
+++ b/packages/wonder-blocks-labeled-field/tsconfig-build.json
@@ -9,7 +9,7 @@
       {"path": "../wonder-blocks-color/tsconfig-build.json"},
       {"path": "../wonder-blocks-core/tsconfig-build.json"},
       {"path": "../wonder-blocks-layout/tsconfig-build.json"},
-      {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+      {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
       {"path": "../wonder-blocks-typography/tsconfig-build.json"},
   ]
 }

--- a/packages/wonder-blocks-layout/package.json
+++ b/packages/wonder-blocks-layout/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1"
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "^1.0.0"

--- a/packages/wonder-blocks-layout/src/util/specs.ts
+++ b/packages/wonder-blocks-layout/src/util/specs.ts
@@ -1,11 +1,11 @@
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {MediaSize, MediaSpec} from "./types";
 
 // All possible valid media sizes
 export const VALID_MEDIA_SIZES: Array<MediaSize> = ["small", "medium", "large"];
 
-const mediaDefaultSpecLargeMarginWidth = Spacing.large_24;
+const mediaDefaultSpecLargeMarginWidth = spacing.large_24;
 
 // The default spec for media layout, currently available in
 // three different settings (roughly mobile, tablet, and desktop).
@@ -13,19 +13,19 @@ export const MEDIA_DEFAULT_SPEC: MediaSpec = {
     small: {
         query: "(max-width: 767px)",
         totalColumns: 4,
-        gutterWidth: Spacing.medium_16,
-        marginWidth: Spacing.medium_16,
+        gutterWidth: spacing.medium_16,
+        marginWidth: spacing.medium_16,
     },
     medium: {
         query: "(min-width: 768px) and (max-width: 1023px)",
         totalColumns: 8,
-        gutterWidth: Spacing.xLarge_32,
-        marginWidth: Spacing.large_24,
+        gutterWidth: spacing.xLarge_32,
+        marginWidth: spacing.large_24,
     },
     large: {
         query: "(min-width: 1024px)",
         totalColumns: 12,
-        gutterWidth: Spacing.xLarge_32,
+        gutterWidth: spacing.xLarge_32,
         marginWidth: mediaDefaultSpecLargeMarginWidth,
         maxWidth: 1120 + mediaDefaultSpecLargeMarginWidth * 2,
     },
@@ -36,8 +36,8 @@ export const MEDIA_INTERNAL_SPEC: MediaSpec = {
     large: {
         query: "(min-width: 1px)",
         totalColumns: 12,
-        gutterWidth: Spacing.xLarge_32,
-        marginWidth: Spacing.medium_16,
+        gutterWidth: spacing.xLarge_32,
+        marginWidth: spacing.medium_16,
     },
 };
 
@@ -46,13 +46,13 @@ export const MEDIA_MODAL_SPEC: MediaSpec = {
     small: {
         query: "(max-width: 767px)",
         totalColumns: 4,
-        gutterWidth: Spacing.medium_16,
-        marginWidth: Spacing.medium_16,
+        gutterWidth: spacing.medium_16,
+        marginWidth: spacing.medium_16,
     },
     large: {
         query: "(min-width: 768px)",
         totalColumns: 12,
-        gutterWidth: Spacing.xLarge_32,
-        marginWidth: Spacing.xxLarge_48,
+        gutterWidth: spacing.xLarge_32,
+        marginWidth: spacing.xxLarge_48,
     },
 };

--- a/packages/wonder-blocks-layout/tsconfig-build.json
+++ b/packages/wonder-blocks-layout/tsconfig-build.json
@@ -7,6 +7,6 @@
     },
     "references": [
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -20,7 +20,7 @@
     "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1"
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -7,7 +7,7 @@ import {addStyle} from "@khanacademy/wonder-blocks-core";
 import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import externalLinkIcon from "@phosphor-icons/core/bold/arrow-square-out-bold.svg";
 
 import type {
@@ -153,10 +153,10 @@ const styles: Record<string, any> = {};
 
 const linkContentStyles = StyleSheet.create({
     startIcon: {
-        marginInlineEnd: Spacing.xxxSmall_4,
+        marginInlineEnd: spacing.xxxSmall_4,
     },
     endIcon: {
-        marginInlineStart: Spacing.xxxSmall_4,
+        marginInlineStart: spacing.xxxSmall_4,
     },
     centered: {
         // Manually align the bottom of start/end icons with the text baseline.

--- a/packages/wonder-blocks-link/tsconfig-build.json
+++ b/packages/wonder-blocks-link/tsconfig-build.json
@@ -11,6 +11,6 @@
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -21,7 +21,6 @@
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon-button": "^5.1.8",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
     "@khanacademy/wonder-blocks-theming": "^1.3.0",
     "@khanacademy/wonder-blocks-timing": "^4.0.2",
     "@khanacademy/wonder-blocks-tokens": "^0.1.0",

--- a/packages/wonder-blocks-modal/src/components/modal-content.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-content.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {
@@ -66,10 +66,10 @@ const themedStylesFn: ThemedStylesFn<ModalDialogThemeContract> = (theme) => ({
     content: {
         flex: 1,
         minHeight: "100%",
-        padding: Spacing.xLarge_32,
+        padding: spacing.xLarge_32,
         boxSizing: "border-box",
         [small]: {
-            padding: `${Spacing.xLarge_32}px ${Spacing.medium_16}px`,
+            padding: `${spacing.xLarge_32}px ${spacing.medium_16}px`,
         },
     },
 });

--- a/packages/wonder-blocks-modal/src/components/modal-footer.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-footer.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 type Props = {
     children: React.ReactNode;
@@ -39,11 +39,11 @@ const styles = StyleSheet.create({
     footer: {
         flex: "0 0 auto",
         boxSizing: "border-box",
-        minHeight: Spacing.xxxLarge_64,
-        paddingLeft: Spacing.medium_16,
-        paddingRight: Spacing.medium_16,
-        paddingTop: Spacing.xSmall_8,
-        paddingBottom: Spacing.xSmall_8,
+        minHeight: spacing.xxxLarge_64,
+        paddingLeft: spacing.medium_16,
+        paddingRight: spacing.medium_16,
+        paddingTop: spacing.xSmall_8,
+        paddingBottom: spacing.xSmall_8,
 
         display: "flex",
         flexDirection: "row",

--- a/packages/wonder-blocks-modal/tsconfig-build.json
+++ b/packages/wonder-blocks-modal/tsconfig-build.json
@@ -13,7 +13,6 @@
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
         {"path": "../wonder-blocks-theming/tsconfig-build.json"},
         {"path": "../wonder-blocks-timing/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},

--- a/packages/wonder-blocks-pill/package.json
+++ b/packages/wonder-blocks-pill/package.json
@@ -20,7 +20,6 @@
     "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-link": "^6.0.5",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
     "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },

--- a/packages/wonder-blocks-pill/tsconfig-build.json
+++ b/packages/wonder-blocks-pill/tsconfig-build.json
@@ -10,7 +10,6 @@
         {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-link/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -20,7 +20,6 @@
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon-button": "^5.1.8",
     "@khanacademy/wonder-blocks-modal": "^4.2.1",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
     "@khanacademy/wonder-blocks-tooltip": "^2.1.25",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import Colors from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import CloseButton from "./close-button";
 
@@ -105,13 +105,13 @@ export default class PopoverContentCore extends React.Component<Props> {
 
 const styles = StyleSheet.create({
     content: {
-        borderRadius: Spacing.xxxSmall_4,
+        borderRadius: spacing.xxxSmall_4,
         border: `solid 1px ${Colors.offBlack16}`,
         backgroundColor: Colors.white,
-        boxShadow: `0 ${Spacing.xSmall_8}px ${Spacing.xSmall_8}px 0 ${Colors.offBlack8}`,
+        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${Colors.offBlack8}`,
         margin: 0,
-        maxWidth: Spacing.medium_16 * 18, // 288px
-        padding: Spacing.large_24,
+        maxWidth: spacing.medium_16 * 18, // 288px
+        padding: spacing.large_24,
         overflow: "hidden",
         justifyContent: "center",
     },
@@ -134,8 +134,8 @@ const styles = StyleSheet.create({
     closeButton: {
         margin: 0,
         position: "absolute",
-        right: Spacing.xxxSmall_4,
-        top: Spacing.xxxSmall_4,
+        right: spacing.xxxSmall_4,
+        top: spacing.xxxSmall_4,
         // Allows the button to be above the title and/or custom content
         zIndex: 1,
     },

--- a/packages/wonder-blocks-popover/src/components/popover-content.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, HeadingSmall} from "@khanacademy/wonder-blocks-typography";
 
 import type {PopoverContextType} from "./popover-context";
@@ -265,7 +265,7 @@ const styles = StyleSheet.create({
      * Shared styles
      */
     actions: {
-        marginTop: Spacing.large_24,
+        marginTop: spacing.large_24,
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "flex-end",
@@ -276,7 +276,7 @@ const styles = StyleSheet.create({
     },
 
     title: {
-        marginBottom: Spacing.xSmall_8,
+        marginBottom: spacing.xSmall_8,
     },
 
     /**
@@ -285,10 +285,10 @@ const styles = StyleSheet.create({
     iconContainer: {
         alignItems: "center",
         justifyContent: "center",
-        height: Spacing.xxxLarge_64,
-        width: Spacing.xxxLarge_64,
-        minWidth: Spacing.xxxLarge_64,
-        marginRight: Spacing.medium_16,
+        height: spacing.xxxLarge_64,
+        width: spacing.xxxLarge_64,
+        minWidth: spacing.xxxLarge_64,
+        marginRight: spacing.medium_16,
         overflow: "hidden",
     },
 
@@ -304,16 +304,16 @@ const styles = StyleSheet.create({
      * Illustration styles
      */
     image: {
-        marginBottom: Spacing.large_24,
-        marginLeft: -Spacing.large_24,
-        marginRight: -Spacing.large_24,
-        marginTop: -Spacing.large_24,
-        width: `calc(100% + ${Spacing.large_24 * 2}px)`,
+        marginBottom: spacing.large_24,
+        marginLeft: -spacing.large_24,
+        marginRight: -spacing.large_24,
+        marginTop: -spacing.large_24,
+        width: `calc(100% + ${spacing.large_24 * 2}px)`,
     },
 
     imageToBottom: {
-        marginBottom: -Spacing.large_24,
-        marginTop: Spacing.large_24,
+        marginBottom: -spacing.large_24,
+        marginTop: spacing.large_24,
         order: 1,
     },
 });

--- a/packages/wonder-blocks-popover/tsconfig-build.json
+++ b/packages/wonder-blocks-popover/tsconfig-build.json
@@ -11,7 +11,6 @@
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-modal/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
         {"path": "../wonder-blocks-tooltip/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]

--- a/packages/wonder-blocks-search-field/package.json
+++ b/packages/wonder-blocks-search-field/package.json
@@ -21,7 +21,7 @@
     "@khanacademy/wonder-blocks-form": "^4.4.0",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
     "@khanacademy/wonder-blocks-icon-button": "^5.1.8",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -10,7 +10,7 @@ import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Color from "@khanacademy/wonder-blocks-color";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {defaultLabels} from "../util/constants";
@@ -207,13 +207,13 @@ const styles = StyleSheet.create({
     inputContainer: {
         boxSizing: "border-box",
         flexDirection: "row",
-        borderRadius: Spacing.xxxSmall_4,
+        borderRadius: spacing.xxxSmall_4,
         alignItems: "center",
         height: 40,
     },
     searchIcon: {
-        marginLeft: Spacing.xSmall_8,
-        marginRight: Spacing.xSmall_8,
+        marginLeft: spacing.xSmall_8,
+        marginRight: spacing.xSmall_8,
         position: "absolute",
     },
     dismissIcon: {
@@ -232,8 +232,8 @@ const styles = StyleSheet.create({
         },
         width: "100%",
         color: "inherit",
-        paddingLeft: Spacing.large_24 + Spacing.medium_16,
-        paddingRight: Spacing.large_24 + Spacing.medium_16,
+        paddingLeft: spacing.large_24 + spacing.medium_16,
+        paddingRight: spacing.large_24 + spacing.medium_16,
     },
 });
 

--- a/packages/wonder-blocks-search-field/tsconfig-build.json
+++ b/packages/wonder-blocks-search-field/tsconfig-build.json
@@ -12,7 +12,7 @@
         {"path": "../wonder-blocks-form/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-switch/tsconfig-build.json
+++ b/packages/wonder-blocks-switch/tsconfig-build.json
@@ -9,7 +9,7 @@
         {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-theming/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-theming/tsconfig-build.json
+++ b/packages/wonder-blocks-theming/tsconfig-build.json
@@ -8,7 +8,6 @@
     "references": [
         {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-toolbar/package.json
+++ b/packages/wonder-blocks-toolbar/package.json
@@ -18,7 +18,7 @@
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -6,7 +6,7 @@ import {StyleSheet} from "aphrodite";
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     HeadingSmall,
     LabelLarge,
@@ -151,8 +151,8 @@ const sharedStyles = StyleSheet.create({
         flexDirection: "row",
         justifyContent: "space-between",
         minHeight: 66,
-        paddingLeft: Spacing.medium_16,
-        paddingRight: Spacing.medium_16,
+        paddingLeft: spacing.medium_16,
+        paddingRight: spacing.medium_16,
         width: "100%",
     },
     small: {
@@ -193,6 +193,6 @@ const sharedStyles = StyleSheet.create({
         color: Color.offBlack64,
     },
     titles: {
-        padding: Spacing.small_12,
+        padding: spacing.small_12,
     },
 });

--- a/packages/wonder-blocks-toolbar/tsconfig-build.json
+++ b/packages/wonder-blocks-toolbar/tsconfig-build.json
@@ -8,7 +8,7 @@
     "references": [
         {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -20,7 +20,7 @@
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
     "@khanacademy/wonder-blocks-modal": "^4.2.1",
-    "@khanacademy/wonder-blocks-spacing": "^4.0.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -2,7 +2,7 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import Colors from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import TooltipContent from "./tooltip-content";
@@ -141,10 +141,10 @@ const styles = StyleSheet.create({
 
     content: {
         maxWidth: 472,
-        borderRadius: Spacing.xxxSmall_4,
+        borderRadius: spacing.xxxSmall_4,
         border: `solid 1px ${Colors.offBlack16}`,
         backgroundColor: Colors.white,
-        boxShadow: `0 ${Spacing.xSmall_8}px ${Spacing.xSmall_8}px 0 ${Colors.offBlack8}`,
+        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${Colors.offBlack8}`,
         justifyContent: "center",
     },
 });

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-content.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 
@@ -78,7 +78,7 @@ export default class TooltipContent extends React.Component<Props> {
                 testId={this.props.testId}
             >
                 {title}
-                {title && children && <Strut size={Spacing.xxxSmall_4} />}
+                {title && children && <Strut size={spacing.xxxSmall_4} />}
                 {children}
             </View>
         );
@@ -87,10 +87,10 @@ export default class TooltipContent extends React.Component<Props> {
 
 const styles = StyleSheet.create({
     withoutTitle: {
-        padding: `10px ${Spacing.medium_16}px`,
+        padding: `10px ${spacing.medium_16}px`,
     },
 
     withTitle: {
-        padding: Spacing.medium_16,
+        padding: spacing.medium_16,
     },
 });

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -3,7 +3,7 @@ import {css, StyleSheet} from "aphrodite";
 
 import Colors from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
@@ -212,7 +212,7 @@ export default class TooltipTail extends React.Component<Props> {
                  */}
                 <feGaussianBlur
                     in="SourceAlpha"
-                    stdDeviation={Spacing.xxSmall_6 / 2}
+                    stdDeviation={spacing.xxSmall_6 / 2}
                 />
 
                 {/* Here we adjust the alpha (feFuncA) linearly so as to blend
@@ -423,12 +423,12 @@ export default class TooltipTail extends React.Component<Props> {
  * (i.e. placement="top"). When the tail points to the left or right instead,
  * the width/height are inverted.
  */
-const DISTANCE_FROM_ANCHOR = Spacing.xSmall_8;
+const DISTANCE_FROM_ANCHOR = spacing.xSmall_8;
 
-const MIN_DISTANCE_FROM_CORNERS = Spacing.xSmall_8;
+const MIN_DISTANCE_FROM_CORNERS = spacing.xSmall_8;
 
-const ARROW_WIDTH = Spacing.large_24;
-const ARROW_HEIGHT = Spacing.small_12;
+const ARROW_WIDTH = spacing.large_24;
+const ARROW_HEIGHT = spacing.small_12;
 
 const styles = StyleSheet.create({
     /**

--- a/packages/wonder-blocks-tooltip/tsconfig-build.json
+++ b/packages/wonder-blocks-tooltip/tsconfig-build.json
@@ -10,7 +10,7 @@
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
         {"path": "../wonder-blocks-modal/tsconfig-build.json"},
-        {"path": "../wonder-blocks-spacing/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]
 }

--- a/wb-codemod/bin/cli.js
+++ b/wb-codemod/bin/cli.js
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable import/no-commonjs */
 const {parseArgs} = require("node:util");
-const {run} = require("../src/wb-codemodd");
+const {run} = require("../src/wb-codemod");
 
 const HELP_TEXT = `
 Usage: wb-codemod [options] <files>

--- a/wb-codemod/transforms/__tests__/migrate-spacing-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-spacing-to-tokens.test.ts
@@ -1,0 +1,31 @@
+import transform from "../migrate-spacing-to-tokens";
+
+// eslint-disable-next-line import/no-commonjs, @typescript-eslint/no-var-requires
+const defineInlineTest = require("jscodeshift/dist/testUtils").defineInlineTest;
+
+const transformOptions = {
+    printOptions: {
+        objectCurlySpacing: false,
+    },
+};
+
+describe("migrate-spacing-to-tokens", () => {
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `import Spacing from "@khanacademy/wonder-blocks-spacing";`,
+        `import {spacing} from "@khanacademy/wonder-blocks-tokens";`,
+        "should replace default import with named import",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `import {color, spacing} from "@khanacademy/wonder-blocks-tokens";`,
+        "should add a named import to the existing import declaration",
+    );
+});

--- a/wb-codemod/transforms/__tests__/migrate-spacing-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-spacing-to-tokens.test.ts
@@ -28,4 +28,15 @@ import {color} from "@khanacademy/wonder-blocks-tokens";
         `import {color, spacing} from "@khanacademy/wonder-blocks-tokens";`,
         "should add a named import to the existing import declaration",
     );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `import {spacing} from "@khanacademy/wonder-blocks-tokens";`,
+        "should delete the import declaration if the tokens.spacing named import is already used",
+    );
 });

--- a/wb-codemod/transforms/migrate-spacing-to-tokens.ts
+++ b/wb-codemod/transforms/migrate-spacing-to-tokens.ts
@@ -1,0 +1,69 @@
+import {API, FileInfo, Options} from "jscodeshift";
+
+// From
+const SOURCE_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-spacing";
+const SOURCE_SPECIFIER = "Spacing";
+// To
+const TARGET_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-tokens";
+const TARGET_SPECIFIER = "spacing";
+
+/**
+ * Transforms:
+ * import Spacing from "@khanacademy/wonder-blocks-spacing"
+ * const padding = Spacing.xxx;
+ *
+ * to:
+ * import {spacing} from "@khanacademy/wonder-blocks-tokens"
+ * const padding = spacing.xxx;
+ */
+export default function transform(file: FileInfo, api: API, options: Options) {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+
+    // Step 1: Verify if the import exists
+    const sourceImport = root.find(j.ImportDeclaration, {
+        source: {value: SOURCE_IMPORT_DECLARATION},
+    });
+
+    // If the import doesn't exist, we don't need to do anything.
+    if (sourceImport.size() === 0) {
+        return;
+    }
+
+    // Step 2: Replace the import
+    const targetImport = root.find(j.ImportDeclaration, {
+        source: {value: TARGET_IMPORT_DECLARATION},
+    });
+
+    sourceImport.forEach((path) => {
+        // Replace default import with named import
+        const targetSpecifier = j.importSpecifier(
+            j.identifier(TARGET_SPECIFIER),
+        );
+
+        // If the import is already used, we add a named import to the existing
+        // import declaration.
+        if (targetImport.size() > 0) {
+            targetImport.get().node.specifiers.push(targetSpecifier);
+            // Remove the import declaration
+            j(path).remove();
+            return;
+        }
+
+        // Create a new import declaration.
+        const newTargetImport = j.importDeclaration(
+            [targetSpecifier],
+            j.literal(TARGET_IMPORT_DECLARATION),
+        );
+
+        // Replace the existing import declaration with the new one.
+        j(path).replaceWith(newTargetImport);
+    });
+
+    // Step 3: Replace the usage
+    root.find(j.Identifier, {name: SOURCE_SPECIFIER}).forEach((path) => {
+        path.node.name = TARGET_SPECIFIER;
+    });
+
+    return root.toSource(options.printOptions);
+}

--- a/wb-codemod/transforms/migrate-spacing-to-tokens.ts
+++ b/wb-codemod/transforms/migrate-spacing-to-tokens.ts
@@ -1,4 +1,4 @@
-import {API, FileInfo, Options} from "jscodeshift";
+import {API, FileInfo, ModuleSpecifier, Options} from "jscodeshift";
 
 // From
 const SOURCE_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-spacing";
@@ -44,7 +44,17 @@ export default function transform(file: FileInfo, api: API, options: Options) {
         // If the import is already used, we add a named import to the existing
         // import declaration.
         if (targetImport.size() > 0) {
-            targetImport.get().node.specifiers.push(targetSpecifier);
+            // NOTE: We only add the specifier if it doesn't exist already.
+            const specifierExists = targetImport
+                .get()
+                .node.specifiers.some(
+                    (specifier: ModuleSpecifier) =>
+                        specifier.local?.name === TARGET_SPECIFIER,
+                );
+
+            if (!specifierExists) {
+                targetImport.get().node.specifiers.push(targetSpecifier);
+            }
             // Remove the import declaration
             j(path).remove();
             return;


### PR DESCRIPTION
## Summary:

Migrated the spacing tokens from `wonder-blocks-spacing` to
`wonder-blocks-tokens`. This change is part of the larger effort to migrate
all tokens to `wonder-blocks-tokens`.

To migrate the spacing tokens, I did the following:

Ran the codemod created in #2174:

```
npx @khanacademy/wb-codemod -t migrate-spacing-to-tokens packages/ __docs__/
```

Then I manually updated the remaining instances that were not updated by the
codemod (e.g. MDX files).

Finally, I ran prettier to format the files and fix any linting issues.


Issue: WB-1643

## Test plan:

Verify that all the checks pass and also verify that the storybook stories
render correctly.