### PR TITLE
TextField and TextArea: add `error` prop

### DIFF
--- a/.changeset/cold-cows-sit.md
+++ b/.changeset/cold-cows-sit.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+- TextArea and TextField: Adds `error` prop so that the components can be put in an error state explicitly. This is useful for backend validation errors after a form has already been submitted.

--- a/__docs__/wonder-blocks-form/text-area-variants.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area-variants.stories.tsx
@@ -10,8 +10,6 @@ import {TextArea} from "@khanacademy/wonder-blocks-form";
 /**
  * The following stories are used to generate the pseudo states for the
  * TextArea component. This is only used for visual testing in Chromatic.
- *
- * Note: Error state is not shown on initial render if the TextArea value is empty.
  */
 export default {
     title: "Packages / Form / TextArea / All Variants",
@@ -40,7 +38,7 @@ const states = [
     },
     {
         label: "Error",
-        props: {validate: () => "Error"},
+        props: {error: true},
     },
 ];
 const States = (props: {

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -159,13 +159,27 @@ export const ReadOnly: StoryComponentType = {
 };
 
 /**
+ * If the `error` prop is set to true, the TextArea will have error styling and
+ * `aria-invalid` set to `true`.
+ *
+ * Note: The `required` and `validate` props can also put the TextArea in an
+ * error state.
+ */
+export const Error: StoryComponentType = {
+    args: {
+        value: "With error",
+        error: true,
+    },
+};
+
+/**
  * If the textarea fails validation, `TextArea` will have error styling.
  * Note that we will internally set the correct `aria-invalid` attribute to the
  * `textarea` element:
  * - `aria-invalid="true"` if there is an error message.
  * - `aria-invalid="false"` if there is no error message.
  */
-export const Error: StoryComponentType = {
+export const ErrorFromValidation: StoryComponentType = {
     args: {
         value: "khan",
         validate(value: string) {

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -166,6 +166,9 @@ export const ReadOnly: StoryComponentType = {
  * If the `error` prop is set to true, the TextArea will have error styling and
  * `aria-invalid` set to `true`.
  *
+ * This is useful for scenarios where we want to show an error message on a
+ * specific field after a form is submitted (server validation).
+ *
  * Note: The `required` and `validate` props can also put the TextArea in an
  * error state.
  */
@@ -178,6 +181,10 @@ export const Error: StoryComponentType = {
 
 /**
  * If the textarea fails validation, `TextArea` will have error styling.
+ *
+ * This is useful for scenarios where we want to show error messages while a
+ * user is filling out a form (client validation).
+ *
  * Note that we will internally set the correct `aria-invalid` attribute to the
  * `textarea` element:
  * - `aria-invalid="true"` if there is an error message.
@@ -209,7 +216,7 @@ export const ErrorFromValidation: StoryComponentType = {
  * goes away since it is a valid email.
  * 3. When the Submit button is pressed, another error message is shown (this
  * simulates backend validation).
- * 4. When you enter any other email address and submit it, the error message is
+ * 4. When you enter any other email address, the error message is
  * cleared.
  */
 export const ErrorFromPropAndValidation = (args: PropsFor<typeof TextArea>) => {
@@ -223,6 +230,8 @@ export const ErrorFromPropAndValidation = (args: PropsFor<typeof TextArea>) => {
 
     const handleChange = (newValue: string) => {
         setValue(newValue);
+        // Clear the backend error message on change
+        setBackendErrorMessage(null);
     };
 
     const errorMessage = validationErrorMessage || backendErrorMessage;

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -166,13 +166,14 @@ export const ReadOnly: StoryComponentType = {
  * If the `error` prop is set to true, the TextArea will have error styling and
  * `aria-invalid` set to `true`.
  *
- * This is useful for scenarios where we want to show an error message on a
+ * This is useful for scenarios where we want to show an error on a
  * specific field after a form is submitted (server validation).
  *
  * Note: The `required` and `validate` props can also put the TextArea in an
  * error state.
  */
 export const Error: StoryComponentType = {
+    render: ControlledTextArea,
     args: {
         value: "With error",
         error: true,
@@ -182,13 +183,13 @@ export const Error: StoryComponentType = {
 /**
  * If the textarea fails validation, `TextArea` will have error styling.
  *
- * This is useful for scenarios where we want to show error messages while a
+ * This is useful for scenarios where we want to show errors while a
  * user is filling out a form (client validation).
  *
  * Note that we will internally set the correct `aria-invalid` attribute to the
  * `textarea` element:
- * - `aria-invalid="true"` if there is an error message.
- * - `aria-invalid="false"` if there is no error message.
+ * - `aria-invalid="true"` if there is an error.
+ * - `aria-invalid="false"` if there is no error.
  */
 export const ErrorFromValidation: StoryComponentType = {
     args: {
@@ -206,7 +207,7 @@ export const ErrorFromValidation: StoryComponentType = {
 /**
  * This example shows how the `error` and `validate` props can both be used to
  * put the field in an error state. This is useful for scenarios where we want
- * to show error messages while a user is filling out a form (client validation)
+ * to show error while a user is filling out a form (client validation)
  * and after a form is submitted (server validation).
  *
  * In this example:

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -178,6 +178,12 @@ export const Error: StoryComponentType = {
         value: "With error",
         error: true,
     },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**
@@ -202,6 +208,12 @@ export const ErrorFromValidation: StoryComponentType = {
         },
     },
     render: ControlledTextArea,
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**

--- a/__docs__/wonder-blocks-form/text-field-variants.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field-variants.stories.tsx
@@ -10,8 +10,6 @@ import {TextField} from "@khanacademy/wonder-blocks-form";
 /**
  * The following stories are used to generate the pseudo states for the
  * TextField component. This is only used for visual testing in Chromatic.
- *
- * Note: Error state is not shown on initial render if the TextField value is empty.
  */
 export default {
     title: "Packages / Form / TextField / All Variants",
@@ -40,7 +38,7 @@ const states = [
     },
     {
         label: "Error",
-        props: {validate: () => "Error"},
+        props: {error: true},
     },
 ];
 const States = (props: {

--- a/__docs__/wonder-blocks-form/text-field.argtypes.ts
+++ b/__docs__/wonder-blocks-form/text-field.argtypes.ts
@@ -174,6 +174,18 @@ export default {
         },
     },
 
+    error: {
+        description: "Whether this field is in an error state.",
+        table: {
+            type: {
+                summary: "boolean",
+            },
+        },
+        control: {
+            type: "boolean",
+        },
+    },
+
     /**
      * Number-specific props
      */

--- a/__docs__/wonder-blocks-form/text-field.argtypes.ts
+++ b/__docs__/wonder-blocks-form/text-field.argtypes.ts
@@ -163,7 +163,7 @@ export default {
 
     validate: {
         description:
-            "Provide a validation for the input value. Return a string error message or null | void for a valid input.",
+            "Provide a validation for the input value. Return a string error message or null | void for a valid input. \n Use this for errors that are shown to the user while they are filling out a form.",
         table: {
             type: {
                 summary: "(value: string) => ?string",
@@ -175,7 +175,8 @@ export default {
     },
 
     error: {
-        description: "Whether this field is in an error state.",
+        description:
+            "Whether this field is in an error state. \n Use this for errors that are triggered by something external to the component (example: an error after form submission).",
         table: {
             type: {
                 summary: "boolean",

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -464,6 +464,12 @@ export const Error: StoryComponentType = {
         error: true,
         validate: undefined,
     },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**
@@ -479,6 +485,12 @@ export const Error: StoryComponentType = {
  */
 export const ErrorFromValidation: StoryComponentType = {
     render: ErrorRender,
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**
@@ -699,6 +711,10 @@ ErrorLight.parameters = {
             story: `If an input value fails validation and the
         \`light\` prop is true, \`TextField\` will have light error styling.`,
         },
+    },
+    chromatic: {
+        // Disabling because this doesn't test anything visual.
+        disableSnapshot: true,
     },
 };
 

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -452,6 +452,19 @@ function ErrorRender() {
 }
 
 /**
+ * If the `error` prop is set to true, the TextField will have error styling and
+ * `aria-invalid` set to `true`.
+ *
+ * Note: The `required` and `validate` props can also put the TextField in an
+ * error state.
+ */
+export const Error: StoryComponentType = {
+    args: {
+        error: true,
+    },
+};
+
+/**
  * If an input value fails validation, `TextField` will have error styling.
  *
  * Note that we will internally set the correct `aria-invalid` attribute to the
@@ -459,7 +472,7 @@ function ErrorRender() {
  * - aria-invalid="true" if there is an error message.
  * - aria-invalid="false" if there is no error message.
  */
-export const Error: StoryComponentType = {
+export const ErrorFromValidation: StoryComponentType = {
     render: ErrorRender,
 };
 

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -451,6 +451,9 @@ function ErrorRender(args: PropsFor<typeof TextField>) {
  * If the `error` prop is set to true, the TextField will have error styling and
  * `aria-invalid` set to `true`.
  *
+ * This is useful for scenarios where we want to show an error message on a
+ * specific field after a form is submitted (server validation).
+ *
  * Note: The `required` and `validate` props can also put the TextField in an
  * error state.
  */
@@ -462,6 +465,9 @@ export const Error: StoryComponentType = {
 
 /**
  * If an input value fails validation, `TextField` will have error styling.
+ *
+ * This is useful for scenarios where we want to show error messages while a
+ * user is filling out a form (client validation).
  *
  * Note that we will internally set the correct `aria-invalid` attribute to the
  * `input` element:
@@ -485,7 +491,7 @@ export const ErrorFromValidation: StoryComponentType = {
  * goes away since it is a valid email.
  * 3. When the Submit button is pressed, another error message is shown (this
  * simulates backend validation).
- * 4. When you enter any other email address and submit it, the error message is
+ * 4. When you enter any other email address, the error message is
  * cleared.
  */
 export const ErrorFromPropAndValidation = (
@@ -501,6 +507,8 @@ export const ErrorFromPropAndValidation = (
 
     const handleChange = (newValue: string) => {
         setValue(newValue);
+        // Clear the backend error message on change
+        setBackendErrorMessage(null);
     };
 
     const errorMessage = validationErrorMessage || backendErrorMessage;

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -2,11 +2,15 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import {View, Text as _Text} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View, Text as _Text} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import Button from "@khanacademy/wonder-blocks-button";
-import {LabelLarge, Body} from "@khanacademy/wonder-blocks-typography";
+import {
+    LabelLarge,
+    Body,
+    LabelSmall,
+} from "@khanacademy/wonder-blocks-typography";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
@@ -393,10 +397,9 @@ Telephone.parameters = {
     },
 };
 
-function ErrorRender() {
+function ErrorRender(args: PropsFor<typeof TextField>) {
     const [value, setValue] = React.useState("khan");
     const [errorMessage, setErrorMessage] = React.useState<any>();
-    const [focused, setFocused] = React.useState(false);
 
     const handleChange = (newValue: string) => {
         setValue(newValue);
@@ -419,17 +422,10 @@ function ErrorRender() {
         }
     };
 
-    const handleFocus = () => {
-        setFocused(true);
-    };
-
-    const handleBlur = () => {
-        setFocused(false);
-    };
-
     return (
         <View>
             <TextField
+                {...args}
                 id="tf-7"
                 type="email"
                 value={value}
@@ -438,13 +434,13 @@ function ErrorRender() {
                 onValidate={handleValidate}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
-                onFocus={handleFocus}
-                onBlur={handleBlur}
             />
-            {!focused && errorMessage && (
+            {(errorMessage || args.error) && (
                 <View>
                     <Strut size={spacing.xSmall_8} />
-                    <_Text style={styles.errorMessage}>{errorMessage}</_Text>
+                    <_Text style={styles.errorMessage}>
+                        {errorMessage || "Error from error prop"}
+                    </_Text>
                 </View>
             )}
         </View>
@@ -474,6 +470,85 @@ export const Error: StoryComponentType = {
  */
 export const ErrorFromValidation: StoryComponentType = {
     render: ErrorRender,
+};
+
+/**
+ * This example shows how the `error` and `validate` props can both be used to
+ * put the field in an error state. This is useful for scenarios where we want
+ * to show error messages while a user is filling out a form (client validation)
+ * and after a form is submitted (server validation).
+ *
+ * In this example:
+ * 1. It starts with an invalid email. The error message shown is the message returned
+ * by the `validate` function prop
+ * 2. Once the email is fixed to `test@test.com`, the validation error message
+ * goes away since it is a valid email.
+ * 3. When the Submit button is pressed, another error message is shown (this
+ * simulates backend validation).
+ * 4. When you enter any other email address and submit it, the error message is
+ * cleared.
+ */
+export const ErrorFromPropAndValidation = (
+    args: PropsFor<typeof TextField>,
+) => {
+    const [value, setValue] = React.useState(args.value || "test@test,com");
+    const [validationErrorMessage, setValidationErrorMessage] = React.useState<
+        string | null | undefined
+    >(null);
+    const [backendErrorMessage, setBackendErrorMessage] = React.useState<
+        string | null | undefined
+    >(null);
+
+    const handleChange = (newValue: string) => {
+        setValue(newValue);
+    };
+
+    const errorMessage = validationErrorMessage || backendErrorMessage;
+
+    return (
+        <View>
+            <TextField
+                {...args}
+                value={value}
+                onChange={handleChange}
+                validate={(value: string) => {
+                    const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+                    if (!emailRegex.test(value)) {
+                        return "Please enter a valid email";
+                    }
+                }}
+                onValidate={setValidationErrorMessage}
+                error={!!errorMessage}
+            />
+            <Strut size={spacing.xxSmall_6} />
+            {errorMessage && (
+                <LabelSmall style={styles.errorMessage}>
+                    {errorMessage}
+                </LabelSmall>
+            )}
+            <Strut size={spacing.xxSmall_6} />
+            <Button
+                onClick={() => {
+                    if (value === "test@test.com") {
+                        setBackendErrorMessage(
+                            "This email is already being used, please try another email.",
+                        );
+                    } else {
+                        setBackendErrorMessage(null);
+                    }
+                }}
+            >
+                Submit
+            </Button>
+        </View>
+    );
+};
+
+ErrorFromPropAndValidation.parameters = {
+    chromatic: {
+        // Disabling because this doesn't test anything visual.
+        disableSnapshot: true,
+    },
 };
 
 export const Light: StoryComponentType = () => {

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -426,22 +426,22 @@ function ErrorRender(args: PropsFor<typeof TextField>) {
     return (
         <View>
             <TextField
-                {...args}
                 id="tf-7"
                 type="email"
-                value={value}
                 placeholder="Email"
                 validate={validate}
                 onValidate={handleValidate}
-                onChange={handleChange}
                 onKeyDown={handleKeyDown}
+                {...args}
+                value={value}
+                onChange={handleChange}
             />
             {(errorMessage || args.error) && (
                 <View>
-                    <Strut size={spacing.xSmall_8} />
-                    <_Text style={styles.errorMessage}>
+                    <Strut size={spacing.xxSmall_6} />
+                    <LabelSmall style={styles.errorMessage}>
                         {errorMessage || "Error from error prop"}
-                    </_Text>
+                    </LabelSmall>
                 </View>
             )}
         </View>
@@ -452,28 +452,30 @@ function ErrorRender(args: PropsFor<typeof TextField>) {
  * If the `error` prop is set to true, the TextField will have error styling and
  * `aria-invalid` set to `true`.
  *
- * This is useful for scenarios where we want to show an error message on a
+ * This is useful for scenarios where we want to show an error on a
  * specific field after a form is submitted (server validation).
  *
  * Note: The `required` and `validate` props can also put the TextField in an
  * error state.
  */
 export const Error: StoryComponentType = {
+    render: ErrorRender,
     args: {
         error: true,
+        validate: undefined,
     },
 };
 
 /**
  * If an input value fails validation, `TextField` will have error styling.
  *
- * This is useful for scenarios where we want to show error messages while a
+ * This is useful for scenarios where we want to show errors while a
  * user is filling out a form (client validation).
  *
  * Note that we will internally set the correct `aria-invalid` attribute to the
  * `input` element:
- * - aria-invalid="true" if there is an error message.
- * - aria-invalid="false" if there is no error message.
+ * - aria-invalid="true" if there is an error.
+ * - aria-invalid="false" if there is no error.
  */
 export const ErrorFromValidation: StoryComponentType = {
     render: ErrorRender,
@@ -482,7 +484,7 @@ export const ErrorFromValidation: StoryComponentType = {
 /**
  * This example shows how the `error` and `validate` props can both be used to
  * put the field in an error state. This is useful for scenarios where we want
- * to show error messages while a user is filling out a form (client validation)
+ * to show errors while a user is filling out a form (client validation)
  * and after a form is submitted (server validation).
  *
  * In this example:

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -805,6 +805,48 @@ describe("TextArea", () => {
                 const textArea = await screen.findByRole("textbox");
                 expect(textArea).toHaveAttribute("aria-invalid", "false");
             });
+
+            it("should set aria-invalid to true if the error prop is true", async () => {
+                // Arrange
+                render(
+                    <TextArea value="text" onChange={() => {}} error={true} />,
+                    defaultOptions,
+                );
+
+                // Act
+
+                // Assert
+                const textArea = await screen.findByRole("textbox");
+                expect(textArea).toHaveAttribute("aria-invalid", "true");
+            });
+
+            it("should set aria-invalid to false if the error prop is false", async () => {
+                // Arrange
+                render(
+                    <TextArea value="text" onChange={() => {}} error={false} />,
+                    defaultOptions,
+                );
+
+                // Act
+
+                // Assert
+                const textArea = await screen.findByRole("textbox");
+                expect(textArea).toHaveAttribute("aria-invalid", "false");
+            });
+
+            it("should set aria-invalid to false if the error prop is not provided", async () => {
+                // Arrange
+                render(
+                    <TextArea value="text" onChange={() => {}} />,
+                    defaultOptions,
+                );
+
+                // Act
+
+                // Assert
+                const textArea = await screen.findByRole("textbox");
+                expect(textArea).toHaveAttribute("aria-invalid", "false");
+            });
         });
     });
 

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
@@ -707,4 +707,37 @@ describe("TextField", () => {
             expect(input).toHaveFocus();
         });
     });
+
+    it("should set aria-invalid to true if the error prop is true", async () => {
+        // Arrange
+        render(<TextField value="text" onChange={() => {}} error={true} />);
+
+        // Act
+
+        // Assert
+        const input = await screen.findByRole("textbox");
+        expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("should set aria-invalid to false if the error prop is false", async () => {
+        // Arrange
+        render(<TextField value="text" onChange={() => {}} error={false} />);
+
+        // Act
+
+        // Assert
+        const input = await screen.findByRole("textbox");
+        expect(input).toHaveAttribute("aria-invalid", "false");
+    });
+
+    it("should set aria-invalid to false if the error prop is not provided", async () => {
+        // Arrange
+        render(<TextField value="text" onChange={() => {}} />);
+
+        // Act
+
+        // Assert
+        const input = await screen.findByRole("textbox");
+        expect(input).toHaveAttribute("aria-invalid", "false");
+    });
 });

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -215,7 +215,9 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             ...otherProps
         } = props;
 
-        const [error, setError] = React.useState<string | null>(null);
+        const [errorMessage, setErrorMessage] = React.useState<string | null>(
+            null,
+        );
 
         const ids = useUniqueIdWithMock("text-area");
         const uniqueId = id ?? ids.get("id");
@@ -231,7 +233,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         const handleValidation = (newValue: string) => {
             if (validate) {
                 const error = validate(newValue) || null;
-                setError(error);
+                setErrorMessage(error);
                 if (onValidate) {
                     onValidate(error);
                 }
@@ -241,7 +243,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                         ? required
                         : defaultErrorMessage;
                 const error = newValue ? null : requiredString;
-                setError(error);
+                setErrorMessage(error);
                 if (onValidate) {
                     onValidate(error);
                 }
@@ -267,13 +269,13 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                 styles.default,
                 !disabled && styles.defaultFocus,
                 disabled && styles.disabled,
-                !!error && styles.error,
+                !!errorMessage && styles.error,
             ];
             const lightStyles = [
                 styles.light,
                 !disabled && styles.lightFocus,
                 disabled && styles.lightDisabled,
-                !!error && styles.lightError,
+                !!errorMessage && styles.lightError,
             ];
             return [...baseStyles, ...(light ? lightStyles : defaultStyles)];
         };
@@ -305,7 +307,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     onBlur={onBlur} // TextArea can be blurred if it is disabled
                     required={!!required}
                     {...otherProps}
-                    aria-invalid={!!error}
+                    aria-invalid={!!errorMessage}
                 />
             </View>
         );

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -133,6 +133,9 @@ type TextAreaProps = AriaProps & {
     /**
      * Provide a validation for the textarea value.
      * Return a string error message or null | void for a valid input.
+     *
+     * Use this for errors that are shown to the user while they are filling out
+     * a form.
      */
     validate?: (value: string) => string | null | void;
     /**
@@ -141,6 +144,9 @@ type TextAreaProps = AriaProps & {
     onValidate?: (errorMessage?: string | null | undefined) => unknown;
     /**
      * Whether the textarea is in an error state.
+     *
+     * Use this for errors that are triggered by something external to the
+     * component (example: an error after form submission).
      */
     error?: boolean;
     /**

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -140,6 +140,10 @@ type TextAreaProps = AriaProps & {
      */
     onValidate?: (errorMessage?: string | null | undefined) => unknown;
     /**
+     * Whether the textarea is in an error state.
+     */
+    error?: boolean;
+    /**
      * Whether this textarea is required to continue, or the error message to
      * render if this textarea is left blank.
      *
@@ -211,6 +215,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             resizeType,
             light,
             rootStyle,
+            error,
             // Should only include aria related props
             ...otherProps
         } = props;
@@ -218,6 +223,8 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         const [errorMessage, setErrorMessage] = React.useState<string | null>(
             null,
         );
+
+        const hasError = error || !!errorMessage;
 
         const ids = useUniqueIdWithMock("text-area");
         const uniqueId = id ?? ids.get("id");
@@ -269,13 +276,13 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                 styles.default,
                 !disabled && styles.defaultFocus,
                 disabled && styles.disabled,
-                !!errorMessage && styles.error,
+                hasError && styles.error,
             ];
             const lightStyles = [
                 styles.light,
                 !disabled && styles.lightFocus,
                 disabled && styles.lightDisabled,
-                !!errorMessage && styles.lightError,
+                hasError && styles.lightError,
             ];
             return [...baseStyles, ...(light ? lightStyles : defaultStyles)];
         };
@@ -307,7 +314,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     onBlur={onBlur} // TextArea can be blurred if it is disabled
                     required={!!required}
                     {...otherProps}
-                    aria-invalid={!!errorMessage}
+                    aria-invalid={hasError}
                 />
             </View>
         );

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -48,6 +48,9 @@ type CommonProps = AriaProps & {
     /**
      * Provide a validation for the input value.
      * Return a string error message or null | void for a valid input.
+     *
+     * Use this for errors that are shown to the user while they are filling out
+     * a form.
      */
     validate?: (value: string) => string | null | void;
     /**
@@ -76,6 +79,9 @@ type CommonProps = AriaProps & {
     placeholder?: string;
     /**
      * Whether the input is in an error state.
+     *
+     * Use this for errors that are triggered by something external to the
+     * component (example: an error after form submission).
      */
     error?: boolean;
     /**

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -75,6 +75,10 @@ type CommonProps = AriaProps & {
      */
     placeholder?: string;
     /**
+     * Whether the input is in an error state.
+     */
+    error?: boolean;
+    /**
      * Whether this field is required to to continue, or the error message to
      * render if this field is left blank.
      *
@@ -240,21 +244,22 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
     };
 
     getStyles = (): StyleType => {
-        const {disabled, light} = this.props;
+        const {disabled, light, error} = this.props;
         const {errorMessage} = this.state;
+        const hasError = error || !!errorMessage;
         // Base styles are the styles that apply regardless of light mode
         const baseStyles = [styles.input, typographyStyles.LabelMedium];
         const defaultStyles = [
             styles.default,
             !disabled && styles.defaultFocus,
             disabled && styles.disabled,
-            !!errorMessage && styles.error,
+            hasError && styles.error,
         ];
         const lightStyles = [
             styles.light,
             !disabled && styles.lightFocus,
             disabled && styles.lightDisabled,
-            !!errorMessage && styles.lightError,
+            hasError && styles.lightError,
         ];
         return [...baseStyles, ...(light ? lightStyles : defaultStyles)];
     };
@@ -274,6 +279,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             autoFocus,
             autoComplete,
             forwardedRef,
+            error,
             // The following props are being included here to avoid
             // passing them down to the otherProps spread
             /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -289,6 +295,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             ...otherProps
         } = this.props;
 
+        const hasError = error || !!this.state.errorMessage;
         return (
             <IDProvider id={id} scope="text-field">
                 {(uniqueId) => (
@@ -309,9 +316,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                         autoFocus={autoFocus}
                         autoComplete={autoComplete}
                         ref={forwardedRef}
-                        aria-invalid={
-                            this.state.errorMessage ? "true" : "false"
-                        }
+                        aria-invalid={hasError}
                         {...otherProps}
                     />
                 )}

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -159,7 +159,7 @@ type State = {
     /**
      * Displayed when the validation fails.
      */
-    error: string | null | undefined;
+    errorMessage: string | null | undefined;
 };
 
 /**
@@ -176,12 +176,12 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
         super(props);
         if (props.validate && props.value !== "") {
             // Ensures error is updated on unmounted server-side renders
-            this.state.error = props.validate(props.value) || null;
+            this.state.errorMessage = props.validate(props.value) || null;
         }
     }
 
     state: State = {
-        error: null,
+        errorMessage: null,
     };
 
     componentDidMount() {
@@ -195,7 +195,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
 
         if (validate) {
             const maybeError = validate(newValue) || null;
-            this.setState({error: maybeError}, () => {
+            this.setState({errorMessage: maybeError}, () => {
                 if (onValidate) {
                     onValidate(maybeError);
                 }
@@ -204,7 +204,7 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
             const requiredString =
                 typeof required === "string" ? required : defaultErrorMessage;
             const maybeError = newValue ? null : requiredString;
-            this.setState({error: maybeError}, () => {
+            this.setState({errorMessage: maybeError}, () => {
                 if (onValidate) {
                     onValidate(maybeError);
                 }
@@ -241,20 +241,20 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
 
     getStyles = (): StyleType => {
         const {disabled, light} = this.props;
-        const {error} = this.state;
+        const {errorMessage} = this.state;
         // Base styles are the styles that apply regardless of light mode
         const baseStyles = [styles.input, typographyStyles.LabelMedium];
         const defaultStyles = [
             styles.default,
             !disabled && styles.defaultFocus,
             disabled && styles.disabled,
-            !!error && styles.error,
+            !!errorMessage && styles.error,
         ];
         const lightStyles = [
             styles.light,
             !disabled && styles.lightFocus,
             disabled && styles.lightDisabled,
-            !!error && styles.lightError,
+            !!errorMessage && styles.lightError,
         ];
         return [...baseStyles, ...(light ? lightStyles : defaultStyles)];
     };
@@ -309,7 +309,9 @@ class TextField extends React.Component<PropsWithForwardRef, State> {
                         autoFocus={autoFocus}
                         autoComplete={autoComplete}
                         ref={forwardedRef}
-                        aria-invalid={this.state.error ? "true" : "false"}
+                        aria-invalid={
+                            this.state.errorMessage ? "true" : "false"
+                        }
                         {...otherProps}
                     />
                 )}


### PR DESCRIPTION
## Summary:
Adds an `error` prop to TextField and TextArea components so they can be put in an error state declaratively. This is useful for validation that happens after a form submission.

Related to the LabeledField work:
- By having an error prop, the LabeledField component will set the `error` prop to `true` if it is provided with an error message (will do this in a separate PR for LabeledField work)
- The error prop is consistent with other fields such as the SingleSelect, MultiSelect, and Combobox components. I'll be updating SearchField in another PR (with other updates)!
- These changes can be released separately from the LabeledField changes since they are incremental changes to existing components

Issue: WB-1777

## Test plan:

### TextField
- Setting the `error` prop puts the component in an error state (`aria-invalid` is set to `true` and error styling is applied) (`?path=/story/packages-form-textfield--error`)
- Validation continues to put the component in an error state if the value is not valid (`?path=/story/packages-form-textfield--error-from-validation`)
- Required prop continues to put the component in an error state if a value is cleared (`?path=/story/packages-form-textfield--required`)

### TextArea
- Setting the `error` prop puts the component in an error state (`aria-invalid` is set to `true` and error styling is applied) (`?path=/story/packages-form-textarea--error`)
- Validation continues to put the component in an error state if the value is not valid (`?path=/story/packages-form-textarea--error-from-validation`)
- Required prop continues to put the component in an error state if a value is cleared (`?path=/story/packages-form-textarea--required`)