### PR TITLE
Improve color contrast on CircularSpinner

### DIFF
--- a/.changeset/neat-shoes-approve.md
+++ b/.changeset/neat-shoes-approve.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-progress-spinner": patch
+---
+
+Update CircularSpinner color to offBlack50 for improved color contrast for accessibility

--- a/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
+++ b/packages/wonder-blocks-progress-spinner/src/components/circular-spinner.tsx
@@ -21,7 +21,7 @@ const paths = {
 
 const colors = {
     light: color.white,
-    dark: color.offBlack16,
+    dark: color.offBlack50,
 } as const;
 
 const StyledPath = addStyle("path");


### PR DESCRIPTION
## Summary:
Update CircularSpinner color to offBlack50 for a higher contrast. This aligns with the [Figma component](https://www.figma.com/design/pmQkmkD4FwfIjEPVVtFn9Q/Add-our-color-tokens-in-Wonder-Blocks-to-Figma?node-id=1654-25&t=yMni3FwChqE5x2w1-4) as well

Issue: WB-1743

## Test plan:
1. Confirm the CircularSpinner is using offBlack50 (`?path=/story/packages-progressspinner-circularspinner--default`)