### PR TITLE
[initialfallback] Rename WithSSRPlaceholder to InitialFallback

### DIFF
--- a/.changeset/wicked-carrots-hope.md
+++ b/.changeset/wicked-carrots-hope.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-core": major
+"@khanacademy/wonder-blocks-layout": minor
+---
+
+Renamed `WithSSRPlaceholder` to `InitialFallback`. This includes changing the `placeholder` prop to `fallback` so it's closer to `Suspense` usage.

--- a/__docs__/wonder-blocks-core/initial-fallback.stories.tsx
+++ b/__docs__/wonder-blocks-core/initial-fallback.stories.tsx
@@ -2,16 +2,16 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
-import {View, WithSSRPlaceholder} from "@khanacademy/wonder-blocks-core";
-import packageConfig from "../../packages/wonder-blocks-core/package.json";
+import {View, InitialFallback} from "@khanacademy/wonder-blocks-core";
+import packageConfig from "@khanacademy/wonder-blocks-core/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 
-type StoryComponentType = StoryObj<typeof WithSSRPlaceholder>;
+type StoryComponentType = StoryObj<typeof InitialFallback>;
 
 export default {
-    title: "Packages / Core / WithSSRPlaceholder",
-    component: WithSSRPlaceholder,
+    title: "Packages / Core / InitialFallback",
+    component: InitialFallback,
     parameters: {
         componentSubtitle: (
             <ComponentInfo
@@ -33,7 +33,7 @@ export default {
         },
     },
     args: {
-        placeholder: (): React.ReactElement => (
+        fallback: (): React.ReactElement => (
             <View>
                 This gets rendered on server, and also on the client for the
                 very first render (the rehydration render)
@@ -46,19 +46,19 @@ export default {
             </View>
         ),
     },
-} as Meta<typeof WithSSRPlaceholder>;
+} as Meta<typeof InitialFallback>;
 
 export const Default: StoryComponentType = {};
 
 export const WithoutPlaceholder: StoryComponentType = () => (
-    <WithSSRPlaceholder placeholder={null}>
+    <InitialFallback fallback={null}>
         {() => (
             <View>
                 This is rendered only by the client, while nothing was rendered
                 on the server.
             </View>
         )}
-    </WithSSRPlaceholder>
+    </InitialFallback>
 );
 
 WithoutPlaceholder.parameters = {
@@ -104,24 +104,24 @@ export const NestedComponent: StoryComponentType = (): React.ReactElement => {
                 The list below should have three render entries; root
                 placeholder, root children render, and child children render. If
                 there are two child renders that means that the second forced
-                render is still occurring for nested WithSSRPlaceholder
-                components, which would be a bug.
+                render is still occurring for nested InitialFallback components,
+                which would be a bug.
             </Body>
             <ul id={resultsId} />
             <Body>
-                And below this is the actual WithSSRPlaceholder nesting, which
+                And below this is the actual InitialFallback nesting, which
                 should just show the child render.
             </Body>
-            <WithSSRPlaceholder
-                placeholder={() => (
+            <InitialFallback
+                fallback={() => (
                     <View>{trackAndRender("Root: placeholder")}</View>
                 )}
             >
                 {() => {
                     addTrackedRender("Root: render");
                     return (
-                        <WithSSRPlaceholder
-                            placeholder={() => (
+                        <InitialFallback
+                            fallback={() => (
                                 <View>
                                     {trackAndRender(
                                         "Child: placeholder (should never see me)",
@@ -132,10 +132,10 @@ export const NestedComponent: StoryComponentType = (): React.ReactElement => {
                             {() => (
                                 <View>{trackAndRender("Child: render")}</View>
                             )}
-                        </WithSSRPlaceholder>
+                        </InitialFallback>
                     );
                 }}
-            </WithSSRPlaceholder>
+            </InitialFallback>
         </View>
     );
 };
@@ -143,7 +143,7 @@ export const NestedComponent: StoryComponentType = (): React.ReactElement => {
 NestedComponent.parameters = {
     docs: {
         description: {
-            story: "Here, we nest two `WithSSRPlaceholder` components and use an array to track rendering, so that we can see how only the top level `WithSSRPlaceholder` component skips the initial render.",
+            story: "Here, we nest two `InitialFallback` components and use an array to track rendering, so that we can see how only the top level `InitialFallback` component skips the initial render.",
         },
     },
 };
@@ -186,19 +186,19 @@ export const SideBySide: StoryComponentType = (): React.ReactElement => {
             </Body>
             <ul id={resultsId} />
             <Body>
-                And below this are the WithSSRPlaceholder component trees, which
+                And below this are the InitialFallback component trees, which
                 should just show their child renders.
             </Body>
-            <WithSSRPlaceholder
-                placeholder={() => (
+            <InitialFallback
+                fallback={() => (
                     <View>{trackAndRender("Root 1: placeholder")}</View>
                 )}
             >
                 {() => {
                     addTrackedRender("Root 1: render");
                     return (
-                        <WithSSRPlaceholder
-                            placeholder={() => (
+                        <InitialFallback
+                            fallback={() => (
                                 <View>
                                     {trackAndRender(
                                         "Child 1: placeholder (should never see me)",
@@ -209,20 +209,20 @@ export const SideBySide: StoryComponentType = (): React.ReactElement => {
                             {() => (
                                 <View>{trackAndRender("Child 1: render")}</View>
                             )}
-                        </WithSSRPlaceholder>
+                        </InitialFallback>
                     );
                 }}
-            </WithSSRPlaceholder>
-            <WithSSRPlaceholder
-                placeholder={() => (
+            </InitialFallback>
+            <InitialFallback
+                fallback={() => (
                     <View>{trackAndRender("Root 2: placeholder")}</View>
                 )}
             >
                 {() => {
                     addTrackedRender("Root 2: render");
                     return (
-                        <WithSSRPlaceholder
-                            placeholder={() => (
+                        <InitialFallback
+                            fallback={() => (
                                 <View>
                                     {trackAndRender(
                                         "Child 2: placeholder (should never see me)",
@@ -233,10 +233,10 @@ export const SideBySide: StoryComponentType = (): React.ReactElement => {
                             {() => (
                                 <View>{trackAndRender("Child 2: render")}</View>
                             )}
-                        </WithSSRPlaceholder>
+                        </InitialFallback>
                     );
                 }}
-            </WithSSRPlaceholder>
+            </InitialFallback>
         </View>
     );
 };
@@ -244,7 +244,7 @@ export const SideBySide: StoryComponentType = (): React.ReactElement => {
 SideBySide.parameters = {
     docs: {
         description: {
-            story: "In this example, we have side-by-side `WithSSRPlaceholder` components. This demonstrates how component non-nested `WithSSRPlaceholder` components independently track the first render.",
+            story: "In this example, we have side-by-side `InitialFallback` components. This demonstrates how component non-nested `InitialFallback` components independently track the first render.",
         },
     },
 };

--- a/__docs__/wonder-blocks-core/initial-fallback.stories.tsx
+++ b/__docs__/wonder-blocks-core/initial-fallback.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {View, InitialFallback} from "@khanacademy/wonder-blocks-core";
-import packageConfig from "@khanacademy/wonder-blocks-core/package.json";
+import packageConfig from "../../packages/wonder-blocks-core/package.json";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 

--- a/packages/wonder-blocks-core/src/components/__tests__/initial-fallback.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/initial-fallback.test.tsx
@@ -2,22 +2,22 @@ import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 import {render} from "@testing-library/react";
 
-import WithSSRPlaceholder from "../with-ssr-placeholder";
+import InitialFallback from "../initial-fallback";
 import {RenderStateRoot} from "../render-state-root";
 
-describe("WithSSRPlaceholder", () => {
+describe("InitialFallback", () => {
     describe("client-side rendering", () => {
         test("calls placeholder render first, then the actual content render", async () => {
             // Arrange
             const mockPlaceholder = jest.fn(() => null);
             await new Promise((resolve: any) => {
                 const nodes = (
-                    <WithSSRPlaceholder placeholder={mockPlaceholder}>
+                    <InitialFallback fallback={mockPlaceholder}>
                         {() => {
                             resolve();
                             return null;
                         }}
-                    </WithSSRPlaceholder>
+                    </InitialFallback>
                 );
 
                 // Act
@@ -43,15 +43,15 @@ describe("WithSSRPlaceholder", () => {
                     };
 
                     const placeholder = () => (
-                        <WithSSRPlaceholder placeholder={nestedPlaceholder}>
+                        <InitialFallback fallback={nestedPlaceholder}>
                             {mockChildrenNotCalled}
-                        </WithSSRPlaceholder>
+                        </InitialFallback>
                     );
 
                     const nodes = (
-                        <WithSSRPlaceholder placeholder={placeholder}>
+                        <InitialFallback fallback={placeholder}>
                             {() => null}
-                        </WithSSRPlaceholder>
+                        </InitialFallback>
                     );
 
                     // Act
@@ -60,7 +60,7 @@ describe("WithSSRPlaceholder", () => {
 
                 // Assert
                 // Our promise doesn't resolve until the placeholder of our nested
-                // WithSSRPlaceholder is rendered, therefore if we get here it means
+                // InitialFallback is rendered, therefore if we get here it means
                 // that the test is doing what we'd expect.
                 // In addition, if our code is working right, the children of the
                 // nested placeholder should have been skipped.
@@ -73,18 +73,18 @@ describe("WithSSRPlaceholder", () => {
                 const mockPlaceholderNotCalled = jest.fn(() => null);
                 await new Promise((resolve: any) => {
                     const nodes = (
-                        <WithSSRPlaceholder placeholder={mockPlaceholder}>
+                        <InitialFallback fallback={mockPlaceholder}>
                             {() => (
-                                <WithSSRPlaceholder
-                                    placeholder={mockPlaceholderNotCalled}
+                                <InitialFallback
+                                    fallback={mockPlaceholderNotCalled}
                                 >
                                     {() => {
                                         resolve();
                                         return null;
                                     }}
-                                </WithSSRPlaceholder>
+                                </InitialFallback>
                             )}
-                        </WithSSRPlaceholder>
+                        </InitialFallback>
                     );
 
                     // Act
@@ -92,7 +92,7 @@ describe("WithSSRPlaceholder", () => {
                 });
 
                 // Assert
-                // Our promise doesn't resolve until the children of our nested WithSSRPlaceholder
+                // Our promise doesn't resolve until the children of our nested InitialFallback
                 // are rendered, therefore we don't get here until that and so if the
                 // parent placeholder has been called, it must have been called first.
                 // In addition, if our code is working right, the placeholder of the
@@ -110,9 +110,9 @@ describe("WithSSRPlaceholder", () => {
             const mockPlaceholder = jest.fn(() => null);
 
             const nodes = (
-                <WithSSRPlaceholder placeholder={mockPlaceholder}>
+                <InitialFallback fallback={mockPlaceholder}>
                     {mockChildren}
-                </WithSSRPlaceholder>
+                </InitialFallback>
             );
 
             // Act
@@ -128,9 +128,9 @@ describe("WithSSRPlaceholder", () => {
             const mockChildren = jest.fn(() => null);
 
             const nodes = (
-                <WithSSRPlaceholder placeholder={null}>
+                <InitialFallback fallback={null}>
                     {mockChildren}
-                </WithSSRPlaceholder>
+                </InitialFallback>
             );
 
             // Act
@@ -146,15 +146,15 @@ describe("WithSSRPlaceholder", () => {
                 // Arrange
                 const expectation = "CHILD PLACEHOLDER";
                 const placeholder = (
-                    <WithSSRPlaceholder placeholder={() => expectation}>
+                    <InitialFallback fallback={() => expectation}>
                         {() => "This won't render"}
-                    </WithSSRPlaceholder>
+                    </InitialFallback>
                 );
 
                 const nodes = (
-                    <WithSSRPlaceholder placeholder={() => placeholder}>
+                    <InitialFallback fallback={() => placeholder}>
                         {() => "This won't render"}
-                    </WithSSRPlaceholder>
+                    </InitialFallback>
                 );
 
                 // Act
@@ -167,16 +167,15 @@ describe("WithSSRPlaceholder", () => {
             test("in parent children, renders as null", () => {
                 // Arrange
                 const placeholder = (
-                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
-                    <WithSSRPlaceholder placeholder={undefined}>
+                    <InitialFallback fallback={null}>
                         {() => "This won't render"}
-                    </WithSSRPlaceholder>
+                    </InitialFallback>
                 );
 
                 const nodes = (
-                    <WithSSRPlaceholder placeholder={() => placeholder}>
+                    <InitialFallback fallback={() => placeholder}>
                         {() => "This won't render"}
-                    </WithSSRPlaceholder>
+                    </InitialFallback>
                 );
 
                 // Act
@@ -195,12 +194,12 @@ describe("WithSSRPlaceholder", () => {
             await new Promise((resolve: any) => {
                 const nodes = (
                     <RenderStateRoot>
-                        <WithSSRPlaceholder placeholder={mockPlaceholder}>
+                        <InitialFallback fallback={mockPlaceholder}>
                             {() => {
                                 resolve();
                                 return null;
                             }}
-                        </WithSSRPlaceholder>
+                        </InitialFallback>
                     </RenderStateRoot>
                 );
 
@@ -222,9 +221,9 @@ describe("WithSSRPlaceholder", () => {
 
             const nodes = (
                 <RenderStateRoot>
-                    <WithSSRPlaceholder placeholder={mockPlaceholder}>
+                    <InitialFallback fallback={mockPlaceholder}>
                         {mockChildren}
-                    </WithSSRPlaceholder>
+                    </InitialFallback>
                 </RenderStateRoot>
             );
 
@@ -242,9 +241,9 @@ describe("WithSSRPlaceholder", () => {
 
             const nodes = (
                 <RenderStateRoot>
-                    <WithSSRPlaceholder placeholder={null}>
+                    <InitialFallback fallback={null}>
                         {mockChildren}
-                    </WithSSRPlaceholder>
+                    </InitialFallback>
                 </RenderStateRoot>
             );
 

--- a/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/unique-id-provider.test.tsx
@@ -7,7 +7,7 @@ import View from "../view";
 import SsrIDFactory from "../../util/ssr-id-factory";
 import UniqueIDFactory from "../../util/unique-id-factory";
 import UniqueIDProvider from "../unique-id-provider";
-import WithSSRPlaceholder from "../with-ssr-placeholder";
+import InitialFallback from "../initial-fallback";
 import {RenderStateRoot} from "../render-state-root";
 
 describe("UniqueIDProvider", () => {
@@ -138,19 +138,19 @@ describe("UniqueIDProvider", () => {
         });
     });
 
-    describe("inside a WithSSRPlaceholder", () => {
+    describe("inside a InitialFallback", () => {
         test("it should pass an id to its children", () => {
             // Arrange
             const foo = jest.fn(() => null);
             const nodes = (
-                <WithSSRPlaceholder placeholder={null}>
+                <InitialFallback fallback={null}>
                     {() => (
                         <UniqueIDProvider mockOnFirstRender={false}>
                             {/* @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call. | TS2554 - Expected 0 arguments, but got 1. */}
                             {(ids: any) => foo(ids.get(""))}
                         </UniqueIDProvider>
                     )}
-                </WithSSRPlaceholder>
+                </InitialFallback>
             );
 
             // Act

--- a/packages/wonder-blocks-core/src/components/unique-id-provider.tsx
+++ b/packages/wonder-blocks-core/src/components/unique-id-provider.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import WithSSRPlaceholder from "./with-ssr-placeholder";
+import InitialFallback from "./initial-fallback";
 
 import UniqueIDFactory from "../util/unique-id-factory";
 import SsrIDFactory from "../util/ssr-id-factory";
@@ -79,7 +79,7 @@ export default class UniqueIDProvider extends React.Component<Props> {
 
         // If this is our first render, we're going to stop right here.
         // Note: `firstRender` will be `false` on the first render if this
-        // component is a descendant of a `WithSSRPlaceholder`.
+        // component is a descendant of a `InitialFallback`.
         if (firstRender) {
             if (mockOnFirstRender) {
                 // We're allowing an initial render, so let's pass our mock
@@ -99,13 +99,13 @@ export default class UniqueIDProvider extends React.Component<Props> {
     }
 
     render(): React.ReactNode {
-        // Here we use the WithSSRPlaceholder component to control
+        // Here we use the InitialFallback component to control
         // when we render and whether we provide a mock or real
         // identifier factory.
         return (
-            <WithSSRPlaceholder placeholder={() => this._performRender(true)}>
+            <InitialFallback fallback={() => this._performRender(true)}>
                 {() => this._performRender(false)}
-            </WithSSRPlaceholder>
+            </InitialFallback>
         );
     }
 }

--- a/packages/wonder-blocks-core/src/index.ts
+++ b/packages/wonder-blocks-core/src/index.ts
@@ -7,7 +7,7 @@ import type {
 
 export {default as Text} from "./components/text";
 export {default as View} from "./components/view";
-export {default as WithSSRPlaceholder} from "./components/with-ssr-placeholder";
+export {default as InitialFallback} from "./components/initial-fallback";
 export {default as IDProvider} from "./components/id-provider";
 export {default as UniqueIDProvider} from "./components/unique-id-provider";
 export {default as addStyle} from "./util/add-style";

--- a/packages/wonder-blocks-layout/src/components/media-layout.tsx
+++ b/packages/wonder-blocks-layout/src/components/media-layout.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type {StyleDeclaration} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import {WithSSRPlaceholder} from "@khanacademy/wonder-blocks-core";
+import {InitialFallback} from "@khanacademy/wonder-blocks-core";
 import MediaLayoutContext from "./media-layout-context";
 import type {MediaSize, MediaSpec} from "../util/types";
 import type {Context} from "./media-layout-context";
@@ -245,9 +245,9 @@ class MediaLayoutInternal extends React.Component<CombinedProps, State> {
 
     render() {
         return (
-            <WithSSRPlaceholder placeholder={() => this.renderContent(true)}>
+            <InitialFallback fallback={() => this.renderContent(true)}>
                 {() => this.renderContent(this.isUnsupportedEnvironment())}
-            </WithSSRPlaceholder>
+            </InitialFallback>
         );
     }
 }


### PR DESCRIPTION
## Summary:
This renames `WithSSRPlaceholder` to more accurately reflect its purpose. This includes changing the `placeholder` prop to `fallback` so that we more closely match the `React.Suspense` API.

### To update code using `WithSSRPlaceholder`:

1. Find/replace `WithSSRPlaceholder placeholder=` in files using that component to `InitialFallback fallback=`
2. Find/replace `WithSSRPlaceholder` to `InitialFallback`

Issue: XXX-XXXX

## Test plan:
`yarn test`
`yarn typecheck`
`yarn start:storybook` and view the docs for the `InitialFallback` component