### PR TITLE
WB-1741: Button is missing focus styles when secondary and disabled

### DIFF
--- a/.changeset/soft-seas-sparkle.md
+++ b/.changeset/soft-seas-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-button": patch
+---
+
+Fixes a UI issue where secondary buttons weren't displaying the focus ring when disabled + focused

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -460,6 +460,7 @@ export const _generateStyles = (
                     outlineColor: light
                         ? theme.color.border.secondary.inverse
                         : theme.color.border.disabled,
+                    outlineStyle: "solid",
                     outlineWidth: theme.border.width.disabled,
                 },
             },


### PR DESCRIPTION
## Summary:

Fixes a UI issue where secondary buttons weren't displaying the focus ring when
disabled + focused.

Issue: WB-1741

## Test plan:

Navigate to the Button variants story in Storybook and verify that the focus
ring is displayed when a secondary button is disabled and focused.

/?path=/story/packages-button--variants

<img width="447" alt="Screenshot 2024-08-21 at 3 03 07 PM" src="https://github.com/user-attachments/assets/d31d5056-bef0-4fd1-97c7-94fe92f3ff23">
