### PR TITLE
WB-1779: Add startIcon prop to Combobox

### DIFF
--- a/.changeset/old-pears-fix.md
+++ b/.changeset/old-pears-fix.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Add `startIcon` prop to Combobox

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -6,7 +6,7 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
@@ -440,8 +440,39 @@ export const Error: Story = {
  * In this example, we show how this is done by setting the `startIcon` prop.
  */
 export const StartIcon: Story = {
+    render: function Render(args: PropsFor<typeof Combobox>) {
+        const [_, updateArgs] = useArgs();
+
+        return (
+            <View style={{gap: spacing.medium_16}}>
+                <LabelMedium>Default:</LabelMedium>
+                <Combobox
+                    {...args}
+                    onChange={(newValue) => {
+                        updateArgs({value: newValue});
+                        action("onChange")(newValue);
+                    }}
+                />
+                <LabelMedium>Disabled:</LabelMedium>
+                <Combobox
+                    {...args}
+                    disabled={true}
+                    onChange={(newValue) => {
+                        updateArgs({value: newValue});
+                        action("onChange")(newValue);
+                    }}
+                />
+            </View>
+        );
+    },
     args: {
         children: items,
-        startIcon: <PhosphorIcon icon={magnifyingGlassIcon} size="medium" />,
+        startIcon: (
+            <PhosphorIcon
+                icon={magnifyingGlassIcon}
+                size="medium"
+                color={color.offBlack64}
+            />
+        ),
     },
 };

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -4,10 +4,10 @@ import {Meta, StoryObj} from "@storybook/react";
 import {expect, userEvent, within} from "@storybook/test";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
-import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
+import magnifyingGlassIcon from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 
 import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -433,11 +433,16 @@ export const Error: Story = {
 };
 
 /**
- * With start icon, you can customize the icon that appears at the beginning of
+ * With `startIcon`, you can customize the icon that appears at the beginning of
  * the Combobox. This is useful when you want to add a custom icon to the
  * component.
  *
- * In this example, we show how this is done by setting the `startIcon` prop.
+ * **NOTE:** When `startIcon` is set, we set some default values for the icon:
+ * - `size`: "small"
+ * - `color`: `semanticColor.icon.default`
+ *
+ * You can customize the size and color of the icon by passing the `size` and
+ * `color` props to the `PhosphorIcon` component.
  */
 export const StartIcon: Story = {
     render: function Render(args: PropsFor<typeof Combobox>) {
@@ -445,17 +450,56 @@ export const StartIcon: Story = {
 
         return (
             <View style={{gap: spacing.medium_16}}>
-                <LabelMedium>Default:</LabelMedium>
+                <LabelMedium>With default size and color:</LabelMedium>
                 <Combobox
                     {...args}
+                    startIcon={
+                        <PhosphorIcon icon={magnifyingGlassIcon} size="small" />
+                    }
                     onChange={(newValue) => {
                         updateArgs({value: newValue});
                         action("onChange")(newValue);
                     }}
                 />
-                <LabelMedium>Disabled:</LabelMedium>
+                <LabelMedium>With custom size:</LabelMedium>
                 <Combobox
                     {...args}
+                    startIcon={
+                        <PhosphorIcon
+                            icon={magnifyingGlassIcon}
+                            size="medium"
+                        />
+                    }
+                    onChange={(newValue) => {
+                        updateArgs({value: newValue});
+                        action("onChange")(newValue);
+                    }}
+                />
+                <LabelMedium>With custom color:</LabelMedium>
+                <Combobox
+                    {...args}
+                    startIcon={
+                        <PhosphorIcon
+                            icon={magnifyingGlassIcon}
+                            size="small"
+                            color={semanticColor.icon.action}
+                        />
+                    }
+                    onChange={(newValue) => {
+                        updateArgs({value: newValue});
+                        action("onChange")(newValue);
+                    }}
+                />
+                <LabelMedium>Disabled (overrides color prop):</LabelMedium>
+                <Combobox
+                    {...args}
+                    startIcon={
+                        <PhosphorIcon
+                            icon={magnifyingGlassIcon}
+                            size="small"
+                            color={semanticColor.icon.action}
+                        />
+                    }
                     disabled={true}
                     onChange={(newValue) => {
                         updateArgs({value: newValue});
@@ -467,12 +511,5 @@ export const StartIcon: Story = {
     },
     args: {
         children: items,
-        startIcon: (
-            <PhosphorIcon
-                icon={magnifyingGlassIcon}
-                size="medium"
-                color={color.offBlack64}
-            />
-        ),
     },
 };

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -453,9 +453,7 @@ export const StartIcon: Story = {
                 <LabelMedium>With default size and color:</LabelMedium>
                 <Combobox
                     {...args}
-                    startIcon={
-                        <PhosphorIcon icon={magnifyingGlassIcon} size="small" />
-                    }
+                    startIcon={<PhosphorIcon icon={magnifyingGlassIcon} />}
                     onChange={(newValue) => {
                         updateArgs({value: newValue});
                         action("onChange")(newValue);

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -4,10 +4,13 @@ import {Meta, StoryObj} from "@storybook/react";
 import {expect, userEvent, within} from "@storybook/test";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
+import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
+
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {allProfilesWithPictures} from "./option-item-examples";
 
@@ -426,5 +429,19 @@ export const Error: Story = {
     args: {
         children: items,
         error: true,
+    },
+};
+
+/**
+ * With start icon, you can customize the icon that appears at the beginning of
+ * the Combobox. This is useful when you want to add a custom icon to the
+ * component.
+ *
+ * In this example, we show how this is done by setting the `startIcon` prop.
+ */
+export const StartIcon: Story = {
+    args: {
+        children: items,
+        startIcon: <PhosphorIcon icon={magnifyingGlassIcon} size="medium" />,
     },
 };

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/combobox.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/combobox.test.tsx
@@ -1,12 +1,14 @@
-import * as React from "react";
-import {render, screen, waitFor} from "@testing-library/react";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render, screen, waitFor} from "@testing-library/react";
+import * as React from "react";
+import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {PointerEventsCheckLevel, userEvent} from "@testing-library/user-event";
-import Combobox from "../combobox";
-import OptionItem from "../option-item";
 import {defaultComboboxLabels} from "../../util/constants";
 import {MaybeValueOrValues} from "../../util/types";
+import Combobox from "../combobox";
+import OptionItem from "../option-item";
 
 const doRender = (element: React.ReactElement) => {
     render(element, {wrapper: RenderStateRoot});
@@ -303,6 +305,31 @@ describe("Combobox", () => {
 
         // Assert
         expect(screen.getByRole("combobox")).not.toHaveFocus();
+    });
+
+    it("should include an icon at the beginning of the combobox", () => {
+        // Arrange
+
+        // Act
+        doRender(
+            <Combobox
+                selectionType="single"
+                value=""
+                startIcon={
+                    <PhosphorIcon
+                        icon={magnifyingGlassIcon}
+                        testId="start-icon"
+                    />
+                }
+            >
+                <OptionItem label="option 1" value="option1" />
+                <OptionItem label="option 2" value="option2" />
+                <OptionItem label="option 3" value="option3" />
+            </Combobox>,
+        );
+
+        // Assert
+        expect(screen.getByTestId("start-icon")).toBeInTheDocument();
     });
 
     describe("dismiss button", () => {

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -1,4 +1,3 @@
-import {start} from "repl";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -1,3 +1,4 @@
+import {start} from "repl";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -11,7 +12,12 @@ import {
 } from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {border, color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    color,
+    semanticColor,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -495,10 +501,16 @@ export default function Combobox({
         }
 
         const startIconElement = React.cloneElement(startIcon, {
+            // Provide a default size for the icon that can be overridden by
+            // the consumer.
+            size: "small",
             ...startIcon.props,
-            // Override the disable state of the icon to match the combobox
+            // Override the disabled state of the icon to match the combobox
             // state.
-            color: disabled ? color.offBlack32 : startIcon.props.color,
+            color: disabled
+                ? color.offBlack32
+                : // Use the color passed in, otherwise use the default color.
+                  startIcon.props.color ?? semanticColor.icon.primary,
         } as Partial<React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>>);
 
         return <View style={styles.iconWrapper}>{startIconElement}</View>;
@@ -710,12 +722,6 @@ const styles = StyleSheet.create({
         background: color.fadedRed8,
         border: `1px solid ${color.red}`,
         color: color.offBlack,
-    },
-    /**
-     * Start icon styles
-     */
-    iconDisabled: {
-        color: color.offBlack32,
     },
     /**
      * Combobox input styles

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -1,3 +1,4 @@
+import {start} from "repl";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -135,8 +136,7 @@ type Props = {
     autoComplete?: "none" | "list" | undefined;
 
     /**
-     * The icon (wrapped by a button) that allows opening the listbox widget
-     * when pressed/activated. Defaults to caretDown.
+     * An optional decorative icon to display at the start of the combobox.
      */
     startIcon?: React.ReactElement<
         React.ComponentProps<typeof PhosphorIcon>
@@ -487,6 +487,24 @@ export default function Combobox({
         return [labelFromSelected];
     }, [children, labelFromSelected, selected]);
 
+    /**
+     * Renders the start icon if provided.
+     */
+    const maybeRenderStartIcon = () => {
+        if (!startIcon) {
+            return null;
+        }
+
+        const startIconElement = React.cloneElement(startIcon, {
+            ...startIcon.props,
+            // Override the disable state of the icon to match the combobox
+            // state.
+            color: disabled ? color.offBlack32 : startIcon.props.color,
+        } as Partial<React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>>);
+
+        return <View style={styles.iconWrapper}>{startIconElement}</View>;
+    };
+
     const pillIdPrefix = id ? `${id}-pill-` : ids.get("pill");
 
     const currentActiveDescendant = !openState
@@ -544,9 +562,7 @@ export default function Combobox({
                         removeSelectedLabel={labels.removeSelected}
                     />
                 )}
-                {startIcon && (
-                    <View style={styles.iconWrapper}>{startIcon}</View>
-                )}
+                {maybeRenderStartIcon()}
 
                 <TextField
                     id={ids.get("input")}
@@ -695,6 +711,12 @@ const styles = StyleSheet.create({
         background: color.fadedRed8,
         border: `1px solid ${color.red}`,
         color: color.offBlack,
+    },
+    /**
+     * Start icon styles
+     */
+    iconDisabled: {
+        color: color.offBlack32,
     },
     /**
      * Combobox input styles

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -14,6 +14,7 @@ import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {border, color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {useListbox} from "../hooks/use-listbox";
 import {useMultipleSelection} from "../hooks/use-multiple-selection";
 import {
@@ -132,6 +133,14 @@ type Props = {
      */
     // TODO(WB-1740): Add support to `inline` and `both` values.
     autoComplete?: "none" | "list" | undefined;
+
+    /**
+     * The icon (wrapped by a button) that allows opening the listbox widget
+     * when pressed/activated. Defaults to caretDown.
+     */
+    startIcon?: React.ReactElement<
+        React.ComponentProps<typeof PhosphorIcon>
+    > | null;
 };
 
 /**
@@ -158,6 +167,7 @@ export default function Combobox({
     opened,
     placeholder,
     selectionType = "single",
+    startIcon,
     testId,
     value = "",
 }: Props) {
@@ -534,6 +544,10 @@ export default function Combobox({
                         removeSelectedLabel={labels.removeSelected}
                     />
                 )}
+                {startIcon && (
+                    <View style={styles.iconWrapper}>{startIcon}</View>
+                )}
+
                 <TextField
                     id={ids.get("input")}
                     testId={testId}
@@ -738,5 +752,12 @@ const styles = StyleSheet.create({
         // The clear button is positioned to the left of the arrow button.
         // This is calculated based on the padding + width of the arrow button.
         right: spacing.xLarge_32 + spacing.xSmall_8,
+    },
+    iconWrapper: {
+        padding: spacing.xxxSmall_4,
+        // View has a default minWidth of 0, which causes the label text
+        // to encroach on the icon when it needs to truncate. We can fix
+        // this by setting the minWidth to auto.
+        minWidth: "auto",
     },
 });


### PR DESCRIPTION
## Summary:

Adds a new `startIcon` prop (optional) to the Combobox component. This prop
will allow to optinally add an icon to the left of the input field.

This use case will be helpful for the AI tools case where we want to use a
search icon.


Issue: https://khanacademy.atlassian.net/browse/WB-1779

## Test plan:

Verify that the `Start icon` docs make sense and that the example works as
expected.

/?path=/docs/packages-dropdown-combobox--docs#start%20icon

<img width="1076" alt="Screenshot 2024-11-18 at 3 21 00 PM" src="https://github.com/user-attachments/assets/00e70b53-92cf-4b35-8cbd-30695e2a7a13">
