### PR TITLE
Communicate checked status to screenreaders when OptionItems are used in ActionMenu

### DIFF
--- a/.changeset/small-avocados-complain.md
+++ b/.changeset/small-avocados-complain.md
@@ -1,10 +1,14 @@
 ---
 "@khanacademy/wonder-blocks-clickable": patch
 "@khanacademy/wonder-blocks-dropdown": patch
-"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-cell": minor
 ---
 
 Improves accessibility of the checked status on `OptionItem` components used
 within the `ActionMenu` component. The checked status is communicated to
 screenreaders by using a `menuitemcheckbox` role with the `aria-checked`
 attribute (instead of `aria-selected`).
+    - `CellCore` (used by `CompactCell` and `DetailCell`) has a new optional
+    prop for `aria-checked`
+    - `ClickableRole` type now supports the `menuitemcheckbox` role
+    - `OptionItem`'s `role` prop now also supports the `menuitemcheckbox` role

--- a/.changeset/small-avocados-complain.md
+++ b/.changeset/small-avocados-complain.md
@@ -1,0 +1,10 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+Improves accessibility of the checked status on `OptionItem` components used
+within the `ActionMenu` component. The checked status is communicated to
+screenreaders by using a `menuitemcheckbox` role with the `aria-checked`
+attribute (instead of `aria-selected`).

--- a/__docs__/wonder-blocks-cell/compact-cell.argtypes.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.argtypes.tsx
@@ -205,11 +205,9 @@ export default {
     /**
      * Accessibility
      */
-    ariaLabel: {
+    "aria-label": {
         name: "aria-label",
-        control: {
-            type: "string",
-        },
+        control: {type: "text"},
         description: "Used to announce the cell's content to screen readers.",
         table: {
             category: "Accessibility",
@@ -219,16 +217,24 @@ export default {
             },
         },
     },
-    ariaSelected: {
+    "aria-selected": {
         name: "aria-selected",
-        control: {
-            type: "string",
-        },
+        control: {type: "boolean"},
         description: " Used to indicate the current element is selected",
         table: {
             category: "Accessibility",
             type: {
-                summary: "string",
+                summary: "boolean",
+            },
+        },
+    },
+    "aria-checked": {
+        name: "aria-checked",
+        control: {type: "boolean"},
+        table: {
+            category: "Accessibility",
+            type: {
+                summary: "boolean",
             },
         },
     },
@@ -243,6 +249,7 @@ export default {
             "listbox",
             "menu",
             "menuitem",
+            "menuitemcheckbox",
             "radio",
             "tab",
         ],
@@ -250,7 +257,7 @@ export default {
             category: "Accessibility",
             type: {
                 summary: "ClickableRole",
-                detail: `"button" | "link" | "checkbox" | "radio" | "listbox" | "option" | "menuitem" | "menu" | "tab"`,
+                detail: `"button" | "link" | "checkbox" | "radio" | "listbox" | "option" | "menuitem" | "menuitemcheckbox" | "menu" | "tab"`,
             },
         },
     },

--- a/__docs__/wonder-blocks-clickable/clickable.argtypes.ts
+++ b/__docs__/wonder-blocks-clickable/clickable.argtypes.ts
@@ -255,6 +255,7 @@ export default {
             "listbox",
             "menu",
             "menuitem",
+            "menuitemcheckbox",
             "radio",
             "tab",
         ],
@@ -262,7 +263,7 @@ export default {
             category: "Accessibility",
             type: {
                 summary: "ClickableRole",
-                detail: `"button" | "link" | "checkbox" | "radio" | "listbox" | "option" | "menuitem" | "menu" | "tab"`,
+                detail: `"button" | "link" | "checkbox" | "radio" | "listbox" | "option" | "menuitem" | "menuitemcheckbox" | "menu" | "tab"`,
             },
         },
     },

--- a/packages/wonder-blocks-cell/src/components/internal/__tests__/cell-core.test.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/__tests__/cell-core.test.tsx
@@ -157,4 +157,60 @@ describe("CellCore", () => {
         // eslint-disable-next-line testing-library/no-node-access
         expect(elem.parentElement).toHaveStyle("align-self: flex-start");
     });
+
+    describe("aria-checked", () => {
+        it("should add aria-checked if aria-checked is set and it is a link", () => {
+            // Arrange
+
+            // Act
+            const {container} = render(
+                <CellCore aria-checked={true} href="#">
+                    <div>cell core content</div>
+                </CellCore>,
+            );
+
+            // Assert
+            // Verify that the root element has the aria-current attribute
+            // eslint-disable-next-line testing-library/no-node-access
+            expect(container.firstChild).toHaveAttribute(
+                "aria-checked",
+                "true",
+            );
+        });
+
+        it("should add aria-checked if aria-checked is set and it has an onClick handler", () => {
+            // Arrange
+
+            // Act
+            const {container} = render(
+                <CellCore aria-checked={true} onClick={jest.fn()}>
+                    <div>cell core content</div>
+                </CellCore>,
+            );
+
+            // Assert
+            // Verify that the root element has the aria-current attribute
+            // eslint-disable-next-line testing-library/no-node-access
+            expect(container.firstChild).toHaveAttribute(
+                "aria-checked",
+                "true",
+            );
+        });
+
+        it("should not add aria-checked if it is not clickable", () => {
+            // Arrange
+
+            // Act
+            const {container} = render(
+                <CellCore aria-checked={true}>
+                    <div>cell core content</div>
+                </CellCore>,
+            );
+
+            // Assert
+            // Verify that the root element has the aria-current attribute
+            // eslint-disable-next-line testing-library/no-node-access
+            expect(container.firstChild).not.toHaveAttribute("aria-checked");
+        });
+    });
 });

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -173,6 +173,7 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
         onClick,
         "aria-label": ariaLabel,
         "aria-selected": ariaSelected,
