### PR TITLE
SearchField: Add validation props and refine states

### DIFF
--- a/.changeset/breezy-bears-teach.md
+++ b/.changeset/breezy-bears-teach.md
@@ -5,4 +5,5 @@
 # SearchField
 
 - Adds `error`, `instantValidation`, `validate`, and `onValidate` props to be consistent with form components.
+- Refine magnifying glass icon styling to make it match Figma more (smaller, bold icon, spacing, update disabled state)
 - Hide the clear button if the SearchField is disabled

--- a/.changeset/breezy-bears-teach.md
+++ b/.changeset/breezy-bears-teach.md
@@ -5,5 +5,5 @@
 # SearchField
 
 - Adds `error`, `instantValidation`, `validate`, and `onValidate` props to be consistent with form components.
-- Refine magnifying glass icon and dismiss icon button styling to make it match Figma more (smaller, bold icon, spacing, update disabled state)
+- Refine magnifying glass icon styling to make it match Figma more (smaller, bold icon, spacing, update disabled state)
 - Hide the clear button if the SearchField is disabled

--- a/.changeset/breezy-bears-teach.md
+++ b/.changeset/breezy-bears-teach.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-search-field": minor
+---
+
+SearchField: Adds `error`, `instantValidation`, `validate`, and `onValidate` props to be consistent with form components.

--- a/.changeset/breezy-bears-teach.md
+++ b/.changeset/breezy-bears-teach.md
@@ -5,5 +5,4 @@
 # SearchField
 
 - Adds `error`, `instantValidation`, `validate`, and `onValidate` props to be consistent with form components.
-- Refine icon styling and use semantic color tokens
 - Hide the clear button if the SearchField is disabled

--- a/.changeset/breezy-bears-teach.md
+++ b/.changeset/breezy-bears-teach.md
@@ -2,4 +2,8 @@
 "@khanacademy/wonder-blocks-search-field": minor
 ---
 
-SearchField: Adds `error`, `instantValidation`, `validate`, and `onValidate` props to be consistent with form components.
+# SearchField
+
+- Adds `error`, `instantValidation`, `validate`, and `onValidate` props to be consistent with form components.
+- Refine icon styling and use semantic color tokens
+- Hide the clear button if the SearchField is disabled

--- a/.changeset/breezy-bears-teach.md
+++ b/.changeset/breezy-bears-teach.md
@@ -5,5 +5,5 @@
 # SearchField
 
 - Adds `error`, `instantValidation`, `validate`, and `onValidate` props to be consistent with form components.
-- Refine magnifying glass icon styling to make it match Figma more (smaller, bold icon, spacing, update disabled state)
+- Refine magnifying glass icon and dismiss icon button styling to make it match Figma more (smaller, bold icon, spacing, update disabled state)
 - Hide the clear button if the SearchField is disabled

