### PR TITLE
Change data-test-id to data-testid to match React Testing Library's default

### DIFF
--- a/.changeset/silent-melons-play.md
+++ b/.changeset/silent-melons-play.md
@@ -1,19 +1,19 @@
 ---
-"@khanacademy/wonder-blocks-progress-spinner": patch
-"@khanacademy/wonder-blocks-breadcrumbs": patch
-"@khanacademy/wonder-blocks-icon-button": patch
-"@khanacademy/wonder-blocks-accordion": patch
-"@khanacademy/wonder-blocks-clickable": patch
-"@khanacademy/wonder-blocks-dropdown": patch
-"@khanacademy/wonder-blocks-popover": patch
-"@khanacademy/wonder-blocks-testing": patch
-"@khanacademy/wonder-blocks-button": patch
-"@khanacademy/wonder-blocks-modal": patch
-"@khanacademy/wonder-blocks-core": patch
-"@khanacademy/wonder-blocks-form": patch
-"@khanacademy/wonder-blocks-icon": patch
-"@khanacademy/wonder-blocks-link": patch
-"@khanacademy/wonder-blocks-pill": patch
+"@khanacademy/wonder-blocks-progress-spinner": minor
+"@khanacademy/wonder-blocks-breadcrumbs": minor
+"@khanacademy/wonder-blocks-icon-button": minor
+"@khanacademy/wonder-blocks-accordion": minor
+"@khanacademy/wonder-blocks-clickable": minor
+"@khanacademy/wonder-blocks-dropdown": minor
+"@khanacademy/wonder-blocks-popover": minor
+"@khanacademy/wonder-blocks-testing": minor
+"@khanacademy/wonder-blocks-button": minor
+"@khanacademy/wonder-blocks-modal": minor
+"@khanacademy/wonder-blocks-core": minor
+"@khanacademy/wonder-blocks-form": minor
+"@khanacademy/wonder-blocks-icon": minor
+"@khanacademy/wonder-blocks-link": minor
+"@khanacademy/wonder-blocks-pill": minor
 ---
 
 Change testId to render the default Testing Library HTML attribute: data-testid (was data-test-id)

--- a/.changeset/silent-melons-play.md
+++ b/.changeset/silent-melons-play.md
@@ -1,0 +1,19 @@
+---
+"@khanacademy/wonder-blocks-progress-spinner": patch
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-testing": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-icon": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-pill": patch
+---
+
+Change testId to render the default Testing Library HTML attribute: data-testid (was data-test-id)

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,16 +1,11 @@
 import * as React from "react";
 import wonderBlocksTheme from "./wonder-blocks-theme";
-import {configure} from "@storybook/test";
 
 import {color} from "@khanacademy/wonder-blocks-tokens";
 import Link from "@khanacademy/wonder-blocks-link";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
 import {RenderStateRoot} from "../packages/wonder-blocks-core/src";
 import {Preview} from "@storybook/react";
