### PR TITLE
[🔥AUDIT🔥] Fix up plural form fallback when no translation is present.

### DIFF
--- a/.changeset/dry-kangaroos-boil.md
+++ b/.changeset/dry-kangaroos-boil.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-i18n": patch
+---
+
+Fix a bug with pluralization for fallback untranslated languages.

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-store.test.ts
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n-store.test.ts
@@ -84,10 +84,10 @@ describe("getPluralTranslation", () => {
         // Act
         const result = getPluralTranslation(
             {
-                lang: TEST_LOCALE,
+                lang: "en",
                 messages: ["test singular", "test plural"],
             },
-            0,
+            1,
         );
 
         // Assert
@@ -104,10 +104,10 @@ describe("getPluralTranslation", () => {
         // Act
         const result = getPluralTranslation(
             {
-                lang: TEST_LOCALE,
+                lang: "en",
                 messages: ["test singular", "test plural"],
             },
-            1,
+            2,
         );
 
         // Assert
@@ -135,10 +135,10 @@ describe("getPluralTranslation", () => {
         // Act
         const result = getPluralTranslation(
             {
-                lang: TEST_LOCALE,
+                lang: "en",
                 messages: ["test singular", "test plural"],
             },
-            0,
+            1,
         );
 
         // Assert

--- a/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
+++ b/packages/wonder-blocks-i18n/src/functions/__tests__/i18n.test.ts
@@ -142,6 +142,17 @@ describe("i18n", () => {
             expect(result).toMatchInlineSnapshot(`"arrrr mateys"`);
         });
 
+        it("ngettext should handle missing translations", () => {
+            // Arrange
+            jest.spyOn(Locale, "getLocale").mockImplementation(() => "ru");
+
+            // Act
+            const result = ngettext("Singular", "Plural", 0);
+
+            // Assert
+            expect(result).toMatchInlineSnapshot(`"Plural"`);
+        });
+
         it("doNotTranslate should not translate", () => {
             // Arrange
             loadTranslations(TEST_LOCALE, {

--- a/packages/wonder-blocks-i18n/src/functions/i18n.ts
+++ b/packages/wonder-blocks-i18n/src/functions/i18n.ts
@@ -3,7 +3,6 @@
 /* To fix, remove an entry above, run ka-lint, and fix errors. */
 import * as React from "react";
 
-import {allPluralForms} from "./plural-forms";
 import {getLocale} from "./locale";
 import {PluralConfigurationObject} from "./types";
 import {getPluralTranslation, getSingularTranslation} from "./i18n-store";
@@ -46,8 +45,6 @@ interface _Overloads {
             | undefined,
     ): string;
 }
-
-type Language = keyof typeof allPluralForms;
 
 const interpolationMarker = /%\(([\w_]+)\)s/g;
 
@@ -210,7 +207,7 @@ export const ngettext: ngettextOverloads = (
         typeof singular === "object"
             ? singular
             : {
-                  lang: getLocale(),
+                  lang: "en",
                   // We know plural is a string if singular is not a config object
                   messages: [singular, plural as any],
               };
@@ -220,11 +217,7 @@ export const ngettext: ngettextOverloads = (
     const actualOptions: NGetOptions =
         (typeof singular === "object" ? num : (options as any)) || {};
 
-    // Get the translated string
-    const idx = ngetpos(actualNum, pluralConfObj.lang);
-
-    // The common (non-error) case is messages[idx].
-    const translation = getPluralTranslation(pluralConfObj, idx);
+    const translation = getPluralTranslation(pluralConfObj, actualNum);
 
     // Get the options to substitute into the string.
     // We automatically add in the 'magic' option-variable 'num'.
@@ -243,20 +236,6 @@ export const ngettext: ngettextOverloads = (
  */
 const formatNumber = (num: number): string => {
     return Intl.NumberFormat(getLocale()).format(num);
-};
-
-/*
- * Return the ngettext position that matches the given number and lang.
- *
- * Arguments:
- *  - num: The number upon which to toggle the plural forms.
- *  - lang: The language to use as the basis for the pluralization.
- */
-export const ngetpos = function (num: number, lang?: Language): number {
-    const pluralForm = (lang && allPluralForms[lang]) || allPluralForms["en"];
-    const pos = pluralForm(num);
-    // Map true to 1 and false to 0, keep any numeric return value the same.
-    return pos === true ? 1 : pos ? pos : 0;
 };
 
 /*

--- a/packages/wonder-blocks-i18n/src/index.ts
+++ b/packages/wonder-blocks-i18n/src/index.ts
@@ -4,9 +4,12 @@ export {
     ngettext,
     doNotTranslate,
     doNotTranslateYet, // used by handlebars translation functions in webapp
-    ngetpos,
 } from "./functions/i18n";
-export {loadTranslations, clearTranslations} from "./functions/i18n-store";
+export {
+    loadTranslations,
+    clearTranslations,
+    ngetpos,
+} from "./functions/i18n-store";
 
 export {localeToFixed, getDecimalSeparator} from "./functions/l10n";
 export {getLocale, setLocale} from "./functions/locale";


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I may have introduced this in my last fix, actually - but this now helps us ensure that we don't accidentally use the other language pluralization rules when we are falling back to English strings.

Issue: FEI-6007

## Test plan:
The tests pass!