### PR TITLE
Automatically format the number for the current locale in ngettext.

### DIFF
--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
@@ -390,50 +390,47 @@ describe("i18n", () => {
                 });
             });
 
-            describe("with num substitution and num option", () => {
+            describe("with num substitution and non-en locale", () => {
                 it("should return plural form for num 0", () => {
                     // Arrange
+                    jest.spyOn(Locale, "getLocale").mockImplementation(
+                        () => "fr-fr",
+                    );
+                    const formatSpy = jest.spyOn(Intl, "NumberFormat");
 
                     // Act
-                    const result = ngettext(
-                        "Singular %(num)s",
-                        "Plural %(num)s",
-                        0,
-                        {num: 5},
-                    );
+                    ngettext("Singular %(num)s", "Plural %(num)s", 0);
 
                     // Assert
-                    expect(result).toEqual("Plural 5");
+                    expect(formatSpy).toHaveBeenCalledWith("fr-fr");
                 });
 
                 it("should return singular form for num 1", () => {
                     // Arrange
+                    jest.spyOn(Locale, "getLocale").mockImplementation(
+                        () => "fr-fr",
+                    );
+                    const formatSpy = jest.spyOn(Intl, "NumberFormat");
 
                     // Act
-                    const result = ngettext(
-                        "Singular %(num)s",
-                        "Plural %(num)s",
-                        1,
-                        {num: 5},
-                    );
+                    ngettext("Singular %(num)s", "Plural %(num)s", 1);
 
                     // Assert
-                    expect(result).toEqual("Singular 5");
+                    expect(formatSpy).toHaveBeenCalledWith("fr-fr");
                 });
 
                 it("should return plural form for num 2 or more", () => {
                     // Arrange
+                    jest.spyOn(Locale, "getLocale").mockImplementation(
+                        () => "fr-fr",
+                    );
+                    const formatSpy = jest.spyOn(Intl, "NumberFormat");
 
                     // Act
-                    const result = ngettext(
-                        "Singular %(num)s",
-                        "Plural %(num)s",
-                        2,
-                        {num: 5},
-                    );
+                    ngettext("Singular %(num)s", "Plural %(num)s", 2000);
 
                     // Assert
-                    expect(result).toEqual("Plural 5");
+                    expect(formatSpy).toHaveBeenCalledWith("fr-fr");
                 });
             });
 

--- a/packages/wonder-blocks-i18n/src/functions/i18n.ts
+++ b/packages/wonder-blocks-i18n/src/functions/i18n.ts
@@ -5,6 +5,7 @@ import * as React from "react";
 
 import FakeTranslate from "./i18n-faketranslate";
 import {allPluralForms} from "./plural-forms";
+import {getLocale} from "./locale";
 
 type InterpolationOptions<T> = {
     [key: string]: T;
@@ -260,10 +261,21 @@ export const ngettext: ngettextOverloads = (
 
     // Get the options to substitute into the string.
     // We automatically add in the 'magic' option-variable 'num'.
-    actualOptions.num = actualOptions.num || actualNum;
+    actualOptions.num = formatNumber(actualNum);
 
     // Then pass into i18n._ for the actual substitution
     return _(translation, actualOptions);
+};
+
+/**
+ * Format a number to a string using the current locale.
+ * This is a thin wrapper around Intl.NumberFormat.
+ *
+ * @param num the number to format to a string
+ * @returns a formatted number string
+ */
+const formatNumber = (num: number): string => {
+    return Intl.NumberFormat(getLocale()).format(num);
 };
 
 /*


### PR DESCRIPTION
## Summary:
We can't support a custom-formatted num with ngettext when we move to LinguiJS, so we're removing that logic and making it so that the numbers are now formatted using NumberFormat instead (which matches what LinguiJS will do).

I'll have to make a few changes in webapp to remove the few cases where this is happening, so I will release this change at the same time as I release those changes in webapp.

Issue: FEI-5547

## Test plan:
The tests should pass.