### PR TITLE
[encoderpatch] Patch TextEncoder/TextDecoder for tests

### DIFF
--- a/config/jest/test-setup.js
+++ b/config/jest/test-setup.js
@@ -3,6 +3,7 @@ const {StyleSheetTestUtils} = require("aphrodite");
 const {
     mockRequestAnimationFrame,
 } = require("../../utils/testing/mock-request-animation-frame");
+const {TextEncoder, TextDecoder} = require("util");
 
 StyleSheetTestUtils.suppressStyleInjection();
 

--- a/config/jest/test-setup.js
+++ b/config/jest/test-setup.js
@@ -6,6 +6,22 @@ const {
 
 StyleSheetTestUtils.suppressStyleInjection();
 
+
+const attachShims = (targetWindow) => {
+    if (!targetWindow.TextEncoder) {
+        targetWindow.TextEncoder = TextEncoder;
+    }
+    if (!targetWindow.TextDecoder) {
+        targetWindow.TextDecoder = TextDecoder;
+    }
+}
+
+const resetWindow = () => {
+    attachShims(globalThis);
+};
+resetWindow();
+
 beforeEach(() => {
+    resetWindow();
     mockRequestAnimationFrame();
 });


### PR DESCRIPTION
## Summary:
React 18 requires these things but JSDOM doesn't include them, so we shim them

Issue: XXX-XXXX

## Test plan:
`yarn test` before React 18 update and after.