--- a/__docs__/wonder-blocks-search-field/search-field-variants.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field-variants.stories.tsx
@@ -1,0 +1,167 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import type {Meta, StoryObj} from "@storybook/react";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import SearchField from "@khanacademy/wonder-blocks-search-field";
+
+/**
+ * The following stories are used to generate the pseudo states for the
+ * SearchField component. This is only used for visual testing in Chromatic.
+ */
+export default {
+    title: "Packages / SearchField / All Variants",
+    parameters: {
+        docs: {
+            autodocs: false,
+        },
+    },
+} as Meta;
+
+type StoryComponentType = StoryObj<typeof SearchField>;
+
+const longText =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
+const longTextWithNoWordBreak =
+    "Loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliqua";
+
+const states = [
+    {
+        label: "Default",
+        props: {},
+    },
+    {
+        label: "Disabled",
+        props: {disabled: true},
+    },
+    {
+        label: "Error",
+        props: {error: true},
+    },
+];
+const States = (props: {
+    light: boolean;
+    label: string;
+    value?: string;
+    placeholder?: string;
+}) => {
+    return (
+        <View
+            style={[props.light && styles.darkDefault, styles.statesContainer]}
+        >
+            <LabelLarge style={props.light && {color: color.white}}>
+                {props.label}
+            </LabelLarge>
+            <View style={[styles.scenarios]}>
+                {states.map((scenario) => {
+                    return (
+                        <View style={styles.scenario} key={scenario.label}>
+                            <LabelMedium
+                                style={props.light && {color: color.white}}
+                            >
+                                {scenario.label}
+                            </LabelMedium>
+                            <SearchField
+                                value=""
+                                onChange={() => {}}
+                                {...props}
+                                {...scenario.props}
+                            />
+                        </View>
+                    );
+                })}
+            </View>
+        </View>
+    );
+};
+
+const AllVariants = () => (
+    <View>
+        {[false, true].map((light) => {
+            return (
+                <React.Fragment key={`light-${light}`}>
+                    <States light={light} label="Default" />
+                    <States light={light} label="With Value" value="Text" />
+                    <States
+                        light={light}
+                        label="With Value (long)"
+                        value={longText}
+                    />
+                    <States
+                        light={light}
+                        label="With Value (long, no word breaks)"
+                        value={longTextWithNoWordBreak}
+                    />
+                    <States
+                        light={light}
+                        label="With Placeholder"
+                        placeholder="Placeholder text"
+                    />
+                    <States
+                        light={light}
+                        label="With Placeholder (long)"
+                        placeholder={longText}
+                    />
+                    <States
+                        light={light}
+                        label="With Placeholder (long, no word breaks)"
+                        placeholder={longTextWithNoWordBreak}
+                    />
+                </React.Fragment>
+            );
+        })}
+    </View>
+);
+
+export const Default: StoryComponentType = {
+    render: AllVariants,
+};
+
+/**
+ * There are currently only hover styles on the clear button.
+ */
+export const Hover: StoryComponentType = {
+    render: AllVariants,
+    parameters: {pseudo: {hover: true}},
+};
+
+export const Focus: StoryComponentType = {
+    render: AllVariants,
+    parameters: {pseudo: {focusVisible: true}},
+};
+
+export const HoverFocus: StoryComponentType = {
+    name: "Hover + Focus",
+    render: AllVariants,
+    parameters: {pseudo: {hover: true, focusVisible: true}},
+};
+
+/**
+ * There are currently no active styles.
+ */
+export const Active: StoryComponentType = {
+    render: AllVariants,
+    parameters: {pseudo: {active: true}},
+};
+
+const styles = StyleSheet.create({
+    darkDefault: {
+        backgroundColor: color.darkBlue,
+    },
+    statesContainer: {
+        padding: spacing.medium_16,
+    },
+    scenarios: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: spacing.xxxLarge_64,
+        flexWrap: "wrap",
+    },
+    scenario: {
+        gap: spacing.small_12,
+        overflow: "hidden",
+    },
+});

