### PR TITLE
Popover: Add reason param to onClose callback

### DIFF
--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -9,6 +9,7 @@ import {fireEvent} from "@storybook/testing-library";
 import Popover from "../popover";
 import PopoverContent from "../popover-content";
 import {PopoverContentCore} from "../../index";
+import {CloseReason} from "../popover-event-listener";
 
 describe("Popover", () => {
     it("should set the anchor as the popover ref", async () => {
@@ -297,6 +298,127 @@ describe("Popover", () => {
 
             // Assert
             expect(anchorButton).toHaveFocus();
+        });
+
+        it("should close with reason of blur", async () => {
+            let closeReason = "";
+            const onClose = (reason: CloseReason) => {
+                closeReason = reason;
+            };
+            // Arrange
+            render(
+                <View>
+                    <Button id="button-to-close">Click here to close</Button>
+                    <Popover
+                        dismissEnabled={true}
+                        onClose={onClose}
+                        content={
+                            <PopoverContent
+                                closeButtonVisible={true}
+                                title="Should close with reason of blur"
+                                content='Clicking outside of the popover, the close reason should be "blur".'
+                            />
+                        }
+                    >
+                        <Button>Open popover</Button>
+                    </Popover>
+                </View>,
+            );
+
+            const anchorButton = screen.getByRole("button", {
+                name: "Open popover",
+            });
+
+            // open the popover
+            userEvent.click(anchorButton);
+            await screen.findByRole("dialog");
+
+            // Act
+            const closeButton = screen.getByRole("button", {
+                name: "Click here to close",
+            });
+            // We have to click twice.
+            closeButton.click();
+            closeButton.click();
+            expect(closeReason).toBe("blur");
+        });
+
+        it("should close with reason of dismissed when clicking close button", async () => {
+            let closeReason = "";
+            const onClose = (reason: CloseReason) => {
+                closeReason = reason;
+            };
+            // Arrange
+            render(
+                <View>
+                    <Popover
+                        dismissEnabled={true}
+                        onClose={onClose}
+                        content={
+                            <PopoverContent
+                                closeButtonVisible={true}
+                                title="Should close with reason of dismissed"
+                                content='After dismissing the popover, reason should be "dismissed".'
+                            />
+                        }
+                    >
+                        <Button>Open popover</Button>
+                    </Popover>
+                </View>,
+            );
+
+            const anchorButton = screen.getByRole("button", {
+                name: "Open popover",
+            });
+
+            // open the popover
+            userEvent.click(anchorButton);
+            await screen.findByRole("dialog");
+
+            // Act
+            const closeButton = screen.getByRole("button", {
+                name: "Close Popover",
+            });
+            closeButton.click();
+            expect(closeReason).toBe("dismissed");
+        });
+
+        it("should close with reason of dismissed when pressing Esc", async () => {
+            let closeReason = "";
+            const onClose = (reason: CloseReason) => {
+                closeReason = reason;
+            };
+            // Arrange
+            render(
+                <View>
+                    <Popover
+                        dismissEnabled={true}
+                        onClose={onClose}
+                        content={
+                            <PopoverContent
+                                closeButtonVisible={true}
+                                title="Should close with reason of dismissed"
+                                content='After dismissing the popover, reason should be "dismissed".'
+                            />
+                        }
+                    >
+                        <Button>Open popover</Button>
+                    </Popover>
+                </View>,
+            );
+
+            const anchorButton = screen.getByRole("button", {
+                name: "Open popover",
+            });
+
+            // open the popover
+            userEvent.click(anchorButton);
+            await screen.findByRole("dialog");
+
+            // Act
+            // we try to close it pressing the Escape key
+            userEvent.keyboard("{esc}");
+            expect(closeReason).toBe("dismissed");
         });
 
         it("should return focus to a specific element if closedFocusId is set", async () => {

--- a/packages/wonder-blocks-popover/src/components/close-button.tsx
+++ b/packages/wonder-blocks-popover/src/components/close-button.tsx
@@ -5,6 +5,7 @@ import xIcon from "@phosphor-icons/core/regular/x.svg";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
 import PopoverContext from "./popover-context";
+import {CloseReason} from "./popover-event-listener";
 
 type Props = AriaProps & {
     /**
@@ -47,7 +48,7 @@ export default class CloseButton extends React.Component<Props> {
                         <IconButton
                             icon={xIcon}
                             aria-label={ariaLabel}
-                            onClick={close}
+                            onClick={() => close?.(CloseReason.DISMISSED)}
                             kind={light ? "primary" : "tertiary"}
                             light={light}
                             style={style}

--- a/packages/wonder-blocks-popover/src/components/popover-context.ts
+++ b/packages/wonder-blocks-popover/src/components/popover-context.ts
@@ -1,13 +1,14 @@
 import * as React from "react";
 
 import type {Placement} from "@khanacademy/wonder-blocks-tooltip";
+import {CloseReason} from "./popover-event-listener";
 
 export type PopoverContextType = {
     /**
      * Facilitates passing the `onClose` handler from the Popover down to its
      * children.
      */
-    close?: () => unknown;
+    close?: (reason: CloseReason) => unknown;
     /**
      * Facilitates passing this value from Popover (via TooltipPopper) down to
      * PopoverContent. This is needed here to reposition the illustration to the

--- a/packages/wonder-blocks-popover/src/components/popover-event-listener.ts
+++ b/packages/wonder-blocks-popover/src/components/popover-event-listener.ts
@@ -5,11 +5,18 @@ import {isFocusable} from "../util/util";
 import PopoverContent from "./popover-content";
 import PopoverContentCore from "./popover-content-core";
 
+// Enum for the reason the modal is closing: either by clicking outside, clicking the X or pressing the esc key, or by interacting.
+export enum CloseReason {
+    BLUR = "blur",
+    DISMISSED = "dismissed",
+    UNKNOWN = "unknown",
+}
+
 type Props = {
     /**
      * Called when `esc` is pressed
      */
-    onClose: (shouldReturnFocus: boolean) => unknown;
+    onClose: (shouldReturnFocus: boolean, reason: CloseReason) => unknown;
     /**
      * Popover Content ref.
      * Will close the popover when clicking outside this element.
@@ -62,7 +69,7 @@ export default class PopoverEventListener extends React.Component<
             e.stopPropagation();
             // In the case of the Escape key, we should return focus to the
             // trigger button.
-            this.props.onClose(true);
+            this.props.onClose(true, CloseReason.DISMISSED);
         }
     };
 
@@ -86,7 +93,7 @@ export default class PopoverEventListener extends React.Component<
             const shouldReturnFocus = !isFocusable(e.target as any);
             // If that's the case, we need to prevent the default behavior of
             // returning the focus to the trigger button.
-            this.props.onClose(shouldReturnFocus);
+            this.props.onClose(shouldReturnFocus, CloseReason.BLUR);
         }
     };
 

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -17,7 +17,7 @@ import PopoverContext from "./popover-context";
 import PopoverAnchor from "./popover-anchor";
 import PopoverDialog from "./popover-dialog";
 import FocusManager from "./focus-manager";
-import PopoverEventListener from "./popover-event-listener";
+import PopoverEventListener, {CloseReason} from "./popover-event-listener";
 
 type PopoverContents =
     | React.ReactElement<React.ComponentProps<typeof PopoverContent>>
@@ -92,7 +92,7 @@ type Props = AriaProps &
         /**
          * Called when the popover closes
          */
-        onClose?: () => unknown;
+        onClose?: (reason: CloseReason) => unknown;
         /**
          * Test ID used for e2e testing.
          */
@@ -204,11 +204,12 @@ export default class Popover extends React.Component<Props, State> {
     /**
      * Popover dialog closed
      */
-    handleClose: (shouldReturnFocus?: boolean) => void = (
+    handleClose: (shouldReturnFocus?: boolean, reason?: CloseReason) => void = (
         shouldReturnFocus = true,
+        reason,
     ) => {
         this.setState({opened: false}, () => {
-            this.props.onClose?.();
+            this.props.onClose?.(reason || CloseReason.UNKNOWN);
 
             if (shouldReturnFocus) {
                 this.maybeReturnFocus();
@@ -221,6 +222,7 @@ export default class Popover extends React.Component<Props, State> {
      */
     handleOpen: () => void = () => {
         if (this.props.dismissEnabled && this.state.opened) {
+            // TODO(rjcorwin) Why is this here?
             this.handleClose(true);
         } else {
             this.setState({opened: true});
@@ -303,7 +305,8 @@ export default class Popover extends React.Component<Props, State> {
         return (
             <PopoverContext.Provider
                 value={{
-                    close: this.handleClose,
+                    close: (closeReason) =>
+                        this.handleClose(undefined, closeReason),
                     placement: placement,
                 }}
             >


### PR DESCRIPTION
This diff adds a `reason` param to Popover component's `onClose` callback. Popovers are closed for the following reasons:

1. The dismiss button is clicked. In this case the reason is "dismissed".
2. The user pressed escape.  In this case the reason is "dismissed".
3. The user clicked outside of the scope of the Popover. In this case the reason is "blur".
4. The Popover is opened again, in which case the the reason is currently "unknown". There is possibly room for improvement here, please see TODO. 