### PR TITLE
IconButton: Add id prop, fix type to set 'button' as default

### DIFF
--- a/.changeset/friendly-moose-type.md
+++ b/.changeset/friendly-moose-type.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": minor
+---
+
+Adds `id` prop and fixes `type` prop to set 'button' as default value.

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
@@ -183,6 +183,23 @@ describe("IconButton", () => {
         expect(onClickMock).not.toBeCalled();
     });
 
+    it("sets the 'id' prop on the underlying element", async () => {
+        // Arrange
+        render(
+            <IconButton
+                icon={magnifyingGlassIcon}
+                aria-label="search"
+                id="icon-button"
+            />,
+        );
+
+        // Act
+        const button = await screen.findByRole("button");
+
+        // Assert
+        expect(button).toHaveAttribute("id", "icon-button");
+    });
+
     it("sets the 'target' prop on the underlying element", async () => {
         // Arrange
         render(
@@ -321,7 +338,18 @@ describe("IconButton", () => {
         });
     });
 
-    describe("type='submit'", () => {
+    describe("type", () => {
+        it("should set type attribute to 'button' by default", async () => {
+            // Arrange
+            render(<IconButton icon={magnifyingGlassIcon} />);
+
+            // Act
+            const button = await screen.findByRole("button");
+
+            // Assert
+            expect(button).toHaveAttribute("type", "button");
+        });
+
         it("should submit button within form via click", async () => {
             // Arrange
             const submitFnMock = jest.fn();

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -93,6 +93,7 @@ const IconButtonCore: React.ForwardRefExoticComponent<
         skipClientNav,
         style,
         testId,
+        type = "button",
         ...restProps
     } = props;
     const {theme, themeName} = useScopedTheme(IconButtonThemeContext);
@@ -142,7 +143,7 @@ const IconButtonCore: React.ForwardRefExoticComponent<
         } else {
             return (
                 <StyledButton
-                    type="button"
+                    type={type}
                     {...commonProps}
                     onClick={disabled ? undefined : restProps.onClick}
                     aria-disabled={disabled}

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -10,6 +10,10 @@ export type IconButtonSize = "xsmall" | "small" | "medium" | "large";
 
 export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
     /**
+     * A unique identifier for the IconButton.
+     */
+    id?: string;
+    /**
      * A Phosphor icon asset (imported as a static SVG file).
      */
     icon: PhosphorIconAsset;


### PR DESCRIPTION
## Summary:

Following up on #2325, this PR fixes an issue that I introduced in the
IconButton component, which was that the type prop was not being set to 'button'
by default.

This PR fixes that issue and also adds an optional `id` prop to the
IconButton component.

NOTE: We set `button` as the default type because it is the most common use case
of how browsers interpret the type attribute of a button element. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type

Issue: XXX-XXXX

## Test plan:

Verify that the IconButton component works as expected with the new changes.

Also verify that that the tests pass.

/iframe.html?args=id:some-identifier&id=packages-iconbutton--default&viewMode=story

<img width="1249" alt="Screenshot 2024-10-01 at 11 50 01 AM" src="https://github.com/user-attachments/assets/aa2af01c-be26-43ed-83f4-e19da73ed90c">
