### PR TITLE
WB-1642.2: Migrate color imports from wb-color to wb-tokens

### DIFF
--- a/.changeset/four-melons-breathe.md
+++ b/.changeset/four-melons-breathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wb-codemod": minor
+---
+
+Add color transform to migrate color imports to tokens

--- a/.changeset/seven-penguins-explain.md
+++ b/.changeset/seven-penguins-explain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add fadedBlue24 color token

--- a/.changeset/yellow-news-whisper.md
+++ b/.changeset/yellow-news-whisper.md
@@ -1,0 +1,20 @@
+---
+"@khanacademy/wonder-blocks-progress-spinner": patch
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-labeled-field": patch
+"@khanacademy/wonder-blocks-search-field": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-banner": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-link": patch
+---
+
+Migrate wb-color imports to use tokens.color

--- a/.storybook/components/token-table.tsx
+++ b/.storybook/components/token-table.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const StyledTable = addStyle("table");
 const StyledTableRow = addStyle("tr");
@@ -81,11 +80,11 @@ const styles = StyleSheet.create({
         width: "100%",
     },
     header: {
-        backgroundColor: Color.offWhite,
+        backgroundColor: color.offWhite,
     },
     row: {
-        borderTop: `1px solid ${Color.offBlack8}`,
-        backgroundColor: Color.white,
+        borderTop: `1px solid ${color.offBlack8}`,
+        backgroundColor: color.white,
     },
     cell: {
         padding: spacing.xSmall_8,

--- a/__docs__/_overview_.mdx
+++ b/__docs__/_overview_.mdx
@@ -1,10 +1,9 @@
 import {Meta} from "@storybook/blocks";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Caption} from "@khanacademy/wonder-blocks-typography";
 
 import ComponentGallery from "./components/gallery/component-gallery";
@@ -49,7 +48,7 @@ export const styles = StyleSheet.create({
             height: "200px",
         },
     },
-    heroCaption: {fontSize: 16, color: Color.offBlack64},
+    heroCaption: {fontSize: 16, color: color.offBlack64},
 });
 
 <View style={styles.heroWrapper}>

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -3,11 +3,10 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Banner from "@khanacademy/wonder-blocks-banner";
 
