### PR TITLE
WB-1755: Toolbar - Allow title to also support React nodes

### DIFF
--- a/.changeset/tame-mice-lick.md
+++ b/.changeset/tame-mice-lick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-toolbar": minor
+---
+
+Allow title to also support React nodes

--- a/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
@@ -7,6 +7,7 @@ import magnifyingGlassPlus from "@phosphor-icons/core/regular/magnifying-glass-p
 import magnifyingGlassMinus from "@phosphor-icons/core/regular/magnifying-glass-minus.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
@@ -44,6 +45,23 @@ export const leftContentMappings: Mappings = {
             <Strut size={spacing.medium_16} />
             <IconButton icon={magnifyingGlassPlus} kind="primary" />
         </>
+    ),
+    exitWithTitle: (
+        <View
+            style={{
+                flexDirection: "row",
+                gap: spacing.medium_16,
+                placeItems: "center",
+            }}
+        >
+            <Button startIcon={xIcon} kind="tertiary">
+                Exit
+            </Button>
+            |
+            <LabelLarge>
+                Algebra Test<sup>BETA</sup>
+            </LabelLarge>
+        </View>
     ),
 };
 

--- a/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import Toolbar from "@khanacademy/wonder-blocks-toolbar";
 import packageConfig from "../../packages/wonder-blocks-toolbar/package.json";
@@ -209,5 +209,29 @@ Dark.parameters = {
                 "A toolbar can be also used in a dark color scheme.\n\n" +
                 "**Note:** Notice that there's a white hairline in this case, and that the background is transparent (to allow the Dark Blue or illustrated background to come through).",
         },
+    },
+};
+
+/**
+ * Sometimes we need to have a custom toolbar to include a custom component or a
+ * more complex layout in the center of the toolbar. This can be achieved by
+ * passing a React node to the `title` prop.
+ *
+ * **NOTE:** This approach should be used with caution, as it may break the
+ * layout of the toolbar.
+ */
+export const CustomToolbar: StoryComponentType = {
+    args: {
+        leftContent: leftContentMappings.exitWithTitle,
+        rightContent: rightContentMappings.primaryButton,
+        title: (
+            <View
+                style={{
+                    width: 300,
+                    height: spacing.xSmall_8,
+                    background: semanticColor.mastery.primary,
+                }}
+            />
+        ),
     },
 };

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -40,20 +40,14 @@ type Props = AriaProps & {
      */
     subtitle?: string;
     /**
-     * The main title rendered in larger bold text.
+     * The main title rendered in larger bold text. It also supports rendering
+     * React nodes (use with caution).
      */
-    title?: string;
+    title?: string | React.ReactNode;
     /**
      * Test ID used for e2e testing.
      */
     testId?: string;
-};
-
-type DefaultProps = {
-    color: Props["color"];
-    leftContent: Props["leftContent"];
-    rightContent: Props["rightContent"];
-    size: Props["size"];
 };
 
 /**
@@ -73,74 +67,70 @@ type DefaultProps = {
  * />
  * ```
  */
-export default class Toolbar extends React.Component<Props> {
-    static defaultProps: DefaultProps = {
-        color: "light",
-        leftContent: null,
-        rightContent: null,
-        size: "medium",
-    };
+export default function Toolbar({
+    color = "light",
+    leftContent,
+    rightContent,
+    size = "medium",
+    subtitle,
+    title,
+}: Props): React.ReactElement {
+    const TitleComponent = subtitle ? LabelLarge : HeadingSmall;
 
-    render(): React.ReactNode {
-        const {color, leftContent, rightContent, size, subtitle, title} =
-            this.props;
-
-        const TitleComponent = subtitle ? LabelLarge : HeadingSmall;
-
-        return (
+    return (
+        <View
+            style={[
+                sharedStyles.container,
+                color === "dark" && sharedStyles.dark,
+                size === "small" && sharedStyles.small,
+            ]}
+        >
             <View
                 style={[
-                    sharedStyles.container,
-                    color === "dark" && sharedStyles.dark,
-                    size === "small" && sharedStyles.small,
+                    sharedStyles.column,
+                    sharedStyles.leftColumn,
+                    title ? sharedStyles.withTitle : null,
                 ]}
             >
-                <View
-                    style={[
-                        sharedStyles.column,
-                        sharedStyles.leftColumn,
-                        title ? sharedStyles.withTitle : null,
-                    ]}
-                >
-                    {leftContent}
-                </View>
-
-                {title && (
-                    <View
-                        style={[sharedStyles.column, sharedStyles.wideColumn]}
-                    >
-                        <View
-                            style={[sharedStyles.titles, sharedStyles.center]}
-                        >
-                            <TitleComponent id="wb-toolbar-title">
-                                {title}
-                            </TitleComponent>
-                            {subtitle && (
-                                <LabelSmall
-                                    style={
-                                        color === "light" &&
-                                        sharedStyles.subtitle
-                                    }
-                                >
-                                    {subtitle}
-                                </LabelSmall>
-                            )}
-                        </View>
-                    </View>
-                )}
-
-                <View
-                    style={[
-                        sharedStyles.column,
-                        sharedStyles.rightColumn,
-                        title ? sharedStyles.withTitle : null,
-                    ]}
-                >
-                    {rightContent}
-                </View>
+                {leftContent}
             </View>
-        );
-    }
+
+            {title && typeof title === "string" ? (
+                <View style={[sharedStyles.column, sharedStyles.wideColumn]}>
+                    <View style={[sharedStyles.titles, sharedStyles.center]}>
+                        <TitleComponent id="wb-toolbar-title">
+                            {title}
+                        </TitleComponent>
+                        {subtitle && (
+                            <LabelSmall
+                                style={
+                                    color === "light" && sharedStyles.subtitle
+                                }
+                            >
+                                {subtitle}
+                            </LabelSmall>
+                        )}
+                    </View>
+                </View>
+            ) : (
+                // We don't use wideColumn here to allow more flexibility with
+                // the custom node.
+                <View style={[sharedStyles.column]}>
+                    <View style={[sharedStyles.titles]}>{title}</View>
+                </View>
+            )}
+
+            <View
+                style={[
+                    sharedStyles.column,
+                    sharedStyles.rightColumn,
+                    title ? sharedStyles.withTitle : null,
+                ]}
+            >
+                {rightContent}
+            </View>
+        </View>
+    );
 }
 
 const sharedStyles = StyleSheet.create({


### PR DESCRIPTION
## Summary:

There’s a valid use case where a toolbar needs to use a progress bar in the
center area. Right now, that part of the layout only accepts a title as a
string.

See design screenshot for reference:

<img width="1205" alt="Screenshot 2024-08-30 at 1 56 40 PM" src="https://github.com/user-attachments/assets/4b81c8f5-6f2b-4517-9f5e-e5d311a475a1">


This change allows the title to also accept React nodes, which will allow
engineers to use more complex components in that part of the layout.

Issue: https://khanacademy.atlassian.net/browse/WB-1755

## Test plan:

Navigate to the new story in the toolbar documentation and verify that the
progress bar is displayed in the center area.

/?path=/docs/packages-toolbar--docs#custom%20toolbar

<img width="1081" alt="Screenshot 2024-08-30 at 1 56 15 PM" src="https://github.com/user-attachments/assets/beec88e2-c511-47d9-a79a-b11d071debc0">
