### PR TITLE
TextArea height improvements

### DIFF
--- a/.changeset/tall-lions-hug.md
+++ b/.changeset/tall-lions-hug.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+`TextArea`: Updates the `min-height` of the textarea element so that when it is resized vertically using the resize control, the smallest it can get is equivalent to 1 row of the textarea.

--- a/.changeset/twenty-eels-travel.md
+++ b/.changeset/twenty-eels-travel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+`TextArea`: Adds `rootStyle` prop for styling to the root node

--- a/__docs__/wonder-blocks-form/text-area.argtypes.ts
+++ b/__docs__/wonder-blocks-form/text-area.argtypes.ts
@@ -57,6 +57,17 @@ export default {
             category: "Visual style",
         },
     },
+    rootStyle: {
+        table: {
+            type: {
+                summary: "StyleType",
+            },
+            category: "Visual style",
+        },
+        control: {
+            type: "null",
+        },
+    },
 
     /**
      * Events

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -486,6 +486,29 @@ export const CustomStyle: StoryComponentType = {
 };
 
 /**
+ * Custom styling can be passed to the root node of the component using the
+ * `rootStyle` prop. If possible, try to use this prop carefully and use the
+ * `style` prop instead.
+ *
+ * This example shows that applying root styles can enable the textarea to fill
+ * in the remaining height.
+ */
+export const RootStyle: StoryComponentType = {
+    render(args) {
+        return (
+            <View style={{height: "500px", gap: spacing.large_24}}>
+                <div>Example flex item child </div>
+                <TextArea
+                    {...args}
+                    style={{height: "100%"}}
+                    rootStyle={{flexGrow: 1}}
+                />
+            </View>
+        );
+    },
+};
+
+/**
  * A ref can be passed to the component to have access to the textarea element.
  */
 export const WithRef = () => {

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -35,6 +35,12 @@ type TextAreaProps = AriaProps & {
      */
     style?: StyleType;
     /**
+     * Custom styles for the root node of the component.
+     * If possible, try to use this prop carefully and use the `style` prop
+     * instead.
+     */
+    rootStyle?: StyleType;
+    /**
      * Provide hints or examples of what to enter.
      */
     placeholder?: string;
@@ -198,6 +204,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             required,
             resizeType,
             light,
+            rootStyle,
             // Should only include aria related props
             ...otherProps
         } = props;
@@ -265,7 +272,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             return [...baseStyles, ...(light ? lightStyles : defaultStyles)];
         };
         return (
-            <View style={{width: "100%"}}>
+            <View style={[{width: "100%"}, rootStyle]}>
                 <StyledTextArea
                     id={uniqueId}
                     data-testid={testId}

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -9,7 +9,13 @@ import {
     addStyle,
     View,
 } from "@khanacademy/wonder-blocks-core";
-import {border, color, mix, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    color,
+    font,
+    mix,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
 type TextAreaProps = AriaProps & {
@@ -306,12 +312,19 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
 );
 
+const VERTICAL_SPACING_PX = 10;
+
 const styles = StyleSheet.create({
     textarea: {
         borderRadius: border.radius.medium_4,
         boxSizing: "border-box",
-        padding: `10px ${spacing.medium_16}px`,
-        minHeight: "1em",
+        padding: `${VERTICAL_SPACING_PX}px ${spacing.medium_16}px`,
+        // This minHeight is equivalent to when the textarea has one row
+        minHeight: `${
+            VERTICAL_SPACING_PX * 2 +
+            font.lineHeight.medium +
+            2 * border.width.hairline
+        }px`,
     },
     default: {
         background: color.white,


### PR DESCRIPTION
## Summary:
- Adds rootStyle prop. This provides flexibility so that the root node can be styled
  - A useful scenario for this is if the textarea element needs to fill in the remaining height of a flex container. In this scenario, the root node of TextArea can be styled with `flex-grow: 1` and the textarea element can be styled with `height: 100%`
- Sets textarea element's `min-height` to the height of the textarea when it has 1 row

Issue: WB-1749

## Test plan:
`rootStyle` prop:
- Review documentation/stories for rootStyle
  - (`?path=/docs/packages-form-textarea--docs`)
  - (`?path=/story/packages-form-textarea--root-style`)

minHeight:
- Confirm that the smallest you can resize the textarea to is equivalent to when there is 1 row