### PR TITLE
WB-1642.1: Add transform to migrate color to tokens

### DIFF
--- a/.changeset/four-melons-breathe.md
+++ b/.changeset/four-melons-breathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wb-codemod": minor
+---
+
+Add color transform to migrate color imports to tokens

--- a/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
@@ -39,7 +39,7 @@ const color = color.red;
 import Color from "@khanacademy/wonder-blocks-color";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 `,
-        `import {spacing, color} from "@khanacademy/wonder-blocks-tokens";`,
+        `import {color, spacing} from "@khanacademy/wonder-blocks-tokens";`,
         "should add a named import to the existing import declaration",
     );
 
@@ -52,5 +52,32 @@ import {color} from "@khanacademy/wonder-blocks-tokens";
 `,
         `import {color} from "@khanacademy/wonder-blocks-tokens";`,
         "should delete the import declaration if the tokens.color named import is already used",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Color, {fade} from "@khanacademy/wonder-blocks-color";
+`,
+        `
+import {fade} from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+`,
+        "should keep the color import if there are other named imports in the source import declaration",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `
+import {fade} from "@khanacademy/wonder-blocks-color";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+`,
+        "should keep the color import if there are other named imports in the source import declaration and move the default import to the existing target import",
     );
 });

--- a/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
@@ -1,0 +1,56 @@
+import transform from "../migrate-color-to-tokens";
+
+// eslint-disable-next-line import/no-commonjs, @typescript-eslint/no-var-requires
+const defineInlineTest = require("jscodeshift/dist/testUtils").defineInlineTest;
+
+const transformOptions = {
+    printOptions: {
+        objectCurlySpacing: false,
+    },
+};
+
+describe("migrate-color-to-tokens", () => {
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `import Color from "@khanacademy/wonder-blocks-color";`,
+        `import {color} from "@khanacademy/wonder-blocks-tokens";`,
+        "should replace default import with named import",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Colors from "@khanacademy/wonder-blocks-color";
+const color = Colors.red;
+    `,
+        `
+import {color} from "@khanacademy/wonder-blocks-tokens";
+const color = color.red;
+    `,
+        "should replace default import with named import when using a different name",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Color from "@khanacademy/wonder-blocks-color";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `import {spacing, color} from "@khanacademy/wonder-blocks-tokens";`,
+        "should add a named import to the existing import declaration",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `import {color} from "@khanacademy/wonder-blocks-tokens";`,
+        "should delete the import declaration if the tokens.color named import is already used",
+    );
+});

--- a/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
@@ -23,11 +23,11 @@ describe("migrate-color-to-tokens", () => {
         transformOptions,
         `
 import Colors from "@khanacademy/wonder-blocks-color";
-const color = Colors.red;
+const bgColor = Colors.red;
     `,
         `
 import {color} from "@khanacademy/wonder-blocks-tokens";
-const color = color.red;
+const bgColor = color.red;
     `,
         "should replace default import with named import when using a different name",
     );
@@ -79,5 +79,17 @@ import {fade} from "@khanacademy/wonder-blocks-color";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 `,
         "should keep the color import if there are other named imports in the source import declaration and move the default import to the existing target import",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import {fade, mix} from "@khanacademy/wonder-blocks-color";
+`,
+        `
+import {fade, mix} from "@khanacademy/wonder-blocks-color";
+`,
+        "should do nothing if Color is not imported",
     );
 });

--- a/wb-codemod/transforms/migrate-color-to-tokens.ts
+++ b/wb-codemod/transforms/migrate-color-to-tokens.ts
@@ -53,6 +53,11 @@ export default function transform(file: FileInfo, api: API, options: Options) {
             (specifier) => specifier.type === "ImportDefaultSpecifier",
         );
 
+        // If there's no default specifier, we don't need to do anything.
+        if (!defaultSpecifier) {
+            return;
+        }
+
         // There might be cases where the default specifier uses a different
         // name from the one defined in SOURCE_SPECIFIER, so we need to make
         // sure we use the correct name to complete step 3.
