### PR TITLE
WB-1681: Tooltip: Add `autoUpdate` prop to force updating the tooltip position

### DIFF
--- a/.changeset/quick-chicken-remain.md
+++ b/.changeset/quick-chicken-remain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tooltip": minor
+---
+
+Add autoUpdate prop to update the tooltip position when the trigger element changes

--- a/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
+++ b/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
@@ -40,4 +40,31 @@ export default {
         },
         options: Object.keys(color) as Array<string>,
     },
+    autoUpdate: {
+        description:
+            "Whether the tooltip should automatically update its position when the anchor element changes size or position.",
+        control: {
+            type: "boolean",
+        },
+        table: {
+            type: {
+                summary: "boolean",
+            },
+        },
+    },
+    opened: {
+        description:
+            `Whether the tooltip is currently open.\n\n` +
+            `Using this prop makes the component behave as a controlled
+            component. The parent is responsible for managing the
+            opening/closing of the tooltip when using this prop.`,
+        control: {
+            type: "boolean",
+        },
+        table: {
+            type: {
+                summary: "boolean",
+            },
+        },
+    },
 };

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -351,6 +351,79 @@ WithStyle.play = async ({canvasElement}) => {
     });
 };
 
+/**
+ * Tooltip by default (and for performance reasons) only updates its position
+ * under the following conditions:
+ *
+ * 1. When the window is resized.
+ * 2. When the scroll position changes.
+ *
+ * However, there are cases where you might want the tooltip to update its
+ * position when the trigger element changes. This can be done by setting the
+ * `autoUpdate` prop to `true`.
+ */
+export const AutoUpdate: StoryComponentType = {
+    render: function Render() {
+        const [position, setPosition] = React.useState<{
+            x: number;
+            y: number;
+        } | null>(null);
+        return (
+            <View style={[styles.centered, styles.row, {position: "relative"}]}>
+                <Tooltip
+                    content="This is a tooltip that auto-updates its position when the trigger element changes."
+                    opened={true}
+                    autoUpdate={true}
+                >
+                    <View
+                        style={[
+                            position && {
+                                position: "absolute",
+                                top: position.y,
+                                left: position.x,
+                            },
+                        ]}
+                    >
+                        Trigger element
+                    </View>
+                </Tooltip>
+                <Button
+                    onClick={() => {
+                        setPosition({
+                            x: Math.floor(Math.random() * 200),
+                            y: Math.floor(Math.random() * 200),
+                        });
+                    }}
+                >
+                    Click to update trigger position
+                </Button>
+            </View>
+        );
+    },
+    play: async ({canvasElement}) => {
+        // Arrange
+        const canvas = within(canvasElement.ownerDocument.body);
+
+        // Get HTML elements
+        const tooltip = await canvas.findByRole("tooltip");
+        const initialLeft = tooltip.getBoundingClientRect().left;
+        const initialTop = tooltip.getBoundingClientRect().top;
+
+        // Act
+        await userEvent.click(canvas.getByRole("button"));
+
+        // Wait for the tooltip to update its position
+        const newTooltip = await canvas.findByRole("tooltip");
+        const newLeft = newTooltip.getBoundingClientRect().left;
+        const newTop = newTooltip.getBoundingClientRect().top;
+
+        // Assert
+        // The tooltip should have updated its position
+        await expect(initialLeft).not.toEqual(newLeft);
+        await expect(initialTop).not.toEqual(newTop);
+    },
+};
+
 const styles = StyleSheet.create({
     storyCanvas: {
         // NOTE: This is needed for Chromatic to include the tooltip bubble.

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -3,26 +3,9 @@ import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import TooltipContent from "./tooltip-content";
 import TooltipTail from "./tooltip-tail";
-
-import type {getRefFn, Offset, Placement} from "../util/types";
-
-export type PopperElementProps = {
-    /** The placement of the bubble with respect to the anchor. */
-    placement: Placement;
-    /** Whether the bubble is out of bounds or not. */
-    isReferenceHidden?: boolean | null | undefined;
-    /** A callback for updating the ref of the bubble itself. */
-    updateBubbleRef?: getRefFn;
-    /** A callback for updating the ref of the bubble's tail. */
-    updateTailRef?: getRefFn;
-    /** Where the tail is to be rendered. */
-    tailOffset?: Offset;
-    /** Additional styles to be applied by the bubble. */
-    style?: StyleType;
-};
+import {PopperElementProps} from "../util/types";
 
 export type Props = {
     /** The unique identifier for this component. */

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
@@ -6,7 +6,6 @@ import * as React from "react";
 import {Popper} from "react-popper";
 import type {PopperChildrenProps} from "react-popper";
 
-import {useIsMounted} from "@khanacademy/wonder-blocks-core";
 import RefTracker from "../util/ref-tracker";
 import type {
     Placement,
@@ -37,31 +36,10 @@ type Props = {
 };
 
 /**
- * A ref tracker for the bubble element.
- */
-const _bubbleRefTracker: RefTracker = new RefTracker();
-/**
- * A ref tracker for the tail element.
- */
-const _tailRefTracker: RefTracker = new RefTracker();
-/**
- * A MutationObserver that watches for changes to the anchor element.
- */
-let _observer: MutationObserver | null = null;
-/**
- * A function that can be called to update the popper.
- * @see https://popper.js.org/docs/v2/lifecycle/#manual-update
- */
-let _popperUpdate: PopperUpdateFn | null = null;
-
-/**
  * A component that wraps react-popper's Popper component to provide a
  * consistent interface for positioning floating elements.
  */
-export default function TooltipPopper(props: Props): React.ReactElement {
-    const isMounted = useIsMounted();
-    const {anchorElement, autoUpdate, placement} = props;
-
+export default class TooltipPopper extends React.Component<Props> {
     /**
      * Automatically updates the position of the floating element when necessary
      * to ensure it stays anchored.
@@ -73,47 +51,65 @@ export default function TooltipPopper(props: Props): React.ReactElement {
      * TODO(WB-1680): Replace this with floating-ui's autoUpdate feature.
      * @see https://floating-ui.com/docs/autoupdate
      */
-    React.useEffect(() => {
+    componentDidMount() {
+        const {anchorElement, autoUpdate} = this.props;
         if (!anchorElement || !autoUpdate) {
             return;
         }
 
-        if (isMounted()) {
-            _observer = new MutationObserver(async () => {
-                // Update the popper when the anchor element changes.
-                await _popperUpdate?.();
-            });
+        this._observer = new MutationObserver(() => {
+            // Update the popper when the anchor element changes.
+            this._popperUpdate?.();
+        });
 
-            // Check for DOM changes to the anchor element.
-            _observer.observe(anchorElement, {
-                attributes: true,
-                childList: true,
-                subtree: true,
-            });
-        }
+        // Check for DOM changes to the anchor element.
+        this._observer.observe(anchorElement, {
+            attributes: true,
+            childList: true,
+            subtree: true,
+        });
+    }
 
-        return function cleanup() {
-            _observer?.disconnect();
-        };
-    }, [isMounted, anchorElement, autoUpdate]);
+    componentWillUnmount() {
+        this._observer?.disconnect();
+    }
 
-    const _renderPositionedContent = (
+    /**
+     * A ref tracker for the bubble element.
+     */
+    _bubbleRefTracker: RefTracker = new RefTracker();
+    /**
+     * A ref tracker for the tail element.
+     */
+    _tailRefTracker: RefTracker = new RefTracker();
+    /**
+     * A MutationObserver that watches for changes to the anchor element.
+     */
+    _observer: MutationObserver | null = null;
+    /**
+     * A function that can be called to update the popper.
+     * @see https://popper.js.org/docs/v2/lifecycle/#manual-update
+     */
+    _popperUpdate: PopperUpdateFn | null = null;
+
+    _renderPositionedContent(
         popperProps: PopperChildrenProps,
-    ): React.ReactNode => {
-        const {children} = props;
+    ): React.ReactNode {
+        const {children} = this.props;
 
         // We'll hide some complexity from the children here and ensure
         // that our placement always has a value.
-        const placement: Placement = popperProps.placement || props.placement;
+        const placement: Placement =
+            popperProps.placement || this.props.placement;
 
         // Just in case the callbacks have changed, let's update our reference
         // trackers.
-        _bubbleRefTracker.setCallback(popperProps.ref);
-        _tailRefTracker.setCallback(popperProps.arrowProps.ref);
+        this._bubbleRefTracker.setCallback(popperProps.ref);
+        this._tailRefTracker.setCallback(popperProps.arrowProps.ref);
 
         // Store a reference to the update function so that we can call it
         // later if needed.
-        _popperUpdate = popperProps.update;
+        this._popperUpdate = popperProps.update;
 
         // Here we translate from the react-popper's PropperChildrenProps
         // to our own TooltipBubbleProps.
@@ -131,7 +127,7 @@ export default function TooltipPopper(props: Props): React.ReactElement {
                 position: popperProps.style.position,
                 transform: popperProps.style.transform,
             },
-            updateBubbleRef: _bubbleRefTracker.updateRef,
+            updateBubbleRef: this._bubbleRefTracker.updateRef,
             tailOffset: {
                 bottom: popperProps.arrowProps.style.bottom,
                 right: popperProps.arrowProps.style.right,
@@ -139,27 +135,31 @@ export default function TooltipPopper(props: Props): React.ReactElement {
                 left: popperProps.arrowProps.style.left,
                 transform: popperProps.arrowProps.style.transform,
             },
-            updateTailRef: _tailRefTracker.updateRef,
+            updateTailRef: this._tailRefTracker.updateRef,
             isReferenceHidden: popperProps.isReferenceHidden,
         } as const;
         return children(bubbleProps);
-    };
+    }
 
-    return (
-        <Popper
-            referenceElement={anchorElement}
-            strategy="fixed"
-            placement={placement}
-            modifiers={[
-                {
-                    name: "preventOverflow",
-                    options: {
-                        rootBoundary: "viewport",
+    render(): React.ReactNode {
+        const {anchorElement, placement} = this.props;
+
+        return (
+            <Popper
+                referenceElement={anchorElement}
+                strategy="fixed"
+                placement={placement}
+                modifiers={[
+                    {
+                        name: "preventOverflow",
+                        options: {
+                            rootBoundary: "viewport",
+                        },
                     },
-                },
-            ]}
-        >
-            {_renderPositionedContent}
-        </Popper>
-    );
+                ]}
+            >
+                {(props) => this._renderPositionedContent(props)}
+            </Popper>
+        );
+    }
 }

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -260,13 +260,17 @@ export default class Tooltip extends React.Component<Props, State> {
     }
 
     _renderTooltipAnchor(ids?: IIdentifierFactory): React.ReactNode {
-        const {children, forceAnchorFocusivity} = this.props;
+        const {autoUpdate, children, forceAnchorFocusivity} = this.props;
         const {active, activeBubble} = this.state;
 
         const popperHost = this._getHost();
 
+        // Only render the popper if the anchor element is available so that we
+        // can position the popper correctly. If autoUpdate is false, we don't
+        // need to wait for the anchor element to render the popper.
+        const shouldAnchorExist = autoUpdate ? this.state.anchorElement : true;
         const shouldBeVisible =
-            popperHost && (active || activeBubble) && this.state.anchorElement;
+            popperHost && (active || activeBubble) && shouldAnchorExist;
 
         // TODO(kevinb): update to use ReactPopper's React 16-friendly syntax
         return (

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -46,6 +46,12 @@ type Props = AriaProps &
          * Optional title for the tooltip content.
          */
         title?: string | React.ReactElement<React.ComponentProps<Typography>>;
+
+        /**
+         * Whether the tooltip should update its position when the anchor
+         * element changes size or position. Defaults to false.
+         */
+        autoUpdate?: boolean;
         /**
          * The content to render in the tooltip.
          */
@@ -221,6 +227,7 @@ export default class Tooltip extends React.Component<Props, State> {
             <TooltipPopper
                 anchorElement={this.state.anchorElement}
                 placement={placement}
+                autoUpdate={this.props.autoUpdate}
             >
                 {(props) => (
                     <TooltipBubble
@@ -258,6 +265,9 @@ export default class Tooltip extends React.Component<Props, State> {
 
         const popperHost = this._getHost();
 
+        const shouldBeVisible =
+            popperHost && (active || activeBubble) && this.state.anchorElement;
+
         // TODO(kevinb): update to use ReactPopper's React 16-friendly syntax
         return (
             <React.Fragment>
@@ -269,8 +279,7 @@ export default class Tooltip extends React.Component<Props, State> {
                 >
                     {children}
                 </TooltipAnchor>
-                {popperHost &&
-                    (active || activeBubble) &&
+                {shouldBeVisible &&
                     ReactDOM.createPortal(this._renderPopper(ids), popperHost)}
             </React.Fragment>
         );

--- a/packages/wonder-blocks-tooltip/src/index.ts
+++ b/packages/wonder-blocks-tooltip/src/index.ts
@@ -1,5 +1,4 @@
-import type {Placement} from "./util/types";
-import type {PopperElementProps} from "./components/tooltip-bubble";
+import type {Placement, PopperElementProps} from "./util/types";
 
 import Tooltip from "./components/tooltip";
 import TooltipContent from "./components/tooltip-content";

--- a/packages/wonder-blocks-tooltip/src/util/types.ts
+++ b/packages/wonder-blocks-tooltip/src/util/types.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {State as PopperState} from "@popperjs/core";
 import type {CSSProperties} from "aphrodite";
 
 export type getRefFn = (
@@ -37,4 +39,23 @@ export type Placement =
 export type ContentStyle = {
     color?: CSSProperties["color"];
     padding?: CSSProperties["padding"];
+};
+
+export type PopperUpdateFn = () => Promise<null | Partial<PopperState>>;
+
+export type PopperElementProps = {
+    /** The placement of the bubble with respect to the anchor. */
+    placement: Placement;
+    /** Whether the bubble is out of bounds or not. */
+    isReferenceHidden?: boolean | null | undefined;
+    /** A callback for updating the ref of the bubble itself. */
+    updateBubbleRef?: getRefFn;
+    /** A callback for updating the ref of the bubble's tail. */
+    updateTailRef?: getRefFn;
+    /** Where the tail is to be rendered. */
+    tailOffset?: Offset;
+    /** Additional styles to be applied by the bubble. */
+    style?: StyleType;
+    /** A callback to update the popper. */
+    update?: PopperUpdateFn;
 };


### PR DESCRIPTION
## Summary:

Adds a new `autoUpdate` prop to update the tooltip position when the trigger element changes.

This is useful for cases where the trigger element changes its position after
the tooltip is shown, like when the trigger element is a draggable element.

PopperJS does not update the tooltip position when the trigger element changes
by default, so we need to force the update.

After different approaches, I decided to use `MutationObserver` to listen to
changes in the trigger element and update the tooltip position when needed.

**NOTE:** The newer version of PopperJS (floating-ui) have an `autoUpdate`
middleware that does the same thing, but it's not available in the version we
are using. This prop uses the same naming to be consistent with the newer
version (if we decide to upgrade in the future).

Issue: XXX-XXXX

## Test plan:

Navigate to the tooltip storybook and test the new `autoUpdate` prop.

/?path=/story/tooltip-tooltip--auto-update


https://github.com/Khan/wonder-blocks/assets/843075/ca2e592e-b144-447a-9a64-ec5ca6a9751d

