### PR TITLE
Include lint and test jobs for node-ci-push workflow

### DIFF
--- a/.github/workflows/node-ci-push.yml
+++ b/.github/workflows/node-ci-push.yml
@@ -68,3 +68,100 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage/coverage-final.json
+
+  lint:
+    name: Lint
+    needs: prime_cache_primary
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install & cache node_modules
+        uses: Khan/actions@shared-node-cache-v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Get All Changed Files
+        uses: Khan/actions@get-changed-files-v2
+        id: changed
+
+      - id: js-ts-files
+        name: Find .js, .ts changed files
+        uses: Khan/actions@filter-files-v1
+        with:
+          changed-files: ${{ steps.changed.outputs.files }}
+          extensions: '.js,.jsx,.ts,.tsx'
+
+      - id: eslint-reset
+        uses: Khan/actions@filter-files-v1
+        name: Files that would trigger a full eslint run
+        with:
+          changed-files: ${{ steps.changed.outputs.files }}
+          files: '.eslintrc.js,yarn.lock,.eslintignore'
+
+      - id: typecheck-reset
+        uses: Khan/actions@filter-files-v1
+        name: Files that would trigger a typecheck run
+        with:
+          changed-files: ${{ steps.changed.outputs.files }}
+          files: '.yarn.lock'
+
+      # Linting / type checking
+      - name: Eslint
+        uses: Khan/actions@full-or-limited-v0
+        with:
+          full-trigger: ${{ steps.eslint-reset.outputs.filtered }}
+          full: yarn lint:ci .
+          limited-trigger: ${{ steps.js-ts-files.outputs.filtered }}
+          limited: yarn lint:ci {}
+
+      - name: Typecheck
+        if: always() # always run this check until we update the eslint config
+        # if: steps.js-ts-files.outputs.filtered != '[]' || steps.typecheck-reset.outputs.filtered != '[]'
+        run: yarn typecheck
+
+      - name: Build .js bundles
+        run: yarn build
+
+      - name: Build .d.ts types
+        run: yarn build:types
+
+      - name: Check package.json files
+        run: node utils/publish/pre-publish-check-ci.js
+
+  test:
+    name: Test
+    needs: prime_cache_primary
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [20.x]
+        shard: ["1/2", "2/2"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install & cache node_modules
+        uses: Khan/actions@shared-node-cache-v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      # Testing and coverage
+      - name: Run jest tests with coverage
+        run: yarn coverage:ci --shard ${{ matrix.shard }}
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/coverage-final.json


### PR DESCRIPTION
## Summary 
- lint and test jobs from node-ci-pr.yml are copied over to node-ci-push.yml
- this is done so that feature branches can be updated with the latest changes in main (there are currently branch protection rules on feature/* branches that require these status checks to pass)

Issue: XXX-XXXX