### PR TITLE
Add `viewportPadding` prop to `Tooltip` and `Popover` components

### DIFF
--- a/.changeset/cuddly-chefs-care.md
+++ b/.changeset/cuddly-chefs-care.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-popover": minor
+"@khanacademy/wonder-blocks-tooltip": minor
+---
+
+Adds a `viewportPadding` prop to provide spacing between the popper and the viewport edges. If this prop is not provided, default spacing is applied.

--- a/__docs__/wonder-blocks-popover/popover.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover.argtypes.tsx
@@ -151,8 +151,8 @@ export default {
     viewportPadding: {
         description:
             `If \`rootBoundary\` is \`viewport\`, this padding value is ` +
-            `used to provide spacing between the popper and the viewport.` +
-            `If not provided, default spacing is applied.`,
+            `used to provide spacing between the popper and the viewport. ` +
+            `If not provided, default spacing of 12px is applied.`,
         control: {
             type: "number",
         },

--- a/__docs__/wonder-blocks-popover/popover.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover.argtypes.tsx
@@ -148,4 +148,13 @@ export default {
             type: "boolean",
         },
     },
+    viewportPadding: {
+        description:
+            `If \`rootBoundary\` is \`viewport\`, this padding value is ` +
+            `used to provide spacing between the popper and the viewport.` +
+            `If not provided, default spacing is applied.`,
+        control: {
+            type: "number",
+        },
+    },
 };

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
@@ -832,4 +832,60 @@ export const WithCustomAriaDescribedBy = ({
             </Popover>
         </View>
     );
+};
+
+export const InCorners = (args: PropsFor<typeof Popover>) => {
+    const [openedIndex, setOpenedIndex] = React.useState<number>(0);
+    const renderPopover = (index: number) => {
+        return (
+            <Popover
+                {...args}
+                content={
+                    <PopoverContent
+                        closeButtonVisible
+                        content="The default version only includes text."
+                        title="A simple popover"
+                    />
+                }
+                dismissEnabled
+                onClose={() => setOpenedIndex(-1)}
+                opened={openedIndex === index}
+            >
+                <Button onClick={() => setOpenedIndex(index)}>
+                    Open default popover
+                </Button>
+            </Popover>
+        );
+    };
+    return (
+        <View
+            style={{
+                height: "100vh",
+                width: "100vw",
+                justifyContent: "space-between",
+            }}
+        >
+            <View
+                style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                }}
+            >
+                {renderPopover(0)}
+                {renderPopover(1)}
+            </View>
+            <View
+                style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                }}
+            >
+                {renderPopover(2)}
+                {renderPopover(3)}
+            </View>
+        </View>
+    );
+};
+InCorners.parameters = {
+    layout: "fullscreen",
 };

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -834,6 +834,14 @@ export const WithCustomAriaDescribedBy = ({
     );
 };
 
+/**
+ * If the Popover is placed near the edge of the viewport, default spacing of
+ * 12px is applied to provide spacing between the Popover and the viewport. This
+ * spacing value can be overridden using the `viewportPadding` prop.
+ *
+ * Note: The `viewportPadding` prop is only applied when `rootBoundary` is
+ * `viewport`.
+ */
 export const InCorners = (args: PropsFor<typeof Popover>) => {
     const [openedIndex, setOpenedIndex] = React.useState<number>(0);
     const renderPopover = (index: number) => {

--- a/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
+++ b/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
@@ -70,8 +70,8 @@ export default {
     viewportPadding: {
         description:
             `If \`rootBoundary\` is \`viewport\`, this padding value is ` +
-            `used to provide spacing between the popper and the viewport.` +
-            `If not provided, default spacing is applied.`,
+            `used to provide spacing between the popper and the viewport. ` +
+            `If not provided, default spacing of 12px is applied.`,
         control: {
             type: "number",
         },

--- a/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
+++ b/__docs__/wonder-blocks-tooltip/tooltip.argtypes.ts
@@ -67,4 +67,13 @@ export default {
             },
         },
     },
+    viewportPadding: {
+        description:
+            `If \`rootBoundary\` is \`viewport\`, this padding value is ` +
+            `used to provide spacing between the popper and the viewport.` +
+            `If not provided, default spacing is applied.`,
+        control: {
+            type: "number",
+        },
+    },
 };

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -8,7 +8,7 @@ import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 import info from "@phosphor-icons/core/regular/info.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
@@ -43,9 +43,12 @@ export default {
         chromatic: {delay: 500},
     },
     decorators: [
-        (Story): React.ReactElement => (
-            <View style={styles.storyCanvas}>{Story()}</View>
-        ),
+        (Story, {parameters}): React.ReactElement =>
+            parameters.layout === "fullscreen" ? (
+                Story()
+            ) : (
+                <View style={styles.storyCanvas}>{Story()}</View>
+            ),
     ],
 } as Meta<typeof Tooltip>;
 
