### PR TITLE
LabeledTextField: Fix `onValidate` prop to be called properly

### DIFF
--- a/.changeset/ten-forks-repair.md
+++ b/.changeset/ten-forks-repair.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Fix onValidate prop so it gets properly called when it is defined in the call site

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
@@ -703,4 +703,45 @@ describe("Required LabeledTextField", () => {
             errorMessage,
         );
     });
+
+    test("displays an error even when onValidate is set", async () => {
+        // Arrange
+        const errorMessage = "Empty string!";
+
+        const validate = (value: string): string | null | undefined => {
+            if (value === "") {
+                return errorMessage;
+            }
+        };
+
+        const TextFieldWrapper = () => {
+            const [value, setValue] = React.useState("initial");
+            return (
+                <LabeledTextField
+                    label="Label"
+                    value={value}
+                    onChange={setValue}
+                    validate={validate}
+                    onValidate={jest.fn()}
+                    testId="test-labeled-text-field"
+                />
+            );
+        };
+
+        render(<TextFieldWrapper />);
+
+        const textField = await screen.findByTestId(
+            "test-labeled-text-field-field",
+        );
+        textField.focus();
+        await userEvent.clear(textField);
+
+        // Act
+        textField.blur();
+
+        // Assert
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            errorMessage,
+        );
+    });
 });

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -220,6 +220,12 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
             autoComplete,
             forwardedRef,
             ariaDescribedby,
+            // NOTE: We are not using this prop, but we need to remove it from
+            // `otherProps` so it doesn't override the `handleValidate` function
+            // call. We use `otherProps` due to a limitation in TypeScript where
+            // we can't easily extract the props when using a discriminated
+            // union.
+            onValidate: _,
             // numeric input props
             ...otherProps
         } = this.props;


### PR DESCRIPTION
## Summary:

Fixes an issue where the `onValidate` prop was not being called when the
callback was provided in the call site. This caused a weird behavior where
the `handleValidate` function inside `LabeledTextField` never got called.

See https://github.com/Khan/webapp/actions/runs/9273558563/job/25513924364?pr=22121
for more context in the failure.

Issue: XXX-XXXX

## Test plan:

Verify that unit tests pass.