### PR TITLE
WB-1666: OptionItem not vertically centered when horizontalRule is set (fix)

### DIFF
--- a/.changeset/short-numbers-cheer.md
+++ b/.changeset/short-numbers-cheer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fix an issue where OptionItem is not vertically centered

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -822,6 +822,7 @@ export const CustomOptionItems: StoryComponentType = {
                         <OptionItem
                             key={user.id}
                             value={user.id}
+                            horizontalRule="full-width"
                             label={user.name}
                             leftAccessory={user.picture}
                             subtitle1={

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -235,8 +235,6 @@ const styles = StyleSheet.create({
         // Reset the default styles for the cell element so it can grow
         // vertically.
         minHeight: "unset",
-        // Make sure that the item is always at least as tall as 40px.
-        paddingBlock: spacing.xxxxSmall_2,
 
         /**
          * States
@@ -314,7 +312,10 @@ const styles = StyleSheet.create({
     },
     itemContainer: {
         minHeight: "unset",
-        padding: spacing.xSmall_8,
+        // Make sure that the item is always at least as tall as 40px.
+        padding: `${spacing.xSmall_8 + spacing.xxxxSmall_2}px ${
+            spacing.xSmall_8
+        }px`,
         paddingRight: spacing.medium_16,
         whiteSpace: "nowrap",
     },


### PR DESCRIPTION
## Summary:

There is a visual issue when the `horizontalRule` prop is set to `true` in the
`OptionItem` component. The `OptionItem` component is not vertically centered
as causes to include a padding after the horizontal rule.

This PR fixes that by applying the correct padding to the `OptionItem` component
to make it vertically centered when the `horizontalRule` prop is set.

Issue: WB-1666

## Test plan:

1. Navigate to /?path=/story/dropdown-singleselect--custom-option-items.
2. Focus on different option items by pressing `Tab`.
2. Verify that the `OptionItem` component is vertically centered and the
horizontal rule is correctly aligned to the bottom of the component.

Alternatively, navigate to /?path=/story/dropdown-optionitem--horizontal-rule and verify the alignment.

| BEFORE | AFTER |
|--------|--------|
| ![Screenshot 2024-02-15 at 3 40 27 PM (1)](https://github.com/Khan/wonder-blocks/assets/843075/01cc8f0b-7233-4e67-8413-2591ec018363) | <img width="338" alt="Screenshot 2024-02-21 at 12 00 58 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/755c703f-2f4b-4210-8fcc-6cfb3200dda5"> | 