### PR TITLE
Prevent dropdown item focus when enableTypeAhead is false

### DIFF
--- a/.changeset/afraid-coats-call.md
+++ b/.changeset/afraid-coats-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Prevent dropdown item focus when enableTypeAhead is false

--- a/.changeset/afraid-coats-call.md
+++ b/.changeset/afraid-coats-call.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/wonder-blocks-dropdown": minor
+"@khanacademy/wonder-blocks-dropdown": patch
 ---
 
 Prevent dropdown item focus when enableTypeAhead is false

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -519,7 +519,7 @@ const VirtualizedSingleSelect = function (props: Props): React.ReactElement {
  */
 export const VirtualizedFilterableWithoutEnableTypeAhead: StoryComponentType = {
     name: "Virtualized (isFilterable:true, enableTypeAhead:false)",
-    render: () => <VirtualizedSingleSelect enableTypeAhead={false} />,
+    render: () => <VirtualizedSingleSelect enableTypeAhead={false} selectedValue={"ZW"}/>,
     parameters: {
         chromatic: {
             // we don't need screenshots because this story only tests behavior.
@@ -538,7 +538,7 @@ export const VirtualizedFilterableWithoutEnableTypeAhead: StoryComponentType = {
  */
 export const VirtualizedFilterable: StoryComponentType = {
     name: "Virtualized (isFilterable:true, enableTypeAhead:true)",
-    render: () => <VirtualizedSingleSelect />,
+    render: () => <VirtualizedSingleSelect enableTypeAhead={true} />,
     parameters: {
         chromatic: {
             // we don't need screenshots because this story only tests behavior.

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -519,7 +519,9 @@ const VirtualizedSingleSelect = function (props: Props): React.ReactElement {
  */
 export const VirtualizedFilterableWithoutEnableTypeAhead: StoryComponentType = {
     name: "Virtualized (isFilterable:true, enableTypeAhead:false)",
-    render: () => <VirtualizedSingleSelect enableTypeAhead={false} selectedValue={"ZW"}/>,
+    render: () => (
+        <VirtualizedSingleSelect enableTypeAhead={false} selectedValue={"ZW"} />
+    ),
     parameters: {
         chromatic: {
             // we don't need screenshots because this story only tests behavior.

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -481,6 +481,7 @@ const optionItems = allCountries.map(([code, translatedName]) => (
 ));
 
 type Props = {
+    enableTypeAhead?: boolean;
     selectedValue?: string | null | undefined;
     opened?: boolean;
 };
@@ -502,6 +503,7 @@ const VirtualizedSingleSelect = function (props: Props): React.ReactElement {
                 selectedValue={selectedValue}
                 dropdownStyle={styles.fullBleed}
                 style={styles.fullBleed}
+                enableTypeAhead={props.enableTypeAhead}
             >
                 {optionItems}
             </SingleSelect>
@@ -515,8 +517,27 @@ const VirtualizedSingleSelect = function (props: Props): React.ReactElement {
  * option items. Note that this example shows how we can add custom styles to
  * the dropdown as well.
  */
+export const VirtualizedFilterableWithoutEnableTypeAhead: StoryComponentType = {
+    name: "Virtualized (isFilterable:true, enableTypeAhead:false)",
+    render: () => <VirtualizedSingleSelect enableTypeAhead={false} />,
+    parameters: {
+        chromatic: {
+            // we don't need screenshots because this story only tests behavior.
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
+ * When there are many options, you could use a search filter in the
+ * SingleSelect. The search filter will be performed toward the labels of the
+ * option items. The enableTypeAhead will focus on the first dropdown item
+ * whose label starts with the search filter.
+ * Note that this example shows how we can add custom styles to the dropdown
+ * as well.
+ */
 export const VirtualizedFilterable: StoryComponentType = {
-    name: "Virtualized (isFilterable)",
+    name: "Virtualized (isFilterable:true, enableTypeAhead:true)",
     render: () => <VirtualizedSingleSelect />,
     parameters: {
         chromatic: {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -571,9 +571,10 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusPreviousItem(): void {
-        if (this.isSearchFieldFocused() && !this.props.enableTypeAhead) {
-            this.focusedIndex = this.state.itemRefs.length - 1;
-        } else if (this.focusedIndex === 0) {
+        if (
+            this.focusedIndex === 0 ||
+            (this.isSearchFieldFocused() && !this.props.enableTypeAhead)
+        ) {
             // Move the focus to the search field if it is the first item.
             if (this.hasSearchField() && !this.isSearchFieldFocused()) {
                 return this.focusSearchField();
@@ -587,9 +588,10 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusNextItem(): void {
-        if (this.isSearchFieldFocused() && !this.props.enableTypeAhead) {
-            this.focusedIndex = 0;
-        } else if (this.focusedIndex === this.state.itemRefs.length - 1) {
+        if (
+            this.focusedIndex === this.state.itemRefs.length - 1 ||
+            (this.isSearchFieldFocused() && !this.props.enableTypeAhead)
+        ) {
             // Move the focus to the search field if it is the last item.
             if (this.hasSearchField() && !this.isSearchFieldFocused()) {
                 return this.focusSearchField();

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -381,7 +381,7 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props) {
-        const {open} = this.props;
+        const {open, searchText} = this.props;
 
         if (prevProps.open !== open) {
             this.updateEventListeners();
@@ -396,7 +396,7 @@ class DropdownCore extends React.Component<Props, State> {
             // Very rarely do the set of focusable items change if the menu
             // hasn't been re-opened. This is for cases like a {Select all}
             // option that becomes disabled iff all the options are selected.
-            if (sameItemsFocusable) {
+            if (sameItemsFocusable || prevProps.searchText !== searchText) {
                 return;
             } else {
                 // If the set of items that was focusabled changed, it's very
@@ -411,7 +411,7 @@ class DropdownCore extends React.Component<Props, State> {
                     // Can't find the originally focused item, return focus to
                     // the first item that IS focusable
                     this.focusedIndex = 0;
-                    // Reset the knowlege that things had been clicked
+                    // Reset the knowledge that things had been clicked
                     this.itemsClicked = false;
                     this.scheduleToFocusCurrentItem();
                 } else {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -571,10 +571,9 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusPreviousItem(): void {
-        if (this.isSearchFieldFocused() && !this.props.enableTypeAhead){
+        if (this.isSearchFieldFocused() && !this.props.enableTypeAhead) {
             this.focusedIndex = this.state.itemRefs.length - 1;
-        }
-        else if (this.focusedIndex === 0) {
+        } else if (this.focusedIndex === 0) {
             // Move the focus to the search field if it is the first item.
             if (this.hasSearchField() && !this.isSearchFieldFocused()) {
                 return this.focusSearchField();
@@ -588,10 +587,9 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusNextItem(): void {
-        if (this.isSearchFieldFocused() && !this.props.enableTypeAhead){
+        if (this.isSearchFieldFocused() && !this.props.enableTypeAhead) {
             this.focusedIndex = 0;
-        }
-        else if (this.focusedIndex === this.state.itemRefs.length - 1) {
+        } else if (this.focusedIndex === this.state.itemRefs.length - 1) {
             // Move the focus to the search field if it is the last item.
             if (this.hasSearchField() && !this.isSearchFieldFocused()) {
                 return this.focusSearchField();

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -571,7 +571,10 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusPreviousItem(): void {
-        if (this.focusedIndex === 0) {
+        if (this.isSearchFieldFocused() && !this.props.enableTypeAhead){
+            this.focusedIndex = this.state.itemRefs.length - 1;
+        }
+        else if (this.focusedIndex === 0) {
             // Move the focus to the search field if it is the first item.
             if (this.hasSearchField() && !this.isSearchFieldFocused()) {
                 return this.focusSearchField();
@@ -585,7 +588,10 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusNextItem(): void {
-        if (this.focusedIndex === this.state.itemRefs.length - 1) {
+        if (this.isSearchFieldFocused() && !this.props.enableTypeAhead){
+            this.focusedIndex = 0;
+        }
+        else if (this.focusedIndex === this.state.itemRefs.length - 1) {
             // Move the focus to the search field if it is the last item.
             if (this.hasSearchField() && !this.isSearchFieldFocused()) {
                 return this.focusSearchField();


### PR DESCRIPTION
## Summary:
Requirement: When enableTypeAhead is set to false, Single Select component should not auto focus on a dropdown item when the search text changes.
This PR prvents the dropdown item from from focus when the search text changes the first time. 

Issue: DIST-4569

## Test plan: