### PR TITLE
Fix Banner styling for custom action buttons

### DIFF
--- a/.changeset/new-rice-punch.md
+++ b/.changeset/new-rice-punch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": patch
+---
+
+Banner: Fix styling issue where buttons are cropped when used as a custom action

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -431,6 +431,31 @@ export const WithCustomAction: StoryComponentType = {
 };
 
 /**
+ * **NOTE: Custom actions are discouraged and should only be used as a last resort!**.
+ *
+ * Another example with a custom action using a primary button.
+ * See **With Custom Action** story for more details.
+ */
+export const WithCustomActionPrimary: StoryComponentType = {
+    render: () => (
+        <Banner
+            text="some text"
+            layout="floating"
+            actions={[
+                {
+                    type: "custom",
+                    node: (
+                        <Button size="small" onClick={() => {}}>
+                            Custom Action
+                        </Button>
+                    ),
+                },
+            ]}
+        />
+    ),
+};
+
+/**
  * Here is an example that includes both a normal action and a custom action.
  */
 export const WithMixedActions: StoryComponentType = {
@@ -449,6 +474,14 @@ export const WithMixedActions: StoryComponentType = {
                     node: (
                         <Button kind="tertiary" size="small" onClick={() => {}}>
                             Custom button
+                        </Button>
+                    ),
+                },
+                {
+                    type: "custom",
+                    node: (
+                        <Button size="small" onClick={() => {}}>
+                            Custom button 2
                         </Button>
                     ),
                 },

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -204,7 +204,7 @@ const Banner = (props: Props): React.ReactElement => {
             if (action.type === "custom") {
                 return (
                     <View style={styles.action} key={`custom-action-${i}`}>
-                        <View style={styles.customAction}>{action.node}</View>
+                        {action.node}
                     </View>
                 );
             }
@@ -349,16 +349,14 @@ const styles = StyleSheet.create({
         justifyContent: "flex-start",
         marginTop: spacing.xSmall_8,
         marginBottom: spacing.xSmall_8,
+        // Set the height to remove the padding from buttons
+        height: 18,
+        alignItems: "center",
     },
     action: {
         marginLeft: spacing.xSmall_8,
         marginRight: spacing.xSmall_8,
         justifyContent: "center",
-        // Set the height to remove the padding from buttons
-        height: 18,
-    },
-    customAction: {
-        flexShrink: 0,
     },
     link: {
         fontSize: 14,

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -204,7 +204,7 @@ const Banner = (props: Props): React.ReactElement => {
             if (action.type === "custom") {
                 return (
                     <View style={styles.action} key={`custom-action-${i}`}>
-                        {action.node}
+                        <View style={styles.customAction}>{action.node}</View>
                     </View>
                 );
             }
@@ -356,6 +356,9 @@ const styles = StyleSheet.create({
         justifyContent: "center",
         // Set the height to remove the padding from buttons
         height: 18,
+    },
+    customAction: {
+        flexShrink: 0,
     },
     link: {
         fontSize: 14,


### PR DESCRIPTION
## Summary:
Fixing styling issue where non-tertiary buttons get cropped when used as a custom action in the banner component.

Issue: WB-1716

## Test plan:
- Confirm buttons look as expected in the banner (`?path=/story/packages-banner--with-custom-action-primary`)
- Confirm a mix of actions and custom actions look as expected in the banner (`?path=/story/packages-banner--with-mixed-actions`)

## Screenshots:
Mixed actions (before & after changes)
<img width="1726" alt="before-mixed" src="https://github.com/Khan/wonder-blocks/assets/14334617/360e8945-de62-48aa-b259-e5049ad3a33e">
<img width="1728" alt="after-mixed" src="https://github.com/Khan/wonder-blocks/assets/14334617/7f506d9b-c379-4cd9-adf6-4e61a6ee1d58">

Primary button for custom action (before & after changes) 
<img width="1728" alt="before-primary" src="https://github.com/Khan/wonder-blocks/assets/14334617/0d3a859c-a110-4433-b1eb-e9dfe28af6e7">
<img width="1726" alt="after-primary" src="https://github.com/Khan/wonder-blocks/assets/14334617/508f6b86-6c4d-4af6-9025-1b00fba9bbb4">



