### PR TITLE
Allow TextField number input to use min, max, and step props

### DIFF
--- a/.changeset/swift-days-refuse.md
+++ b/.changeset/swift-days-refuse.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+TextField number inputs can now use `min`, `max`, and `snap` props

--- a/__docs__/wonder-blocks-form/labeled-text-field.argtypes.ts
+++ b/__docs__/wonder-blocks-form/labeled-text-field.argtypes.ts
@@ -203,6 +203,46 @@ export default {
     },
 
     /**
+     * Number-specific props
+     */
+    min: {
+        description: "The minimum value for a number input.",
+        table: {
+            category: "Number",
+            type: {
+                summary: "number",
+            },
+        },
+        control: {
+            type: "number",
+        },
+    },
+    max: {
+        description: "The maximum value for a number input.",
+        table: {
+            category: "Number",
+            type: {
+                summary: "number",
+            },
+        },
+        control: {
+            type: "number",
+        },
+    },
+    step: {
+        description: "The step value for a number input.",
+        table: {
+            category: "Number",
+            type: {
+                summary: "number",
+            },
+        },
+        control: {
+            type: "number",
+        },
+    },
+
+    /**
      * Events
      */
     onValidate: {

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -160,7 +160,12 @@ RequiredWithSpecifiedText.parameters = {
 };
 
 export const Number: StoryComponentType = () => {
-    const [value, setValue] = React.useState("18");
+    const [value, setValue] = React.useState("1234");
+    const [value2, setValue2] = React.useState("12");
+
+    const handleChange = (newValue: string) => {
+        setValue(newValue);
+    };
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
         if (event.key === "Enter") {
@@ -169,22 +174,46 @@ export const Number: StoryComponentType = () => {
     };
 
     return (
-        <LabeledTextField
-            label="Age"
-            type="number"
-            description="Please enter your age"
-            value={value}
-            onChange={setValue}
-            placeholder="Age"
-            onKeyDown={handleKeyDown}
-        />
+        <View style={styles.column}>
+            <LabeledTextField
+                label="Age"
+                id="tf-3"
+                description="Please enter your age"
+                type="number"
+                value={value}
+                placeholder="Number"
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+            />
+            <Strut size={spacing.small_12} />
+            <LabeledTextField
+                id="tf-3a"
+                label={`The following text field has a min of 0, a max of 15,
+                    and a snap of 3`}
+                type="number"
+                value={value2}
+                placeholder="Number"
+                onChange={setValue2}
+                onKeyDown={handleKeyDown}
+                min={0}
+                max={15}
+                step={3}
+            />
+        </View>
     );
 };
 
 Number.parameters = {
     docs: {
         description: {
-            story: "An input field with type `number` will only take numeric characters as input.",
+            story: `An input field with type \`number\` will only take
+                numeric characters as input.\n\nNumber inputs have a few props
+                that other input types don't have - \`min\`, \`max\`, and
+                \`step\`. In this example, the first number input has no
+                restrictions, while the second number input has a minimum
+                value of 0, a maximum value of 15, and a step of 3. Observe
+                that using the arrow keys will automatically snap to the
+                snap step, and stop at the min and max values.`,
         },
     },
 };

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -189,7 +189,7 @@ export const Number: StoryComponentType = () => {
             <LabeledTextField
                 id="tf-3a"
                 label={`The following text field has a min of 0, a max of 15,
-                    and a snap of 3`}
+                    and a step of 3`}
                 type="number"
                 value={value2}
                 placeholder="Number"
@@ -213,7 +213,7 @@ Number.parameters = {
                 restrictions, while the second number input has a minimum
                 value of 0, a maximum value of 15, and a step of 3. Observe
                 that using the arrow keys will automatically snap to the
-                snap step, and stop at the min and max values.`,
+                step, and stop at the min and max values.`,
         },
     },
 };

--- a/__docs__/wonder-blocks-form/text-field.argtypes.ts
+++ b/__docs__/wonder-blocks-form/text-field.argtypes.ts
@@ -172,6 +172,46 @@ export default {
     },
 
     /**
+     * Number-specific props
+     */
+    min: {
+        description: "The minimum value for a number input.",
+        table: {
+            category: "Number",
+            type: {
+                summary: "number",
+            },
+        },
+        control: {
+            type: "number",
+        },
+    },
+    max: {
+        description: "The maximum value for a number input.",
+        table: {
+            category: "Number",
+            type: {
+                summary: "number",
+            },
+        },
+        control: {
+            type: "number",
+        },
+    },
+    step: {
+        description: "The step value for a number input.",
+        table: {
+            category: "Number",
+            type: {
+                summary: "number",
+            },
+        },
+        control: {
+            type: "number",
+        },
+    },
+
+    /**
      * Events
      */
     onValidate: {

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -138,7 +138,7 @@ export const Number: StoryComponentType = () => {
     };
 
     return (
-        <View style={styles.column}>
+        <View>
             <TextField
                 id="tf-3"
                 type="number"
@@ -149,7 +149,7 @@ export const Number: StoryComponentType = () => {
             />
             <Strut size={spacing.small_12} />
             <Body>
-                The following text field has a min of 0, a max of 15, and a snap
+                The following text field has a min of 0, a max of 15, and a step
                 of 3
             </Body>
             <TextField
@@ -177,7 +177,7 @@ Number.parameters = {
                 restrictions, while the second number input has a minimum
                 value of 0, a maximum value of 15, and a step of 3. Observe
                 that using the arrow keys will automatically snap to the
-                snap step, and stop at the min and max values.`,
+                step, and stop at the min and max values.`,
         },
     },
 };
@@ -896,8 +896,5 @@ const styles = StyleSheet.create({
     },
     fieldWithButton: {
         marginBottom: spacing.medium_16,
-    },
-    column: {
-        flexDirection: "column",
     },
 });

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -6,7 +6,7 @@ import {View, Text as _Text} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import Button from "@khanacademy/wonder-blocks-button";
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {LabelLarge, Body} from "@khanacademy/wonder-blocks-typography";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
@@ -124,7 +124,8 @@ Required.parameters = {
 };
 
 export const Number: StoryComponentType = () => {
-    const [value, setValue] = React.useState("12345");
+    const [value, setValue] = React.useState("1234");
+    const [value2, setValue2] = React.useState("12");
 
     const handleChange = (newValue: string) => {
         setValue(newValue);
@@ -137,21 +138,46 @@ export const Number: StoryComponentType = () => {
     };
 
     return (
-        <TextField
-            id="tf-3"
-            type="number"
-            value={value}
-            placeholder="Number"
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-        />
+        <View style={styles.column}>
+            <TextField
+                id="tf-3"
+                type="number"
+                value={value}
+                placeholder="Number"
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+            />
+            <Strut size={spacing.small_12} />
+            <Body>
+                The following text field has a min of 0, a max of 15, and a snap
+                of 3
+            </Body>
+            <TextField
+                id="tf-3a"
+                type="number"
+                value={value2}
+                placeholder="Number"
+                onChange={setValue2}
+                onKeyDown={handleKeyDown}
+                min={0}
+                max={15}
+                step={3}
+            />
+        </View>
     );
 };
 
 Number.parameters = {
     docs: {
         description: {
-            story: "An input field with type `number` will only take numeric characters as input.",
+            story: `An input field with type \`number\` will only take
+                numeric characters as input.\n\nNumber inputs have a few props
+                that other input types don't have - \`min\`, \`max\`, and
+                \`step\`. In this example, the first number input has no
+                restrictions, while the second number input has a minimum
+                value of 0, a maximum value of 15, and a step of 3. Observe
+                that using the arrow keys will automatically snap to the
+                snap step, and stop at the min and max values.`,
         },
     },
 };
