### PR TITLE
LabeledField(part4): styling and error icon

### DIFF
--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -13,6 +13,11 @@ import {
     SingleSelect,
 } from "@khanacademy/wonder-blocks-dropdown";
 import SearchField from "@khanacademy/wonder-blocks-search-field";
+import {
+    HeadingLarge,
+    HeadingMedium,
+    HeadingSmall,
+} from "@khanacademy/wonder-blocks-typography";
 
 /**
  * The `LabeledField` component provides common elements for a form field such
@@ -178,8 +183,11 @@ export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
     const [textFieldValue, setTextFieldValue] = React.useState("");
     const longText =
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
+    const longTextWithNoBreak =
+        "LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequatDuisauteiruredolorinreprehenderitinvoluptatevelitessecillumdoloreeufugiatnullapariatur";
     return (
         <View style={{gap: spacing.large_24}}>
+            <HeadingLarge>Scenarios</HeadingLarge>
             <LabeledField
                 {...args}
                 label="Label only"
@@ -226,12 +234,29 @@ export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
                     />
                 }
             />
+            <HeadingMedium>Text Scenarios</HeadingMedium>
+            <HeadingSmall>With Long Text</HeadingSmall>
             <LabeledField
                 required={true}
                 {...args}
                 label={longText}
                 error={longText}
                 description={longText}
+                field={
+                    <TextField
+                        value="invalid value"
+                        onChange={() => {}}
+                        validate={() => "Error message"}
+                    />
+                }
+            />
+            <HeadingSmall>With Long Text and No Word Break</HeadingSmall>
+            <LabeledField
+                required={true}
+                {...args}
+                label={longTextWithNoBreak}
+                error={longTextWithNoBreak}
+                description={longTextWithNoBreak}
                 field={
                     <TextField
                         value="invalid value"

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -176,7 +176,8 @@ export const Light: StoryComponentType = {
  */
 export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
     const [textFieldValue, setTextFieldValue] = React.useState("");