-
-configure({
-    testIdAttribute: "data-test-id",
-});
 
 /**
  * WB Official breakpoints

--- a/__docs__/wonder-blocks-core/view.argtypes.ts
+++ b/__docs__/wonder-blocks-core/view.argtypes.ts
@@ -48,7 +48,7 @@ export default {
 
     testId: {
         description:
-            "Test ID used for e2e testing. This sets the `data-test-id` attribute on the rendered element.",
+            "Test ID used for e2e testing. This sets the `data-testid` attribute on the rendered element.",
         control: {type: "text"},
         table: {
             type: {

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -477,7 +477,7 @@ export const CustomActionItems: StoryComponentType = {
                 }
                 onClick={action("user profile clicked!")}
                 style={{
-                    [":hover [data-test-id=new-pill]" as any]: {
+                    [":hover [data-testid=new-pill]" as any]: {
                         backgroundColor: color.white,
                         color: color.blue,
                     },

--- a/__docs__/wonder-blocks-testing/exports.harness-adapters.mdx
+++ b/__docs__/wonder-blocks-testing/exports.harness-adapters.mdx
@@ -88,7 +88,7 @@ The `portal` adapter ensures there is a mounting point in the DOM for components
 type Config = string;
 ```
 
-The configuration is just a string providing the identifier to give the added element. The adapter will then render alongside the harnessed component, an empty `div` element with both the `id` and `data-test-id` attributes set to the configuration value.
+The configuration is just a string providing the identifier to give the added element. The adapter will then render alongside the harnessed component, an empty `div` element with both the `id` and `data-testid` attributes set to the configuration value.
 
 The default configuration for this adapter is for it to not be used.
 

--- a/config/jest/test-setup.js
+++ b/config/jest/test-setup.js
@@ -1,13 +1,8 @@
 const {StyleSheetTestUtils} = require("aphrodite");
-const {configure} = require("@testing-library/react");
 
 const {
     mockRequestAnimationFrame,
 } = require("../../utils/testing/mock-request-animation-frame");
-
-configure({
-    testIdAttribute: "data-test-id",
-});
 
 StyleSheetTestUtils.suppressStyleInjection();
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "yarn lint:ci .",
     "lint:ci": "eslint --ext .ts --ext .js --ext .tsx --ext .jsx",
     "publish:ci": "yarn run lint:pkg-json && node utils/publish/pre-publish-check-ci.js && git diff --stat --exit-code HEAD && yarn build && yarn build:types && changeset publish",
-    "start": "start:storybook",
+    "start": "yarn start:storybook",
     "start:storybook": "storybook dev -p 6061",
     "test:common": "yarn run build && yarn run lint && yarn run alex && yarn run typecheck",
     "test:coverage": "yarn run test:common && yarn run jest --coverage",

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
@@ -172,7 +172,7 @@ describe("AccordionSection", () => {
         expect(header).toBeVisible();
     });
 
-    test("uses the header's testId as button's data-test-id", () => {
+    test("uses the header's testId as button's data-testid", () => {
         // Arrange
         render(
             <AccordionSection header="Title" testId="accordion-section">
@@ -186,7 +186,7 @@ describe("AccordionSection", () => {
 
         // Assert
         expect(button).toHaveAttribute(
-            "data-test-id",
+            "data-testid",
             "accordion-section-header",
         );
     });

--- a/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/__tests__/breadcrumbs.test.tsx
@@ -20,7 +20,7 @@ describe("Breadcrumbs", () => {
         expect(lastItem).toHaveAttribute("aria-current", "page");
     });
 
-    it("should add data-test-id if testId is set", () => {
+    it("should add data-testid if testId is set", () => {
         // Arrange, Act
         render(
             <Breadcrumbs testId="test">
@@ -31,7 +31,7 @@ describe("Breadcrumbs", () => {
 
         // Assert
         expect(screen.getByRole("navigation")).toHaveAttribute(
-            "data-test-id",
+            "data-testid",
             "test",
         );
     });

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
@@ -57,7 +57,7 @@ const BreadcrumbsItem = React.forwardRef(function BreadcrumbsItem(
         <StyledListItem
             {...otherProps}
             style={styles.item}
-            data-test-id={testId}
+            data-testid={testId}
             ref={ref}
         >
             {children}

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs.tsx
@@ -82,7 +82,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(
         <nav
             {...otherProps}
             aria-label={ariaLabel}
-            data-test-id={testId}
+            data-testid={testId}
             ref={ref}
         >
             <StyledList style={styles.container}>

--- a/packages/wonder-blocks-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
+++ b/packages/wonder-blocks-button/src/__tests__/__snapshots__/custom-snapshot.test.tsx.snap
@@ -3952,7 +3952,7 @@ exports[`ButtonCore kind:primary size:medium spinner:true 1`] = `
     }
   >
     <svg
-      data-test-id="button-spinner"
+      data-testid="button-spinner"
       height={24}
       viewBox="0 0 24 24"
       width={24}
@@ -4082,7 +4082,7 @@ exports[`ButtonCore kind:primary size:small spinner:true 1`] = `
     }
   >
     <svg
-      data-test-id="button-spinner"
+      data-testid="button-spinner"
       height={16}
       viewBox="0 0 16 16"
       width={16}
@@ -8093,7 +8093,7 @@ exports[`ButtonCore kind:secondary size:medium spinner:true 1`] = `
     }
   >
     <svg
-      data-test-id="button-spinner"
+      data-testid="button-spinner"
       height={24}
       viewBox="0 0 24 24"
       width={24}
@@ -8228,7 +8228,7 @@ exports[`ButtonCore kind:secondary size:small spinner:true 1`] = `
     }
   >
     <svg
-      data-test-id="button-spinner"
+      data-testid="button-spinner"
       height={16}
       viewBox="0 0 16 16"
       width={16}
@@ -12223,7 +12223,7 @@ exports[`ButtonCore kind:tertiary size:medium spinner:true 1`] = `
     }
   >
     <svg
-      data-test-id="button-spinner"
+      data-testid="button-spinner"
       height={24}
       viewBox="0 0 24 24"
       width={24}
@@ -12354,7 +12354,7 @@ exports[`ButtonCore kind:tertiary size:small spinner:true 1`] = `
     }
   >
     <svg
-      data-test-id="button-spinner"
+      data-testid="button-spinner"
       height={16}
       viewBox="0 0 16 16"
       width={16}

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -97,7 +97,7 @@ const ButtonCore: React.ForwardRefExoticComponent<
         ];
 
         const commonProps = {
-            "data-test-id": testId,
+            "data-testid": testId,
             id: id,
             role: "button",
             style: [defaultStyle, style],

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.tsx
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.tsx
@@ -335,7 +335,7 @@ describe("ClickableBehavior", () => {
             <ClickableBehavior disabled={false} onClick={(e: any) => {}}>
                 {(state: any, childrenProps: any) => {
                     return (
-                        <button data-test-id="test-button-1" {...childrenProps}>
+                        <button data-testid="test-button-1" {...childrenProps}>
                             Label
                         </button>
                     );
@@ -359,7 +359,7 @@ describe("ClickableBehavior", () => {
             >
                 {(state: any, childrenProps: any) => {
                     return (
-                        <button data-test-id="test-button-2" {...childrenProps}>
+                        <button data-testid="test-button-2" {...childrenProps}>
                             Label
                         </button>
                     );
@@ -383,7 +383,7 @@ describe("ClickableBehavior", () => {
             >
                 {(state: any, childrenProps: any) => {
                     return (
-                        <button data-test-id="test-button-3" {...childrenProps}>
+                        <button data-testid="test-button-3" {...childrenProps}>
                             Label
                         </button>
                     );
@@ -406,7 +406,7 @@ describe("ClickableBehavior", () => {
             >
                 {(state: any, childrenProps: any) => {
                     return (
-                        <div data-test-id="test-div-1" {...childrenProps}>
+                        <div data-testid="test-div-1" {...childrenProps}>
                             Label
                         </div>
                     );

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -323,7 +323,7 @@ const Clickable = React.forwardRef(function Clickable(
                     {(state, childrenProps) =>
                         getCorrectTag(state, router, {
                             ...restProps,
-                            "data-test-id": testId,
+                            "data-testid": testId,
                             style: getStyle(state),
                             ...childrenProps,
                         })
@@ -348,7 +348,7 @@ const Clickable = React.forwardRef(function Clickable(
                     {(state, childrenProps) =>
                         getCorrectTag(state, router, {
                             ...restProps,
-                            "data-test-id": testId,
+                            "data-testid": testId,
                             style: getStyle(state),
                             ...childrenProps,
                         })

--- a/packages/wonder-blocks-core/src/components/text.tsx
+++ b/packages/wonder-blocks-core/src/components/text.tsx
@@ -57,12 +57,12 @@ const Text = React.forwardRef(function Text(
         : styleAttributes.className;
 
     return (
-        // @ts-expect-error [FEI-5019] - TS2322 - Type '{ children: ReactNode; style: any; className: string; "data-test-id": string | undefined; tabIndex?: number | undefined; id?: string | undefined; "data-modal-launcher-portal"?: boolean | undefined; ... 69 more ...; onBlur?: ((e: FocusEvent<...>) => unknown) | undefined; }' is not assignable to type 'IntrinsicAttributes'.
+        // @ts-expect-error [FEI-5019] - TS2322 - Type '{ children: ReactNode; style: any; className: string; "data-testid": string | undefined; tabIndex?: number | undefined; id?: string | undefined; "data-modal-launcher-portal"?: boolean | undefined; ... 69 more ...; onBlur?: ((e: FocusEvent<...>) => unknown) | undefined; }' is not assignable to type 'IntrinsicAttributes'.
         <Tag
             {...otherProps}
             style={styleAttributes.style}
             className={classNames}
-            data-test-id={testId}
+            data-testid={testId}
             ref={ref}
         >
             {children}

--- a/packages/wonder-blocks-core/src/components/view.tsx
+++ b/packages/wonder-blocks-core/src/components/view.tsx
@@ -72,7 +72,8 @@ const View: React.ForwardRefExoticComponent<
     const {testId, tag = "div", ...restProps} = props;
     const commonProps = {
         ...restProps,
-        "data-test-id": testId,
+        // Note: this matches the default test id that Testing Library uses!
+        "data-testid": testId,
     } as const;
 
     switch (tag) {

--- a/packages/wonder-blocks-core/src/util/__tests__/add-style.test.tsx
+++ b/packages/wonder-blocks-core/src/util/__tests__/add-style.test.tsx
@@ -29,7 +29,7 @@ describe("addStyle", () => {
 
     it("should set the className if no style is provided", () => {
         // Arrange
-        render(<StyledDiv className="foo" data-test-id="styled-div" />);
+        render(<StyledDiv className="foo" data-testid="styled-div" />);
 
         // Act
         const div = screen.getByTestId("styled-div");
@@ -44,7 +44,7 @@ describe("addStyle", () => {
             <StyledDiv
                 className="foo"
                 style={{width: "100%"}}
-                data-test-id="styled-div"
+                data-testid="styled-div"
             />,
         );
 
@@ -60,7 +60,7 @@ describe("addStyle", () => {
 
     it("should set the class if an stylesheet style is provided", () => {
         // Arrange
-        render(<StyledDiv style={styles.foo} data-test-id="styled-div" />);
+        render(<StyledDiv style={styles.foo} data-testid="styled-div" />);
 
         // Act
         const div = screen.getByTestId("styled-div");
@@ -75,7 +75,7 @@ describe("addStyle", () => {
             <StyledDiv
                 className="foo"
                 style={styles.foo}
-                data-test-id="styled-div"
+                data-testid="styled-div"
             />,
         );
 
@@ -97,7 +97,7 @@ describe("addStyle", () => {
             <StyledDiv
                 className="foo"
                 style={styles.foo}
-                data-test-id="styled-div"
+                data-testid="styled-div"
                 ref={ref}
             />,
         );

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.tsx
@@ -363,7 +363,7 @@ describe("ActionMenu", () => {
         const opener = await screen.findByRole("button");
 
         // Assert
-        expect(opener).toHaveAttribute("data-test-id", "some-test-id");
+        expect(opener).toHaveAttribute("data-testid", "some-test-id");
     });
 
     describe("Controlled component", () => {
@@ -393,7 +393,7 @@ describe("ActionMenu", () => {
                         <ActionItem label="Delete" />
                     </ActionMenu>
                     <button
-                        data-test-id="parent-button"
+                        data-testid="parent-button"
                         onClick={() => handleToggleMenu(true)}
                     />
                 </React.Fragment>
@@ -508,7 +508,7 @@ describe("ActionMenu", () => {
                     menuText="Action menu!"
                     opener={() => (
                         <button
-                            data-test-id="custom-opener"
+                            data-testid="custom-opener"
                             aria-label="Custom opener"
                         />
                     )}
@@ -522,7 +522,7 @@ describe("ActionMenu", () => {
             const opener = await screen.findByLabelText("Custom opener");
 
             // Assert
-            expect(opener).toHaveAttribute("data-test-id", "custom-opener");
+            expect(opener).toHaveAttribute("data-testid", "custom-opener");
         });
 
         it("verifies testId is not passed from the parent element", async () => {
@@ -543,7 +543,7 @@ describe("ActionMenu", () => {
             const opener = await screen.findByLabelText("Custom opener");
 
             // Assert
-            expect(opener).not.toHaveAttribute("data-test-id");
+            expect(opener).not.toHaveAttribute("data-testid");
         });
 
         it("passes the menu text to the custom opener", async () => {
@@ -555,10 +555,7 @@ describe("ActionMenu", () => {
                     onChange={onChange}
                     selectedValues={[]}
                     opener={({text}: any) => (
-                        <button
-                            onClick={jest.fn()}
-                            data-test-id="custom-opener"
-                        >
+                        <button onClick={jest.fn()} data-testid="custom-opener">
                             {text}
                         </button>
                     )}

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.tsx
@@ -33,7 +33,7 @@ describe("DropdownCore", () => {
         const underTest = () =>
             render(
                 <div>
-                    <button data-test-id="external-button" />
+                    <button data-testid="external-button" />
                     <DropdownCore
                         initialFocusedIndex={0}
                         // mock the items
@@ -237,7 +237,7 @@ describe("DropdownCore", () => {
 
         const {container} = render(
             <div>
-                <button data-test-id="external-button" />
+                <button data-testid="external-button" />
                 <DropdownCore
                     initialFocusedIndex={0}
                     // mock the items
@@ -289,7 +289,7 @@ describe("DropdownCore", () => {
     it.skip("opens on down key as expected", async () => {
         // Arrange
         const handleOpenChangedMock = jest.fn();
-        const opener = <button data-test-id="opener" />;
+        const opener = <button data-testid="opener" />;
 
         render(
             <DropdownCore
@@ -470,7 +470,7 @@ describe("DropdownCore", () => {
                 role="listbox"
                 open={true}
                 // mock the opener elements
-                opener={<button data-test-id="opener" />}
+                opener={<button data-testid="opener" />}
                 onOpenChanged={jest.fn()}
             />,
         );

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-popper.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-popper.test.tsx
@@ -13,7 +13,7 @@ describe("DropdownPopper", () => {
         render(
             <DropdownPopper referenceElement={referenceElement}>
                 {() => (
-                    <div data-test-id="dropdown-container">
+                    <div data-testid="dropdown-container">
                         dropdown container
                     </div>
                 )}
@@ -35,7 +35,7 @@ describe("DropdownPopper", () => {
                 alignment="right"
             >
                 {() => (
-                    <div data-test-id="dropdown-container">
+                    <div data-testid="dropdown-container">
                         dropdown container
                     </div>
                 )}
@@ -63,7 +63,7 @@ describe("DropdownPopper", () => {
         render(
             <DropdownPopper referenceElement={referenceElement}>
                 {() => (
-                    <div data-test-id="dropdown-container">
+                    <div data-testid="dropdown-container">
                         dropdown container
                     </div>
                 )}

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -262,7 +262,7 @@ describe("MultiSelect", () => {
             const opener = await screen.findByRole("button");
 
             // Assert
-            expect(opener).toHaveAttribute("data-test-id", "some-test-id");
+            expect(opener).toHaveAttribute("data-testid", "some-test-id");
         });
     });
 
@@ -312,7 +312,7 @@ describe("MultiSelect", () => {
                         <OptionItem label="item 3" value="3" />
                     </MultiSelect>
                     <button
-                        data-test-id="parent-button"
+                        data-testid="parent-button"
                         onClick={() => handleToggleMenu(true)}
                     />
                 </React.Fragment>
@@ -958,7 +958,7 @@ describe("MultiSelect", () => {
                     onChange={onChange}
                     opener={() => (
                         <button
-                            data-test-id="custom-opener"
+                            data-testid="custom-opener"
                             aria-label="Custom opener"
                         />
                     )}
@@ -972,7 +972,7 @@ describe("MultiSelect", () => {
             const opener = await screen.findByLabelText("Custom opener");
 
             // Assert
-            expect(opener).toHaveAttribute("data-test-id", "custom-opener");
+            expect(opener).toHaveAttribute("data-testid", "custom-opener");
         });
 
         it("verifies testId is not passed from the parent element", async () => {
@@ -994,7 +994,7 @@ describe("MultiSelect", () => {
             const opener = await screen.findByLabelText("Custom opener");
 
             // Assert
-            expect(opener).not.toHaveAttribute("data-test-id", "custom-opener");
+            expect(opener).not.toHaveAttribute("data-testid", "custom-opener");
         });
 
         it("passes the current label to the custom opener (no items selected)", async () => {
@@ -1010,10 +1010,7 @@ describe("MultiSelect", () => {
                     testId="openTest"
                     onChange={jest.fn()}
                     opener={({text}: any) => (
-                        <button
-                            onClick={jest.fn()}
-                            data-test-id="custom-opener"
-                        >
+                        <button onClick={jest.fn()} data-testid="custom-opener">
                             {text}
                         </button>
                     )}
@@ -1045,7 +1042,7 @@ describe("MultiSelect", () => {
                         opener={({text}: any) => (
                             <button
                                 onClick={jest.fn()}
-                                data-test-id="custom-opener"
+                                data-testid="custom-opener"
                             >
                                 {text}
                             </button>
@@ -1086,7 +1083,7 @@ describe("MultiSelect", () => {
                         opener={({text}: any) => (
                             <button
                                 onClick={jest.fn()}
-                                data-test-id="custom-opener"
+                                data-testid="custom-opener"
                             >
                                 {text}
                             </button>
@@ -1127,7 +1124,7 @@ describe("MultiSelect", () => {
                         opener={({text}: any) => (
                             <button
                                 onClick={jest.fn()}
-                                data-test-id="custom-opener"
+                                data-testid="custom-opener"
                             >
                                 {text}
                             </button>

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -396,7 +396,7 @@ describe("SingleSelect", () => {
                         <OptionItem label="item 3" value="3" />
                     </SingleSelect>
                     <button
-                        data-test-id="parent-button"
+                        data-testid="parent-button"
                         onClick={() => handleToggleMenu(true)}
                     />
                 </React.Fragment>
@@ -561,7 +561,7 @@ describe("SingleSelect", () => {
             const opener = await screen.findByLabelText("Custom opener");
 
             // Assert
-            expect(opener).not.toHaveAttribute("data-test-id");
+            expect(opener).not.toHaveAttribute("data-testid");
         });
 
         it("passes the placeholder text to the custom opener", async () => {

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -80,7 +80,7 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
                 style={defaultStyle}
                 type="button"
                 {...restProps}
-                data-test-id={testId}
+                data-testid={testId}
             >
                 <View
                     style={

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -1026,7 +1026,7 @@ class DropdownCore extends React.Component<Props, State> {
                 aria-atomic="true"
                 aria-relevant="additions text"
                 style={styles.srOnly}
-                data-test-id="dropdown-live-region"
+                data-testid="dropdown-live-region"
             >
                 {open && labels.someResults(totalItems)}
             </StyledSpan>

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
@@ -51,7 +51,7 @@ class DropdownOpener extends React.Component<Props> {
     };
 
     getTestIdFromProps: (childrenProps?: any) => string = (childrenProps) => {
-        return childrenProps.testId || childrenProps["data-test-id"];
+        return childrenProps.testId || childrenProps["data-testid"];
     };
 
     renderAnchorChildren(
@@ -81,7 +81,7 @@ class DropdownOpener extends React.Component<Props> {
                 : clickableChildrenProps.onClick,
             // try to get the testId from the child element
             // If it's not set, try to fallback to the parent's testId
-            "data-test-id": childrenTestId || testId,
+            "data-testid": childrenTestId || testId,
         });
     }
 

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
@@ -92,7 +92,7 @@ const DropdownPopper = function ({
                     <div
                         ref={ref}
                         style={style}
-                        data-test-id="dropdown-popper"
+                        data-testid="dropdown-popper"
                         data-placement={placement}
                     >
                         {children(shouldHidePopper)}

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -134,7 +134,7 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                             {...sharedProps}
                             aria-expanded={open ? "true" : "false"}
                             aria-haspopup="listbox"
-                            data-test-id={testId}
+                            data-testid={testId}
                             disabled={disabled}
                             id={id}
                             style={style}

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
@@ -441,7 +441,7 @@ describe("LabeledTextField", () => {
 
         // Assert
         const input = await screen.findByRole("textbox");
-        expect(input).toHaveAttribute("data-test-id", `${testId}-field`);
+        expect(input).toHaveAttribute("data-testid", `${testId}-field`);
     });
 
     it("readOnly prop is passed to textfield", async () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
@@ -425,7 +425,7 @@ describe("TextField", () => {
 
         // Assert
         const input = await screen.findByRole("textbox");
-        expect(input).toHaveAttribute("data-test-id", testId);
+        expect(input).toHaveAttribute("data-testid", testId);
     });
 
     it("aria props are passed to the input element", async () => {

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -109,7 +109,7 @@ const CheckboxCore = React.forwardRef(function CheckboxCore(
                 // component, but we handle the click via ClickableBehavior
                 onChange={handleChange}
                 style={defaultStyle}
-                data-test-id={testId}
+                data-testid={testId}
             />
             {checked || checked == null ? checkboxIcon : <></>}
         </React.Fragment>

--- a/packages/wonder-blocks-form/src/components/checkbox-group.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.tsx
@@ -130,7 +130,7 @@ const CheckboxGroup = React.forwardRef(function CheckboxGroup(
     const allChildren = React.Children.toArray(children).filter(Boolean);
 
     return (
-        <StyledFieldset data-test-id={testId} style={styles.fieldset} ref={ref}>
+        <StyledFieldset data-testid={testId} style={styles.fieldset} ref={ref}>
             {/* We have a View here because fieldset cannot be used with flexbox*/}
             <View style={style}>
                 {label && (

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -46,7 +46,7 @@ const StyledInput = addStyle("input");
                 // component, but we handle the click via ClickableBehavior
                 onChange={handleChange}
                 style={defaultStyle}
-                data-test-id={testId}
+                data-testid={testId}
                 ref={ref}
             />
             {disabled && checked && <span style={disabledChecked} />}

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -115,7 +115,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(
     const allChildren = React.Children.toArray(children).filter(Boolean);
 
     return (
-        <StyledFieldset data-test-id={testId} style={styles.fieldset} ref={ref}>
+        <StyledFieldset data-testid={testId} style={styles.fieldset} ref={ref}>
             {/* We have a View here because fieldset cannot be used with flexbox*/}
             <View style={style}>
                 {label && (

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -278,7 +278,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                 onKeyDown={onKeyDown}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}
-                data-test-id={testId}
+                data-testid={testId}
                 readOnly={readOnly}
                 autoFocus={autoFocus}
                 autoComplete={autoComplete}

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -116,7 +116,7 @@ const IconButtonCore: React.ForwardRefExoticComponent<
         const child = <IconChooser size={size} icon={icon} />;
 
         const commonProps = {
-            "data-test-id": testId,
+            "data-testid": testId,
             style: [defaultStyle, style],
             ...restProps,
         } as const;

--- a/packages/wonder-blocks-icon/src/components/phosphor-icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/phosphor-icon.tsx
@@ -111,7 +111,7 @@ export const PhosphorIcon = React.forwardRef(function PhosphorIcon(
                 },
                 style,
             ]}
-            data-test-id={testId}
+            data-testid={testId}
             ref={ref}
         />
     );

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -69,7 +69,7 @@ const LinkCore = React.forwardRef(function LinkCore(
         ];
 
         const commonProps = {
-            "data-test-id": testId,
+            "data-testid": testId,
             style: [defaultStyles, style],
             target,
             ...restProps,

--- a/packages/wonder-blocks-modal/src/components/__tests__/close-button.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/close-button.test.tsx
@@ -30,7 +30,7 @@ describe("CloseButton", () => {
 
         // Assert
         expect(closeButton).toHaveAttribute(
-            "data-test-id",
+            "data-testid",
             "modal-example-close",
         );
     });

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-backdrop.test.tsx
@@ -7,9 +7,9 @@ import OnePaneDialog from "../one-pane-dialog";
 
 const exampleModal = (
     <OnePaneDialog
-        content={<div data-test-id="example-modal-content" />}
+        content={<div data-testid="example-modal-content" />}
         title="Title"
-        footer={<div data-test-id="example-modal-footer" />}
+        footer={<div data-testid="example-modal-footer" />}
         testId="example-modal-test-id"
     />
 );

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-header.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-header.test.tsx
@@ -69,7 +69,7 @@ describe("ModalHeader", () => {
 
         // Assert
         expect(title).toHaveAttribute(
-            "data-test-id",
+            "data-testid",
             "test-example-header-title",
         );
     });
@@ -90,7 +90,7 @@ describe("ModalHeader", () => {
 
         // Assert
         expect(subtitle).toHaveAttribute(
-            "data-test-id",
+            "data-testid",
             "test-example-header-subtitle",
         );
     });

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-panel.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-panel.test.tsx
@@ -37,6 +37,6 @@ describe("ModalPanel", () => {
         const closeButton = screen.getByLabelText("Close modal");
 
         // Assert
-        expect(closeButton).toHaveAttribute("data-test-id", "test-id-close");
+        expect(closeButton).toHaveAttribute("data-testid", "test-id-close");
     });
 });

--- a/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/one-pane-dialog.test.tsx
@@ -23,7 +23,7 @@ describe("OnePaneDialog", () => {
 
         // Assert
         expect(dialog).toHaveAttribute(
-            "data-test-id",
+            "data-testid",
             "one-pane-dialog-example",
         );
     });

--- a/packages/wonder-blocks-pill/src/components/__tests__/pill.test.tsx
+++ b/packages/wonder-blocks-pill/src/components/__tests__/pill.test.tsx
@@ -27,7 +27,7 @@ describe("Pill", () => {
         // Assert
         expect(pillRef.current).toHaveAttribute("id", "pill-id");
         expect(pillRef.current).toHaveAttribute("role", "radio");
-        expect(pillRef.current).toHaveAttribute("data-test-id", "pill-test-id");
+        expect(pillRef.current).toHaveAttribute("data-testid", "pill-test-id");
     });
 
     test("should set attributes correctly (with onClick)", async () => {
@@ -48,7 +48,7 @@ describe("Pill", () => {
         // Assert
         expect(pillRef.current).toHaveAttribute("id", "pill-id");
         expect(pillRef.current).toHaveAttribute("role", "radio");
-        expect(pillRef.current).toHaveAttribute("data-test-id", "pill-test-id");
+        expect(pillRef.current).toHaveAttribute("data-testid", "pill-test-id");
     });
 
     test("is Clickable if onClick is passed in (mouse click)", async () => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/initial-focus.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/initial-focus.test.tsx
@@ -12,10 +12,10 @@ describe("InitialFocus", () => {
         // Arrange
         render(
             <InitialFocus initialFocusId="initial-focus-id">
-                <div data-test-id="container">
-                    <button data-test-id="item-0" />
-                    <button data-test-id="item-1" id="initial-focus-id" />
-                    <button data-test-id="item-2" />
+                <div data-testid="container">
+                    <button data-testid="item-0" />
+                    <button data-testid="item-1" id="initial-focus-id" />
+                    <button data-testid="item-2" />
                 </div>
             </InitialFocus>,
         );
@@ -33,10 +33,10 @@ describe("InitialFocus", () => {
         // Arrange
         render(
             <InitialFocus>
-                <div data-test-id="container">
-                    <button data-test-id="item-0" />
-                    <button data-test-id="item-1" id="initial-focus-id" />
-                    <button data-test-id="item-2" />
+                <div data-testid="container">
+                    <button data-testid="item-0" />
+                    <button data-testid="item-1" id="initial-focus-id" />
+                    <button data-testid="item-2" />
                 </div>
             </InitialFocus>,
         );
@@ -55,7 +55,7 @@ describe("InitialFocus", () => {
         // Arrange
         render(
             <InitialFocus>
-                <div data-test-id="container">
+                <div data-testid="container">
                     <p>no focusable elements here</p>
                 </div>
             </InitialFocus>,

--- a/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
+++ b/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
@@ -80,7 +80,7 @@ export default class CircularSpinner extends React.Component<Props> {
                 width={height}
                 height={height}
                 viewBox={`0 0 ${height} ${height}`}
-                data-test-id={testId}
+                data-testid={testId}
             >
                 <StyledPath
                     style={[styles.loadingSpinner, {fill: color}]}

--- a/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.tsx
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/mock-gql-fetch.test.tsx
@@ -22,7 +22,7 @@ describe("#mockGqlFetch", () => {
                     });
                 }, [gqlFetch]);
 
-                return <div data-test-id="result">{result}</div>;
+                return <div data-testid="result">{result}</div>;
             };
 
             // Act
@@ -60,7 +60,7 @@ describe("#mockGqlFetch", () => {
                     });
                 }, [gqlFetch]);
 
-                return <div data-test-id="result">{result}</div>;
+                return <div data-testid="result">{result}</div>;
             };
 
             // Act
@@ -99,7 +99,7 @@ describe("#mockGqlFetch", () => {
                     });
                 }, [gqlFetch]);
 
-                return <div data-test-id="result">{result}</div>;
+                return <div data-testid="result">{result}</div>;
             };
 
             // Act
@@ -135,7 +135,7 @@ describe("#mockGqlFetch", () => {
                     });
                 }, [gqlFetch]);
 
-                return <div data-test-id="result">{result}</div>;
+                return <div data-testid="result">{result}</div>;
             };
 
             // Act

--- a/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.tsx
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/wb-data-integration.test.tsx
@@ -21,7 +21,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
                 });
             }, [gqlFetch]);
 
