### PR TITLE
Fix hydration error in MediaLayout component

### DIFF
--- a/.changeset/few-mugs-speak.md
+++ b/.changeset/few-mugs-speak.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-layout": minor
+---
+
+Fix hydration issue in MediaLayout component

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout-context.test.tsx
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout-context.test.tsx
@@ -19,32 +19,33 @@ describe("MediaLayoutContext", () => {
     });
 
     describe("overrideSize", () => {
-        it("should override the currentSize", async () => {
+        it("should override the currentSize", () => {
             // Arrange
             resizeWindow("large");
+            const capturePropsFn = jest.fn();
 
             // Act
-            const args: any = await new Promise((resolve: any, reject: any) => {
-                render(
-                    <MediaLayoutContext.Provider
-                        value={{
-                            overrideSize: "small",
-                            ssrSize: "large",
-                            mediaSpec: MEDIA_DEFAULT_SPEC,
+            render(
+                <MediaLayoutContext.Provider
+                    value={{
+                        overrideSize: "small",
+                        ssrSize: "large",
+                        mediaSpec: MEDIA_DEFAULT_SPEC,
+                    }}
+                >
+                    <MediaLayout styleSheets={{}}>
+                        {({mediaSize, mediaSpec, styles}: any) => {
+                            capturePropsFn({mediaSize, mediaSpec, styles});
+                            return <View>Hello, world!</View>;
                         }}
-                    >
-                        <MediaLayout styleSheets={{}}>
-                            {({mediaSize, mediaSpec, styles}: any) => {
-                                resolve({mediaSize, mediaSpec, styles});
-                                return <View>Hello, world!</View>;
-                            }}
-                        </MediaLayout>
-                    </MediaLayoutContext.Provider>,
-                );
-            });
+                    </MediaLayout>
+                </MediaLayoutContext.Provider>,
+            );
 
             // Assert
-            expect(args.mediaSize).toEqual("small");
+            expect(capturePropsFn).toHaveBeenCalledWith(
+                expect.objectContaining({mediaSize: "small"}),
+            );
         });
     });
 
@@ -53,51 +54,54 @@ describe("MediaLayoutContext", () => {
             jest.spyOn(Server, "isServerSide").mockReturnValue(true);
         });
 
-        it("should use the default ssrSize on the server", async () => {
+        it("should use the default ssrSize on initial render", () => {
             // Arrange
-            const promise = new Promise((resolve: any, reject: any) => {
-                render(
-                    <MediaLayout styleSheets={{}}>
-                        {({mediaSize, mediaSpec, styles}: any) => {
-                            resolve({mediaSize, mediaSpec, styles});
-                            return <View>Hello, world!</View>;
-                        }}
-                    </MediaLayout>,
-                );
-            });
+            const capturePropsFn = jest.fn();
 
             // Act
-            const args: any = await promise;
+            render(
+                <MediaLayout styleSheets={{}}>
+                    {({mediaSize, mediaSpec, styles}: any) => {
+                        capturePropsFn({mediaSize, mediaSpec, styles});
+                        return <View>Hello, world!</View>;
+                    }}
+                </MediaLayout>,
+            );
 
             // Assert
-            expect(args.mediaSize).toEqual("large");
+            expect(capturePropsFn).toHaveBeenNthCalledWith(
+                1,
+                expect.objectContaining({mediaSize: "large"}),
+            );
         });
 
-        it("should use the provided ssrSize on the server", async () => {
+        it("should use the provided ssrSize on initial render", () => {
             // Arrange
+            const capturePropsFn = jest.fn();
 
             // Act
-            const args: any = await new Promise((resolve: any, reject: any) => {
-                render(
-                    <MediaLayoutContext.Provider
-                        value={{
-                            overrideSize: undefined,
-                            ssrSize: "small",
-                            mediaSpec: MEDIA_DEFAULT_SPEC,
+            render(
+                <MediaLayoutContext.Provider
+                    value={{
+                        overrideSize: undefined,
+                        ssrSize: "small",
+                        mediaSpec: MEDIA_DEFAULT_SPEC,
+                    }}
+                >
+                    <MediaLayout styleSheets={{}}>
+                        {({mediaSize, mediaSpec, styles}: any) => {
+                            capturePropsFn({mediaSize, mediaSpec, styles});
+                            return <View>Hello, world!</View>;
                         }}
-                    >
-                        <MediaLayout styleSheets={{}}>
-                            {({mediaSize, mediaSpec, styles}: any) => {
-                                resolve({mediaSize, mediaSpec, styles});
-                                return <View>Hello, world!</View>;
-                            }}
-                        </MediaLayout>
-                    </MediaLayoutContext.Provider>,
-                );
-            });
+                    </MediaLayout>
+                </MediaLayoutContext.Provider>,
+            );
 
             // Assert
-            expect(args.mediaSize).toEqual("small");
+            expect(capturePropsFn).toHaveBeenNthCalledWith(
+                1,
+                expect.objectContaining({mediaSize: "small"}),
+            );
         });
     });
 
@@ -105,57 +109,59 @@ describe("MediaLayoutContext", () => {
         it("MEDIA_INTERNAL_SPEC is always large", async () => {
             // Arrange
             resizeWindow("small");
+            const capturePropsFn = jest.fn();
 
             // Act
-            const args: any = await new Promise((resolve: any, reject: any) => {
-                render(
-                    <MediaLayoutContext.Provider
-                        value={{
-                            overrideSize: undefined,
-                            ssrSize: "small",
-                            mediaSpec: MEDIA_INTERNAL_SPEC,
+            render(
+                <MediaLayoutContext.Provider
+                    value={{
+                        overrideSize: undefined,
+                        ssrSize: "small",
+                        mediaSpec: MEDIA_INTERNAL_SPEC,
+                    }}
+                >
+                    <MediaLayout styleSheets={{}}>
+                        {({mediaSize, mediaSpec, styles}: any) => {
+                            capturePropsFn({mediaSize, mediaSpec, styles});
+                            return <View>Hello, world!</View>;
                         }}
-                    >
-                        <MediaLayout styleSheets={{}}>
-                            {({mediaSize, mediaSpec, styles}: any) => {
-                                resolve({mediaSize, mediaSpec, styles});
-                                return <View>Hello, world!</View>;
-                            }}
-                        </MediaLayout>
-                    </MediaLayoutContext.Provider>,
-                );
-            });
+                    </MediaLayout>
+                </MediaLayoutContext.Provider>,
+            );
 
             // Assert
-            expect(args.mediaSize).toEqual("large");
+            expect(capturePropsFn).toHaveBeenLastCalledWith(
+                expect.objectContaining({mediaSize: "large"}),
+            );
         });
 
         it("MEDIA_MODAL_SPEC is not medium", async () => {
             // Arrange
             resizeWindow("medium");
+            const capturePropsFn = jest.fn();
 
             // Act
-            const args: any = await new Promise((resolve: any, reject: any) => {
-                render(
-                    <MediaLayoutContext.Provider
-                        value={{
-                            overrideSize: undefined,
-                            ssrSize: "small",
-                            mediaSpec: MEDIA_MODAL_SPEC,
+            render(
+                <MediaLayoutContext.Provider
+                    value={{
+                        overrideSize: undefined,
+                        ssrSize: "small",
+                        mediaSpec: MEDIA_MODAL_SPEC,
+                    }}
+                >
+                    <MediaLayout styleSheets={{}}>
+                        {({mediaSize, mediaSpec, styles}: any) => {
+                            capturePropsFn({mediaSize, mediaSpec, styles});
+                            return <View>Hello, world!</View>;
                         }}
-                    >
-                        <MediaLayout styleSheets={{}}>
-                            {({mediaSize, mediaSpec, styles}: any) => {
-                                resolve({mediaSize, mediaSpec, styles});
-                                return <View>Hello, world!</View>;
-                            }}
-                        </MediaLayout>
-                    </MediaLayoutContext.Provider>,
-                );
-            });
+                    </MediaLayout>
+                </MediaLayoutContext.Provider>,
+            );
 
             // Assert
-            expect(args.mediaSize).toEqual("large");
+            expect(capturePropsFn).toHaveBeenLastCalledWith(
+                expect.objectContaining({mediaSize: "large"}),
+            );
         });
     });
 });

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.tsx
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.tsx
@@ -13,70 +13,67 @@ describe("MediaLayout", () => {
     });
 
     describe("mediaSize", () => {
-        it("should be small when viewport width < 768", async () => {
+        it("should be small when viewport width < 768", () => {
             // Arrange
             resizeWindow("small");
+            const capturePropsFn = jest.fn();
 
             // Act
-            const args: any = await new Promise((resolve: any, reject: any) => {
-                render(
-                    <MediaLayout>
-                        {({mediaSize, mediaSpec, styles}: any) => {
-                            resolve({mediaSize, mediaSpec, styles});
-                            return (
-                                <View style={styles.test}>Hello, world!</View>
-                            );
-                        }}
-                    </MediaLayout>,
-                );
-            });
+            render(
+                <MediaLayout>
+                    {({mediaSize, mediaSpec, styles}: any) => {
+                        capturePropsFn({mediaSize, mediaSpec, styles});
+                        return <View style={styles.test}>Hello, world!</View>;
+                    }}
+                </MediaLayout>,
+            );
 
             // Assert
-            expect(args.mediaSize).toEqual("small");
+            expect(capturePropsFn).toHaveBeenCalledWith(
+                expect.objectContaining({mediaSize: "small"}),
+            );
         });
 
-        it("should be medium when viewport 768 < width < 1024", async () => {
+        it("should be medium when viewport 768 < width < 1024", () => {
             // Arrange
             resizeWindow("medium");
+            const capturePropsFn = jest.fn();
 
             // Act
-            const args: any = await new Promise((resolve: any, reject: any) => {
-                render(
-                    <MediaLayout>
-                        {({mediaSize, mediaSpec, styles}: any) => {
-                            resolve({mediaSize, mediaSpec, styles});
-                            return (
-                                <View style={styles.test}>Hello, world!</View>
-                            );
-                        }}
-                    </MediaLayout>,
-                );
-            });
+            render(
+                <MediaLayout>
+                    {({mediaSize, mediaSpec, styles}: any) => {
+                        capturePropsFn({mediaSize, mediaSpec, styles});
+                        return <View style={styles.test}>Hello, world!</View>;
+                    }}
+                </MediaLayout>,
+            );
 
             // Assert
-            expect(args.mediaSize).toEqual("medium");
+            expect(capturePropsFn).toHaveBeenCalledWith(
+                expect.objectContaining({mediaSize: "medium"}),
+            );
         });
 
-        it("should be medium when viewport width > 1024", async () => {
+        it("should be medium when viewport width > 1024", () => {
             // Arrange
             resizeWindow("large");
+            const capturePropsFn = jest.fn();
 
             // Act
-            const args: any = await new Promise((resolve: any, reject: any) => {
-                render(
-                    <MediaLayout>
-                        {({mediaSize, mediaSpec, styles}: any) => {
-                            resolve({mediaSize, mediaSpec, styles});
-                            return (
-                                <View style={styles.test}>Hello, world!</View>
-                            );
-                        }}
-                    </MediaLayout>,
-                );
-            });
+            render(
+                <MediaLayout>
+                    {({mediaSize, mediaSpec, styles}: any) => {
+                        capturePropsFn({mediaSize, mediaSpec, styles});
+                        return <View style={styles.test}>Hello, world!</View>;
+                    }}
+                </MediaLayout>,
+            );
 
             // Assert
-            expect(args.mediaSize).toEqual("large");
+            expect(capturePropsFn).toHaveBeenCalledWith(
+                expect.objectContaining({mediaSize: "large"}),
+            );
         });
     });
 
@@ -86,7 +83,7 @@ describe("MediaLayout", () => {
         ${"medium"}
         ${"large"}
     `("styleSheets - $size", ({size}: {size: MediaSize}) => {
-        it(`should always provide styles from all`, async () => {
+        it(`should always provide styles from all`, () => {
             // Arrange
             const styleSheets = {
                 all: StyleSheet.create({
@@ -117,7 +114,7 @@ describe("MediaLayout", () => {
 
         it(`"mdOrSmaller" should match ${
             size === "large" ? "not" : ""
-        } "${size}"`, async () => {
+        } "${size}"`, () => {
             // Arrange
             const styleSheets = {
                 mdOrSmaller: StyleSheet.create({
@@ -158,7 +155,7 @@ describe("MediaLayout", () => {
 
         it(`"mdOrLarger" should match ${
             size === "small" ? "not" : ""
-        } "${size}"`, async () => {
+        } "${size}"`, () => {
             // Arrange
             const styleSheets = {
                 mdOrLarger: StyleSheet.create({
@@ -197,7 +194,7 @@ describe("MediaLayout", () => {
             expect(style.color).toBe(expectedColor);
         });
 
-        it(`styles should win over "all" styles`, async () => {
+        it(`styles should win over "all" styles`, () => {
             // Arrange
             const styleSheets = {
                 all: StyleSheet.create({
@@ -247,7 +244,7 @@ describe("MediaLayout", () => {
         });
 
         if (size !== "large") {
-            it(`"${size}" styles should win over "mdOrSmaller" styles`, async () => {
+            it(`"${size}" styles should win over "mdOrSmaller" styles`, () => {
                 // Arrange
                 const styleSheets = {
                     mdOrSmaller: StyleSheet.create({
@@ -292,7 +289,7 @@ describe("MediaLayout", () => {
         }
 
         if (size !== "small") {
-            it(`"${size}" styles should win over "mdOrLarger" styles`, async () => {
+            it(`"${size}" styles should win over "mdOrLarger" styles`, () => {
                 // Arrange
                 const styleSheets = {
                     mdOrLarger: StyleSheet.create({
@@ -338,7 +335,7 @@ describe("MediaLayout", () => {
     });
 
     describe("window resizing", () => {
-        it("should update the style when the window gets smaller", async () => {
+        it("should update the style when the window gets smaller", () => {
             // Arrange
             const styleSheets = {
                 large: StyleSheet.create({
@@ -378,7 +375,7 @@ describe("MediaLayout", () => {
             expect(style.color).toBe("orange");
         });
 
-        it("should update the style when the window gets larger", async () => {
+        it("should update the style when the window gets larger", () => {
             // Arrange
             const styleSheets = {
                 large: StyleSheet.create({

--- a/packages/wonder-blocks-layout/src/components/media-layout.tsx
+++ b/packages/wonder-blocks-layout/src/components/media-layout.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type {StyleDeclaration} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import {Server} from "@khanacademy/wonder-blocks-core";
+import {WithSSRPlaceholder} from "@khanacademy/wonder-blocks-core";
 import MediaLayoutContext from "./media-layout-context";
 import type {MediaSize, MediaSpec} from "../util/types";
 import type {Context} from "./media-layout-context";
@@ -138,15 +138,10 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
         return DEFAULT_SIZE;
     }
 
-    // We assume that we're running on the server (or, at least, an unsupported
-    // environment) if there is no window object or matchMedia function
-    // available.
-    isServerSide() {
-        return (
-            Server.isServerSide() ||
-            typeof window === "undefined" ||
-            !window.matchMedia
-        );
+    // We assume that we're running on an unsupported environment) if there is
+    // no window object or matchMedia function available.
+    isUnsupportedEnvironment() {
+        return typeof window === "undefined" || !window.matchMedia;
     }
 
     // Generate a mock Aphrodite StyleSheet based upon the current mediaSize
@@ -209,7 +204,7 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
         return mockStyleSheet;
     }
 
-    render(): React.ReactNode {
+    renderContent(initialRender: boolean): React.ReactNode {
         const {children, mediaSpec, ssrSize, overrideSize} = this.props;
 
         const queries = [
@@ -223,7 +218,7 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
 
         // We need to create the MediaQueryLists during the first render in order
         // to query whether any of them match.
-        if (!this.isServerSide()) {
+        if (!initialRender) {
             for (const query of queries.filter(
                 (query) => !mediaQueryLists[query],
             )) {
@@ -239,13 +234,21 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
         // the current MediaSpec.
         const mediaSize =
             overrideSize ||
-            (this.isServerSide() && ssrSize) ||
+            (initialRender && ssrSize) ||
             this.getCurrentSize(mediaSpec);
 
         // Generate a mock stylesheet
         const styles = this.getMockStyleSheet(mediaSize);
 
         return children({mediaSize, mediaSpec, styles});
+    }
+
+    render() {
+        return (
+            <WithSSRPlaceholder placeholder={() => this.renderContent(true)}>
+                {() => this.renderContent(this.isUnsupportedEnvironment())}
+            </WithSSRPlaceholder>
+        );
     }
 }
 


### PR DESCRIPTION
## Summary:
In working with React 18, I identified some hydration issues in our main website. One of these is in how the `MediaLayout` component renders. Previous to this change, it would render one way on the server and then another locally. Now we use the `WithSSRPlaceholder` to ensure we retain the same structure on initial render, whether on the server or on the client.

It's a reasonable simple change - I've done my best to leave the original code intact to minimize the change.

I have also updated the tests:
- to remove promise use (when we update the Testing Library and React in Wonder Blocks, the promise approach won't work right)
- to fix the tests that were failing after updating things to properly hydrate

Issue: FEI-5498

## Test plan:
`yarn test`

Integrating this into webapp, and verifying that the hydration issue is resolved.