### PR TITLE
SearchField: Remove -field postfix from id

### DIFF
--- a/.changeset/cuddly-fireants-cheat.md
+++ b/.changeset/cuddly-fireants-cheat.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/wonder-blocks-search-field": minor
+"@khanacademy/wonder-blocks-search-field": patch
 ---
 
 SearchField: Remove "-field" that was automatically appended to the id.

--- a/.changeset/cuddly-fireants-cheat.md
+++ b/.changeset/cuddly-fireants-cheat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-search-field": minor
+---
+
+SearchField: Remove "-field" that was automatically appended to the id.

--- a/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
+++ b/packages/wonder-blocks-search-field/src/components/__tests__/search-field.test.tsx
@@ -350,7 +350,7 @@ describe("SearchField", () => {
         const searchField = await screen.findByTestId("search-field-test");
 
         // Assert
-        expect(searchField).toHaveAttribute("id", "some-random-id-field");
+        expect(searchField).toHaveAttribute("id", "some-random-id");
     });
 
     test("uses a unique ID if one is not provided", async () => {
@@ -367,9 +367,7 @@ describe("SearchField", () => {
         const searchField = await screen.findByTestId("search-field-test");
 
         // Assert
-        expect(searchField.getAttribute("id")).toMatch(
-            /^uid-search-field.*-field$/,
-        );
+        expect(searchField.getAttribute("id")).toMatch(/^uid-search-field.*$/);
     });
 
     test("has focus if autoFocus is true", async () => {

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -173,7 +173,7 @@ const SearchField: React.ForwardRefExoticComponent<
                         aria-hidden="true"
                     />
                     <TextField
-                        id={`${uniqueId}-field`}
+                        id={uniqueId}
                         type="text"
                         autoFocus={autoFocus}
                         disabled={disabled}


### PR DESCRIPTION
# Summary:
Previously, the SearchField component was appending "-field" to the end of a provided id prop. We remove this post-fix and now use the `id` prop as is

This change is needed so when SearchField is used with LabeledField, LabeledField will set the id of the field element and wire it up with the label element. Since LabeledField works with a variety of components, the id shouldn't be modified by the field.

Issue: WB-1771

## Test plan:
- Confirm that the id on the search field is the same value as the id prop (`/?path=/story/packages-searchfield--default&args=id:test123`)
![Screenshot 2024-11-18 at 3 08 19 PM](https://github.com/user-attachments/assets/30fccac6-842a-4aad-ac39-92c5290721cf)
- Verify with the npm snapshot if there will be any breaking unit/e2e tests in webapp due to the internal id change