@@ -127,7 +132,7 @@ export default function transform(file: FileInfo, api: API, options: Options) {
         }
     });
 
-    // Step 3: Replace the usage
+    // Step 3: Replace the call sites that use the default specifier.
     root.find(j.Identifier, {name: sourceSpecifier}).forEach((path) => {
         path.node.name = TARGET_SPECIFIER;
     });

--- a/wb-codemod/transforms/migrate-color-to-tokens.ts
+++ b/wb-codemod/transforms/migrate-color-to-tokens.ts
@@ -1,0 +1,100 @@
+import {
+    API,
+    FileInfo,
+    ModuleSpecifier,
+    ImportDeclaration,
+    Options,
+} from "jscodeshift";
+
+// From
+const SOURCE_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-color";
+const SOURCE_SPECIFIER = "Color";
+// To
+const TARGET_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-tokens";
+const TARGET_SPECIFIER = "color";
+
+/**
+ * Transforms:
+ * import Color from "@khanacademy/wonder-blocks-color"
+ * const bgColor = Color.blue;
+ *
+ * to:
+ * import {color} from "@khanacademy/wonder-blocks-tokens"
+ * const bgColor = color.blue;
+ */
+export default function transform(file: FileInfo, api: API, options: Options) {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+
+    // Use the default specifier as the source specifier.
+    let sourceSpecifier = SOURCE_SPECIFIER;
+
+    // Step 1: Verify if the import exists
+    const sourceImport = root.find(j.ImportDeclaration, {
+        source: {value: SOURCE_IMPORT_DECLARATION},
+    });
+
+    // If the import doesn't exist, we don't need to do anything.
+    if (sourceImport.size() === 0) {
+        return;
+    }
+
+    // Step 2: Replace the import
+    const targetImport = root.find(j.ImportDeclaration, {
+        source: {value: TARGET_IMPORT_DECLARATION},
+    });
+
+    sourceImport.forEach((path) => {
+        // Find the default specifier
+        const defaultSpecifier = path.value.specifiers?.find(
+            (specifier) => specifier.type === "ImportDefaultSpecifier",
+        );
+
+        // There might be cases where the default specifier uses a different
+        // name from the one defined in SOURCE_SPECIFIER, so we need to make
+        // sure we use the correct name to complete step 3.
+        if (defaultSpecifier?.local) {
+            sourceSpecifier = defaultSpecifier.local?.name;
+        }
+
+        // Replace default import with named import
+        const targetSpecifier = j.importSpecifier(
+            j.identifier(TARGET_SPECIFIER),
+        );
+
+        // If the import is already used, we add a named import to the existing
+        // import declaration.
+        if (targetImport.size() > 0) {
+            // NOTE: We only add the specifier if it doesn't exist already.
+            const specifierExists = targetImport
+                .get()
+                .node.specifiers.some(
+                    (specifier: ModuleSpecifier) =>
+                        specifier.local?.name === TARGET_SPECIFIER,
+                );
+
+            if (!specifierExists) {
+                targetImport.get().node.specifiers.push(targetSpecifier);
+            }
+            // Remove the import declaration
+            j(path).remove();
+            return;
+        }
+
+        // Create a new import declaration.
+        const newTargetImport = j.importDeclaration(
+            [targetSpecifier],
+            j.literal(TARGET_IMPORT_DECLARATION),
+        );
+
+        // Replace the existing import declaration with the new one.
+        j(path).replaceWith(newTargetImport);
+    });
+
+    // Step 3: Replace the usage
+    root.find(j.Identifier, {name: sourceSpecifier}).forEach((path) => {
+        path.node.name = TARGET_SPECIFIER;
+    });
+
+    return root.toSource(options.printOptions);
+}


### PR DESCRIPTION
## Summary:

Creates a codemod to migrate the wb-color imports to wb-tokens. This will allow
us to have a consistent spacing across the repo(s) and make it easier to change
in the future.

Issue: WB-1642

## Test plan:

- Run the codemod on the repo (next PR).
- Run unit tests for the codemod.