### PR TITLE
Improve responsiveness of BirthdayPicker

### DIFF
--- a/.changeset/fluffy-forks-check.md
+++ b/.changeset/fluffy-forks-check.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": patch
+---
+
+Add responsive default to BirthdayPicker

--- a/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
+++ b/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
@@ -32,6 +32,9 @@ const meta: Meta<typeof BirthdayPicker> = {
                 excludeDecorators: true,
             },
         },
+        viewport: {
+            defaultViewport: "large",
+        },
     },
     decorators: [(Story): React.ReactElement => <View>{Story()}</View>],
 };
@@ -169,6 +172,25 @@ export const BirthdayPickerVerticalWithError: StoryComponentType = {
             description: {
                 story: "A vertical BirthdayPicker may have an error. It should show beneath all the dropdowns.",
             },
+        },
+    },
+};
+
+export const BirthdayPickerMobile: StoryComponentType = {
+    args: {
+        onChange: (date?: string | null) => {
+            // eslint-disable-next-line no-console
+            console.log("Date selected: ", date);
+        },
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "A BirthdayPicker will reflow on small screens to stack controls rather than position them side-by-side.",
+            },
+        },
+        viewport: {
+            defaultViewport: "small",
         },
     },
 };

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -306,7 +306,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 placeholder={this.labels.month}
                 onChange={this.handleMonthChange}
                 selectedValue={month}
-                style={{minWidth, ...defaultStyles.input, ...dropdownStyle}}
+                style={[{minWidth}, defaultStyles.input, dropdownStyle]}
                 testId="birthday-picker-month"
             >
                 {/* eslint-disable-next-line import/no-named-as-default-member */}
@@ -336,11 +336,13 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                     placeholder={this.labels.day}
                     onChange={this.handleDayChange}
                     selectedValue={day}