@@ -508,4 +511,54 @@ export const InTopCorner = {
             </Tooltip>
         </View>
     ),
+};
+
+export const InCorners = {
+    parameters: {
+        layout: "fullscreen",
+        chromatic: {
+            // Disabling snapshot since this is for testing purposes
+            disableSnapshot: true,
+        },
+    },
+    render: (args: PropsFor<typeof Tooltip>) => {
+        const renderTooltip = () => {
+            return (
+                <Tooltip
+                    {...args}
+                    content="This is an example descriptor that's long with more content to see if it will display properly in different browsers"
+                >
+                    <Button>Open tooltip</Button>
+                </Tooltip>
+            );
+        };
+        return (
+            <View
+                style={{
+                    height: "100vh",
+                    width: "100vw",
+                    justifyContent: "space-between",
+                }}
+            >
+                <View
+                    style={{
+                        flexDirection: "row",
+                        justifyContent: "space-between",
+                    }}
+                >
+                    {renderTooltip()}
+                    {renderTooltip()}
+                </View>
+                <View
+                    style={{
+                        flexDirection: "row",
+                        justifyContent: "space-between",
+                    }}
+                >
+                    {renderTooltip()}
+                    {renderTooltip()}
+                </View>
+            </View>
+        );
+    },
 };

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -513,6 +513,11 @@ export const InTopCorner = {
     ),
 };
 
