### PR TITLE
PoC: Add `makeStyled("tag")` that provides an object with named component (i.e., StyledSpan)

### DIFF
--- a/.changeset/rotten-icons-build.md
+++ b/.changeset/rotten-icons-build.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Deprecates `addStyle` in favor of the `makeStyled`, which returns a named component. This allows a linting config to target the correct name.

--- a/__docs__/wonder-blocks-core/add-style.mdx
+++ b/__docs__/wonder-blocks-core/add-style.mdx
@@ -7,6 +7,10 @@ import * as AddStyleStories from './add-style.stories';
 
 # addStyle
 
+For most purposes, you will want to use `makeStyled` instead of `addStyle` in
+order to create styled components with consistent names. This helps with
+linting.
+
 The `addStyle` function is a HOC that accepts a **React Component** or a **DOM**
 **intrinsic** ("div", "span", etc.) as its first argument and optional default
 styles as its second argument. This HOC returns a **React Component** with a

--- a/__docs__/wonder-blocks-core/make-styled.mdx
+++ b/__docs__/wonder-blocks-core/make-styled.mdx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import {Meta, Story, Canvas} from "@storybook/blocks";
+import * as MakeStyledStories from "./make-styled.stories";
+
+<Meta of={MakeStyledStories} />
+
+# makeStyled
+
+The `makeStyled` function accepts a **DOM intrinsic** ("div", "span", etc.) as
+its first argument and optional default styles as its second argument. This
+returns a named **React Component** with a `style` prop included, ready to be
+rendered.
+
+_Note: this differs from using a bare **DOM intrinsic** with a `style`
+prop. The bare **DOM** **intrinsic** will generate inline styles whereas a
+component that has been wrapped with `makeStyled` will process the styles with
+[Aphrodite](https://github.com/Khan/aphrodite). As a result, always use
+`makeStyled` if you need to style the component/element._
+
+## Usage
+
+```js
+import {makeStyled} from "@khanacademy/wonder-blocks-core";
+
+makeStyled(
+    Tag: keyof JSX.IntrinsicElements,
+    defaultStyle?: StyleType
+): React.Element;
+```
+
+## API
+
+| Argument       | TypeScript Type               | Default    | Description                          |
+| -------------- | ----------------------------- | ---------- | ------------------------------------ |
+| `Tag`          | `keyof JSX.IntrinsicElements` | _Required_ | The tag name that will be decorated. |
+| `defaultStyle` | `StyleType`                   | null       | The initial styles to be applied.    |
+
+## Examples
+
+It's recommended to create your styled component using `makeStyled` outside of the
+component so we don't have to create a new instance on every render.
+
+### 1. Adding default styles
+
+You can create a new styled component by using the `makeStyled` function. Note
+here that you can also define default styles for this component by passing an
+initial style object to this function:
+
+```tsx
+import {StyleSheet} from "aphrodite";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {makeStyled} from "@khanacademy/wonder-blocks-core";
+
+const {StyledInput} = makeStyled("input", styles.input);
+
+const styles = StyleSheet.create({
+    input: {
+        background: color.white,
+        borderColor: color.offBlack16,
+        borderRadius: spacing.xxxSmall_4,
+        fontSize: spacing.medium_16,
+        padding: spacing.xSmall_8,
+    },
+});
+
+const MyComponent = () => {
+    return <StyledInput type="text" placeholder: "This is a styled input" />;
+};
+```
+
+<Canvas sourceState="none" of={MakeStyledStories.WithDefaultStyle} />
+
+### 2. Overriding a default style
+
+After defining default styles, you can also customize the instance by adding
+and/or merging styles using the `style` prop in your newly created styled
+component.
+
+```tsx
+import {StyleSheet} from "aphrodite";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {makeStyled} from "@khanacademy/wonder-blocks-core";
+
+const {StyledInput} = makeStyled("input", styles.input);
+
+const styles = StyleSheet.create({
+    input: {
+        background: color.white,
+        borderColor: color.offBlack16,
+        borderRadius: spacing.xxxSmall_4,
+        fontSize: spacing.medium_16,
+        padding: spacing.xSmall_8,
+    },
+    error: {
+        background: fade(color.red, 0.16),
+        borderColor: color.red,
+    },
+});
+
+const MyComponent = () => {
+    return <StyledInput type="text" placeholder: "This is a styled input" style={styles.error} />;
+};
+```
+
+<Canvas sourceState="none" of={MakeStyledStories.OverrideStyles} />
+
+### 3. Adding styles dynamically
+
+This example shows that you can dynamically create styles by adding them to the
+`style` prop only when you need them.
+
+```tsx
+import {StyleSheet} from "aphrodite";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {makeStyled} from "@khanacademy/wonder-blocks-core";
+
+const {StyledInput} = makeStyled("input", styles.input);
+
+const styles = StyleSheet.create({
+    input: {
+        background: color.white,
+        borderColor: color.offBlack16,
+        borderRadius: spacing.xxxSmall_4,
+        fontSize: spacing.medium_16,
+        padding: spacing.xSmall_8,
+    },
+    error: {
+        background: fade(color.red, 0.16),
+        borderColor: color.red,
+    },
+});
+
+const MyComponent = () => {
+    const [error, setError] = React.useState(false);
+    const {StyledInput} = makeStyled("input", styles.input);
+    return (
+        <View>
+            <Checkbox
+                label="Click here to add the error style to the input"
+                checked={error}
+                onChange={() => setError(!error)}
+            />
+            <StyledInput
+                style={[styles.input, error && styles.error]}
+                type="text"
+                placeholder="Lorem ipsum"
+            />
+        </View>
+    );
+};
+```
+
+<Canvas sourceState="none" of={MakeStyledStories.AddingStylesDynamically} />

--- a/__docs__/wonder-blocks-core/make-styled.stories.tsx
+++ b/__docs__/wonder-blocks-core/make-styled.stories.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import type {Meta} from "@storybook/react";
+import {fade, spacing, color} from "@khanacademy/wonder-blocks-tokens";
+import {makeStyled, View} from "@khanacademy/wonder-blocks-core";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
+
+const styles = StyleSheet.create({
+    input: {
+        // default style for all instances of StyledInput
+        background: color.white,
+        border: `1px solid ${color.offBlack16}`,
+        borderRadius: spacing.xxxSmall_4,
+        fontSize: spacing.medium_16,
+        padding: spacing.xSmall_8,
+    },
+    error: {
+        background: fade(color.red, 0.16),
+        borderColor: color.red,
+    },
+});
+
+const {StyledInput} = makeStyled("input", styles.input);
+
+export default {
+    title: "Packages / Core / makeStyled",
+    component: StyledInput,
+} satisfies Meta;
+
+export const WithDefaultStyle = {
+    args: {
+        type: "text",
+        placeholder: "This is a styled input",
+    },
+};
+
+export const OverrideStyles = {
+    args: {
+        type: "text",
+        placeholder: "With an error style",
+        style: styles.error,
+    },
+};
+
+const DynamicStyledInput = () => {
+    const [error, setError] = React.useState(false);
+    const {StyledInput} = makeStyled("input", styles.input);
+    return (
+        <View>
+            <Checkbox
+                label="Click here to add the error style to the input"
+                checked={error}
+                onChange={() => setError(!error)}
+            />
+            <StyledInput
+                style={[styles.input, error && styles.error]}
+                type="text"
+                placeholder="Lorem ipsum"
+            />
+        </View>
+    );
+};
+
+export const AddingStylesDynamically = {
+    render: () => <DynamicStyledInput />,
+    name: "Adding styles dynamically",
+};

--- a/packages/wonder-blocks-core/src/components/view.tsx
+++ b/packages/wonder-blocks-core/src/components/view.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import addStyle from "../util/add-style";
+import {makeStyled} from "../util/add-style";
 
 import type {TextViewSharedProps} from "../util/types";
 
@@ -33,11 +33,11 @@ type Props = TextViewSharedProps & {
     tag?: ValidViewTags;
 };
 
-const StyledDiv = addStyle("div", styles.default);
-const StyledArticle = addStyle("article", styles.default);
-const StyledAside = addStyle("aside", styles.default);
-const StyledNav = addStyle("nav", styles.default);
-const StyledSection = addStyle("section", styles.default);
+const {StyledDiv} = makeStyled("div", styles.default);
+const {StyledArticle} = makeStyled("article", styles.default);
+const {StyledAside} = makeStyled("aside", styles.default);
+const {StyledNav} = makeStyled("nav", styles.default);
+const {StyledSection} = makeStyled("section", styles.default);
 
 /**
  * View is a building block for constructing other components. `View` roughly

--- a/packages/wonder-blocks-core/src/index.ts
+++ b/packages/wonder-blocks-core/src/index.ts
@@ -10,7 +10,7 @@ export {default as View} from "./components/view";
 export {default as InitialFallback} from "./components/initial-fallback";
 export {default as IDProvider} from "./components/id-provider";
 export {default as UniqueIDProvider} from "./components/unique-id-provider";
-export {default as addStyle} from "./util/add-style";
+export {default as addStyle, makeStyled} from "./util/add-style";
 export {default as Server} from "./util/server";
 export {
     useUniqueIdWithMock,

--- a/packages/wonder-blocks-core/src/util/__tests__/add-style.test.tsx
+++ b/packages/wonder-blocks-core/src/util/__tests__/add-style.test.tsx
@@ -4,8 +4,6 @@ import {screen, render} from "@testing-library/react";
 
 import {makeStyled} from "../add-style";
 
-// const StyledDiv = addStyle("div");
-
 const styles = StyleSheet.create({
     foo: {
         height: "100%",

--- a/packages/wonder-blocks-core/src/util/__tests__/add-style.test.tsx
+++ b/packages/wonder-blocks-core/src/util/__tests__/add-style.test.tsx
@@ -2,15 +2,17 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {screen, render} from "@testing-library/react";
 
-import addStyle from "../add-style";
+import {makeStyled} from "../add-style";
 
-const StyledDiv = addStyle("div");
+// const StyledDiv = addStyle("div");
 
 const styles = StyleSheet.create({
     foo: {
         height: "100%",
     },
 });
+
+const {StyledDiv} = makeStyled("div");
 
 describe("addStyle", () => {
     let SNAPSHOT_INLINE_APHRODITE: any;

--- a/packages/wonder-blocks-core/src/util/add-style.tsx
+++ b/packages/wonder-blocks-core/src/util/add-style.tsx
@@ -5,15 +5,46 @@ import {processStyleList} from "./util";
 
 import type {StyleType} from "./types";
 
+type StyledProps = {
+    className?: string;
+    style?: StyleType;
+    children?: React.ReactNode;
+} & Omit<React.ComponentProps<"div">, "style">; // Removes the 'style' prop from the original component
+
+type StyledElement<
+    T extends keyof JSX.IntrinsicElements,
+    Props extends StyledProps,
+> = React.ForwardRefExoticComponent<
+    React.PropsWithoutRef<Props> & React.RefAttributes<IntrinsicElementsMap[T]>
+>;
+
+type NamedStyledType<
+    T extends keyof JSX.IntrinsicElements,
+    Props extends StyledProps,
+> = {
+    [K in T as `Styled${Capitalize<T & string>}`]: StyledElement<T, Props>;
+};
+
+export const makeStyled = <
+    T extends keyof JSX.IntrinsicElements,
+    Props extends StyledProps,
+>(
+    Component: T,
+    defaultStyle?: StyleType,
+): NamedStyledType<T, Props> => {
+    const styledComponentName = `Styled${Component.charAt(
+        0,
+    ).toUpperCase()}${Component.slice(1)}` as `Styled${Capitalize<T & string>}`;
+    return {
+        [styledComponentName]: addStyle(Component, defaultStyle),
+    } as NamedStyledType<T, Props>;
+};
+
 export default function addStyle<
     // We extend `React.ComponentType<any>` to support `addStyle(Link)` with
     // react-router's `Link` component.
     T extends React.ComponentType<any> | keyof JSX.IntrinsicElements,
-    Props extends {
-        className?: string;
-        style?: StyleType;
-        children?: React.ReactNode;
-    } & Omit<React.ComponentProps<T>, "style">, // Removes the 'style' prop from the original component
+    Props extends StyledProps,
 >(
     Component: T,
     defaultStyle?: StyleType,

--- a/packages/wonder-blocks-core/src/util/add-style.tsx
+++ b/packages/wonder-blocks-core/src/util/add-style.tsx
@@ -55,7 +55,7 @@ export const makeStyled = <Tag extends string & keyof JSX.IntrinsicElements>(
     } as NamedStyledTag<Tag>);
 
 /**
- * @deprecated Use `makeStyled` instead.
+ * If you are decorating a native element, use `makeStyled` instead.
  */
 export default function addStyle<
     // We extend `React.ComponentType<any>` to support `addStyle(Link)` with

--- a/packages/wonder-blocks-core/src/util/add-style.tsx
+++ b/packages/wonder-blocks-core/src/util/add-style.tsx
@@ -5,16 +5,34 @@ import {processStyleList} from "./util";
 
 import type {StyleType} from "./types";
 
-type StyledProps<T extends keyof JSX.IntrinsicElements> = {
+/**
+ * The props that can be passed to a styled component. Removes the `style` prop
+ * from the original component and replaces with the Aphrodite style object.
+ */
+type StyledProps<
+    T extends React.ComponentType<any> | keyof JSX.IntrinsicElements,
+> = {
     className?: string;
     style?: StyleType;
     children?: React.ReactNode;
 } & Omit<React.ComponentProps<T>, "style">;
 
+/**
+ * This type only exists to be mapped in NamedStyledTag.
+ * An object with a key, `Styled`, and the value is the styled component.
+ * There may be a way to accomplish this without an intermediate type, but
+ * this was the simplest way to get it working.
+ */
 interface StyledTag<T extends keyof JSX.IntrinsicElements> {
     Styled: ReturnType<typeof addStyle<T, StyledProps<T>>>;
 }
 
+/**
+ * A mapped type that appends the tag name to the keys in StyledTag. Since
+ * there is only one key in StyledTag, the key will be `Styled${Tag}`. For
+ * example, if Tag is "div", the key will be `StyledDiv`. The value is the
+ * styled component.
+ */
 type NamedStyledTag<Tag extends string & keyof JSX.IntrinsicElements> = {
     [Property in keyof StyledTag<Tag> as `${Property}${Capitalize<Tag>}`]: StyledTag<Tag>[Property];
 };
@@ -43,11 +61,7 @@ export default function addStyle<
     // We extend `React.ComponentType<any>` to support `addStyle(Link)` with
     // react-router's `Link` component.
     T extends React.ComponentType<any> | keyof JSX.IntrinsicElements,
-    Props extends {
-        className?: string;
-        style?: StyleType;
-        children?: React.ReactNode;
-    } & Omit<React.ComponentProps<T>, "style">, // Removes the 'style' prop from the original component
+    Props extends StyledProps<T>,
 >(
     Component: T,
     defaultStyle?: StyleType,

--- a/packages/wonder-blocks-core/src/util/add-style.tsx
+++ b/packages/wonder-blocks-core/src/util/add-style.tsx
@@ -19,15 +19,26 @@ type NamedStyledTag<Tag extends string & keyof JSX.IntrinsicElements> = {
     [Property in keyof StyledTag<Tag> as `${Property}${Capitalize<Tag>}`]: StyledTag<Tag>[Property];
 };
 
+/**
+ * Creates a styled component with the given tag name.
+ * @param tag The tag name of the native element.
+ * @param defaultStyle Optional. The default style to apply to the component.
+ * @returns An object with a single key, `Styled${tag}`, which is the styled component.
+ */
 export const makeStyled = <Tag extends string & keyof JSX.IntrinsicElements>(
-    Component: Tag,
+    tag: Tag,
     defaultStyle?: StyleType,
 ) =>
     ({
-        [`Styled${Component.charAt(0).toUpperCase()}${Component.slice(1)}`]:
-            addStyle(Component, defaultStyle),
+        [`Styled${tag.charAt(0).toUpperCase()}${tag.slice(1)}`]: addStyle(
+            tag,
+            defaultStyle,
+        ),
     } as NamedStyledTag<Tag>);
 
+/**
+ * @deprecated Use `makeStyled` instead.
+ */
 export default function addStyle<
     // We extend `React.ComponentType<any>` to support `addStyle(Link)` with
     // react-router's `Link` component.

--- a/packages/wonder-blocks-core/src/util/add-style.tsx
+++ b/packages/wonder-blocks-core/src/util/add-style.tsx
@@ -37,14 +37,18 @@ export const makeStyled = <
     ).toUpperCase()}${Component.slice(1)}` as `Styled${Capitalize<T & string>}`;
     return {
         [styledComponentName]: addStyle(Component, defaultStyle),
-    } as NamedStyledType<T, Props>;
+    } as unknown as NamedStyledType<T, Props>;
 };
 
 export default function addStyle<
     // We extend `React.ComponentType<any>` to support `addStyle(Link)` with
     // react-router's `Link` component.
     T extends React.ComponentType<any> | keyof JSX.IntrinsicElements,
-    Props extends StyledProps,
+    Props extends {
+        className?: string;
+        style?: StyleType;
+        children?: React.ReactNode;
+    } & Omit<React.ComponentProps<T>, "style">, // Removes the 'style' prop from the original component
 >(
     Component: T,
     defaultStyle?: StyleType,


### PR DESCRIPTION
@beaesguerra is exploring using more a11y rules in eslint, but there is an issue-- `addStyle` allows components to have any arbitrary name, so it's impossible to map native elements to custom components.

We can enforce consistent naming by using some newer TS features to force return types to have specific names, like `StyledSpan` or `StyledDiv`.

For example, `makeStyled("div")` yields `{StyledDiv}`!

We can deprecate `addStyle` in favor of `makeDiv` and migrate uses in `webapp` in order to allow eslint configs to be effective.