-                    style={{
-                        minWidth: FIELD_MIN_WIDTH_DAY,
-                        ...defaultStyles.input,
-                        ...dropdownStyle,
-                    }}
+                    style={[
+                        {
+                            minWidth: FIELD_MIN_WIDTH_DAY,
+                        },
+                        defaultStyles.input,
+                        dropdownStyle,
+                    ]}
                     testId="birthday-picker-day"
                 >
                     {Array.from(Array(31)).map((_, day) => (
@@ -375,7 +377,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 placeholder={this.labels.year}
                 onChange={this.handleYearChange}
                 selectedValue={year}
-                style={{minWidth, ...defaultStyles.input, ...dropdownStyle}}
+                style={[{minWidth}, defaultStyles.input, dropdownStyle]}
                 // Allows displaying the dropdown options without truncating
                 // them when the user zooms in the browser.
                 dropdownStyle={{minWidth: 150}}

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -164,8 +164,6 @@ export default class BirthdayPicker extends React.Component<Props, State> {
     // @ts-expect-error [FEI-5019] - TS2564 - Property 'labels' has no initializer and is not definitely assigned in the constructor.
     labels: Labels;
 
-    mobileMediaQuery: MediaQueryList | undefined;
-
     constructor(props: Props) {
         super(props);
 

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -1,5 +1,6 @@
 import moment from "moment"; // NOTE: DO NOT use named imports; 'moment' does not support named imports
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
 import {StyleType, View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -129,6 +130,25 @@ const FIELD_MIN_WIDTH_MONTH_YEAR = 167;
  * />
  * ```
  */
+
+const screenSize = {
+    small: "@media (max-width: 682px)",
+};
+
+const defaultStyles = StyleSheet.create({
+    wrapper: {
+        flexDirection: "row",
+        [screenSize.small]: {
+            flexDirection: "column",
+        },
+    },
+    input: {
+        [screenSize.small]: {
+            minWidth: "100%",
+        },
+    },
+});
+
 export default class BirthdayPicker extends React.Component<Props, State> {
     /**
      * Strings used for placeholders and error message. These are used this way
@@ -285,7 +305,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 placeholder={this.labels.month}
                 onChange={this.handleMonthChange}
                 selectedValue={month}
-                style={{minWidth, ...dropdownStyle}}
+                style={{minWidth, ...defaultStyles.input, ...dropdownStyle}}
                 testId="birthday-picker-month"
             >
                 {/* eslint-disable-next-line import/no-named-as-default-member */}
@@ -315,7 +335,11 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                     placeholder={this.labels.day}
                     onChange={this.handleDayChange}
                     selectedValue={day}
-                    style={{minWidth: 100, ...dropdownStyle}}
+                    style={{
+                        minWidth: 100,
+                        ...defaultStyles.input,
+                        ...dropdownStyle,
+                    }}
                     testId="birthday-picker-day"
                 >
                     {Array.from(Array(31)).map((_, day) => (
@@ -345,7 +369,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 placeholder={this.labels.year}
                 onChange={this.handleYearChange}
                 selectedValue={year}
-                style={{minWidth, ...dropdownStyle}}
+                style={{minWidth, ...defaultStyles.input, ...dropdownStyle}}
                 // Allows displaying the dropdown options without truncating
                 // them when the user zooms in the browser.
                 dropdownStyle={{minWidth: 150}}
@@ -363,13 +387,20 @@ export default class BirthdayPicker extends React.Component<Props, State> {
     }
 
     render(): React.ReactNode {
-        const {style} = this.props;
+        const {style, monthYearOnly} = this.props;
+
+        const minWidth = monthYearOnly
+            ? FIELD_MIN_WIDTH_MONTH_YEAR
+            : FIELD_MIN_WIDTH_FULL;
 
         return (
             <>
                 <View
                     testId="birthday-picker"
-                    style={{flexDirection: "row", ...style}}
+                    style={{
+                        ...defaultStyles.wrapper,
+                        ...style,
+                    }}
                 >
                     {this.renderMonth()}
 

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -1,6 +1,6 @@
 import moment from "moment"; // NOTE: DO NOT use named imports; 'moment' does not support named imports
 import * as React from "react";
-import {CSSProperties, StyleSheet} from "aphrodite";
+import {StyleSheet} from "aphrodite";
 import {StyleType, View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -133,6 +133,26 @@ const FIELD_MIN_WIDTH_DAY = 100;
  * ```
  */
 
+/* [WB-1655] Update with media query tokens */
+const xsMin = "520px";
+
+const screenSizes = {
+    small: `@media (max-width: ${xsMin})`,
+};
+
+const defaultStyles = StyleSheet.create({
+    wrapper: {
+        flexDirection: "row",
+        [screenSizes.small]: {
+            flexDirection: "column",
+        },
+    },
+    input: {
+        [screenSizes.small]: {
+            minWidth: "100%",
+        },
+    },
+});
 export default class BirthdayPicker extends React.Component<Props, State> {
     /**
      * Strings used for placeholders and error message. These are used this way
@@ -145,8 +165,6 @@ export default class BirthdayPicker extends React.Component<Props, State> {
     labels: Labels;
 
     mobileMediaQuery: MediaQueryList | undefined;
-
-    wrapperFlexDirection: CSSProperties["flexDirection"] | undefined;
 
     constructor(props: Props) {
         super(props);
@@ -278,18 +296,6 @@ export default class BirthdayPicker extends React.Component<Props, State> {
         );
     }
 
-    getMonthYearWidth(
-        monthYearOnly: boolean | undefined,
-    ): CSSProperties["minWidth"] {
-        if (this.mobileMediaQuery?.matches) {
-            return "100%";
-        } else {
-            return monthYearOnly
-                ? FIELD_MIN_WIDTH_MONTH_YEAR
-                : FIELD_MIN_WIDTH_FULL;
-        }
-    }
-
     renderMonth(): React.ReactNode {
         const {disabled, monthYearOnly, dropdownStyle} = this.props;
         const {month} = this.state;
@@ -302,7 +308,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 placeholder={this.labels.month}
                 onChange={this.handleMonthChange}
                 selectedValue={month}
-                style={{minWidth, ...dropdownStyle}}
+                style={{minWidth, ...defaultStyles.input, ...dropdownStyle}}
                 testId="birthday-picker-month"
             >
                 {/* eslint-disable-next-line import/no-named-as-default-member */}
@@ -322,10 +328,6 @@ export default class BirthdayPicker extends React.Component<Props, State> {
             return null;
         }
 
-        const minWidth = this.mobileMediaQuery?.matches
-            ? "100%"
-            : FIELD_MIN_WIDTH_DAY;
-
         return (
             <>
                 <Strut size={spacing.xSmall_8} />
@@ -337,7 +339,8 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                     onChange={this.handleDayChange}
                     selectedValue={day}
                     style={{
-                        minWidth,
+                        minWidth: FIELD_MIN_WIDTH_DAY,
+                        ...defaultStyles.input,
                         ...dropdownStyle,
                     }}
                     testId="birthday-picker-day"
@@ -354,6 +357,12 @@ export default class BirthdayPicker extends React.Component<Props, State> {
         );
     }
 
+    getMonthYearWidth(monthYearOnly: boolean | undefined): number {
+        return monthYearOnly
+            ? FIELD_MIN_WIDTH_MONTH_YEAR
+            : FIELD_MIN_WIDTH_FULL;
+    }
+
     renderYear(): React.ReactNode {
         const {disabled, monthYearOnly, dropdownStyle} = this.props;
         const {year} = this.state;
@@ -368,7 +377,10 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 placeholder={this.labels.year}
                 onChange={this.handleYearChange}
                 selectedValue={year}
-                style={{minWidth, ...dropdownStyle}}
+                style={{minWidth, ...defaultStyles.input, ...dropdownStyle}}
+                // Allows displaying the dropdown options without truncating
+                // them when the user zooms in the browser.
+                dropdownStyle={{minWidth: 150}}
                 testId="birthday-picker-year"
             >
                 {Array.from(Array(120)).map((_, yearOffset) => (
@@ -383,46 +395,13 @@ export default class BirthdayPicker extends React.Component<Props, State> {
     }
 
     render(): React.ReactNode {
-        const {style, monthYearOnly} = this.props;
-
-        const minWidth = monthYearOnly
-            ? FIELD_MIN_WIDTH_MONTH_YEAR
-            : FIELD_MIN_WIDTH_FULL;
-
-        const mobileMinWidth =
-            minWidth * 2 + FIELD_MIN_WIDTH_DAY + spacing.xSmall_8;
-
-        this.mobileMediaQuery = window.matchMedia(
-            `(max-width: ${mobileMinWidth}px)`,
-        );
-
-        // component isn't reflowing on resize
-        const handleOrientationChange = (
-            mql: MediaQueryListEvent | MediaQueryList,
-        ): void => {
-            if (mql.matches) {
-                this.wrapperFlexDirection = "column";
-            } else {
-                this.wrapperFlexDirection = "row";
-            }
-            console.log(mql.matches, this.wrapperFlexDirection);
-        };
-
-        handleOrientationChange(this.mobileMediaQuery);
-
-        this.mobileMediaQuery.addEventListener(
-            "change",
-            handleOrientationChange,
-        );
+        const {style} = this.props;
 
         return (
             <>
                 <View
                     testId="birthday-picker"
-                    style={{
-                        flexDirection: this.wrapperFlexDirection,
-                        ...style,
-                    }}
+                    style={[defaultStyles.wrapper, style]}
                 >
                     {this.renderMonth()}
 


### PR DESCRIPTION
The BirthdayPicker gets cut off at small viewport widths: https://khanacademy.atlassian.net/browse/WB-1739

In this PR, I opted for a hard-coded breakpoint in CSS to change the flexDirection.
  - This will be updated with https://khanacademy.atlassian.net/browse/WB-1655 for media query tokens in a separate PR!

I also preserved the somewhat recent change of allowing style and dropdownStyle props in https://github.com/Khan/wonder-blocks/pull/2288.