-
+    const longText =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
     return (
         <View style={{gap: spacing.large_24}}>
             <LabeledField
@@ -217,6 +218,20 @@ export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
                 label="With description and error"
                 error="Error message"
                 description="Description"
+                field={
+                    <TextField
+                        value="invalid value"
+                        onChange={() => {}}
+                        validate={() => "Error message"}
+                    />
+                }
+            />
+            <LabeledField
+                required={true}
+                {...args}
+                label={longText}
+                error={longText}
+                description={longText}
                 field={
                     <TextField
                         value="invalid value"

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -168,7 +168,10 @@ export default function LabeledField(props: Props) {
                 <View style={styles.errorSection}>
                     <PhosphorIcon
                         icon={WarningCircle}
-                        style={light ? styles.lightError : styles.error}
+                        style={[
+                            styles.errorIcon,
+                            light ? styles.lightError : styles.error,
+                        ]}
                         role="img"
                         aria-label={labels.errorIconAriaLabel}
                     />
@@ -229,6 +232,9 @@ const styles = StyleSheet.create({
     },
     lightError: {
         color: color.fadedRed,
+    },
+    errorIcon: {
+        marginTop: "1px", // This vertically aligns the icon with the text
     },
     required: {
         color: color.red,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
+import WarningCircle from "@phosphor-icons/core/bold/warning-circle-bold.svg";
 
 import {
     View,
@@ -10,6 +11,7 @@ import {
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 type Props = {
     /**
@@ -148,14 +150,22 @@ export default function LabeledField(props: Props) {
         return (
             <React.Fragment>
                 <Strut size={spacing.small_12} />
-                <LabelSmall
-                    style={light ? styles.lightError : styles.error}
-                    role="alert"
-                    id={errorId}
-                    testId={testId && `${testId}-error`}
-                >
-                    {error}
-                </LabelSmall>
+                <View style={styles.errorSection}>
+                    <PhosphorIcon
+                        icon={WarningCircle}
+                        style={light ? styles.lightError : styles.error}
+                        role="img"
+                        aria-label="Error"
+                    />
+                    <LabelSmall
+                        style={light ? styles.lightError : styles.error}
+                        role="alert"
+                        id={errorId}
+                        testId={testId && `${testId}-error`}
+                    >
+                        {error}
+                    </LabelSmall>
+                </View>
             </React.Fragment>
         );
     }
@@ -194,6 +204,10 @@ const styles = StyleSheet.create({
     },
     lightDescription: {
         color: color.white64,
+    },
+    errorSection: {
+        flexDirection: "row",
+        gap: spacing.xSmall_8,
     },
     error: {
         color: color.red,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -67,6 +67,20 @@ type Props = {
      * Change the field’s sub-components to fit a dark background.
      */
     light?: boolean;
+    /**
+     * The object containing the custom labels used inside this component.
+     *
+     * This is useful for internationalization. Defaults to English.
+     */
+    labels?: LabeledFieldLabels;
+};
+
+type LabeledFieldLabels = {
+    errorIconAriaLabel: string;
+};
+
+const defaultLabeledFieldLabels: LabeledFieldLabels = {
+    errorIconAriaLabel: "Error",
 };
 
 const StyledSpan = addStyle("span");
@@ -86,6 +100,7 @@ export default function LabeledField(props: Props) {
         light,
         description,
         error,
+        labels = defaultLabeledFieldLabels,
     } = props;
 
     const ids = useUniqueIdWithMock("labeled-field");
@@ -155,7 +170,7 @@ export default function LabeledField(props: Props) {
                         icon={WarningCircle}
                         style={light ? styles.lightError : styles.error}
                         role="img"
-                        aria-label="Error"
+                        aria-label={labels.errorIconAriaLabel}
                     />
                     <LabelSmall
                         style={light ? styles.lightError : styles.error}

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -113,7 +113,10 @@ export default function LabeledField(props: Props) {
     function renderLabel(): React.ReactNode {
         const requiredIcon = (
             <StyledSpan
-                style={light ? styles.lightRequired : styles.required}
+                style={[
+                    styles.textWordBreak,
+                    light ? styles.lightRequired : styles.required,
+                ]}
                 aria-hidden={true}
             >
                 {" "}
@@ -124,7 +127,10 @@ export default function LabeledField(props: Props) {
         return (
             <React.Fragment>
                 <LabelMedium
-                    style={light ? styles.lightLabel : styles.label}
+                    style={[
+                        styles.textWordBreak,
+                        light ? styles.lightLabel : styles.label,
+                    ]}
                     tag="label"
                     htmlFor={fieldId}
                     testId={testId && `${testId}-label`}
@@ -146,7 +152,10 @@ export default function LabeledField(props: Props) {
         return (
             <React.Fragment>
                 <LabelSmall
-                    style={light ? styles.lightDescription : styles.description}
+                    style={[
+                        styles.textWordBreak,
+                        light ? styles.lightDescription : styles.description,
+                    ]}
                     testId={testId && `${testId}-description`}
                     id={descriptionId}
                 >
@@ -176,7 +185,11 @@ export default function LabeledField(props: Props) {
                         aria-label={labels.errorIconAriaLabel}
                     />
                     <LabelSmall
-                        style={light ? styles.lightError : styles.error}
+                        style={[
+                            styles.textWordBreak,
+                            styles.errorMessage,
+                            light ? styles.lightError : styles.error,
+                        ]}
                         role="alert"
                         id={errorId}
                         testId={testId && `${testId}-error`}
@@ -236,10 +249,16 @@ const styles = StyleSheet.create({
     errorIcon: {
         marginTop: "1px", // This vertically aligns the icon with the text
     },
+    errorMessage: {
+        minWidth: "0",
+    },
     required: {
         color: semanticColor.status.critical.foreground,
     },
     lightRequired: {
         color: color.fadedRed,
+    },
+    textWordBreak: {
+        overflowWrap: "break-word",
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -9,7 +9,7 @@ import {
     useUniqueIdWithMock,
 } from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
@@ -212,13 +212,13 @@ export default function LabeledField(props: Props) {
 
 const styles = StyleSheet.create({
     label: {
-        color: color.offBlack,
+        color: semanticColor.text.primary,
     },
     lightLabel: {
-        color: color.white,
+        color: semanticColor.text.inverse,
     },
     description: {
-        color: color.offBlack64,
+        color: semanticColor.text.secondary,
     },
     lightDescription: {
         color: color.white64,
@@ -228,7 +228,7 @@ const styles = StyleSheet.create({
         gap: spacing.xSmall_8,
     },
     error: {
-        color: color.red,
+        color: semanticColor.status.critical.foreground,
     },
     lightError: {
         color: color.fadedRed,
@@ -237,7 +237,7 @@ const styles = StyleSheet.create({
         marginTop: "1px", // This vertically aligns the icon with the text
     },
     required: {
-        color: color.red,
+        color: semanticColor.status.critical.foreground,
     },
     lightRequired: {
         color: color.fadedRed,


### PR DESCRIPTION
## Summary:
use semantic colors where possible. light styles don't have corresponding semantic tokens
Handle long text with no word break
visually align icon with text
Add long text scenario story
Add  prop for error icon aria-label
Add error icon to error message

Issue: WB-1503

## Test plan: