### PR TITLE
Add test that exhibits Popover warning

### DIFF
--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.regression.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.regression.test.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import {render, screen, waitFor} from "@testing-library/react";
+import Popover from "../popover";
+
+describe("Popover", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    it("should do something", async () => {
+        render(
+            <div style={{maxWidth: "400px", margin: "2em"}}>
+                <Popover
+                    content={<div>Hello world!</div>}
+                    dismissEnabled
+                    opened={true}
+                >
+                    <div>Open me</div>
+                </Popover>
+                <button aria-label="Keypad toggle">{"open keypad"}</button>
+            </div>,
+        );
+
+        await waitFor(() => expect(screen.getByText("Open me")).toBeVisible());
+    });
+});


### PR DESCRIPTION
## Summary:

This PR doesn't intend to land anything. It does however provide a unit test that causes React to `console.error()` a warning: ``React does not recognize the `uniqueId` prop on a DOM element.`` 

Issue: "none"

## Test plan:

`yarn jest packages/wonder-blocks-popover/src/components/__tests__/popover.regression.test.tsx`