### PR TITLE
Require `aria-labelledby` in ModalDialog (WCAG 2.1 4.1.2)

### DIFF
--- a/.changeset/weak-melons-destroy.md
+++ b/.changeset/weak-melons-destroy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": major
+---
+
+Makes optional `aria-labelledby` prop required

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -116,9 +116,9 @@ export const Default: StoryComponentType = {
         <View style={styles.previewSizer}>
             <View style={styles.modalPositioner}>
                 <ModalDialog
+                    {...args}
                     aria-labelledby="modal-title-0"
                     aria-describedby="modal-desc-0"
-                    {...args}
                 >
                     <ModalPanel
                         content={
@@ -264,9 +264,9 @@ export const WithDarkPanel: StoryComponentType = {
         <View style={styles.previewSizer}>
             <View style={styles.modalPositioner}>
                 <ModalDialog
+                    {...args}
                     aria-labelledby="modal-title-0"
                     aria-describedby="modal-desc-0"
-                    {...args}
                 >
                     <ModalPanel
                         content={

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -300,12 +300,15 @@ export const TwoPanels: StoryComponentType = {
         } as const;
 
         return (
-            <ModalDialog style={twoPaneDialogStyle}>
+            <ModalDialog
+                style={twoPaneDialogStyle}
+                aria-labelledby="sidebar-title-id"
+            >
                 <View style={panelGroupStyle}>
                     <ModalPanel
                         content={
                             <View>
-                                <Title>Sidebar</Title>
+                                <Title id="sidebar-title-id">Sidebar</Title>
                                 <Strut size={spacing.large_24} />
                                 <Body>
                                     Lorem ipsum dolor sit amet, consectetur

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-dialog.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-dialog.test.tsx
@@ -9,8 +9,8 @@ describe("ModalDialog", () => {
 
         // Act
         render(
-            <ModalDialog>
-                <h1>A modal</h1>
+            <ModalDialog aria-labelledby="123">
+                <h1 id="123">A modal</h1>
                 <p>The contents</p>
             </ModalDialog>,
         );
@@ -41,11 +41,12 @@ describe("ModalDialog", () => {
 
         // Act
         render(
-            <ModalDialog aria-describedby="dialog-body">
-                <>
-                    <h1>A modal</h1>
-                    <p id="dialog-body">The contents</p>
-                </>
+            <ModalDialog
+                aria-labelledby="dialog-title"
+                aria-describedby="dialog-body"
+            >
+                <h1 id="dialog-title">A modal</h1>
+                <p id="dialog-body">The contents</p>
             </ModalDialog>,
         );
 
@@ -59,7 +60,11 @@ describe("ModalDialog", () => {
         // Arrange
 
         // Act
-        render(<ModalDialog testId="test-id">A modal</ModalDialog>);
+        render(
+            <ModalDialog aria-labelledby="dialog-title" testId="test-id">
+                <h1 id="dialog-title">A modal</h1>
+            </ModalDialog>,
+        );
 
         // Assert
         expect(screen.getByTestId("test-id")).toBeInTheDocument();
@@ -70,7 +75,11 @@ describe("ModalDialog", () => {
         const ref: React.RefObject<HTMLDivElement> = React.createRef();
 
         // Act
-        render(<ModalDialog ref={ref}>A modal</ModalDialog>);
+        render(
+            <ModalDialog ref={ref} aria-labelledby="dialog-title">
+                <h1 id="dialog-title">A modal</h1>
+            </ModalDialog>,
+        );
 
         // Assert
         expect(ref.current).toBeInstanceOf(HTMLDivElement);

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
@@ -44,9 +44,10 @@ type Props = {
      */
     testId?: string;
     /**
-     * The ID of the title labelling this dialog, if applicable.
+     * The ID of the title labelling this dialog. Required.
+     * See WCAG 2.1: 4.1.2 Name, Role, Value
      */
-    "aria-labelledby"?: string;
+    "aria-labelledby": string;
     /**
      * The ID of the content describing this dialog, if applicable.
      */

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
@@ -75,11 +75,8 @@ const ModalDialogCore = React.forwardRef(function ModalDialogCore(
         style,
         children,
         testId,
-        /* eslint-disable react/prop-types */
-        // the react/prop-types plugin does not like these
         "aria-labelledby": ariaLabelledBy,
         "aria-describedby": ariaDescribedBy,
-        /* eslint-enable react/prop-types */
     } = props;
 
     const {theme} = useScopedTheme(ModalDialogThemeContext);


### PR DESCRIPTION
Requires `aria-labelledby` to comply with A-level WCAG success criterion 4.1.2