-            return <div data-test-id="result">{result}</div>;
+            return <div data-testid="result">{result}</div>;
         };
 
         // Act
@@ -59,7 +59,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
                 });
             }, [gqlFetch]);
 
-            return <div data-test-id="result">{result}</div>;
+            return <div data-testid="result">{result}</div>;
         };
 
         // Act
@@ -98,7 +98,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
                 });
             }, [gqlFetch]);
 
-            return <div data-test-id="result">{result}</div>;
+            return <div data-testid="result">{result}</div>;
         };
 
         // Act
@@ -134,7 +134,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
                 });
             }, [gqlFetch]);
 
-            return <div data-test-id="result">{result}</div>;
+            return <div data-testid="result">{result}</div>;
         };
 
         // Act
@@ -172,7 +172,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
                 });
             }, [gqlFetch]);
 
-            return <div data-test-id="result">{result}</div>;
+            return <div data-testid="result">{result}</div>;
         };
 
         // Act
@@ -210,7 +210,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
                 });
             }, [gqlFetch]);
 
-            return <div data-test-id="result">{result}</div>;
+            return <div data-testid="result">{result}</div>;
         };
 
         // Act
@@ -248,7 +248,7 @@ describe("integrating mockGqlFetch, RespondWith, GqlRouter and useGql", () => {
                 });
             }, [gqlFetch]);
 
