### PR TITLE
Allow SingleSelect and MultiSelect to be focusable when disabled

### DIFF
--- a/.changeset/rotten-actors-flow.md
+++ b/.changeset/rotten-actors-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Allow `SingleSelect` and `MultiSelect` to be focusable when disabled. These components now have `aria-disabled` when the `disabled` prop is `true`. This makes it so screenreaders will continue to communicate that the component is disabled, while allowing focus on the disabled component. Focus styling is also added to the disabled state.

--- a/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
+++ b/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
@@ -105,17 +105,18 @@ export const BirthdayPickerWithCustomLabels: StoryComponentType = {
     },
 };
 
+/**
+ * A BirthdayPicker can be disabled by passing the `disabled` prop. This will
+ * disable all the dropdown controls and prevent them from being interacted with.
+ *
+ * Note: The `disabled` prop sets the `aria-disabled` attribute to `true`
+ * instead of setting the `disabled` attribute. This is so that the component
+ * remains focusable while communicating to screen readers that it is disabled.
+ */
 export const DisabledBirthdayPicker: StoryComponentType = {
     args: {
         onChange: () => {},
         disabled: true,
-    },
-    parameters: {
-        docs: {
-            description: {
-                story: "A BirthdayPicker can be disabled by passing the `disabled` prop. This will disable all the dropdown controls and prevent them from being interacted with.",
-            },
-        },
     },
 };
 

