### PR TITLE
[ssradapterrename] Rename ssr to renderState

### DIFF
--- a/.changeset/good-pandas-attack.md
+++ b/.changeset/good-pandas-attack.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": major
+---
+
+Rename ssr adapter to renderState

--- a/__docs__/wonder-blocks-testing/exports.harness-adapters.mdx
+++ b/__docs__/wonder-blocks-testing/exports.harness-adapters.mdx
@@ -16,7 +16,7 @@ const DefaultAdapters = {
     data: data.adapter,
     portal: portal.adapter,
     router: router.adapter,
-    ssr: ssr.adapter,
+    renderState: renderState.adapter,
 };
 
 /**
@@ -28,7 +28,7 @@ const DefaultConfigs: Configs<typeof DefaultAdapters> = {
     data: data.defaultConfig,
     portal: portal.defaultConfig,
     router: router.defaultConfig,
-    ssr: ssr.defaultConfig,
+    renderState: renderState.defaultConfig,
 };
 ```
 
@@ -43,7 +43,7 @@ There are four build-in adapters:
 -   [`data`](#data)
 -   [`portal`](#portal)
 -   [`router`](#router)
--   [`ssr`](#ssr)
+-   [`renderState`](#renderState)
 
 ## boundary
 
@@ -203,12 +203,14 @@ The first of these provides the most flexibility, basically supporting full conf
 
 By default, the router adapter is configured with `{location: "/"}`.
 
-## ssr
+## renderState
 
-The `ssr` adapter ensures that the render state is being managed by rendering a `RenderStateRoot` component around the harnessed component.
+The `renderState` adapter ensures that the render state is being managed by rendering a `RenderStateRoot` component around the harnessed component.
 
 ```ts
 type Config = true | null;
 ```
 
-By default, this adapter is off since state changes occur when `RenderStateRoot` is used that may require tests to make accommodations, such as adding appropriate `act` or `waitFor` calls when using Testing Library.
+By default, this adapter is off as state changes occur when `RenderStateRoot` is used, and these may require tests to make accommodations, such as adding appropriate `act` or `waitFor` calls when using Testing Library.
+
+However, when off, any component or hook rendered during testing that requires render state will likely throw an error.

--- a/__docs__/wonder-blocks-testing/types.test-harness-adapters.mdx
+++ b/__docs__/wonder-blocks-testing/types.test-harness-adapters.mdx
@@ -24,7 +24,7 @@ const DefaultAdapters = {
     data: data.adapter,
     portal: portal.adapter,
     router: router.adapter,
-    ssr: ssr.adapter,
+    renderState: renderState.adapter,
 };
 ```
 
@@ -36,7 +36,7 @@ type DefaultAdaptersType = {|
    data: typeof data.adapter,
    portal: typeof portal.adapter,
    router: typeof router.adapter,
-   ssr: typeof ssr.adapter,
+   renderState: typeof renderState.adapter,
 |};
 ```
 

--- a/__docs__/wonder-blocks-testing/types.test-harness-configs.mdx
+++ b/__docs__/wonder-blocks-testing/types.test-harness-configs.mdx
@@ -22,7 +22,7 @@ const DefaultAdapters = {
     data: data.adapter,
     portal: portal.adapter,
     router: router.adapter,
-    ssr: ssr.adapter,
+    renderState: renderState.adapter,
 };
 ```
 
@@ -34,7 +34,7 @@ type DefaultAdaptersType = {|
     data: typeof data.adapter,
     portal: typeof portal.adapter,
     router: typeof router.adapter,
-    ssr: typeof ssr.adapter,
+    renderState: typeof renderState.adapter,
 |};
 ```
 
@@ -46,7 +46,7 @@ const DefaultConfigs: TestHarnessConfigs<typeof DefaultAdapters> = {
     data: data.defaultConfig,
     portal: portal.defaultConfig,
     router: router.defaultConfig,
-    ssr: ssr.defaultConfig,
+    renderState: renderState.defaultConfig,
 };
 ```
 

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/__snapshots__/render-state.test.tsx.snap
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/__snapshots__/render-state.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SSR.adapter should throw on bad configuration ({"thisConfig": "isNotValid"}) 1`] = `"Unexpected configuration: set config to null to turn this adapter off"`;
+
+exports[`SSR.adapter should throw on bad configuration (false) 1`] = `"Unexpected configuration: set config to null to turn this adapter off"`;
+
+exports[`SSR.adapter should throw on bad configuration (string) 1`] = `"Unexpected configuration: set config to null to turn this adapter off"`;

--- a/packages/wonder-blocks-testing/src/harness/adapters/__tests__/render-state.test.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/__tests__/render-state.test.tsx
@@ -3,7 +3,7 @@ import {render, screen} from "@testing-library/react";
 import * as WBCore from "@khanacademy/wonder-blocks-core";
 import {makeTestHarness} from "@khanacademy/wonder-blocks-testing-core";
 
-import * as SSR from "../ssr";
+import * as RenderState from "../render-state";
 
 jest.mock("@khanacademy/wonder-stuff-core", () => {
     const actualCore = jest.requireActual("@khanacademy/wonder-stuff-core");
@@ -22,7 +22,7 @@ describe("SSR.adapter", () => {
         const renderStateRootSpy = jest.spyOn(WBCore, "RenderStateRoot");
 
         // Act
-        render(SSR.adapter(children, true));
+        render(RenderState.adapter(children, true));
 
         // Assert
         expect(renderStateRootSpy).toHaveBeenCalledWith(
@@ -39,7 +39,7 @@ describe("SSR.adapter", () => {
         const children = <div>CHILDREN!</div>;
 
         // Act
-        render(SSR.adapter(children, true));
+        render(RenderState.adapter(children, true));
 
         // Assert
         expect(screen.getByText("CHILDREN!")).toBeInTheDocument();
@@ -53,10 +53,10 @@ describe("SSR.adapter", () => {
         };
         const testHarness = makeTestHarness(
             {
-                ssr: SSR.adapter,
+                renderState: RenderState.adapter,
             },
             {
-                ssr: true,
+                renderState: true,
             },
         );
         const Harnessed = testHarness(ComponentNeedsSsr);
@@ -78,7 +78,7 @@ describe("SSR.adapter", () => {
         const children = <div>CHILDREN!</div>;
 
         // Act
-        const underTest = () => render(SSR.adapter(children, config));
+        const underTest = () => render(RenderState.adapter(children, config));
 
         // Assert
         expect(underTest).toThrowErrorMatchingSnapshot();

--- a/packages/wonder-blocks-testing/src/harness/adapters/index.ts
+++ b/packages/wonder-blocks-testing/src/harness/adapters/index.ts
@@ -1,7 +1,7 @@
 import {harnessAdapters} from "@khanacademy/wonder-blocks-testing-core";
 import type {TestHarnessConfigs} from "@khanacademy/wonder-blocks-testing-core";
 import * as data from "./data";
-import * as ssr from "./ssr";
+import * as renderState from "./render-state";
 
 /**
  * NOTE: We do not type `DefaultAdapters` with `Adapters` here because we want
@@ -21,7 +21,7 @@ export const DefaultAdapters = {
     data: data.adapter,
     portal: harnessAdapters.DefaultAdapters.portal,
     router: harnessAdapters.DefaultAdapters.router,
-    ssr: ssr.adapter,
+    renderState: renderState.adapter,
 } as const;
 
 /**
@@ -30,5 +30,5 @@ export const DefaultAdapters = {
 export const DefaultConfigs: TestHarnessConfigs<typeof DefaultAdapters> = {
     ...harnessAdapters.DefaultConfigs,
     data: data.defaultConfig,
-    ssr: ssr.defaultConfig,
+    renderState: renderState.defaultConfig,
 } as const;

--- a/packages/wonder-blocks-testing/src/harness/adapters/render-state.tsx
+++ b/packages/wonder-blocks-testing/src/harness/adapters/render-state.tsx
@@ -13,11 +13,15 @@ type Config = true;
 export const defaultConfig: Config | null = null;
 
 /**
- * Test harness adapter for supporting portals.
+ * Test harness adapter for supporting render state-based hooks and components.
  *
- * Some components rely on rendering with a React Portal. This adapter ensures
- * that the DOM contains a mounting point for the portal with the expected
- * identifier.
+ * Some components and hooks utilize the render state context to manage what
+ * they render and when. In order for this to work, a `RenderStateRoot`
+ * component must be present to track the current render state.
+ *
+ * This adapter wraps the children in a `RenderStateRoot` component to enable
+ * the render state context. This adapter should be used when testing components
+ * that rely on the render state.
  */
 export const adapter: TestHarnessAdapter<Config> = (
     children: React.ReactNode,


### PR DESCRIPTION
## Summary:
This renames the `ssr` test harness adapter to `renderState` to more accurately reflect its purpose.

Issue: XXX-XXXX

## Test plan:
`yarn test`
`yarn typecheck`
`yarn start:storybook` and check the docs referencing this look right under Wonder Blocks Testing.