### PR TITLE
Pass aria attributes to pill

### DIFF
--- a/.changeset/tender-frogs-appear.md
+++ b/.changeset/tender-frogs-appear.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-pill": minor
+---
+
+Aria props are now properly applied to pill component.

--- a/packages/wonder-blocks-pill/src/components/__tests__/pill.test.tsx
+++ b/packages/wonder-blocks-pill/src/components/__tests__/pill.test.tsx
@@ -37,6 +37,7 @@ describe("Pill", () => {
             <Pill
                 id="pill-id"
                 role="radio"
+                aria-checked="true"
                 testId="pill-test-id"
                 onClick={() => {}}
                 ref={pillRef}
@@ -49,6 +50,7 @@ describe("Pill", () => {
         expect(pillRef.current).toHaveAttribute("id", "pill-id");
         expect(pillRef.current).toHaveAttribute("role", "radio");
         expect(pillRef.current).toHaveAttribute("data-testid", "pill-test-id");
+        expect(pillRef.current).toHaveAttribute("aria-checked", "true");
     });
 
     test("is Clickable if onClick is passed in (mouse click)", async () => {

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -118,6 +118,7 @@ const Pill = React.forwardRef(function Pill(
         onClick,
         style,
         testId,
+        ...ariaProps
     } = props;
 
     let wrapperSizeStyle;
@@ -150,6 +151,7 @@ const Pill = React.forwardRef(function Pill(
                 style={[defaultStyles, colorStyles.clickableWrapper, style]}
                 testId={testId}
                 ref={ref as React.ForwardedRef<HTMLButtonElement>}
+                {...ariaProps}
             >
                 {() => <PillInner size={size}>{children}</PillInner>}
             </Clickable>
@@ -163,6 +165,7 @@ const Pill = React.forwardRef(function Pill(
             style={[defaultStyles, style]}
             testId={testId}
             ref={ref as React.ForwardedRef<HTMLElement>}
+            {...ariaProps}
         >
             <PillInner size={size}>{children}</PillInner>
         </View>

--- a/packages/wonder-blocks-popover/src/components/popover-content.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content.tsx
@@ -15,7 +15,7 @@ type CommonProps = AriaProps & {
     /**
      * The content to render inside the popover.
      */
-    content: React.ReactNode;
+    content: string;
     /**
      * The popover title
      */

--- a/packages/wonder-blocks-popover/src/components/popover-content.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content.tsx
@@ -15,7 +15,7 @@ type CommonProps = AriaProps & {
     /**
      * The content to render inside the popover.
      */
-    content: string;
+    content: React.ReactNode;
     /**
      * The popover title
      */


### PR DESCRIPTION
Previously, aria attributes were accepted as props, but nothing was done with them. I have passed the aria attributes to the `clickable` and the `view` so that they can be used.