+/**
+ * If the Tooltip is placed near the edge of the viewport, default spacing of
+ * 12px is applied to provide spacing between the Tooltip and the viewport. This
+ * spacing value can be overridden using the `viewportPadding` prop.
+ */
 export const InCorners = {
     parameters: {
         layout: "fullscreen",

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -127,7 +127,7 @@ type Props = AriaProps &
         /**
          * If `rootBoundary` is `viewport`, this padding value is used to provide
          * spacing between the popper and the viewport. If not provided, default
-         * spacing is applied.
+         * spacing of 12px is applied.
          */
         viewportPadding?: number;
     }>;

--- a/packages/wonder-blocks-popover/src/components/popover.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover.tsx
@@ -124,6 +124,12 @@ type Props = AriaProps &
          * on where there is available room within the document body.
          */
         rootBoundary?: RootBoundary;
+        /**
+         * If `rootBoundary` is `viewport`, this padding value is used to provide
+         * spacing between the popper and the viewport. If not provided, default
+         * spacing is applied.
+         */
+        viewportPadding?: number;
     }>;
 
 type State = Readonly<{
@@ -290,6 +296,7 @@ export default class Popover extends React.Component<Props, State> {
             "aria-label": ariaLabel,
             "aria-describedby": ariaDescribedBy,
             rootBoundary,
+            viewportPadding,
         } = this.props;
         const {anchorElement} = this.state;
 
@@ -302,6 +309,7 @@ export default class Popover extends React.Component<Props, State> {
                 anchorElement={anchorElement}
                 placement={placement}
                 rootBoundary={rootBoundary}
+                viewportPadding={viewportPadding}
             >
                 {(props: PopperElementProps) => (
                     <PopoverDialog

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
@@ -48,7 +48,7 @@ type Props = {
     /**
      * If `rootBoundary` is `viewport`, this padding value is used to provide
      * spacing between the popper and the viewport. If not provided, default
-     * spacing is applied.
+     * spacing of 12px is applied.
      */
     viewportPadding?: number;
 };

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-popper.tsx
@@ -10,6 +10,7 @@ import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import type {ModifierArguments, RootBoundary} from "@popperjs/core";
 import type {FlipModifier} from "@popperjs/core/lib/modifiers/flip";
 import type {PreventOverflowModifier} from "@popperjs/core/lib/modifiers/preventOverflow";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import type {
     Placement,
     PopperElementProps,
@@ -44,10 +45,17 @@ type Props = {
      * on where there is available room within the document body.
      */
     rootBoundary?: RootBoundary;
+    /**
+     * If `rootBoundary` is `viewport`, this padding value is used to provide
+     * spacing between the popper and the viewport. If not provided, default
+     * spacing is applied.
+     */
+    viewportPadding?: number;
 };
 
 type DefaultProps = {
     rootBoundary: Props["rootBoundary"];
+    viewportPadding: Props["viewportPadding"];
 };
 
 const filterPopperPlacement = (
@@ -125,6 +133,7 @@ const smallViewportModifier: SmallViewportModifier = {
 export default class TooltipPopper extends React.Component<Props> {
     static defaultProps: DefaultProps = {
         rootBoundary: "viewport",
+        viewportPadding: spacing.small_12,
     };
 
     /**
@@ -230,7 +239,8 @@ export default class TooltipPopper extends React.Component<Props> {
     }
 
     render(): React.ReactNode {
-        const {anchorElement, placement, rootBoundary} = this.props;
+        const {anchorElement, placement, rootBoundary, viewportPadding} =
+            this.props;
 
         // TODO(WB-1680): Use floating-ui's
         const modifiers: Modifiers[] = [smallViewportModifier];
@@ -240,6 +250,7 @@ export default class TooltipPopper extends React.Component<Props> {
                 name: "preventOverflow",
                 options: {
                     rootBoundary: "viewport",
+                    padding: viewportPadding,
                 },
             });
         } else {

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -119,7 +119,7 @@ type Props = AriaProps &
         /**
          * If `rootBoundary` is `viewport`, this padding value is used to provide
          * spacing between the popper and the viewport. If not provided, default
-         * spacing is applied.
+         * spacing of 12px is applied.
          */
         viewportPadding?: number;
     }>;

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -116,6 +116,12 @@ type Props = AriaProps &
          * Optional background color.
          */
         backgroundColor?: keyof typeof color;
+        /**
+         * If `rootBoundary` is `viewport`, this padding value is used to provide
+         * spacing between the popper and the viewport. If not provided, default
+         * spacing is applied.
+         */
+        viewportPadding?: number;
     }>;
 
 type State = Readonly<{
@@ -228,6 +234,7 @@ export default class Tooltip extends React.Component<Props, State> {
                 anchorElement={this.state.anchorElement}
                 placement={placement}
                 autoUpdate={this.props.autoUpdate}
+                viewportPadding={this.props.viewportPadding}
             >
                 {(props) => (
                     <TooltipBubble


### PR DESCRIPTION
## Summary:
This new `viewportPadding` prop provides spacing between the popper and the viewport edges in the `Tooltip` and `Popover` components. If this prop is not provided, default spacing is applied so that the popper contents are not too close to the edge by default. This can be overridden to support different use cases.

Note: `viewportPadding` is only applied if the `rootBoundary` prop is set to `viewport`. `Tooltip` will always use `viewport` for the `rootBoundary`, however, this prop is exposed in the `Popover` component

Issue: WB-1756

## Test plan:
- Tooltip
  - Confirm that default spacing is applied to the Tooltip contents when it is in the corners (`?path=/story/packages-tooltip-tooltip--in-corners`)
  - Confirm that changing the `viewportPadding` control in Storybook updates the spacing between the Tooltip popper and the viewport edge
  - Confirm prop documentation makes sense (`?path=/docs/packages-tooltip-tooltip--docs`)
- Popover
  - Confirm that default spacing is applied to the Popover contents when it is in the corners (`?path=/story/packages-popover-popover--in-corners`)
  - Confirm that changing the `viewportPadding` control in Storybook updates the spacing between the Popover popper and the viewport edge 
  - Confirm prop documentation makes sense (`?path=/docs/packages-popover-popover--docs`)
- Confirm that Tooltip and Popover components in webapp continue to work as expected