### PR TITLE
WB-1673: Fix year dropdown width to avoid truncating the text when the user zooms in

### DIFF
--- a/.changeset/thick-spiders-wave.md
+++ b/.changeset/thick-spiders-wave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": patch
+---
+
+Fix year dropdown width to avoid truncating the text when the user zooms in

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -338,6 +338,9 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 onChange={this.handleYearChange}
                 selectedValue={year}
                 style={{minWidth}}
+                // Allows displaying the dropdown options without truncating
+                // them when the user zooms in the browser.
+                dropdownStyle={{minWidth: 150}}
                 testId="birthday-picker-year"
             >
                 {Array.from(Array(120)).map((_, yearOffset) => (


### PR DESCRIPTION
## Summary:

Fixes the width of the year dropdown to prevent the text from being truncated
when the user zooms in. This happened in Firefox, so we are setting a min-width
to the dropdown (listbox) to prevent this from happening.

Issue: WB-1673

## Test plan:

/?path=/story/birthdaypicker--birthday-picker-default

1. Open the year dropdown in the BirthdayPicker component.
2. Zoom in the browser (to at least 30%).
3. Verify that the text is not truncated.


https://github.com/Khan/wonder-blocks/assets/843075/a6362f54-b906-4894-989f-cfb9f5c5fa4a