--- a/__docs__/wonder-blocks-dropdown/multi-select-variants.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select-variants.stories.tsx
@@ -1,0 +1,145 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import type {Meta, StoryObj} from "@storybook/react";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {HeadingLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+
+/**
+ * The following stories are used to generate the pseudo states for the
+ * multi select component. This is only used for visual testing in Chromatic.
+ */
+export default {
+    title: "Packages / Dropdown / MultiSelect / All Variants",
+    parameters: {
+        docs: {
+            autodocs: false,
+        },
+    },
+} as Meta;
+
+type StoryComponentType = StoryObj<typeof MultiSelect>;
+
+const defaultProps = {
+    onChange: () => {},
+};
+
+const selectItems = [
+    <OptionItem label="item 1" value="1" />,
+    <OptionItem label="item 2" value="2" />,
+    <OptionItem label="item 3" value="3" />,
+];
+
+const KindVariants = ({light}: {light: boolean}) => {
+    return (
+        <ThemeSwitcherContext.Consumer>
+            {(theme) => (
+                <>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
+                            Default
+                        </LabelMedium>
+                        <MultiSelect {...defaultProps} light={light}>
+                            {selectItems}
+                        </MultiSelect>
+                    </View>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
+                            Disabled
+                        </LabelMedium>
+                        <MultiSelect
+                            {...defaultProps}
+                            light={light}
+                            disabled={true}
+                        >
+                            {selectItems}
+                        </MultiSelect>
+                    </View>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
+                            Error
+                        </LabelMedium>
+                        <MultiSelect
+                            {...defaultProps}
+                            light={light}
+                            error={true}
+                        >
+                            {selectItems}
+                        </MultiSelect>
+                    </View>
+                </>
+            )}
+        </ThemeSwitcherContext.Consumer>
+    );
+};
+
+const VariantsByTheme = ({themeName = "Default"}: {themeName?: string}) => (
+    <View style={{marginBottom: spacing.large_24}}>
+        <HeadingLarge>{themeName} theme</HeadingLarge>
+        <View style={styles.grid}>
+            <KindVariants light={false} />
+            <KindVariants light={true} />
+        </View>
+    </View>
+);
+
+const AllVariants = () => (
+    <>
+        <VariantsByTheme />
+        <ThemeSwitcherContext.Provider value="khanmigo">
+            <VariantsByTheme themeName="Khanmigo" />
+        </ThemeSwitcherContext.Provider>
+    </>
+);
+
+export const Default: StoryComponentType = {
+    render: AllVariants,
+};
+
+const styles = StyleSheet.create({
+    darkDefault: {
+        backgroundColor: color.darkBlue,
+    },
+    darkKhanmigo: {
+        backgroundColor: color.eggplant,
+    },
+    grid: {
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 250px)",
+        gap: spacing.large_24,
+    },
+    gridRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: spacing.medium_16,
+        justifyContent: "space-between",
+        padding: spacing.medium_16,
+    },
+});

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -386,6 +386,10 @@ export const DropdownInModal: StoryComponentType = {
 /**
  * `MultiSelect` can be disabled by passing `disabled={true}`. This can be
  * useful when you want to disable a control temporarily.
+ *
+ * Note: The `disabled` prop sets the `aria-disabled` attribute to `true`
+ * instead of setting the `disabled` attribute. This is so that the component
+ * remains focusable while communicating to screen readers that it is disabled.
  */
 export const Disabled: StoryComponentType = {
     render: () => (

--- a/__docs__/wonder-blocks-dropdown/single-select-variants.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select-variants.stories.tsx
@@ -1,0 +1,146 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import type {Meta, StoryObj} from "@storybook/react";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {HeadingLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {SingleSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+
+/**
+ * The following stories are used to generate the pseudo states for the
+ * single select component. This is only used for visual testing in Chromatic.
+ */
+export default {
+    title: "Packages / Dropdown / SingleSelect / All Variants",
+    parameters: {
+        docs: {
+            autodocs: false,
+        },
+    },
+} as Meta;
+
+type StoryComponentType = StoryObj<typeof SingleSelect>;
+
+const defaultProps = {
+    placeholder: "Placeholder",
+    onChange: () => {},
+};
+
+const selectItems = [
+    <OptionItem label="item 1" value="1" />,
+    <OptionItem label="item 2" value="2" />,
+    <OptionItem label="item 3" value="3" />,
+];
+
+const KindVariants = ({light}: {light: boolean}) => {
+    return (
+        <ThemeSwitcherContext.Consumer>
+            {(theme) => (
+                <>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
+                            Default
+                        </LabelMedium>
+                        <SingleSelect {...defaultProps} light={light}>
+                            {selectItems}
+                        </SingleSelect>
+                    </View>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
+                            Disabled
+                        </LabelMedium>
+                        <SingleSelect
+                            {...defaultProps}
+                            light={light}
+                            disabled={true}
+                        >
+                            {selectItems}
+                        </SingleSelect>
+                    </View>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
+                            Error
+                        </LabelMedium>
+                        <SingleSelect
+                            {...defaultProps}
+                            light={light}
+                            error={true}
+                        >
+                            {selectItems}
+                        </SingleSelect>
+                    </View>
+                </>
+            )}
+        </ThemeSwitcherContext.Consumer>
+    );
+};
+
+const VariantsByTheme = ({themeName = "Default"}: {themeName?: string}) => (
+    <View style={{marginBottom: spacing.large_24}}>
+        <HeadingLarge>{themeName} theme</HeadingLarge>
+        <View style={styles.grid}>
+            <KindVariants light={false} />
+            <KindVariants light={true} />
+        </View>
+    </View>
+);
+
+const AllVariants = () => (
+    <>
+        <VariantsByTheme />
+        <ThemeSwitcherContext.Provider value="khanmigo">
+            <VariantsByTheme themeName="Khanmigo" />
+        </ThemeSwitcherContext.Provider>
+    </>
+);
+
+export const Default: StoryComponentType = {
+    render: AllVariants,
+};
+
+const styles = StyleSheet.create({
+    darkDefault: {
+        backgroundColor: color.darkBlue,
+    },
+    darkKhanmigo: {
+        backgroundColor: color.eggplant,
+    },
+    grid: {
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 250px)",
+        gap: spacing.large_24,
+    },
+    gridRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: spacing.medium_16,
+        justifyContent: "space-between",
+        padding: spacing.medium_16,
+    },
+});

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -335,7 +335,12 @@ export const LongOptionLabels: StoryComponentType = {
 };
 
 /**
- * This select is disabled and cannot be interacted with.
+ * `SingleSelect` can be disabled by passing `disabled={true}`. This can be
+ * useful when you want to disable a control temporarily.
+ *
+ * Note: The `disabled` prop sets the `aria-disabled` attribute to `true`
+ * instead of setting the `disabled` attribute. This is so that the component
+ * remains focusable while communicating to screen readers that it is disabled.
  */
 export const Disabled: StoryComponentType = {
     render: (args) => (

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
@@ -162,9 +162,9 @@ describe("BirthdayPicker", () => {
             );
 
             // Assert
-            expect(monthPicker).toBeDisabled();
-            expect(dayPicker).toBeDisabled();
-            expect(yearPicker).toBeDisabled();
+            expect(monthPicker).toHaveAttribute("aria-disabled", "true");
+            expect(dayPicker).toHaveAttribute("aria-disabled", "true");
+            expect(yearPicker).toHaveAttribute("aria-disabled", "true");
         });
 
         it("renders an error with an invalid default value", async () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -1590,4 +1590,90 @@ describe("MultiSelect", () => {
             );
         });
     });
+
+    describe("a11y > Focusable", () => {
+        it("should be focusable", () => {
+            // Arrange
+            doRender(
+                <MultiSelect onChange={jest.fn()} testId="select-focus-test">
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const multiSelect = screen.getByTestId("select-focus-test");
+            multiSelect.focus();
+
+            // Assert
+            expect(multiSelect).toHaveFocus();
+        });
+
+        it("should be focusable when disabled", () => {
+            // Arrange
+            doRender(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    testId="select-focus-test"
+                    disabled={true}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            const multiSelect = screen.getByTestId("select-focus-test");
+            multiSelect.focus();
+
+            // Assert
+            expect(multiSelect).toHaveFocus();
+        });
+    });
+
+    describe("Disabled state", () => {
+        it("should set the `aria-disabled` attribute to `true` if `disabled` prop is `true`", () => {
+            // Arrange
+
+            // Act
+            doRender(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    testId="select-focus-test"
+                    disabled={true}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+            const multiSelect = screen.getByTestId("select-focus-test");
+
+            // Assert
+            expect(multiSelect).toHaveAttribute("aria-disabled", "true");
+        });
+
+        it("should not set the `disabled` attribute if `disabled` prop is `true` since `aria-disabled` is used instead", () => {
+            // Arrange
+
+            // Act
+            doRender(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    testId="select-focus-test"
+                    disabled={true}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </MultiSelect>,
+            );
+            const multiSelect = screen.getByTestId("select-focus-test");
+
+            // Assert
+            expect(multiSelect).not.toHaveAttribute("disabled");
+        });
+    });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1128,4 +1128,97 @@ describe("SingleSelect", () => {
             );
         });
     });
+
+    describe("a11y > Focusable", () => {
+        it("should be focusable", () => {
+            // Arrange
+            doRender(
+                <SingleSelect
+                    placeholder="Default placeholder"
+                    onChange={jest.fn()}
+                    testId="select-focus-test"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+
+            // Act
+            const singleSelect = screen.getByTestId("select-focus-test");
+            singleSelect.focus();
+
+            // Assert
+            expect(singleSelect).toHaveFocus();
+        });
+
+        it("should be focusable when disabled", () => {
+            // Arrange
+            doRender(
+                <SingleSelect
+                    placeholder="Default placeholder"
+                    onChange={jest.fn()}
+                    testId="select-focus-test"
+                    disabled={true}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+
+            // Act
+            const singleSelect = screen.getByTestId("select-focus-test");
+            singleSelect.focus();
+
+            // Assert
+            expect(singleSelect).toHaveFocus();
+        });
+    });
+
+    describe("Disabled state", () => {
+        it("should set the `aria-disabled` attribute to `true` if `disabled` prop is `true`", () => {
+            // Arrange
+
+            // Act
+            doRender(
+                <SingleSelect
+                    placeholder="Default placeholder"
+                    onChange={jest.fn()}
+                    testId="select-focus-test"
+                    disabled={true}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+            const singleSelect = screen.getByTestId("select-focus-test");
+
+            // Assert
+            expect(singleSelect).toHaveAttribute("aria-disabled", "true");
+        });
+
+        it("should not set the `disabled` attribute if `disabled` prop is `true` since `aria-disabled` is used instead", () => {
+            // Arrange
+
+            // Act
+            doRender(
+                <SingleSelect
+                    placeholder="Default placeholder"
+                    onChange={jest.fn()}
+                    testId="select-focus-test"
+                    disabled={true}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                    <OptionItem label="item 3" value="3" />
+                </SingleSelect>,
+            );
+            const singleSelect = screen.getByTestId("select-focus-test");
+
+            // Assert
+            expect(singleSelect).not.toHaveAttribute("disabled");
+        });
+    });
 });

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -261,6 +261,9 @@ const _generateStyles = (
                 borderColor: mix(tokens.color.white32, tokens.color.blue),
                 color: mix(tokens.color.white32, tokens.color.blue),
                 cursor: "auto",
+                ":focus": {
+                    boxShadow: `0 0 0 1px ${tokens.color.offBlack32}, 0 0 0 3px ${tokens.color.fadedBlue}`,
+                },
             },
         };
     } else {
@@ -293,6 +296,9 @@ const _generateStyles = (
                 borderColor: tokens.color.offBlack16,
                 color: tokens.color.offBlack64,
                 cursor: "auto",
+                ":focus": {
+                    boxShadow: `0 0 0 1px ${tokens.color.white}, 0 0 0 3px ${tokens.color.offBlack32}`,
+                },
             },
         };
     }

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -132,10 +132,10 @@ export default class SelectOpener extends React.Component<SelectOpenerProps> {
                     return (
                         <StyledButton
                             {...sharedProps}
+                            aria-disabled={disabled}
                             aria-expanded={open ? "true" : "false"}
                             aria-haspopup="listbox"
                             data-testid={testId}
-                            disabled={disabled}
                             id={id}
                             style={style}
                             type="button"


### PR DESCRIPTION
## Summary:
- Use `aria-disabled` instead of `disabled` for SelectOpener so that the disabled state can be focusable. This makes it consistent with disabled buttons
- Add focus styling for disabled SelectOpener for both light and non-light types
- Add single/multiselect variant stories with states. When creating the new stories to show all the variants, I noticed two things (I will address these in a separate pull request!):
  - The error state styling needs to be updated when the `light` prop is `true` 
  - The state styling (focus, hover, active) can be moved from JS to CSS pseudoclasses (ie. `:focus-visible`, `:hover`, `:active`). By doing this, we can simplify logic and also utilize the Storybook pseudostates addon for visual regression tests (I'll add stories for the different states once this is updated!) 


Issue: WB-1238

## Test plan:
- Verify that the components using SelectOpener (SingleSelect, MultiSelect, BirthdayPicker) can be focused on when they are in a disabled state
- Verify focus styling on the SingleSelect and MultiSelect components (specifically when they are disabled)
- Verify that screen readers still communicate that the components are in a disabled state (from the `aria-disabled` attribute)
- Verify new all variants stories:
  - `?path=/docs/packages-dropdown-singleselect-all-variants--docs`
  - `?path=/docs/packages-dropdown-multiselect-all-variants--docs`

## Screen recording:
Single Select - VoiceOver (Safari) and Keyboard Navigation 

https://github.com/Khan/wonder-blocks/assets/14334617/017ee324-2fd5-4da5-9cf2-3d2ee69dfe77


