### PR TITLE
WB-1092: Make id prop optional in TextField

### DIFF
--- a/.changeset/chatty-crews-visit.md
+++ b/.changeset/chatty-crews-visit.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-form": major
+"@khanacademy/wonder-blocks-search-field": patch
+---
+
+Make `id` prop optional in `TextField`.

--- a/.changeset/chatty-crews-visit.md
+++ b/.changeset/chatty-crews-visit.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/wonder-blocks-form": major
+"@khanacademy/wonder-blocks-form": minor
 "@khanacademy/wonder-blocks-search-field": patch
 ---
 

--- a/__docs__/wonder-blocks-form/text-field.argtypes.ts
+++ b/__docs__/wonder-blocks-form/text-field.argtypes.ts
@@ -2,8 +2,9 @@ import type {InputType} from "@storybook/csf";
 
 export default {
     id: {
-        description: "The unique identifier for the input.",
-        type: {name: "string", required: true},
+        description:
+            "An optional unique identifier for the TextField. If no id is specified, a unique id will be auto-generated.",
+        type: {name: "string"},
         table: {
             type: {
                 summary: "string",

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -32,7 +32,6 @@ type StoryComponentType = StoryObj<typeof TextField>;
 
 export const Default: StoryComponentType = {
     args: {
-        id: "some-id",
         type: "text",
         value: "",
         disabled: false,

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
@@ -61,10 +61,13 @@ describe("LabeledTextField", () => {
         render(<LabeledTextField label="Label" value="" onChange={() => {}} />);
 
         // Assert
-        // Since the generated id is unique, we cannot know what it will be.
-        // We only test if the id attribute starts with "uid-" and ends with "-field".
+        // Since the generated id is unique, we cannot know what it will be. We
+        // only test if the id attribute starts with "uid-", then followed by
+        // "text-field-" as the scope assigned to IDProvider.
         const input = await screen.findByRole("textbox");
-        expect(input.getAttribute("id")).toMatch(/uid-.*-field/);
+        expect(input.getAttribute("id")).toMatch(
+            /uid-labeled-text-field.*-field/,
+        );
     });
 
     it("type prop is passed to input", async () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
@@ -8,6 +8,33 @@ import Button from "@khanacademy/wonder-blocks-button";
 import TextField from "../text-field";
 
 describe("TextField", () => {
+    it("id prop is passed to input", async () => {
+        // Arrange
+
+        // Act
+        render(<TextField id="custom-id" value="" onChange={() => {}} />);
+
+        // Assert
+        expect(await screen.findByRole("textbox")).toHaveAttribute(
+            "id",
+            "custom-id",
+        );
+    });
+
+    it("auto-generated id is passed to input when id prop is not set", async () => {
+        // Arrange
+
+        // Act
+        render(<TextField value="" onChange={() => {}} />);
+
+        // Assert
+        // Since the generated id is unique, we cannot know what it will be. We
+        // only test if the id attribute starts with "uid-", then followed by
+        // "text-field-" as the scope assigned to IDProvider.
+        const input = await screen.findByRole("textbox");
+        expect(input.getAttribute("id")).toMatch(/uid-text-field-.*$/);
+    });
+
     it("textfield is focused", async () => {
         // Arrange
         render(<TextField id="tf-1" value="" onChange={() => {}} />);

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {mix, color, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {IDProvider, addStyle} from "@khanacademy/wonder-blocks-core";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
@@ -20,9 +20,10 @@ const StyledInput = addStyle("input");
 
 type CommonProps = AriaProps & {
     /**
-     * The unique identifier for the input.
+     * An optional unique identifier for the TextField.
+     * If no id is specified, a unique id will be auto-generated.
      */
-    id: string;
+    id?: string;
     /**
      * The input value.
      */
@@ -270,43 +271,47 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
         } = this.props;
 
         return (
-            <StyledInput
-                style={[
-                    styles.input,
-                    typographyStyles.LabelMedium,
-                    styles.default,
-                    // Prioritizes disabled, then focused, then error (if any)
-                    disabled
-                        ? styles.disabled
-                        : this.state.focused
-                        ? [styles.focused, light && styles.defaultLight]
-                        : !!this.state.error && [
-                              styles.error,
-                              light && styles.errorLight,
-                          ],
-                    // Cast `this.state.error` into boolean since it's being
-                    // used as a conditional
-                    !!this.state.error && styles.error,
-                    style && style,
-                ]}
-                id={id}
-                type={type}
-                placeholder={placeholder}
-                value={value}
-                name={name}
-                disabled={disabled}
-                onChange={this.handleChange}
-                onKeyDown={onKeyDown}
-                onFocus={this.handleFocus}
-                onBlur={this.handleBlur}
-                data-testid={testId}
-                readOnly={readOnly}
-                autoFocus={autoFocus}
-                autoComplete={autoComplete}
-                ref={forwardedRef}
-                {...otherProps}
-                aria-invalid={this.state.error ? "true" : "false"}
-            />
+            <IDProvider id={id} scope="text-field">
+                {(uniqueId) => (
+                    <StyledInput
+                        style={[
+                            styles.input,
+                            typographyStyles.LabelMedium,
+                            styles.default,
+                            // Prioritizes disabled, then focused, then error (if any)
+                            disabled
+                                ? styles.disabled
+                                : this.state.focused
+                                ? [styles.focused, light && styles.defaultLight]
+                                : !!this.state.error && [
+                                      styles.error,
+                                      light && styles.errorLight,
+                                  ],
+                            // Cast `this.state.error` into boolean since it's being
+                            // used as a conditional
+                            !!this.state.error && styles.error,
+                            style && style,
+                        ]}
+                        id={uniqueId}
+                        type={type}
+                        placeholder={placeholder}
+                        value={value}
+                        name={name}
+                        disabled={disabled}
+                        onChange={this.handleChange}
+                        onKeyDown={onKeyDown}
+                        onFocus={this.handleFocus}
+                        onBlur={this.handleBlur}
+                        data-testid={testId}
+                        readOnly={readOnly}
+                        autoFocus={autoFocus}
+                        autoComplete={autoComplete}
+                        ref={forwardedRef}
+                        {...otherProps}
+                        aria-invalid={this.state.error ? "true" : "false"}
+                    />
+                )}
+            </IDProvider>
         );
     }
 }

--- a/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
+++ b/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
@@ -367,7 +367,9 @@ describe("SearchField", () => {
         const searchField = await screen.findByTestId("search-field-test");
 
         // Assert
-        expect(searchField.getAttribute("id")).toMatch(/^uid-.*-field$/);
+        expect(searchField.getAttribute("id")).toMatch(
+            /^uid-search-field.*-field$/,
+        );
     });
 
     test("has focus if autoFocus is true", async () => {


### PR DESCRIPTION
## Summary:

- Changed `id` prop to be optional.
- Use `IDProvider` to automatically generate the `id` if it’s not provided by
the caller.

Issue: WB-1092

## Test plan:

1. In Storybook, verify that the Default story auto-generates the `id` for the
input field: `?path=/story/packages-form-textfield--default`.
<img width="1944" alt="Screenshot 2024-06-05 at 4 30 53 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/b6d17fb1-7760-4d94-a643-36c0f7005a1d">

2. Modify the Default story to provide an `id` prop and verify that the `id` is
now used in the input field: `?path=/story/packages-form-textfield--default&args=id:some-custom-id`.
<img width="1649" alt="Screenshot 2024-06-05 at 4 31 49 PM" src="https://github.com/Khan/wonder-blocks/assets/843075/8c2431cd-b04f-4b7d-b37a-ae11dfc4f833">

