### PR TITLE
Add `instantValidation` prop for TextArea

### DIFF
--- a/.changeset/chatty-moles-brush.md
+++ b/.changeset/chatty-moles-brush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+Adds `instantValidation` prop for TextArea

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -295,12 +295,23 @@ ErrorFromPropAndValidation.parameters = {
 
 /**
  * The `instantValidation` prop controls when validation is triggered. Validation
- * is only triggered if the `validate` or `required` props are set.
+ * is triggered if the `validate` or `required` props are set.
+ *
+ * It is preferred to set `instantValidation` to `false` so that the user isn't
+ * shown an error until they are done with a field. Note: if `instantValidation`
+ * is not explicitly set, it defaults to `true` since this is the current
+ * behaviour of existing usage. Validation on blur needs to be opted in.
  *
  * Validation is triggered:
- * 1. On mount if the `value` prop is not empty
- * 2. If `instantValidation` is `true`, validation occurs `onChange` (default)
- * 3. If `instantValidation` is `false`, validation occurs `onBlur`
+ * - On mount if the `value` prop is not empty
+ * - If `instantValidation` is `true`, validation occurs `onChange` (default)
+ * - If `instantValidation` is `false`, validation occurs `onBlur`
+ *
+ * When `required` is set to `true`:
+ * - If `instantValidation` is `true`, the required error message is shown after
+ * a value is cleared
+ * - If `instantValidation` is `false`, the required error message is shown
+ * whenever the user tabs away from the required field
  */
 export const InstantValidation: StoryComponentType = {
     args: {
@@ -314,21 +325,55 @@ export const InstantValidation: StoryComponentType = {
     render: (args) => {
         return (
             <View style={{gap: spacing.small_12}}>
-                <LabelSmall htmlFor="instant-validation-true">
-                    Instant Validation: true
+                <LabelSmall htmlFor="instant-validation-true-not-required">
+                    Validation on mount if there is a value
                 </LabelSmall>
                 <ControlledTextArea
                     {...args}
-                    id="instant-validation-true"
+                    id="instant-validation-true-not-required"
+                    value="invalid"
+                />
+                <LabelSmall htmlFor="instant-validation-true-not-required">
+                    Error shown immediately (instantValidation: true, required:
+                    false)
+                </LabelSmall>
+                <ControlledTextArea
+                    {...args}
+                    id="instant-validation-true-not-required"
                     instantValidation={true}
                 />
-                <LabelSmall htmlFor="instant-validation-false">
-                    Instant Validation: false
+                <LabelSmall htmlFor="instant-validation-false-not-required">
+                    Error shown onBlur (instantValidation: false, required:
+                    false)
                 </LabelSmall>
                 <ControlledTextArea
                     {...args}
-                    id="instant-validation-false"
+                    id="instant-validation-false-not-required"
                     instantValidation={false}
+                />
+
+                <LabelSmall htmlFor="instant-validation-true-required">
+                    Error shown immediately after clearing the value
+                    (instantValidation: true, required: true)
+                </LabelSmall>
+                <ControlledTextArea
+                    {...args}
+                    validate={undefined}
+                    value="T"
+                    id="instant-validation-true-required"
+                    instantValidation={true}
+                    required="Required"
+                />
+                <LabelSmall htmlFor="instant-validation-false-required">
+                    Error shown on blur if it is empty (instantValidation:
+                    false, required: true)
+                </LabelSmall>
+                <ControlledTextArea
+                    {...args}
+                    validate={undefined}
+                    id="instant-validation-false-required"
+                    instantValidation={false}
+                    required="Required"
                 />
             </View>
         );

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -294,6 +294,54 @@ ErrorFromPropAndValidation.parameters = {
 };
 
 /**
+ * The `instantValidation` prop controls when validation is triggered. Validation
+ * is only triggered if the `validate` or `required` props are set.
+ *
+ * Validation is triggered:
+ * 1. On mount if the `value` prop is not empty
+ * 2. If `instantValidation` is `true`, validation occurs `onChange` (default)
+ * 3. If `instantValidation` is `false`, validation occurs `onBlur`
+ */
+export const InstantValidation: StoryComponentType = {
+    args: {
+        validate(value: string) {
+            const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@.\s]+$/;
+            if (!emailRegex.test(value)) {
+                return "Please enter a valid email";
+            }
+        },
+    },
+    render: (args) => {
+        return (
+            <View style={{gap: spacing.small_12}}>
+                <LabelSmall htmlFor="instant-validation-true">
+                    Instant Validation: true
+                </LabelSmall>
+                <ControlledTextArea
+                    {...args}
+                    id="instant-validation-true"
+                    instantValidation={true}
+                />
+                <LabelSmall htmlFor="instant-validation-false">
+                    Instant Validation: false
+                </LabelSmall>
+                <ControlledTextArea
+                    {...args}
+                    id="instant-validation-false"
+                    instantValidation={false}
+                />
+            </View>
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
  * A required field will have error styling if the field is left blank. To
  * observe this, type something into the field, backspace all the way,
  * and then shift focus out of the field.

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -1376,7 +1376,7 @@ describe("TextArea", () => {
             });
 
             describe("instantValidation=true", () => {
-                it("should call validate each time the value changes if the instantValidation prop is true", async () => {
+                it("should call validate each time the value changes", async () => {
                     // Arrange
                     const validate = jest.fn();
                     render(
@@ -1446,7 +1446,7 @@ describe("TextArea", () => {
                 });
             });
             describe("instantValidation=false", () => {
-                it("should call validate once the user leaves the field if the instantValidation prop is false", async () => {
+                it("should call validate once the user leaves the field", async () => {
                     // Arrange
                     const validate = jest.fn();
                     render(
@@ -1466,7 +1466,7 @@ describe("TextArea", () => {
                     expect(validate).toHaveBeenCalledExactlyOnceWith("test");
                 });
 
-                it("should call onValidate once the user leaves the field if the instantValidation prop is false", async () => {
+                it("should call onValidate once the user leaves the field", async () => {
                     // Arrange
                     const handleValidate = jest.fn();
                     const errorMsg = "error message";

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -1546,7 +1546,7 @@ describe("TextArea", () => {
                     expect(field).toHaveAttribute("aria-invalid", "false");
                 });
 
-                it("should call onValidate with an empty string when the user changes the value after there was an error", async () => {
+                it("should call onValidate with an null when the user changes the value after there was an error", async () => {
                     // Arrange
                     const handleValidate = jest.fn();
                     const errorMsg = "error message";
@@ -1570,7 +1570,7 @@ describe("TextArea", () => {
                     // Assert
                     expect(handleValidate.mock.calls).toStrictEqual([
                         [errorMsg],
-                        [""],
+                        [null],
                     ]);
                 });
 

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -1546,7 +1546,7 @@ describe("TextArea", () => {
                     expect(field).toHaveAttribute("aria-invalid", "false");
                 });
 
-                it("should call onValidate with an null when the user changes the value after there was an error", async () => {
+                it("should call onValidate with null when the user changes the value after there was an error", async () => {
                     // Arrange
                     const handleValidate = jest.fn();
                     const errorMsg = "error message";

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -1568,7 +1568,10 @@ describe("TextArea", () => {
                     await userEvent.type(field, "tests");
 
                     // Assert
-                    expect(handleValidate).toHaveBeenLastCalledWith("");
+                    expect(handleValidate.mock.calls).toStrictEqual([
+                        [errorMsg],
+                        [""],
+                    ]);
                 });
 
                 it("should not call the validate prop on blur if it is disabled", async () => {
@@ -1659,9 +1662,10 @@ describe("TextArea", () => {
                         await userEvent.tab();
 
                         // Assert
-                        expect(onValidate).toHaveBeenLastCalledWith(
-                            requiredMessage,
-                        );
+                        expect(onValidate.mock.calls).toStrictEqual([
+                            [null],
+                            [requiredMessage],
+                        ]);
                     });
 
                     it("shound be in error state if it is required, the value is empty, and the user tabs away", async () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -1160,6 +1160,28 @@ describe("TextArea", () => {
                 expect(textArea).toHaveAttribute("aria-invalid", "false");
             });
 
+            it("should not be in an error state if it is required, the field is empty, and a user tabs through the field", async () => {
+                // Arrange
+                render(
+                    <TextArea
+                        value=""
+                        onChange={() => {}}
+                        required="Required"
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                // Tab into field
+                await userEvent.tab();
+                // Tab out of field
+                await userEvent.tab();
+
+                // Assert
+                const textArea = await screen.findByRole("textbox");
+                expect(textArea).toHaveAttribute("aria-invalid", "false");
+            });
+
             it("shound update with error if it is required and the value changes to an empty string", async () => {
                 // Arrange
                 render(
@@ -1566,6 +1588,152 @@ describe("TextArea", () => {
 
                     // Assert
                     expect(validate).not.toHaveBeenCalled();
+                });
+
+                describe("required", () => {
+                    it("shound be in error state if it is required, the value changes to an empty string, and the user tabs away", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTextArea
+                                value="T"
+                                required="Required"
+                                instantValidation={false}
+                            />,
+                            defaultOptions,
+                        );
+
+                        // Act
+                        const field = await screen.findByRole("textbox");
+                        await userEvent.type(field, "{backspace}");
+                        await userEvent.tab();
+
+                        // Assert
+                        const textArea = await screen.findByRole("textbox");
+                        expect(textArea).toHaveAttribute(
+                            "aria-invalid",
+                            "true",
+                        );
+                    });
+
+                    it("shound call onValidate with the required message if it is required, the value changes to an empty string, and the user tabs away", async () => {
+                        // Arrange
+                        const onValidate = jest.fn();
+                        const requiredMessage = "Required";
+                        render(
+                            <ControlledTextArea
+                                value="T"
+                                required={requiredMessage}
+                                instantValidation={false}
+                                onValidate={onValidate}
+                            />,
+                            defaultOptions,
+                        );
+
+                        // Act
+                        const field = await screen.findByRole("textbox");
+                        await userEvent.type(field, "{backspace}");
+                        await userEvent.tab();
+
+                        // Assert
+                        expect(onValidate).toHaveBeenLastCalledWith(
+                            requiredMessage,
+                        );
+                    });
+
+                    it("shound be in error state if it is required, the value is empty, and the user tabs away", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTextArea
+                                required="Required"
+                                instantValidation={false}
+                            />,
+                            defaultOptions,
+                        );
+
+                        // Act
+                        // Tab into field
+                        await userEvent.tab();
+                        // Tab out of field
+                        await userEvent.tab();
+
+                        // Assert
+                        const textArea = await screen.findByRole("textbox");
+                        expect(textArea).toHaveAttribute(
+                            "aria-invalid",
+                            "true",
+                        );
+                    });
+
+                    it("shound call onValidate with the required message if it is required, the value is empty, and the user tabs away", async () => {
+                        // Arrange
+                        const onValidate = jest.fn();
+                        const requiredMessage = "Required";
+                        render(
+                            <ControlledTextArea
+                                required={requiredMessage}
+                                onValidate={onValidate}
+                                instantValidation={false}
+                            />,
+                            defaultOptions,
+                        );
+
+                        // Act
+                        // Tab into field
+                        await userEvent.tab();
+                        // Tab out of field
+                        await userEvent.tab();
+
+                        // Assert
+                        expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                            requiredMessage,
+                        );
+                    });
+
+                    it("should not be in error state if it is not required, the value is empty, and the user tabs away", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTextArea
+                                required={undefined}
+                                instantValidation={false}
+                            />,
+                            defaultOptions,
+                        );
+
+                        // Act
+                        // Tab into field
+                        await userEvent.tab();
+                        // Tab out of field
+                        await userEvent.tab();
+
+                        // Assert
+                        const textArea = await screen.findByRole("textbox");
+                        expect(textArea).toHaveAttribute(
+                            "aria-invalid",
+                            "false",
+                        );
+                    });
+
+                    it("should not call onValidate if it is not required, the value is empty, and the user tabs away", async () => {
+                        // Arrange
+                        const onValidate = jest.fn();
+                        render(
+                            <ControlledTextArea
+                                required={undefined}
+                                instantValidation={false}
+                                onValidate={onValidate}
+                            />,
+                            defaultOptions,
+                        );
+
+                        // Act
+                        // Tab into field
+                        await userEvent.tab();
+                        // Tab out of field
+                        await userEvent.tab();
+
+                        // Assert
+                        expect(onValidate).not.toHaveBeenCalled();
+                    });
                 });
             });
         });

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -1579,6 +1579,7 @@ describe("TextArea", () => {
                             value="test"
                             validate={validate}
                             disabled={true}
+                            instantValidation={false}
                         />,
                         defaultOptions,
                     );
@@ -1612,6 +1613,29 @@ describe("TextArea", () => {
                         expect(textArea).toHaveAttribute(
                             "aria-invalid",
                             "true",
+                        );
+                    });
+
+                    it("shound not be in error state if it is required, the value changes to an empty string, and the user has not tabbed away", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTextArea
+                                value="T"
+                                required="Required"
+                                instantValidation={false}
+                            />,
+                            defaultOptions,
+                        );
+
+                        // Act
+                        const field = await screen.findByRole("textbox");
+                        await userEvent.type(field, "{backspace}");
+
+                        // Assert
+                        const textArea = await screen.findByRole("textbox");
+                        expect(textArea).toHaveAttribute(
+                            "aria-invalid",
+                            "false",
                         );
                     });
 

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -266,10 +266,13 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         const handleBlur = (event: React.FocusEvent<HTMLTextAreaElement>) => {
             // Only handle validation on blur if instantValidation is false
             if (!instantValidation) {
-                // Only handle validation when there is a value in the field so
-                // a user tabbing through fields doesn't trigger the error state
-                // when the field is left empty
-                if (event.target.value) {
+                // Handle validation on blur if:
+                // 1. There is a value in the field so a user tabbing through
+                // fields doesn't trigger the error state when the field is left
+                // empty. Or,
+                // 2. The field is required. Tabbing through an empty field that
+                // is required will trigger the error state
+                if (event.target.value || required) {
                     handleValidation(event.target.value);
                 }
             }

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -255,9 +255,9 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     // If instantValidation is false and there is an error
                     // message, error needs to be cleared when the user updates
                     // the value
-                    setErrorMessage("");
+                    setErrorMessage(null);
                     if (onValidate) {
-                        onValidate("");
+                        onValidate(null);
                     }
                 }
             }


### PR DESCRIPTION
## Summary:
- Adds instantValidation prop so there is an option to validate on blur. If instantValidation is false, the error is also cleared on change
- If textarea is required and instantValidation is false, validate whenever the user tabs away from the field

Issue: WB-1781

Next: I'll work on refactoring TextField to a function component first and then will add the same `instantValidation` prop to TextField

## Test plan:
- Instant Validation docs are reviewed (`/?path=/docs/packages-form-textarea--docs#instant%20validation`)
- Instant Validation works as expected (see docs for expected behaviour) (`/?path=/story/packages-form-textarea--instant-validation`)