--- a/__docs__/wonder-blocks-search-field/search-field-variants.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field-variants.stories.tsx
@@ -154,7 +154,6 @@ const styles = StyleSheet.create({
         padding: spacing.medium_16,
     },
     scenarios: {
-        display: "flex",
         flexDirection: "row",
         alignItems: "center",
         gap: spacing.xxxLarge_64,

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -54,7 +54,10 @@ export default {
 type StoryComponentType = StoryObj<typeof SearchField>;
 
 const Template = (args: PropsFor<typeof SearchField>) => {
-    const [value, setValue] = React.useState("");
+    const [value, setValue] = React.useState(args?.value || "");
+    const [errorMessage, setErrorMessage] = React.useState<
+        string | null | undefined
+    >("");
 
     const handleChange = (newValue: string) => {
         setValue(newValue);
@@ -67,15 +70,26 @@ const Template = (args: PropsFor<typeof SearchField>) => {
     };
 
     return (
-        <SearchField
-            {...args}
-            value={value}
-            onChange={handleChange}
-            onKeyDown={(e) => {
-                action("onKeyDown")(e);
-                handleKeyDown(e);
-            }}
-        />
+        <View>
+            <SearchField
+                {...args}
+                value={value}
+                onChange={handleChange}
+                onKeyDown={(e) => {
+                    action("onKeyDown")(e);
+                    handleKeyDown(e);
+                }}
+                onValidate={setErrorMessage}
+            />
+            {(errorMessage || args.error) && (
+                <>
+                    <Strut size={spacing.xSmall_8} />
+                    <LabelSmall style={styles.errorMessage}>
+                        {errorMessage || "Error from error prop"}
+                    </LabelSmall>
+                </>
+            )}
+        </View>
     );
 };
 
@@ -248,21 +262,30 @@ export const Validation: StoryComponentType = {
                 return "Too short. Value should be at least 5 characters";
             }
         },
-        instantValidation: false,
     },
-    render: function Render(args: PropsFor<typeof SearchField>) {
-        const [errorMessage, setErrorMessage] = React.useState<
-            string | null | undefined
-        >(null);
+    render: (args) => {
         return (
-            <View>
-                <Template {...args} onValidate={setErrorMessage} />
-                <Strut size={spacing.xxSmall_6} />
-                {(errorMessage || args.error) && (
-                    <LabelSmall style={styles.errorMessage}>
-                        {errorMessage || "Error from error prop"}
-                    </LabelSmall>
-                )}
+            <View style={{gap: spacing.small_12}}>
+                <LabelSmall htmlFor="instant-validation-true">
+                    Validation on mount if there is a value
+                </LabelSmall>
+                <Template {...args} id="instant-validation-true" value="T" />
+                <LabelSmall htmlFor="instant-validation-true">
+                    Error shown immediately (instantValidation: true)
+                </LabelSmall>
+                <Template
+                    {...args}
+                    id="instant-validation-true"
+                    instantValidation={true}
+                />
+                <LabelSmall htmlFor="instant-validation-false">
+                    Error shown onBlur (instantValidation: false)
+                </LabelSmall>
+                <Template
+                    {...args}
+                    id="instant-validation-false"
+                    instantValidation={false}
+                />
             </View>
         );
     },

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -3,16 +3,17 @@ import {StyleSheet} from "aphrodite";
 import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import {View} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {LabelLarge, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-search-field/package.json";
 import SearchFieldArgtypes from "./search-field.argtypes";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 /**
  * `SearchField` helps users input text to search for relevant content. It is
@@ -52,7 +53,7 @@ export default {
 
 type StoryComponentType = StoryObj<typeof SearchField>;
 
-const Template = (args: any) => {
+const Template = (args: PropsFor<typeof SearchField>) => {
     const [value, setValue] = React.useState("");
 
     const handleChange = (newValue: string) => {
@@ -227,9 +228,45 @@ export const Error: StoryComponentType = {
     render: Template,
 };
 
+/**
+ * The SearchField supports `validate`, `onValidate`, and `instantValidation`
+ * props. See docs for the TextField component for more details since
+ * SearchField uses TextField internally.
+ */
+export const Validation: StoryComponentType = {
+    args: {
+        validate(value) {
+            if (value.length < 5) {
+                return "Too short. Value should be at least 5 characters";
+            }
+        },
+        instantValidation: false,
+    },
+    render: function Render(args: PropsFor<typeof SearchField>) {
+        const [errorMessage, setErrorMessage] = React.useState<
+            string | null | undefined
+        >(null);
+        return (
+            <View>
+                <Template {...args} onValidate={setErrorMessage} />
+                <Strut size={spacing.xxSmall_6} />
+                {(errorMessage || args.error) && (
+                    <LabelSmall style={styles.errorMessage}>
+                        {errorMessage || "Error from error prop"}
+                    </LabelSmall>
+                )}
+            </View>
+        );
+    },
+};
+
 const styles = StyleSheet.create({
     darkBackground: {
         background: color.darkBlue,
         padding: spacing.medium_16,
+    },
+    errorMessage: {
+        color: color.red,
+        paddingLeft: spacing.xxxSmall_4,
     },
 });

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -70,7 +70,7 @@ const Template = (args: PropsFor<typeof SearchField>) => {
     };
 
     return (
-        <View>
+        <View style={{gap: spacing.xSmall_8}}>
             <SearchField
                 {...args}
                 value={value}
@@ -82,12 +82,9 @@ const Template = (args: PropsFor<typeof SearchField>) => {
                 onValidate={setErrorMessage}
             />
             {(errorMessage || args.error) && (
-                <>
-                    <Strut size={spacing.xSmall_8} />
-                    <LabelSmall style={styles.errorMessage}>
-                        {errorMessage || "Error from error prop"}
-                    </LabelSmall>
-                </>
+                <LabelSmall style={styles.errorMessage}>
+                    {errorMessage || "Error from error prop"}
+                </LabelSmall>
             )}
         </View>
     );

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -226,6 +226,12 @@ export const Error: StoryComponentType = {
         error: true,
     },
     render: Template,
+    parameters: {
+        chromatic: {
+            // Disabling because this is covered by the All Variants stories
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**
@@ -257,6 +263,12 @@ export const Validation: StoryComponentType = {
                 )}
             </View>
         );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
     },
 };
 

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -13,7 +13,6 @@ import SearchField from "@khanacademy/wonder-blocks-search-field";
 import ComponentInfo from "../../.storybook/components/component-info";
 import packageConfig from "../../packages/wonder-blocks-search-field/package.json";
 import SearchFieldArgtypes from "./search-field.argtypes";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 /**
  * `SearchField` helps users input text to search for relevant content. It is

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -217,6 +217,16 @@ export const WithAutofocus: StoryComponentType = {
     },
 };
 
+/**
+ * The SearchField can be put in an error state using the `error` prop.
+ */
+export const Error: StoryComponentType = {
+    args: {
+        error: true,
+    },
+    render: Template,
+};
+
 const styles = StyleSheet.create({
     darkBackground: {
         background: color.darkBlue,

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -236,8 +236,10 @@ export const Error: StoryComponentType = {
 
 /**
  * The SearchField supports `validate`, `onValidate`, and `instantValidation`
- * props. See docs for the TextField component for more details since
- * SearchField uses TextField internally.
+ * props.
+ *
+ * See docs for the TextField component for more details around validation
+ * since SearchField uses TextField internally.
  */
 export const Validation: StoryComponentType = {
     args: {

--- a/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
+++ b/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
@@ -210,6 +210,19 @@ describe("SearchField", () => {
         expect(dismissIcon).toBeInTheDocument();
     });
 
+    test("does not display the clear icon button if the field is disabled", async () => {
+        // Arrange
+        render(
+            <SearchField value="Value" onChange={() => {}} disabled={true} />,
+        );
+
+        // Act
+        const clearButton = screen.queryByRole("button");
+
+        // Assert
+        expect(clearButton).not.toBeInTheDocument();
+    });
+
     test("clear button clears any text in the field", async () => {
         // Arrange
         const SearchFieldWrapper = () => {

--- a/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
+++ b/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
@@ -612,6 +612,26 @@ describe("SearchField", () => {
                 expect(validate).toHaveBeenCalledWith("t");
             });
 
+            it("should not call the validate prop before a user leaves the field", async () => {
+                // Arrange
+                const validate = jest.fn();
+                render(
+                    <ControlledSearchField
+                        value=""
+                        onChange={() => {}}
+                        validate={validate}
+                        instantValidation={false}
+                    />,
+                );
+                const field = await screen.findByRole("textbox");
+
+                // Act
+                await userEvent.type(field, "t");
+
+                // Assert
+                expect(validate).not.toHaveBeenCalled();
+            });
+
             it("should call the onValidate prop when the field is validated after a user leaves the field", async () => {
                 // Arrange
                 const onValidate = jest.fn();

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import xIcon from "@phosphor-icons/core/bold/x-bold.svg";
+import xIcon from "@phosphor-icons/core/regular/x.svg";
 import magnifyingGlassIcon from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
@@ -181,7 +181,7 @@ const SearchField: React.ForwardRefExoticComponent<
         return (
             <IconButton
                 icon={xIcon}
-                size="xsmall"
+                size="small"
                 kind="tertiary"
                 onClick={handleClear}
                 style={styles.dismissIcon}

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import xIcon from "@phosphor-icons/core/regular/x.svg";
-import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
+import magnifyingGlassIcon from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {View, IDProvider} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {defaultLabels} from "../util/constants";
@@ -195,8 +195,14 @@ const SearchField: React.ForwardRefExoticComponent<
                 <View onClick={onClick} style={[styles.inputContainer, style]}>
                     <PhosphorIcon
                         icon={magnifyingGlassIcon}
-                        size="medium"
-                        color={color.offBlack64}
+                        size="small"
+                        color={
+                            disabled
+                                ? light
+                                    ? color.white32
+                                    : semanticColor.action.disabled.default
+                                : semanticColor.icon.primary
+                        }
                         style={styles.searchIcon}
                         aria-hidden="true"
                     />
@@ -260,7 +266,7 @@ const styles = StyleSheet.create({
         display: "flex",
         flex: 1,
         width: "100%",
-        paddingLeft: spacing.large_24 + spacing.medium_16,
+        paddingLeft: spacing.xLarge_32,
         paddingRight: spacing.large_24 + spacing.medium_16,
     },
 });

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import xIcon from "@phosphor-icons/core/regular/x.svg";
-import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
+import magnifyingGlassIcon from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {View, IDProvider} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {defaultLabels} from "../util/constants";
@@ -59,6 +59,10 @@ type Props = AriaProps & {
      * Test ID used for e2e testing.
      */
     testId?: string;
+    /**
+     * Whether the search field is in an error state.
+     */
+    error?: boolean;
     /**
      * Called when the value has changed.
      */
@@ -123,6 +127,7 @@ const SearchField: React.ForwardRefExoticComponent<
         placeholder,
         style,
         testId,
+        error,
         onClick,
         onChange,
         onFocus,
@@ -167,8 +172,8 @@ const SearchField: React.ForwardRefExoticComponent<
                 <View onClick={onClick} style={[styles.inputContainer, style]}>
                     <PhosphorIcon
                         icon={magnifyingGlassIcon}
-                        size="medium"
-                        color={color.offBlack64}
+                        size="small"
+                        color={semanticColor.icon.primary}
                         style={styles.searchIcon}
                         aria-hidden="true"
                     />
@@ -182,6 +187,7 @@ const SearchField: React.ForwardRefExoticComponent<
                         onFocus={onFocus}
                         onBlur={onBlur}
                         placeholder={placeholder}
+                        error={error}
                         ref={(node) => {
                             // We have to set the value of both refs to
                             // the HTMLInputElement from TextField.

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import xIcon from "@phosphor-icons/core/regular/x.svg";
-import magnifyingGlassIcon from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
+import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {View, IDProvider} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {defaultLabels} from "../util/constants";
@@ -195,8 +195,8 @@ const SearchField: React.ForwardRefExoticComponent<
                 <View onClick={onClick} style={[styles.inputContainer, style]}>
                     <PhosphorIcon
                         icon={magnifyingGlassIcon}
-                        size="small"
-                        color={semanticColor.icon.primary}
+                        size="medium"
+                        color={color.offBlack64}
                         style={styles.searchIcon}
                         aria-hidden="true"
                     />

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -151,7 +151,7 @@ const SearchField: React.ForwardRefExoticComponent<
 
     // @ts-expect-error [FEI-5019] - TS2322 - Type '() => JSX.Element | null' is not assignable to type '() => ReactElement<any, string | JSXElementConstructor<any>>'.
     const maybeRenderClearIconButton: () => React.ReactElement = () => {
-        if (!value.length) {
+        if (!value.length || disabled) {
             return null;
         }
 

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -64,6 +64,26 @@ type Props = AriaProps & {
      */
     error?: boolean;
     /**
+     * Provide a validation for the input value.
+     * Return a string error message or null | void for a valid input.
+     *
+     * Use this for errors that are shown to the user while they are filling out
+     * a form.
+     */
+    validate?: (value: string) => string | null | void;
+    /**
+     * Called right after the SearchField is validated.
+     */
+    onValidate?: (errorMessage?: string | null | undefined) => unknown;
+    /**
+     * If true, SearchField is validated as the user types (onChange). If false,
+     * it is validated when the user's focus moves out of the field (onBlur).
+     * It is preferred that instantValidation is set to `false`, however, it
+     * defaults to `true` for consistency with form components like TextField
+     * and TextArea.
+     */
+    instantValidation?: boolean;
+    /**
      * Called when the value has changed.
      */
     onChange: (newValue: string) => unknown;
@@ -128,6 +148,9 @@ const SearchField: React.ForwardRefExoticComponent<
         style,
         testId,
         error,
+        instantValidation = true,
+        validate,
+        onValidate,
         onClick,
         onChange,
         onFocus,
@@ -183,6 +206,9 @@ const SearchField: React.ForwardRefExoticComponent<
                         autoFocus={autoFocus}
                         disabled={disabled}
                         light={light}
+                        instantValidation={instantValidation}
+                        validate={validate}
+                        onValidate={onValidate}
                         onChange={onChange}
                         onFocus={onFocus}
                         onBlur={onBlur}

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -255,9 +255,6 @@ const styles = StyleSheet.create({
         margin: 0,
         position: "absolute",
         right: 0,
-        ":hover": {
-            border: "none",
-        },
     },
     inputStyleReset: {
         display: "flex",

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import xIcon from "@phosphor-icons/core/regular/x.svg";
+import xIcon from "@phosphor-icons/core/bold/x-bold.svg";
 import magnifyingGlassIcon from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
@@ -181,6 +181,7 @@ const SearchField: React.ForwardRefExoticComponent<
         return (
             <IconButton
                 icon={xIcon}
+                size="xsmall"
                 kind="tertiary"
                 onClick={handleClear}
                 style={styles.dismissIcon}
@@ -260,7 +261,7 @@ const styles = StyleSheet.create({
     dismissIcon: {
         margin: 0,
         position: "absolute",
-        right: 0,
+        right: spacing.xxxSmall_4,
     },
     inputStyleReset: {
         display: "flex",

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -9,7 +9,7 @@ import {View, IDProvider} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {defaultLabels} from "../util/constants";
@@ -236,11 +236,7 @@ const styles = StyleSheet.create({
     inputStyleReset: {
         display: "flex",
         flex: 1,
-        "::placeholder": {
-            color: color.offBlack64,
-        },
         width: "100%",
-        color: "inherit",
         paddingLeft: spacing.large_24 + spacing.medium_16,
         paddingRight: spacing.large_24 + spacing.medium_16,
     },


### PR DESCRIPTION
## Summary:
To make the SearchField component more consistent with other form field components like TextField and TextArea, we add validation related props to the component. See [LabeledField Implementation Spec](https://khanacademy.atlassian.net/wiki/spaces/WB/pages/2261352551/LabeledField+Implementation+Spec) for more details!

The changes include:
- Add error, instantValidation, validate, onValidate props to SearchField
- Minor tweaks
  - Hide clear icon button if the field is disabled
  - Refine magnifying glass icon styling to make it [match Figma component](https://www.figma.com/design/VbVu3h2BpBhH80niq101MHHE/%F0%9F%92%A0-Main-Components?node-id=13840-8605&t=83MBW2IFJ6nx42vp-4) more (smaller, bold icon, spacing, update disabled state)
- Storybook:
  - Add error and validation stories for SearchField
  - Add variant stories for SearchField states

Issue: WB-1761

## Test plan:
- Review Storybook docs for Error and Validation stories
  - `?path=/docs/packages-searchfield--docs#error`
  - `?path=/docs/packages-searchfield--docs#validation`
- Review prop documentation for SearchField (`?path=/docs/packages-searchfield--docs`)
- Review new Search Field All Variants stories (`?path=/docs/packages-searchfield-all-variants--docs`)
- Review Chromatic diff for styling updates (left some comments in the UI Tests!)