### PR TITLE
fix(LEMS-2225): add conditional aria-describedby logic

### DIFF
--- a/.changeset/plenty-rockets-breathe.md
+++ b/.changeset/plenty-rockets-breathe.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-popover": patch
 ---
 
-Testing adding aria-describedby
+Adding logic for aria-describedby

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -756,7 +756,11 @@ export const WithCustomAriaLabel: StoryComponentType = {
 /**
  * With custom aria-describedby - overrides the default aria-describedby
  */
-export const WithCustomAriaDescribedBy = ({placement}: {placement: Placement}) => {
+export const WithCustomAriaDescribedBy = ({
+    placement,
+}: {
+    placement: Placement;
+}) => {
     const [opened, setOpened] = React.useState(false);
 
     return (

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -6,10 +6,10 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {HeadingMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import type {Placement} from "@khanacademy/wonder-blocks-tooltip";
 
-import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
+import {Popover, PopoverContent, PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
 import packageConfig from "../../packages/wonder-blocks-popover/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
@@ -86,6 +86,16 @@ const styles = StyleSheet.create({
         padding: spacing.large_24,
         flexDirection: "row",
         gap: spacing.medium_16,
+    },
+    srOnly: {
+        border: 0,
+        clip: "rect(0,0,0,0)",
+        height: 1,
+        margin: -1,
+        overflow: "hidden",
+        padding: 0,
+        position: "absolute",
+        width: 1,
     },
 });
 
@@ -741,4 +751,43 @@ export const CustomAriaLabel: StoryComponentType = {
         onClose: () => {},
         "aria-label": "Popover with custom aria label",
     } as PopoverArgs,
+};
+
+
+export const CustomAriaDescribedBy = ({placement}: {placement: Placement}) => {
+
+    const [opened, setOpened] = React.useState(true);
+
+    return (
+        <View style={styles.example}>
+            <Popover
+                aria-label="Popover with custom aria label"
+                aria-describedby="PopoverTitle"
+                placement={placement}
+                opened={opened}
+                onClose={() => setOpened(false)}
+                content={
+                    <>
+                        <HeadingMedium id="PopoverTitle" style={styles.srOnly}>Sample text that would describe the navigation of the expression widget</HeadingMedium>
+                        <PopoverContentCore
+                            closeButtonVisible
+                        >
+                            <>
+                                Popover Content
+                            </>
+                        </PopoverContentCore>
+                    </>
+
+                }
+            >
+                <Button
+                    onClick={() => {
+                        setOpened(true);
+                    }}
+                >
+                    {`Open popover`}
+                </Button>
+            </Popover>
+        </View>
+    );
 };

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -9,7 +9,7 @@ import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import type {Placement} from "@khanacademy/wonder-blocks-tooltip";
 
-import {Popover, PopoverContent, PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
+import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
 import packageConfig from "../../packages/wonder-blocks-popover/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
@@ -739,7 +739,7 @@ export const PopoverAlignment: StoryComponentType = {
  * With custom aria-label - overrides the default aria-describedby and aria-labelledby
  */
 
-export const CustomAriaLabel: StoryComponentType = {
+export const WithCustomAriaLabel: StoryComponentType = {
     args: {
         children: <Button>Open popover</Button>,
         content: ContentMappings.withTextOnly,
@@ -753,31 +753,30 @@ export const CustomAriaLabel: StoryComponentType = {
     } as PopoverArgs,
 };
 
-
-export const CustomAriaDescribedBy = ({placement}: {placement: Placement}) => {
-
-    const [opened, setOpened] = React.useState(true);
+export const WithAriaDescribedBy = ({placement}: {placement: Placement}) => {
+    const [opened, setOpened] = React.useState(false);
 
     return (
         <View style={styles.example}>
             <Popover
-                aria-label="Popover with custom aria label"
-                aria-describedby="PopoverTitle"
+                id="Popover"
                 placement={placement}
                 opened={opened}
                 onClose={() => setOpened(false)}
                 content={
                     <>
-                        <HeadingMedium id="PopoverTitle" style={styles.srOnly}>Sample text that would describe the navigation of the expression widget</HeadingMedium>
-                        <PopoverContentCore
-                            closeButtonVisible
+                        <HeadingMedium
+                            id="Popover-content"
+                            style={styles.srOnly}
                         >
-                            <>
-                                Popover Content
-                            </>
-                        </PopoverContentCore>
+                            Hidden text that would describe the popover content
+                        </HeadingMedium>
+                        <PopoverContent
+                            title="Title"
+                            content="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip commodo."
+                            closeButtonVisible
+                        />
                     </>
-
                 }
             >
                 <Button

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -736,7 +736,7 @@ export const PopoverAlignment: StoryComponentType = {
 };
 
 /**
- * With custom aria-label - overrides the default aria-describedby and aria-labelledby
+ * With custom aria-label - overrides the default aria-labelledby
  */
 
 export const WithCustomAriaLabel: StoryComponentType = {
@@ -753,20 +753,23 @@ export const WithCustomAriaLabel: StoryComponentType = {
     } as PopoverArgs,
 };
 
-export const WithAriaDescribedBy = ({placement}: {placement: Placement}) => {
+/**
+ * With custom aria-describedby - overrides the default aria-describedby
+ */
+export const WithCustomAriaDescribedBy = ({placement}: {placement: Placement}) => {
     const [opened, setOpened] = React.useState(false);
 
     return (
         <View style={styles.example}>
             <Popover
-                id="Popover"
+                aria-describedby="custom-popover-description"
                 placement={placement}
                 opened={opened}
                 onClose={() => setOpened(false)}
                 content={
                     <>
                         <HeadingMedium
-                            id="Popover-content"
+                            id="custom-popover-description"
                             style={styles.srOnly}
                         >
                             Hidden text that would describe the popover content

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -583,17 +583,21 @@ describe("Popover", () => {
             ).toBeInTheDocument();
         });
 
-        it("should announce a popover correctly by reading the aria label", async () => {
+        it("should announce a popover correctly by reading the aria-label attribute", async () => {
             // Arrange
             render(
                 <Popover
+                    id="test-popover"
                     onClose={jest.fn()}
                     aria-label="Popover Aria Label"
                     content={
-                        <PopoverContentCore>
-                            <button data-close-button onClick={close}>
-                                Close Popover
-                            </button>
+                        <PopoverContentCore closeButtonVisible={true}>
+                            <h1 id="test-popover-title">
+                                This is a popover title
+                            </h1>
+                            <p id="test-popover-content">
+                                This is a popover description
+                            </p>
                         </PopoverContentCore>
                     }
                 >
@@ -602,19 +606,59 @@ describe("Popover", () => {
             );
 
             // Act
-            // Open the popover
-            const openButton = await screen.findByRole("button", {
-                name: "Open default popover",
-            });
-
-            await userEvent.click(openButton);
-            const popover = await screen.findByRole("dialog");
+            await userEvent.click(
+                await screen.findByRole("button", {
+                    name: "Open default popover",
+                }),
+            );
 
             // Assert
+            expect(
+                screen.getByLabelText("Popover Aria Label"),
+            ).toBeInTheDocument();
 
-            expect(popover).toHaveAttribute("aria-label", "Popover Aria Label");
-            expect(popover).not.toHaveAttribute("aria-labelledby");
-            expect(popover).not.toHaveAttribute("aria-describedby");
+            expect(
+                await screen.findByRole("dialog", {
+                    description: "This is a popover description",
+                }),
+            ).toBeInTheDocument();
+        });
+
+        it("should announce a popover correctly by reading the describing contents", async () => {
+            // Arrange
+            render(
+                <Popover
+                    id="test-popover"
+                    onClose={jest.fn()}
+                    aria-describedby="describing-popover-id"
+                    content={
+                        <PopoverContentCore closeButtonVisible={true}>
+                            <h1 id="test-popover-title">
+                                This is a popover title
+                            </h1>
+                            <p id="describing-popover-id">
+                                This is a popover description
+                            </p>
+                        </PopoverContentCore>
+                    }
+                >
+                    <Button>Open default popover</Button>
+                </Popover>,
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {
+                    name: "Open default popover",
+                }),
+            );
+
+            //Assert
+            expect(
+                await screen.findByRole("dialog", {
+                    description: "This is a popover description",
+                }),
+            ).toBeInTheDocument();
         });
 
         it("should correctly describe the popover content core's aria label", async () => {

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -618,15 +618,9 @@ describe("Popover", () => {
                     name: "Popover Aria Label",
                 }),
             ).toBeInTheDocument();
-
-            expect(
-                await screen.findByRole("dialog", {
-                    description: "This is a popover description",
-                }),
-            ).toBeInTheDocument();
         });
 
-        it("should announce a popover correctly by reading the describing contents", async () => {
+        it("should announce a popover correctly by reading the title contents", async () => {
             // Arrange
             render(
                 <Popover
@@ -661,7 +655,38 @@ describe("Popover", () => {
                     name: "This is a popover title",
                 }),
             ).toBeInTheDocument();
+        });
 
+        it("should announce a popover correctly by reading the describing contents", async () => {
+            // Arrange
+            render(
+                <Popover
+                    id="test-popover"
+                    onClose={jest.fn()}
+                    aria-describedby="describing-popover-id"
+                    content={
+                        <PopoverContentCore closeButtonVisible={true}>
+                            <h1 id="test-popover-title">
+                                This is a popover title
+                            </h1>
+                            <p id="describing-popover-id">
+                                This is a popover description
+                            </p>
+                        </PopoverContentCore>
+                    }
+                >
+                    <Button>Open default popover</Button>
+                </Popover>,
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {
+                    name: "Open default popover",
+                }),
+            );
+
+            //Assert
             expect(
                 await screen.findByRole("dialog", {
                     description: "This is a popover description",

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -614,7 +614,9 @@ describe("Popover", () => {
 
             // Assert
             expect(
-                screen.getByLabelText("Popover Aria Label"),
+                await screen.findByRole("dialog", {
+                    name: "Popover Aria Label",
+                }),
             ).toBeInTheDocument();
 
             expect(

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover.test.tsx
@@ -658,6 +658,12 @@ describe("Popover", () => {
             //Assert
             expect(
                 await screen.findByRole("dialog", {
+                    name: "This is a popover title",
+                }),
+            ).toBeInTheDocument();
+
+            expect(
+                await screen.findByRole("dialog", {
                     description: "This is a popover description",
                 }),
             ).toBeInTheDocument();

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -282,16 +282,8 @@ export default class Popover extends React.Component<Props, State> {
         } = this.props;
         const {anchorElement} = this.state;
 
-        /**
-         * If aria-describedby is provided, use that id as a reference to the content
-         * If only aria-label is provided, don't use aria-describedby
-         * If both are provided, use aria-label as the label (automatically done by SR)
-         * If neither are provided, use the uniqueId to reference the content
-         *  > Don't want to have aria-describedby set by default in case there isn't something
-         *  > for the SR to reference.
-         */
-        const describedBy =
-            ariaDescribedBy || (ariaLabel ? undefined : `${uniqueId}-content`);
+        const describedBy = ariaDescribedBy || `${uniqueId}-content`;
+
         const ariaLabelledBy = ariaLabel ? undefined : `${uniqueId}-title`;
 
         const popperContent = (

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -281,7 +281,7 @@ export default class Popover extends React.Component<Props, State> {
         } = this.props;
         const {anchorElement} = this.state;
 
-        const ariaDescribedBy = ariaLabel ? undefined : `${uniqueId}-content`;
+        const ariaDescribedBy = `${uniqueId}-content`;
         const ariaLabelledBy = ariaLabel ? undefined : `${uniqueId}-title`;
 
         const popperContent = (
@@ -289,9 +289,9 @@ export default class Popover extends React.Component<Props, State> {
                 {(props: PopperElementProps) => (
                     <PopoverDialog
                         {...props}
-                        aria-label={ariaLabel}
                         aria-describedby={ariaDescribedBy}
                         aria-labelledby={ariaLabelledBy}
+                        aria-label={ariaLabel}
                         id={uniqueId}
                         onUpdate={(placement) => this.setState({placement})}
                         showTail={showTail}

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -278,10 +278,20 @@ export default class Popover extends React.Component<Props, State> {
             showTail,
             portal,
             "aria-label": ariaLabel,
+            "aria-describedby": ariaDescribedBy,
         } = this.props;
         const {anchorElement} = this.state;
 
-        const ariaDescribedBy = `${uniqueId}-content`;
+        /**
+         * If aria-describedby is provided, use that id as a reference to the content
+         * If only aria-label is provided, don't use aria-describedby
+         * If both are provided, use aria-label as the label (automatically done by SR)
+         * If neither are provided, use the uniqueId to reference the content
+         *  > Don't want to have aria-describedby set by default in case there isn't something
+         *  > for the SR to reference.
+         */
+        const describedBy =
+            ariaDescribedBy || (ariaLabel ? undefined : `${uniqueId}-content`);
         const ariaLabelledBy = ariaLabel ? undefined : `${uniqueId}-title`;
 
         const popperContent = (
@@ -289,9 +299,9 @@ export default class Popover extends React.Component<Props, State> {
                 {(props: PopperElementProps) => (
                     <PopoverDialog
                         {...props}
-                        aria-describedby={ariaDescribedBy}
-                        aria-labelledby={ariaLabelledBy}
                         aria-label={ariaLabel}
+                        aria-describedby={describedBy}
+                        aria-labelledby={ariaLabelledBy}
                         id={uniqueId}
                         onUpdate={(placement) => this.setState({placement})}
                         showTail={showTail}


### PR DESCRIPTION
## Summary:
Adds conditional logic to allow aria-describedby to be:
- defined by the user (overrides default)
- available in addition to `aria-label` or `aria-labelledby`

Issue: LEMS-2225

## Test plan:
1. `yarn start` in branch or [chromatic link](https://5e1bf4b385e3fb0020b7073c-lzlzfekdzl.chromatic.com/?path=/docs/overview--docs)
2. Navigate to Popover stories
3. Choose `With custom aria described by` story 
4. Story includes hidden element that should be read out by the screen reader 

## Screenshots

https://github.com/user-attachments/assets/a46ca21a-71ac-442a-891b-98dc675701fb