@@ -870,5 +896,8 @@ const styles = StyleSheet.create({
     },
     fieldWithButton: {
         marginBottom: spacing.medium_16,
+    },
+    column: {
+        flexDirection: "column",
     },
 });

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -5,6 +5,7 @@ import {IDProvider, StyleType} from "@khanacademy/wonder-blocks-core";
 import FieldHeading from "./field-heading";
 import TextField from "./text-field";
 import type {NumericInputProps} from "./text-field";
+import {OmitConstrained} from "../util/types";
 
 type WithForwardRef = {
     forwardedRef: React.ForwardedRef<HTMLInputElement>;
@@ -269,7 +270,7 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
     }
 }
 
-type ExportProps = Omit<
+type ExportProps = OmitConstrained<
     JSX.LibraryManagedAttributes<
         typeof LabeledTextField,
         React.ComponentProps<typeof LabeledTextField>

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -4,12 +4,13 @@ import {IDProvider, StyleType} from "@khanacademy/wonder-blocks-core";
 
 import FieldHeading from "./field-heading";
 import TextField, {TextFieldType} from "./text-field";
+import type {NumericProps} from "./text-field";
 
 type WithForwardRef = {
     forwardedRef: React.ForwardedRef<HTMLInputElement>;
 };
 
-type Props = {
+type Props = NumericProps & {
     /**
      * An optional unique identifier for the TextField.
      * If no id is specified, a unique id will be auto-generated.
@@ -213,6 +214,9 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
             autoComplete,
             forwardedRef,
             ariaDescribedby,
+            min,
+            max,
+            step,
         } = this.props;
 
         return (
@@ -247,6 +251,9 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
                                 readOnly={readOnly}
                                 autoComplete={autoComplete}
                                 ref={forwardedRef}
+                                min={min}
+                                max={max}
+                                step={step}
                             />
                         }
                         label={label}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -3,23 +3,19 @@ import * as React from "react";
 import {IDProvider, StyleType} from "@khanacademy/wonder-blocks-core";
 
 import FieldHeading from "./field-heading";
-import TextField, {TextFieldType} from "./text-field";
-import type {NumericProps} from "./text-field";
+import TextField from "./text-field";
+import type {NumericInputProps} from "./text-field";
 
 type WithForwardRef = {
     forwardedRef: React.ForwardedRef<HTMLInputElement>;
 };
 
-type Props = NumericProps & {
+type CommonProps = {
     /**
      * An optional unique identifier for the TextField.
      * If no id is specified, a unique id will be auto-generated.
      */
     id?: string;
-    /**
-     * Determines the type of input. Defaults to text.
-     */
-    type: TextFieldType;
     /**
      * Provide a label for the TextField.
      */
@@ -123,6 +119,15 @@ type Props = NumericProps & {
     autoComplete?: string;
 };
 
+type OtherInputProps = CommonProps & {
+    /**
+     * Determines the type of input. Defaults to text.
+     */
+    type?: "text" | "password" | "email" | "tel";
+};
+
+type FullNumericInputProps = NumericInputProps & CommonProps;
+type Props = OtherInputProps | FullNumericInputProps;
 type PropsWithForwardRef = Props & WithForwardRef;
 
 type DefaultProps = {
@@ -214,9 +219,8 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
             autoComplete,
             forwardedRef,
             ariaDescribedby,
-            min,
-            max,
-            step,
+            // numeric input props
+            ...otherProps
         } = this.props;
 
         return (
@@ -251,9 +255,7 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
                                 readOnly={readOnly}
                                 autoComplete={autoComplete}
                                 ref={forwardedRef}
-                                min={min}
-                                max={max}
-                                step={step}
+                                {...otherProps}
                             />
                         }
                         label={label}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -3,19 +3,23 @@ import * as React from "react";
 import {IDProvider, StyleType} from "@khanacademy/wonder-blocks-core";
 
 import FieldHeading from "./field-heading";
-import TextField from "./text-field";
-import type {NumericInputProps} from "./text-field";
+import TextField, {TextFieldType} from "./text-field";
+import type {NumericProps} from "./text-field";
 
 type WithForwardRef = {
     forwardedRef: React.ForwardedRef<HTMLInputElement>;
 };
 
-type CommonProps = {
+type Props = NumericProps & {
     /**
      * An optional unique identifier for the TextField.
      * If no id is specified, a unique id will be auto-generated.
      */
     id?: string;
+    /**
+     * Determines the type of input. Defaults to text.
+     */
+    type: TextFieldType;
     /**
      * Provide a label for the TextField.
      */
@@ -119,15 +123,6 @@ type CommonProps = {
     autoComplete?: string;
 };
 
-type OtherInputProps = CommonProps & {
-    /**
-     * Determines the type of input. Defaults to text.
-     */
-    type?: "text" | "password" | "email" | "tel";
-};
-
-type FullNumericInputProps = NumericInputProps & CommonProps;
-type Props = OtherInputProps | FullNumericInputProps;
 type PropsWithForwardRef = Props & WithForwardRef;
 
 type DefaultProps = {
@@ -219,8 +214,9 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
             autoComplete,
             forwardedRef,
             ariaDescribedby,
-            // numeric input props
-            ...otherProps
+            min,
+            max,
+            step,
         } = this.props;
 
         return (
@@ -255,7 +251,9 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
                                 readOnly={readOnly}
                                 autoComplete={autoComplete}
                                 ref={forwardedRef}
-                                {...otherProps}
+                                min={min}
+                                max={max}
+                                step={step}
                             />
                         }
                         label={label}

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -124,7 +124,7 @@ type OtherInputProps = CommonProps & {
     /**
      * Determines the type of input. Defaults to text.
      */
-    type?: "text" | "password" | "email" | "tel";
+    type: "text" | "password" | "email" | "tel";
 };
 
 type FullNumericInputProps = NumericInputProps & CommonProps;

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -18,7 +18,7 @@ const defaultErrorMessage = "This field is required.";
 const StyledInput = addStyle("input");
 
 // Props that are only available for inputs of type "number".
-type NumericProps = {
+export type NumericProps = {
     /**
      * The minimum numeric value for the input.
      */

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -115,12 +115,12 @@ type CommonProps = AriaProps & {
 };
 
 type OtherInputProps = CommonProps & {
-    type?: "text" | "password" | "email" | "tel";
+    type: "text" | "password" | "email" | "tel";
 };
 
 // Props that are only available for inputs of type "number".
 export type NumericInputProps = {
-    type?: "number";
+    type: "number";
     /**
      * The minimum numeric value for the input.
      */

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -6,6 +6,7 @@ import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
+import {OmitConstrained} from "../util/types";
 
 export type TextFieldType = "text" | "password" | "email" | "number" | "tel";
 
@@ -361,7 +362,7 @@ const styles = StyleSheet.create({
     },
 });
 
-type ExportProps = Omit<
+type ExportProps = OmitConstrained<
     JSX.LibraryManagedAttributes<
         typeof TextField,
         React.ComponentProps<typeof TextField>

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -17,109 +17,8 @@ const defaultErrorMessage = "This field is required.";
 
 const StyledInput = addStyle("input");
 
-type CommonProps = AriaProps & {
-    /**
-     * The unique identifier for the input.
-     */
-    id: string;
-    /**
-     * The input value.
-     */
-    value: string;
-    /**
-     * The name for the input control. This is submitted along with
-     * the form data.
-     */
-    name?: string;
-    /**
-     * Makes a read-only input field that cannot be focused. Defaults to false.
-     */
-    disabled: boolean;
-    /**
-     * Provide a validation for the input value.
-     * Return a string error message or null | void for a valid input.
-     */
-    validate?: (value: string) => string | null | void;
-    /**
-     * Called right after the TextField input is validated.
-     */
-    onValidate?: (errorMessage?: string | null | undefined) => unknown;
-    /**
-     * Called when the value has changed.
-     */
-    onChange: (newValue: string) => unknown;
-    /**
-     * Called when a key is pressed.
-     */
-    onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => unknown;
-    /**
-     * Called when the element has been focused.
-     */
-    onFocus?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
-    /**
-     * Called when the element has been blurred.
-     */
-    onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
-    /**
-     * Provide hints or examples of what to enter.
-     */
-    placeholder?: string;
-    /**
-     * Whether this field is required to to continue, or the error message to
-     * render if this field is left blank.
-     *
-     * This can be a boolean or a string.
-     *
-     * String:
-     * Please pass in a translated string to use as the error message that will
-     * render if the user leaves this field blank. If this field is required,
-     * and a string is not passed in, a default untranslated string will render
-     * upon error.
-     * Note: The string will not be used if a `validate` prop is passed in.
-     *
-     * Example message: i18n._("A password is required to log in.")
-     *
-     * Boolean:
-     * True/false indicating whether this field is required. Please do not pass
-     * in `true` if possible - pass in the error string instead.
-     * If `true` is passed, and a `validate` prop is not passed, that means
-     * there is no corresponding message and the default untranlsated message
-     * will be used.
-     */
-    required?: boolean | string;
-    /**
-     * Change the default focus ring color to fit a dark background.
-     */
-    light: boolean;
-    /**
-     * Custom styles for the input.
-     */
-    style?: StyleType;
-    /**
-     * Optional test ID for e2e testing.
-     */
-    testId?: string;
-    /**
-     * Specifies if the input field is read-only.
-     */
-    readOnly?: boolean;
-    /**
-     * Whether this field should autofocus on page load.
-     */
-    autoFocus?: boolean;
-    /**
-     * Specifies if the input field allows autocomplete.
-     */
-    autoComplete?: string;
-};
-
-type OtherInputProps = CommonProps & {
-    type?: "text" | "password" | "email" | "tel";
-};
-
 // Props that are only available for inputs of type "number".
-export type NumericInputProps = {
-    type?: "number";
+export type NumericProps = {
     /**
      * The minimum numeric value for the input.
      */
@@ -135,8 +34,107 @@ export type NumericInputProps = {
     step?: number;
 };
 
-type FullNumericInputProps = CommonProps & NumericInputProps;
-type Props = OtherInputProps | FullNumericInputProps;
+type Props = AriaProps &
+    NumericProps & {
+        /**
+         * The unique identifier for the input.
+         */
+        id: string;
+        /**
+         * Determines the type of input. Defaults to text.
+         */
+        type: TextFieldType;
+        /**
+         * The input value.
+         */
+        value: string;
+        /**
+         * The name for the input control. This is submitted along with
+         * the form data.
+         */
+        name?: string;
+        /**
+         * Makes a read-only input field that cannot be focused. Defaults to false.
+         */
+        disabled: boolean;
+        /**
+         * Provide a validation for the input value.
+         * Return a string error message or null | void for a valid input.
+         */
+        validate?: (value: string) => string | null | void;
+        /**
+         * Called right after the TextField input is validated.
+         */
+        onValidate?: (errorMessage?: string | null | undefined) => unknown;
+        /**
+         * Called when the value has changed.
+         */
+        onChange: (newValue: string) => unknown;
+        /**
+         * Called when a key is pressed.
+         */
+        onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => unknown;
+        /**
+         * Called when the element has been focused.
+         */
+        onFocus?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
+        /**
+         * Called when the element has been blurred.
+         */
+        onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
+        /**
+         * Provide hints or examples of what to enter.
+         */
+        placeholder?: string;
+        /**
+         * Whether this field is required to to continue, or the error message to
+         * render if this field is left blank.
+         *
+         * This can be a boolean or a string.
+         *
+         * String:
+         * Please pass in a translated string to use as the error message that will
+         * render if the user leaves this field blank. If this field is required,
+         * and a string is not passed in, a default untranslated string will render
+         * upon error.
+         * Note: The string will not be used if a `validate` prop is passed in.
+         *
+         * Example message: i18n._("A password is required to log in.")
+         *
+         * Boolean:
+         * True/false indicating whether this field is required. Please do not pass
+         * in `true` if possible - pass in the error string instead.
+         * If `true` is passed, and a `validate` prop is not passed, that means
+         * there is no corresponding message and the default untranlsated message
+         * will be used.
+         */
+        required?: boolean | string;
+        /**
+         * Change the default focus ring color to fit a dark background.
+         */
+        light: boolean;
+        /**
+         * Custom styles for the input.
+         */
+        style?: StyleType;
+        /**
+         * Optional test ID for e2e testing.
+         */
+        testId?: string;
+        /**
+         * Specifies if the input field is read-only.
+         */
+        readOnly?: boolean;
+        /**
+         * Whether this field should autofocus on page load.
+         */
+        autoFocus?: boolean;
+        /**
+         * Specifies if the input field allows autocomplete.
+         */
+        autoComplete?: string;
+    };
+
 type PropsWithForwardRef = Props & WithForwardRef;
 
 type DefaultProps = {
@@ -254,6 +252,9 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             autoFocus,
             autoComplete,
             forwardedRef,
+            min,
+            max,
+            step,
             // The following props are being included here to avoid
             // passing them down to the otherProps spread
             /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -267,6 +268,12 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             // Should only include Aria related props
             ...otherProps
         } = this.props;
+
+        if ((min || max || step) && type !== "number") {
+            throw new Error(
+                'The props `min`, `max`, and `step` can only be used with `type="number"`.',
+            );
+        }
 
         return (
             <StyledInput
@@ -303,6 +310,9 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                 autoFocus={autoFocus}
                 autoComplete={autoComplete}
                 ref={forwardedRef}
+                min={min}
+                max={max}
+                step={step}
                 {...otherProps}
                 aria-invalid={this.state.error ? "true" : "false"}
             />

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -17,105 +17,123 @@ const defaultErrorMessage = "This field is required.";
 
 const StyledInput = addStyle("input");
 
-type Props = AriaProps & {
+// Props that are only available for inputs of type "number".
+type NumericProps = {
     /**
-     * The unique identifier for the input.
+     * The minimum numeric value for the input.
      */
-    id: string;
+    min?: number;
     /**
-     * Determines the type of input. Defaults to text.
+     * The maximum numeric value for the input.
      */
-    type: TextFieldType;
+    max?: number;
     /**
-     * The input value.
+     * The numeric value to increment or decrement by.
+     * Requires the input to be multiples of this value.
      */
-    value: string;
-    /**
-     * The name for the input control. This is submitted along with
-     * the form data.
-     */
-    name?: string;
-    /**
-     * Makes a read-only input field that cannot be focused. Defaults to false.
-     */
-    disabled: boolean;
-    /**
-     * Provide a validation for the input value.
-     * Return a string error message or null | void for a valid input.
-     */
-    validate?: (value: string) => string | null | void;
-    /**
-     * Called right after the TextField input is validated.
-     */
-    onValidate?: (errorMessage?: string | null | undefined) => unknown;
-    /**
-     * Called when the value has changed.
-     */
-    onChange: (newValue: string) => unknown;
-    /**
-     * Called when a key is pressed.
-     */
-    onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => unknown;
-    /**
-     * Called when the element has been focused.
-     */
-    onFocus?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
-    /**
-     * Called when the element has been blurred.
-     */
-    onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
-    /**
-     * Provide hints or examples of what to enter.
-     */
-    placeholder?: string;
-    /**
-     * Whether this field is required to to continue, or the error message to
-     * render if this field is left blank.
-     *
-     * This can be a boolean or a string.
-     *
-     * String:
-     * Please pass in a translated string to use as the error message that will
-     * render if the user leaves this field blank. If this field is required,
-     * and a string is not passed in, a default untranslated string will render
-     * upon error.
-     * Note: The string will not be used if a `validate` prop is passed in.
-     *
-     * Example message: i18n._("A password is required to log in.")
-     *
-     * Boolean:
-     * True/false indicating whether this field is required. Please do not pass
-     * in `true` if possible - pass in the error string instead.
-     * If `true` is passed, and a `validate` prop is not passed, that means
-     * there is no corresponding message and the default untranlsated message
-     * will be used.
-     */
-    required?: boolean | string;
-    /**
-     * Change the default focus ring color to fit a dark background.
-     */
-    light: boolean;
-    /**
-     * Custom styles for the input.
-     */
-    style?: StyleType;
-    /**
-     * Optional test ID for e2e testing.
-     */
-    testId?: string;
-    /**
-     * Specifies if the input field is read-only.
-     */
-    readOnly?: boolean;
-    /**
-     * Whether this field should autofocus on page load.
-     */
-    autoFocus?: boolean;
-    /**
-     * Specifies if the input field allows autocomplete.
-     */
-    autoComplete?: string;
+    step?: number;
 };
+
+type Props = AriaProps &
+    NumericProps & {
+        /**
+         * The unique identifier for the input.
+         */
+        id: string;
+        /**
+         * Determines the type of input. Defaults to text.
+         */
+        type: TextFieldType;
+        /**
+         * The input value.
+         */
+        value: string;
+        /**
+         * The name for the input control. This is submitted along with
+         * the form data.
+         */
+        name?: string;
+        /**
+         * Makes a read-only input field that cannot be focused. Defaults to false.
+         */
+        disabled: boolean;
+        /**
+         * Provide a validation for the input value.
+         * Return a string error message or null | void for a valid input.
+         */
+        validate?: (value: string) => string | null | void;
+        /**
+         * Called right after the TextField input is validated.
+         */
+        onValidate?: (errorMessage?: string | null | undefined) => unknown;
+        /**
+         * Called when the value has changed.
+         */
+        onChange: (newValue: string) => unknown;
+        /**
+         * Called when a key is pressed.
+         */
+        onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => unknown;
+        /**
+         * Called when the element has been focused.
+         */
+        onFocus?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
+        /**
+         * Called when the element has been blurred.
+         */
+        onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
+        /**
+         * Provide hints or examples of what to enter.
+         */
+        placeholder?: string;
+        /**
+         * Whether this field is required to to continue, or the error message to
+         * render if this field is left blank.
+         *
+         * This can be a boolean or a string.
+         *
+         * String:
+         * Please pass in a translated string to use as the error message that will
+         * render if the user leaves this field blank. If this field is required,
+         * and a string is not passed in, a default untranslated string will render
+         * upon error.
+         * Note: The string will not be used if a `validate` prop is passed in.
+         *
+         * Example message: i18n._("A password is required to log in.")
+         *
+         * Boolean:
+         * True/false indicating whether this field is required. Please do not pass
+         * in `true` if possible - pass in the error string instead.
+         * If `true` is passed, and a `validate` prop is not passed, that means
+         * there is no corresponding message and the default untranlsated message
+         * will be used.
+         */
+        required?: boolean | string;
+        /**
+         * Change the default focus ring color to fit a dark background.
+         */
+        light: boolean;
+        /**
+         * Custom styles for the input.
+         */
+        style?: StyleType;
+        /**
+         * Optional test ID for e2e testing.
+         */
+        testId?: string;
+        /**
+         * Specifies if the input field is read-only.
+         */
+        readOnly?: boolean;
+        /**
+         * Whether this field should autofocus on page load.
+         */
+        autoFocus?: boolean;
+        /**
+         * Specifies if the input field allows autocomplete.
+         */
+        autoComplete?: string;
+    };
 
 type PropsWithForwardRef = Props & WithForwardRef;
 
@@ -234,6 +252,9 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             autoFocus,
             autoComplete,
             forwardedRef,
+            min,
+            max,
+            step,
             // The following props are being included here to avoid
             // passing them down to the otherProps spread
             /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -247,6 +268,12 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             // Should only include Aria related props
             ...otherProps
         } = this.props;
+
+        if ((min || max || step) && type !== "number") {
+            throw new Error(
+                'The props `min`, `max`, and `step` can only be used with `type="number"`.',
+            );
+        }
 
         return (
             <StyledInput
@@ -283,6 +310,9 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                 autoFocus={autoFocus}
                 autoComplete={autoComplete}
                 ref={forwardedRef}
+                min={min}
+                max={max}
+                step={step}
                 {...otherProps}
                 aria-invalid={this.state.error ? "true" : "false"}
             />

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -17,8 +17,109 @@ const defaultErrorMessage = "This field is required.";
 
 const StyledInput = addStyle("input");
 
+type CommonProps = AriaProps & {
+    /**
+     * The unique identifier for the input.
+     */
+    id: string;
+    /**
+     * The input value.
+     */
+    value: string;
+    /**
+     * The name for the input control. This is submitted along with
+     * the form data.
+     */
+    name?: string;
+    /**
+     * Makes a read-only input field that cannot be focused. Defaults to false.
+     */
+    disabled: boolean;
+    /**
+     * Provide a validation for the input value.
+     * Return a string error message or null | void for a valid input.
+     */
+    validate?: (value: string) => string | null | void;
+    /**
+     * Called right after the TextField input is validated.
+     */
+    onValidate?: (errorMessage?: string | null | undefined) => unknown;
+    /**
+     * Called when the value has changed.
+     */
+    onChange: (newValue: string) => unknown;
+    /**
+     * Called when a key is pressed.
+     */
+    onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => unknown;
+    /**
+     * Called when the element has been focused.
+     */
+    onFocus?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
+    /**
+     * Called when the element has been blurred.
+     */
+    onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
+    /**
+     * Provide hints or examples of what to enter.
+     */
+    placeholder?: string;
+    /**
+     * Whether this field is required to to continue, or the error message to
+     * render if this field is left blank.
+     *
+     * This can be a boolean or a string.
+     *
+     * String:
+     * Please pass in a translated string to use as the error message that will
+     * render if the user leaves this field blank. If this field is required,
+     * and a string is not passed in, a default untranslated string will render
+     * upon error.
+     * Note: The string will not be used if a `validate` prop is passed in.
+     *
+     * Example message: i18n._("A password is required to log in.")
+     *
+     * Boolean:
+     * True/false indicating whether this field is required. Please do not pass
+     * in `true` if possible - pass in the error string instead.
+     * If `true` is passed, and a `validate` prop is not passed, that means
+     * there is no corresponding message and the default untranlsated message
+     * will be used.
+     */
+    required?: boolean | string;
+    /**
+     * Change the default focus ring color to fit a dark background.
+     */
+    light: boolean;
+    /**
+     * Custom styles for the input.
+     */
+    style?: StyleType;
+    /**
+     * Optional test ID for e2e testing.
+     */
+    testId?: string;
+    /**
+     * Specifies if the input field is read-only.
+     */
+    readOnly?: boolean;
+    /**
+     * Whether this field should autofocus on page load.
+     */
+    autoFocus?: boolean;
+    /**
+     * Specifies if the input field allows autocomplete.
+     */
+    autoComplete?: string;
+};
+
+type OtherInputProps = CommonProps & {
+    type?: "text" | "password" | "email" | "tel";
+};
+
 // Props that are only available for inputs of type "number".
-export type NumericProps = {
+export type NumericInputProps = {
+    type?: "number";
     /**
      * The minimum numeric value for the input.
      */
@@ -34,107 +135,8 @@ export type NumericProps = {
     step?: number;
 };
 
-type Props = AriaProps &
-    NumericProps & {
-        /**
-         * The unique identifier for the input.
-         */
-        id: string;
-        /**
-         * Determines the type of input. Defaults to text.
-         */
-        type: TextFieldType;
-        /**
-         * The input value.
-         */
-        value: string;
-        /**
-         * The name for the input control. This is submitted along with
-         * the form data.
-         */
-        name?: string;
-        /**
-         * Makes a read-only input field that cannot be focused. Defaults to false.
-         */
-        disabled: boolean;
-        /**
-         * Provide a validation for the input value.
-         * Return a string error message or null | void for a valid input.
-         */
-        validate?: (value: string) => string | null | void;
-        /**
-         * Called right after the TextField input is validated.
-         */
-        onValidate?: (errorMessage?: string | null | undefined) => unknown;
-        /**
-         * Called when the value has changed.
-         */
-        onChange: (newValue: string) => unknown;
-        /**
-         * Called when a key is pressed.
-         */
-        onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => unknown;
-        /**
-         * Called when the element has been focused.
-         */
-        onFocus?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
-        /**
-         * Called when the element has been blurred.
-         */
-        onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
-        /**
-         * Provide hints or examples of what to enter.
-         */
-        placeholder?: string;
-        /**
-         * Whether this field is required to to continue, or the error message to
-         * render if this field is left blank.
-         *
-         * This can be a boolean or a string.
-         *
-         * String:
-         * Please pass in a translated string to use as the error message that will
-         * render if the user leaves this field blank. If this field is required,
-         * and a string is not passed in, a default untranslated string will render
-         * upon error.
-         * Note: The string will not be used if a `validate` prop is passed in.
-         *
-         * Example message: i18n._("A password is required to log in.")
-         *
-         * Boolean:
-         * True/false indicating whether this field is required. Please do not pass
-         * in `true` if possible - pass in the error string instead.
-         * If `true` is passed, and a `validate` prop is not passed, that means
-         * there is no corresponding message and the default untranlsated message
-         * will be used.
-         */
-        required?: boolean | string;
-        /**
-         * Change the default focus ring color to fit a dark background.
-         */
-        light: boolean;
-        /**
-         * Custom styles for the input.
-         */
-        style?: StyleType;
-        /**
-         * Optional test ID for e2e testing.
-         */
-        testId?: string;
-        /**
-         * Specifies if the input field is read-only.
-         */
-        readOnly?: boolean;
-        /**
-         * Whether this field should autofocus on page load.
-         */
-        autoFocus?: boolean;
-        /**
-         * Specifies if the input field allows autocomplete.
-         */
-        autoComplete?: string;
-    };
-
+type FullNumericInputProps = CommonProps & NumericInputProps;
+type Props = OtherInputProps | FullNumericInputProps;
 type PropsWithForwardRef = Props & WithForwardRef;
 
 type DefaultProps = {
@@ -252,9 +254,6 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             autoFocus,
             autoComplete,
             forwardedRef,
-            min,
-            max,
-            step,
             // The following props are being included here to avoid
             // passing them down to the otherProps spread
             /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -268,16 +267,6 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             // Should only include Aria related props
             ...otherProps
         } = this.props;
-
-        // TODO: Remove this check once we update to React 19 and make this
-        // a function component. As is, adding type restrictions alone won't
-        // prevent these props from being used with the wrong type, because
-        // the ref forwarding causes weird type issues involving unions.
-        if ((min || max || step) && type !== "number") {
-            throw new Error(
-                'The props `min`, `max`, and `step` can only be used with `type="number"`.',
-            );
-        }
 
         return (
             <StyledInput
@@ -314,9 +303,6 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                 autoFocus={autoFocus}
                 autoComplete={autoComplete}
                 ref={forwardedRef}
-                min={min}
-                max={max}
-                step={step}
                 {...otherProps}
                 aria-invalid={this.state.error ? "true" : "false"}
             />

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -17,8 +17,109 @@ const defaultErrorMessage = "This field is required.";
 
 const StyledInput = addStyle("input");
 
+type CommonProps = AriaProps & {
+    /**
+     * The unique identifier for the input.
+     */
+    id: string;
+    /**
+     * The input value.
+     */
+    value: string;
+    /**
+     * The name for the input control. This is submitted along with
+     * the form data.
+     */
+    name?: string;
+    /**
+     * Makes a read-only input field that cannot be focused. Defaults to false.
+     */
+    disabled: boolean;
+    /**
+     * Provide a validation for the input value.
+     * Return a string error message or null | void for a valid input.
+     */
+    validate?: (value: string) => string | null | void;
+    /**
+     * Called right after the TextField input is validated.
+     */
+    onValidate?: (errorMessage?: string | null | undefined) => unknown;
+    /**
+     * Called when the value has changed.
+     */
+    onChange: (newValue: string) => unknown;
+    /**
+     * Called when a key is pressed.
+     */
+    onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => unknown;
+    /**
+     * Called when the element has been focused.
+     */
+    onFocus?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
+    /**
+     * Called when the element has been blurred.
+     */
+    onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
+    /**
+     * Provide hints or examples of what to enter.
+     */
+    placeholder?: string;
+    /**
+     * Whether this field is required to to continue, or the error message to
+     * render if this field is left blank.
+     *
+     * This can be a boolean or a string.
+     *
+     * String:
+     * Please pass in a translated string to use as the error message that will
+     * render if the user leaves this field blank. If this field is required,
+     * and a string is not passed in, a default untranslated string will render
+     * upon error.
+     * Note: The string will not be used if a `validate` prop is passed in.
+     *
+     * Example message: i18n._("A password is required to log in.")
+     *
+     * Boolean:
+     * True/false indicating whether this field is required. Please do not pass
+     * in `true` if possible - pass in the error string instead.
+     * If `true` is passed, and a `validate` prop is not passed, that means
+     * there is no corresponding message and the default untranlsated message
+     * will be used.
+     */
+    required?: boolean | string;
+    /**
+     * Change the default focus ring color to fit a dark background.
+     */
+    light: boolean;
+    /**
+     * Custom styles for the input.
+     */
+    style?: StyleType;
+    /**
+     * Optional test ID for e2e testing.
+     */
+    testId?: string;
+    /**
+     * Specifies if the input field is read-only.
+     */
+    readOnly?: boolean;
+    /**
+     * Whether this field should autofocus on page load.
+     */
+    autoFocus?: boolean;
+    /**
+     * Specifies if the input field allows autocomplete.
+     */
+    autoComplete?: string;
+};
+
+type OtherInputProps = CommonProps & {
+    type?: "text" | "password" | "email" | "tel";
+};
+
 // Props that are only available for inputs of type "number".
-export type NumericProps = {
+export type NumericInputProps = {
+    type?: "number";
     /**
      * The minimum numeric value for the input.
      */
@@ -34,107 +135,8 @@ export type NumericProps = {
     step?: number;
 };
 
-type Props = AriaProps &
-    NumericProps & {
-        /**
-         * The unique identifier for the input.
-         */
-        id: string;
-        /**
-         * Determines the type of input. Defaults to text.
-         */
-        type: TextFieldType;
-        /**
-         * The input value.
-         */
-        value: string;
-        /**
-         * The name for the input control. This is submitted along with
-         * the form data.
-         */
-        name?: string;
-        /**
-         * Makes a read-only input field that cannot be focused. Defaults to false.
-         */
-        disabled: boolean;
-        /**
-         * Provide a validation for the input value.
-         * Return a string error message or null | void for a valid input.
-         */
-        validate?: (value: string) => string | null | void;
-        /**
-         * Called right after the TextField input is validated.
-         */
-        onValidate?: (errorMessage?: string | null | undefined) => unknown;
-        /**
-         * Called when the value has changed.
-         */
-        onChange: (newValue: string) => unknown;
-        /**
-         * Called when a key is pressed.
-         */
-        onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => unknown;
-        /**
-         * Called when the element has been focused.
-         */
-        onFocus?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
-        /**
-         * Called when the element has been blurred.
-         */
-        onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
-        /**
-         * Provide hints or examples of what to enter.
-         */
-        placeholder?: string;
-        /**
-         * Whether this field is required to to continue, or the error message to
-         * render if this field is left blank.
-         *
-         * This can be a boolean or a string.
-         *
-         * String:
-         * Please pass in a translated string to use as the error message that will
-         * render if the user leaves this field blank. If this field is required,
-         * and a string is not passed in, a default untranslated string will render
-         * upon error.
-         * Note: The string will not be used if a `validate` prop is passed in.
-         *
-         * Example message: i18n._("A password is required to log in.")
-         *
-         * Boolean:
-         * True/false indicating whether this field is required. Please do not pass
-         * in `true` if possible - pass in the error string instead.
-         * If `true` is passed, and a `validate` prop is not passed, that means
-         * there is no corresponding message and the default untranlsated message
-         * will be used.
-         */
-        required?: boolean | string;
-        /**
-         * Change the default focus ring color to fit a dark background.
-         */
-        light: boolean;
-        /**
-         * Custom styles for the input.
-         */
-        style?: StyleType;
-        /**
-         * Optional test ID for e2e testing.
-         */
-        testId?: string;
-        /**
-         * Specifies if the input field is read-only.
-         */
-        readOnly?: boolean;
-        /**
-         * Whether this field should autofocus on page load.
-         */
-        autoFocus?: boolean;
-        /**
-         * Specifies if the input field allows autocomplete.
-         */
-        autoComplete?: string;
-    };
-
+type FullNumericInputProps = CommonProps & NumericInputProps;
+type Props = OtherInputProps | FullNumericInputProps;
 type PropsWithForwardRef = Props & WithForwardRef;
 
 type DefaultProps = {
@@ -252,9 +254,6 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             autoFocus,
             autoComplete,
             forwardedRef,
-            min,
-            max,
-            step,
             // The following props are being included here to avoid
             // passing them down to the otherProps spread
             /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -268,12 +267,6 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             // Should only include Aria related props
             ...otherProps
         } = this.props;
-
-        if ((min || max || step) && type !== "number") {
-            throw new Error(
-                'The props `min`, `max`, and `step` can only be used with `type="number"`.',
-            );
-        }
 
         return (
             <StyledInput
@@ -310,9 +303,6 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                 autoFocus={autoFocus}
                 autoComplete={autoComplete}
                 ref={forwardedRef}
-                min={min}
-                max={max}
-                step={step}
                 {...otherProps}
                 aria-invalid={this.state.error ? "true" : "false"}
             />

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -269,6 +269,10 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             ...otherProps
         } = this.props;
 
+        // TODO: Remove this check once we update to React 19 and make this
+        // a function component. As is, adding type restrictions alone won't
+        // prevent these props from being used with the wrong type, because
+        // the ref forwarding causes weird type issues involving unions.
         if ((min || max || step) && type !== "number") {
             throw new Error(
                 'The props `min`, `max`, and `step` can only be used with `type="number"`.',

--- a/packages/wonder-blocks-form/src/util/types.ts
+++ b/packages/wonder-blocks-form/src/util/types.ts
@@ -77,3 +77,9 @@ export type RadioGroupProps = {
     /** Value of the selected radio item. */
     selectedValue: string;
 };
+
+// For more information, see:
+// https://github.com/microsoft/TypeScript/wiki/FAQ#add-a-key-constraint-to-omit
+export type OmitConstrained<T, K> = {
+    [P in keyof T as Exclude<P, K & keyof any>]: T[P];
+};


### PR DESCRIPTION
## Summary:
HTML `<input>` elements have `min`, `max`, and `step` props.

Adding them here to TextField to better align with HTML props.

Issue: none

## Test plan:
Storybook
http://localhost:6061/?path=/story/packages-form-textfield--number