### PR TITLE
WB-1668: Tokens: Add 24% color shades

### DIFF
--- a/.changeset/rotten-cheetahs-guess.md
+++ b/.changeset/rotten-cheetahs-guess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add new shades of existing colors (24%).

--- a/packages/wonder-blocks-tokens/src/tokens/color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/color.ts
@@ -1,23 +1,35 @@
 // TODO(WB-1642): Move wonder-blocks-color to tokens
 import Color, {fade, mix} from "@khanacademy/wonder-blocks-color";
 
+const fadedColorWithWhite = (color: string, alpha: number) =>
+    mix(fade(color, alpha), Color.white);
+
 export const color = {
     // Wonder Blocks base colors
     ...Color,
-    // New colors
-    activeBlue: mix(Color.offBlack32, Color.blue),
-    fadedBlue: mix(fade(Color.blue, 0.32), Color.white),
-    fadedBlue24: fade(Color.blue, 0.24),
-    fadedBlue16: fade(Color.blue, 0.16),
-    fadedBlue8: fade(Color.blue, 0.08),
-    activeRed: mix(Color.offBlack32, Color.red),
-    fadedRed: mix(fade(Color.red, 0.32), Color.white),
-    fadedRed16: fade(Color.red, 0.16),
-    fadedRed8: fade(Color.red, 0.08),
-    fadedGreen16: fade(Color.green, 0.16),
-    fadedGold16: fade(Color.gold, 0.16),
-    // Additional colors (e.g. for use in other themes)
-    // Khanmigo
+    // Additional colors
     white32: fade(Color.white, 0.32),
+    // Blue shades
+    activeBlue: mix(Color.offBlack32, Color.blue),
+    fadedBlue: fadedColorWithWhite(Color.blue, 0.32),
+    fadedBlue24: fadedColorWithWhite(Color.blue, 0.24),
+    fadedBlue16: fadedColorWithWhite(Color.blue, 0.16),
+    fadedBlue8: fadedColorWithWhite(Color.blue, 0.08),
+    // Red shades
+    activeRed: mix(Color.offBlack32, Color.red),
+    fadedRed: fadedColorWithWhite(Color.red, 0.32),
+    fadedRed24: fadedColorWithWhite(Color.red, 0.24),
+    fadedRed16: fadedColorWithWhite(Color.red, 0.16),
+    fadedRed8: fadedColorWithWhite(Color.red, 0.08),
+    // Green shades
+    fadedGreen24: fadedColorWithWhite(Color.green, 0.24),
+    fadedGreen16: fadedColorWithWhite(Color.green, 0.16),
+    // Gold shades
+    fadedGold24: fadedColorWithWhite(Color.gold, 0.24),
+    fadedGold16: fadedColorWithWhite(Color.gold, 0.16),
+    // Purple shades
+    fadedPurple24: fadedColorWithWhite(Color.purple, 0.24),
+    fadedPurple16: fadedColorWithWhite(Color.purple, 0.16),
+    // Khanmigo
     eggplant: "#5f1e5c",
 };


### PR DESCRIPTION
## Summary:

- Add some new color tokens to existing primary colors. These new tokens are 24%
lighter than the original ones, and will be used for some cards in the WHAM
project.

- Also fixed a very small issue with the existing faded colors, which were not
including a mix with white. The change is minimal, but still worth as it allows
to convert the shade from an alpha value to a solid color.

Issue: https://khanacademy.atlassian.net/browse/WB-1668

## Test plan:

Verify that the new colors are included and that the snapshots look correct.

<img width="711" alt="Screenshot 2024-02-23 at 3 54 31 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/057b9050-dd52-4b9c-a0fc-345146be6899">
