### PR TITLE
LabeledField(part3): Wire up attributes

### DIFF
--- a/.changeset/pink-turtles-sleep.md
+++ b/.changeset/pink-turtles-sleep.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/wonder-blocks-labeled-field": patch
+"@khanacademy/wonder-blocks-labeled-field": minor
 ---
 
 LabeledField: Wire up attributes for elements and apply attributes to the field element

--- a/.changeset/pink-turtles-sleep.md
+++ b/.changeset/pink-turtles-sleep.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": patch
+---
+
+LabeledField: Wire up attributes for elements and apply attributes to the field element

--- a/__docs__/wonder-blocks-labeled-field/accessibility.mdx
+++ b/__docs__/wonder-blocks-labeled-field/accessibility.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/blocks";
 
-<Meta title="Packages / LabeledField / LabeledField / Accessibility" />
+<Meta title="Packages / LabeledField / Accessibility" />
 # LabeledField Accessibility
 
 The `LabeledField` component should be used in forms whenever possible. Benefits

--- a/__docs__/wonder-blocks-labeled-field/accessibility.mdx
+++ b/__docs__/wonder-blocks-labeled-field/accessibility.mdx
@@ -1,0 +1,20 @@
+import {Meta} from "@storybook/blocks";
+
+<Meta title="Packages / LabeledField / LabeledField / Accessibility" />
+# LabeledField Accessibility
+
+The `LabeledField` component should be used in forms whenever possible. Benefits
+for using this component include:
+- Consistent styling for the label, description, and error message
+- HTML attributes are wired up automatically for accessibility:
+  - A `label` element is used with the `for` attribute set to the
+  `id` of the field element
+  - The field element will have `aria-describedby` set to the element ids for
+  the description and error
+
+## Guidelines
+- Make sure the `id` prop for `LabeledField` is unique to the page. If the `id`
+prop is not provided, a unique id will be auto-generated!
+- The `LabeledField` component does not need to be used with the `CheckboxGroup`
+ or `RadioGroup` components since those components already have accessible labels
+ built-in when the `label` prop is used.

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -22,7 +22,7 @@ import SearchField from "@khanacademy/wonder-blocks-search-field";
  * `LabeledField` component so that our form fields are consistent and accessible.
  */
 export default {
-    title: "Packages / LabeledField / LabeledField",
+    title: "Packages / LabeledField",
     component: LabeledField,
     parameters: {
         componentSubtitle: (

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -174,7 +174,7 @@ export const Light: StoryComponentType = {
  * The following story shows what the LabeledField looks like when different
  * props are set.
  */
-export const Combinations = (args: PropsFor<typeof LabeledField>) => {
+export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
     const [textFieldValue, setTextFieldValue] = React.useState("");
 
     return (

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -169,3 +169,49 @@ export const Light: StoryComponentType = {
     },
     render: AllFields,
 };
+
+/**
+ * The following story shows what the LabeledField looks like when different
+ * props are set.
+ */
+export const Combinations = (args: PropsFor<typeof LabeledField>) => {
+    const [textFieldValue, setTextFieldValue] = React.useState("");
+
+    return (
+        <View style={{gap: spacing.large_24}}>
+            <LabeledField
+                {...args}
+                label="Label only"
+                field={
+                    <TextField
+                        value={textFieldValue}
+                        onChange={setTextFieldValue}
+                    />
+                }
+            />
+            <LabeledField
+                {...args}
+                label="With description"
+                description="Description"
+                field={
+                    <TextField
+                        value={textFieldValue}
+                        onChange={setTextFieldValue}
+                    />
+                }
+            />
+            <LabeledField
+                {...args}
+                label="With Error"
+                error="Error message"
+                field={
+                    <TextField
+                        value="invalid value"
+                        onChange={() => {}}
+                        validate={() => "Error message"}
+                    />
+                }
+            />
+        </View>
+    );
+};

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -202,8 +202,21 @@ export const Combinations = (args: PropsFor<typeof LabeledField>) => {
             />
             <LabeledField
                 {...args}
-                label="With Error"
+                label="With error"
                 error="Error message"
+                field={
+                    <TextField
+                        value="invalid value"
+                        onChange={() => {}}
+                        validate={() => "Error message"}
+                    />
+                }
+            />
+            <LabeledField
+                {...args}
+                label="With description and error"
+                error="Error message"
+                description="Description"
                 field={
                     <TextField
                         value="invalid value"

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -368,6 +368,8 @@ describe("LabeledField", () => {
                     <LabeledField
                         field={<TextField value="" onChange={() => {}} />}
                         label="Label"
+                        description="Description for the field"
+                        error="Error message"
                     />,
                     defaultOptions,
                 );

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -240,8 +240,124 @@ describe("LabeledField", () => {
     });
 
     describe("Attributes", () => {
-        it("should autogenerate ids for the elements if the id prop is not provided", () => {});
-        it("should use the id prop for element ids", () => {});
+        it("should use the id prop for the base of element ids", () => {
+            // Arrange
+            const id = "example-id";
+            const label = "Label";
+            const description = "Description of the field";
+            const error = "Error message";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    id={id}
+                    label={label}
+                    description={description}
+                    error={error}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const labelEl = screen.getByText(label);
+            const descriptionEl = screen.getByText(description);
+            const fieldEl = screen.getByRole("textbox");
+            const errorEl = screen.getByText(error);
+
+            // Assert
+            expect(labelEl.id).toBe(`${id}-label`);
+            expect(descriptionEl.id).toBe(`${id}-description`);
+            expect(fieldEl.id).toBe(`${id}-field`);
+            expect(errorEl.id).toBe(`${id}-error`);
+        });
+
+        it("should autogenerate ids for the elements if the id prop is not provided", () => {
+            // Arrange
+            const label = "Label";
+            const description = "Description of the field";
+            const error = "Error message";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label={label}
+                    description={description}
+                    error={error}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const labelEl = screen.getByText(label);
+            const descriptionEl = screen.getByText(description);
+            const fieldEl = screen.getByRole("textbox");
+            const errorEl = screen.getByText(error);
+
+            // Assert
+            expect(labelEl.id).toInclude("-label");
+            expect(descriptionEl.id).toInclude("-description");
+            expect(fieldEl.id).toInclude("-field");
+            expect(errorEl.id).toInclude("-error");
+        });
+
+        it("should use the testId prop for the base of test ids", () => {
+            // Arrange
+            const testId = "test-id";
+            const label = "Label";
+            const description = "Description of the field";
+            const error = "Error message";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    testId={testId}
+                    label={label}
+                    description={description}
+                    error={error}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const labelEl = screen.getByText(label);
+            const descriptionEl = screen.getByText(description);
+            const fieldEl = screen.getByRole("textbox");
+            const errorEl = screen.getByText(error);
+
+            // Assert
+            expect(labelEl).toHaveAttribute("data-testid", `${testId}-label`);
+            expect(descriptionEl).toHaveAttribute(
+                "data-testid",
+                `${testId}-description`,
+            );
+            expect(fieldEl).toHaveAttribute("data-testid", `${testId}-field`);
+            expect(errorEl).toHaveAttribute("data-testid", `${testId}-error`);
+        });
+
+        it("should not include testId on elements if testId prop is not provided", () => {
+            // Arrange
+            const label = "Label";
+            const description = "Description of the field";
+            const error = "Error message";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label={label}
+                    description={description}
+                    error={error}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const labelEl = screen.getByText(label);
+            const descriptionEl = screen.getByText(description);
+            const fieldEl = screen.getByRole("textbox");
+            const errorEl = screen.getByText(error);
+
+            // Assert
+            expect(labelEl).not.toHaveAttribute("data-testid");
+            expect(descriptionEl).not.toHaveAttribute("data-testid");
+            expect(fieldEl).not.toHaveAttribute("data-testid");
+            expect(errorEl).not.toHaveAttribute("data-testid");
+        });
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -441,41 +441,6 @@ describe("LabeledField", () => {
                 // Assert
                 expect(inputEl).toHaveAttribute("aria-describedby", errorEl.id);
             });
-
-            it("should mark the field with aria-required if the required prop is set to true", () => {
-                // Arrange
-                render(
-                    <LabeledField
-                        field={<TextField value="" onChange={() => {}} />}
-                        label="Label"
-                        required={true}
-                    />,
-                    defaultOptions,
-                );
-
-                // Act
-                const inputEl = screen.getByRole("textbox");
-
-                // Assert
-                expect(inputEl).toHaveAttribute("aria-required", "true");
-            });
-
-            it("should not mark the field with aria-required if the required prop is not set", () => {
-                // Arrange
-                render(
-                    <LabeledField
-                        field={<TextField value="" onChange={() => {}} />}
-                        label="Label"
-                    />,
-                    defaultOptions,
-                );
-
-                // Act
-                const inputEl = screen.getByRole("textbox");
-
-                // Assert
-                expect(inputEl).not.toHaveAttribute("aria-required");
-            });
         });
     });
 });

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -240,123 +240,144 @@ describe("LabeledField", () => {
     });
 
     describe("Attributes", () => {
-        it("should use the id prop for the base of element ids", () => {
-            // Arrange
-            const id = "example-id";
-            const label = "Label";
-            const description = "Description of the field";
-            const error = "Error message";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    id={id}
-                    label={label}
-                    description={description}
-                    error={error}
-                />,
-                defaultOptions,
+        const id = "example-id";
+        const label = "Label";
+        const description = "Description of the field";
+        const error = "Error message";
+        const testId = "test-id";
+
+        const getLabel = () => screen.getByText(label);
+        const getDescription = () => screen.getByText(description);
+        const getField = () => screen.getByRole("textbox");
+        const getError = () => screen.getByRole("alert");
+
+        describe("id", () => {
+            it.each([
+                ["label", `${id}-label`, getLabel],
+                ["description", `${id}-description`, getDescription],
+                ["field", `${id}-field`, getField],
+                ["error", `${id}-error`, getError],
+            ])(
+                "should have the id for the %s element set to %s",
+                (
+                    _elementType: string, // unused directly but is used for the test name using %s
+                    expectedId: string,
+                    getElement: () => HTMLElement,
+                ) => {
+                    // Arrange
+                    render(
+                        <LabeledField
+                            field={<TextField value="" onChange={() => {}} />}
+                            id={id}
+                            label={label}
+                            description={description}
+                            error={error}
+                        />,
+                        defaultOptions,
+                    );
+
+                    // Act
+                    const el = getElement();
+
+                    // Assert
+                    expect(el.id).toBe(expectedId);
+                },
             );
 
-            // Act
-            const labelEl = screen.getByText(label);
-            const descriptionEl = screen.getByText(description);
-            const fieldEl = screen.getByRole("textbox");
-            const errorEl = screen.getByText(error);
+            it.each([
+                ["label", "-label", getLabel],
+                ["description", "-description", getDescription],
+                ["field", "-field", getField],
+                ["error", "-error", getError],
+            ])(
+                "should have an auto-generated id for the %s element that ends with %s",
+                (
+                    _elementType: string, // unused directly but is used for the test name using %s
+                    expectedPostfix: string,
+                    getElement: () => HTMLElement,
+                ) => {
+                    // Arrange
+                    render(
+                        <LabeledField
+                            field={<TextField value="" onChange={() => {}} />}
+                            label={label}
+                            description={description}
+                            error={error}
+                        />,
+                        defaultOptions,
+                    );
 
-            // Assert
-            expect(labelEl.id).toBe(`${id}-label`);
-            expect(descriptionEl.id).toBe(`${id}-description`);
-            expect(fieldEl.id).toBe(`${id}-field`);
-            expect(errorEl.id).toBe(`${id}-error`);
+                    // Act
+                    const el = getElement();
+
+                    // Assert
+                    expect(el.id).toEndWith(expectedPostfix);
+                },
+            );
         });
 
-        it("should autogenerate ids for the elements if the id prop is not provided", () => {
-            // Arrange
-            const label = "Label";
-            const description = "Description of the field";
-            const error = "Error message";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    label={label}
-                    description={description}
-                    error={error}
-                />,
-                defaultOptions,
+        describe("testId", () => {
+            it.each([
+                ["label", `${testId}-label`, getLabel],
+                ["description", `${testId}-description`, getDescription],
+                ["field", `${testId}-field`, getField],
+                ["error", `${testId}-error`, getError],
+            ])(
+                "should use the testId prop to set the %s element's data-testid attribute to %s",
+                (
+                    _elementType: string, // unused directly but is used for the test name using %s
+                    expectedTestId: string,
+                    getElement: () => HTMLElement,
+                ) => {
+                    // Arrange
+                    render(
+                        <LabeledField
+                            field={<TextField value="" onChange={() => {}} />}
+                            testId={testId}
+                            label={label}
+                            description={description}
+                            error={error}
+                        />,
+                        defaultOptions,
+                    );
+
+                    // Act
+                    const el = getElement();
+
+                    // Assert
+                    expect(el).toHaveAttribute("data-testid", expectedTestId);
+                },
             );
 
-            // Act
-            const labelEl = screen.getByText(label);
-            const descriptionEl = screen.getByText(description);
-            const fieldEl = screen.getByRole("textbox");
-            const errorEl = screen.getByText(error);
+            it.each([
+                ["label", getLabel],
+                ["description", getDescription],
+                ["field", getField],
+                ["error", getError],
+            ])(
+                "should not set the data-testid attribute on the %s element if the testId prop is not set",
+                (
+                    _elementType: string, // unused directly but is used for the test name using %s
+                    getElement: () => HTMLElement,
+                ) => {
+                    // Arrange
+                    render(
+                        <LabeledField
+                            field={<TextField value="" onChange={() => {}} />}
+                            label={label}
+                            description={description}
+                            error={error}
+                        />,
+                        defaultOptions,
+                    );
 
-            // Assert
-            expect(labelEl.id).toInclude("-label");
-            expect(descriptionEl.id).toInclude("-description");
-            expect(fieldEl.id).toInclude("-field");
-            expect(errorEl.id).toInclude("-error");
-        });
+                    // Act
+                    const el = getElement();
 
-        it("should use the testId prop for the base of test ids", () => {
-            // Arrange
-            const testId = "test-id";
-            const label = "Label";
-            const description = "Description of the field";
-            const error = "Error message";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    testId={testId}
-                    label={label}
-                    description={description}
-                    error={error}
-                />,
-                defaultOptions,
+                    // Assert
+                    expect(el).not.toHaveAttribute("data-testid");
+                },
             );
-
-            // Act
-            const labelEl = screen.getByText(label);
-            const descriptionEl = screen.getByText(description);
-            const fieldEl = screen.getByRole("textbox");
-            const errorEl = screen.getByText(error);
-
-            // Assert
-            expect(labelEl).toHaveAttribute("data-testid", `${testId}-label`);
-            expect(descriptionEl).toHaveAttribute(
-                "data-testid",
-                `${testId}-description`,
-            );
-            expect(fieldEl).toHaveAttribute("data-testid", `${testId}-field`);
-            expect(errorEl).toHaveAttribute("data-testid", `${testId}-error`);
-        });
-
-        it("should not include testId on elements if testId prop is not provided", () => {
-            // Arrange
-            const label = "Label";
-            const description = "Description of the field";
-            const error = "Error message";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    label={label}
-                    description={description}
-                    error={error}
-                />,
-                defaultOptions,
-            );
-
-            // Act
-            const labelEl = screen.getByText(label);
-            const descriptionEl = screen.getByText(description);
-            const fieldEl = screen.getByRole("textbox");
-            const errorEl = screen.getByText(error);
-
-            // Assert
-            expect(labelEl).not.toHaveAttribute("data-testid");
-            expect(descriptionEl).not.toHaveAttribute("data-testid");
-            expect(fieldEl).not.toHaveAttribute("data-testid");
-            expect(errorEl).not.toHaveAttribute("data-testid");
         });
 
         it("should persist original attributes on the field if it is not overridden", () => {

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -238,4 +238,91 @@ describe("LabeledField", () => {
         // LabelSmall has a font-size of 16px
         expect(description).toHaveStyle("font-size: 14px");
     });
+
+    describe("Attributes", () => {
+        it("should autogenerate ids for the elements if the id prop is not provided", () => {});
+        it("should use the id prop for element ids", () => {});
+    });
+
+    describe("Accessibility", () => {
+        describe("Axe", () => {
+            it("should have no accessibility violations", async () => {
+                // Arrange
+                const {container} = render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                    />,
+                    defaultOptions,
+                );
+                // Act
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+        });
+        describe("ARIA", () => {
+            it("should render a label tag with the for attribute set to the id of the field", () => {
+                // Arrange
+                const label = "Label";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label={label}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const labelEl = screen.getByText(label);
+                const inputEl = screen.getByRole("textbox");
+
+                // Assert
+                expect(labelEl).toHaveAttribute("for", inputEl.id);
+            });
+
+            it("should set aria-describedby on the field to the id of the description", () => {
+                // Arrange
+                const description = "Description of the field";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        description={description}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const descriptionEl = screen.getByText(description);
+                const inputEl = screen.getByRole("textbox");
+
+                // Assert
+                expect(inputEl).toHaveAttribute(
+                    "aria-describedby",
+                    descriptionEl.id,
+                );
+            });
+
+            it("should set the aria-describedby on the field to the id of the error", () => {
+                // Arrange
+                const error = "Error message";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        error={error}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const errorEl = screen.getByText(error);
+                const inputEl = screen.getByRole("textbox");
+
+                // Assert
+                expect(inputEl).toHaveAttribute("aria-describedby", errorEl.id);
+            });
+        });
+    });
 });

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -358,6 +358,29 @@ describe("LabeledField", () => {
             expect(fieldEl).not.toHaveAttribute("data-testid");
             expect(errorEl).not.toHaveAttribute("data-testid");
         });
+
+        it("should persist original attributes on the field if it is not overridden", () => {
+            // Arrange
+            render(
+                <LabeledField
+                    field={
+                        <TextField
+                            value=""
+                            onChange={() => {}}
+                            name="name-example"
+                        />
+                    }
+                    label="Label"
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const fieldEl = screen.getByRole("textbox");
+
+            // Assert
+            expect(fieldEl).toHaveAttribute("name", "name-example");
+        });
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -6,7 +6,12 @@ import {I18nInlineMarkup} from "@khanacademy/wonder-blocks-i18n";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import LabeledField from "../labeled-field";
+
+const defaultOptions = {
+    wrapper: RenderStateRoot,
+};
 
 describe("LabeledField", () => {
     it("LabeledField renders the label text", () => {
@@ -19,6 +24,7 @@ describe("LabeledField", () => {
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
                 label={label}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -36,6 +42,7 @@ describe("LabeledField", () => {
                 label="Label"
                 description={description}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -53,6 +60,7 @@ describe("LabeledField", () => {
                 label="Label"
                 error={error}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -70,6 +78,7 @@ describe("LabeledField", () => {
                 label="Label"
                 testId={testId}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -89,6 +98,7 @@ describe("LabeledField", () => {
                 description="Description"
                 testId={testId}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -108,6 +118,7 @@ describe("LabeledField", () => {
                 error="Error"
                 testId={testId}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -128,6 +139,7 @@ describe("LabeledField", () => {
                 id={id}
                 testId={testId}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -149,6 +161,7 @@ describe("LabeledField", () => {
                 id={id}
                 testId={testId}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -173,6 +186,7 @@ describe("LabeledField", () => {
                 error="Error"
                 style={styles.style1}
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -193,6 +207,7 @@ describe("LabeledField", () => {
                     </I18nInlineMarkup>
                 }
             />,
+            defaultOptions,
         );
 
         // Assert
@@ -215,6 +230,7 @@ describe("LabeledField", () => {
                     </I18nInlineMarkup>
                 }
             />,
+            defaultOptions,
         );
 
         // Assert

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -323,6 +323,41 @@ describe("LabeledField", () => {
                 // Assert
                 expect(inputEl).toHaveAttribute("aria-describedby", errorEl.id);
             });
+
+            it("should mark the field with aria-required if the required prop is set to true", () => {
+                // Arrange
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        required={true}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const inputEl = screen.getByRole("textbox");
+
+                // Assert
+                expect(inputEl).toHaveAttribute("aria-required", "true");
+            });
+
+            it("should not mark the field with aria-required if the required prop is not set", () => {
+                // Arrange
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const inputEl = screen.getByRole("textbox");
+
+                // Assert
+                expect(inputEl).not.toHaveAttribute("aria-required");
+            });
         });
     });
 });

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -479,7 +479,7 @@ describe("LabeledField", () => {
                 );
 
                 // Act
-                const errorEl = screen.getByText(error);
+                const errorEl = screen.getByRole("alert");
                 const inputEl = screen.getByRole("textbox");
 
                 // Assert

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -71,8 +71,10 @@ export default function LabeledField(props: Props) {
         description,
         error,
     } = props;
+
     const ids = useUniqueIdWithMock("labeled-field");
     const uniqueId = id ?? ids.get("id");
+    const labelId = `${uniqueId}-label`;
     const descriptionId = `${uniqueId}-description`;
     const fieldId = `${uniqueId}-field`;
     const errorId = `${uniqueId}-error`;
@@ -95,6 +97,7 @@ export default function LabeledField(props: Props) {
                     tag="label"
                     htmlFor={fieldId}
                     testId={testId && `${testId}-label`}
+                    id={labelId}
                 >
                     {label}
                     {required && requiredIcon}
@@ -149,6 +152,7 @@ export default function LabeledField(props: Props) {
             .filter(Boolean)
             .join(" "),
         "aria-required": required,
+        testId: testId && `${testId}-field`,
     });
 
     return (

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {View, addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
+import {
+    View,
+    addStyle,
+    StyleType,
+    useUniqueIdWithMock,
+} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
@@ -66,6 +71,8 @@ export default function LabeledField(props: Props) {
         description,
         error,
     } = props;
+    const ids = useUniqueIdWithMock("labeled-field");
+    const uniqueId = id ?? ids.get("id");
 
     function renderLabel(): React.ReactNode {
         const requiredIcon = (
@@ -83,7 +90,7 @@ export default function LabeledField(props: Props) {
                 <LabelMedium
                     style={light ? styles.lightLabel : styles.label}
                     tag="label"
-                    htmlFor={id && `${id}-field`}
+                    htmlFor={`${uniqueId}-field`}
                     testId={testId && `${testId}-label`}
                 >
                     {label}
@@ -123,7 +130,7 @@ export default function LabeledField(props: Props) {
                 <LabelSmall
                     style={light ? styles.lightError : styles.error}
                     role="alert"
-                    id={id && `${id}-error`}
+                    id={`${uniqueId}-error`}
                     testId={testId && `${testId}-error`}
                 >
                     {error}

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -146,21 +146,23 @@ export default function LabeledField(props: Props) {
         );
     }
 
-    const fieldWithAttributes = React.cloneElement(field, {
-        id: fieldId,
-        "aria-describedby": [description && descriptionId, error && errorId]
-            .filter(Boolean)
-            .join(" "),
-        "aria-required": required,
-        testId: testId && `${testId}-field`,
-    });
+    function renderField() {
+        return React.cloneElement(field, {
+            id: fieldId,
+            "aria-describedby": [description && descriptionId, error && errorId]
+                .filter(Boolean)
+                .join(" "),
+            "aria-required": required,
+            testId: testId && `${testId}-field`,
+        });
+    }
 
     return (
         <View style={style}>
             {renderLabel()}
             {maybeRenderDescription()}
             <Strut size={spacing.xSmall_8} />
-            {fieldWithAttributes}
+            {renderField()}
             {maybeRenderError()}
         </View>
     );

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -148,6 +148,7 @@ export default function LabeledField(props: Props) {
         "aria-describedby": [description && descriptionId, error && errorId]
             .filter(Boolean)
             .join(" "),
+        "aria-required": required,
     });
 
     return (

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -15,7 +15,7 @@ type Props = {
     /**
      * The form field component.
      */
-    field: React.ReactNode;
+    field: React.ReactElement;
     /**
      * The title for the label element.
      */

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -73,6 +73,9 @@ export default function LabeledField(props: Props) {
     } = props;
     const ids = useUniqueIdWithMock("labeled-field");
     const uniqueId = id ?? ids.get("id");
+    const descriptionId = `${uniqueId}-description`;
+    const fieldId = `${uniqueId}-field`;
+    const errorId = `${uniqueId}-error`;
 
     function renderLabel(): React.ReactNode {
         const requiredIcon = (
@@ -90,7 +93,7 @@ export default function LabeledField(props: Props) {
                 <LabelMedium
                     style={light ? styles.lightLabel : styles.label}
                     tag="label"
-                    htmlFor={`${uniqueId}-field`}
+                    htmlFor={fieldId}
                     testId={testId && `${testId}-label`}
                 >
                     {label}
@@ -111,6 +114,7 @@ export default function LabeledField(props: Props) {
                 <LabelSmall
                     style={light ? styles.lightDescription : styles.description}
                     testId={testId && `${testId}-description`}
+                    id={descriptionId}
                 >
                     {description}
                 </LabelSmall>
@@ -130,7 +134,7 @@ export default function LabeledField(props: Props) {
                 <LabelSmall
                     style={light ? styles.lightError : styles.error}
                     role="alert"
-                    id={`${uniqueId}-error`}
+                    id={errorId}
                     testId={testId && `${testId}-error`}
                 >
                     {error}
@@ -139,12 +143,19 @@ export default function LabeledField(props: Props) {
         );
     }
 
+    const fieldWithAttributes = React.cloneElement(field, {
+        id: fieldId,
+        "aria-describedby": [description && descriptionId, error && errorId]
+            .filter(Boolean)
+            .join(" "),
+    });
+
     return (
         <View style={style}>
             {renderLabel()}
             {maybeRenderDescription()}
             <Strut size={spacing.xSmall_8} />
-            {field}
+            {fieldWithAttributes}
             {maybeRenderError()}
         </View>
     );

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -166,7 +166,7 @@ export default function LabeledField(props: Props) {
             "aria-describedby": [description && descriptionId, error && errorId]
                 .filter(Boolean)
                 .join(" "),
-            "aria-required": required,
+            required,
             testId: testId && `${testId}-field`,
         });
     }

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -37,14 +37,28 @@ type Props = {
      */
     style?: StyleType;
     /**
-     * A unique id to link the label (and optional error) to the field.
+     * A unique id to use as the base of the ids for the elements within the component.
+     * Here is how the id is used for the different elements in the component:
+     * - The label will have an id formatted as `${id}-label`
+     * - The description will have an id formatted as `${id}-description`
+     * - The field will have an id formatted as `${id}-field`
+     * - The error will have an id formatted as `${id}-error`
      *
-     * The label will assume that the field will have its id formatted as `${id}-field`.
-     * The field can assume that the error will have its id formatted as `${id}-error`.
+     * If the `id` prop is not provided, a base unique id will be auto-generated.
+     * This is important so that the different elements can be wired up together
+     * for accessibility!
+     *
+     * Note: When using the `LabeledField` component, an `id` provided to the
+     * field component (ex: a TextField component) will be overridden.
      */
     id?: string;
     /**
-     * Optional test ID for e2e testing.
+     * Optional test id for e2e testing. Here is how the test id is used for the
+     * different elements in the component:
+     * - The label will have a testId formatted as `${testId}-label`
+     * - The description will have a testId formatted as `${testId}-description`
+     * - The field will have a testId formatted as `${testId}-field`
+     * - The error will have a testId formatted as `${testId}-error`
      */
     testId?: string;
     /**


### PR DESCRIPTION
## Summary:
- Use an auto-generated unique id if the `id` prop is not provided
- Wire up elements within the component
  - the `label` element's `for` attribute is the field `id`
  -  `aria-describedby` on the field has the ids of the description and/or error message elements
- Apply attributes to the field element:
  - `id`
  - `aria-describedby`
  - `required` if the `required` prop is set to `true`
  - `testId`

Issue: WB-1503

## Test plan:
- Tests are passing
- Updated documentation makes sense:
  - `?path=/docs/packages-labeledfield-labeledfield--docs`
  - `?path=/docs/packages-labeledfield-labeledfield-accessibility--docs`
- There are no a11y warnings in the Storybook Accessibility add on for the LabeledField stories
  - Note: There are warnings for the LabeledField stories with the different field examples. They are related to an issue with the SearchField component and will be addressed in WB-1771!