+        "aria-checked": ariaChecked,
         target,
         role,
         rootStyle,
@@ -189,6 +190,7 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
                 hideDefaultFocusRing={true}
                 aria-label={ariaLabel ? ariaLabel : undefined}
                 aria-selected={ariaSelected ? ariaSelected : undefined}
+                aria-checked={ariaChecked}
                 role={role}
                 target={target}
                 style={[

--- a/packages/wonder-blocks-cell/src/util/types.ts
+++ b/packages/wonder-blocks-cell/src/util/types.ts
@@ -138,6 +138,10 @@ export type CellProps = {
      */
     "aria-selected"?: AriaProps["aria-selected"];
     /**
+     * Used to indicate the current item is checked.
+     */
+    "aria-checked"?: AriaProps["aria-checked"];
+    /**
      * Optinal href which Cell should direct to, uses client-side routing
      * by default if react-router is present.
      */

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -8,6 +8,7 @@ export type ClickableRole =
     | "listbox"
     | "menu"
     | "menuitem"
+    | "menuitemcheckbox"
     | "option"
     | "radio"
     | "switch"

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.tsx
@@ -634,20 +634,20 @@ describe("ActionMenu", () => {
             await userEvent.click(opener);
 
             // Assert
-            expect(
-                (
-                    await screen.findAllByRole("menuitemcheckbox", {
-                        hidden: true,
-                    })
-                ).at(0),
-            ).toHaveAttribute("aria-checked", "false");
-            expect(
-                (
-                    await screen.findAllByRole("menuitemcheckbox", {
-                        hidden: true,
-                    })
-                ).at(1),
-            ).toHaveAttribute("aria-checked", "false");
+            const menuItemCheckboxes = await screen.findAllByRole(
+                "menuitemcheckbox",
+                {
+                    hidden: true,
+                },
+            );
+            expect(menuItemCheckboxes.at(0)).toHaveAttribute(
+                "aria-checked",
+                "false",
+            );
+            expect(menuItemCheckboxes.at(1)).toHaveAttribute(
+                "aria-checked",
+                "false",
+            );
         });
 
         it("Should render selected option items with `aria-checked` set to `true`", async () => {
@@ -678,13 +678,16 @@ describe("ActionMenu", () => {
             await userEvent.click(opener);
 
             // Assert
-            expect(
-                (
-                    await screen.findAllByRole("menuitemcheckbox", {
-                        hidden: true,
-                    })
-                ).at(0),
-            ).toHaveAttribute("aria-checked", "true");
+            const menuItemCheckboxes = await screen.findAllByRole(
+                "menuitemcheckbox",
+                {
+                    hidden: true,
+                },
+            );
+            expect(menuItemCheckboxes.at(0)).toHaveAttribute(
+                "aria-checked",
+                "true",
+            );
         });
 
         it("Should not use `aria-selected` attribute on selected and non-selected options", async () => {
@@ -715,20 +718,18 @@ describe("ActionMenu", () => {
             await userEvent.click(opener);
 
             // Assert
-            expect(
-                (
-                    await screen.findAllByRole("menuitemcheckbox", {
-                        hidden: true,
-                    })
-                ).at(0),
-            ).not.toHaveAttribute("aria-selected");
-            expect(
-                (
-                    await screen.findAllByRole("menuitemcheckbox", {
-                        hidden: true,
-                    })
-                ).at(1),
-            ).not.toHaveAttribute("aria-selected");
+            const menuItemCheckboxes = await screen.findAllByRole(
+                "menuitemcheckbox",
+                {
+                    hidden: true,
+                },
+            );
+            expect(menuItemCheckboxes.at(0)).not.toHaveAttribute(
+                "aria-selected",
+            );
+            expect(menuItemCheckboxes.at(1)).not.toHaveAttribute(
+                "aria-selected",
+            );
         });
 
         it("Should render action items with `role=menuitem` and option items with `role=menuitemcheckbox`", async () => {
@@ -826,13 +827,16 @@ describe("ActionMenu", () => {
                 await userEvent.click(opener);
 
                 // Assert
-                expect(
-                    (
-                        await screen.findAllByRole("menuitemcheckbox", {
-                            hidden: true,
-                        })
-                    ).at(0),
-                ).toHaveAttribute("aria-checked", "true");
+                const menuItemCheckboxes = await screen.findAllByRole(
+                    "menuitemcheckbox",
+                    {
+                        hidden: true,
+                    },
+                );
+                expect(menuItemCheckboxes.at(0)).toHaveAttribute(
+                    "aria-checked",
+                    "true",
+                );
             });
 
             it("Should render non-selected option items with `aria-checked=false` when there are many options", async () => {
@@ -860,13 +864,16 @@ describe("ActionMenu", () => {
                 await userEvent.click(opener);
 
                 // Assert
-                expect(
-                    (
-                        await screen.findAllByRole("menuitemcheckbox", {
-                            hidden: true,
-                        })
-                    ).at(0),
-                ).toHaveAttribute("aria-checked", "false");
+                const menuItemCheckboxes = await screen.findAllByRole(
+                    "menuitemcheckbox",
+                    {
+                        hidden: true,
+                    },
+                );
+                expect(menuItemCheckboxes.at(0)).toHaveAttribute(
+                    "aria-checked",
+                    "false",
+                );
             });
 
             it("Should not use `aria-selected` attribute on selected and non-selected options", async () => {
@@ -894,20 +901,18 @@ describe("ActionMenu", () => {
                 await userEvent.click(opener);
 
                 // Assert
-                expect(
-                    (
-                        await screen.findAllByRole("menuitemcheckbox", {
-                            hidden: true,
-                        })
-                    ).at(0),
-                ).not.toHaveAttribute("aria-selected");
-                expect(
-                    (
-                        await screen.findAllByRole("menuitemcheckbox", {
-                            hidden: true,
-                        })
-                    ).at(1),
-                ).not.toHaveAttribute("aria-selected");
+                const menuItemCheckboxes = await screen.findAllByRole(
+                    "menuitemcheckbox",
+                    {
+                        hidden: true,
+                    },
+                );
+                expect(menuItemCheckboxes.at(0)).not.toHaveAttribute(
+                    "aria-selected",
+                );
+                expect(menuItemCheckboxes.at(1)).not.toHaveAttribute(
+                    "aria-selected",
+                );
             });
         });
     });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.tsx
@@ -572,4 +572,343 @@ describe("ActionMenu", () => {
             expect(opener).toHaveTextContent("Action menu!");
         });
     });
+
+    describe("With OptionItems", () => {
+        it("Should render option items with `role=menuitemcheckbox`", async () => {
+            // Arrange
+            render(
+                <ActionMenu
+                    menuText="Action menu!"
+                    testId="openTest"
+                    onChange={onChange}
+                >
+                    <OptionItem
+                        label="Toggle A"
+                        value="toggle-a"
+                        testId="toggle-a"
+                    />
+                    <OptionItem
+                        label="Toggle B"
+                        value="toggle-b"
+                        testId="toggle-b"
+                    />
+                </ActionMenu>,
+            );
+
+            // Act
+            // open the menu
+            const opener = await screen.findByRole("button");
+            await userEvent.click(opener);
+
+            // Assert
+            expect(
+                await screen.findAllByRole("menuitemcheckbox", {hidden: true}),
+            ).toHaveLength(2);
+        });
+
+        it("Should render non-selected option items with `aria-checked` set to `false`", async () => {
+            // Arrange
+            render(
+                <ActionMenu
+                    menuText="Action menu!"
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={[]}
+                >
+                    <OptionItem
+                        label="Toggle A"
+                        value="toggle-a"
+                        testId="toggle-a"
+                    />
+                    <OptionItem
+                        label="Toggle B"
+                        value="toggle-b"
+                        testId="toggle-b"
+                    />
+                </ActionMenu>,
+            );
+
+            // Act
+            // open the menu
+            const opener = await screen.findByRole("button");
+            await userEvent.click(opener);
+
+            // Assert
+            expect(
+                (
+                    await screen.findAllByRole("menuitemcheckbox", {
+                        hidden: true,
+                    })
+                ).at(0),
+            ).toHaveAttribute("aria-checked", "false");
+            expect(
+                (
+                    await screen.findAllByRole("menuitemcheckbox", {
+                        hidden: true,
+                    })
+                ).at(1),
+            ).toHaveAttribute("aria-checked", "false");
+        });
+
+        it("Should render selected option items with `aria-checked` set to `true`", async () => {
+            // Arrange
+            render(
+                <ActionMenu
+                    menuText="Action menu!"
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={["toggle-a"]}
+                >
+                    <OptionItem
+                        label="Toggle A"
+                        value="toggle-a"
+                        testId="toggle-a"
+                    />
+                    <OptionItem
+                        label="Toggle B"
+                        value="toggle-b"
+                        testId="toggle-b"
+                    />
+                </ActionMenu>,
+            );
+
+            // Act
+            // open the menu
+            const opener = await screen.findByRole("button");
+            await userEvent.click(opener);
+
+            // Assert
+            expect(
+                (
+                    await screen.findAllByRole("menuitemcheckbox", {
+                        hidden: true,
+                    })
+                ).at(0),
+            ).toHaveAttribute("aria-checked", "true");
+        });
+
+        it("Should not use `aria-selected` attribute on selected and non-selected options", async () => {
+            // Arrange
+            render(
+                <ActionMenu
+                    menuText="Action menu!"
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={["toggle-a"]}
+                >
+                    <OptionItem
+                        label="Toggle A"
+                        value="toggle-a"
+                        testId="toggle-a"
+                    />
+                    <OptionItem
+                        label="Toggle B"
+                        value="toggle-b"
+                        testId="toggle-b"
+                    />
+                </ActionMenu>,
+            );
+
+            // Act
+            // open the menu
+            const opener = await screen.findByRole("button");
+            await userEvent.click(opener);
+
+            // Assert
+            expect(
+                (
+                    await screen.findAllByRole("menuitemcheckbox", {
+                        hidden: true,
+                    })
+                ).at(0),
+            ).not.toHaveAttribute("aria-selected");
+            expect(
+                (
+                    await screen.findAllByRole("menuitemcheckbox", {
+                        hidden: true,
+                    })
+                ).at(1),
+            ).not.toHaveAttribute("aria-selected");
+        });
+
+        it("Should render action items with `role=menuitem` and option items with `role=menuitemcheckbox`", async () => {
+            // Arrange
+            render(
+                <ActionMenu
+                    menuText="Action menu!"
+                    testId="openTest"
+                    onChange={onChange}
+                >
+                    <ActionItem label="Action" />
+                    <OptionItem
+                        label="Toggle A"
+                        value="toggle-a"
+                        testId="toggle-a"
+                    />
+                </ActionMenu>,
+            );
+
+            // Act
+            // open the menu
+            const opener = await screen.findByRole("button");
+            await userEvent.click(opener);
+
+            // Assert
+            expect(
+                await screen.findAllByRole("menuitem", {hidden: true}),
+            ).toHaveLength(1);
+            expect(
+                await screen.findAllByRole("menuitemcheckbox", {hidden: true}),
+            ).toHaveLength(1);
+        });
+
+        describe("With Virtualization", () => {
+            it("Should render option items with `role=menuitemcheckbox` when there are many options", async () => {
+                // Arrange
+                render(
+                    <ActionMenu
+                        menuText="Action menu!"
+                        testId="openTest"
+                        onChange={onChange}
+                    >
+                        {[...new Array(126)].map((_, i) => (
+                            <OptionItem
+                                label={`Toggle ${i}`}
+                                key={i}
+                                value={`toggle-${i}`}
+                            />
+                        ))}
+                    </ActionMenu>,
+                );
+
+                // Act
+                // open the menu
+                const opener = await screen.findByRole("button");
+                await userEvent.click(opener);
+
+                // Assert
+                // Note there are less than the option items amount because they are
+                // virtualized
+                expect(
+                    await screen.findAllByRole("menuitemcheckbox", {
+                        hidden: true,
+                    }),
+                ).toHaveLength(14);
+                expect(
+                    screen.queryAllByRole("menuitem", {
+                        hidden: true,
+                    }),
+                ).toHaveLength(0);
+            });
+
+            it("Should render selected option items with `aria-checked=true` when there are many options", async () => {
+                // Arrange
+                render(
+                    <ActionMenu
+                        menuText="Action menu!"
+                        testId="openTest"
+                        onChange={onChange}
+                        selectedValues={["toggle-0"]}
+                    >
+                        {[...new Array(126)].map((_, i) => (
+                            <OptionItem
+                                label={`Toggle ${i}`}
+                                key={i}
+                                value={`toggle-${i}`}
+                            />
+                        ))}
+                    </ActionMenu>,
+                );
+
+                // Act
+                // open the menu
+                const opener = await screen.findByRole("button");
+                await userEvent.click(opener);
+
+                // Assert
+                expect(
+                    (
+                        await screen.findAllByRole("menuitemcheckbox", {
+                            hidden: true,
+                        })
+                    ).at(0),
+                ).toHaveAttribute("aria-checked", "true");
+            });
+
+            it("Should render non-selected option items with `aria-checked=false` when there are many options", async () => {
+                // Arrange
+                render(
+                    <ActionMenu
+                        menuText="Action menu!"
+                        testId="openTest"
+                        onChange={onChange}
+                        selectedValues={[]}
+                    >
+                        {[...new Array(126)].map((_, i) => (
+                            <OptionItem
+                                label={`Toggle ${i}`}
+                                key={i}
+                                value={`toggle-${i}`}
+                            />
+                        ))}
+                    </ActionMenu>,
+                );
+
+                // Act
+                // open the menu
+                const opener = await screen.findByRole("button");
+                await userEvent.click(opener);
+
+                // Assert
+                expect(
+                    (
+                        await screen.findAllByRole("menuitemcheckbox", {
+                            hidden: true,
+                        })
+                    ).at(0),
+                ).toHaveAttribute("aria-checked", "false");
+            });
+
+            it("Should not use `aria-selected` attribute on selected and non-selected options", async () => {
+                // Arrange
+                render(
+                    <ActionMenu
+                        menuText="Action menu!"
+                        testId="openTest"
+                        onChange={onChange}
+                        selectedValues={["toggle-0"]}
+                    >
+                        {[...new Array(126)].map((_, i) => (
+                            <OptionItem
+                                label={`Toggle ${i}`}
+                                key={i}
+                                value={`toggle-${i}`}
+                            />
+                        ))}
+                    </ActionMenu>,
+                );
+
+                // Act
+                // open the menu
+                const opener = await screen.findByRole("button");
+                await userEvent.click(opener);
+
+                // Assert
+                expect(
+                    (
+                        await screen.findAllByRole("menuitemcheckbox", {
+                            hidden: true,
+                        })
+                    ).at(0),
+                ).not.toHaveAttribute("aria-selected");
+                expect(
+                    (
+                        await screen.findAllByRole("menuitemcheckbox", {
+                            hidden: true,
+                        })
+                    ).at(1),
+                ).not.toHaveAttribute("aria-selected");
+            });
+        });
+    });
 });

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
@@ -203,14 +203,18 @@ export default class ActionMenu extends React.Component<Props, State> {
                 };
                 // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'ReactChild | ReactFragment | ReactPortal' is not assignable to parameter of type 'ReactElement<any, string | JSXElementConstructor<any>>'.
             } else if (OptionItem.isClassOf(item)) {
+                const selected = selectedValues
+                    ? selectedValues.includes(value)
+                    : false;
                 return {
                     ...itemObject,
                     populatedProps: {
                         onToggle: this.handleOptionSelected,
-                        selected: selectedValues
-                            ? selectedValues.includes(value)
-                            : false,
+                        selected,
                         variant: "check",
+                        role: "menuitemcheckbox",
+                        "aria-checked": selected,
+                        "aria-selected": undefined,
                     },
                 };
             } else {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -861,7 +861,7 @@ class DropdownCore extends React.Component<Props, State> {
                 },
                 // Only pass the ref if the item is focusable.
                 ref: focusable ? currentRef : null,
-                role: itemRole,
+                role: populatedProps.role || itemRole,
             });
         });
     }
