### PR TITLE
WB-1754: Refactor Combobox to consume handleChange from useListbox instead of relying on useEffect

### DIFF
--- a/.changeset/real-taxis-develop.md
+++ b/.changeset/real-taxis-develop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Change useListbox logic to allow passing a handler for when the selected value changes (instead of relying on useEffect in the caller)

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/combobox.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/combobox.test.tsx
@@ -153,6 +153,29 @@ describe("Combobox", () => {
         expect(screen.getByRole("combobox")).toHaveValue("");
     });
 
+    it("should reset the input to its previous selected value when the user presses Escape", async () => {
+        // Arrange
+        const userEvent = doRender(
+            <Combobox selectionType="single" value="option2">
+                <OptionItem label="option 1" value="option1" />
+                <OptionItem label="option 2" value="option2" />
+                <OptionItem label="option 3" value="option3" />
+            </Combobox>,
+        );
+
+        // Focus the combobox
+        await userEvent.tab();
+        await screen.findByRole("listbox", {hidden: true});
+
+        // Act
+        const combobox = screen.getByRole("combobox");
+        // Input an invalid value, then press Escape
+        await userEvent.type(combobox, "Test{Escape}");
+
+        // Assert
+        expect(screen.getByRole("combobox")).toHaveValue("option 2");
+    });
+
     it("should reopen the listbox when the user presses ArrowDown", async () => {
         // Arrange
         const userEvent = doRender(

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -415,7 +415,7 @@ export default function Combobox({
         if (openState) {
             comboboxRef.current?.focus();
         }
-    }, [isControlled, openState]);
+    }, [openState]);
 
     // The labels of the selected value(s).
     const selectedLabels = React.useMemo(() => {

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -417,14 +417,25 @@ export default function Combobox({
         }
     }, [isControlled, openState]);
 
-    // The labels of the selected values.
+    // The labels of the selected value(s).
     const selectedLabels = React.useMemo(() => {
-        // NOTE: Using the children prop to get the labels of the selected
-        // values, even when the list of options is filtered.
-        return children
-            .filter((item) => selected?.includes(item.props.value))
-            .map((item) => getLabel(item.props) as string);
-    }, [children, selected]);
+        // For multiple selection, convert the selected value(s) to an array of
+        // labels.
+        if (Array.isArray(selected)) {
+            return selected.map((value) => {
+                // NOTE: Using the children prop to get the labels of the
+                // selected values, even when the list of options is filtered.
+                const item = children.find(
+                    (item) => item.props.value === value,
+                );
+                return item ? getLabel(item?.props) : "";
+            });
+        }
+
+        // Single selection mode still wraps the selected value in an array
+        // to allow for a consistent API in ComboboxLiveRegion.
+        return [labelFromSelected];
+    }, [children, labelFromSelected, selected]);
 
     const pillIdPrefix = id ? `${id}-pill-` : ids.get("pill");
 

--- a/packages/wonder-blocks-dropdown/src/hooks/use-listbox.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-listbox.tsx
@@ -30,6 +30,11 @@ type Props = {
      * The type of selection that the listbox supports.
      */
     selectionType: "single" | "multiple";
+
+    /**
+     * Callback that is called when the value of the listbox changes.
+     */
+    onChange?: (value: MaybeValueOrValues) => void;
 };
 
 /**
@@ -46,6 +51,7 @@ export function useListbox({
     disabled,
     disableSpaceSelection,
     id,
+    onChange,
     selectionType = "single",
     value,
 }: Props) {
@@ -70,7 +76,7 @@ export function useListbox({
     };
 
     const focusPreviousItem = React.useCallback(() => {
-        if (focusedIndex === 0) {
+        if (focusedIndex <= 0) {
             focusItem(options.length - 1);
         } else {
             focusItem(focusedIndex - 1);
@@ -97,6 +103,9 @@ export function useListbox({
                 setSelected(optionItem.props.value);
                 // TODO(WB-1754): Add a callback for single selection to notify
                 // parent components of the change.
+                if (onChange) {
+                    onChange(optionItem.props.value);
+                }
             } else {
                 setSelected((prevSelected) => {
                     const newSelectedValue = updateMultipleSelection(
@@ -104,11 +113,15 @@ export function useListbox({
                         optionItem.props.value,
                     );
 
+                    if (onChange) {
+                        onChange(newSelectedValue);
+                    }
+
                     return newSelectedValue;
                 });
             }
         },
-        [options, selectionType],
+        [onChange, options, selectionType],
     );
 
     const handleKeyDown = React.useCallback(


### PR DESCRIPTION
## Summary:

Currently, the Combobox component uses useEffect to determine when the selected
value changes.

This is causing some sync issues between the hook (`useListbox`) and its caller
(`Combobox`), as we rely on side effects to verify when the value changes.

For example, there was a case where the combobox was not closing when the same
option was selected twice in a row.

This PR takes a different approach to let the consumer component know when an
option is selected via a handler exposed from the hook.

Also took the opportunity to reorganize/cleanup the code in the Combobox
component.

Issue: https://khanacademy.atlassian.net/browse/WB-1754

## Test plan:

Navigate to the Combobox story in Storybook and verify that the component
behaves as expected.

Also open the combobox, select an option, verify that the selected value is
displayed in the input, and that the listbox is closed.

Open it again, select the same option, and verify that the listbox is closed
without changing the input value.

| BEFORE | AFTER |
|--------|--------|
| https://github.com/user-attachments/assets/ca6d6f2b-f7ef-4379-828f-5d51accb178c | https://github.com/user-attachments/assets/0eb10944-2d18-4a29-8d7e-304df8c7b49a | 