@@ -127,7 +126,7 @@ export const Kinds: StoryComponentType = {
  * added around the floating banner so that it will not touch its outline.
  */
 export const Layouts: StoryComponentType = () => {
-    const borderStyle = {border: `2px solid ${Color.pink}`} as const;
+    const borderStyle = {border: `2px solid ${color.pink}`} as const;
     const floatingContainerStyle = {padding: spacing.xSmall_8} as const;
 
     return (

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -12,10 +12,9 @@ import pencilSimpleBold from "@phosphor-icons/core/bold/pencil-simple-bold.svg";
 import plus from "@phosphor-icons/core/regular/plus.svg";
 
 import {fireEvent, userEvent, within} from "@storybook/testing-library";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     LabelMedium,
     LabelLarge,
@@ -110,7 +109,7 @@ export const Tertiary: StoryComponentType = {
         const computedStyleLabel = getComputedStyle(innerLabel, ":after");
 
         // Resting style
-        await expect(button).toHaveStyle(`color: ${Color.blue}`);
+        await expect(button).toHaveStyle(`color: ${color.blue}`);
         await expect(button).toHaveTextContent("Hello, world!");
 
         // Hover style
@@ -151,7 +150,7 @@ export const styles: StyleDeclaration = StyleSheet.create({
         minWidth: 140,
     },
     example: {
-        background: Color.offWhite,
+        background: color.offWhite,
         padding: spacing.medium_16,
     },
     label: {
@@ -249,7 +248,7 @@ WithColor.parameters = {
 };
 
 export const Dark: StoryComponentType = () => (
-    <View style={{backgroundColor: Color.darkBlue, padding: spacing.medium_16}}>
+    <View style={{backgroundColor: color.darkBlue, padding: spacing.medium_16}}>
         <View style={{flexDirection: "row"}}>
             <Button onClick={() => {}} light={true}>
                 Hello, world!

--- a/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
@@ -3,9 +3,8 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import packageConfig from "../../packages/wonder-blocks-cell/package.json";
@@ -153,7 +152,7 @@ export const CompactCellBoth: StoryComponentType = {
                 <PhosphorIcon
                     icon={IconMappings.calendar}
                     size="medium"
-                    color={Color.blue}
+                    color={color.blue}
                 />
             }
         />
@@ -248,11 +247,11 @@ export const CompactCellWithCustomStyles: StoryComponentType = () => (
             <PhosphorIcon icon={IconMappings.article} size="medium" />
         }
         rightAccessory={
-            <PhosphorIcon icon={IconMappings.calendar} color={Color.white} />
+            <PhosphorIcon icon={IconMappings.calendar} color={color.white} />
         }
         style={{
-            background: Color.darkBlue,
-            color: Color.white,
+            background: color.darkBlue,
+            color: color.white,
         }}
         onClick={() => {}}
     />
@@ -395,7 +394,7 @@ export const CompactCellsAsListItems: StoryComponentType = {
                     }
                     href="https://khanacademy.org"
                     horizontalRule="full-width"
-                    style={{background: Color.offBlack50}}
+                    style={{background: color.offBlack50}}
                 />
             </View>
             <View role="listitem">
@@ -408,7 +407,7 @@ export const CompactCellsAsListItems: StoryComponentType = {
                         />
                     }
                     onClick={() => {}}
-                    style={{background: Color.pink}}
+                    style={{background: color.pink}}
                     horizontalRule="full-width"
                 />
             </View>
@@ -425,7 +424,7 @@ export const CompactCellsAsListItems: StoryComponentType = {
 
 const styles = StyleSheet.create({
     example: {
-        backgroundColor: Color.offWhite,
+        backgroundColor: color.offWhite,
         padding: spacing.large_24,
         width: 320 + spacing.xxLarge_48,
     },

--- a/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
@@ -4,8 +4,7 @@ import {MemoryRouter, Route, Switch} from "react-router-dom";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
@@ -315,7 +314,7 @@ export const DetailCellsAsListItems: StoryComponentType = {
                     }
                     href="https://khanacademy.org"
                     horizontalRule="full-width"
-                    style={{background: Color.offBlack50}}
+                    style={{background: color.offBlack50}}
                 />
             </View>
             <View role="listitem">
@@ -328,7 +327,7 @@ export const DetailCellsAsListItems: StoryComponentType = {
                         />
                     }
                     onClick={() => {}}
-                    style={{background: Color.pink}}
+                    style={{background: color.pink}}
                     horizontalRule="full-width"
                 />
             </View>
@@ -345,12 +344,12 @@ export const DetailCellsAsListItems: StoryComponentType = {
 
 const styles = StyleSheet.create({
     example: {
-        backgroundColor: Color.offWhite,
+        backgroundColor: color.offWhite,
         padding: spacing.large_24,
         width: 376,
     },
     navigation: {
-        border: `1px dashed ${Color.lightBlue}`,
+        border: `1px dashed ${color.lightBlue}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
     },

--- a/__docs__/wonder-blocks-clickable/accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-clickable/accessibility.stories.mdx
@@ -2,10 +2,9 @@ import {Meta, Story, Canvas} from "@storybook/blocks";
 import {StyleSheet} from "aphrodite";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
@@ -135,23 +134,23 @@ make sure to use `href` and `skipClientNav={true}.
 
 export const styles = StyleSheet.create({
     resting: {
-        boxShadow: `inset 0px 0px 1px 1px ${Color.lightBlue}`,
+        boxShadow: `inset 0px 0px 1px 1px ${color.lightBlue}`,
         padding: spacing.xSmall_8,
     },
     hovered: {
         textDecoration: "underline",
-        backgroundColor: Color.blue,
-        color: Color.white,
+        backgroundColor: color.blue,
+        color: color.white,
     },
     pressed: {
-        color: Color.darkBlue,
+        color: color.darkBlue,
     },
     focused: {
-        outline: `solid 4px ${Color.lightBlue}`,
+        outline: `solid 4px ${color.lightBlue}`,
     },
     panel: {
         padding: spacing.medium_16,
-        boxShadow: `inset 0px 0px 0 1px ${Color.offBlack8}`,
+        boxShadow: `inset 0px 0px 0 1px ${color.offBlack8}`,
     },
 });
 

--- a/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
@@ -3,8 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import packageConfig from "../../packages/wonder-blocks-clickable/package.json";
@@ -165,18 +164,18 @@ const styles = StyleSheet.create({
     },
     newButton: {
         border: "none",
-        backgroundColor: Color.white,
+        backgroundColor: color.white,
         width: "100%",
     },
     hovered: {
         textDecoration: "underline",
-        backgroundColor: Color.blue,
-        color: Color.white,
+        backgroundColor: color.blue,
+        color: color.white,
     },
     pressed: {
-        backgroundColor: Color.darkBlue,
+        backgroundColor: color.darkBlue,
     },
     focused: {
-        outline: `solid 4px ${Color.lightBlue}`,
+        outline: `solid 4px ${color.lightBlue}`,
     },
 });

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -4,8 +4,7 @@ import {MemoryRouter, Route, Switch} from "react-router-dom";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
@@ -313,21 +312,21 @@ const styles = StyleSheet.create({
     },
     hovered: {
         textDecoration: "underline",
-        backgroundColor: Color.teal,
+        backgroundColor: color.teal,
     },
     pressed: {
-        color: Color.blue,
+        color: color.blue,
     },
     focused: {
-        outline: `solid 4px ${Color.lightBlue}`,
+        outline: `solid 4px ${color.lightBlue}`,
     },
     centerText: {
         gap: spacing.medium_16,
         textAlign: "center",
     },
     dark: {
-        backgroundColor: Color.darkBlue,
-        color: Color.white,
+        backgroundColor: color.darkBlue,
+        color: color.white,
         padding: spacing.xSmall_8,
     },
     row: {
@@ -338,13 +337,13 @@ const styles = StyleSheet.create({
         marginRight: spacing.large_24,
     },
     navigation: {
-        border: `1px dashed ${Color.lightBlue}`,
+        border: `1px dashed ${color.lightBlue}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
     },
     disabled: {
-        color: Color.white,
-        backgroundColor: Color.offBlack64,
+        color: color.white,
+        backgroundColor: color.offBlack64,
     },
     button: {
         maxWidth: 150,

--- a/__docs__/wonder-blocks-color/swatch.tsx
+++ b/__docs__/wonder-blocks-color/swatch.tsx
@@ -3,14 +3,13 @@ import {StyleSheet} from "aphrodite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Caption,
     LabelLarge,
     LabelSmall,
     LabelXSmall,
 } from "@khanacademy/wonder-blocks-typography";
-import Color from "@khanacademy/wonder-blocks-color";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
 type Segments = 1 | 2 | 3;
@@ -29,40 +28,44 @@ const UseType = {
 /**
  * Get the color swatch information for a given color and segment count.
  */
-const getColorSegments = (segments: Segments, color: string, dark: boolean) => {
+const getColorSegments = (
+    segments: Segments,
+    colorSegment: string,
+    dark: boolean,
+) => {
     switch (segments) {
         case 1:
             return [
                 {
-                    foreground: dark ? color : Color.white64,
-                    background: dark ? Color.darkBlue : color,
+                    foreground: dark ? colorSegment : color.white64,
+                    background: dark ? color.darkBlue : colorSegment,
                 },
             ];
         case 2:
             return [
                 {
-                    foreground: color,
-                    background: color,
+                    foreground: colorSegment,
+                    background: colorSegment,
                 },
                 {
-                    foreground: color,
-                    background: Color.darkBlue,
+                    foreground: colorSegment,
+                    background: color.darkBlue,
                 },
             ];
         case 3:
         default:
             return [
                 {
-                    foreground: Color.white,
-                    background: color,
+                    foreground: color.white,
+                    background: colorSegment,
                 },
                 {
-                    foreground: color,
-                    background: Color.offWhite,
+                    foreground: colorSegment,
+                    background: color.offWhite,
                 },
                 {
-                    foreground: color,
-                    background: Color.white,
+                    foreground: colorSegment,
+                    background: color.white,
                 },
             ];
     }
@@ -130,7 +133,7 @@ export const Swatch = ({
 
 const styles = StyleSheet.create({
     container: {
-        color: Color.offBlack,
+        color: color.offBlack,
         flexDirection: "row",
         marginBottom: spacing.xLarge_32,
     },
@@ -139,22 +142,22 @@ const styles = StyleSheet.create({
         flexBasis: "30%",
     },
     tag: {
-        background: Color.offWhite,
-        border: `solid 1px ${Color.offBlack8}`,
+        background: color.offWhite,
+        border: `solid 1px ${color.offBlack8}`,
         borderRadius: spacing.xxxxSmall_2,
         margin: `${spacing.xxxSmall_4}px 0`,
         padding: `0 ${spacing.xxxSmall_4}px`,
     },
     usage: {
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
     swatch: {
         flexDirection: "row",
         flexBasis: "70%",
         borderRadius: spacing.xxxSmall_4,
-        background: Color.white,
-        boxShadow: `0 1px ${spacing.xxxSmall_4}px 0 ${Color.offBlack8}`,
-        border: `1px solid ${Color.offBlack16}`,
+        background: color.white,
+        boxShadow: `0 1px ${spacing.xxxSmall_4}px 0 ${color.offBlack8}`,
+        border: `1px solid ${color.offBlack16}`,
         overflow: "hidden",
         height: spacing.xxxLarge_64,
     },

--- a/__docs__/wonder-blocks-core/add-style.stories.mdx
+++ b/__docs__/wonder-blocks-core/add-style.stories.mdx
@@ -5,7 +5,7 @@ import {StyleSheet} from "aphrodite";
 import {fade} from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing, color} from "@khanacademy/wonder-blocks-tokens";
 
 <Meta title="Core / addStyle" />
 

--- a/__docs__/wonder-blocks-core/add-style.stories.mdx
+++ b/__docs__/wonder-blocks-core/add-style.stories.mdx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, Story, Source, Canvas, ArgsTable} from "@storybook/blocks";
 import {StyleSheet} from "aphrodite";
 
-import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import {fade} from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -12,15 +12,15 @@ import {spacing} from "@khanacademy/wonder-blocks-tokens";
 export const styles = StyleSheet.create({
     input: {
         // default style for all instances of StyledInput
-        background: Color.white,
-        border: `1px solid ${Color.offBlack16}`,
+        background: color.white,
+        border: `1px solid ${color.offBlack16}`,
         borderRadius: spacing.xxxSmall_4,
         fontSize: spacing.medium_16,
         padding: spacing.xSmall_8,
     },
     error: {
-        background: fade(Color.red, 0.16),
-        borderColor: Color.red,
+        background: fade(color.red, 0.16),
+        borderColor: color.red,
     },
 });
 
@@ -85,8 +85,7 @@ component so we don't have to create a new instance on every render.
 
 ```js
 import {StyleSheet} from "aphrodite";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 
 const StyledInput = addStyle("input", styles.input);
@@ -94,15 +93,15 @@ const StyledInput = addStyle("input", styles.input);
 const styles = StyleSheet.create({
     // default style for all instances of StyledInput
     input: {
-        background: Color.white,
-        borderColor: Color.offBlack16,
+        background: color.white,
+        borderColor: color.offBlack16,
         borderRadius: spacing.xxxSmall_4,
         fontSize: spacing.medium_16,
         padding: spacing.xSmall_8,
     },
     error: {
-        background: fade(Color.red, 0.16),
-        borderColor: Color.red,
+        background: fade(color.red, 0.16),
+        borderColor: color.red,
     },
 });
 ```

--- a/__docs__/wonder-blocks-core/exports.use-latest-ref.stories.mdx
+++ b/__docs__/wonder-blocks-core/exports.use-latest-ref.stories.mdx
@@ -4,8 +4,7 @@ import {useLatestRef, View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import Color from "@khanacademy/wonder-blocks-color";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 <Meta
     title="Core / Exports / useLatestRef()"
@@ -96,7 +95,7 @@ export function Context({children}) {
                 border: "1px solid #ccc",
                 boxShadow: "inset 1px 1px 6px #0001",
                 padding: spacing.medium_16,
-                background: Color.offWhite,
+                background: color.offWhite,
             }}
         >
             {children}

--- a/__docs__/wonder-blocks-core/view.stories.tsx
+++ b/__docs__/wonder-blocks-core/view.stories.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     HeadingMedium,
     LabelMedium,
@@ -53,8 +52,8 @@ export const InlineStyles: StoryComponentType = () => (
             style={[
                 styles.container,
                 {
-                    background: Color.lightBlue,
-                    border: `1px solid ${Color.blue}`,
+                    background: color.lightBlue,
+                    border: `1px solid ${color.blue}`,
                     padding: spacing.xxxSmall_4,
                 },
             ]}
@@ -136,19 +135,19 @@ DefiningLayout.parameters = {
 
 const styles = StyleSheet.create({
     container: {
-        background: Color.offBlack8,
+        background: color.offBlack8,
         gap: spacing.medium_16,
         padding: spacing.xLarge_32,
     },
 
     view: {
-        border: `1px dashed ${Color.lightBlue}`,
+        border: `1px dashed ${color.lightBlue}`,
         gap: spacing.medium_16,
         padding: spacing.medium_16,
     },
 
     item: {
-        background: Color.offBlack32,
+        background: color.offBlack32,
         padding: spacing.medium_16,
     },
 });

--- a/__docs__/wonder-blocks-data/exports.data.stories.mdx
+++ b/__docs__/wonder-blocks-data/exports.data.stories.mdx
@@ -56,8 +56,7 @@ import {Body, BodyMonospace} from "@khanacademy/wonder-blocks-typography";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Data} from "@khanacademy/wonder-blocks-data";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const myValidHandler = () =>
     new Promise((resolve, reject) =>
@@ -92,7 +91,7 @@ const myInvalidHandler = () =>
                 }
 
                 return (
-                    <BodyMonospace style={{color: Color.red}}>
+                    <BodyMonospace style={{color: color.red}}>
                         ERROR: {result.error}
                     </BodyMonospace>
                 );
@@ -113,8 +112,6 @@ import {Body, BodyMonospace} from "@khanacademy/wonder-blocks-typography";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Data, initializeHydrationCache} from "@khanacademy/wonder-blocks-data";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const myHandler = () => {
     throw new Error(

--- a/__docs__/wonder-blocks-data/exports.intercept-requests.stories.mdx
+++ b/__docs__/wonder-blocks-data/exports.intercept-requests.stories.mdx
@@ -43,7 +43,6 @@ import {Body, BodyMonospace} from "@khanacademy/wonder-blocks-typography";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {InterceptRequests, Data} from "@khanacademy/wonder-blocks-data";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Color from "@khanacademy/wonder-blocks-color";
 
 const myHandler = () => Promise.reject(new Error("You should not see this!"));
 

--- a/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
@@ -1,11 +1,10 @@
 import {Meta} from "@storybook/react";
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import Color from "@khanacademy/wonder-blocks-color";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {ActionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
@@ -27,12 +26,12 @@ const defaultArgs = {
 
 const styles = StyleSheet.create({
     example: {
-        background: Color.offWhite,
+        background: color.offWhite,
         padding: spacing.medium_16,
         width: 300,
     },
     items: {
-        background: Color.white,
+        background: color.white,
     },
 });
 

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -7,12 +7,11 @@ import {useArgs} from "@storybook/preview-api";
 import {action} from "@storybook/addon-actions";
 
 import {userEvent, within} from "@storybook/testing-library";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Pill from "@khanacademy/wonder-blocks-pill";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {
     ActionItem,
@@ -124,7 +123,7 @@ export default {
 
 const styles = StyleSheet.create({
     example: {
-        background: Color.offWhite,
+        background: color.offWhite,
         padding: spacing.medium_16,
     },
     exampleExtended: {
@@ -146,22 +145,22 @@ const styles = StyleSheet.create({
      * Custom opener styles
      */
     customOpener: {
-        borderLeft: `5px solid ${Color.blue}`,
+        borderLeft: `5px solid ${color.blue}`,
         borderRadius: spacing.xxxSmall_4,
-        background: Color.lightBlue,
-        color: Color.white,
+        background: color.lightBlue,
+        color: color.white,
         padding: spacing.medium_16,
     },
     focused: {
-        color: Color.offWhite,
+        color: color.offWhite,
     },
     hovered: {
         textDecoration: "underline",
-        color: Color.offWhite,
+        color: color.offWhite,
         cursor: "pointer",
     },
     pressed: {
-        color: Color.blue,
+        color: color.blue,
     },
 });
 
@@ -480,8 +479,8 @@ export const CustomActionItems: StoryComponentType = {
                 onClick={action("user profile clicked!")}
                 style={{
                     [":hover [data-test-id=new-pill]" as any]: {
-                        backgroundColor: Color.white,
-                        color: Color.blue,
+                        backgroundColor: color.white,
+                        color: color.blue,
                     },
                 }}
             />,

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -6,10 +6,9 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import Pill from "@khanacademy/wonder-blocks-pill";
@@ -79,7 +78,7 @@ export default {
 
 const styles = StyleSheet.create({
     example: {
-        background: Color.offWhite,
+        background: color.offWhite,
         padding: spacing.medium_16,
     },
     setWidth: {
@@ -112,22 +111,22 @@ const styles = StyleSheet.create({
      * Custom opener styles
      */
     customOpener: {
-        borderLeft: `5px solid ${Color.blue}`,
+        borderLeft: `5px solid ${color.blue}`,
         borderRadius: spacing.xxxSmall_4,
-        background: Color.lightBlue,
-        color: Color.white,
+        background: color.lightBlue,
+        color: color.white,
         padding: spacing.medium_16,
     },
     focused: {
-        color: Color.offWhite,
+        color: color.offWhite,
     },
     hovered: {
         textDecoration: "underline",
-        color: Color.offWhite,
+        color: color.offWhite,
         cursor: "pointer",
     },
     pressed: {
-        color: Color.blue,
+        color: color.blue,
     },
 });
 

--- a/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
@@ -1,11 +1,10 @@
 import {Meta} from "@storybook/react";
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import Color from "@khanacademy/wonder-blocks-color";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
@@ -24,12 +23,12 @@ const defaultArgs = {
 
 const styles = StyleSheet.create({
     example: {
-        background: Color.offWhite,
+        background: color.offWhite,
         padding: spacing.medium_16,
         width: 300,
     },
     items: {
-        background: Color.white,
+        background: color.white,
     },
 });
 

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -6,14 +6,14 @@ import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import {fade} from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import Pill from "@khanacademy/wonder-blocks-pill";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingLarge,
@@ -101,7 +101,7 @@ export default {
 
 const styles = StyleSheet.create({
     example: {
-        background: Color.offWhite,
+        background: color.offWhite,
         padding: spacing.medium_16,
     },
     rowRight: {
@@ -120,22 +120,22 @@ const styles = StyleSheet.create({
      * Custom opener styles
      */
     customOpener: {
-        borderLeft: `5px solid ${Color.blue}`,
+        borderLeft: `5px solid ${color.blue}`,
         borderRadius: spacing.xxxSmall_4,
-        background: Color.lightBlue,
-        color: Color.white,
+        background: color.lightBlue,
+        color: color.white,
         padding: spacing.medium_16,
     },
     focused: {
-        backgroundColor: fade(Color.lightBlue, 0.8),
+        backgroundColor: fade(color.lightBlue, 0.8),
     },
     hovered: {
         textDecoration: "underline",
-        color: Color.offWhite,
+        color: color.offWhite,
         cursor: "pointer",
     },
     pressed: {
-        backgroundColor: Color.blue,
+        backgroundColor: color.blue,
     },
 
     fullBleed: {
@@ -159,7 +159,7 @@ const styles = StyleSheet.create({
     darkBackgroundWrapper: {
         flexDirection: "row",
         justifyContent: "flex-end",
-        backgroundColor: Color.darkBlue,
+        backgroundColor: color.darkBlue,
         width: "100%",
         height: 200,
         paddingRight: spacing.medium_16,
@@ -760,7 +760,7 @@ export const AutoFocusDisabled: StoryComponentType = {
                                 style={styles.fullBleed}
                             />
                             <PhosphorIcon
-                                color={Color.blue}
+                                color={color.blue}
                                 icon={IconMappings.clockBold}
                                 size="small"
                                 style={styles.icon}

--- a/__docs__/wonder-blocks-form/checkbox-accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-form/checkbox-accessibility.stories.mdx
@@ -2,10 +2,11 @@ import * as React from "react";
 import {Meta, Story, Canvas} from "@storybook/blocks";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
+
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 
 <Meta
     title="Form/Checkbox/Accessibility"
@@ -144,6 +145,6 @@ nor the Space key will toggle the Checkbox.
 
 export const styles = StyleSheet.create({
     error: {
-        color: Color.red,
+        color: color.red,
     },
 });

--- a/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
@@ -3,8 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge, LabelXSmall} from "@khanacademy/wonder-blocks-typography";
 
 import {Choice, CheckboxGroup} from "@khanacademy/wonder-blocks-form";
@@ -321,7 +320,7 @@ const styles = StyleSheet.create({
     },
     title: {
         paddingBottom: spacing.xSmall_8,
-        borderBottom: `1px solid ${Color.offBlack64}`,
+        borderBottom: `1px solid ${color.offBlack64}`,
     },
     // Multiple choice styling
     multipleChoice: {
@@ -331,7 +330,7 @@ const styles = StyleSheet.create({
         justifyContent: "center",
     },
     description: {
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
     last: {
         borderBottom: "solid 1px #CCC",

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -4,8 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Button from "@khanacademy/wonder-blocks-button";
 import Link from "@khanacademy/wonder-blocks-link";
@@ -731,14 +730,14 @@ AutoComplete.parameters = {
 
 const styles = StyleSheet.create({
     darkBackground: {
-        background: Color.darkBlue,
+        background: color.darkBlue,
         padding: `${spacing.medium_16}px`,
     },
     whiteColor: {
-        color: Color.white,
+        color: color.white,
     },
     offWhiteColor: {
-        color: Color.white64,
+        color: color.white64,
     },
     button: {
         maxWidth: 150,

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -3,9 +3,8 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View, Text as _Text} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import Button from "@khanacademy/wonder-blocks-button";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
@@ -843,24 +842,24 @@ AutoComplete.parameters = {
 
 const styles = StyleSheet.create({
     errorMessage: {
-        color: Color.red,
+        color: color.red,
         paddingLeft: spacing.xxxSmall_4,
     },
     errorMessageLight: {
-        color: Color.white,
+        color: color.white,
         paddingLeft: spacing.xxxSmall_4,
     },
     darkBackground: {
-        backgroundColor: Color.darkBlue,
+        backgroundColor: color.darkBlue,
         padding: spacing.medium_16,
     },
     customField: {
-        backgroundColor: Color.darkBlue,
-        color: Color.white,
+        backgroundColor: color.darkBlue,
+        color: color.white,
         border: "none",
         maxWidth: 250,
         "::placeholder": {
-            color: Color.white64,
+            color: color.white64,
         },
     },
     button: {

--- a/__docs__/wonder-blocks-i18n/i18n-inline-markup.stories.tsx
+++ b/__docs__/wonder-blocks-i18n/i18n-inline-markup.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import type {Meta, StoryObj} from "@storybook/react";
-import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
@@ -105,7 +105,7 @@ export const HandlingTranslationErrors: StoryComponentType = {
                     <Tooltip
                         content={
                             <TooltipContent>
-                                <LabelMedium style={{color: Color.red}}>
+                                <LabelMedium style={{color: color.red}}>
                                     {error.message}
                                 </LabelMedium>
                             </TooltipContent>
@@ -114,7 +114,7 @@ export const HandlingTranslationErrors: StoryComponentType = {
                         <PhosphorIcon
                             size="small"
                             icon={IconMappings.xCircleBold}
-                            color={Color.red}
+                            color={color.red}
                         />
                     </Tooltip>
                 )}

--- a/__docs__/wonder-blocks-icon/accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-icon/accessibility.stories.mdx
@@ -1,9 +1,8 @@
 import {Meta, Story, Canvas} from "@storybook/blocks";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "./phosphor-icon.argtypes";
@@ -58,7 +57,7 @@ More information about all these points can be found in the
             <LabelMedium>High contrast icon (GOOD):</LabelMedium>
             <PhosphorIcon
                 icon={IconMappings.checkCircle}
-                style={{color: Color.blue, marginInlineStart: spacing.xSmall_8}}
+                style={{color: color.blue, marginInlineStart: spacing.xSmall_8}}
             />
         </View>
         <View style={{flexDirection: "row"}}>
@@ -66,7 +65,7 @@ More information about all these points can be found in the
             <PhosphorIcon
                 icon={IconMappings.xCircle}
                 style={{
-                    color: Color.lightBlue,
+                    color: color.lightBlue,
                     marginInlineStart: spacing.xSmall_8,
                 }}
             />

--- a/__docs__/wonder-blocks-layout/media-layout.stories.tsx
+++ b/__docs__/wonder-blocks-layout/media-layout.stories.tsx
@@ -2,9 +2,8 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingSmall,
@@ -50,20 +49,20 @@ export const Default: StoryComponentType = {
         styleSheets: {
             large: StyleSheet.create({
                 test: {
-                    backgroundColor: Color.darkBlue,
-                    color: Color.white,
+                    backgroundColor: color.darkBlue,
+                    color: color.white,
                 },
             }),
             medium: StyleSheet.create({
                 test: {
-                    backgroundColor: Color.blue,
-                    color: Color.white,
+                    backgroundColor: color.blue,
+                    color: color.white,
                 },
             }),
             small: StyleSheet.create({
                 test: {
-                    backgroundColor: Color.lightBlue,
-                    color: Color.white,
+                    backgroundColor: color.lightBlue,
+                    color: color.white,
                 },
             }),
         },
@@ -81,20 +80,20 @@ export const ScreenSizeStyles: StoryComponentType = () => {
     const styleSheets = {
         large: StyleSheet.create({
             test: {
-                backgroundColor: Color.darkBlue,
-                color: Color.white,
+                backgroundColor: color.darkBlue,
+                color: color.white,
             },
         }),
         medium: StyleSheet.create({
             test: {
-                backgroundColor: Color.blue,
-                color: Color.white,
+                backgroundColor: color.blue,
+                color: color.white,
             },
         }),
         small: StyleSheet.create({
             test: {
-                backgroundColor: Color.lightBlue,
-                color: Color.white,
+                backgroundColor: color.lightBlue,
+                color: color.white,
             },
         }),
     } as const;
@@ -129,7 +128,7 @@ export const AllStyles: StoryComponentType = () => {
         all: StyleSheet.create({
             // use shared styles for all sizes
             test: {
-                color: Color.white,
+                color: color.white,
                 padding: spacing.medium_16,
             },
         }),
@@ -137,20 +136,20 @@ export const AllStyles: StoryComponentType = () => {
         large: StyleSheet.create({
             // override the `padding` prop` here
             test: {
-                backgroundColor: Color.darkBlue,
+                backgroundColor: color.darkBlue,
                 padding: spacing.xxLarge_48,
             },
         }),
 
         medium: StyleSheet.create({
             test: {
-                backgroundColor: Color.blue,
+                backgroundColor: color.blue,
             },
         }),
 
         small: StyleSheet.create({
             test: {
-                backgroundColor: Color.lightBlue,
+                backgroundColor: color.lightBlue,
             },
         }),
     } as const;
@@ -186,15 +185,15 @@ export const CustomSpec: StoryComponentType = () => {
         large: StyleSheet.create({
             example: {
                 alignItems: "center",
-                backgroundColor: Color.darkBlue,
-                color: Color.white,
+                backgroundColor: color.darkBlue,
+                color: color.white,
                 padding: spacing.xxxLarge_64,
             },
         }),
 
         small: StyleSheet.create({
             example: {
-                backgroundColor: Color.lightBlue,
+                backgroundColor: color.lightBlue,
                 padding: spacing.small_12,
             },
         }),

--- a/__docs__/wonder-blocks-layout/spring.stories.tsx
+++ b/__docs__/wonder-blocks-layout/spring.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 import Button from "@khanacademy/wonder-blocks-button";
 
 import {Spring, Strut} from "@khanacademy/wonder-blocks-layout";
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
     },
     spring: {
         alignSelf: "center",
-        backgroundColor: Color.darkBlue,
+        backgroundColor: color.darkBlue,
     },
     thin: {
         height: "4px",

--- a/__docs__/wonder-blocks-layout/strut.stories.tsx
+++ b/__docs__/wonder-blocks-layout/strut.stories.tsx
@@ -3,9 +3,8 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
 import Button from "@khanacademy/wonder-blocks-button";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import packageConfig from "../../packages/wonder-blocks-layout/package.json";
@@ -123,7 +122,7 @@ const styles = StyleSheet.create({
     },
     strut: {
         alignSelf: "center",
-        backgroundColor: Color.darkBlue,
+        backgroundColor: color.darkBlue,
     },
     thin: {
         height: "4px",

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -9,11 +9,10 @@ import {StyleSheet} from "aphrodite";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingSmall,
@@ -71,7 +70,7 @@ Primary.play = async ({canvasElement}) => {
     const link = canvas.getByRole("link");
 
     // Resting style
-    await expect(link).toHaveStyle(`color: ${Color.blue}`);
+    await expect(link).toHaveStyle(`color: ${color.blue}`);
 
     // Hover style
     await userEvent.hover(link);
@@ -80,7 +79,7 @@ Primary.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.blue} dashed 2px`,
     // );
     await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.blue} solid`,
+        `text-decoration: underline ${color.blue} solid`,
     );
 
     // Focus style with keyboard navigation
@@ -118,7 +117,7 @@ Secondary.play = async ({canvasElement}) => {
     const link = canvas.getByRole("link");
 
     // Resting style
-    await expect(link).toHaveStyle(`color: ${Color.offBlack64}`);
+    await expect(link).toHaveStyle(`color: ${color.offBlack64}`);
 
     // Hover style
     await userEvent.hover(link);
@@ -127,7 +126,7 @@ Secondary.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.offBlack64} dashed 2px`,
     // );
     await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.offBlack64} solid`,
+        `text-decoration: underline ${color.offBlack64} solid`,
     );
 
     // Focus style with keyboard navigation
@@ -140,7 +139,7 @@ Secondary.play = async ({canvasElement}) => {
     // Mousedown style
     await fireEvent.mouseDown(link);
     await expect(link).toHaveStyle(
-        `text-decoration: underline solid ${Color.offBlack}`,
+        `text-decoration: underline solid ${color.offBlack}`,
     );
 };
 
@@ -186,7 +185,7 @@ LightPrimary.play = async ({canvasElement}) => {
     const link = canvas.getByRole("link");
 
     // Resting style
-    await expect(link).toHaveStyle(`color: ${Color.white}`);
+    await expect(link).toHaveStyle(`color: ${color.white}`);
 
     // Hover style
     await userEvent.hover(link);
@@ -195,7 +194,7 @@ LightPrimary.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.white} dashed 2px`,
     // );
     await expect(link).toHaveStyle(
-        `text-decoration: underline ${Color.white} solid`,
+        `text-decoration: underline ${color.white} solid`,
     );
 
     // Focus style with keyboard navigation
@@ -328,7 +327,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
         {/* Light */}
         <View
             style={{
-                backgroundColor: Color.darkBlue,
+                backgroundColor: color.darkBlue,
                 padding: spacing.large_24,
             }}
         >
@@ -378,7 +377,7 @@ export const StartAndEndIcons: StoryComponentType = () => (
             >
                 This is a multi-line link with start and end icons
             </Link>
-            <Body style={{color: Color.white}}>
+            <Body style={{color: color.white}}>
                 This is an inline{" "}
                 <Link
                     href="#"
@@ -480,7 +479,7 @@ Inline.play = async ({canvasElement}) => {
     const secondaryLink = canvas.getByRole("link", {name: "Secondary link"});
 
     // Resting style
-    await expect(primaryLink).toHaveStyle(`color: ${Color.blue}`);
+    await expect(primaryLink).toHaveStyle(`color: ${color.blue}`);
 
     // Hover style
     await userEvent.hover(primaryLink);
@@ -489,7 +488,7 @@ Inline.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.blue} dashed 2px`,
     // );
     await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.blue} solid`,
+        `text-decoration: underline ${color.blue} solid`,
     );
 
     // Focus style with keyboard navigation
@@ -513,7 +512,7 @@ Inline.play = async ({canvasElement}) => {
     /* *** Secondary link styles***  */
 
     // Resting style
-    await expect(secondaryLink).toHaveStyle(`color: ${Color.offBlack}`);
+    await expect(secondaryLink).toHaveStyle(`color: ${color.offBlack}`);
 
     // Hover style
     await userEvent.hover(secondaryLink);
@@ -522,7 +521,7 @@ Inline.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.offBlack} dashed 2px`,
     // );
     await expect(secondaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.offBlack} solid`,
+        `text-decoration: underline ${color.offBlack} solid`,
     );
 
     // Focus style with keyboard navigation
@@ -546,7 +545,7 @@ Inline.play = async ({canvasElement}) => {
 };
 
 export const InlineLight: StoryComponentType = () => (
-    <Body style={{color: Color.white}}>
+    <Body style={{color: color.white}}>
         This is an inline{" "}
         <Link href="#" inline={true} light={true}>
             Primary link
@@ -599,7 +598,7 @@ InlineLight.play = async ({canvasElement}) => {
     const primaryLink = canvas.getByRole("link", {name: "Primary link"});
 
     // Resting style
-    await expect(primaryLink).toHaveStyle(`color: ${Color.white}`);
+    await expect(primaryLink).toHaveStyle(`color: ${color.white}`);
 
     // Hover style
     await userEvent.hover(primaryLink);
@@ -608,7 +607,7 @@ InlineLight.play = async ({canvasElement}) => {
     //     `text-decoration: underline ${Color.white} dashed 2px`,
     // );
     await expect(primaryLink).toHaveStyle(
-        `text-decoration: underline ${Color.white} solid`,
+        `text-decoration: underline ${color.white} solid`,
     );
 
     // Focus style with keyboard navigation
@@ -717,7 +716,7 @@ export const Variants: StoryComponentType = () => (
         {/* Light */}
         <View
             style={{
-                backgroundColor: Color.darkBlue,
+                backgroundColor: color.darkBlue,
                 padding: spacing.large_24,
             }}
         >
@@ -755,7 +754,7 @@ export const Variants: StoryComponentType = () => (
             </View>
             <Strut size={spacing.xSmall_8} />
             {/* Inline */}
-            <Body style={{color: Color.white}}>
+            <Body style={{color: color.white}}>
                 This is an{" "}
                 <Link href="#" inline={true} light={true}>
                     Inline Primary link
@@ -965,20 +964,20 @@ RightToLeftWithIcons.parameters = {
 
 const styles = StyleSheet.create({
     darkBackground: {
-        backgroundColor: Color.darkBlue,
-        color: Color.white,
+        backgroundColor: color.darkBlue,
+        color: color.white,
         padding: 10,
     },
     heading: {
         marginRight: spacing.large_24,
     },
     navigation: {
-        border: `1px dashed ${Color.lightBlue}`,
+        border: `1px dashed ${color.lightBlue}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
     },
     pinkLink: {
-        color: Color.pink,
+        color: color.pink,
     },
     row: {
         flexDirection: "row",

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -3,12 +3,11 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 import {useGlobals} from "@storybook/preview-api";
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {Body, Title} from "@khanacademy/wonder-blocks-typography";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {
     ModalLauncher,
@@ -367,7 +366,7 @@ const styles = StyleSheet.create({
     squareDialog: {
         maxHeight: 500,
         maxWidth: 500,
-        backgroundColor: Color.darkBlue,
+        backgroundColor: color.darkBlue,
     },
     smallSquarePanel: {
         maxHeight: 400,

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -3,10 +3,9 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, Title} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -350,8 +349,8 @@ export const TwoPanels: StoryComponentType = {
 export const WithStyle: StoryComponentType = {
     render: () => {
         const modalStyles = {
-            color: Color.blue,
-            border: `2px solid ${Color.darkBlue}`,
+            color: color.blue,
+            border: `2px solid ${color.darkBlue}`,
             borderRadius: 20,
         } as const;
 

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -8,11 +8,10 @@ import {
     BreadcrumbsItem,
 } from "@khanacademy/wonder-blocks-breadcrumbs";
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
@@ -364,7 +363,7 @@ export const WithStyle: StoryComponentType = () => (
                     </Body>
                 }
                 style={{
-                    color: Color.blue,
+                    color: color.blue,
                     maxWidth: 1000,
                 }}
             />

--- a/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
@@ -2,11 +2,10 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import type {Meta, StoryObj} from "@storybook/react";
-import Color from "@khanacademy/wonder-blocks-color";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingSmall,
@@ -68,7 +67,7 @@ const styles = StyleSheet.create({
     action: {
         backgroundColor: "transparent",
         border: "none",
-        color: Color.white,
+        color: color.white,
         cursor: "pointer",
         margin: spacing.small_12,
         padding: spacing.xxSmall_6,
@@ -133,7 +132,7 @@ const CustomPopoverContent = (
                     <>
                         <PhosphorIcon
                             icon={IconMappings.pencilSimple}
-                            color={Color.gold}
+                            color={color.gold}
                             size="large"
                         />
                         <LabelLarge>Option 1</LabelLarge>
@@ -145,7 +144,7 @@ const CustomPopoverContent = (
                     <>
                         <PhosphorIcon
                             icon={IconMappings.pencilSimple}
-                            color={Color.green}
+                            color={color.green}
                             size="large"
                         />
                         <LabelLarge>Option 2</LabelLarge>
@@ -157,7 +156,7 @@ const CustomPopoverContent = (
                     <>
                         <PhosphorIcon
                             icon={IconMappings.pencilSimple}
-                            color={Color.blue}
+                            color={color.blue}
                             size="large"
                         />
                         <LabelLarge>Option 3</LabelLarge>

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -3,10 +3,9 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import type {Placement} from "@khanacademy/wonder-blocks-tooltip";
 
@@ -82,7 +81,7 @@ const styles = StyleSheet.create({
         justifyContent: "space-between",
     },
     playground: {
-        border: `1px dashed ${Color.lightBlue}`,
+        border: `1px dashed ${color.lightBlue}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
         flexDirection: "row",

--- a/__docs__/wonder-blocks-progress-spinner/circular-spinner.stories.tsx
+++ b/__docs__/wonder-blocks-progress-spinner/circular-spinner.stories.tsx
@@ -2,9 +2,8 @@ import * as React from "react";
 import {StyleSheet, css} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {CircularSpinner} from "@khanacademy/wonder-blocks-progress-spinner";
 
@@ -148,9 +147,9 @@ Inline.parameters = {
 
 export const WithStyle: StoryComponentType = () => {
     const spinnerStyle = {
-        border: `solid 5px ${Color.teal}`,
+        border: `solid 5px ${color.teal}`,
         borderRadius: "50%",
-        backgroundColor: Color.offWhite,
+        backgroundColor: color.offWhite,
     } as const;
 
     return <CircularSpinner style={spinnerStyle} />;
@@ -170,7 +169,7 @@ WithStyle.parameters = {
 
 const styles = StyleSheet.create({
     darkBackground: {
-        background: Color.darkBlue,
+        background: color.darkBlue,
         padding: spacing.xLarge_32,
         width: "100%",
         alignItems: "center",

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -5,8 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import SearchField from "@khanacademy/wonder-blocks-search-field";
@@ -192,7 +191,7 @@ WithAutofocus.parameters = {
 
 const styles = StyleSheet.create({
     darkBackground: {
-        background: Color.darkBlue,
+        background: color.darkBlue,
         padding: spacing.medium_16,
     },
 });

--- a/__docs__/wonder-blocks-spacing/spacing-table.tsx
+++ b/__docs__/wonder-blocks-spacing/spacing-table.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const StyledTable = addStyle("table");
 const StyledTableRow = addStyle("tr");
@@ -45,7 +44,7 @@ export default function SpacingTable(): React.ReactElement {
                         <StyledTableCell style={styles.cell}>
                             <View
                                 style={{
-                                    backgroundColor: Color.purple,
+                                    backgroundColor: color.purple,
                                     // @ts-expect-error [FEI-5019] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ readonly xxxxSmall_2: 2; readonly xxxSmall_4: 4; readonly xxSmall_6: 6; readonly xSmall_8: 8; readonly small_12: 12; readonly medium_16: 16; readonly large_24: 24; readonly xLarge_32: 32; readonly xxLarge_48: 48; readonly xxxLarge_64: 64; }'.
                                     width: spacing[spaceName],
                                     height: spacing.medium_16,
@@ -55,7 +54,7 @@ export default function SpacingTable(): React.ReactElement {
                         <StyledTableCell style={styles.cell}>
                             <View
                                 style={{
-                                    backgroundColor: Color.purple,
+                                    backgroundColor: color.purple,
                                     width: spacing.medium_16,
                                     // @ts-expect-error [FEI-5019] - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ readonly xxxxSmall_2: 2; readonly xxxSmall_4: 4; readonly xxSmall_6: 6; readonly xSmall_8: 8; readonly small_12: 12; readonly medium_16: 16; readonly large_24: 24; readonly xLarge_32: 32; readonly xxLarge_48: 48; readonly xxxLarge_64: 64; }'.
                                     height: spacing[spaceName],
@@ -78,18 +77,18 @@ const styles = StyleSheet.create({
         width: "100%",
     },
     header: {
-        backgroundColor: Color.offWhite,
+        backgroundColor: color.offWhite,
     },
     row: {
-        borderTop: `1px solid ${Color.offBlack8}`,
+        borderTop: `1px solid ${color.offBlack8}`,
     },
     cell: {
         padding: spacing.xSmall_8,
         verticalAlign: "middle",
     },
     tag: {
-        background: Color.offWhite,
-        border: `solid 1px ${Color.offBlack8}`,
+        background: color.offWhite,
+        border: `solid 1px ${color.offBlack8}`,
         borderRadius: spacing.xxxxSmall_2,
         display: "inline-block",
         margin: `${spacing.xxxSmall_4}px 0`,

--- a/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
@@ -6,8 +6,7 @@ import {CompactCell, DetailCell} from "@khanacademy/wonder-blocks-cell";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import packageConfig from "../../packages/wonder-blocks-switch/package.json";
@@ -91,7 +90,7 @@ export const WithLabelAndDescription: StoryComponentType = (() => {
                 </LabelMedium>
                 <LabelSmall
                     id="desc-for-switch-with-desc"
-                    style={{color: Color.offBlack64}}
+                    style={{color: color.offBlack64}}
                 >
                     Sleep is important for your health. The benefits of a good
                     night sleep include improved memory, longer life, and
@@ -128,7 +127,7 @@ export const WithLabelAndOnOff: StoryComponentType = (() => {
                 aria-labelledby="label-for-switch-with-on-off"
             />
             <LabelSmall
-                style={{marginLeft: spacing.xSmall_8, color: Color.offBlack64}}
+                style={{marginLeft: spacing.xSmall_8, color: color.offBlack64}}
                 aria-hidden={true}
             >
                 {checked ? "ON" : "OFF"}
@@ -197,7 +196,7 @@ export const InsideDetailCell: StoryComponentType = (() => {
             subtitle2={
                 <LabelSmall
                     id="desc-for-switch-inside-detail-cell"
-                    style={{color: Color.offBlack64}}
+                    style={{color: color.offBlack64}}
                 >
                     I am a long description that does not change the state of
                     the switch. Click me all you want and nothing will change.

--- a/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
+++ b/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
@@ -1,4 +1,4 @@
-import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
     placement: {
@@ -38,6 +38,6 @@ export default {
         control: {
             type: "select",
         },
-        options: Object.keys(Color) as Array<string>,
+        options: Object.keys(color) as Array<string>,
     },
 };

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -8,12 +8,11 @@ import {expect} from "@storybook/jest";
 import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
@@ -310,7 +309,7 @@ export const WithStyle: StoryComponentType = () => {
         <View style={[styles.centered, styles.row]}>
             <Tooltip
                 contentStyle={{
-                    color: Color.white,
+                    color: color.white,
                     padding: spacing.xLarge_32,
                 }}
                 content={`This is a styled tooltip.`}
@@ -383,7 +382,7 @@ const styles = StyleSheet.create({
         height: "200vh",
     },
     block: {
-        border: `solid 1px ${Color.lightBlue}`,
+        border: `solid 1px ${color.lightBlue}`,
         width: spacing.xLarge_32,
         height: spacing.xLarge_32,
         alignItems: "center",

--- a/__docs__/wonder-blocks-typography/accessibility.stories.mdx
+++ b/__docs__/wonder-blocks-typography/accessibility.stories.mdx
@@ -1,10 +1,9 @@
 import {Meta, Story, Canvas} from "@storybook/blocks";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
@@ -80,12 +79,12 @@ More information about all these points and more can be found in the
                 <PhosphorIcon icon={IconMappings.xCircle} style={styles.incorrect} />
                 <Body>The color contrast for the following text is too low:</Body>
             </View>
-            <Body style={{color: Color.offBlack32}}>The quick brown fox jumps over the lazy dog</Body>
+            <Body style={{color: color.offBlack32}}>The quick brown fox jumps over the lazy dog</Body>
             <View style={styles.explanation}>
                 <PhosphorIcon icon={IconMappings.checkCircle} style={styles.correct} />
                 <Body>The color contrast for the following text is adequate:</Body>
             </View>
-            <Body style={{color: Color.offBlack}}>The quick brown fox jumps over the lazy dog</Body>
+            <Body style={{color: color.offBlack}}>The quick brown fox jumps over the lazy dog</Body>
         </View>
     </Story>
 </Canvas>
@@ -139,12 +138,12 @@ export const styles = StyleSheet.create({
         marginTop: spacing.xSmall_8,
     },
     correct: {
-        color: Color.green,
+        color: color.green,
         marginRight: spacing.xxxSmall_4,
         paddingTop: spacing.xxxxSmall_2,
     },
     incorrect: {
-        color: Color.red,
+        color: color.red,
         marginRight: spacing.xxxSmall_4,
         paddingTop: spacing.xxxxSmall_2,
     },

--- a/__docs__/wonder-blocks-typography/typography.stories.tsx
+++ b/__docs__/wonder-blocks-typography/typography.stories.tsx
@@ -2,10 +2,9 @@ import * as React from "react";
 import {css, StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Title,
     HeadingLarge,
@@ -120,10 +119,10 @@ export const WithStyle: StoryObj<typeof Title> = {
     render: () => {
         const styles = StyleSheet.create({
             blueText: {
-                color: Color.blue,
+                color: color.blue,
             },
             highlighted: {
-                background: Color.offBlack16,
+                background: color.offBlack16,
             },
         });
 
@@ -367,7 +366,7 @@ Paragraph.parameters = {
 
 export const LineHeight: StoryObj<any> = () => {
     const style = {
-        outline: `1px solid ${Color.offBlack}`,
+        outline: `1px solid ${color.offBlack}`,
         marginBottom: spacing.small_12,
     } as const;
 

--- a/packages/wonder-blocks-banner/package.json
+++ b/packages/wonder-blocks-banner/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-button": "^6.2.5",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
     "@khanacademy/wonder-blocks-icon-button": "^5.1.8",

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -4,12 +4,11 @@ import {StyleSheet} from "aphrodite";
 import xIcon from "@phosphor-icons/core/regular/x.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon, PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import Link from "@khanacademy/wonder-blocks-link";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 import infoIcon from "@phosphor-icons/core/regular/info.svg";
@@ -122,26 +121,26 @@ const getValuesForKind = (kind: BannerKind): BannerValues => {
     switch (kind) {
         case "success":
             return {
-                color: Color.green,
+                color: color.green,
                 icon: successIcon,
                 role: "status",
             };
         case "warning":
             return {
-                color: Color.gold,
+                color: color.gold,
                 icon: warningIcon,
                 role: "alert",
                 ariaLive: "polite",
             };
         case "critical":
             return {
-                color: Color.red,
+                color: color.red,
                 icon: criticalIcon,
                 role: "alert",
             };
         default:
             return {
-                color: Color.blue,
+                color: color.blue,
                 icon: infoIcon,
                 role: "status",
             };
@@ -303,7 +302,7 @@ const styles = StyleSheet.create({
         // the base color needs to be hard-coded as white for the
         // intended pastel background color to show up correctly
         // on dark backgrounds.
-        backgroundColor: Color.white,
+        backgroundColor: color.white,
     },
     containerInner: {
         flexDirection: "row",
@@ -318,7 +317,7 @@ const styles = StyleSheet.create({
         marginInlineStart: spacing.xxxxSmall_2,
         marginInlineEnd: spacing.xSmall_8,
         alignSelf: "flex-start",
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
     labelAndButtonsContainer: {
         flex: 1,

--- a/packages/wonder-blocks-banner/tsconfig-build.json
+++ b/packages/wonder-blocks-banner/tsconfig-build.json
@@ -7,7 +7,6 @@
     },
     "references": [
         {"path": "../wonder-blocks-button/tsconfig-build.json"},
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},

--- a/packages/wonder-blocks-birthday-picker/package.json
+++ b/packages/wonder-blocks-birthday-picker/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-dropdown": "^5.1.3",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -2,10 +2,9 @@ import moment from "moment"; // NOTE: DO NOT use named imports; 'moment' does no
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Color from "@khanacademy/wonder-blocks-color";
 import {SingleSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import infoIcon from "@phosphor-icons/core/bold/info-bold.svg";
 
@@ -253,11 +252,11 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                     <PhosphorIcon
                         size="small"
                         icon={infoIcon}
-                        color={Color.red}
+                        color={color.red}
                         aria-hidden="true"
                     />
                     <Strut size={spacing.xxxSmall_4} />
-                    <Body style={{color: Color.red}}>{error}</Body>
+                    <Body style={{color: color.red}}>{error}</Body>
                 </View>
             </>
         );

--- a/packages/wonder-blocks-birthday-picker/tsconfig-build.json
+++ b/packages/wonder-blocks-birthday-picker/tsconfig-build.json
@@ -6,7 +6,6 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-dropdown/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-clickable": "^4.0.12",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
     "@khanacademy/wonder-blocks-progress-spinner": "^2.0.25",

--- a/packages/wonder-blocks-button/tsconfig-build.json
+++ b/packages/wonder-blocks-button/tsconfig-build.json
@@ -7,7 +7,6 @@
     },
     "references": [
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-progress-spinner/tsconfig-build.json"},

--- a/packages/wonder-blocks-cell/package.json
+++ b/packages/wonder-blocks-cell/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-clickable": "^4.0.12",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
     "@khanacademy/wonder-blocks-tokens": "^0.1.0",

--- a/packages/wonder-blocks-cell/src/components/detail-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import CellCore from "./internal/cell-core";
@@ -95,7 +94,7 @@ const DetailCell = function (props: DetailCellProps): React.ReactElement {
 
 const styles = StyleSheet.create({
     subtitle: {
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
 
     // This is to override the default padding of the CellCore innerWrapper.

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -5,9 +5,9 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import {fade} from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {CellMeasurements, getHorizontalRuleStyles} from "./common";
 
@@ -220,8 +220,8 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
 
 const styles = StyleSheet.create({
     wrapper: {
-        background: Color.white,
-        color: Color.offBlack,
+        background: color.white,
+        color: color.offBlack,
         display: "flex",
         minHeight: CellMeasurements.cellMinHeight,
         textAlign: "left",
@@ -262,7 +262,7 @@ const styles = StyleSheet.create({
     accessoryRight: {
         // The right accessory will have this color by default. Unless the
         // accessory element overrides that color internally.
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
 
     /**
@@ -304,36 +304,36 @@ const styles = StyleSheet.create({
             // that the focus ring is drawn inside the cell.
             width: `calc(100% - ${spacing.xxxSmall_4}px)`,
             height: `calc(100% - ${spacing.xxxSmall_4}px)`,
-            border: `${spacing.xxxxSmall_2}px solid ${Color.blue}`,
+            border: `${spacing.xxxxSmall_2}px solid ${color.blue}`,
             borderRadius: spacing.xxxSmall_4,
         },
 
         // hover + enabled
         [":hover[aria-disabled=false]" as any]: {
-            background: Color.offBlack8,
+            background: color.offBlack8,
         },
 
         // pressed + enabled
         [":active[aria-disabled=false]" as any]: {
-            background: Color.offBlack16,
+            background: color.offBlack16,
         },
     },
 
     active: {
-        background: fade(Color.blue, 0.08),
-        color: Color.blue,
+        background: fade(color.blue, 0.08),
+        color: color.blue,
 
         [":hover[aria-disabled=false]" as any]: {
-            background: fade(Color.blue, 0.16),
+            background: fade(color.blue, 0.16),
         },
 
         [":active[aria-disabled=false]" as any]: {
-            background: fade(Color.blue, 0.24),
+            background: fade(color.blue, 0.24),
         },
     },
 
     disabled: {
-        color: Color.offBlack32,
+        color: color.offBlack32,
         ":focus-visible": {
             // Prevent the focus ring from being displayed when the cell is
             // disabled.
@@ -342,11 +342,11 @@ const styles = StyleSheet.create({
     },
 
     accessoryActive: {
-        color: Color.blue,
+        color: color.blue,
     },
 
     accessoryDisabled: {
-        color: Color.offBlack,
+        color: color.offBlack,
         opacity: 0.32,
     },
 });

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -5,7 +5,6 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {fade} from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
@@ -320,15 +319,15 @@ const styles = StyleSheet.create({
     },
 
     active: {
-        background: fade(color.blue, 0.08),
+        background: color.fadedBlue8,
         color: color.blue,
 
         [":hover[aria-disabled=false]" as any]: {
-            background: fade(color.blue, 0.16),
+            background: color.fadedBlue16,
         },
 
         [":active[aria-disabled=false]" as any]: {
-            background: fade(color.blue, 0.24),
+            background: color.fadedBlue24,
         },
     },
 

--- a/packages/wonder-blocks-cell/src/components/internal/common.ts
+++ b/packages/wonder-blocks-cell/src/components/internal/common.ts
@@ -1,7 +1,6 @@
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import type {HorizontalRuleVariant} from "../../util/types";
@@ -62,7 +61,7 @@ const styles = StyleSheet.create({
             // align border to the right of the cell
             right: 0,
             height: spacing.xxxxSmall_2,
-            boxShadow: `inset 0px -1px 0px ${Color.offBlack8}`,
+            boxShadow: `inset 0px -1px 0px ${color.offBlack8}`,
         },
     },
 

--- a/packages/wonder-blocks-cell/tsconfig-build.json
+++ b/packages/wonder-blocks-cell/tsconfig-build.json
@@ -7,7 +7,6 @@
     },
     "references": [
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},

--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-core": "^6.3.1"
+    "@khanacademy/wonder-blocks-core": "^6.3.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -5,7 +5,7 @@ import {__RouterContext} from "react-router";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 
 import getClickableBehavior from "../util/get-clickable-behavior";
 import type {ClickableRole, ClickableState} from "./clickable-behavior";
@@ -396,20 +396,20 @@ const styles = StyleSheet.create({
     },
     focused: {
         ":focus": {
-            outline: `solid 2px ${Color.blue}`,
+            outline: `solid 2px ${color.blue}`,
         },
     },
     focusedLight: {
-        outline: `solid 2px ${Color.white}`,
+        outline: `solid 2px ${color.white}`,
     },
     disabled: {
-        color: Color.offBlack32,
+        color: color.offBlack32,
         cursor: "not-allowed",
         ":focus": {
             outline: "none",
         },
         ":focus-visible": {
-            outline: `solid 2px ${Color.blue}`,
+            outline: `solid 2px ${color.blue}`,
         },
     },
 });

--- a/packages/wonder-blocks-clickable/tsconfig-build.json
+++ b/packages/wonder-blocks-clickable/tsconfig-build.json
@@ -7,5 +7,6 @@
     },
     "references": [
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-clickable/tsconfig-build.json
+++ b/packages/wonder-blocks-clickable/tsconfig-build.json
@@ -6,7 +6,6 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -18,6 +18,7 @@
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-cell": "^3.2.0",
     "@khanacademy/wonder-blocks-clickable": "^4.0.12",
+    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -2,15 +2,15 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {CompactCell} from "@khanacademy/wonder-blocks-cell";
-import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import type {PropsFor, StyleType} from "@khanacademy/wonder-blocks-core";
 
 import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 
-const {blue, white, offBlack, offBlack32} = Color;
+const {blue, white, offBlack, offBlack32} = color;
 
 type CompactCellProps = PropsFor<typeof CompactCell>;
 
@@ -190,7 +190,7 @@ const styles = StyleSheet.create({
             // Override the default focus state for the cell element, so that it
             // can be added programmatically to the button element.
             borderRadius: spacing.xxxSmall_4,
-            outline: `${spacing.xxxxSmall_2}px solid ${Color.blue}`,
+            outline: `${spacing.xxxxSmall_2}px solid ${color.blue}`,
             outlineOffset: -spacing.xxxxSmall_2,
         },
 

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {CompactCell} from "@khanacademy/wonder-blocks-cell";
-import {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
@@ -10,7 +9,7 @@ import type {PropsFor, StyleType} from "@khanacademy/wonder-blocks-core";
 
 import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 
-const {blue, white, offBlack, offBlack32} = color;
+const {blue, white, offBlack} = color;
 
 type CompactCellProps = PropsFor<typeof CompactCell>;
 
@@ -212,8 +211,8 @@ const styles = StyleSheet.create({
 
         // active and pressed states
         [":active[aria-disabled=false]" as any]: {
-            color: mix(fade(blue, 0.32), white),
-            background: mix(offBlack32, blue),
+            color: color.fadedBlue,
+            background: color.activeBlue,
         },
     },
     shared: {

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
-import Color, {SemanticColor, mix} from "@khanacademy/wonder-blocks-color";
+import {SemanticColor, mix} from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import type {ClickableState} from "@khanacademy/wonder-blocks-clickable";
@@ -150,21 +150,21 @@ const sharedStyles = StyleSheet.create({
 
 const styles: Record<string, any> = {};
 
-const _generateStyles = (color: string) => {
-    const buttonType = color;
+const _generateStyles = (localColor: string) => {
+    const buttonType = localColor;
     if (styles[buttonType]) {
         return styles[buttonType];
     }
 
-    const {offBlack32} = Color;
-    const activeColor = mix(offBlack32, color);
+    const {offBlack32} = color;
+    const activeColor = mix(offBlack32, localColor);
 
     let newStyles: Record<string, any> = {};
 
     newStyles = {
         default: {
             background: "none",
-            color: color,
+            color: localColor,
         },
         focus: {
             ":after": {

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
-import {SemanticColor, mix} from "@khanacademy/wonder-blocks-color";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -56,7 +55,7 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
             ...restProps
         } = this.props;
 
-        const buttonColor = SemanticColor.controlDefault;
+        const buttonColor = color.blue;
         const buttonStyles = _generateStyles(buttonColor);
         const disabled = disabledProp;
 
@@ -157,7 +156,7 @@ const _generateStyles = (localColor: string) => {
     }
 
     const {offBlack32} = color;
-    const activeColor = mix(offBlack32, localColor);
+    const activeColor = color.activeBlue;
 
     let newStyles: Record<string, any> = {};
 

--- a/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 
-const {offBlack16, offBlack50, offWhite} = Color;
+const {offBlack16, offBlack50, offWhite} = color;
 
 /**
  * Props describing the state of the OptionItem, shared by the check

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -7,9 +7,9 @@ import * as ReactDOM from "react-dom";
 import {StyleSheet} from "aphrodite";
 import {VariableSizeList as List} from "react-window";
 
-import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import {fade} from "@khanacademy/wonder-blocks-color";
 
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle, PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
@@ -1058,12 +1058,12 @@ const styles = StyleSheet.create({
     },
 
     dropdown: {
-        backgroundColor: Color.white,
+        backgroundColor: color.white,
         borderRadius: 4,
         paddingTop: spacing.xxxSmall_4,
         paddingBottom: spacing.xxxSmall_4,
-        border: `solid 1px ${Color.offBlack16}`,
-        boxShadow: `0px 8px 8px 0px ${fade(Color.offBlack, 0.1)}`,
+        border: `solid 1px ${color.offBlack16}`,
+        boxShadow: `0px 8px 8px 0px ${fade(color.offBlack, 0.1)}`,
         // We use a custom property to set the max height of the dropdown.
         // This comes from the maxHeight custom modifier.
         // @see ../util/popper-max-height-modifier.ts
@@ -1085,7 +1085,7 @@ const styles = StyleSheet.create({
     },
 
     noResult: {
-        color: Color.offBlack64,
+        color: color.offBlack64,
         alignSelf: "center",
         marginTop: spacing.xxSmall_6,
     },

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
-import {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {mix} from "@khanacademy/wonder-blocks-color";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
@@ -228,9 +228,7 @@ export default class OptionItem extends React.Component<OptionProps> {
     }
 }
 
-const {blue, white, offBlack, offBlack32} = color;
-
-const activeBlue = mix(offBlack32, blue);
+const {blue, white, offBlack} = color;
 
 const styles = StyleSheet.create({
     item: {
@@ -277,8 +275,8 @@ const styles = StyleSheet.create({
 
         // active and pressed states
         [":active[aria-disabled=false]" as any]: {
-            color: mix(fade(blue, 0.32), white),
-            background: activeBlue,
+            color: color.fadedBlue,
+            background: color.activeBlue,
         },
 
         // checkbox states (see checkbox.tsx)
@@ -289,7 +287,7 @@ const styles = StyleSheet.create({
             color: blue,
         },
         [":active[aria-disabled=false] .check" as any]: {
-            color: activeBlue,
+            color: color.activeBlue,
         },
 
         [":is([aria-selected=true]) .checkbox" as any]: {
@@ -311,7 +309,7 @@ const styles = StyleSheet.create({
             color: color.offWhite,
         },
         [":active[aria-disabled=false] .subtitle" as any]: {
-            color: mix(fade(blue, 0.16), white),
+            color: mix(color.fadedBlue16, white),
         },
     },
     itemContainer: {

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
-import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 import {AriaProps, StyleType, View} from "@khanacademy/wonder-blocks-core";
@@ -228,7 +228,7 @@ export default class OptionItem extends React.Component<OptionProps> {
     }
 }
 
-const {blue, white, offBlack, offBlack32} = Color;
+const {blue, white, offBlack, offBlack32} = color;
 
 const activeBlue = mix(offBlack32, blue);
 
@@ -247,7 +247,7 @@ const styles = StyleSheet.create({
             // Override the default focus state for the cell element, so that it
             // can be added programmatically to the button element.
             borderRadius: spacing.xxxSmall_4,
-            outline: `${spacing.xxxxSmall_2}px solid ${Color.blue}`,
+            outline: `${spacing.xxxxSmall_2}px solid ${color.blue}`,
             outlineOffset: -spacing.xxxxSmall_2,
         },
 
@@ -304,11 +304,11 @@ const styles = StyleSheet.create({
          * Cell states
          */
         [":is([aria-disabled=false]) .subtitle" as any]: {
-            color: Color.offBlack64,
+            color: color.offBlack64,
         },
 
         [":hover[aria-disabled=false] .subtitle" as any]: {
-            color: Color.offWhite,
+            color: color.offWhite,
         },
         [":active[aria-disabled=false] .subtitle" as any]: {
             color: mix(fade(blue, 0.16), white),

--- a/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
@@ -4,8 +4,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {View} from "@khanacademy/wonder-blocks-core";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
@@ -41,7 +40,7 @@ export default class SeparatorItem extends React.Component<{
 
 const styles = StyleSheet.create({
     separator: {
-        boxShadow: `0 -1px ${Color.offBlack16}`,
+        boxShadow: `0 -1px ${color.offBlack16}`,
         height: 1,
         minHeight: 1,
         marginTop: spacing.xxxSmall_4,

--- a/packages/wonder-blocks-dropdown/tsconfig-build.json
+++ b/packages/wonder-blocks-dropdown/tsconfig-build.json
@@ -8,6 +8,7 @@
     "references": [
         {"path": "../wonder-blocks-cell/tsconfig-build.json"},
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
+        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-i18n/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
@@ -3,7 +3,7 @@ import {render, screen, fireEvent} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {StyleSheet} from "aphrodite";
-import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 import LabeledTextField from "../labeled-text-field";
 
 describe("LabeledTextField", () => {
@@ -394,7 +394,7 @@ describe("LabeledTextField", () => {
 
         // Assert
         expect(textField).toHaveStyle({
-            boxShadow: `0px 0px 0px 1px ${Color.blue}, 0px 0px 0px 2px ${Color.white}`,
+            boxShadow: `0px 0px 0px 1px ${color.blue}, 0px 0px 0px 2px ${color.white}`,
         });
     });
 

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 import minusIcon from "@phosphor-icons/core/bold/minus-bold.svg";
 
@@ -26,7 +26,7 @@ function mapCheckedToAriaChecked(value: Checked): AriaChecked {
     }
 }
 
-const {blue, red, white, offWhite, offBlack16, offBlack32, offBlack50} = Color;
+const {blue, red, white, offWhite, offBlack16, offBlack32, offBlack50} = color;
 
 // The checkbox size
 const size = spacing.medium_16;

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {mix} from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -153,10 +153,10 @@ const sharedStyles = StyleSheet.create({
     },
 });
 
-const fadedBlue = mix(fade(blue, 0.16), white);
-const activeBlue = mix(offBlack32, blue);
-const fadedRed = mix(fade(red, 0.08), white);
-const activeRed = mix(offBlack32, red);
+const fadedBlue = mix(color.fadedBlue16, white);
+const activeBlue = color.activeBlue;
+const fadedRed = mix(color.fadedRed8, white);
+const activeRed = color.activeRed;
 
 const colors = {
     default: {

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View, UniqueIDProvider} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import CheckboxCore from "./checkbox-core";
@@ -172,13 +171,13 @@ const styles = StyleSheet.create({
         marginTop: -2,
     },
     disabledLabel: {
-        color: Color.offBlack32,
+        color: color.offBlack32,
     },
     description: {
         // 16 for icon + 8 for spacing strut
         marginLeft: spacing.medium_16 + spacing.xSmall_8,
         marginTop: spacing.xxxSmall_4,
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -2,9 +2,8 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {View, addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 type Props = {
@@ -137,15 +136,15 @@ export default class FieldHeading extends React.Component<Props> {
 
 const styles = StyleSheet.create({
     label: {
-        color: Color.offBlack,
+        color: color.offBlack,
     },
     description: {
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
     error: {
-        color: Color.red,
+        color: color.red,
     },
     required: {
-        color: Color.red,
+        color: color.red,
     },
 });

--- a/packages/wonder-blocks-form/src/components/group-styles.ts
+++ b/packages/wonder-blocks-form/src/components/group-styles.ts
@@ -1,7 +1,6 @@
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleDeclaration} from "aphrodite";
 
@@ -18,12 +17,12 @@ const styles: StyleDeclaration = StyleSheet.create({
 
     description: {
         marginTop: spacing.xxxSmall_4,
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
 
     error: {
         marginTop: spacing.xxxSmall_4,
-        color: Color.red,
+        color: color.red,
     },
 
     defaultLineGap: {

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 
 import type {ChoiceCoreProps, Checked} from "../util/types";
 
-const {blue, red, white, offWhite, offBlack16, offBlack32, offBlack50} = Color;
+const {blue, red, white, offWhite, offBlack16, offBlack32, offBlack50} = color;
 
 const StyledInput = addStyle("input");
 

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {mix} from "@khanacademy/wonder-blocks-color";
 import {color} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 
@@ -91,20 +91,18 @@ const sharedStyles = StyleSheet.create({
         borderWidth: 1,
     },
 });
-const fadedBlue = mix(fade(blue, 0.16), white);
-const activeBlue = mix(offBlack32, blue);
-const fadedRed = mix(fade(red, 0.08), white);
-const activeRed = mix(offBlack32, red);
+const fadedBlue = mix(color.fadedBlue16, white);
+const fadedRed = mix(color.fadedRed8, white);
 const colors = {
     default: {
         faded: fadedBlue,
         base: blue,
-        active: activeBlue,
+        active: color.activeBlue,
     },
     error: {
         faded: fadedRed,
         base: red,
-        active: activeRed,
+        active: color.activeRed,
     },
 } as const;
 const styles: Record<string, any> = {};
@@ -161,7 +159,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
 
                 ":active": {
                     backgroundColor: palette.faded,
-                    borderColor: error ? activeRed : blue,
+                    borderColor: error ? color.activeRed : blue,
                     borderWidth: 2,
                 },
             },

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
@@ -302,42 +302,42 @@ const styles = StyleSheet.create({
         boxShadow: "none",
     },
     default: {
-        background: Color.white,
-        border: `1px solid ${Color.offBlack16}`,
-        color: Color.offBlack,
+        background: color.white,
+        border: `1px solid ${color.offBlack16}`,
+        color: color.offBlack,
         "::placeholder": {
-            color: Color.offBlack64,
+            color: color.offBlack64,
         },
     },
     error: {
-        background: `${mix(fade(Color.red, 0.06), Color.white)}`,
-        border: `1px solid ${Color.red}`,
-        color: Color.offBlack,
+        background: `${mix(fade(color.red, 0.06), color.white)}`,
+        border: `1px solid ${color.red}`,
+        color: color.offBlack,
         "::placeholder": {
-            color: Color.offBlack64,
+            color: color.offBlack64,
         },
     },
     disabled: {
-        background: Color.offWhite,
-        border: `1px solid ${Color.offBlack16}`,
-        color: Color.offBlack64,
+        background: color.offWhite,
+        border: `1px solid ${color.offBlack16}`,
+        color: color.offBlack64,
         "::placeholder": {
-            color: Color.offBlack32,
+            color: color.offBlack32,
         },
     },
     focused: {
-        background: Color.white,
-        border: `1px solid ${Color.blue}`,
-        color: Color.offBlack,
+        background: color.white,
+        border: `1px solid ${color.blue}`,
+        color: color.offBlack,
         "::placeholder": {
-            color: Color.offBlack64,
+            color: color.offBlack64,
         },
     },
     defaultLight: {
-        boxShadow: `0px 0px 0px 1px ${Color.blue}, 0px 0px 0px 2px ${Color.white}`,
+        boxShadow: `0px 0px 0px 1px ${color.blue}, 0px 0px 0px 2px ${color.white}`,
     },
     errorLight: {
-        boxShadow: `0px 0px 0px 1px ${Color.red}, 0px 0px 0px 2px ${Color.white}`,
+        boxShadow: `0px 0px 0px 1px ${color.red}, 0px 0px 0px 2px ${color.white}`,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {mix} from "@khanacademy/wonder-blocks-color";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
@@ -310,7 +310,7 @@ const styles = StyleSheet.create({
         },
     },
     error: {
-        background: `${mix(fade(color.red, 0.06), color.white)}`,
+        background: `${mix(color.fadedRed8, color.white)}`,
         border: `1px solid ${color.red}`,
         color: color.offBlack,
         "::placeholder": {

--- a/packages/wonder-blocks-grid/package.json
+++ b/packages/wonder-blocks-grid/package.json
@@ -16,7 +16,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
     "@khanacademy/wonder-blocks-tokens": "^0.1.0"

--- a/packages/wonder-blocks-grid/tsconfig-build.json
+++ b/packages/wonder-blocks-grid/tsconfig-build.json
@@ -6,7 +6,6 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},

--- a/packages/wonder-blocks-labeled-field/package.json
+++ b/packages/wonder-blocks-labeled-field/package.json
@@ -17,7 +17,6 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
     "@khanacademy/wonder-blocks-tokens": "^0.1.0",

--- a/packages/wonder-blocks-labeled-field/tsconfig-build.json
+++ b/packages/wonder-blocks-labeled-field/tsconfig-build.json
@@ -6,7 +6,6 @@
       "rootDir": "src",
   },
   "references": [
-      {"path": "../wonder-blocks-color/tsconfig-build.json"},
       {"path": "../wonder-blocks-core/tsconfig-build.json"},
       {"path": "../wonder-blocks-layout/tsconfig-build.json"},
       {"path": "../wonder-blocks-tokens/tsconfig-build.json"},

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -4,10 +4,10 @@ import {Link} from "react-router-dom";
 import {__RouterContext} from "react-router";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import Color, {mix, fade} from "@khanacademy/wonder-blocks-color";
+import {mix, fade} from "@khanacademy/wonder-blocks-color";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import externalLinkIcon from "@phosphor-icons/core/bold/arrow-square-out-bold.svg";
 
 import type {
@@ -192,7 +192,7 @@ const _generateStyles = (
         throw new Error("Only primary link is visitable");
     }
 
-    const {blue, pink, purple, white, offBlack, offBlack32, offBlack64} = Color;
+    const {blue, pink, purple, white, offBlack, offBlack32, offBlack64} = color;
 
     // Standard purple
     const linkPurple = mix(fade(offBlack, 0.08), purple);

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -197,11 +197,11 @@ const _generateStyles = (
     // Standard purple
     const linkPurple = mix(fade(offBlack, 0.08), purple);
     // Light blue
-    const fadedBlue = mix(fade(blue, 0.32), white);
+    const fadedBlue = color.fadedBlue;
     // Light pink
     const activeLightVisited = mix(fade(white, 0.32), pink);
     // Dark blue
-    const activeDefaultPrimary = mix(offBlack32, blue);
+    const activeDefaultPrimary = color.activeBlue;
 
     const primaryDefaultTextColor = light ? white : blue;
     const secondaryDefaultTextColor = inline ? offBlack : offBlack64;

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@babel/runtime": "^7.18.6",
     "@khanacademy/wonder-blocks-breadcrumbs": "^2.1.10",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon-button": "^5.1.8",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",

--- a/packages/wonder-blocks-modal/src/components/modal-backdrop.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-backdrop.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {ModalLauncherPortalAttributeName} from "../util/constants";
 
@@ -167,6 +167,6 @@ const styles = StyleSheet.create({
         //     now!
         overflow: "auto",
 
-        background: Color.offBlack64,
+        background: color.offBlack64,
     },
 });

--- a/packages/wonder-blocks-modal/src/components/modal-footer.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-footer.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 type Props = {
     children: React.ReactNode;
@@ -50,6 +49,6 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "flex-end",
 
-        boxShadow: `0px -1px 0px ${Color.offBlack16}`,
+        boxShadow: `0px -1px 0px ${color.offBlack16}`,
     },
 });

--- a/packages/wonder-blocks-modal/tsconfig-build.json
+++ b/packages/wonder-blocks-modal/tsconfig-build.json
@@ -7,7 +7,6 @@
     },
     "references": [
         {"path": "../wonder-blocks-breadcrumbs/tsconfig-build.json"},
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-form/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -16,10 +16,10 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-icon-button": "^5.1.8",
     "@khanacademy/wonder-blocks-modal": "^4.2.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-tooltip": "^2.1.25",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"
   },

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -2,9 +2,8 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import Colors from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import CloseButton from "./close-button";
 
@@ -106,9 +105,9 @@ export default class PopoverContentCore extends React.Component<Props> {
 const styles = StyleSheet.create({
     content: {
         borderRadius: spacing.xxxSmall_4,
-        border: `solid 1px ${Colors.offBlack16}`,
-        backgroundColor: Colors.white,
-        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${Colors.offBlack8}`,
+        border: `solid 1px ${color.offBlack16}`,
+        backgroundColor: color.white,
+        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,
         margin: 0,
         maxWidth: spacing.medium_16 * 18, // 288px
         padding: spacing.large_24,
@@ -119,13 +118,13 @@ const styles = StyleSheet.create({
      * Theming
      */
     blue: {
-        backgroundColor: Colors.blue,
-        color: Colors.white,
+        backgroundColor: color.blue,
+        color: color.white,
     },
 
     darkBlue: {
-        backgroundColor: Colors.darkBlue,
-        color: Colors.white,
+        backgroundColor: color.darkBlue,
+        color: color.white,
     },
 
     /**

--- a/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TooltipTail} from "@khanacademy/wonder-blocks-tooltip";
-import Color from "@khanacademy/wonder-blocks-color";
+import * as tokens from "@khanacademy/wonder-blocks-tokens";
 
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import type {
@@ -83,7 +83,7 @@ export default class PopoverDialog extends React.Component<Props> {
         const contentProps = children.props as any;
 
         // extract the background color from the popover content
-        const color: keyof typeof Color = contentProps.emphasized
+        const color: keyof typeof tokens.color = contentProps.emphasized
             ? "blue"
             : contentProps.color;
 

--- a/packages/wonder-blocks-popover/tsconfig-build.json
+++ b/packages/wonder-blocks-popover/tsconfig-build.json
@@ -6,11 +6,11 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-modal/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-tooltip/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]

--- a/packages/wonder-blocks-progress-spinner/package.json
+++ b/packages/wonder-blocks-progress-spinner/package.json
@@ -16,7 +16,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-core": "^6.3.1"
+    "@khanacademy/wonder-blocks-core": "^6.3.1",
+    "@khanacademy/wonder-blocks-tokens": "^0.1.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.5",

--- a/packages/wonder-blocks-progress-spinner/package.json
+++ b/packages/wonder-blocks-progress-spinner/package.json
@@ -16,7 +16,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1"
   },
   "peerDependencies": {

--- a/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
+++ b/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
@@ -20,8 +20,8 @@ const paths = {
 } as const;
 
 const colors = {
-    light: Color.white,
-    dark: Color.offBlack16,
+    light: color.white,
+    dark: color.offBlack16,
 } as const;
 
 const StyledPath = addStyle("path");

--- a/packages/wonder-blocks-progress-spinner/tsconfig-build.json
+++ b/packages/wonder-blocks-progress-spinner/tsconfig-build.json
@@ -6,7 +6,7 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
+        {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
     ]
 }

--- a/packages/wonder-blocks-search-field/package.json
+++ b/packages/wonder-blocks-search-field/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-form": "^4.4.0",
     "@khanacademy/wonder-blocks-icon": "^4.0.1",

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -9,8 +9,7 @@ import {View, IDProvider} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Color from "@khanacademy/wonder-blocks-color";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {defaultLabels} from "../util/constants";
@@ -165,7 +164,7 @@ const SearchField: React.ForwardRefExoticComponent<
                     <PhosphorIcon
                         icon={magnifyingGlassIcon}
                         size="medium"
-                        color={Color.offBlack64}
+                        color={color.offBlack64}
                         style={styles.searchIcon}
                         aria-hidden="true"
                     />
@@ -228,7 +227,7 @@ const styles = StyleSheet.create({
         display: "flex",
         flex: 1,
         "::placeholder": {
-            color: Color.offBlack64,
+            color: color.offBlack64,
         },
         width: "100%",
         color: "inherit",

--- a/packages/wonder-blocks-search-field/tsconfig-build.json
+++ b/packages/wonder-blocks-search-field/tsconfig-build.json
@@ -7,7 +7,6 @@
     },
     "references": [
         {"path": "../wonder-blocks-button/tsconfig-build.json"},
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-form/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},

--- a/packages/wonder-blocks-tokens/src/tokens/color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/color.ts
@@ -7,6 +7,7 @@ export const color = {
     // New colors
     activeBlue: mix(Color.offBlack32, Color.blue),
     fadedBlue: mix(fade(Color.blue, 0.32), Color.white),
+    fadedBlue24: fade(Color.blue, 0.24),
     fadedBlue16: fade(Color.blue, 0.16),
     fadedBlue8: fade(Color.blue, 0.08),
     activeRed: mix(Color.offBlack32, Color.red),

--- a/packages/wonder-blocks-toolbar/package.json
+++ b/packages/wonder-blocks-toolbar/package.json
@@ -16,7 +16,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-tokens": "^0.1.0",
     "@khanacademy/wonder-blocks-typography": "^2.1.10"

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -4,9 +4,8 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     HeadingSmall,
     LabelLarge,
@@ -146,7 +145,7 @@ export default class Toolbar extends React.Component<Props> {
 
 const sharedStyles = StyleSheet.create({
     container: {
-        border: `1px solid ${Color.offBlack16}`,
+        border: `1px solid ${color.offBlack16}`,
         flex: 1,
         flexDirection: "row",
         justifyContent: "space-between",
@@ -159,8 +158,8 @@ const sharedStyles = StyleSheet.create({
         minHeight: 50,
     },
     dark: {
-        backgroundColor: Color.darkBlue,
-        boxShadow: `0 1px 0 0 ${Color.white64}`,
+        backgroundColor: color.darkBlue,
+        boxShadow: `0 1px 0 0 ${color.white64}`,
         color: "white",
     },
     column: {
@@ -190,7 +189,7 @@ const sharedStyles = StyleSheet.create({
         textAlign: "center",
     },
     subtitle: {
-        color: Color.offBlack64,
+        color: color.offBlack64,
     },
     titles: {
         padding: spacing.small_12,

--- a/packages/wonder-blocks-toolbar/tsconfig-build.json
+++ b/packages/wonder-blocks-toolbar/tsconfig-build.json
@@ -6,7 +6,6 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -16,7 +16,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "@khanacademy/wonder-blocks-color": "^3.0.0",
     "@khanacademy/wonder-blocks-core": "^6.3.1",
     "@khanacademy/wonder-blocks-layout": "^2.0.25",
     "@khanacademy/wonder-blocks-modal": "^4.2.1",

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -1,8 +1,7 @@
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
-import Colors from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import TooltipContent from "./tooltip-content";
@@ -32,7 +31,7 @@ export type Props = {
     children: React.ReactElement<React.ComponentProps<typeof TooltipContent>>;
     onActiveChanged: (active: boolean) => unknown;
     /** Optional background color. */
-    backgroundColor?: keyof typeof Colors;
+    backgroundColor?: keyof typeof color;
 } & PopperElementProps; // (v3 beta introduces this) // TODO(somewhatabstract): Update react-docgen to support spread operators
 
 type State = {
@@ -88,7 +87,7 @@ export default class TooltipBubble extends React.Component<Props, State> {
                     style={[
                         styles.content,
                         backgroundColor && {
-                            backgroundColor: Colors[backgroundColor],
+                            backgroundColor: color[backgroundColor],
                         },
                     ]}
                 >
@@ -142,9 +141,9 @@ const styles = StyleSheet.create({
     content: {
         maxWidth: 472,
         borderRadius: spacing.xxxSmall_4,
-        border: `solid 1px ${Colors.offBlack16}`,
-        backgroundColor: Colors.white,
-        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${Colors.offBlack8}`,
+        border: `solid 1px ${color.offBlack16}`,
+        backgroundColor: color.white,
+        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,
         justifyContent: "center",
     },
 });

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import {css, StyleSheet} from "aphrodite";
 
-import Colors from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
@@ -17,7 +16,7 @@ export type Props = {
      * NOTE: Added to support custom popovers
      * @ignore
      */
-    color: keyof typeof Colors;
+    color: keyof typeof color;
     /** The offset of the tail indicating where it should be positioned. */
     offset?: Offset;
     /** The placement of the tail with respect to the tooltip anchor. */
@@ -240,9 +239,9 @@ export default class TooltipTail extends React.Component<Props> {
              */
             <g key="dropshadow" transform={`translate(${offsetShadowX},5.5)`}>
                 <polyline
-                    fill={Colors.offBlack16}
+                    fill={color.offBlack16}
                     points={points.join(" ")}
-                    stroke={Colors.offBlack32}
+                    stroke={color.offBlack32}
                     filter={`url(#${dropShadowFilterId})`}
                 />
             </g>,
@@ -350,7 +349,7 @@ export default class TooltipTail extends React.Component<Props> {
         const {trimlinePoints, points, height, width} =
             this._calculateDimensionsFromPlacement();
 
-        const {color, show} = this.props;
+        const {color: arrowColor, show} = this.props;
 
         if (!show) {
             // If we aren't showing the tail, we still need to take up space
@@ -367,7 +366,6 @@ export default class TooltipTail extends React.Component<Props> {
                 aria-hidden
             >
                 {this._maybeRenderDropshadow(points)}
-
                 {/**
                  * Draw the actual background of the tooltip arrow.
                  *
@@ -375,24 +373,22 @@ export default class TooltipTail extends React.Component<Props> {
                  * outline, it draws over white and not the dropshadow behind.
                  */}
                 <polyline
-                    fill={Colors[color]}
-                    stroke={Colors[color]}
+                    fill={color[arrowColor]}
+                    stroke={color[arrowColor]}
                     points={points.join(" ")}
                 />
-
                 {/* Draw the tooltip outline around the tooltip arrow. */}
                 <polyline
                     // Redraw the stroke on top of the background color,
                     // so that the ends aren't extra dark where they meet
                     // the border of the tooltip.
-                    fill={Colors[color]}
+                    fill={color[arrowColor]}
                     points={points.join(" ")}
-                    stroke={Colors.offBlack16}
+                    stroke={color.offBlack16}
                 />
-
                 {/* Draw a trimline to make the arrow appear flush */}
                 <polyline
-                    stroke={Colors[color]}
+                    stroke={color[arrowColor]}
                     points={trimlinePoints.join(" ")}
                 />
             </svg>

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -27,7 +27,7 @@ import {
 import {maybeGetPortalMountedModalHostElement} from "@khanacademy/wonder-blocks-modal";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
-import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 
 import TooltipAnchor from "./tooltip-anchor";
 import TooltipBubble from "./tooltip-bubble";
@@ -109,7 +109,7 @@ type Props = AriaProps &
         /**
          * Optional background color.
          */
-        backgroundColor?: keyof typeof Color;
+        backgroundColor?: keyof typeof color;
     }>;
 
 type State = Readonly<{

--- a/packages/wonder-blocks-tooltip/tsconfig-build.json
+++ b/packages/wonder-blocks-tooltip/tsconfig-build.json
@@ -6,7 +6,6 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../wonder-blocks-color/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
         {"path": "../wonder-blocks-modal/tsconfig-build.json"},

--- a/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
@@ -39,7 +39,7 @@ const color = color.red;
 import Color from "@khanacademy/wonder-blocks-color";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 `,
-        `import {spacing, color} from "@khanacademy/wonder-blocks-tokens";`,
+        `import {color, spacing} from "@khanacademy/wonder-blocks-tokens";`,
         "should add a named import to the existing import declaration",
     );
 
@@ -52,5 +52,32 @@ import {color} from "@khanacademy/wonder-blocks-tokens";
 `,
         `import {color} from "@khanacademy/wonder-blocks-tokens";`,
         "should delete the import declaration if the tokens.color named import is already used",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Color, {fade} from "@khanacademy/wonder-blocks-color";
+`,
+        `
+import {fade} from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+`,
+        "should keep the color import if there are other named imports in the source import declaration",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Color, {fade} from "@khanacademy/wonder-blocks-color";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `
+import {fade} from "@khanacademy/wonder-blocks-color";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+`,
+        "should keep the color import if there are other named imports in the source import declaration and move the default import to the existing target import",
     );
 });

--- a/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
@@ -1,0 +1,56 @@
+import transform from "../migrate-color-to-tokens";
+
+// eslint-disable-next-line import/no-commonjs, @typescript-eslint/no-var-requires
+const defineInlineTest = require("jscodeshift/dist/testUtils").defineInlineTest;
+
+const transformOptions = {
+    printOptions: {
+        objectCurlySpacing: false,
+    },
+};
+
+describe("migrate-color-to-tokens", () => {
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `import Color from "@khanacademy/wonder-blocks-color";`,
+        `import {color} from "@khanacademy/wonder-blocks-tokens";`,
+        "should replace default import with named import",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Colors from "@khanacademy/wonder-blocks-color";
+const color = Colors.red;
+    `,
+        `
+import {color} from "@khanacademy/wonder-blocks-tokens";
+const color = color.red;
+    `,
+        "should replace default import with named import when using a different name",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Color from "@khanacademy/wonder-blocks-color";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `import {spacing, color} from "@khanacademy/wonder-blocks-tokens";`,
+        "should add a named import to the existing import declaration",
+    );
+
+    defineInlineTest(
+        transform,
+        transformOptions,
+        `
+import Color from "@khanacademy/wonder-blocks-color";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+`,
+        `import {color} from "@khanacademy/wonder-blocks-tokens";`,
+        "should delete the import declaration if the tokens.color named import is already used",
+    );
+});

--- a/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
+++ b/wb-codemod/transforms/__tests__/migrate-color-to-tokens.test.ts
@@ -86,10 +86,16 @@ import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
         transformOptions,
         `
 import {fade, mix} from "@khanacademy/wonder-blocks-color";
+const Color = {red: "red"};
+// This Color definition comes from a different module.
+const bgColor = Color.red;
 `,
         `
 import {fade, mix} from "@khanacademy/wonder-blocks-color";
+const Color = {red: "red"};
+// This Color definition comes from a different module.
+const bgColor = Color.red;
 `,
-        "should do nothing if Color is not imported",
+        "should do nothing if Color is not imported from @khanacademy/wonder-blocks-color",
     );
 });

--- a/wb-codemod/transforms/migrate-color-to-tokens.ts
+++ b/wb-codemod/transforms/migrate-color-to-tokens.ts
@@ -31,6 +31,7 @@ export default function transform(file: FileInfo, api: API, options: Options) {
 
     // Use the default specifier as the source specifier.
     let sourceSpecifier = SOURCE_SPECIFIER;
+    let hasDefaultSpecifier = true;
 
     // Step 1: Verify if the import exists
     const sourceImport = root.find(j.ImportDeclaration, {
@@ -55,6 +56,7 @@ export default function transform(file: FileInfo, api: API, options: Options) {
 
         // If there's no default specifier, we don't need to do anything.
         if (!defaultSpecifier) {
+            hasDefaultSpecifier = false;
             return;
         }
 
@@ -132,10 +134,14 @@ export default function transform(file: FileInfo, api: API, options: Options) {
         }
     });
 
-    // Step 3: Replace the call sites that use the default specifier.
-    root.find(j.Identifier, {name: sourceSpecifier}).forEach((path) => {
-        path.node.name = TARGET_SPECIFIER;
-    });
+    // NOTE: We only need to replace the usage if the source import has a
+    // default specifier. Otherwise, we don't need to do anything.
+    if (hasDefaultSpecifier) {
+        // Step 3: Replace the call sites that use the default specifier.
+        root.find(j.Identifier, {name: sourceSpecifier}).forEach((path) => {
+            path.node.name = TARGET_SPECIFIER;
+        });
+    }
 
     return root.toSource(options.printOptions);
 }

--- a/wb-codemod/transforms/migrate-color-to-tokens.ts
+++ b/wb-codemod/transforms/migrate-color-to-tokens.ts
@@ -1,0 +1,100 @@
+import {
+    API,
+    FileInfo,
+    ModuleSpecifier,
+    ImportDeclaration,
+    Options,
+} from "jscodeshift";
+
+// From
+const SOURCE_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-color";
+const SOURCE_SPECIFIER = "Color";
+// To
+const TARGET_IMPORT_DECLARATION = "@khanacademy/wonder-blocks-tokens";
+const TARGET_SPECIFIER = "color";
+
+/**
+ * Transforms:
+ * import Color from "@khanacademy/wonder-blocks-color"
+ * const bgColor = Color.blue;
+ *
+ * to:
+ * import {color} from "@khanacademy/wonder-blocks-tokens"
+ * const bgColor = color.blue;
+ */
+export default function transform(file: FileInfo, api: API, options: Options) {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+
+    // Use the default specifier as the source specifier.
+    let sourceSpecifier = SOURCE_SPECIFIER;
+
+    // Step 1: Verify if the import exists
+    const sourceImport = root.find(j.ImportDeclaration, {
+        source: {value: SOURCE_IMPORT_DECLARATION},
+    });
+
+    // If the import doesn't exist, we don't need to do anything.
+    if (sourceImport.size() === 0) {
+        return;
+    }
+
+    // Step 2: Replace the import
+    const targetImport = root.find(j.ImportDeclaration, {
+        source: {value: TARGET_IMPORT_DECLARATION},
+    });
+
+    sourceImport.forEach((path) => {
+        // Find the default specifier
+        const defaultSpecifier = path.value.specifiers?.find(
+            (specifier) => specifier.type === "ImportDefaultSpecifier",
+        );
+
+        // There might be cases where the default specifier uses a different
+        // name from the one defined in SOURCE_SPECIFIER, so we need to make
+        // sure we use the correct name to complete step 3.
+        if (defaultSpecifier?.local) {
+            sourceSpecifier = defaultSpecifier.local?.name;
+        }
+
+        // Replace default import with named import
+        const targetSpecifier = j.importSpecifier(
+            j.identifier(TARGET_SPECIFIER),
+        );
+
+        // If the import is already used, we add a named import to the existing
+        // import declaration.
+        if (targetImport.size() > 0) {
+            // NOTE: We only add the specifier if it doesn't exist already.
+            const specifierExists = targetImport
+                .get()
+                .node.specifiers.some(
+                    (specifier: ModuleSpecifier) =>
+                        specifier.local?.name === TARGET_SPECIFIER,
+                );
+
+            if (!specifierExists) {
+                targetImport.get().node.specifiers.push(targetSpecifier);
+            }
+            // Remove the import declaration
+            j(path).remove();
+            return;
+        }
+
+        // Create a new import declaration.
+        const newTargetImport = j.importDeclaration(
+            [targetSpecifier],
+            j.literal(TARGET_IMPORT_DECLARATION),
+        );
+
+        // Replace the existing import declaration with the new one.
+        j(path).replaceWith(newTargetImport);
+    });
+
+    // Step 3: Replace the usage
+    root.find(j.Identifier, {name: sourceSpecifier}).forEach((path) => {
+        path.node.name = TARGET_SPECIFIER;
+    });
+
+    return root.toSource(options.printOptions);
+}


### PR DESCRIPTION
## Summary:

Migrated the `color` tokens from `wonder-blocks-color` to
`wonder-blocks-tokens`. This change is part of the larger effort to migrate all
tokens to `wonder-blocks-tokens`.

To migrate the Color tokens, I did the following:

Ran the codemod created in #2178:

npx @khanacademy/wb-codemod -t migrate-color-to-tokens packages/ __docs__/
Then I manually updated the remaining instances that were not updated by the
codemod (e.g. MDX files).

Finally, I ran prettier to format the files and fix any linting issues.

Issue: WB-1642

## Test plan:

Verify that all the checks pass and also verify that the storybook stories
render correctly.