@@ -879,6 +879,7 @@ class DropdownCore extends React.Component<Props, State> {
         const itemRole = this.getItemRole();
 
         return this.props.items.map((item, index) => {
+            const {populatedProps} = item;
             if (!SeparatorItem.isClassOf(item.component) && item.focusable) {
                 focusCounter += 1;
             }
@@ -887,7 +888,7 @@ class DropdownCore extends React.Component<Props, State> {
 
             return {
                 ...item,
-                role: itemRole,
+                role: populatedProps.role || itemRole,
                 ref: item.focusable
                     ? this.state.itemRefs[focusIndex]
                         ? this.state.itemRefs[focusIndex].ref

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -65,7 +65,7 @@ type OptionProps = AriaProps & {
     /**
      * Aria role to use, defaults to "option".
      */
-    role: "menuitem" | "option";
+    role: "menuitem" | "option" | "menuitemcheckbox";
     /**
      * Test ID used for e2e testing.
      */


### PR DESCRIPTION
## Summary:
When OptionItems are used within an ActionMenu, they should have role="menuitemcheckbox" and use aria-checked instead of aria-selected

Issue: WB-1659

## Test plan:
- Confirm that an ActionMenu with OptionItems communicates when an option item is selected (`?path=/story/packages-dropdown-actionmenu--with-option-items`)
  - rendered option items should have role="menuitemcheckbox" and aria-checked="true"
  - screenreaders communicate the checked status

## Screen Recording
### Before & After
In the before videos, the selected option item in the menu is not communicated to the user using a screen reader. In the after videos, it is communicated (safari reads out "Checkmark", Chrome reads out "checked")

#### Safari

https://github.com/Khan/wonder-blocks/assets/14334617/114ac914-0ece-4e65-a886-987e8ba2f163

https://github.com/Khan/wonder-blocks/assets/14334617/b54486bb-ec8a-4fc0-a38b-1093267782ff

#### Chrome

https://github.com/Khan/wonder-blocks/assets/14334617/24dc0246-34a4-4c1f-a5d8-26386bb55619

https://github.com/Khan/wonder-blocks/assets/14334617/bfb849c7-6dab-44a5-8a0e-5b442b167796








