### PR TITLE
Fix plural forms configiration for Khmer locale

### DIFF
--- a/.changeset/thick-maps-provide.md
+++ b/.changeset/thick-maps-provide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-i18n": patch
+---
+
+Fix plural forms configuration for Khmer locale

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
@@ -624,6 +624,24 @@ describe("i18n", () => {
             });
         });
 
+        describe("other no plurals locale (using km)", () => {
+            it("should return other for 0", () => {
+                // Arrange
+
+                // Act
+                const result = ngettext(
+                    {
+                        lang: "km",
+                        messages: ["Other"],
+                    },
+                    0,
+                );
+
+                // Assert
+                expect(result).toEqual("Other");
+            });
+        });
+
         describe("multiple plurals local (using pl)", () => {
             it("should return second plural form for 0", () => {
                 // Arrange

--- a/packages/wonder-blocks-i18n/src/functions/plural-forms.ts
+++ b/packages/wonder-blocks-i18n/src/functions/plural-forms.ts
@@ -74,7 +74,7 @@ export const allPluralForms: PluralFormsMap = {
     "ja": likeJapanese,
     "ka": likeEnglish,
     "kk": likeEnglish,
-    "km": likeEnglish,
+    "km": likeJapanese,
     "kn": likeEnglish,
     "ko": likeJapanese,
     "ky": likeJapanese,


### PR DESCRIPTION
## Summary:
It only has "other", but was configured "like english", resulting in a crash
on km.khanacademy.org for pages with plural form platform strings.

Further details can be seen on Slack: https://khanacademy.slack.com/archives/C3SLM30AW/p1727281143856849

Issue: https://khanacademy.atlassian.net/browse/CP-8661

Test Plan:
 - After making a release of `wonder-blocks-i18n` package and deploying webapp
 - Verify https://km.khanacademy.org/math/early-math/cc-early-math-counting-topic doesn't crash