### PR TITLE
WB-1679: Set aria-invalid inside TextField when validation fails

### DIFF
--- a/.changeset/ten-pumas-tap.md
+++ b/.changeset/ten-pumas-tap.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Set aria-invalid directly in `TextField` to inform the user when the validation fails and there's an error in the input field.

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -267,7 +267,7 @@ Email.parameters = {
         description: {
             story: `An input field with type \`email\` will automatically
         validate an input on submit to ensure it's either formatted properly
-        or blank. \`TextField\` will run validation on blur if the
+        or blank. \`TextField\` will run validation on change if the
         \`validate\` prop is passed in, as in this example.`,
         },
     },
@@ -360,7 +360,7 @@ Telephone.parameters = {
     },
 };
 
-export const Error: StoryComponentType = () => {
+function ErrorRender() {
     const [value, setValue] = React.useState("khan");
 
     const validate = (value: string) => {
@@ -388,15 +388,19 @@ export const Error: StoryComponentType = () => {
             onKeyDown={handleKeyDown}
         />
     );
-};
+}
 
-Error.parameters = {
-    docs: {
-        description: {
-            story: `If an input value fails validation,
-        \`TextField\` will have error styling.`,
-        },
-    },
+/**
+ * If an input value fails validation, `LabeledTextField` will have error
+ * styling.
+ *
+ * Note that we will internally set the correct `aria-invalid` attribute to the
+ * `input` element:
+ * - aria-invalid="true" if there is an error message.
+ * - aria-invalid="false" if there is no error message.
+ */
+export const Error: StoryComponentType = {
+    render: ErrorRender,
 };
 
 export const Light: StoryComponentType = (args: any) => {

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -290,7 +290,7 @@ Email.parameters = {
         description: {
             story: `An input field with type \`email\` will automatically
         validate an input on submit to ensure it's either formatted properly
-        or blank. \`TextField\` will run validation on blur if the
+        or blank. \`TextField\` will run validation on change if the
         \`validate\` prop is passed in, as in this example.`,
         },
     },
@@ -365,7 +365,7 @@ Telephone.parameters = {
     },
 };
 
-export const Error: StoryComponentType = () => {
+function ErrorRender() {
     const [value, setValue] = React.useState("khan");
     const [errorMessage, setErrorMessage] = React.useState<any>();
     const [focused, setFocused] = React.useState(false);
@@ -421,15 +421,18 @@ export const Error: StoryComponentType = () => {
             )}
         </View>
     );
-};
+}
 
