### PR TITLE
LabeledTextField: Adjust styling for light prop for improved color contrast

### DIFF
--- a/.changeset/sharp-maps-leave.md
+++ b/.changeset/sharp-maps-leave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Improve `LabeledTextField` styling when the `light` prop is `true`. This improves the color contrast of the label, required indicator, description, and error message when the component is used on dark backgrounds.

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -440,7 +440,7 @@ export const Error: StoryComponentType = {
  * `light` prop is set to `true`:
  * - the underlying `TextField` will have a light border when focused
  * - a specific light styling is used for the error state, as seen in the
- * `ErrorLight\` story
+ * `ErrorLight` story
  * - the text in the component (label, required indicator, description, and
  * error message) are modified to work on the dark background
  */

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -436,6 +436,15 @@ export const Error: StoryComponentType = {
     render: ErrorRender,
 };
 
+/**
+ * The `light` prop is intended to be used on a dark background. When the
+ * `light` prop is set to `true`:
+ * - the underlying `TextField` will have a light border when focused
+ * - a specific light styling is used for the error state, as seen in the
+ * `ErrorLight\` story
+ * - the text in the component (label, required indicator, description, and
+ * error message) are modified to work on the dark background
+ */
 export const Light: StoryComponentType = (args: any) => {
     const [value, setValue] = React.useState("");
 
@@ -466,18 +475,10 @@ Light.args = {
     disabled: false,
 };
 
-Light.parameters = {
-    docs: {
-        description: {
-            story: `If the \`light\` prop is set to true, the
-        underlying \`TextField\` will have a light border when focused.
-        This is intended to be used on a dark background. There is also a
-        specific light styling for the error state, as seen in the
-        \`ErrorLight\` story.`,
-        },
-    },
-};
-
+/**
+ * If an input value fails validation and the `light\` prop is true,
+ * `TextField` will have light error styling.
+ */
 export const ErrorLight: StoryComponentType = (args: any) => {
     const [value, setValue] = React.useState("khan");
 
@@ -517,15 +518,6 @@ export const ErrorLight: StoryComponentType = (args: any) => {
 
 ErrorLight.args = {
     disabled: false,
-};
-
-ErrorLight.parameters = {
-    docs: {
-        description: {
-            story: `If an input value fails validation and the
-        \`light\` prop is true, \`TextField\` will have light error styling.`,
-        },
-    },
 };
 
 export const Disabled: StoryComponentType = () => (

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -3,7 +3,6 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Button from "@khanacademy/wonder-blocks-button";
@@ -459,7 +458,7 @@ export const Light: StoryComponentType = (args: any) => {
             <LabeledTextField
                 {...args}
                 label="Name"
-                description={<LabelSmall>Please enter your name</LabelSmall>}
+                description="Please enter your name"
                 value={value}
                 onChange={setValue}
                 placeholder="Name"
@@ -500,9 +499,7 @@ export const ErrorLight: StoryComponentType = (args: any) => {
             <LabeledTextField
                 {...args}
                 label="Email"
-                description={
-                    <LabelSmall>Please provide your personal email</LabelSmall>
-                }
+                description="Please provide your personal email"
                 type="email"
                 value={value}
                 light={true}

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Button from "@khanacademy/wonder-blocks-button";
 import Link from "@khanacademy/wonder-blocks-link";

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -452,11 +452,7 @@ export const Light: StoryComponentType = (args: any) => {
                 label={
                     <LabelMedium style={styles.whiteColor}>Name</LabelMedium>
                 }
-                description={
-                    <LabelSmall style={styles.offWhiteColor}>
-                        Please enter your name
-                    </LabelSmall>
-                }
+                description={<LabelSmall>Please enter your name</LabelSmall>}
                 value={value}
                 onChange={setValue}
                 placeholder="Name"
@@ -507,9 +503,7 @@ export const ErrorLight: StoryComponentType = (args: any) => {
                     <LabelMedium style={styles.whiteColor}>Email</LabelMedium>
                 }
                 description={
-                    <LabelSmall style={styles.offWhiteColor}>
-                        Please provide your personal email
-                    </LabelSmall>
+                    <LabelSmall>Please provide your personal email</LabelSmall>
                 }
                 type="email"
                 value={value}
@@ -772,9 +766,6 @@ const styles = StyleSheet.create({
     },
     whiteColor: {
         color: color.white,
-    },
-    offWhiteColor: {
-        color: color.white64,
     },
     button: {
         maxWidth: 150,

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -479,7 +479,7 @@ Light.parameters = {
 };
 
 /**
- * If an input value fails validation and the `light\` prop is true,
+ * If an input value fails validation and the `light` prop is true,
  * `TextField` will have light error styling.
  */
 export const ErrorLight: StoryComponentType = (args: any) => {

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Button from "@khanacademy/wonder-blocks-button";

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -449,9 +449,7 @@ export const Light: StoryComponentType = (args: any) => {
         <View style={styles.darkBackground}>
             <LabeledTextField
                 {...args}
-                label={
-                    <LabelMedium style={styles.whiteColor}>Name</LabelMedium>
-                }
+                label={<LabelMedium>Name</LabelMedium>}
                 description={<LabelSmall>Please enter your name</LabelSmall>}
                 value={value}
                 onChange={setValue}
@@ -499,9 +497,7 @@ export const ErrorLight: StoryComponentType = (args: any) => {
         <View style={styles.darkBackground}>
             <LabeledTextField
                 {...args}
-                label={
-                    <LabelMedium style={styles.whiteColor}>Email</LabelMedium>
-                }
+                label={<LabelMedium>Email</LabelMedium>}
                 description={
                     <LabelSmall>Please provide your personal email</LabelSmall>
                 }
@@ -763,9 +759,6 @@ const styles = StyleSheet.create({
     darkBackground: {
         background: color.darkBlue,
         padding: `${spacing.medium_16}px`,
-    },
-    whiteColor: {
-        color: color.white,
     },
     button: {
         maxWidth: 150,

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -449,7 +449,7 @@ export const Light: StoryComponentType = (args: any) => {
         <View style={styles.darkBackground}>
             <LabeledTextField
                 {...args}
-                label={<LabelMedium>Name</LabelMedium>}
+                label="Name"
                 description={<LabelSmall>Please enter your name</LabelSmall>}
                 value={value}
                 onChange={setValue}
@@ -497,7 +497,7 @@ export const ErrorLight: StoryComponentType = (args: any) => {
         <View style={styles.darkBackground}>
             <LabeledTextField
                 {...args}
-                label={<LabelMedium>Email</LabelMedium>}
+                label="Email"
                 description={
                     <LabelSmall>Please provide your personal email</LabelSmall>
                 }

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -454,24 +454,28 @@ export const Light: StoryComponentType = (args: any) => {
     };
 
     return (
-        <View style={styles.darkBackground}>
-            <LabeledTextField
-                {...args}
-                label="Name"
-                description="Please enter your name"
-                value={value}
-                onChange={setValue}
-                placeholder="Name"
-                light={true}
-                onKeyDown={handleKeyDown}
-                required={true}
-            />
-        </View>
+        <LabeledTextField
+            {...args}
+            label="Name"
+            description="Please enter your name"
+            value={value}
+            onChange={setValue}
+            placeholder="Name"
+            light={true}
+            onKeyDown={handleKeyDown}
+            required={true}
+        />
     );
 };
 
 Light.args = {
     disabled: false,
+};
+
+Light.parameters = {
+    backgrounds: {
+        default: "darkBlue",
+    },
 };
 
 /**
@@ -495,26 +499,30 @@ export const ErrorLight: StoryComponentType = (args: any) => {
     };
 
     return (
-        <View style={styles.darkBackground}>
-            <LabeledTextField
-                {...args}
-                label="Email"
-                description="Please provide your personal email"
-                type="email"
-                value={value}
-                light={true}
-                onChange={setValue}
-                placeholder="Email"
-                validate={validate}
-                onKeyDown={handleKeyDown}
-                required={true}
-            />
-        </View>
+        <LabeledTextField
+            {...args}
+            label="Email"
+            description="Please provide your personal email"
+            type="email"
+            value={value}
+            light={true}
+            onChange={setValue}
+            placeholder="Email"
+            validate={validate}
+            onKeyDown={handleKeyDown}
+            required={true}
+        />
     );
 };
 
 ErrorLight.args = {
     disabled: false,
+};
+
+ErrorLight.parameters = {
+    backgrounds: {
+        default: "darkBlue",
+    },
 };
 
 export const Disabled: StoryComponentType = () => (
@@ -747,10 +755,6 @@ AutoComplete.parameters = {
 };
 
 const styles = StyleSheet.create({
-    darkBackground: {
-        background: color.darkBlue,
-        padding: `${spacing.medium_16}px`,
-    },
     button: {
         maxWidth: 150,
     },

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -456,6 +456,7 @@ export const Light: StoryComponentType = (args: any) => {
                 placeholder="Name"
                 light={true}
                 onKeyDown={handleKeyDown}
+                required={true}
             />
         </View>
     );
@@ -508,6 +509,7 @@ export const ErrorLight: StoryComponentType = (args: any) => {
                 placeholder="Email"
                 validate={validate}
                 onKeyDown={handleKeyDown}
+                required={true}
             />
         </View>
     );

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -82,7 +82,7 @@ export default class FieldHeading extends React.Component<Props> {
     }
 
     maybeRenderDescription(): React.ReactNode | null | undefined {
-        const {description, testId} = this.props;
+        const {description, testId, light} = this.props;
 
         if (!description) {
             return null;
@@ -91,7 +91,7 @@ export default class FieldHeading extends React.Component<Props> {
         return (
             <React.Fragment>
                 <LabelSmall
-                    style={styles.description}
+                    style={light ? styles.lightDescription : styles.description}
                     testId={testId && `${testId}-description`}
                 >
                     {description}
@@ -144,6 +144,9 @@ const styles = StyleSheet.create({
     },
     description: {
         color: color.offBlack64,
+    },
+    lightDescription: {
+        color: color.white64,
     },
     error: {
         color: color.red,

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -59,7 +59,10 @@ export default class FieldHeading extends React.Component<Props> {
         const {label, id, required, testId, light} = this.props;
 
         const requiredIcon = (
-            <StyledSpan style={styles.required} aria-hidden={true}>
+            <StyledSpan
+                style={light ? styles.lightRequired : styles.required}
+                aria-hidden={true}
+            >
                 {" "}
                 *
             </StyledSpan>
@@ -159,5 +162,8 @@ const styles = StyleSheet.create({
     },
     required: {
         color: color.red,
+    },
+    lightRequired: {
+        color: color.fadedRed,
     },
 });

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -42,6 +42,10 @@ type Props = {
      * Optional test ID for e2e testing.
      */
     testId?: string;
+    /**
+     * Change the field’s sub-components to fit a dark background.
+     */
+    light?: boolean;
 };
 
 const StyledSpan = addStyle("span");

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -102,7 +102,7 @@ export default class FieldHeading extends React.Component<Props> {
     }
 
     maybeRenderError(): React.ReactNode | null | undefined {
-        const {error, id, testId} = this.props;
+        const {error, id, testId, light} = this.props;
 
         if (!error) {
             return null;
@@ -112,7 +112,7 @@ export default class FieldHeading extends React.Component<Props> {
             <React.Fragment>
                 <Strut size={spacing.small_12} />
                 <LabelSmall
-                    style={styles.error}
+                    style={light ? styles.lightError : styles.error}
                     role="alert"
                     id={id && `${id}-error`}
                     testId={testId && `${testId}-error`}
@@ -147,6 +147,9 @@ const styles = StyleSheet.create({
     },
     error: {
         color: color.red,
+    },
+    lightError: {
+        color: color.fadedRed,
     },
     required: {
         color: color.red,

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -56,7 +56,7 @@ const StyledSpan = addStyle("span");
  */
 export default class FieldHeading extends React.Component<Props> {
     renderLabel(): React.ReactNode {
-        const {label, id, required, testId} = this.props;
+        const {label, id, required, testId, light} = this.props;
 
         const requiredIcon = (
             <StyledSpan style={styles.required} aria-hidden={true}>
@@ -68,7 +68,7 @@ export default class FieldHeading extends React.Component<Props> {
         return (
             <React.Fragment>
                 <LabelMedium
-                    style={styles.label}
+                    style={light ? styles.lightLabel : styles.label}
                     tag="label"
                     htmlFor={id && `${id}-field`}
                     testId={testId && `${testId}-label`}
@@ -141,6 +141,9 @@ export default class FieldHeading extends React.Component<Props> {
 const styles = StyleSheet.create({
     label: {
         color: color.offBlack,
+    },
+    lightLabel: {
+        color: color.white,
     },
     description: {
         color: color.offBlack64,

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -241,6 +241,7 @@ class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
                         id={uniqueId}
                         testId={testId}
                         style={style}
+                        light={light}
                         field={
                             <TextField
                                 id={`${uniqueId}-field`}


### PR DESCRIPTION
## Summary:
- Use the `LabeledTextField`'s `light` prop in `FieldHeading` to apply light styling for the label, required indicator, description, and the error message. This improves the color contrast of the elements in `LabelledTextField` when used on a dark background. This aligns with the specs in [Figma](https://www.figma.com/design/VbVu3h2BpBhH80niq101MHHE/%F0%9F%92%A0-Main-Components?node-id=13840-8635&t=sq9ZCuTcvzXGme48-4)
- Updated documentation for the `Light` and `Error Light` stories

Issue: WB-1744

## Test plan:
1. Review the LabelledTextField Light and ErrorLight documentation (`?path=/docs/packages-form-labeledtextfield--docs`)
2. Review the Light and ErrorLight stories
- `?path=/story/packages-form-labeledtextfield--light` 
- `?path=/story/packages-form-labeledtextfield--error-light`

<img width="1720" alt="Screenshot 2024-08-22 at 3 17 58 PM" src="https://github.com/user-attachments/assets/5cdba942-d2d0-4822-9e46-554bfd1ec3c4">

<img width="1719" alt="Screenshot 2024-08-22 at 3 16 40 PM" src="https://github.com/user-attachments/assets/ce1ec255-35cd-4337-92c6-cfa753bf19e9">
