### PR TITLE
Add in loadTranslations/clearTranslations to i18n, use stored messages if they exist.

### DIFF
--- a/.changeset/dull-stingrays-mate.md
+++ b/.changeset/dull-stingrays-mate.md
@@ -1,6 +1,5 @@
 ---
 "@khanacademy/wonder-blocks-i18n": minor
-"@khanacademy/wonder-blocks-form": patch
 ---
 
 Add loadTranslations/clearTranslations methods to wonder-blocks-i18n.

--- a/.changeset/dull-stingrays-mate.md
+++ b/.changeset/dull-stingrays-mate.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-i18n": minor
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Add loadTranslations/clearTranslations methods to wonder-blocks-i18n.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
     "files.associations": {
         "*.flow": "plaintext",
     },
-    "flow.enabled": false
+    "flow.enabled": false,
+    "jest.jestCommandLine": "yarn jest"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -44,7 +44,7 @@
                 "focus": false,
                 "panel": "dedicated"
             },
-            "script": "test",
+            "script": "jest",
             "group": {
                 "kind": "test",
                 "isDefault": true

--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.tsx
@@ -187,7 +187,11 @@ describe("FieldHeading", () => {
         render(
             <FieldHeading
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
-                label={<I18nInlineMarkup>Hello, world!</I18nInlineMarkup>}
+                label={
+                    <I18nInlineMarkup b={(s: string) => <b>{s}</b>}>
+                        {"<b>Test</b> Hello, world!"}
+                    </I18nInlineMarkup>
+                }
             />,
         );
 
@@ -205,7 +209,11 @@ describe("FieldHeading", () => {
             <FieldHeading
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
                 label={<Body>Hello, world</Body>}
-                description={<I18nInlineMarkup>description</I18nInlineMarkup>}
+                description={
+                    <I18nInlineMarkup b={(s: string) => <b>{s}</b>}>
+                        {"<b>Test</b> description"}
+                    </I18nInlineMarkup>
+                }
             />,
         );
 

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-store.test.ts
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-store.test.ts
@@ -1,0 +1,147 @@
+import {
+    clearTranslations,
+    getPluralTranslation,
+    getSingularTranslation,
+    loadTranslations,
+} from "../i18n-store";
+import {setLocale} from "../locale";
+
+describe("getSingularTranslation", () => {
+    const TEST_LOCALE = "en-pt";
+
+    afterEach(() => {
+        clearTranslations(TEST_LOCALE);
+    });
+
+    it("should return the translated string", () => {
+        // Arrange
+        loadTranslations(TEST_LOCALE, {
+            test: "arrrr matey",
+        });
+        setLocale(TEST_LOCALE);
+
+        // Act
+        const result = getSingularTranslation("test");
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(`"arrrr matey"`);
+    });
+
+    it("should return the original string if no translation found", () => {
+        // Arrange
+        loadTranslations(TEST_LOCALE, {
+            test2: "arrrr matey",
+        });
+        setLocale(TEST_LOCALE);
+
+        // Act
+        const result = getSingularTranslation("test");
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(`"test"`);
+    });
+
+    it("should return the translated string even if it's plural", () => {
+        // Arrange
+        loadTranslations(TEST_LOCALE, {
+            test: ["arrrr matey", "arrrr mateys"],
+        });
+        setLocale(TEST_LOCALE);
+
+        // Act
+        const result = getSingularTranslation("test");
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(`"arrrr matey"`);
+    });
+
+    it("should return a fake translation", () => {
+        // Arrange
+        setLocale("boxes");
+
+        // Act
+        const result = getSingularTranslation("test");
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(`"□□□□"`);
+    });
+});
+
+describe("getPluralTranslation", () => {
+    const TEST_LOCALE = "en-pt";
+
+    afterEach(() => {
+        clearTranslations(TEST_LOCALE);
+    });
+
+    it("should return the translated plural singular string", () => {
+        // Arrange
+        loadTranslations(TEST_LOCALE, {
+            test: "arrrr matey",
+        });
+        setLocale(TEST_LOCALE);
+
+        // Act
+        const result = getPluralTranslation(
+            {
+                lang: TEST_LOCALE,
+                messages: ["test singular", "test plural"],
+            },
+            0,
+        );
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(`"test singular"`);
+    });
+
+    it("should return the translated plural string", () => {
+        // Arrange
+        loadTranslations(TEST_LOCALE, {
+            test: "arrrr matey",
+        });
+        setLocale(TEST_LOCALE);
+
+        // Act
+        const result = getPluralTranslation(
+            {
+                lang: TEST_LOCALE,
+                messages: ["test singular", "test plural"],
+            },
+            1,
+        );
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(`"test plural"`);
+    });
+
+    it("should return the original string if no translation found", () => {
+        // Arrange
+        loadTranslations(TEST_LOCALE, {
+            test: "arrrr matey",
+        });
+        setLocale(TEST_LOCALE);
+
+        // Act
+        const result = getSingularTranslation("test2");
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(`"test2"`);
+    });
+
+    it("should return a fake translation", () => {
+        // Arrange
+        setLocale("boxes");
+
+        // Act
+        const result = getPluralTranslation(
+            {
+                lang: TEST_LOCALE,
+                messages: ["test singular", "test plural"],
+            },
+            0,
+        );
+
+        // Assert
+        expect(result).toMatchInlineSnapshot(`"□□□□ □□□□□□□□"`);
+    });
+});

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
@@ -3,6 +3,7 @@ import * as React from "react";
 import * as Locale from "../locale";
 import * as FakeTranslate from "../i18n-faketranslate";
 import {_, $_, ngettext, doNotTranslate, doNotTranslateYet} from "../i18n";
+import {clearTranslations, loadTranslations} from "../i18n-store";
 
 jest.mock("react", () => {
     return {
@@ -27,7 +28,7 @@ describe("i18n", () => {
         jest.clearAllMocks();
     });
 
-    describe("integration tests", () => {
+    describe("FakeTranslate integration tests", () => {
         beforeEach(() => {
             jest.spyOn(Locale, "getLocale").mockImplementation(() => "boxes");
         });
@@ -66,6 +67,79 @@ describe("i18n", () => {
 
             // Assert
             expect(result).toEqual(expectation);
+        });
+
+        it("doNotTranslate should not translate", () => {
+            // Arrange
+
+            // Act
+            const result = doNotTranslate("Test");
+
+            // Assert
+            expect(result).toEqual("Test");
+        });
+
+        it("doNotTranslateYet should not translate", () => {
+            // Arrange
+
+            // Act
+            const result = doNotTranslateYet("Test");
+
+            // Assert
+            expect(result).toEqual("Test");
+        });
+    });
+
+    describe("I18nStore integration tests", () => {
+        const TEST_LOCALE = "en-pt";
+
+        afterEach(() => {
+            clearTranslations(TEST_LOCALE);
+        });
+
+        beforeEach(() => {
+            jest.spyOn(Locale, "getLocale").mockImplementation(
+                () => TEST_LOCALE,
+            );
+        });
+
+        it("_ should translate", () => {
+            // Arrange
+            loadTranslations(TEST_LOCALE, {
+                test: "arrrr matey",
+            });
+
+            // Act
+            const result = _("test");
+
+            // Assert
+            expect(result).toMatchInlineSnapshot(`"arrrr matey"`);
+        });
+
+        it("$_ should translate", () => {
+            // Arrange
+            loadTranslations(TEST_LOCALE, {
+                test: "arrrr matey",
+            });
+
+            // Act
+            const result = $_("test");
+
+            // Assert
+            expect(result).toMatchInlineSnapshot(`"arrrr matey"`);
+        });
+
+        it("ngettext should translate", () => {
+            // Arrange
+            loadTranslations(TEST_LOCALE, {
+                Singular: ["arrrr matey", "arrrr mateys"],
+            });
+
+            // Act
+            const result = ngettext("Singular", "Plural", 0);
+
+            // Assert
+            expect(result).toMatchInlineSnapshot(`"Plural"`);
         });
 
         it("doNotTranslate should not translate", () => {

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
@@ -144,22 +144,28 @@ describe("i18n", () => {
 
         it("doNotTranslate should not translate", () => {
             // Arrange
+            loadTranslations(TEST_LOCALE, {
+                test: "arrrr matey",
+            });
 
             // Act
-            const result = doNotTranslate("Test");
+            const result = doNotTranslate("test");
 
             // Assert
-            expect(result).toEqual("Test");
+            expect(result).toEqual("test");
         });
 
         it("doNotTranslateYet should not translate", () => {
             // Arrange
+            loadTranslations(TEST_LOCALE, {
+                test: "arrrr matey",
+            });
 
             // Act
-            const result = doNotTranslateYet("Test");
+            const result = doNotTranslateYet("test");
 
             // Assert
-            expect(result).toEqual("Test");
+            expect(result).toEqual("test");
         });
     });
 

--- a/packages/wonder-blocks-i18n/src/functions/i18n-store.ts
+++ b/packages/wonder-blocks-i18n/src/functions/i18n-store.ts
@@ -1,0 +1,134 @@
+/**
+ * Functions for storing and retrieving translations.
+ *
+ * The i18n store is a simple cache that stores translations for a given locale.
+ */
+import FakeTranslate from "./i18n-faketranslate";
+import {getLocale} from "./locale";
+import {PluralConfigurationObject} from "./types";
+
+// The cache of strings that have been translated, by locale.
+const localeMessageStore = new Map<
+    string,
+    // Singular strings are stored as a string, plural strings are stored as
+    // an arrays of strings.
+    Record<string, string | Array<string>>
+>();
+
+// Create a fake translate object to use if we can't find a translation.
+const {translate: fakeTranslate} = new FakeTranslate();
+
+/**
+ * Get the translation for a given id and locale.
+ *
+ * @param id the id of the string to translate
+ * @param locale the locale to translate to
+ * @returns the translated string, or null if no translation is found
+ */
+const getTranslationFromStore = (id: string, locale: string) => {
+    // See if we have a cache for the locale.
+    const messageCache = localeMessageStore.get(locale);
+
+    if (!messageCache) {
+        return null;
+    }
+
+    // See if we have a cached message for the id.
+    const cachedMessage = messageCache[id];
+
+    if (!cachedMessage) {
+        return null;
+    }
+
+    // We found the translated string (or strings) so we can return it.
+    return cachedMessage;
+};
+
+/**
+ * Get the translation for a given message. If no translation is found, attempt
+ * to get the translation using FakeTranslate. If that fails, return the message.
+ *
+ * @param strOrPluralConfig the id of the string to translate, or a plural
+ * configuration object
+ * @returns the translated string
+ */
+export const getSingularTranslation = (
+    strOrPluralConfig: string | PluralConfigurationObject,
+) => {
+    // Sometimes we're given an argument that's meant for ngettext().  This
+    // happens if the same string is used in both i18n._() and i18n.ngettext()
+    // (.g. a = i18n._(foo); b = i18n.ngettext("foo", "bar", count);
+    // In such cases, only the plural form ends up in the .po file, and
+    // then it gets sent to us for the i18n._() case too.  No problem, though:
+    // we'll just take the singular arg.
+    const id =
+        typeof strOrPluralConfig === "string"
+            ? strOrPluralConfig
+            : strOrPluralConfig.messages[0];
+
+    // We try to find the translation in the cache.
+    const message = getTranslationFromStore(id, getLocale());
+
+    // We found the translation so we can return it.
+    // We need to make sure that we only return the first message, in the case
+    // where there is a plural form for the same message.
+    if (message) {
+        return Array.isArray(message) ? message[0] : message;
+    }
+
+    // Otherwise, there's no translation, so we try to do fake translation.
+    return fakeTranslate(id);
+};
+
+/**
+ * Get the plural translation for a given plural configuration object.
+ *
+ * @param pluralConfig the plural configuration object
+ * @param idx the index of the plural form to use
+ * @returns the translated string
+ */
+export const getPluralTranslation = (
+    pluralConfig: PluralConfigurationObject,
+    idx: number,
+) => {
+    const {lang, messages} = pluralConfig;
+
+    // We try to find the translation in the cache.
+    const translatedMessages = getTranslationFromStore(messages[0], lang);
+
+    // We found the translation so we can return the right plural form.
+    if (translatedMessages) {
+        if (!Array.isArray(translatedMessages)) {
+            // NOTE(john): This should never happen, but we should handle it
+            // just in case.
+            return translatedMessages;
+        }
+        return translatedMessages[idx];
+    }
+
+    // Otherwise, there's no translation, so we try to do fake translation.
+    return fakeTranslate(messages[idx]);
+};
+
+/**
+ * Load locale data into the cache.
+ *
+ * @param locale the locale to load data for
+ * @param data the id-message pairs to load
+ */
+export const loadTranslations = (
+    locale: string,
+    data: Record<string, string | Array<string>>,
+) => {
+    const messageCache = localeMessageStore.get(locale);
+    localeMessageStore.set(locale, {...messageCache, ...data});
+};
+
+/**
+ * Clear locale data from the cache.
+ *
+ * @param locale the locale to clear data for
+ */
+export const clearTranslations = (locale: string) => {
+    localeMessageStore.delete(locale);
+};

--- a/packages/wonder-blocks-i18n/src/functions/types.ts
+++ b/packages/wonder-blocks-i18n/src/functions/types.ts
@@ -14,3 +14,8 @@ export interface IProvideTranslation {
      */
     translate(input: string): string;
 }
+
+export type PluralConfigurationObject = {
+    lang: string;
+    messages: Array<string>;
+};

--- a/packages/wonder-blocks-i18n/src/index.ts
+++ b/packages/wonder-blocks-i18n/src/index.ts
@@ -6,6 +6,7 @@ export {
     doNotTranslateYet, // used by handlebars translation functions in webapp
     ngetpos,
 } from "./functions/i18n";
+export {loadTranslations, clearTranslations} from "./functions/i18n-store";
 
 export {localeToFixed, getDecimalSeparator} from "./functions/l10n";
 export {getLocale, setLocale} from "./functions/locale";


### PR DESCRIPTION
## Summary:
This is adding in functionality that's similar to LinguiJS, to the wonder-blocks-i18n package, so that we can have a store of translated strings and use them for our translations instead of assuming that the strings will already be translated for us.

Issue: FEI-5682

## Test plan:
Tests should pass! I'll be wiring this up in Webapp in a separate PR, once this lands.