-Error.parameters = {
-    docs: {
-        description: {
-            story: `If an input value fails validation,
-        \`TextField\` will have error styling.`,
-        },
-    },
+/**
+ * If an input value fails validation, `TextField` will have error styling.
+ *
+ * Note that we will internally set the correct `aria-invalid` attribute to the
+ * `input` element:
+ * - aria-invalid="true" if there is an error message.
+ * - aria-invalid="false" if there is no error message.
+ */
+export const Error: StoryComponentType = {
+    render: ErrorRender,
 };
 
 export const Light: StoryComponentType = () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
@@ -480,6 +480,81 @@ describe("LabeledTextField", () => {
         const input = await screen.findByRole("textbox");
         expect(input).toHaveAttribute("autoComplete", autoComplete);
     });
+
+    it("aria-invalid is set true if given an invalid input", async () => {
+        // Arrange
+        const handleValidate = jest.fn((errorMessage?: string | null) => {});
+
+        const validate = (value: string): string | null | undefined => {
+            if (value.length < 8) {
+                return "Password must be at least 8 characters long";
+            }
+        };
+
+        const TextFieldWrapper = () => {
+            const [value, setValue] = React.useState("LongerThan8Chars");
+
+            return (
+                <LabeledTextField
+                    label="Label"
+                    value={value}
+                    onChange={setValue}
+                    validate={validate}
+                    onValidate={handleValidate}
+                />
+            );
+        };
+
+        render(<TextFieldWrapper />);
+
+        // Act
+        // Select all text and replace it with the new value.
+        const textbox = await screen.findByRole("textbox");
+        await userEvent.click(textbox);
+        await userEvent.clear(textbox);
+        await userEvent.paste("Short");
+
+        // Assert
+        expect(textbox).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("aria-invalid is set false if given a valid input", async () => {
+        // Arrange
+        const handleValidate = jest.fn((errorMessage?: string | null) => {});
+
+        const validate = (value: string): string | null | undefined => {
+            if (value.length < 8) {
+                return "Password must be at least 8 characters long";
+            }
+        };
+
+        const TextFieldWrapper = () => {
+            const [value, setValue] = React.useState("Short");
+
+            return (
+                <LabeledTextField
+                    label="Label"
+                    value={value}
+                    onChange={setValue}
+                    validate={validate}
+                    onValidate={handleValidate}
+                />
+            );
+        };
+
+        render(<TextFieldWrapper />);
+
+        // Act
+        // Select all text and replace it with the new value.
+        const textbox = await screen.findByRole("textbox");
+        await userEvent.click(textbox);
+        await userEvent.clear(textbox);
+        await userEvent.paste("LongerThan8Chars");
+        const shortTextbox = await screen.findByRole("textbox");
+
+        // Assert
+        expect(shortTextbox).toHaveAttribute("aria-invalid", "false");
+    });
 });
 
 describe("Required LabeledTextField", () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
@@ -257,6 +257,58 @@ describe("TextField", () => {
         expect(handleValidate).toHaveReturnedWith(errorMessage);
     });
 
+    it("aria-invalid is set true if given an invalid input", async () => {
+        // Arrange
+        const handleValidate = jest.fn(
+            (value: string): string | null | undefined => {
+                if (value.length < 8) {
+                    return "Value is too short";
+                }
+            },
+        );
+
+        render(
+            <TextField
+                id={"tf-1"}
+                value="short"
+                validate={handleValidate}
+                onChange={() => {}}
+            />,
+        );
+
+        // Act
+        const textbox = await screen.findByRole("textbox");
+
+        // Assert
+        expect(textbox).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("aria-invalid is set false if given a valid input", async () => {
+        // Arrange
+        const handleValidate = jest.fn(
+            (value: string): string | null | undefined => {
+                if (value.length < 8) {
+                    return "Value is too short";
+                }
+            },
+        );
+
+        render(
+            <TextField
+                id={"tf-1"}
+                value="long enough"
+                validate={handleValidate}
+                onChange={() => {}}
+            />,
+        );
+
+        // Act
+        const textbox = await screen.findByRole("textbox");
+
+        // Assert
+        expect(textbox).toHaveAttribute("aria-invalid", "false");
+    });
+
     it("onValidate is called after input validate", async () => {
         // Arrange
         const errorMessage = "Value is too short";

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -230,9 +230,9 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
                                         ? ariaDescribedby
                                         : `${uniqueId}-error`
                                 }
-                                aria-invalid={
-                                    this.state.error ? "true" : "false"
-                                }
+                                // aria-invalid={
+                                //     this.state.error ? "true" : "false"
+                                // }
                                 aria-required={required ? "true" : "false"}
                                 required={required}
                                 testId={testId && `${testId}-field`}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -230,9 +230,6 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
                                         ? ariaDescribedby
                                         : `${uniqueId}-error`
                                 }
-                                // aria-invalid={
-                                //     this.state.error ? "true" : "false"
-                                // }
                                 aria-required={required ? "true" : "false"}
                                 required={required}
                                 testId={testId && `${testId}-field`}

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -284,6 +284,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                 autoComplete={autoComplete}
                 ref={forwardedRef}
                 {...otherProps}
+                aria-invalid={this.state.error ? "true" : "false"}
             />
         );
     }


### PR DESCRIPTION
## Summary:

Currently, `TextField` accepts a `validate` prop, which updates an internal error
state. We don’t update `aria-invalid` if the validation fails, and that might
mislead folks as they would expect this value to be changed internally.

This PR fixes that by setting `aria-invalid` directly in `TextField` to inform
the user when the validation fails and there's an error in the input field.

Also removed the `aria-invalid` from `LabeledTextField` as it's not necessary
since the error state is already being handled in `TextField`.

Issue: WB-1679

## Test plan:

1. Navigate to the `TextField > Error` story in Storybook.
2. Verify that the `aria-invalid` attribute is set to `true` when the validation
fails.
3. Verify that the `aria-invalid` attribute is set to `false` when the validation
passes.

Do the same for the `LabeledTextField > Error` story.