### PR TITLE
WB-1682: Add faded versions of offBlack

### DIFF
--- a/.changeset/smooth-lies-build.md
+++ b/.changeset/smooth-lies-build.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tokens": minor
 ---
 
-Add faded versions of offBlack and white
+Add faded versions of offBlack

--- a/.changeset/smooth-lies-build.md
+++ b/.changeset/smooth-lies-build.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add faded versions of offBlack and white

--- a/packages/wonder-blocks-tokens/src/tokens/color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/color.ts
@@ -87,4 +87,13 @@ export const color = {
     fadedPurple16: fadedColorWithWhite(baseColors.purple, 0.16),
     // Khanmigo
     eggplant: "#5f1e5c",
+    // Faded versions of offBlack
+    fadedOffBlack64: fadedColorWithWhite(offBlack, 0.64),
+    fadedOffBlack50: fadedColorWithWhite(offBlack, 0.5),
+    fadedOffBlack32: fadedColorWithWhite(offBlack, 0.32),
+    fadedOffBlack16: fadedColorWithWhite(offBlack, 0.16),
+    fadedOffBlack8: fadedColorWithWhite(offBlack, 0.08),
+    // Faded versions of white
+    fadedWhite64: fadedColorWithWhite(white, 0.64),
+    fadedWhite50: fadedColorWithWhite(white, 0.5),
 };

--- a/packages/wonder-blocks-tokens/src/tokens/color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/color.ts
@@ -93,7 +93,4 @@ export const color = {
     fadedOffBlack32: fadedColorWithWhite(offBlack, 0.32),
     fadedOffBlack16: fadedColorWithWhite(offBlack, 0.16),
     fadedOffBlack8: fadedColorWithWhite(offBlack, 0.08),
-    // Faded versions of white
-    fadedWhite64: fadedColorWithWhite(white, 0.64),
-    fadedWhite50: fadedColorWithWhite(white, 0.5),
 };


### PR DESCRIPTION
## Summary:

Based on previous discussions with Design, we are going to add faded versions of
the existing `offBlack` and white `color` tokens.

Currently, our "offBlack" versions are using the `rgba` format, and sometimes we just need the solid version of it, so we are adding those versions to the color tokens.

https://khanacademy.slack.com/archives/C8Z9DSKC7/p1713907216050369?thread_ts=1713907205.849639&cid=C8Z9DSKC7

Issue: https://khanacademy.atlassian.net/browse/WB-1682

## Test plan:

Verify that the new colors are available in the `Tokens > Color` page.

<img width="1178" alt="Screenshot 2024-04-25 at 4 44 01 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/0009bde2-8230-445b-9043-619e036b5c54">
