### PR TITLE
Fixing edge case for opening the Single/MultiSelect when there are no items

### DIFF
--- a/.changeset/moody-dragons-turn.md
+++ b/.changeset/moody-dragons-turn.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+- SingleSelect and MultiSelect: Fixing bug where the components can be opened via keyboard when it is disabled because it has 0 items
+- SingleSelect: If all option items are disabled, the SingleSelect is disabled, similar to the behaviour of the MultiSelect

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -20,6 +20,7 @@ import multiSelectArgtypes from "./multi-select.argtypes";
 import {defaultLabels} from "../../packages/wonder-blocks-dropdown/src/util/constants";
 import {allCountries, allProfilesWithPictures} from "./option-item-examples";
 import {OpenerProps} from "../../packages/wonder-blocks-dropdown/src/util/types";
+import Strut from "../../packages/wonder-blocks-layout/src/components/strut";
 
 type StoryComponentType = StoryObj<typeof MultiSelect>;
 
@@ -385,7 +386,11 @@ export const DropdownInModal: StoryComponentType = {
 
 /**
  * `MultiSelect` can be disabled by passing `disabled={true}`. This can be
- * useful when you want to disable a control temporarily.
+ * useful when you want to disable a control temporarily. It is also disabled
+ * when:
+ * - there are no items
+ * - there are items and they are all disabled
+ *
  *
  * Note: The `disabled` prop sets the `aria-disabled` attribute to `true`
  * instead of setting the `disabled` attribute. This is so that the component
@@ -393,10 +398,28 @@ export const DropdownInModal: StoryComponentType = {
  */
 export const Disabled: StoryComponentType = {
     render: () => (
-        <MultiSelect disabled={true} onChange={() => {}}>
-            <OptionItem label="Mercury" value="1" />
-            <OptionItem label="Venus" value="2" />
-        </MultiSelect>
+        <View>
+            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
+                Disabled prop is set to true
+            </LabelMedium>
+            <MultiSelect disabled={true} onChange={() => {}}>
+                <OptionItem label="Mercury" value="1" />
+                <OptionItem label="Venus" value="2" />
+            </MultiSelect>
+            <Strut size={spacing.xLarge_32} />
+            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
+                No items
+            </LabelMedium>
+            <MultiSelect onChange={() => {}} />
+            <Strut size={spacing.xLarge_32} />
+            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
+                All items are disabled
+            </LabelMedium>
+            <MultiSelect onChange={() => {}}>
+                <OptionItem label="Mercury" value="1" disabled={true} />
+                <OptionItem label="Venus" value="2" disabled={true} />
+            </MultiSelect>
+        </View>
     ),
 };
 

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -363,12 +363,12 @@ export const Disabled: StoryComponentType = {
             <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
                 No items
             </LabelMedium>
-            <SingleSelect placeholder="Choose a Fruit" onChange={() => {}} />
+            <SingleSelect placeholder="Choose a fruit" onChange={() => {}} />
             <Strut size={spacing.xLarge_32} />
             <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
                 All items are disabled
             </LabelMedium>
-            <SingleSelect placeholder="Choose a Fruit" onChange={() => {}}>
+            <SingleSelect placeholder="Choose a fruit" onChange={() => {}}>
                 <OptionItem label="Apple" value="1" disabled={true} />
                 <OptionItem label="Orange" value="2" disabled={true} />
             </SingleSelect>

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -339,6 +339,7 @@ export const LongOptionLabels: StoryComponentType = {
  * useful when you want to disable a control temporarily. It is also disabled
  * when:
  * - there are no items
+ * - there are items and they are all disabled
  *
  * Note: The `disabled` prop sets the `aria-disabled` attribute to `true`
  * instead of setting the `disabled` attribute. This is so that the component
@@ -365,7 +366,7 @@ export const Disabled: StoryComponentType = {
             <SingleSelect placeholder="Choose a Fruit" onChange={() => {}} />
             <Strut size={spacing.xLarge_32} />
             <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
-                If all items are disabled, select is still enabled
+                All items are disabled
             </LabelMedium>
             <SingleSelect placeholder="Choose a Fruit" onChange={() => {}}>
                 <OptionItem label="Apple" value="1" disabled={true} />

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -336,7 +336,9 @@ export const LongOptionLabels: StoryComponentType = {
 
 /**
  * `SingleSelect` can be disabled by passing `disabled={true}`. This can be
- * useful when you want to disable a control temporarily.
+ * useful when you want to disable a control temporarily. It is also disabled
+ * when:
+ * - there are no items
  *
  * Note: The `disabled` prop sets the `aria-disabled` attribute to `true`
  * instead of setting the `disabled` attribute. This is so that the component
@@ -344,14 +346,32 @@ export const LongOptionLabels: StoryComponentType = {
  */
 export const Disabled: StoryComponentType = {
     render: () => (
-        <SingleSelect
-            placeholder="Choose a fruit"
-            onChange={() => {}}
-            selectedValue=""
-            disabled={true}
-        >
-            {items}
-        </SingleSelect>
+        <View>
+            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
+                Disabled prop is set to true
+            </LabelMedium>
+            <SingleSelect
+                placeholder="Choose a fruit"
+                onChange={() => {}}
+                selectedValue=""
+                disabled={true}
+            >
+                {items}
+            </SingleSelect>
+            <Strut size={spacing.xLarge_32} />
+            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
+                No items
+            </LabelMedium>
+            <SingleSelect placeholder="Choose a Fruit" onChange={() => {}} />
+            <Strut size={spacing.xLarge_32} />
+            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
+                If all items are disabled, select is still enabled
+            </LabelMedium>
+            <SingleSelect placeholder="Choose a Fruit" onChange={() => {}}>
+                <OptionItem label="Apple" value="1" disabled={true} />
+                <OptionItem label="Orange" value="2" disabled={true} />
+            </SingleSelect>
+        </View>
     ),
 };
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-constant-condition */
 /* eslint-disable max-lines */
 import * as React from "react";
-import {render, screen, waitFor} from "@testing-library/react";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {
     userEvent as ue,
     PointerEventsCheckLevel,
@@ -1635,6 +1635,57 @@ describe("MultiSelect", () => {
                     <OptionItem label="item 3" value="3" />
                 </MultiSelect>,
             );
+
+            // Assert
+            expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+        });
+
+        it("should not be able to open the select using the keyboard if there are no items", async () => {
+            // Arrange
+            doRender(<MultiSelect onChange={jest.fn()} />);
+
+            // Act
+            // Press the button
+            const button = await screen.findByRole("button");
+            // NOTE: we need to use fireEvent here because await userEvent doesn't
+            // support keyUp/Down events and we use these handlers to override
+            // the default behavior of the button.
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyDown(button, {
+                keyCode: 40,
+            });
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyUp(button, {
+                keyCode: 40,
+            });
+
+            // Assert
+            expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+        });
+
+        it("should not be able to open the select using the keyboard if all items are disabled", async () => {
+            // Arrange
+            doRender(
+                <MultiSelect onChange={jest.fn()}>
+                    <OptionItem label="item 1" value="1" disabled={true} />
+                    <OptionItem label="item 2" value="2" disabled={true} />
+                </MultiSelect>,
+            );
+
+            // Act
+            // Press the button
+            const button = await screen.findByRole("button");
+            // NOTE: we need to use fireEvent here because await userEvent doesn't
+            // support keyUp/Down events and we use these handlers to override
+            // the default behavior of the button.
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyDown(button, {
+                keyCode: 40,
+            });
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyUp(button, {
+                keyCode: 40,
+            });
 
             // Assert
             expect(screen.queryByRole("listbox")).not.toBeInTheDocument();

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1216,7 +1216,7 @@ describe("SingleSelect", () => {
             expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
         });
 
-        it("should be able to open the select using the keyboard if there all items are disabled", async () => {
+        it("should not be able to open the select using the keyboard if all items are disabled", async () => {
             // Arrange
             doRender(
                 <SingleSelect
@@ -1244,7 +1244,7 @@ describe("SingleSelect", () => {
             });
 
             // Assert
-            expect(screen.getByRole("listbox")).toBeInTheDocument();
+            expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
         });
     });
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import * as React from "react";
-import {render, screen} from "@testing-library/react";
+import {fireEvent, render, screen} from "@testing-library/react";
 import {
     userEvent as ue,
     PointerEventsCheckLevel,
@@ -1186,6 +1186,65 @@ describe("SingleSelect", () => {
 
             // Assert
             expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+        });
+
+        it("should not be able to open the select using the keyboard if there are no items", async () => {
+            // Arrange
+            doRender(
+                <SingleSelect
+                    placeholder="Default placeholder"
+                    onChange={jest.fn()}
+                />,
+            );
+
+            // Act
+            // Press the button
+            const button = await screen.findByRole("button");
+            // NOTE: we need to use fireEvent here because await userEvent doesn't
+            // support keyUp/Down events and we use these handlers to override
+            // the default behavior of the button.
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyDown(button, {
+                keyCode: 40,
+            });
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyUp(button, {
+                keyCode: 40,
+            });
+
+            // Assert
+            expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+        });
+
+        it("should be able to open the select using the keyboard if there all items are disabled", async () => {
+            // Arrange
+            doRender(
+                <SingleSelect
+                    placeholder="Default placeholder"
+                    onChange={jest.fn()}
+                >
+                    <OptionItem label="item 1" value="1" disabled={true} />
+                    <OptionItem label="item 2" value="2" disabled={true} />
+                </SingleSelect>,
+            );
+
+            // Act
+            // Press the button
+            const button = await screen.findByRole("button");
+            // NOTE: we need to use fireEvent here because await userEvent doesn't
+            // support keyUp/Down events and we use these handlers to override
+            // the default behavior of the button.
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyDown(button, {
+                keyCode: 40,
+            });
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyUp(button, {
+                keyCode: 40,
+            });
+
+            // Assert
+            expect(screen.getByRole("listbox")).toBeInTheDocument();
         });
     });
 

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -478,11 +478,11 @@ export default class MultiSelect extends React.Component<Props, State> {
         allChildren: React.ReactElement<
             React.ComponentProps<typeof OptionItem>
         >[],
+        isDisabled: boolean,
     ):
         | React.ReactElement<React.ComponentProps<typeof DropdownOpener>>
         | React.ReactElement<React.ComponentProps<typeof SelectOpener>> {
         const {
-            disabled,
             id,
             light,
             opener,
@@ -510,14 +510,11 @@ export default class MultiSelect extends React.Component<Props, State> {
         const {noneSelected} = this.state.labels;
 
         const menuText = this.getMenuText(allChildren);
-        const numOptions = allChildren.filter(
-            (option) => !option.props.disabled,
-        ).length;
 
         const dropdownOpener = opener ? (
             <DropdownOpener
                 onClick={this.handleClick}
-                disabled={numOptions === 0 || disabled}
+                disabled={isDisabled}
                 ref={this.handleOpenerRef}
                 text={menuText}
                 opened={this.state.open}
@@ -527,7 +524,7 @@ export default class MultiSelect extends React.Component<Props, State> {
         ) : (
             <SelectOpener
                 {...sharedProps}
-                disabled={numOptions === 0 || disabled}
+                disabled={isDisabled}
                 id={id}
                 isPlaceholder={menuText === noneSelected}
                 light={light}
@@ -569,7 +566,8 @@ export default class MultiSelect extends React.Component<Props, State> {
             (option) => !option.props.disabled,
         ).length;
         const filteredItems = this.getMenuItems(allChildren);
-        const opener = this.renderOpener(allChildren);
+        const isDisabled = numEnabledOptions === 0 || disabled;
+        const opener = this.renderOpener(allChildren, isDisabled);
 
         return (
             <DropdownCore
@@ -605,7 +603,7 @@ export default class MultiSelect extends React.Component<Props, State> {
                 }}
                 aria-invalid={ariaInvalid}
                 aria-required={ariaRequired}
-                disabled={disabled}
+                disabled={isDisabled}
             />
         );
     }

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -455,10 +455,16 @@ export default class SingleSelect extends React.Component<Props, State> {
             disabled,
         } = this.props;
         const {searchText} = this.state;
-        const allChildren = React.Children.toArray(children).filter(Boolean);
-        // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '(ReactChild | ReactFragment | ReactPortal)[]' is not assignable to parameter of type 'ReactElement<{}, string | JSXElementConstructor<any>>[]'.
+        const allChildren = (
+            React.Children.toArray(children) as Array<
+                React.ReactElement<React.ComponentProps<typeof OptionItem>>
+            >
+        ).filter(Boolean);
+        const numEnabledOptions = allChildren.filter(
+            (option) => !option.props.disabled,
+        ).length;
         const items = this.getMenuItems(allChildren);
-        const isDisabled = allChildren.length === 0 || disabled;
+        const isDisabled = numEnabledOptions === 0 || disabled;
         const opener = this.renderOpener(isDisabled);
 
         return (

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -365,13 +365,12 @@ export default class SingleSelect extends React.Component<Props, State> {
     };
 
     renderOpener(
-        numItems: number,
+        isDisabled: boolean,
     ):
         | React.ReactElement<React.ComponentProps<typeof DropdownOpener>>
         | React.ReactElement<React.ComponentProps<typeof SelectOpener>> {
         const {
             children,
-            disabled,
             error,
             id,
             light,
@@ -413,7 +412,7 @@ export default class SingleSelect extends React.Component<Props, State> {
         const dropdownOpener = opener ? (
             <DropdownOpener
                 onClick={this.handleClick}
-                disabled={numItems === 0 || disabled}
+                disabled={isDisabled}
                 ref={this.handleOpenerRef}
                 text={menuText}
                 opened={this.state.open}
@@ -423,7 +422,7 @@ export default class SingleSelect extends React.Component<Props, State> {
         ) : (
             <SelectOpener
                 {...sharedProps}
-                disabled={numItems === 0 || disabled}
+                disabled={isDisabled}
                 id={id}
                 error={error}
                 isPlaceholder={!selectedItem}
@@ -459,7 +458,8 @@ export default class SingleSelect extends React.Component<Props, State> {
         const allChildren = React.Children.toArray(children).filter(Boolean);
         // @ts-expect-error [FEI-5019] - TS2345 - Argument of type '(ReactChild | ReactFragment | ReactPortal)[]' is not assignable to parameter of type 'ReactElement<{}, string | JSXElementConstructor<any>>[]'.
         const items = this.getMenuItems(allChildren);
-        const opener = this.renderOpener(allChildren.length);
+        const isDisabled = allChildren.length === 0 || disabled;
+        const opener = this.renderOpener(isDisabled);
 
         return (
             <DropdownCore
@@ -490,7 +490,7 @@ export default class SingleSelect extends React.Component<Props, State> {
                 labels={labels}
                 aria-invalid={ariaInvalid}
                 aria-required={ariaRequired}
-                disabled={disabled}
+                disabled={isDisabled}
             />
         );
     }


### PR DESCRIPTION
## Summary:
- Fixing bug where the SingleSelect and MultiSelect components can be opened via keyboard when it is disabled because it has 0 items. The select components should not be able to be opened when the select opener is disabled
- Update SingleSelect to have the same behaviour as MultiSelect: if all option items are disabled, the select should be disabled

Issue: WB-1238

## Test plan:
- Confirm when there are no items, the select components should not be able to be opened using the keyboard
  - `?path=/story/packages-dropdown-singleselect--disabled`
  - `?path=/story/packages-dropdown-multiselect--disabled`