### PR TITLE
[🔥AUDIT🔥] Fix ngettext not returning plural translations.

### DIFF
--- a/.changeset/fresh-vans-love.md
+++ b/.changeset/fresh-vans-love.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-i18n": patch
+---
+
+Fix ngettext not returning plural translations.

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
@@ -139,7 +139,7 @@ describe("i18n", () => {
             const result = ngettext("Singular", "Plural", 0);
 
             // Assert
-            expect(result).toMatchInlineSnapshot(`"Plural"`);
+            expect(result).toMatchInlineSnapshot(`"arrrr mateys"`);
         });
 
         it("doNotTranslate should not translate", () => {

--- a/packages/wonder-blocks-i18n/src/functions/i18n.ts
+++ b/packages/wonder-blocks-i18n/src/functions/i18n.ts
@@ -210,7 +210,7 @@ export const ngettext: ngettextOverloads = (
         typeof singular === "object"
             ? singular
             : {
-                  lang: "en",
+                  lang: getLocale(),
                   // We know plural is a string if singular is not a config object
                   messages: [singular, plural as any],
               };


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This bug is in prod right now, unfortunately. Some strings are appearing untranslated.

Issue: FEI-6007

## Test plan:
This was actually wrong in the tests!! So I fixed the test in the process.