### PR TITLE
[fei5850.1.friendlyobjectmatching] Support undefined variable comparison

### DIFF
--- a/.changeset/old-islands-relax.md
+++ b/.changeset/old-islands-relax.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": major
+---
+
+When mocking GraphQL, consider explicit undefined values in a request to be equivalent to missing keys in a mock

--- a/packages/wonder-blocks-testing/src/gql/__tests__/gql-request-matches-mock.test.ts
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/gql-request-matches-mock.test.ts
@@ -45,7 +45,7 @@ describe("#gqlRequestMatchesMock", () => {
         expect(result).toBe(false);
     });
 
-    it.each([{foo: "bar"}, {foo: "baz", anExtra: "property"}, null])(
+    it.each([{foo: undefined}, {foo: "baz", anExtra: "property"}, null])(
         "should return false if variables don't match",
         (variables: any) => {
             // Arrange
@@ -158,6 +158,7 @@ describe("#gqlRequestMatchesMock", () => {
             },
             {
                 foo: "bar",
+                baz: undefined,
             },
             {my: "context"},
         );


### PR DESCRIPTION
## Summary:
Before this change, these two variables objects are considered different:

```ts
{
    a: undefined,
    b: 1
}
```

```ts
{
    b: 1
}
```

This can be annoying when writing tests, because you have to explicitly set the variable to `undefined` in the expectation if the actual request ends up fetching with an explicit `undefined` value.

To make GraphQL mocks easier, we now consider a missing key to be equivalent to an explicit key with an `undefined` value. This brings this approach to GraphQL mocking inline with Apollo mocks that already do this.

Note that with this implementation, there's no way to assert that an explicit `undefined` variable is included in the request. We could add that if it turns out to be something we really need though I suspect that it is not.

Issue: FEI-5850

## Test plan:
`yarn test`