### PR TITLE
[fei5384.1.medialayout] Make sure MediaLayout respects Server.isServerSide()

### DIFF
--- a/.changeset/four-readers-rush.md
+++ b/.changeset/four-readers-rush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-layout": patch
+---
+
+Updates the MediaLayout component to respect the value of Server.isServerSide()

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout-context.test.tsx
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout-context.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, Server} from "@khanacademy/wonder-blocks-core";
 import {render} from "@testing-library/react";
 
 import MediaLayout from "../media-layout";
@@ -14,8 +14,8 @@ import {
 
 describe("MediaLayoutContext", () => {
     beforeEach(() => {
-        // @ts-expect-error [FEI-5019] - TS2322 - Type '(query: "(max-width: 767px)" | "(min-width: 768px) and (max-width: 1023px)" | "(min-width: 1024px)") => MatchMedia' is not assignable to type '((query: string) => MediaQueryList) & ((query: string) => MediaQueryList)'.
-        window.matchMedia = matchMedia;
+        jest.restoreAllMocks();
+        window.matchMedia = matchMedia as any;
     });
 
     describe("overrideSize", () => {
@@ -24,7 +24,7 @@ describe("MediaLayoutContext", () => {
             resizeWindow("large");
 
             // Act
-            const args = await new Promise((resolve: any, reject: any) => {
+            const args: any = await new Promise((resolve: any, reject: any) => {
                 render(
                     <MediaLayoutContext.Provider
                         value={{
@@ -44,16 +44,17 @@ describe("MediaLayoutContext", () => {
             });
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2571 - Object is of type 'unknown'.
             expect(args.mediaSize).toEqual("small");
         });
     });
 
     describe("ssrSize", () => {
+        beforeEach(() => {
+            jest.spyOn(Server, "isServerSide").mockReturnValue(true);
+        });
+
         it("should use the default ssrSize on the server", async () => {
             // Arrange
-            // @ts-expect-error [FEI-5019] - TS2790 - The operand of a 'delete' operator must be optional.
-            delete window.matchMedia;
             const promise = new Promise((resolve: any, reject: any) => {
                 render(
                     <MediaLayout styleSheets={{}}>
@@ -66,20 +67,17 @@ describe("MediaLayoutContext", () => {
             });
 
             // Act
-            const args = await promise;
+            const args: any = await promise;
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2571 - Object is of type 'unknown'.
             expect(args.mediaSize).toEqual("large");
         });
 
         it("should use the provided ssrSize on the server", async () => {
             // Arrange
-            // @ts-expect-error [FEI-5019] - TS2790 - The operand of a 'delete' operator must be optional.
-            delete window.matchMedia;
 
             // Act
-            const args = await new Promise((resolve: any, reject: any) => {
+            const args: any = await new Promise((resolve: any, reject: any) => {
                 render(
                     <MediaLayoutContext.Provider
                         value={{
@@ -99,7 +97,6 @@ describe("MediaLayoutContext", () => {
             });
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2571 - Object is of type 'unknown'.
             expect(args.mediaSize).toEqual("small");
         });
     });
@@ -110,7 +107,7 @@ describe("MediaLayoutContext", () => {
             resizeWindow("small");
 
             // Act
-            const args = await new Promise((resolve: any, reject: any) => {
+            const args: any = await new Promise((resolve: any, reject: any) => {
                 render(
                     <MediaLayoutContext.Provider
                         value={{
@@ -130,7 +127,6 @@ describe("MediaLayoutContext", () => {
             });
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2571 - Object is of type 'unknown'.
             expect(args.mediaSize).toEqual("large");
         });
 
@@ -139,7 +135,7 @@ describe("MediaLayoutContext", () => {
             resizeWindow("medium");
 
             // Act
-            const args = await new Promise((resolve: any, reject: any) => {
+            const args: any = await new Promise((resolve: any, reject: any) => {
                 render(
                     <MediaLayoutContext.Provider
                         value={{
@@ -159,7 +155,6 @@ describe("MediaLayoutContext", () => {
             });
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2571 - Object is of type 'unknown'.
             expect(args.mediaSize).toEqual("large");
         });
     });

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.tsx
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.tsx
@@ -5,11 +5,11 @@ import {render, screen} from "@testing-library/react";
 
 import MediaLayout from "../media-layout";
 import {resizeWindow, matchMedia} from "../../util/test-util";
+import {MediaSize} from "../../util/types";
 
 describe("MediaLayout", () => {
     beforeEach(() => {
-        // @ts-expect-error [FEI-5019] - TS2322 - Type '(query: "(max-width: 767px)" | "(min-width: 768px) and (max-width: 1023px)" | "(min-width: 1024px)") => MatchMedia' is not assignable to type '((query: string) => MediaQueryList) & ((query: string) => MediaQueryList)'.
-        window.matchMedia = matchMedia;
+        window.matchMedia = matchMedia as any;
     });
 
     describe("mediaSize", () => {
@@ -18,7 +18,7 @@ describe("MediaLayout", () => {
             resizeWindow("small");
 
             // Act
-            const args = await new Promise((resolve: any, reject: any) => {
+            const args: any = await new Promise((resolve: any, reject: any) => {
                 render(
                     <MediaLayout>
                         {({mediaSize, mediaSpec, styles}: any) => {
@@ -32,7 +32,6 @@ describe("MediaLayout", () => {
             });
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2571 - Object is of type 'unknown'.
             expect(args.mediaSize).toEqual("small");
         });
 
@@ -41,7 +40,7 @@ describe("MediaLayout", () => {
             resizeWindow("medium");
 
             // Act
-            const args = await new Promise((resolve: any, reject: any) => {
+            const args: any = await new Promise((resolve: any, reject: any) => {
                 render(
                     <MediaLayout>
                         {({mediaSize, mediaSpec, styles}: any) => {
@@ -55,7 +54,6 @@ describe("MediaLayout", () => {
             });
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2571 - Object is of type 'unknown'.
             expect(args.mediaSize).toEqual("medium");
         });
 
@@ -64,7 +62,7 @@ describe("MediaLayout", () => {
             resizeWindow("large");
 
             // Act
-            const args = await new Promise((resolve: any, reject: any) => {
+            const args: any = await new Promise((resolve: any, reject: any) => {
                 render(
                     <MediaLayout>
                         {({mediaSize, mediaSpec, styles}: any) => {
@@ -78,185 +76,177 @@ describe("MediaLayout", () => {
             });
 
             // Assert
-            // @ts-expect-error [FEI-5019] - TS2571 - Object is of type 'unknown'.
             expect(args.mediaSize).toEqual("large");
         });
     });
 
-    describe("styleSheets", () => {
-        const testSizes = {
-            small: [640, 480],
-            medium: [800, 600],
-            large: [1200, 800],
-        } as const;
+    describe.each`
+        size
+        ${"small"}
+        ${"medium"}
+        ${"large"}
+    `("styleSheets - $size", ({size}: {size: MediaSize}) => {
+        it(`should always provide styles from all`, async () => {
+            // Arrange
+            const styleSheets = {
+                all: StyleSheet.create({
+                    test: {
+                        color: "blue",
+                    },
+                }),
+            } as const;
+            resizeWindow(size);
 
-        for (const size of Object.keys(testSizes)) {
-            it(`should always provide styles from all (${size})`, async () => {
-                // Arrange
-                const styleSheets = {
-                    all: StyleSheet.create({
-                        test: {
-                            color: "blue",
-                        },
-                    }),
-                } as const;
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'string' is not assignable to parameter of type 'MediaSize'.
-                resizeWindow(size);
+            // Act
+            render(
+                <MediaLayout styleSheets={styleSheets}>
+                    {({mediaSize, mediaSpec, styles}: any) => {
+                        return (
+                            <View testId="styled-view" style={styles.test}>
+                                Hello, world!
+                            </View>
+                        );
+                    }}
+                </MediaLayout>,
+            );
+            const style = screen.getByTestId("styled-view").style;
 
-                // Act
-                render(
-                    <MediaLayout styleSheets={styleSheets}>
-                        {({mediaSize, mediaSpec, styles}: any) => {
-                            return (
-                                <View testId="styled-view" style={styles.test}>
-                                    Hello, world!
-                                </View>
-                            );
-                        }}
-                    </MediaLayout>,
-                );
-                const style = screen.getByTestId("styled-view").style;
+            // Assert
+            expect(style.color).toBe("blue");
+        });
 
-                // Assert
-                expect(style.color).toBe("blue");
-            });
+        it(`"mdOrSmaller" should match ${
+            size === "large" ? "not" : ""
+        } "${size}"`, async () => {
+            // Arrange
+            const styleSheets = {
+                mdOrSmaller: StyleSheet.create({
+                    test: {
+                        color: "blue",
+                    },
+                }),
+                large: StyleSheet.create({
+                    test: {
+                        color: "orange",
+                    },
+                }),
+            } as const;
+            resizeWindow(size);
+            const expectedColor = {
+                small: "blue",
+                medium: "blue",
+                large: "orange",
+            }[size];
 
-            it(`"mdOrSmaller" should match ${
-                size === "large" ? "not" : ""
-            } "${size}"`, async () => {
-                // Arrange
-                const styleSheets = {
-                    mdOrSmaller: StyleSheet.create({
-                        test: {
-                            color: "blue",
-                        },
-                    }),
-                    large: StyleSheet.create({
-                        test: {
-                            color: "orange",
-                        },
-                    }),
-                } as const;
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'string' is not assignable to parameter of type 'MediaSize'.
-                resizeWindow(size);
-                const expectedColor = {
-                    small: "blue",
-                    medium: "blue",
-                    large: "orange",
-                }[size];
+            // Act
+            render(
+                <MediaLayout styleSheets={styleSheets}>
+                    {({mediaSize, mediaSpec, styles}: any) => {
+                        return (
+                            <View testId="styled-view" style={styles.test}>
+                                Hello, world!
+                            </View>
+                        );
+                    }}
+                </MediaLayout>,
+            );
+            const style = screen.getByTestId("styled-view").style;
 
-                // Act
-                render(
-                    <MediaLayout styleSheets={styleSheets}>
-                        {({mediaSize, mediaSpec, styles}: any) => {
-                            return (
-                                <View testId="styled-view" style={styles.test}>
-                                    Hello, world!
-                                </View>
-                            );
-                        }}
-                    </MediaLayout>,
-                );
-                const style = screen.getByTestId("styled-view").style;
+            // Assert
+            expect(style.color).toBe(expectedColor);
+        });
 
-                // Assert
-                expect(style.color).toBe(expectedColor);
-            });
+        it(`"mdOrLarger" should match ${
+            size === "small" ? "not" : ""
+        } "${size}"`, async () => {
+            // Arrange
+            const styleSheets = {
+                mdOrLarger: StyleSheet.create({
+                    test: {
+                        color: "blue",
+                    },
+                }),
+                small: StyleSheet.create({
+                    test: {
+                        color: "orange",
+                    },
+                }),
+            } as const;
+            resizeWindow(size);
+            const expectedColor = {
+                small: "orange",
+                medium: "blue",
+                large: "blue",
+            }[size];
 
-            it(`"mdOrLarger" should match ${
-                size === "small" ? "not" : ""
-            } "${size}"`, async () => {
-                // Arrange
-                const styleSheets = {
-                    mdOrLarger: StyleSheet.create({
-                        test: {
-                            color: "blue",
-                        },
-                    }),
-                    small: StyleSheet.create({
-                        test: {
-                            color: "orange",
-                        },
-                    }),
-                } as const;
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'string' is not assignable to parameter of type 'MediaSize'.
-                resizeWindow(size);
-                const expectedColor = {
-                    small: "orange",
-                    medium: "blue",
-                    large: "blue",
-                }[size];
+            // Act
+            render(
+                <MediaLayout styleSheets={styleSheets}>
+                    {({mediaSize, mediaSpec, styles}: any) => {
+                        return (
+                            <View testId="styled-view" style={styles.test}>
+                                Hello, world!
+                            </View>
+                        );
+                    }}
+                </MediaLayout>,
+            );
+            const style = screen.getByTestId("styled-view").style;
 
-                // Act
-                render(
-                    <MediaLayout styleSheets={styleSheets}>
-                        {({mediaSize, mediaSpec, styles}: any) => {
-                            return (
-                                <View testId="styled-view" style={styles.test}>
-                                    Hello, world!
-                                </View>
-                            );
-                        }}
-                    </MediaLayout>,
-                );
-                const style = screen.getByTestId("styled-view").style;
+            // Assert
+            expect(style.color).toBe(expectedColor);
+        });
 
-                // Assert
-                expect(style.color).toBe(expectedColor);
-            });
+        it(`styles should win over "all" styles`, async () => {
+            // Arrange
+            const styleSheets = {
+                all: StyleSheet.create({
+                    test: {
+                        color: "blue",
+                    },
+                }),
+                small: StyleSheet.create({
+                    test: {
+                        color: "orange",
+                    },
+                }),
+                medium: StyleSheet.create({
+                    test: {
+                        color: "teal",
+                    },
+                }),
+                large: StyleSheet.create({
+                    test: {
+                        color: "magenta",
+                    },
+                }),
+            } as const;
+            resizeWindow(size);
+            const expectedColor = {
+                small: "orange",
+                medium: "teal",
+                large: "magenta",
+            }[size];
 
-            it(`"${size}" styles should win over "all" styles`, async () => {
-                // Arrange
-                const styleSheets = {
-                    all: StyleSheet.create({
-                        test: {
-                            color: "blue",
-                        },
-                    }),
-                    small: StyleSheet.create({
-                        test: {
-                            color: "orange",
-                        },
-                    }),
-                    medium: StyleSheet.create({
-                        test: {
-                            color: "teal",
-                        },
-                    }),
-                    large: StyleSheet.create({
-                        test: {
-                            color: "magenta",
-                        },
-                    }),
-                } as const;
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'string' is not assignable to parameter of type 'MediaSize'.
-                resizeWindow(size);
-                const expectedColor = {
-                    small: "orange",
-                    medium: "teal",
-                    large: "magenta",
-                }[size];
+            // Act
+            render(
+                <MediaLayout styleSheets={styleSheets}>
+                    {({mediaSize, mediaSpec, styles}: any) => {
+                        return (
+                            <View testId="styled-view" style={styles.test}>
+                                Hello, world!
+                            </View>
+                        );
+                    }}
+                </MediaLayout>,
+            );
+            const style = screen.getByTestId("styled-view").style;
 
-                // Act
-                render(
-                    <MediaLayout styleSheets={styleSheets}>
-                        {({mediaSize, mediaSpec, styles}: any) => {
-                            return (
-                                <View testId="styled-view" style={styles.test}>
-                                    Hello, world!
-                                </View>
-                            );
-                        }}
-                    </MediaLayout>,
-                );
-                const style = screen.getByTestId("styled-view").style;
+            // Assert
+            expect(style.color).toEqual(expectedColor);
+        });
 
-                // Assert
-                expect(style.color).toEqual(expectedColor);
-            });
-        }
-
-        for (const size of ["small", "medium"]) {
+        if (size !== "large") {
             it(`"${size}" styles should win over "mdOrSmaller" styles`, async () => {
                 // Arrange
                 const styleSheets = {
@@ -276,7 +266,6 @@ describe("MediaLayout", () => {
                         },
                     }),
                 } as const;
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'string' is not assignable to parameter of type 'MediaSize'.
                 resizeWindow(size);
                 const expectedColor = {
                     small: "orange",
@@ -302,7 +291,7 @@ describe("MediaLayout", () => {
             });
         }
 
-        for (const size of ["medium", "large"]) {
+        if (size !== "small") {
             it(`"${size}" styles should win over "mdOrLarger" styles`, async () => {
                 // Arrange
                 const styleSheets = {
@@ -322,7 +311,6 @@ describe("MediaLayout", () => {
                         },
                     }),
                 } as const;
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'string' is not assignable to parameter of type 'MediaSize'.
                 resizeWindow(size);
                 const expectedColor = {
                     medium: "teal",

--- a/packages/wonder-blocks-layout/src/components/media-layout.tsx
+++ b/packages/wonder-blocks-layout/src/components/media-layout.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import type {StyleDeclaration} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
+import {Server} from "@khanacademy/wonder-blocks-core";
 import MediaLayoutContext from "./media-layout-context";
 import type {MediaSize, MediaSpec} from "../util/types";
 import type {Context} from "./media-layout-context";
@@ -141,7 +142,11 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
     // environment) if there is no window object or matchMedia function
     // available.
     isServerSide() {
-        return typeof window === "undefined" || !window.matchMedia;
+        return (
+            Server.isServerSide() ||
+            typeof window === "undefined" ||
+            !window.matchMedia
+        );
     }
 
     // Generate a mock Aphrodite StyleSheet based upon the current mediaSize


### PR DESCRIPTION
## Summary:
I was working on addressing the source of some hydration issues in webapp and discovered the `MediaLayout` component was using a heuristic to determine SSR that meant it was not doing the SSR behavior in our route tests.

I addressed this from the webapp side by deleting the `matchMedia` function when doing our route testing, but I also wanted to fix the core issue here by ensuring the `MediaLayout` component utilizes our central `Server.isServerSide()` function from Wonder Blocks Core.

This PR does that and also modifies the tests acccordingly. I also did some tweaks to the testing to make use of `describe.each` and reduce some nesting.

NOTE: I am not convinced the `MediaLayout` component hydrates properly since I don't see how it guarantees the initial client-side render will match the SSR'd result. However, addressing that is not a goal of this change. If that is an issue, a separate ticket should be logged to address it.

Issue: FEI-5384

## Test plan:
`yarn test`