### PR TITLE
Fix active state styling for tertiary button

### DIFF
--- a/.changeset/light-swans-thank.md
+++ b/.changeset/light-swans-thank.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-button": patch
+---
+
+Fix inconsistent underline height in the active state of the tertiary button.

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -127,7 +127,7 @@ export const Tertiary: StoryComponentType = {
         // eslint-disable-next-line testing-library/prefer-user-event
         await fireEvent.mouseDown(button);
         await expect(innerLabel).toHaveStyle("color: rgb(27, 80, 179)");
-        await expect(computedStyleLabel.height).toBe("1px");
+        await expect(computedStyleLabel.height).toBe("2px");
         await expect(computedStyleLabel.color).toBe("rgb(27, 80, 179)");
     },
 };

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -495,7 +495,7 @@ export const _generateStyles = (
             active: {
                 color: light ? fadedColor : activeColor,
                 ":after": {
-                    height: 1,
+                    height: theme.size.height.tertiaryHover,
                     background: light ? fadedColor : activeColor,
                 },
             },


### PR DESCRIPTION
## Summary:
Use the same theme token for the height of the underline on the active state of the tertiary button so that the hover and active styling are consistent

Issue: WB-1025

## Test plan:
- Confirm that the hover and active state of the tertiary button have a consistent underline thickness

## Screen Recording:
Before & After

https://github.com/Khan/wonder-blocks/assets/14334617/2ce3725e-48f1-49f8-a111-761d1ce48944

