### PR TITLE
[fei5850.3.creator] Add matchGql function

### DIFF
--- a/.changeset/great-paws-ring.md
+++ b/.changeset/great-paws-ring.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-testing-core": minor
+"@khanacademy/wonder-blocks-testing": minor
+---
+
+Add support for hard fails to the request mocking features

--- a/.changeset/old-islands-relax.md
+++ b/.changeset/old-islands-relax.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": major
+---
+
+When mocking GraphQL, consider explicit undefined values in a request to be equivalent to missing keys in a mock

--- a/.changeset/ten-horses-mate.md
+++ b/.changeset/ten-horses-mate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing": minor
+---
+
+Add matchGql function to facilitate type-safe construction of mocked GraphQL requests

--- a/__docs__/wonder-blocks-testing/exports.match-gql.mdx
+++ b/__docs__/wonder-blocks-testing/exports.match-gql.mdx
@@ -1,0 +1,24 @@
+import {Meta} from "@storybook/blocks";
+
+<Meta
+    title="Packages / Testing / Mocking / Exports / matchGql()"
+/>
+
+# matchGql()
+
+```ts
+matchGql<TData, TVariables, TContext>(operation: GqlOperation<TData, TVariables>: MatchApi<TData, TVariables, TContext>;
+```
+
+The `matchGql` function provides an API to easily build mock GraphQL requests for use with the <a href="./?path=/docs/packages-testing-mocking-exports-mockgqlfetch--docs">`mockGqlFetch`</a> API. Using `matchGql` can provide a nicer type checking experience than building the `GqlMockOperation` object manually.
+
+# API
+
+Besides returning a `GqlMockOperation`-compatible object, the `MatchApi` object has a few methods to help build the mock operation.
+
+| Function | Purpose |
+| - | - |
+| `withVariables` | When called, this adds specific variables that should be matched. |
+| `withContext` | When called, this adds specific context values that should be matched. |
+
+Both of these functions return a `GqlMockOperation`-compatible object and can be chained together to build up the mock operation.

--- a/__docs__/wonder-blocks-testing/exports.mock-fetch.mdx
+++ b/__docs__/wonder-blocks-testing/exports.mock-fetch.mdx
@@ -16,10 +16,11 @@ The `mockFetch` function provides an API to easily mock `fetch()` responses. It 
 
 Besides being a function that fits the `fetch()` signature, the return value of `mockFetch()` has an API to customize the behavior of that function. Used in conjunction with the <a href="./?path=/docs/packages-testing-mocking-exports-respondwith--docs">`RespondWith`</a> API, this can create a variety of responses for tests and stories.
 
-| Function            | Purpose                                                                                                                        |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `mockOperation`     | When called, any request that matches the defined mock will respond with the given response.                                   |
+| Function | Purpose |
+| - | - |
+| `mockOperation` | When called, any request that matches the defined mock will respond with the given response. |
 | `mockOperationOnce` | When called, the first request that matches the defined mock will respond with the given response. The mock is only used once. |
+| `configure` | This allows you to configure the behavior of the mock fetch function. |
 
 Both of these functions have the same signature:
 
@@ -30,6 +31,25 @@ type FetchMockOperationFn = (
 ) => FetchMockFn;
 ```
 
-# Operation Matching
+
+## Configuration
+
+The `configure` function allows you to configure the behavior of the mocked fetch function. It takes a partial configuration and applies that to the existing
+configuration. This changes the behavior of all calls to the mocked function.
+
+The full configuration is:
+
+```ts
+{
+    hardFailOnUnmockedRequests: boolean;
+}
+```
+
+| Configuration Key | Purpose |
+| - | - |
+| `hardFailOnUnmockedRequests` | When set to `true`, any unmocked request will throw an error, causing tests to fail. When set to `false`, unmocked requests will reject, which in turn gets handled by the relevant error handling in the code under test - this is the default behavior and is usually what you want so that you don't need to mock every single request that may be invoked during your tests. |
+
+
+## Operation Matching
 
 The `FetchMockOperation` type is either of type `string` or `RegExp`. When specified as a string, the URL of the request must match the string exactly. When specified as a regular expression, the URL of the request must match the regular expression.

--- a/__docs__/wonder-blocks-testing/exports.mock-gql-fetch.mdx
+++ b/__docs__/wonder-blocks-testing/exports.mock-gql-fetch.mdx
@@ -36,6 +36,8 @@ type GqlMockOperationFn = <
 ) => GqlFetchMockFn;
 ```
 
+It is recommended that you use the `matchGql` function to build the `GqlMockOperation` object for use with `mockOperation` and `mockOperationOnce` as it provides a nicer type checking experience.
+
 ## Configuration
 
 The `configure` function allows you to configure the behavior of the mocked fetch function. It takes a partial configuration and applies that to the existing

--- a/__docs__/wonder-blocks-testing/exports.mock-gql-fetch.mdx
+++ b/__docs__/wonder-blocks-testing/exports.mock-gql-fetch.mdx
@@ -16,10 +16,11 @@ The `mockGqlFetch` function provides an API to easily mock GraphQL responses for
 
 Besides being a function that fits the <a href="./?path=/docs/packages-data-types-gqlfetchfn--docs">`GqlFetchFn`</a> signature, the return value of `mockGqlFetch()` has an API to customize the behavior of that function. Used in conjunction with the <a href="./?path=/docs/packages-testing-mocking-exports-respondwith--docs">`RespondWith`</a> API, this can create a variety of GraphQL responses for testing and stories.
 
-| Function            | Purpose                                                                                                                                            |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mockOperation`     | When called, any GraphQL operation that matches the defined mock operation will respond with the given response.                                   |
+| Function | Purpose |
+| - | - |
+| `mockOperation` | When called, any GraphQL operation that matches the defined mock operation will respond with the given response. |
 | `mockOperationOnce` | When called, the first GraphQL operation that matches the defined mock operation will respond with the given response. The mock is only used once. |
+| `configure` | This allows you to configure the behavior of the mock fetch function. |
 
 Both of these functions have the same signature:
 
@@ -35,7 +36,24 @@ type GqlMockOperationFn = <
 ) => GqlFetchMockFn;
 ```
 
-# Operation Matching
+## Configuration
+
+The `configure` function allows you to configure the behavior of the mocked fetch function. It takes a partial configuration and applies that to the existing
+configuration. This changes the behavior of all calls to the mocked function.
+
+The full configuration is:
+
+```ts
+{
+    hardFailOnUnmockedRequests: boolean;
+}
+```
+
+| Configuration Key | Purpose |
+| - | - |
+| `hardFailOnUnmockedRequests` | When set to `true`, any unmocked request will throw an error, causing tests to fail. When set to `false`, unmocked requests will reject, which in turn gets handled by the relevant error handling in the code under test - this is the default behavior and is usually what you want so that you don't need to mock every single request that may be invoked during your tests. |
+
+## Operation Matching
 
 The `matchOperation` parameter given to a `mockOperation` or `mockOperationOnce` function is a `GqlMockOperation` defining the actual GraphQL operation to be matched by the mock. The variables and context of the mocked operation change how the mock is matched against requests.
 