-            return <div data-test-id="result">{result}</div>;
+            return <div data-testid="result">{result}</div>;
         };
 
         // Act

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/css.test.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/css.test.tsx
@@ -19,7 +19,7 @@ describe("Css.adapter", () => {
 
     it("should render the children", () => {
         // Arrange
-        const children = <div data-test-id="children">CHILDREN!</div>;
+        const children = <div data-testid="children">CHILDREN!</div>;
 
         // Act
         render(Css.adapter(children, "test"));
@@ -31,7 +31,7 @@ describe("Css.adapter", () => {
 
     it("should render a container element", () => {
         // Arrange
-        const children = <div data-test-id="children">CHILDREN!</div>;
+        const children = <div data-testid="children">CHILDREN!</div>;
 
         // Act
         render(Css.adapter(children, "test"));
@@ -43,7 +43,7 @@ describe("Css.adapter", () => {
 
     it("should render children as a child of the container element", () => {
         // Arrange
-        const children = <div data-test-id="children">CHILDREN!</div>;
+        const children = <div data-testid="children">CHILDREN!</div>;
 
         // Act
         render(Css.adapter(children, "test"));
@@ -63,7 +63,7 @@ describe("Css.adapter", () => {
         "should apply the given class names from $config to the container element",
         ({config, expectation}: any) => {
             // Arrange
-            const children = <div data-test-id="children">CHILDREN!</div>;
+            const children = <div data-testid="children">CHILDREN!</div>;
 
             // Act
             render(Css.adapter(children, config));
@@ -82,7 +82,7 @@ describe("Css.adapter", () => {
         "should apply the given styles from $config to the container element",
         ({config, expectation}: any) => {
             // Arrange
-            const children = <div data-test-id="children">CHILDREN!</div>;
+            const children = <div data-testid="children">CHILDREN!</div>;
 
             // Act
             render(Css.adapter(children, config));

--- a/packages/wonder-blocks-testing/src/harness/adapters/css.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/css.tsx
@@ -56,7 +56,7 @@ export const adapter: TestHarnessAdapter<Config> = (
     const {classes, style} = normalizeConfig(config);
     return (
         <div
-            data-test-id="css-adapter-container"
+            data-testid="css-adapter-container"
             className={classes.join(" ")}
             style={style}
         >

--- a/packages/wonder-blocks-testing/src/harness/adapters/portal.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/portal.tsx
@@ -19,7 +19,7 @@ export const adapter: TestHarnessAdapter<Config> = (
     config: Config,
 ): React.ReactElement<any> => (
     <>
-        <div id={config} data-test-id={config} />
+        <div id={config} data-testid={config} />
         {children}
     </>
 );


### PR DESCRIPTION
## Summary:

<img width="852" alt="image" src="https://github.com/Khan/wonder-blocks/assets/77138/9289664e-37f8-4df0-a917-99505af5cadc">

<img width="457" alt="image" src="https://github.com/Khan/wonder-blocks/assets/77138/9b01682f-5792-497b-b28f-9532624714ee">


Per a recent conversation in [Slack](https://khanacademy.slack.com/archives/CDHPTMSTB/p1711990121678439) about why `data-testid` isn't working in a Testing Library test, we re-discovered that Wonder Block's choice to use `data-test-id` as the HTML test id attribute doesn't match Testing Library's default (`data-testid`). This predates RTL.

This PR aligns Wonder Blocks test id name with RTL's so that we can remove some customization and make it easier for engineers to do the right thing (ie. follow the RTL [docs](https://testing-library.com/docs/queries/bytestid/)). 

### Related PRs:
  * https://github.com/Khan/perseus/pull/1179
  * https://github.com/Khan/webapp/pull/21335

Issue: FEI-5551

## Test plan:

`yarn test` :checkmark:
`yarn start` - navigate around (`View`'s documentation correctly mentions its `testId` prop renders `data-testid`.