### PR TITLE
[fixexternals] Fix how react-dom/server is imported

### DIFF
--- a/.changeset/gentle-houses-listen.md
+++ b/.changeset/gentle-houses-listen.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wb-dev-build-settings": patch
+"@khanacademy/wonder-blocks-testing-core": patch
+---
+
+Fix how react-dom/server is imported in Wonder Blocks Testing Core

--- a/build-settings/rollup.config.mjs
+++ b/build-settings/rollup.config.mjs
@@ -2,11 +2,13 @@
 /* eslint-disable import/no-commonjs */
 import fs from "fs";
 import path from "path";
-import autoExternal from "rollup-plugin-auto-external";
+import {nodeExternals} from "rollup-plugin-node-externals";
 import babel from "rollup-plugin-babel";
 import resolve from "@rollup/plugin-node-resolve";
+// eslint-disable-next-line import/extensions
+import makeBabelConfig from "./babel.config.js";
 
-const {presets, plugins} = require("./babel.config")({env: () => false});
+const {presets, plugins} = makeBabelConfig({env: () => false});
 
 const createConfig = (pkgName) => {
     const packageJsonPath = path.join("packages", pkgName, "package.json");
@@ -47,7 +49,7 @@ const createConfig = (pkgName) => {
                 browser: true,
                 extensions,
             }),
-            autoExternal({
+            nodeExternals({
                 packagePath: `packages/${pkgName}/package.json`,
             }),
         ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "alex": "alex packages/",
-    "build": "rollup -c ./build-settings/rollup.config.js",
+    "build": "rollup -c ./build-settings/rollup.config.mjs",
     "build:types": "yarn tsc --build tsconfig-build.json && node -r @swc-node/register build-settings/remove-test-types-from-dist.ts",
     "build:storybook": "storybook build --stats-json",
     "clean": "rm -rf packages/wonder-blocks-*/dist && rm -rf packages/wonder-blocks-*/node_modules && rm -f packages/*/*.tsbuildinfo && rm -f utils/tsconfig.tsbuildinfo",
@@ -111,8 +111,8 @@
     "prettier": "^2.8.1",
     "react-refresh": "^0.14.0",
     "rollup": "^2.79.1",
-    "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-babel": "^4.0.0-beta.2",
+    "rollup-plugin-node-externals": "^7.1.2",
     "storybook": "^8.2.1",
     "storybook-addon-pseudo-states": "^3.1.1",
     "typescript": "^4.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5520,12 +5520,6 @@ builtin-modules@^3.3.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
-builtins@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/builtins/-/builtins-2.0.0.tgz#018999641e11252188652dbb2db01ad386fcdc46"
-  dependencies:
-    semver "^5.4.1"
-
 builtins@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-5.0.1.tgz#87f6db9ab0458be728564fa81d876d8d74552fa9"
@@ -11008,7 +11002,7 @@ nopt@^7.0.0:
   dependencies:
     abbrev "^2.0.0"
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
+normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -12011,14 +12005,6 @@ read-pkg-up@^9.1.0:
     read-pkg "^7.1.0"
     type-fest "^2.5.0"
 
-read-pkg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  dependencies:
-    load-json-file "^4.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^3.0.0"
-
 read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
@@ -12510,15 +12496,6 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-auto-external@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-auto-external/-/rollup-plugin-auto-external-2.0.0.tgz#98fd137d66c1cbe0f4e245b31560a72dbde896aa"
-  dependencies:
-    builtins "^2.0.0"
-    read-pkg "^3.0.0"
-    safe-resolve "^1.0.0"
-    semver "^5.5.0"
-
 rollup-plugin-babel@^4.0.0-beta.2:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz#d15bd259466a9d1accbdb2fe2fff17c52d030acb"
@@ -12526,6 +12503,11 @@ rollup-plugin-babel@^4.0.0-beta.2:
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
+
+rollup-plugin-node-externals@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-externals/-/rollup-plugin-node-externals-7.1.2.tgz#19808d2b7ba6e5fc7d1c3bde1930fbcc4a5fe4a8"
+  integrity sha512-cVJFKs+ulZxpMmn/s+oi431d93Jq5+G7Sc5ixWDrL2k+Gj+MqXg0KMNWgKf8Mw5qpaG4jVDpsvuqFfiCvRcGeA==
 
 rollup-pluginutils@^2.8.1:
   version "2.8.2"
@@ -12577,10 +12559,6 @@ safe-regex-test@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
-
-safe-resolve@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/safe-resolve/-/safe-resolve-1.0.0.tgz#fe34f8d29d7a3becfd249d0aa8a799b5c3cf6559"
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -12641,7 +12619,7 @@ semver-diff@^4.0.0:
   dependencies:
     semver "^7.3.5"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
## Summary:
Turns out that the rollup plugin, autoexternals, doesn't handle sub-package improts, like `react-dom/server`. However, reading the issue report on that package, [I saw a link to another](https://github.com/stevenbenisek/rollup-plugin-auto-external/issues/16#issuecomment-557172792), more up-to-date package, that does handle this. So I switched to that package, and now everything works as expected.

I did have to explicitly use the `mjs` extension for the rollup config, but that's a small price to pay for the benefits of the new package.

Issue: XXX-XXXX

## Test plan:
`yarn build` to see that the build works.

I'll also verify the packages in webapp to check everything else is fine, though the storybook should also check out.