--- a/packages/wonder-blocks-testing-core/src/__tests__/mock-requester.test.ts
+++ b/packages/wonder-blocks-testing-core/src/__tests__/mock-requester.test.ts
@@ -35,7 +35,17 @@ describe("#mockRequester", () => {
         );
     });
 
-    it("should throw with helpful details formatted by operationToString if no matching mock is found", async () => {
+    it("should provide a configuration API", () => {
+        // Arrange
+
+        // Act
+        const result = mockRequester(jest.fn(), jest.fn());
+
+        // Assert
+        expect(result).toHaveProperty("configure", expect.any(Function));
+    });
+
+    it("should reject with helpful details formatted by operationToString if no matching mock is found", async () => {
         // Arrange
         const mockFn = mockRequester(
             jest.fn(),
@@ -207,6 +217,58 @@ describe("#mockRequester", () => {
 
             // Assert
             await expect(result).resolves.toBe("TWO");
+        });
+    });
+
+    describe("configure", () => {
+        it("should reject promise on unmocked requests by default", async () => {
+            // Arrange
+            const matcher = jest.fn().mockReturnValue(false);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            const result = mockFn("DO SOMETHING");
+
+            // Assert
+            await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
+                "No matching mock response found for request:
+                    undefined"
+            `);
+        });
+
+        it("should cause hard fail on unmocked requests when hardFailOnUnmockedRequests is set to true", () => {
+            // Arrange
+            const matcher = jest.fn().mockReturnValue(false);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.configure({hardFailOnUnmockedRequests: true});
+            const underTest = () => mockFn("DO SOMETHING");
+
+            // Assert
+            expect(underTest).toThrowErrorMatchingInlineSnapshot(`
+                "No matching mock response found for request:
+                    undefined"
+            `);
+        });
+
+        it("should reject promise on unmocked requests when hardFailOnUnmockedRequests is set to false ", async () => {
+            // Arrange
+            const matcher = jest.fn().mockReturnValue(false);
+            const operationToString = jest.fn();
+            const mockFn = mockRequester(matcher, operationToString);
+
+            // Act
+            mockFn.configure({hardFailOnUnmockedRequests: false});
+            const result = mockFn("DO SOMETHING");
+
+            // Assert
+            await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(`
+                "No matching mock response found for request:
+                    undefined"
+            `);
         });
     });
 });

--- a/packages/wonder-blocks-testing-core/src/fetch/mock-fetch.ts
+++ b/packages/wonder-blocks-testing-core/src/fetch/mock-fetch.ts
@@ -6,7 +6,7 @@ import type {FetchMockFn, FetchMockOperation} from "./types";
  * A mock for the fetch function passed to GqlRouter.
  */
 export const mockFetch = (): FetchMockFn =>
-    mockRequester<FetchMockOperation>(
+    mockRequester<FetchMockOperation, any>(
         fetchRequestMatchesMock,
         // NOTE(somewhatabstract): The indentation is expected on the lines
         // here.

--- a/packages/wonder-blocks-testing-core/src/fetch/types.ts
+++ b/packages/wonder-blocks-testing-core/src/fetch/types.ts
@@ -1,14 +1,65 @@
 import type {MockResponse} from "../respond-with";
+import {ConfigureFn} from "../types";
 
 export type FetchMockOperation = RegExp | string;
 
-type FetchMockOperationFn = (
-    operation: FetchMockOperation,
-    response: MockResponse<any>,
-) => FetchMockFn;
+interface FetchMockOperationFn {
+    (
+        /**
+         * The operation to match.
+         *
+         * This is a string for an exact match, or a regex. This is compared to
+         * to the URL of the fetch request to determine if it is a matching
+         * request.
+         */
+        operation: FetchMockOperation,
+
+        /**
+         * The response to return when the operation is matched.
+         */
+        response: MockResponse<any>,
+    ): FetchMockFn;
+}
 
 export type FetchMockFn = {
+    /**
+     * The mock fetch function.
+     *
+     * This function is a drop-in replacement for the fetch function. You should
+     * not need to call this function directly. Just replace the normal fetch
+     * function implementation with this.
+     */
     (input: RequestInfo, init?: RequestInit): Promise<Response>;
+
+    /**
+     * Mock a fetch operation.
+     *
+     * This adds a response for a given mocked operation. Regardless of how
+     * many times this mock is matched, it will be used.
+     *
+     * @returns The mock fetch function for chaining.
+     */
     mockOperation: FetchMockOperationFn;
+
+    /**
+     * Mock a fetch operation once.
+     *
+     * This adds a response for a given mocked operation that will only be used
+     * once and discarded.
+     *
+     * @returns The mock fetch function for chaining.
+     */
     mockOperationOnce: FetchMockOperationFn;
+
+    /**
+     * Configure the mock fetch function with the given configuration.
+     *
+     * This function is provided as a convenience to allow for configuring the
+     * mock fetch function in a fluent manner. The configuration is applied
+     * to all mocks for a given fetch function; the last configuration applied
+     * will be the one that is used for all mocked operations.
+     *
+     * @returns The mock fetch function for chaining.
+     */
+    configure: ConfigureFn<FetchMockOperation, any>;
 };

--- a/packages/wonder-blocks-testing-core/src/index.ts
+++ b/packages/wonder-blocks-testing-core/src/index.ts
@@ -15,6 +15,8 @@ export type {
     OperationMock,
     OperationMatcher,
     MockOperationFn,
+    MockConfiguration,
+    ConfigureFn,
 } from "./types";
 
 // Test harness framework

--- a/packages/wonder-blocks-testing-core/src/mock-requester.ts
+++ b/packages/wonder-blocks-testing-core/src/mock-requester.ts
@@ -1,23 +1,30 @@
 import type {MockResponse} from "./respond-with";
-import type {OperationMock, OperationMatcher, MockFn} from "./types";
+import type {
+    OperationMock,
+    OperationMatcher,
+    MockFn,
+    MockConfiguration,
+} from "./types";
 
 /**
  * A generic mock request function for using when mocking fetch or gqlFetch.
  */
-export const mockRequester = <TOperationType>(
+export const mockRequester = <TOperationType, TResponseData>(
     operationMatcher: OperationMatcher<any>,
     operationToString: (...args: Array<any>) => string,
-): MockFn<TOperationType> => {
+): MockFn<TOperationType, TResponseData> => {
     // We want this to work in jest and in fixtures to make life easy for folks.
     // This is the array of mocked operations that we will traverse and
     // manipulate.
     const mocks: Array<OperationMock<any>> = [];
 
-    // What we return has to be a drop in replacement for the mocked function
-    // which is how folks will then use this mock.
-    const mockFn: MockFn<TOperationType> = (
+    const configuration: MockConfiguration = {
+        hardFailOnUnmockedRequests: false,
+    };
+
+    const getMatchingMock = (
         ...args: Array<any>
-    ): Promise<Response> => {
+    ): OperationMock<any> | null => {
         // Iterate our mocked operations and find the first one that matches.
         for (const mock of mocks) {
             if (mock.onceOnly && mock.used) {
@@ -26,24 +33,46 @@ export const mockRequester = <TOperationType>(
             }
             if (operationMatcher(mock.operation, ...args)) {
                 mock.used = true;
-                return mock.response();
+                return mock;
             }
         }
+        return null;
+    };
 
-        // Default is to reject with some helpful info on what request
-        // we rejected.
+    // What we return has to be a drop in replacement for the mocked function
+    // which is how folks will then use this mock.
+    const mockFn: MockFn<TOperationType, TResponseData> = (
+        ...args: Array<any>
+    ): Promise<Response> => {
+        const matchingMock = getMatchingMock(...args);
+        if (matchingMock) {
+            return matchingMock.response();
+        }
+
+        // If we get here, there is no match.
         const operation = operationToString(...args);
-        return Promise.reject(
+        const noMatchError =
             new Error(`No matching mock response found for request:
-    ${operation}`),
-        );
+    ${operation}`);
+        if (configuration.hardFailOnUnmockedRequests) {
+            // When we are set to hard fail, we do what Apollo's MockLink
+            // does and throw an error immediately. This catastrophically fails
+            // test cases when a request wasn't matched, which can be brutal
+            // in some cases, though is also helpful for debugging.
+            throw noMatchError;
+        }
+
+        // Our default is to return a rejected promise so that errors
+        // are handled by the code under test rather than hard failing
+        // everything.
+        return Promise.reject(noMatchError);
     };
 
     const addMockedOperation = <TOperation>(
         operation: TOperation,
-        response: MockResponse<any>,
+        response: MockResponse<TResponseData>,
         onceOnly: boolean,
-    ): MockFn<TOperationType> => {
+    ): MockFn<TOperationType, TResponseData> => {
         const mockResponse = () => response.toPromise();
         mocks.push({
             operation,
@@ -56,13 +85,22 @@ export const mockRequester = <TOperationType>(
 
     mockFn.mockOperation = <TOperation>(
         operation: TOperation,
-        response: MockResponse<any>,
-    ): MockFn<TOperationType> => addMockedOperation(operation, response, false);
+        response: MockResponse<TResponseData>,
+    ): MockFn<TOperationType, TResponseData> =>
+        addMockedOperation(operation, response, false);
 
     mockFn.mockOperationOnce = <TOperation>(
         operation: TOperation,
-        response: MockResponse<any>,
-    ): MockFn<TOperationType> => addMockedOperation(operation, response, true);
+        response: MockResponse<TResponseData>,
+    ): MockFn<TOperationType, TResponseData> =>
+        addMockedOperation(operation, response, true);
+
+    mockFn.configure = (
+        config: Partial<MockConfiguration>,
+    ): MockFn<TOperationType, TResponseData> => {
+        Object.assign(configuration, config);
+        return mockFn;
+    };
 
     return mockFn;
 };

--- a/packages/wonder-blocks-testing-core/src/types.ts
+++ b/packages/wonder-blocks-testing-core/src/types.ts
@@ -14,11 +14,46 @@ export type GraphQLJson<TData extends Record<any, any>> =
           }>;
       };
 
-export type MockFn<TOperationType> = {
+export interface MockFn<TOperationType, TResponseData> {
+    /**
+     * The mock fetch function.
+     *
+     * This function is a drop-in replacement for the fetch function being
+     * mocked. It is recommended that a more strongly-typed definition is
+     * provided in the consuming codebase, as this definition is intentionally
+     * loose to allow for mocking any fetch operation.
+     */
     (...args: Array<any>): Promise<Response>;
-    mockOperation: MockOperationFn<TOperationType>;
-    mockOperationOnce: MockOperationFn<TOperationType>;
-};
+
+    /**
+     * Mock a fetch operation.
+     *
+     * This adds a response for a given mocked operation of the given type.
+     * Matches are determined by the operation matcher provided to the
+     * mockRequester function that creates the mock fetch function.
+     */
+    mockOperation: MockOperationFn<TOperationType, TResponseData>;
+
+    /**
+     * Mock a fetch operation once.
+     *
+     * This adds a response for a given mocked operation of the given type that
+     * will only be used once and discarded. Matches are determined by the
+     * operation matcher provided to the mockRequester function that creates the
+     * mock fetch function.
+     */
+    mockOperationOnce: MockOperationFn<TOperationType, TResponseData>;
+
+    /**
+     * Configure the mock fetch function with the given configuration.
+     *
+     * This function is provided as a convenience to allow for configuring the
+     * mock fetch function in a fluent manner. The configuration is applied
+     * to all mocks for a given fetch function; the last configuration applied
+     * will be the one that is used for all mocked operations.
+     */
+    configure: ConfigureFn<TOperationType, TResponseData>;
+}
 
 export type OperationMock<TOperation> = {
     operation: TOperation;
@@ -32,9 +67,41 @@ export type OperationMatcher<TOperation> = (
     ...args: Array<any>
 ) => boolean;
 
-export type MockOperationFn<TOperationType> = <
+export type MockOperationFn<TOperationType, TResponseData> = <
     TOperation extends TOperationType,
 >(
     operation: TOperation,
-    response: MockResponse<any>,
-) => MockFn<TOperationType>;
+    response: MockResponse<TResponseData>,
+) => MockFn<TOperationType, TResponseData>;
+
+/**
+ * Configuration options for mocked fetches.
+ */
+export type MockConfiguration = {
+    /**
+     * If true, any requests that don't match a mock will throw an error
+     * immediately on the request being made; otherwise, if false, unmatched
+     * requests will return a rejected promise.
+     *
+     * Defaults to false. When true, this is akin to the Apollo MockLink
+     * behavior that throws upon the request being. This is useful as it will
+     * clearly fail a test early, indicating that a request was not mocked.
+     * However, that mode requires all requests to be mocked, which can be
+     * cumbersome and unncessary. Having unmocked requests return a rejected
+     * promise is more flexible and allows for more granular control over
+     * mocking, allowing developers to mock only the requests they care about
+     * and let the error handling of their code deal with the rejected promises.
+     */
+    hardFailOnUnmockedRequests: boolean;
+};
+
+export interface ConfigureFn<TOperationType, TResponseData> {
+    /**
+     * Configure the mock fetch function with the given configuration.
+     *
+     * @param config The configuration changes to apply to the mock fetch
+     * function.
+     * @returns The mock fetch function .
+     */
+    (config: Partial<MockConfiguration>): MockFn<TOperationType, TResponseData>;
+}

--- a/packages/wonder-blocks-testing/src/gql/__tests__/gql-request-matches-mock.test.ts
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/gql-request-matches-mock.test.ts
@@ -45,7 +45,7 @@ describe("#gqlRequestMatchesMock", () => {
         expect(result).toBe(false);
     });
 
-    it.each([{foo: "bar"}, {foo: "baz", anExtra: "property"}, null])(
+    it.each([{foo: undefined}, {foo: "baz", anExtra: "property"}, null])(
         "should return false if variables don't match",
         (variables: any) => {
             // Arrange
@@ -158,6 +158,7 @@ describe("#gqlRequestMatchesMock", () => {
             },
             {
                 foo: "bar",
+                baz: undefined,
             },
             {my: "context"},
         );

--- a/packages/wonder-blocks-testing/src/gql/__tests__/match-gql.test.ts
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/match-gql.test.ts
@@ -1,0 +1,115 @@
+import {it, expect, describe} from "@jest/globals";
+
+import {GqlOperation} from "@khanacademy/wonder-blocks-data";
+import {matchGql} from "../match-gql";
+
+describe("matchGql", () => {
+    it("should return a mock operation matcher with the provided operation", () => {
+        // Arrange
+        const operation: GqlOperation<any, any> = {
+            type: "query",
+            id: "getMyStuff",
+        };
+
+        // Act
+        const result = matchGql(operation);
+
+        // Assert
+        expect(result).toStrictEqual(
+            expect.objectContaining({
+                operation,
+            }),
+        );
+    });
+
+    it("should expose the withVariables and withContext methods", () => {
+        // Arrange
+        const operation: GqlOperation<any, any> = {
+            type: "query",
+            id: "getMyStuff",
+        };
+
+        // Act
+        const result = matchGql(operation);
+
+        // Assert
+        expect(result).toStrictEqual(
+            expect.objectContaining({
+                withVariables: expect.any(Function),
+                withContext: expect.any(Function),
+            }),
+        );
+    });
+
+    it("should return a mock operation matcher with the provided variables when withVariables is called", () => {
+        // Arrange
+        const operation: GqlOperation<any, any> = {
+            type: "query",
+            id: "getMyStuff",
+        };
+        const variables = {
+            id: "123",
+        };
+
+        // Act
+        const result = matchGql(operation).withVariables(variables);
+
+        // Assert
+        expect(result).toStrictEqual(
+            expect.objectContaining({
+                operation,
+                variables,
+            }),
+        );
+    });
+
+    it("should return a mock operation matcher with the provided context when withContext is called", () => {
+        // Arrange
+        const operation: GqlOperation<any, any> = {
+            type: "query",
+            id: "getMyStuff",
+        };
+        const context = {
+            locale: "en",
+        };
+
+        // Act
+        const result = matchGql(operation).withContext(context);
+
+        // Assert
+        expect(result).toStrictEqual(
+            expect.objectContaining({
+                operation,
+                context,
+            }),
+        );
+    });
+
+    it("should return a mock operation matcher with the provided context and variables when both withVariables and withContext are called", () => {
+        // Arrange
+        const operation: GqlOperation<any, any> = {
+            type: "query",
+            id: "getMyStuff",
+        };
+        const variables = {
+            id: "123",
+        };
+        const context = {
+            locale: "en",
+        };
+
+        // Act
+        const result = matchGql(operation)
+            .withVariables(variables)
+            .withContext(context);
+
+        // Assert
+        expect(result).toStrictEqual(
+            expect.objectContaining({
+                operation,
+                variables,
+                context,
+            }),
+        );
+    });
+});

--- a/packages/wonder-blocks-testing/src/gql/__tests__/types.typestest.ts
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/types.typestest.ts
@@ -1,6 +1,12 @@
-import {GqlOperation} from "@khanacademy/wonder-blocks-data";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {GqlContext, GqlOperation} from "@khanacademy/wonder-blocks-data";
 import {RespondWith} from "@khanacademy/wonder-blocks-testing-core";
-import type {GqlFetchMockFn} from "../types";
+import type {
+    GqlFetchMockFn,
+    GqlMockOperation,
+    MutableGqlMockOperation,
+} from "../types";
+import {matchGql} from "../match-gql";
 
 type SomeGqlData = {
     a: string;
@@ -16,6 +22,8 @@ const fakeOperation: GqlOperation<SomeGqlData, SomeGqlVariables> = {} as any;
 
 const mockFetch: GqlFetchMockFn = (() => {}) as any;
 
+// -> GqlFetchMockFn tests
+// mockOperation tests
 // should be ok, no variables
 mockFetch.mockOperation(
     {
@@ -95,3 +103,71 @@ mockFetch.mockOperation(
         b: "string",
     }),
 );
+
+// configure tests
+// should be ok
+mockFetch.configure({hardFailOnUnmockedRequests: true});
+
+// should error; invalid configuration
+mockFetch.configure({
+    // @ts-expect-error Type 'boolean' is not assignable to type 'number'.
+    hardFailOnUnmockedRequests: 4,
+});
+
+// -> matchGql tests
+// should be ok, no variables or context
+matchGql(fakeOperation);
+
+// should be ok, with variables
+matchGql(fakeOperation).withVariables({
+    a: "string",
+    b: 42,
+});
+
+// should be ok, with context
+matchGql(fakeOperation).withContext({
+    locale: "en",
+});
+
+// should be ok, with variables and context
+matchGql(fakeOperation)
+    .withVariables({
+        a: "string",
+        b: 42,
+    })
+    .withContext({
+        locale: "en",
+    });
+
+// should be ok, returns a GqlMockOperation
+const x1: GqlMockOperation<SomeGqlData, SomeGqlVariables, GqlContext> =
+    matchGql(fakeOperation);
+
+// should error; not a valid operation
+// @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'GqlOperation<any, any>'.
+matchGql("not an operation");
+
+// should error; invalid variables
+matchGql(fakeOperation).withVariables({
+    // @ts-expect-error Type 'number' is not assignable to type 'string'.
+    a: 42,
+    b: 42,
+});
+
+// should error; invalid context
+matchGql(fakeOperation).withContext({
+    // @ts-expect-error Type 'number' is not assignable to type 'string'.
+    locale: 42,
+});
+
+// should error; invalid variables and context
+matchGql(fakeOperation)
+    .withVariables({
+        // @ts-expect-error Type 'number' is not assignable to type 'string'.
+        a: 42,
+        b: 42,
+    })
+    .withContext({
+        // @ts-expect-error Type 'number' is not assignable to type 'string'.
+        locale: 42,
+    });

--- a/packages/wonder-blocks-testing/src/gql/__tests__/types.typestest.ts
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/types.typestest.ts
@@ -143,6 +143,19 @@ matchGql(fakeOperation)
 const x1: GqlMockOperation<SomeGqlData, SomeGqlVariables, GqlContext> =
     matchGql(fakeOperation);
 
+// should be ok, returns a GqlMockOperation
+const x2: GqlMockOperation<SomeGqlData, SomeGqlVariables, GqlContext> =
+    matchGql(fakeOperation).withVariables({
+        a: "string",
+        b: 42,
+    });
+
+// should be ok, returns a GqlMockOperation
+const x3: GqlMockOperation<SomeGqlData, SomeGqlVariables, GqlContext> =
+    matchGql(fakeOperation).withContext({
+        locale: "en",
+    });
+
 // should error; not a valid operation
 // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'GqlOperation<any, any>'.
 matchGql("not an operation");

--- a/packages/wonder-blocks-testing/src/gql/__tests__/types.typestest.ts
+++ b/packages/wonder-blocks-testing/src/gql/__tests__/types.typestest.ts
@@ -140,21 +140,27 @@ matchGql(fakeOperation)
     });
 
 // should be ok, returns a GqlMockOperation
-const x1: GqlMockOperation<SomeGqlData, SomeGqlVariables, GqlContext> =
-    matchGql(fakeOperation);
+const x1: GqlMockOperation<
+    GqlOperation<SomeGqlData, SomeGqlVariables>,
+    GqlContext
+> = matchGql(fakeOperation);
 
 // should be ok, returns a GqlMockOperation
-const x2: GqlMockOperation<SomeGqlData, SomeGqlVariables, GqlContext> =
-    matchGql(fakeOperation).withVariables({
-        a: "string",
-        b: 42,
-    });
+const x2: GqlMockOperation<
+    GqlOperation<SomeGqlData, SomeGqlVariables>,
+    GqlContext
+> = matchGql(fakeOperation).withVariables({
+    a: "string",
+    b: 42,
+});
 
 // should be ok, returns a GqlMockOperation
-const x3: GqlMockOperation<SomeGqlData, SomeGqlVariables, GqlContext> =
-    matchGql(fakeOperation).withContext({
-        locale: "en",
-    });
+const x3: GqlMockOperation<
+    GqlOperation<SomeGqlData, SomeGqlVariables>,
+    GqlContext
+> = matchGql(fakeOperation).withContext({
+    locale: "en",
+});
 
 // should error; not a valid operation
 // @ts-expect-error Argument of type 'string' is not assignable to parameter of type 'GqlOperation<any, any>'.

--- a/packages/wonder-blocks-testing/src/gql/gql-request-matches-mock.ts
+++ b/packages/wonder-blocks-testing/src/gql/gql-request-matches-mock.ts
@@ -34,7 +34,7 @@ const areObjectsEquivalent = (a: any, b: any): boolean => {
 };
 
 export const gqlRequestMatchesMock = (
-    mock: GqlMockOperation<any, any, any>,
+    mock: GqlMockOperation<any, any>,
     operation: GqlOperation<any, any>,
     variables: Record<any, any> | null | undefined,
     context: GqlContext,

--- a/packages/wonder-blocks-testing/src/gql/match-gql.ts
+++ b/packages/wonder-blocks-testing/src/gql/match-gql.ts
@@ -1,56 +1,18 @@
 import {GqlContext, GqlOperation} from "@khanacademy/wonder-blocks-data";
 import {clone} from "@khanacademy/wonder-stuff-core";
 import {
-    ExtractVariables,
-    GqlMockOperation,
+    MatchApi,
+    MatchApiWithOperation,
     MutableGqlMockOperation,
 } from "./types";
-
-interface WithVariablesFn<
-    TOperation extends GqlOperation<any, any>,
-    TContext extends GqlContext,
-> {
-    (variables: ExtractVariables<TOperation>): WithContextApi<
-        TOperation,
-        TContext
-    > &
-        GqlMockOperation<TOperation, TContext>;
-}
-
-interface WithContextFn<
-    TOperation extends GqlOperation<any, any>,
-    TContext extends GqlContext,
-> {
-    (context: TContext): WithVariablesApi<TOperation, TContext> &
-        GqlMockOperation<TOperation, TContext>;
-}
-
-interface WithVariablesApi<
-    TOperation extends GqlOperation<any, any>,
-    TContext extends GqlContext,
-> {
-    withVariables: WithVariablesFn<TOperation, TContext>;
-}
-
-interface WithContextApi<
-    TOperation extends GqlOperation<any, any>,
-    TContext extends GqlContext,
-> {
-    withContext: WithContextFn<TOperation, TContext>;
-}
-
-interface MatchApi<
-    TOperation extends GqlOperation<any, any>,
-    TContext extends GqlContext,
-> extends WithVariablesApi<TOperation, TContext>,
-        WithContextApi<TOperation, TContext>,
-        GqlMockOperation<TOperation, TContext> {}
 
 interface InternalMatchApi<
     TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
-> extends WithVariablesApi<TOperation, TContext>,
-        WithContextApi<TOperation, TContext>,
+> extends Omit<
+            MatchApi<TOperation, TContext>,
+            "operation | variables | context"
+        >,
         MutableGqlMockOperation<TOperation, TContext> {}
 
 /**
@@ -69,20 +31,14 @@ export const matchGql = <
     TContext extends GqlContext,
 >(
     operation: TOperation,
-): MatchApi<TOperation, TContext> => {
+): MatchApiWithOperation<TOperation, TContext> => {
     const api: InternalMatchApi<TOperation, TContext> = {
         operation,
-        withVariables: (
-            variables: ExtractVariables<TOperation>,
-        ): WithContextApi<TOperation, TContext> &
-            MutableGqlMockOperation<TOperation, TContext> => {
+        withVariables: (variables) => {
             api.variables = clone(variables);
             return api;
         },
-        withContext: (
-            context: TContext,
-        ): WithVariablesApi<TOperation, TContext> &
-            MutableGqlMockOperation<TOperation, TContext> => {
+        withContext: (context) => {
             api.context = clone(context);
             return api;
         },

--- a/packages/wonder-blocks-testing/src/gql/match-gql.ts
+++ b/packages/wonder-blocks-testing/src/gql/match-gql.ts
@@ -1,52 +1,57 @@
 import {GqlContext, GqlOperation} from "@khanacademy/wonder-blocks-data";
 import {clone} from "@khanacademy/wonder-stuff-core";
-import {GqlMockOperation, MutableGqlMockOperation} from "./types";
+import {
+    ExtractVariables,
+    GqlMockOperation,
+    MutableGqlMockOperation,
+} from "./types";
 
 interface WithVariablesFn<
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
 > {
-    (variables: TVariables): WithContextApi<TVariables, TContext> &
-        GqlMockOperation<any, TVariables, TContext>;
+    (variables: ExtractVariables<TOperation>): WithContextApi<
+        TOperation,
+        TContext
+    > &
+        GqlMockOperation<TOperation, TContext>;
 }
 
 interface WithContextFn<
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
 > {
-    (context: TContext): WithVariablesApi<TVariables, TContext> &
-        GqlMockOperation<any, TVariables, TContext>;
+    (context: TContext): WithVariablesApi<TOperation, TContext> &
+        GqlMockOperation<TOperation, TContext>;
 }
 
 interface WithVariablesApi<
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
 > {
-    withVariables: WithVariablesFn<TVariables, TContext>;
+    withVariables: WithVariablesFn<TOperation, TContext>;
 }
 
 interface WithContextApi<
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
 > {
-    withContext: WithContextFn<TVariables, TContext>;
+    withContext: WithContextFn<TOperation, TContext>;
 }
 
 interface MatchApi<
-    TData extends Record<any, any>,
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
-> extends WithVariablesApi<TVariables, TContext>,
-        WithContextApi<TVariables, TContext>,
-        GqlMockOperation<TData, TVariables, TContext> {}
+> extends WithVariablesApi<TOperation, TContext>,
+        WithContextApi<TOperation, TContext>,
+        GqlMockOperation<TOperation, TContext> {}
 
 interface InternalMatchApi<
-    TData extends Record<any, any>,
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
-> extends WithVariablesApi<TVariables, TContext>,
-        WithContextApi<TVariables, TContext>,
-        MutableGqlMockOperation<TData, TVariables, TContext> {}
+> extends WithVariablesApi<TOperation, TContext>,
+        WithContextApi<TOperation, TContext>,
+        MutableGqlMockOperation<TOperation, TContext> {}
 
 /**
  * Create a mock GQL operation matcher.
@@ -60,25 +65,24 @@ interface InternalMatchApi<
  * trying to match a request.
  */
 export const matchGql = <
-    TData extends Record<any, any>,
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
 >(
-    operation: GqlOperation<TData, TVariables>,
-): MatchApi<TData, TVariables, TContext> => {
-    const api: InternalMatchApi<TData, TVariables, TContext> = {
+    operation: TOperation,
+): MatchApi<TOperation, TContext> => {
+    const api: InternalMatchApi<TOperation, TContext> = {
         operation,
         withVariables: (
-            variables: TVariables,
-        ): WithContextApi<TVariables, TContext> &
-            MutableGqlMockOperation<any, TVariables, TContext> => {
+            variables: ExtractVariables<TOperation>,
+        ): WithContextApi<TOperation, TContext> &
+            MutableGqlMockOperation<TOperation, TContext> => {
             api.variables = clone(variables);
             return api;
         },
         withContext: (
             context: TContext,
-        ): WithVariablesApi<TVariables, TContext> &
-            MutableGqlMockOperation<any, TVariables, TContext> => {
+        ): WithVariablesApi<TOperation, TContext> &
+            MutableGqlMockOperation<TOperation, TContext> => {
             api.context = clone(context);
             return api;
         },

--- a/packages/wonder-blocks-testing/src/gql/match-gql.ts
+++ b/packages/wonder-blocks-testing/src/gql/match-gql.ts
@@ -1,0 +1,83 @@
+import {GqlContext, GqlOperation} from "@khanacademy/wonder-blocks-data";
+import {clone} from "@khanacademy/wonder-stuff-core";
+import {GqlMockOperation, MutableGqlMockOperation} from "./types";
+
+interface WithVariablesFn<
+    TVariables extends Record<any, any>,
+    TContext extends GqlContext,
+> {
+    (variables: TVariables): WithContextApi<TVariables, TContext>;
+}
+
+interface WithContextFn<
+    TVariables extends Record<any, any>,
+    TContext extends GqlContext,
+> {
+    (context: TContext): WithVariablesApi<TVariables, TContext>;
+}
+
+interface WithVariablesApi<
+    TVariables extends Record<any, any>,
+    TContext extends GqlContext,
+> {
+    withVariables: WithVariablesFn<TVariables, TContext>;
+}
+
+interface WithContextApi<
+    TVariables extends Record<any, any>,
+    TContext extends GqlContext,
+> {
+    withContext: WithContextFn<TVariables, TContext>;
+}
+
+interface MatchApi<
+    TData extends Record<any, any>,
+    TVariables extends Record<any, any>,
+    TContext extends GqlContext,
+> extends WithVariablesApi<TVariables, TContext>,
+        WithContextApi<TVariables, TContext>,
+        Readonly<GqlMockOperation<TData, TVariables, TContext>> {}
+
+interface InternalMatchApi<
+    TData extends Record<any, any>,
+    TVariables extends Record<any, any>,
+    TContext extends GqlContext,
+> extends WithVariablesApi<TVariables, TContext>,
+        WithContextApi<TVariables, TContext>,
+        MutableGqlMockOperation<TData, TVariables, TContext> {}
+
+/**
+ * Create a mock GQL operation matcher.
+ *
+ * This function is used to create a mock GQL operation matcher. It is
+ * a provided as a convenience to allow for easier type-checking of
+ * operations when building mocks, rather than constructing the object
+ * directly. It provides a fluent API for building a request matcher.
+ *
+ * @param operation The operation to match. This is always used when
+ * trying to match a request.
+ */
+export const matchGql = <
+    TData extends Record<any, any>,
+    TVariables extends Record<any, any>,
+    TContext extends GqlContext,
+>(
+    operation: GqlOperation<TData, TVariables>,
+): MatchApi<TData, TVariables, TContext> => {
+    const api: InternalMatchApi<TData, TVariables, TContext> = {
+        operation,
+        withVariables: (
+            variables: TVariables,
+        ): WithContextApi<TVariables, TContext> => {
+            api.variables = clone(variables);
+            return api;
+        },
+        withContext: (
+            context: TContext,
+        ): WithVariablesApi<TVariables, TContext> => {
+            api.context = clone(context);
+            return api;
+        },
+    };
+    return api;
+};

--- a/packages/wonder-blocks-testing/src/gql/match-gql.ts
+++ b/packages/wonder-blocks-testing/src/gql/match-gql.ts
@@ -6,14 +6,16 @@ interface WithVariablesFn<
     TVariables extends Record<any, any>,
     TContext extends GqlContext,
 > {
-    (variables: TVariables): WithContextApi<TVariables, TContext>;
+    (variables: TVariables): WithContextApi<TVariables, TContext> &
+        MutableGqlMockOperation<any, TVariables, TContext>;
 }
 
 interface WithContextFn<
     TVariables extends Record<any, any>,
     TContext extends GqlContext,
 > {
-    (context: TContext): WithVariablesApi<TVariables, TContext>;
+    (context: TContext): WithVariablesApi<TVariables, TContext> &
+        MutableGqlMockOperation<any, TVariables, TContext>;
 }
 
 interface WithVariablesApi<
@@ -36,7 +38,7 @@ interface MatchApi<
     TContext extends GqlContext,
 > extends WithVariablesApi<TVariables, TContext>,
         WithContextApi<TVariables, TContext>,
-        Readonly<GqlMockOperation<TData, TVariables, TContext>> {}
+        GqlMockOperation<TData, TVariables, TContext> {}
 
 interface InternalMatchApi<
     TData extends Record<any, any>,
@@ -68,13 +70,15 @@ export const matchGql = <
         operation,
         withVariables: (
             variables: TVariables,
-        ): WithContextApi<TVariables, TContext> => {
+        ): WithContextApi<TVariables, TContext> &
+            MutableGqlMockOperation<any, TVariables, TContext> => {
             api.variables = clone(variables);
             return api;
         },
         withContext: (
             context: TContext,
-        ): WithVariablesApi<TVariables, TContext> => {
+        ): WithVariablesApi<TVariables, TContext> &
+            MutableGqlMockOperation<any, TVariables, TContext> => {
             api.context = clone(context);
             return api;
         },

--- a/packages/wonder-blocks-testing/src/gql/match-gql.ts
+++ b/packages/wonder-blocks-testing/src/gql/match-gql.ts
@@ -7,7 +7,7 @@ interface WithVariablesFn<
     TContext extends GqlContext,
 > {
     (variables: TVariables): WithContextApi<TVariables, TContext> &
-        MutableGqlMockOperation<any, TVariables, TContext>;
+        GqlMockOperation<any, TVariables, TContext>;
 }
 
 interface WithContextFn<
@@ -15,7 +15,7 @@ interface WithContextFn<
     TContext extends GqlContext,
 > {
     (context: TContext): WithVariablesApi<TVariables, TContext> &
-        MutableGqlMockOperation<any, TVariables, TContext>;
+        GqlMockOperation<any, TVariables, TContext>;
 }
 
 interface WithVariablesApi<

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.ts
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.ts
@@ -9,7 +9,7 @@ import type {GqlFetchMockFn, GqlMockOperation} from "./types";
  * A mock for the fetch function passed to GqlRouter.
  */
 export const mockGqlFetch = (): GqlFetchMockFn =>
-    mockRequester<GqlMockOperation<any, any, any>, GraphQLJson<any>>(
+    mockRequester<GqlMockOperation<any, any>, GraphQLJson<any>>(
         gqlRequestMatchesMock,
         // Note that the identation at the start of each line is important.
         // TODO(somewhatabstract): Make a stringify that indents each line of

--- a/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.ts
+++ b/packages/wonder-blocks-testing/src/gql/mock-gql-fetch.ts
@@ -1,4 +1,7 @@
-import {mockRequester} from "@khanacademy/wonder-blocks-testing-core";
+import {
+    GraphQLJson,
+    mockRequester,
+} from "@khanacademy/wonder-blocks-testing-core";
 import {gqlRequestMatchesMock} from "./gql-request-matches-mock";
 import type {GqlFetchMockFn, GqlMockOperation} from "./types";
 
@@ -6,7 +9,7 @@ import type {GqlFetchMockFn, GqlMockOperation} from "./types";
  * A mock for the fetch function passed to GqlRouter.
  */
 export const mockGqlFetch = (): GqlFetchMockFn =>
-    mockRequester<GqlMockOperation<any, any, any>>(
+    mockRequester<GqlMockOperation<any, any, any>, GraphQLJson<any>>(
         gqlRequestMatchesMock,
         // Note that the identation at the start of each line is important.
         // TODO(somewhatabstract): Make a stringify that indents each line of

--- a/packages/wonder-blocks-testing/src/gql/types.ts
+++ b/packages/wonder-blocks-testing/src/gql/types.ts
@@ -1,9 +1,16 @@
 import type {GqlOperation, GqlContext} from "@khanacademy/wonder-blocks-data";
 import type {
+    ConfigureFn,
     GraphQLJson,
     MockResponse,
 } from "@khanacademy/wonder-blocks-testing-core";
 
+/**
+ * A GraphQL operation to be mocked.
+ *
+ * This is used to specify what a request must match in order for a mock to
+ * be used.
+ */
 export type GqlMockOperation<
     TData extends Record<any, any>,
     TVariables extends Record<any, any>,
@@ -14,22 +21,77 @@ export type GqlMockOperation<
     context?: TContext;
 };
 
-type GqlMockOperationFn = <
-    TData extends Record<any, any>,
-    TVariables extends Record<any, any>,
-    TContext extends GqlContext,
-    TResponseData extends GraphQLJson<TData>,
->(
-    operation: GqlMockOperation<TData, TVariables, TContext>,
-    response: MockResponse<TResponseData>,
-) => GqlFetchMockFn;
+interface GqlMockOperationFn {
+    <
+        TData extends Record<any, any>,
+        TVariables extends Record<any, any>,
+        TContext extends GqlContext,
+        TResponseData extends GraphQLJson<TData>,
+    >(
+        /**
+         * The operation to match.
+         */
+        operation: GqlMockOperation<TData, TVariables, TContext>,
+        /**
+         * The response to return when the operation is matched.
+         */
+        response: MockResponse<TResponseData>,
+    ): GqlFetchMockFn;
+}
 
-export type GqlFetchMockFn = {
+export interface GqlFetchMockFn {
+    /**
+     * The mock fetch function.
+     *
+     * This function is a drop-in replacement for the gqlFetch function used
+     * by Wonder Blocks Data. You should not need to call this function
+     * directly. Just pass this in places where you would pass a gqlFetch
+     * function, as provided by the GqlRouter.
+     */
     (
         operation: GqlOperation<any, any>,
         variables: Record<any, any> | null | undefined,
         context: GqlContext,
     ): Promise<Response>;
+
+    /**
+     * Mock a fetch operation.
+     *
+     * This adds a response for a given mocked operation. Operations are
+     * matched greedily, so if only the GraphQL operation is provided, then
+     * all requests for that operation will be matched, regardless of
+     * variables or context.
+     *
+     * Regardless of how many times this mock is matched, it will be used.
+     *
+     * @returns The mock fetch function for chaining.
+     */
     mockOperation: GqlMockOperationFn;
+
+    /**
+     * Mock a fetch operation once.
+     *
+     * This adds a response for a given mocked operation. Operations are
+     * matched greedily, so if only the GraphQL operation is provided, then
+     * all requests for that operation will be matched, regardless of
+     * variables or context.
+     *
+     * Once the added mock is used, it will be discarded and no longer match
+     * any requests.
+     *
+     * @returns The mock fetch function for chaining.
+     */
     mockOperationOnce: GqlMockOperationFn;
-};
+
+    /**
+     * Configure the mock fetch function with the given configuration.
+     *
+     * This function is provided as a convenience to allow for configuring the
+     * mock fetch function in a fluent manner. The configuration is applied
+     * to all mocks for a given fetch function; the last configuration applied
+     * will be the one that is used for all mocked operations.
+     *
+     * @returns The mock fetch function for chaining.
+     */
+    configure: ConfigureFn<GqlMockOperation<any, any, any>, GraphQLJson<any>>;
+}

--- a/packages/wonder-blocks-testing/src/gql/types.ts
+++ b/packages/wonder-blocks-testing/src/gql/types.ts
@@ -12,14 +12,27 @@ import type {
  * be used.
  */
 export interface MutableGqlMockOperation<
-    TData extends Record<any, any>,
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
 > {
-    operation: GqlOperation<TData, TVariables>;
-    variables?: TVariables;
+    operation: TOperation;
+    variables?: ExtractVariables<TOperation>;
     context?: TContext;
 }
+
+export type ExtractData<TOperation> = TOperation extends GqlOperation<
+    infer TData,
+    any
+>
+    ? TData
+    : never;
+
+export type ExtractVariables<TOperation> = TOperation extends GqlOperation<
+    any,
+    infer TVariables
+>
+    ? TVariables
+    : never;
 
 /**
  * A GraphQL operation to be mocked.
@@ -28,22 +41,20 @@ export interface MutableGqlMockOperation<
  * be used.
  */
 export type GqlMockOperation<
-    TData extends Record<any, any>,
-    TVariables extends Record<any, any>,
+    TOperation extends GqlOperation<any, any>,
     TContext extends GqlContext,
-> = Readonly<MutableGqlMockOperation<TData, TVariables, TContext>>;
+> = Readonly<MutableGqlMockOperation<TOperation, TContext>>;
 
 interface GqlMockOperationFn {
     <
-        TData extends Record<any, any>,
-        TVariables extends Record<any, any>,
+        TOperation extends GqlOperation<any, any>,
         TContext extends GqlContext,
-        TResponseData extends GraphQLJson<TData>,
+        TResponseData extends GraphQLJson<ExtractData<TOperation>>,
     >(
         /**
          * The operation to match.
          */
-        operation: GqlMockOperation<TData, TVariables, TContext>,
+        operation: GqlMockOperation<TOperation, TContext>,
         /**
          * The response to return when the operation is matched.
          */
@@ -105,5 +116,5 @@ export interface GqlFetchMockFn {
      *
      * @returns The mock fetch function for chaining.
      */
-    configure: ConfigureFn<GqlMockOperation<any, any, any>, GraphQLJson<any>>;
+    configure: ConfigureFn<GqlMockOperation<any, any>, GraphQLJson<any>>;
 }

--- a/packages/wonder-blocks-testing/src/gql/types.ts
+++ b/packages/wonder-blocks-testing/src/gql/types.ts
@@ -118,3 +118,36 @@ export interface GqlFetchMockFn {
      */
     configure: ConfigureFn<GqlMockOperation<any, any>, GraphQLJson<any>>;
 }
+
+interface WithVariablesFn<
+    TOperation extends GqlOperation<any, any>,
+    TContext extends GqlContext,
+> {
+    (variables: ExtractVariables<TOperation>): Omit<
+        MatchApi<TOperation, TContext>,
+        "withVariables"
+    > &
+        GqlMockOperation<TOperation, TContext>;
+}
+
+interface WithContextFn<
+    TOperation extends GqlOperation<any, any>,
+    TContext extends GqlContext,
+> {
+    (context: TContext): Omit<MatchApi<TOperation, TContext>, "withContext"> &
+        GqlMockOperation<TOperation, TContext>;
+}
+
+export interface MatchApi<
+    TOperation extends GqlOperation<any, any>,
+    TContext extends GqlContext,
+> {
+    withVariables: WithVariablesFn<TOperation, TContext>;
+    withContext: WithContextFn<TOperation, TContext>;
+}
+
+export interface MatchApiWithOperation<
+    TOperation extends GqlOperation<any, any>,
+    TContext extends GqlContext,
+> extends GqlMockOperation<TOperation, TContext>,
+        MatchApi<TOperation, TContext> {}

--- a/packages/wonder-blocks-testing/src/gql/types.ts
+++ b/packages/wonder-blocks-testing/src/gql/types.ts
@@ -6,6 +6,22 @@ import type {
 } from "@khanacademy/wonder-blocks-testing-core";
 
 /**
+ * A mutable GraphQL operation to be mocked.
+ *
+ * This is used to specify what a request must match in order for a mock to
+ * be used.
+ */
+export interface MutableGqlMockOperation<
+    TData extends Record<any, any>,
+    TVariables extends Record<any, any>,
+    TContext extends GqlContext,
+> {
+    operation: GqlOperation<TData, TVariables>;
+    variables?: TVariables;
+    context?: TContext;
+}
+
+/**
  * A GraphQL operation to be mocked.
  *
  * This is used to specify what a request must match in order for a mock to
@@ -15,11 +31,7 @@ export type GqlMockOperation<
     TData extends Record<any, any>,
     TVariables extends Record<any, any>,
     TContext extends GqlContext,
-> = {
-    operation: GqlOperation<TData, TVariables>;
-    variables?: TVariables;
-    context?: TContext;
-};
+> = Readonly<MutableGqlMockOperation<TData, TVariables, TContext>>;
 
 interface GqlMockOperationFn {
     <

--- a/packages/wonder-blocks-testing/src/index.ts
+++ b/packages/wonder-blocks-testing/src/index.ts
@@ -13,6 +13,7 @@ export {
     SettleController,
 } from "@khanacademy/wonder-blocks-testing-core";
 export {mockGqlFetch} from "./gql/mock-gql-fetch";
+export {matchGql} from "./gql/match-gql";
 export type {
     MockResponse,
     FetchMockFn,

--- a/packages/wonder-blocks-testing/src/index.ts
+++ b/packages/wonder-blocks-testing/src/index.ts
@@ -19,7 +19,11 @@ export type {
     FetchMockFn,
     FetchMockOperation,
 } from "@khanacademy/wonder-blocks-testing-core";
-export type {GqlFetchMockFn, GqlMockOperation} from "./gql/types";
+export type {
+    GqlFetchMockFn,
+    GqlMockOperation,
+    MatchApiWithOperation,
+} from "./gql/types";
 
 // Test harness framework
 export type {


### PR DESCRIPTION
## Summary:
I added a signature change to webapp to make it easier to do simple mocks of GraphQL requests for a query without specifying variables, etc. However, I noticed that it made type-checking much less helpful. It obfuscated the real issue (such as a bad variable type) by raising a signature mismatch problem. This is not going to help devs find it easier to write GraphQL mocks.

So, I want to back that change out over in webapp and instead, have added this new helper to build a mock. I originally had this be a simple 3 argument function, like this:

```ts
const matchGql = <TData, TVariables, TContext>(query: GqlOperation<TData, TVariables>, variables?: TVariables, context: TContext) => {
  // ...
}
```

However, I noticed a weird issue where if there was a type issue in both the context and variables arguments, only the variables one caused an error and suppressing that error did not cause the context one to be raised at all. This too felt like it was not helpful at all.

So, instead, I have changed to this fluent API style whereby the returned value is a valid `GqlMockOperation` to pass to the `mockOperation` and `mockOperationOnce` calls, but it also has methods to set the variable and context matching.

I have added type tests to verify that we now get helpful errors when the values passed are incorrect.

This means these two things should be equivalent, for example:

```ts
mockGqlFetch.mockOperation({operation: query, variables, context}, RespondWith.graphQLData(data));

mockGqlFetch.mockOperation(matchGql(query, variables, context), RespondWith.graphQLData(data));
```

The type checking feedback for the `matchGql` variant will be much easier to understand and resolve. However, this still isn't enough. Because the query is now inside the `matchGql` call, Typescript doesn't appear to know how to infer the type of `TData` for the query and ensure parity between the `matchGql` call and the `RespondWith.graphQLData` call - so this again becomes hard to manage for devs. I'm working on this - for now...this is a proof-of-concept but not the whole story.

Issue: FEI-5850

## Test plan:
`yarn test`
`yarn typecheck`