### PR TITLE
SingleSelect validation props

### DIFF
--- a/.changeset/mean-ligers-relax.md
+++ b/.changeset/mean-ligers-relax.md
@@ -1,0 +1,10 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+# SingleSelect
+
+- Add `required`, `validate`, and `onValidate` props to support validation.
+- DropdownOpener and SelectOpener:
+  - Add `onBlur` prop
+  - Set `aria-invalid` if it is in an error state.

--- a/.changeset/mean-ligers-relax.md
+++ b/.changeset/mean-ligers-relax.md
@@ -5,6 +5,8 @@
 # SingleSelect
 
 - Add `required`, `validate`, and `onValidate` props to support validation.
+- Set `aria-required` on the opener if the `required` prop is `true` or
+`aria-required` is set
 - DropdownOpener and SelectOpener:
   - Add `onBlur` prop
   - Set `aria-invalid` if it is in an error state.

--- a/.changeset/mean-ligers-relax.md
+++ b/.changeset/mean-ligers-relax.md
@@ -5,8 +5,6 @@
 # SingleSelect
 
 - Add `required`, `validate`, and `onValidate` props to support validation.
-- Set `aria-required` on the opener if the `required` prop is `true` or
-`aria-required` is set
 - DropdownOpener and SelectOpener:
   - Add `onBlur` prop
   - Set `aria-invalid` if it is in an error state.

--- a/.changeset/smooth-poems-buy.md
+++ b/.changeset/smooth-poems-buy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Update `DropdownCore` to check for key presses using `event.key` instead of `event.which` or `event.keyCode` (which are both deprecated now)

--- a/__docs__/wonder-blocks-dropdown/base-select.argtypes.ts
+++ b/__docs__/wonder-blocks-dropdown/base-select.argtypes.ts
@@ -30,10 +30,50 @@ const argTypes: ArgTypes = {
     },
 
     error: {
-        description: "Whether this component is in an error state.",
+        description: `Whether this component is in an error state. Use this for
+            errors that are triggered by something external to the component
+            (example: an error after form submission).`,
         table: {
             category: "States",
             defaultValue: {summary: "false"},
+        },
+    },
+
+    required: {
+        description: `Whether this field is required to to continue, or the
+            error message to render if the select is left blank. Pass in a
+            message instead of "true" if possible.`,
+        table: {
+            category: "States",
+            type: {
+                summary: "boolean | string",
+            },
+        },
+        control: {
+            type: undefined,
+        },
+    },
+
+    validate: {
+        description: `Provide a validation for the selected value. Return a
+            string error message or null | void for a valid input.
+            \n Use this for errors that are shown to the user while they are
+            filling out a form.`,
+        table: {
+            category: "States",
+            type: {
+                summary: "(value: string) => ?string",
+            },
+        },
+    },
+
+    onValidate: {
+        description: "Called right after the field is validated.",
+        table: {
+            category: "Events",
+            type: {
+                summary: "(errorMessage: ?string) => mixed",
+            },
         },
     },
 

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -384,7 +384,9 @@ export const Disabled: StoryComponentType = {
 
 const ControlledSingleSelect = (args: PropsFor<typeof SingleSelect>) => {
     const [opened, setOpened] = React.useState(false);
-    const [selectedValue, setSelectedValue] = React.useState("");
+    const [selectedValue, setSelectedValue] = React.useState(
+        args.selectedValue,
+    );
     const [errorMessage, setErrorMessage] = React.useState<
         null | string | void
     >(null);
@@ -490,7 +492,7 @@ export const ErrorFromValidation: StoryComponentType = {
         return (
             <View style={{gap: spacing.xSmall_8}}>
                 <LabelSmall htmlFor="single-select" tag="label">
-                    Validation example (try picking lemon)
+                    Validation example (try picking lemon to trigger an error)
                 </LabelSmall>
                 <ControlledSingleSelect
                     {...args}

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -382,41 +382,6 @@ export const Disabled: StoryComponentType = {
     ),
 };
 
-const ErrorWrapper = () => {
-    const [error, setError] = React.useState(true);
-    const [selectedValue, setSelectedValue] = React.useState("");
-    const [opened, setOpened] = React.useState(false);
-
-    return (
-        <>
-            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
-                Select any fruit other than lemon to clear the error!
-            </LabelMedium>
-            <SingleSelect
-                error={error}
-                onChange={(value) => {
-                    setSelectedValue(value);
-                    setError(value === "lemon");
-                }}
-                onToggle={setOpened}
-                opened={opened}
-                placeholder="Choose a fruit"
-                selectedValue={selectedValue}
-            >
-                {items}
-            </SingleSelect>
-        </>
-    );
-};
-
-/**
- * This select is in an error state. Selecting any option other than lemon will
- * clear the error state by updating the `error` prop to `false`.
- */
-export const Error: StoryComponentType = {
-    render: ErrorWrapper,
-};
-
 const ControlledSingleSelect = (args: PropsFor<typeof SingleSelect>) => {
     const [opened, setOpened] = React.useState(false);
     const [selectedValue, setSelectedValue] = React.useState("");
@@ -442,44 +407,111 @@ const ControlledSingleSelect = (args: PropsFor<typeof SingleSelect>) => {
             >
                 {items}
             </SingleSelect>
-            <LabelSmall
-                style={{color: semanticColor.status.critical.foreground}}
-            >
-                {errorMessage}
-            </LabelSmall>
+            {(errorMessage || args.error) && (
+                <LabelSmall
+                    style={{color: semanticColor.status.critical.foreground}}
+                >
+                    {errorMessage || "Error from error prop"}
+                </LabelSmall>
+            )}
         </View>
     );
 };
 
-export const Validation = (args: PropsFor<typeof SingleSelect>) => {
-    return (
-        <View style={{gap: spacing.xSmall_8}}>
-            <LabelSmall htmlFor="single-select" tag="label">
-                Validation example (try picking lemon)
-            </LabelSmall>
-            <ControlledSingleSelect
-                {...args}
-                id="single-select"
-                validate={(value) => {
-                    if (value === "lemon") {
-                        return "Pick another option!";
-                    }
-                }}
-            >
-                {items}
-            </ControlledSingleSelect>
-            <LabelSmall htmlFor="single-select-required" tag="label">
-                Validation example (required)
-            </LabelSmall>
-            <ControlledSingleSelect
-                {...args}
-                id="single-select-required"
-                required={"This field is required"}
-            >
-                {items}
-            </ControlledSingleSelect>
-        </View>
-    );
+/**
+ * If the `error` prop is set to true, the field will have error styling and
+ * `aria-invalid` set to `true`.
+ *
+ * This is useful for scenarios where we want to show an error on a
+ * specific field after a form is submitted (server validation).
+ *
+ * Note: The `required` and `validate` props can also put the field in an
+ * error state.
+ */
+export const Error: StoryComponentType = {
+    render: ControlledSingleSelect,
+    args: {
+        error: true,
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this is covered by variants story
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
+ * A required field will have error styling and aria-invalid set to true if the
+ * select is left blank.
+ *
+ * When `required` is set to `true`, validation is triggered:
+ * - When a user tabs away from the select (opener's onBlur event)
+ * - When a user closes the dropdown without selecting a value
+ * (either by pressing escape, clicking away, or clicking on the opener).
+ *
+ * Validation errors are cleared when a valid value is selected. The component
+ * will set aria-invalid to "false" and call the onValidate prop with null.
+ *
+ */
+export const Required: StoryComponentType = {
+    render: ControlledSingleSelect,
+    args: {
+        required: "Custom required error message",
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
+ * If a selected value fails validation, the field will have error styling.
+ *
+ * This is useful for scenarios where we want to show errors while a
+ * user is filling out a form (client validation).
+ *
+ * Note that we will internally set the correct `aria-invalid` attribute to the
+ * field:
+ * - aria-invalid="true" if there is an error.
+ * - aria-invalid="false" if there is no error.
+ *
+ * Validation is triggered:
+ * - On mount if the `value` prop is not empty and it is not required
+ * - When an option is selected
+ *
+ * Validation errors are cleared when a valid value is selected. The component
+ * will set aria-invalid to "false" and call the onValidate prop with null.
+ */
+export const ErrorFromValidation: StoryComponentType = {
+    render: (args: PropsFor<typeof SingleSelect>) => {
+        return (
+            <View style={{gap: spacing.xSmall_8}}>
+                <LabelSmall htmlFor="single-select" tag="label">
+                    Validation example (try picking lemon)
+                </LabelSmall>
+                <ControlledSingleSelect
+                    {...args}
+                    id="single-select"
+                    validate={(value) => {
+                        if (value === "lemon") {
+                            return "Pick another option!";
+                        }
+                    }}
+                >
+                    {items}
+                </ControlledSingleSelect>
+            </View>
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import planetIcon from "@phosphor-icons/core/regular/planet.svg";
@@ -6,8 +7,8 @@ import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
@@ -17,6 +18,7 @@ import {
     Body,
     HeadingLarge,
     LabelMedium,
+    LabelSmall,
 } from "@khanacademy/wonder-blocks-typography";
 import {
     SingleSelect,
@@ -413,6 +415,71 @@ const ErrorWrapper = () => {
  */
 export const Error: StoryComponentType = {
     render: ErrorWrapper,
+};
+
+const ControlledSingleSelect = (args: PropsFor<typeof SingleSelect>) => {
+    const [opened, setOpened] = React.useState(false);
+    const [selectedValue, setSelectedValue] = React.useState("");
+    const [errorMessage, setErrorMessage] = React.useState<
+        null | string | void
+    >(null);
+    return (
+        <View style={{gap: spacing.xSmall_8}}>
+            <SingleSelect
+                {...args}
+                id="single-select"
+                opened={opened}
+                onToggle={setOpened}
+                selectedValue={selectedValue}
+                onChange={setSelectedValue}
+                placeholder="Choose a fruit"
+                validate={(value) => {
+                    if (value === "lemon") {
+                        return "Pick another option!";
+                    }
+                }}
+                onValidate={setErrorMessage}
+            >
+                {items}
+            </SingleSelect>
+            <LabelSmall
+                style={{color: semanticColor.status.critical.foreground}}
+            >
+                {errorMessage}
+            </LabelSmall>
+        </View>
+    );
+};
+
+export const Validation = (args: PropsFor<typeof SingleSelect>) => {
+    return (
+        <View style={{gap: spacing.xSmall_8}}>
+            <LabelSmall htmlFor="single-select" tag="label">
+                Validation example (try picking lemon)
+            </LabelSmall>
+            <ControlledSingleSelect
+                {...args}
+                id="single-select"
+                validate={(value) => {
+                    if (value === "lemon") {
+                        return "Pick another option!";
+                    }
+                }}
+            >
+                {items}
+            </ControlledSingleSelect>
+            <LabelSmall htmlFor="single-select-required" tag="label">
+                Validation example (required)
+            </LabelSmall>
+            <ControlledSingleSelect
+                {...args}
+                id="single-select-required"
+                required={"This field is required"}
+            >
+                {items}
+            </ControlledSingleSelect>
+        </View>
+    );
 };
 
 /**

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/select-opener.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/select-opener.test.tsx
@@ -5,8 +5,8 @@ import {userEvent} from "@testing-library/user-event";
 import SelectOpener from "../select-opener";
 
 describe("SelectOpener", () => {
+    const children = "text";
     describe("onOpenChanged", () => {
-        const children = "text";
         it("should trigger using the mouse", async () => {
             // Arrange
             const onOpenMock = jest.fn();
@@ -216,5 +216,80 @@ describe("SelectOpener", () => {
             // Assert
             expect(onOpenMock).toHaveBeenCalledTimes(0);
         });
+    });
+
+    describe("error prop", () => {
+        it("should set aria-invalid to true if error is true", () => {
+            // Arrange
+            // Act
+            render(
+                <SelectOpener
+                    error={true}
+                    onOpenChanged={jest.fn()}
+                    open={false}
+                >
+                    {children}
+                </SelectOpener>,
+            );
+            // Assert
+            expect(screen.getByRole("button")).toHaveAttribute(
+                "aria-invalid",
+                "true",
+            );
+        });
+
+        it("should set aria-invalid to false if error is false", () => {
+            // Arrange
+            // Act
+            render(
+                <SelectOpener
+                    error={false}
+                    onOpenChanged={jest.fn()}
+                    open={false}
+                >
+                    {children}
+                </SelectOpener>,
+            );
+            // Assert
+            expect(screen.getByRole("button")).toHaveAttribute(
+                "aria-invalid",
+                "false",
+            );
+        });
+
+        it("should set aria-invalid to false if error is not set ", () => {
+            // Arrange
+            // Act
+            render(
+                <SelectOpener onOpenChanged={jest.fn()} open={false}>
+                    {children}
+                </SelectOpener>,
+            );
+            // Assert
+            expect(screen.getByRole("button")).toHaveAttribute(
+                "aria-invalid",
+                "false",
+            );
+        });
+    });
+
+    it("should call onBlur when it is blurred", async () => {
+        // Arrange
+        const onBlur = jest.fn();
+        render(
+            <SelectOpener
+                onBlur={onBlur}
+                open={false}
+                onOpenChanged={jest.fn()}
+            >
+                {children}
+            </SelectOpener>,
+        );
+        // Act
+        await userEvent.tab();
+        await userEvent.tab();
+
+        // Assert
+        expect(onBlur).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/select-opener.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/select-opener.test.tsx
@@ -219,58 +219,31 @@ describe("SelectOpener", () => {
     });
 
     describe("error prop", () => {
-        it("should set aria-invalid to true if error is true", () => {
-            // Arrange
-            // Act
-            render(
-                <SelectOpener
-                    error={true}
-                    onOpenChanged={jest.fn()}
-                    open={false}
-                >
-                    {children}
-                </SelectOpener>,
-            );
-            // Assert
-            expect(screen.getByRole("button")).toHaveAttribute(
-                "aria-invalid",
-                "true",
-            );
-        });
-
-        it("should set aria-invalid to false if error is false", () => {
-            // Arrange
-            // Act
-            render(
-                <SelectOpener
-                    error={false}
-                    onOpenChanged={jest.fn()}
-                    open={false}
-                >
-                    {children}
-                </SelectOpener>,
-            );
-            // Assert
-            expect(screen.getByRole("button")).toHaveAttribute(
-                "aria-invalid",
-                "false",
-            );
-        });
-
-        it("should set aria-invalid to false if error is not set ", () => {
-            // Arrange
-            // Act
-            render(
-                <SelectOpener onOpenChanged={jest.fn()} open={false}>
-                    {children}
-                </SelectOpener>,
-            );
-            // Assert
-            expect(screen.getByRole("button")).toHaveAttribute(
-                "aria-invalid",
-                "false",
-            );
-        });
+        it.each([
+            {ariaInvalid: "true", error: true},
+            {ariaInvalid: "false", error: false},
+            {ariaInvalid: "false", error: undefined},
+        ])(
+            "should set aria-invalid to $ariaInvalid if error is $error",
+            ({ariaInvalid, error}) => {
+                // Arrange
+                // Act
+                render(
+                    <SelectOpener
+                        error={error}
+                        onOpenChanged={jest.fn()}
+                        open={false}
+                    >
+                        {children}
+                    </SelectOpener>,
+                );
+                // Assert
+                expect(screen.getByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    ariaInvalid,
+                );
+            },
+        );
     });
 
     it("should call onBlur when it is blurred", async () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/select-opener.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/select-opener.test.tsx
@@ -258,9 +258,9 @@ describe("SelectOpener", () => {
                 {children}
             </SelectOpener>,
         );
+        await userEvent.tab(); // focus on the opener
         // Act
-        await userEvent.tab();
-        await userEvent.tab();
+        await userEvent.tab(); // blur the opener
 
         // Assert
         expect(onBlur).toHaveBeenCalledTimes(1);

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -6,10 +6,10 @@ import {
     PointerEventsCheckLevel,
 } from "@testing-library/user-event";
 
+import {PropsFor} from "@khanacademy/wonder-blocks-core";
 import OptionItem from "../option-item";
 import SingleSelect from "../single-select";
 import type {SingleSelectLabels} from "../single-select";
-import {PropsFor} from "../../../../wonder-blocks-core/src/util/types";
 
 const doRender = (element: React.ReactElement) => {
     render(element);

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1813,7 +1813,7 @@ describe("SingleSelect", () => {
                 </SingleSelect>
             );
         };
-        describe("validation when a value is selected", () => {
+        describe("when a value is selected", () => {
             it("should call validate prop", async () => {
                 // Arrange
                 const validate = jest.fn();
@@ -1850,6 +1850,7 @@ describe("SingleSelect", () => {
                     errorMessage,
                 );
             });
+
             it("should be in an error state when validation fails", async () => {
                 // Arrange
                 const userEvent = doRender(
@@ -1900,12 +1901,17 @@ describe("SingleSelect", () => {
                 // Assert
                 expect(validate).toHaveBeenCalledExactlyOnceWith("1");
             });
+
             it("should be in an error state on mount if there is an invalid selected value", async () => {
                 // Arrange
                 // Act
                 doRender(
                     <ControlledSingleSelect
-                        validate={() => "Error"}
+                        validate={(value) => {
+                            if (value === "1") {
+                                return "Error";
+                            }
+                        }}
                         selectedValue={"1"}
                     />,
                 );
@@ -1915,6 +1921,27 @@ describe("SingleSelect", () => {
                     "true",
                 );
             });
+
+            it("should not be in an error state on mount if there is a valid selected value", async () => {
+                // Arrange
+                // Act
+                doRender(
+                    <ControlledSingleSelect
+                        validate={(value) => {
+                            if (value === "1") {
+                                return "Error";
+                            }
+                        }}
+                        selectedValue={"2"}
+                    />,
+                );
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "false",
+                );
+            });
+
             it("should not validate on mount if there is no selected value", () => {
                 // Arrange
                 // Act
@@ -1929,6 +1956,7 @@ describe("SingleSelect", () => {
                 // Assert
                 expect(validate).not.toHaveBeenCalled();
             });
+
             it("should not be in an error state on mount if there is no selected value", async () => {
                 // Arrange
                 // Act
@@ -1946,7 +1974,7 @@ describe("SingleSelect", () => {
             });
         });
 
-        describe("picking a value after there was a validation error", () => {
+        describe("interactions after there is a validation error", () => {
             it("should still be in an error state before a value is picked", async () => {
                 // Arrange
                 const errorMessage = "Error message";
@@ -2022,9 +2050,9 @@ describe("SingleSelect", () => {
                     const userEvent = doRender(
                         <ControlledSingleSelect required={requiredMessage} />,
                     );
+                    await userEvent.tab(); // focus on the select
 
                     // Act
-                    await userEvent.tab(); // focus on the select
                     await userEvent.tab(); // leave the select
 
                     // Assert
@@ -2263,6 +2291,7 @@ describe("SingleSelect", () => {
                     // Assert
                     expect(onValidate).not.toHaveBeenCalled();
                 });
+
                 it("should not call onValidate if there is a selected value on the initial render", () => {
                     // Arrange
                     const requiredMessage = "Required field";
@@ -2281,6 +2310,7 @@ describe("SingleSelect", () => {
                     expect(onValidate).not.toHaveBeenCalled();
                 });
             });
+
             describe("picking a value after there was an error", () => {
                 it("should still be in an error state before a value is picked", async () => {
                     // Arrange
@@ -2300,6 +2330,7 @@ describe("SingleSelect", () => {
                         "true",
                     );
                 });
+
                 it("should not be in an error state once a value is picked", async () => {
                     // Arrange
                     const requiredMessage = "Required field";

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1826,7 +1826,7 @@ describe("SingleSelect", () => {
                 // Act
                 await userEvent.click(screen.getByText("item 1"));
                 // Assert
-                expect(validate).toHaveBeenCalledOnce();
+                expect(validate).toHaveBeenCalledExactlyOnceWith("1");
             });
 
             it("should call onValidate prop", async () => {
@@ -1841,7 +1841,6 @@ describe("SingleSelect", () => {
                 );
                 const opener = await screen.findByRole("button");
                 await userEvent.click(opener);
-                onValidate.mockClear(); // Clear the mock
 
                 // Act
                 await userEvent.click(screen.getByText("item 1"));
@@ -1890,17 +1889,31 @@ describe("SingleSelect", () => {
         describe("validation on mount", () => {
             it("should validate on mount if there is a selected value", () => {
                 // Arrange
-                // Act
                 const validate = jest.fn();
+                // Act
                 doRender(
                     <ControlledSingleSelect
                         validate={validate}
                         selectedValue={"1"}
                     />,
                 );
-
                 // Assert
                 expect(validate).toHaveBeenCalledExactlyOnceWith("1");
+            });
+            it("should be in an error state on mount if there is an invalid selected value", async () => {
+                // Arrange
+                // Act
+                doRender(
+                    <ControlledSingleSelect
+                        validate={() => "Error"}
+                        selectedValue={"1"}
+                    />,
+                );
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "true",
+                );
             });
             it("should not validate on mount if there is no selected value", () => {
                 // Arrange
@@ -1915,6 +1928,21 @@ describe("SingleSelect", () => {
 
                 // Assert
                 expect(validate).not.toHaveBeenCalled();
+            });
+            it("should not be in an error state on mount if there is no selected value", async () => {
+                // Arrange
+                // Act
+                doRender(
+                    <ControlledSingleSelect
+                        validate={() => "Error"}
+                        selectedValue={undefined}
+                    />,
+                );
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "false",
+                );
             });
         });
 
@@ -1952,11 +1980,9 @@ describe("SingleSelect", () => {
                         selectedValue={"1"}
                     />,
                 );
-                await userEvent.tab();
-                await userEvent.tab(); // Tab through the select to trigger error
+                await userEvent.click(await screen.findByRole("button")); // Open the dropdown
 
                 // Act
-                await userEvent.click(await screen.findByRole("button")); // Open the dropdown
                 await userEvent.click(await screen.findByText("item 2")); // Pick a value
 
                 // Assert
@@ -2237,7 +2263,7 @@ describe("SingleSelect", () => {
                     // Assert
                     expect(onValidate).not.toHaveBeenCalled();
                 });
-                it("should call onValidate with null if there is a selected value on the initial render", () => {
+                it("should not call onValidate if there is a selected value on the initial render", () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
@@ -2282,9 +2308,9 @@ describe("SingleSelect", () => {
                     );
                     await userEvent.tab();
                     await userEvent.tab(); // Tab through the select to trigger error
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
 
                     // Act
-                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
                     await userEvent.click(await screen.findByText("item 1")); // Pick a value
 
                     // Assert

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -12,11 +12,13 @@ import SingleSelect from "../single-select";
 import type {SingleSelectLabels} from "../single-select";
 
 const doRender = (element: React.ReactElement) => {
-    render(element);
-    return ue.setup({
-        advanceTimers: jest.advanceTimersByTime,
-        pointerEventsCheck: PointerEventsCheckLevel.Never,
-    });
+    return {
+        ...render(element),
+        userEvent: ue.setup({
+            advanceTimers: jest.advanceTimersByTime,
+            pointerEventsCheck: PointerEventsCheckLevel.Never,
+        }),
+    };
 };
 
 describe("SingleSelect", () => {
@@ -170,7 +172,7 @@ describe("SingleSelect", () => {
         describe("mouse", () => {
             it("should open when clicking on the default opener", async () => {
                 // Arrange
-                const userEvent = doRender(uncontrolledSingleSelect);
+                const {userEvent} = doRender(uncontrolledSingleSelect);
                 const opener = await screen.findByText("Choose");
 
                 // Act
@@ -184,7 +186,7 @@ describe("SingleSelect", () => {
 
             it("should focus the first item in the dropdown", async () => {
                 // Arrange
-                const userEvent = doRender(uncontrolledSingleSelect);
+                const {userEvent} = doRender(uncontrolledSingleSelect);
                 const opener = await screen.findByText("Choose");
 
                 // Act
@@ -197,7 +199,7 @@ describe("SingleSelect", () => {
 
             it("should close when clicking on the default opener a second time", async () => {
                 // Arrange
-                const userEvent = doRender(uncontrolledSingleSelect);
+                const {userEvent} = doRender(uncontrolledSingleSelect);
                 const opener = await screen.findByText("Choose");
                 await userEvent.click(opener);
 
@@ -210,7 +212,7 @@ describe("SingleSelect", () => {
 
             it("should close when clicking on an item", async () => {
                 // Arrange
-                const userEvent = doRender(uncontrolledSingleSelect);
+                const {userEvent} = doRender(uncontrolledSingleSelect);
                 const opener = await screen.findByText("Choose");
                 await userEvent.click(opener);
 
@@ -223,7 +225,7 @@ describe("SingleSelect", () => {
 
             it("should call onChange() with the item's value when clicking it", async () => {
                 // Arrange
-                const userEvent = doRender(uncontrolledSingleSelect);
+                const {userEvent} = doRender(uncontrolledSingleSelect);
                 const opener = await screen.findByText("Choose");
                 await userEvent.click(opener);
 
@@ -236,7 +238,7 @@ describe("SingleSelect", () => {
 
             it("should not focus in the first item if autoFocus is disabled", async () => {
                 // Arrange
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <SingleSelect
                         autoFocus={false}
                         onChange={onChange}
@@ -272,7 +274,7 @@ describe("SingleSelect", () => {
                 ({key}: any) => {
                     it("should open when pressing the key when the default opener is focused", async () => {
                         // Arrange
-                        const userEvent = doRender(uncontrolledSingleSelect);
+                        const {userEvent} = doRender(uncontrolledSingleSelect);
                         await userEvent.tab();
 
                         // Act
@@ -286,7 +288,7 @@ describe("SingleSelect", () => {
 
                     it("should focus the first item in the dropdown", async () => {
                         // Arrange
-                        const userEvent = doRender(uncontrolledSingleSelect);
+                        const {userEvent} = doRender(uncontrolledSingleSelect);
                         await userEvent.tab();
 
                         // Act
@@ -305,7 +307,7 @@ describe("SingleSelect", () => {
             // user-event v14. We need to investigate and fix this.
             it.skip("should select an item when pressing {enter}", async () => {
                 // Arrange
-                const userEvent = doRender(uncontrolledSingleSelect);
+                const {userEvent} = doRender(uncontrolledSingleSelect);
                 await userEvent.tab();
                 await userEvent.keyboard("{enter}"); // open
 
@@ -321,7 +323,7 @@ describe("SingleSelect", () => {
             // user-event v14. We need to investigate and fix this.
             it.skip("should select an item when pressing {space}", async () => {
                 // Arrange
-                const userEvent = doRender(uncontrolledSingleSelect);
+                const {userEvent} = doRender(uncontrolledSingleSelect);
                 await userEvent.tab();
                 await userEvent.keyboard("{enter}"); // open
 
@@ -344,7 +346,7 @@ describe("SingleSelect", () => {
             */
             it.skip("should find and select an item using the keyboard", async () => {
                 // Arrange
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <SingleSelect onChange={onChange} placeholder="Choose">
                         <OptionItem label="apple" value="apple" />
                         <OptionItem label="orange" value="orange" />
@@ -365,7 +367,7 @@ describe("SingleSelect", () => {
 
             it("should NOT find/select an item using the keyboard if enableTypeAhead is set false", async () => {
                 // Arrange
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <SingleSelect
                         onChange={onChange}
                         placeholder="Choose"
@@ -391,7 +393,7 @@ describe("SingleSelect", () => {
 
             it("should dismiss the dropdown when pressing {escape}", async () => {
                 // Arrange
-                const userEvent = doRender(uncontrolledSingleSelect);
+                const {userEvent} = doRender(uncontrolledSingleSelect);
                 await userEvent.tab();
                 await userEvent.keyboard("{enter}"); // open
 
@@ -445,7 +447,7 @@ describe("SingleSelect", () => {
         it("opens the menu when the parent updates its state", async () => {
             // Arrange
             const onToggleMock = jest.fn();
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <ControlledComponent onToggle={onToggleMock} />,
             );
 
@@ -461,7 +463,7 @@ describe("SingleSelect", () => {
         it("closes the menu when the parent updates its state", async () => {
             // Arrange
             const onToggleMock = jest.fn();
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <ControlledComponent onToggle={onToggleMock} />,
             );
             // open the menu from the outside
@@ -480,7 +482,7 @@ describe("SingleSelect", () => {
         it("should still allow the opener to open the menu", async () => {
             // Arrange
             const onToggleMock = jest.fn();
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <ControlledComponent onToggle={onToggleMock} />,
             );
 
@@ -493,7 +495,7 @@ describe("SingleSelect", () => {
 
         it("opens the menu when the anchor is clicked once", async () => {
             // Arrange
-            const userEvent = doRender(<ControlledComponent />);
+            const {userEvent} = doRender(<ControlledComponent />);
 
             // Act
             // click on the anchor
@@ -507,7 +509,7 @@ describe("SingleSelect", () => {
 
         it("closes the menu when the anchor is clicked", async () => {
             // Arrange
-            const userEvent = doRender(<ControlledComponent />);
+            const {userEvent} = doRender(<ControlledComponent />);
 
             // Act
             const opener = await screen.findByRole("button", {name: "Choose"});
@@ -526,7 +528,7 @@ describe("SingleSelect", () => {
     describe("Custom Opener", () => {
         it("opens the menu when clicking on the custom opener", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={jest.fn()}
                     placeholder="custom opener"
@@ -557,7 +559,7 @@ describe("SingleSelect", () => {
             // Arrange
             const onClickMock = jest.fn();
 
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={jest.fn()}
                     placeholder="custom opener"
@@ -605,7 +607,7 @@ describe("SingleSelect", () => {
 
         it("passes the placeholder text to the custom opener", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     placeholder="Custom placeholder"
                     testId="openTest"
@@ -662,7 +664,7 @@ describe("SingleSelect", () => {
                 }
             }
 
-            const userEvent = doRender(<ControlledComponent />);
+            const {userEvent} = doRender(<ControlledComponent />);
 
             // Act
             const opener = await screen.findByRole("button");
@@ -680,7 +682,7 @@ describe("SingleSelect", () => {
     describe("isFilterable", () => {
         it("displays SearchField when isFilterable is true", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     light={true}
                     onChange={onChange}
@@ -703,7 +705,7 @@ describe("SingleSelect", () => {
 
         it("filters the items by the search input (case insensitive)", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     isFilterable={true}
@@ -727,7 +729,7 @@ describe("SingleSelect", () => {
 
         it("Type something in SearchField should update searchText in SingleSelect", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     isFilterable={true}
@@ -753,7 +755,7 @@ describe("SingleSelect", () => {
 
         it("Click dismiss button should clear the searchText in SingleSelect", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     isFilterable={true}
@@ -779,7 +781,7 @@ describe("SingleSelect", () => {
 
         it("Open SingleSelect should clear the searchText", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     isFilterable={true}
@@ -807,7 +809,7 @@ describe("SingleSelect", () => {
         // search (which does exist in the page).
         it.skip("should move focus to the dismiss button after pressing {tab} on the text input", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     isFilterable={true}
@@ -836,7 +838,7 @@ describe("SingleSelect", () => {
 
         it("should filter an option", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     placeholder="Choose"
@@ -859,7 +861,7 @@ describe("SingleSelect", () => {
 
         it("should filter out an option if it's not part of the results", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     placeholder="Choose"
@@ -975,7 +977,7 @@ describe("SingleSelect", () => {
     describe("a11y > Live region", () => {
         it("should change the number of options after using the search filter", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     placeholder="Choose"
@@ -1055,7 +1057,7 @@ describe("SingleSelect", () => {
                 filter: "Filtrar",
             };
 
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     placeholder="Escoge una fruta"
@@ -1088,7 +1090,7 @@ describe("SingleSelect", () => {
                 noResults: "No hay resultados",
             };
 
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     onChange={onChange}
                     placeholder="Escoge una fruta"
@@ -1417,7 +1419,7 @@ describe("SingleSelect", () => {
         });
         it("Should auto-generate an id for the dropdown if `dropdownId` prop is not provided", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect placeholder="Choose" onChange={jest.fn()}>
                     <OptionItem label="item 1" value="1" />
                     <OptionItem label="item 2" value="2" />
@@ -1440,7 +1442,7 @@ describe("SingleSelect", () => {
         it("Should use the `dropdownId` prop if provided", async () => {
             // Arrange
             const dropdownId = "test-id";
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     placeholder="Choose"
                     onChange={jest.fn()}
@@ -1467,7 +1469,7 @@ describe("SingleSelect", () => {
         it("Should set the `aria-controls` attribute on the default opener to the provided dropdownId prop", async () => {
             // Arrange
             const dropdownId = "test-id";
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     placeholder="Choose"
                     onChange={jest.fn()}
@@ -1490,7 +1492,7 @@ describe("SingleSelect", () => {
 
         it("Should set the `aria-controls` attribute on the default opener to the auto-generated dropdownId", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect placeholder="Choose" onChange={jest.fn()}>
                     <OptionItem label="item 1" value="1" />
                     <OptionItem label="item 2" value="2" />
@@ -1513,7 +1515,7 @@ describe("SingleSelect", () => {
         it("Should set the `aria-controls` attribute on the custom opener to the provided dropdownId prop", async () => {
             // Arrange
             const dropdownId = "test-id";
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     placeholder="Choose"
                     onChange={jest.fn()}
@@ -1539,7 +1541,7 @@ describe("SingleSelect", () => {
 
         it("Should set the `aria-controls` attribute on the custom opener to the auto-generated dropdownId", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     placeholder="Choose"
                     onChange={jest.fn()}
@@ -1625,7 +1627,7 @@ describe("SingleSelect", () => {
 
         it("updates the aria-expanded value when opening", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect placeholder="Choose" onChange={jest.fn()}>
                     <OptionItem label="item 1" value="1" />
                     <OptionItem label="item 2" value="2" />
@@ -1664,7 +1666,7 @@ describe("SingleSelect", () => {
 
         it("updates the aria-expanded value when opening and using a custom opener", async () => {
             // Arrange
-            const userEvent = doRender(
+            const {userEvent} = doRender(
                 <SingleSelect
                     placeholder="Choose"
                     onChange={jest.fn()}
@@ -1684,61 +1686,6 @@ describe("SingleSelect", () => {
             // Assert
             expect(opener).toHaveAttribute("aria-expanded", "true");
         });
-    });
-
-    describe("a11y > aria-required", () => {
-        it.each([
-            {required: "Custom required error message", ariaRequired: "true"},
-            {required: true, ariaRequired: "true"},
-            {required: false, ariaRequired: "false"},
-            {required: undefined, ariaRequired: "false"},
-        ])(
-            "should set aria-required to $ariaRequired if required is $required",
-            async ({required, ariaRequired}) => {
-                // Arrange
-                doRender(
-                    <SingleSelect
-                        placeholder="Choose"
-                        onChange={jest.fn()}
-                        required={required}
-                    />,
-                );
-
-                // Act
-                const opener = await screen.findByRole("button");
-
-                // Assert
-                expect(opener).toHaveAttribute("aria-required", ariaRequired);
-            },
-        );
-
-        it.each([
-            {required: "Custom required error message", ariaRequired: "true"},
-            {required: true, ariaRequired: "true"},
-            {required: false, ariaRequired: "false"},
-            {required: undefined, ariaRequired: "false"},
-        ])(
-            "should set aria-required to $ariaRequired if required is $required and there is a custom opener",
-            async ({required, ariaRequired}) => {
-                // Arrange
-                doRender(
-                    <SingleSelect
-                        placeholder="Choose"
-                        onChange={jest.fn()}
-                        required={required}
-                        opener={() => (
-                            <button aria-label="Search" onClick={jest.fn()} />
-                        )}
-                    />,
-                );
-
-                // Act
-                const opener = await screen.findByRole("button");
-
-                // Assert
-                expect(opener).toHaveAttribute("aria-required", ariaRequired);
-            },
-        );
     });
 
     describe("a11y > aria-invalid", () => {
@@ -1794,6 +1741,62 @@ describe("SingleSelect", () => {
         );
     });
 
+    describe("a11y > violations", () => {
+        afterEach(() => {
+            jest.useFakeTimers();
+        });
+
+        it("should not have any violations", async () => {
+            // Arrange
+            const {container} = doRender(
+                <SingleSelect
+                    onChange={jest.fn()}
+                    opened={true}
+                    placeholder="Choose"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </SingleSelect>,
+            );
+
+            // Act
+            // Flush any pending timers before switching to real timers
+            // https://testing-library.com/docs/using-fake-timers/
+            jest.runOnlyPendingTimers();
+            // Use real timers for the jest-axe check otherwise the test will timeout
+            // https://github.com/dequelabs/axe-core/issues/3055
+            jest.useRealTimers();
+
+            // Assert
+            await expect(container).toHaveNoA11yViolations();
+        });
+
+        it("should not have any violations when it is open", async () => {
+            // Arrange
+            const {container} = doRender(
+                <SingleSelect
+                    onChange={jest.fn()}
+                    opened={true}
+                    placeholder="Choose"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </SingleSelect>,
+            );
+
+            // Act
+            // Flush any pending timers before switching to real timers
+            // https://testing-library.com/docs/using-fake-timers/
+            jest.runOnlyPendingTimers();
+            // Use real timers for the jest-axe check otherwise the test will timeout
+            // https://github.com/dequelabs/axe-core/issues/3055
+            jest.useRealTimers();
+
+            // Assert
+            await expect(container).toHaveNoA11yViolations();
+        });
+    });
+
     describe("validation", () => {
         const ControlledSingleSelect = (
             props: Partial<PropsFor<typeof SingleSelect>>,
@@ -1817,7 +1820,7 @@ describe("SingleSelect", () => {
             it("should call validate prop", async () => {
                 // Arrange
                 const validate = jest.fn();
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <ControlledSingleSelect validate={validate} />,
                 );
                 const opener = await screen.findByRole("button");
@@ -1833,7 +1836,7 @@ describe("SingleSelect", () => {
                 // Arrange
                 const errorMessage = "error";
                 const onValidate = jest.fn();
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <ControlledSingleSelect
                         validate={() => errorMessage}
                         onValidate={onValidate}
@@ -1853,7 +1856,7 @@ describe("SingleSelect", () => {
 
             it("should be in an error state when validation fails", async () => {
                 // Arrange
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <ControlledSingleSelect validate={() => "Error"} />,
                 );
                 const opener = await screen.findByRole("button");
@@ -1868,7 +1871,7 @@ describe("SingleSelect", () => {
 
             it("should be in an error state when validation fails with a custom opener", async () => {
                 // Arrange
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <ControlledSingleSelect
                         validate={() => "Error"}
                         opener={() => (
@@ -1978,7 +1981,7 @@ describe("SingleSelect", () => {
             it("should still be in an error state before a value is picked", async () => {
                 // Arrange
                 const errorMessage = "Error message";
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <ControlledSingleSelect
                         validate={(value) =>
                             value === "1" ? errorMessage : undefined
@@ -2000,7 +2003,7 @@ describe("SingleSelect", () => {
             it("should not be in an error state once a value is picked", async () => {
                 // Arrange
                 const errorMessage = "Error message";
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <ControlledSingleSelect
                         validate={(value) =>
                             value === "1" ? errorMessage : undefined
@@ -2027,7 +2030,7 @@ describe("SingleSelect", () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect
                             onValidate={onValidate}
                             required={requiredMessage}
@@ -2047,7 +2050,7 @@ describe("SingleSelect", () => {
                 it("should be in an error state", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect required={requiredMessage} />,
                     );
                     await userEvent.tab(); // focus on the select
@@ -2066,7 +2069,7 @@ describe("SingleSelect", () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect
                             onValidate={onValidate}
                             required={requiredMessage}
@@ -2092,7 +2095,7 @@ describe("SingleSelect", () => {
                 it("should be in an error state with a custom opener", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect
                             opener={() => (
                                 <button
@@ -2119,7 +2122,7 @@ describe("SingleSelect", () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect
                             onValidate={onValidate}
                             required={requiredMessage}
@@ -2138,7 +2141,7 @@ describe("SingleSelect", () => {
                 it("should not be in an error state if it is disabled", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect
                             required={requiredMessage}
                             disabled={true}
@@ -2161,7 +2164,7 @@ describe("SingleSelect", () => {
                     // Arrange
                     const onValidate = jest.fn();
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect
                             onValidate={onValidate}
                             required={requiredMessage}
@@ -2181,7 +2184,7 @@ describe("SingleSelect", () => {
                 it("should be in an error state when it is closed", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect required={requiredMessage} />,
                     );
 
@@ -2200,7 +2203,7 @@ describe("SingleSelect", () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect
                             required={requiredMessage}
                             onValidate={onValidate}
@@ -2217,7 +2220,7 @@ describe("SingleSelect", () => {
                 it("should not be in an error state when it is only opened", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect required={requiredMessage} />,
                     );
 
@@ -2237,7 +2240,7 @@ describe("SingleSelect", () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect
                             onValidate={onValidate}
                             required={requiredMessage}
@@ -2258,7 +2261,7 @@ describe("SingleSelect", () => {
                 it("should be in an error state", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect required={requiredMessage} />,
                     );
 
@@ -2315,7 +2318,7 @@ describe("SingleSelect", () => {
                 it("should still be in an error state before a value is picked", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect required={requiredMessage} />,
                     );
                     await userEvent.tab();
@@ -2334,7 +2337,7 @@ describe("SingleSelect", () => {
                 it("should not be in an error state once a value is picked", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
-                    const userEvent = doRender(
+                    const {userEvent} = doRender(
                         <ControlledSingleSelect required={requiredMessage} />,
                     );
                     await userEvent.tab();
@@ -2355,7 +2358,7 @@ describe("SingleSelect", () => {
             it("should use the default required error message if required is set to true", async () => {
                 // Arrange
                 const onValidate = jest.fn();
-                const userEvent = doRender(
+                const {userEvent} = doRender(
                     <ControlledSingleSelect
                         onValidate={onValidate}
                         required={true}

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1741,6 +1741,59 @@ describe("SingleSelect", () => {
         );
     });
 
+    describe("a11y > aria-invalid", () => {
+        it.each([
+            {error: true, ariaInvalid: "true"},
+            {error: false, ariaInvalid: "false"},
+            {error: undefined, ariaInvalid: "false"},
+        ])(
+            "should set aria-invalid to $ariaInvalid if error is $error",
+            async ({error, ariaInvalid}) => {
+                // Arrange
+                doRender(
+                    <SingleSelect
+                        placeholder="Choose"
+                        onChange={jest.fn()}
+                        error={error}
+                    />,
+                );
+
+                // Act
+                const opener = await screen.findByRole("button");
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-invalid", ariaInvalid);
+            },
+        );
+
+        it.each([
+            {error: true, ariaInvalid: "true"},
+            {error: false, ariaInvalid: "false"},
+            {error: undefined, ariaInvalid: "false"},
+        ])(
+            "should set aria-invalid to $ariaInvalid if error is $error and there is a custom opener",
+            async ({error, ariaInvalid}) => {
+                // Arrange
+                doRender(
+                    <SingleSelect
+                        placeholder="Choose"
+                        onChange={jest.fn()}
+                        error={error}
+                        opener={() => (
+                            <button aria-label="Search" onClick={jest.fn()} />
+                        )}
+                    />,
+                );
+
+                // Act
+                const opener = await screen.findByRole("button");
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-invalid", ariaInvalid);
+            },
+        );
+    });
+
     describe("validation", () => {
         const ControlledSingleSelect = (
             props: Partial<PropsFor<typeof SingleSelect>>,

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1686,6 +1686,61 @@ describe("SingleSelect", () => {
         });
     });
 
+    describe("a11y > aria-required", () => {
+        it.each([
+            {required: "Custom required error message", ariaRequired: "true"},
+            {required: true, ariaRequired: "true"},
+            {required: false, ariaRequired: "false"},
+            {required: undefined, ariaRequired: "false"},
+        ])(
+            "should set aria-required to $ariaRequired if required is $required",
+            async ({required, ariaRequired}) => {
+                // Arrange
+                doRender(
+                    <SingleSelect
+                        placeholder="Choose"
+                        onChange={jest.fn()}
+                        required={required}
+                    />,
+                );
+
+                // Act
+                const opener = await screen.findByRole("button");
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-required", ariaRequired);
+            },
+        );
+
+        it.each([
+            {required: "Custom required error message", ariaRequired: "true"},
+            {required: true, ariaRequired: "true"},
+            {required: false, ariaRequired: "false"},
+            {required: undefined, ariaRequired: "false"},
+        ])(
+            "should set aria-required to $ariaRequired if required is $required and there is a custom opener",
+            async ({required, ariaRequired}) => {
+                // Arrange
+                doRender(
+                    <SingleSelect
+                        placeholder="Choose"
+                        onChange={jest.fn()}
+                        required={required}
+                        opener={() => (
+                            <button aria-label="Search" onClick={jest.fn()} />
+                        )}
+                    />,
+                );
+
+                // Act
+                const opener = await screen.findByRole("button");
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-required", ariaRequired);
+            },
+        );
+    });
+
     describe("validation", () => {
         const ControlledSingleSelect = (
             props: Partial<PropsFor<typeof SingleSelect>>,

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1810,6 +1810,55 @@ describe("SingleSelect", () => {
             });
         });
 
+        describe("picking a value after there was a validation error", () => {
+            it("should still be in an error state before a value is picked", async () => {
+                // Arrange
+                const errorMessage = "Error message";
+                const userEvent = doRender(
+                    <ControlledSingleSelect
+                        validate={(value) =>
+                            value === "1" ? errorMessage : undefined
+                        }
+                        selectedValue={"1"}
+                    />,
+                );
+
+                // Act
+                await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "true",
+                );
+            });
+
+            it("should not be in an error state once a value is picked", async () => {
+                // Arrange
+                const errorMessage = "Error message";
+                const userEvent = doRender(
+                    <ControlledSingleSelect
+                        validate={(value) =>
+                            value === "1" ? errorMessage : undefined
+                        }
+                        selectedValue={"1"}
+                    />,
+                );
+                await userEvent.tab();
+                await userEvent.tab(); // Tab through the select to trigger error
+
+                // Act
+                await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+                await userEvent.click(await screen.findByText("item 2")); // Pick a value
+
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "false",
+                );
+            });
+        });
+
         describe("required", () => {
             describe("tabbing through without picking a value", () => {
                 it("should call onValidate prop", async () => {
@@ -1946,26 +1995,10 @@ describe("SingleSelect", () => {
                 });
             });
             describe("opening and closing the dropdown without picking a value", () => {
-                it.only("should call the validate prop when it is closed", async () => {
-                    // Arrange
-                    const validate = jest.fn();
-                    const requiredMessage = "Required field";
-                    const userEvent = doRender(
-                        <ControlledSingleSelect required={requiredMessage} />,
-                    );
-
-                    // Act
-                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
-                    await userEvent.click(await screen.findByRole("button")); // Close the dropdown
-
-                    // Assert
-                    expect(validate).toHaveBeenCalled();
-                });
-
                 it("should call the onValidate prop when it is closed", async () => {
                     // Arrange
-                    const requiredMessage = "Required field";
                     const onValidate = jest.fn();
+                    const requiredMessage = "Required field";
                     const userEvent = doRender(
                         <ControlledSingleSelect
                             onValidate={onValidate}
@@ -1982,6 +2015,7 @@ describe("SingleSelect", () => {
                         requiredMessage,
                     );
                 });
+
                 it("should be in an error state when it is closed", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
@@ -2000,7 +2034,7 @@ describe("SingleSelect", () => {
                     );
                 });
 
-                it("should not call the onValidate prop when it is opened", async () => {
+                it("should not call the onValidate prop when it is only opened", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
@@ -2018,7 +2052,7 @@ describe("SingleSelect", () => {
                     expect(onValidate).not.toHaveBeenCalled();
                 });
 
-                it("should not be in an error state when it is opened", async () => {
+                it("should not be in an error state when it is only opened", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const userEvent = doRender(
@@ -2049,8 +2083,9 @@ describe("SingleSelect", () => {
                     );
 
                     // Act
-                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
-                    await userEvent.keyboard("{Escape}"); // Close the dropdown
+                    await userEvent.tab();
+                    await userEvent.keyboard("{enter}"); // Open the dropdown
+                    await userEvent.keyboard("{escape}"); // Close the dropdown
 
                     // Assert
                     expect(onValidate).toHaveBeenCalledExactlyOnceWith(
@@ -2066,8 +2101,9 @@ describe("SingleSelect", () => {
                     );
 
                     // Act
-                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
-                    await userEvent.keyboard("{Escape}"); // Close the dropdown
+                    await userEvent.tab();
+                    await userEvent.keyboard("{enter}"); // Open the dropdown
+                    await userEvent.keyboard("{escape}"); // Close the dropdown
 
                     // Assert
                     expect(await screen.findByRole("button")).toHaveAttribute(
@@ -2093,7 +2129,7 @@ describe("SingleSelect", () => {
                     // Assert
                     expect(onValidate).not.toHaveBeenCalled();
                 });
-                it("should not onValidate if there is a selected value on the initial render", () => {
+                it("should call onValidate with null if there is a selected value on the initial render", () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
@@ -2112,6 +2148,24 @@ describe("SingleSelect", () => {
                 });
             });
             describe("picking a value after there was an error", () => {
+                it("should still be in an error state before a value is picked", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const userEvent = doRender(
+                        <ControlledSingleSelect required={requiredMessage} />,
+                    );
+                    await userEvent.tab();
+                    await userEvent.tab(); // Tab through the select to trigger error
+
+                    // Act
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+
+                    // Assert
+                    expect(await screen.findByRole("button")).toHaveAttribute(
+                        "aria-invalid",
+                        "true",
+                    );
+                });
                 it("should not be in an error state once a value is picked", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
@@ -2133,7 +2187,7 @@ describe("SingleSelect", () => {
                 });
             });
 
-            it("should use the default required error message is required is set to true", async () => {
+            it("should use the default required error message if required is set to true", async () => {
                 // Arrange
                 const onValidate = jest.fn();
                 const userEvent = doRender(
@@ -2149,7 +2203,7 @@ describe("SingleSelect", () => {
 
                 // Assert
                 expect(onValidate).toHaveBeenCalledExactlyOnceWith(
-                    "This field is required",
+                    "This field is required.",
                 );
             });
         });

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -18,7 +18,7 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {WithActionSchedulerProps} from "@khanacademy/wonder-blocks-timing";
 import DropdownCoreVirtualized from "./dropdown-core-virtualized";
 import SeparatorItem from "./separator-item";
-import {defaultLabels, keyCodes} from "../util/constants";
+import {defaultLabels, keys} from "../util/constants";
 import type {DropdownItem} from "../util/types";
 import DropdownPopper from "./dropdown-popper";
 import {debounce, getLabel, getStringForKey} from "../util/helpers";
@@ -655,7 +655,7 @@ class DropdownCore extends React.Component<Props, State> {
 
     handleKeyDown: (event: React.KeyboardEvent) => void = (event) => {
         const {enableTypeAhead, onOpenChanged, open, searchText} = this.props;
-        const keyCode = event.which || event.keyCode;
+        const key = event.key;
 
         // Listen for the keydown events if we are using ASCII characters.
         if (enableTypeAhead && getStringForKey(event.key)) {
@@ -667,7 +667,7 @@ class DropdownCore extends React.Component<Props, State> {
 
         // If menu isn't open and user presses down, open the menu
         if (!open) {
-            if (keyCode === keyCodes.down) {
+            if (key === keys.down) {
                 event.preventDefault();
                 onOpenChanged(true);
                 return;
@@ -676,8 +676,8 @@ class DropdownCore extends React.Component<Props, State> {
         }
 
         // Handle all other key behavior
-        switch (keyCode) {
-            case keyCodes.tab:
+        switch (key) {
+            case keys.tab:
                 // When we show SearchField and that is focused and the
                 // searchText is entered at least one character, dismiss button
                 // is displayed. When user presses tab, we should move focus to
@@ -688,7 +688,7 @@ class DropdownCore extends React.Component<Props, State> {
                 this.restoreTabOrder();
                 onOpenChanged(false);
                 return;
-            case keyCodes.space:
+            case keys.space:
                 // When we display SearchField and the focus is on it, we should
                 // let the user type space.
                 if (this.isSearchFieldFocused()) {
@@ -697,11 +697,11 @@ class DropdownCore extends React.Component<Props, State> {
                 // Prevent space from scrolling down the page
                 event.preventDefault();
                 return;
-            case keyCodes.up:
+            case keys.up:
                 event.preventDefault();
                 this.focusPreviousItem();
                 return;
-            case keyCodes.down:
+            case keys.down:
                 event.preventDefault();
                 this.focusNextItem();
                 return;
@@ -711,9 +711,9 @@ class DropdownCore extends React.Component<Props, State> {
     // Some keys should be handled during the keyup event instead.
     handleKeyUp: (event: React.KeyboardEvent) => void = (event) => {
         const {onOpenChanged, open} = this.props;
-        const keyCode = event.which || event.keyCode;
-        switch (keyCode) {
-            case keyCodes.space:
+        const key = event.key;
+        switch (key) {
+            case keys.space:
                 // When we display SearchField and the focus is on it, we should
                 // let the user type space.
                 if (this.isSearchFieldFocused()) {
@@ -722,7 +722,7 @@ class DropdownCore extends React.Component<Props, State> {
                 // Prevent space from scrolling down the page
                 event.preventDefault();
                 return;
-            case keyCodes.escape:
+            case keys.escape:
                 // Close only the dropdown, not other elements that are
                 // listening for an escape press
                 if (open) {

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -658,9 +658,9 @@ class DropdownCore extends React.Component<Props, State> {
         const key = event.key;
 
         // Listen for the keydown events if we are using ASCII characters.
-        if (enableTypeAhead && getStringForKey(event.key)) {
+        if (enableTypeAhead && getStringForKey(key)) {
             event.stopPropagation();
-            this.textSuggestion += event.key;
+            this.textSuggestion += key;
             // Trigger the filter logic only after the debounce is resolved.
             this.handleKeyDownDebounced(this.textSuggestion);
         }

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
@@ -77,6 +77,7 @@ class DropdownOpener extends React.Component<Props> {
             opened,
             "aria-controls": ariaControls,
             "aria-haspopup": ariaHasPopUp,
+            "aria-required": ariaRequired,
             id,
             onBlur,
         } = this.props;
@@ -96,6 +97,7 @@ class DropdownOpener extends React.Component<Props> {
             id,
             "aria-expanded": opened ? "true" : "false",
             "aria-haspopup": ariaHasPopUp,
+            "aria-required": ariaRequired,
             onClick: childrenProps.onClick
                 ? (e: React.MouseEvent) => {
                       // This is done to avoid overriding a

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
@@ -43,6 +43,10 @@ type Props = Partial<Omit<AriaProps, "aria-disabled">> & {
      * The unique identifier for the opener.
      */
     id?: string;
+    /**
+     * If the dropdown has an error.
+     */
+    error?: boolean;
 };
 
 type DefaultProps = {
@@ -81,6 +85,7 @@ class DropdownOpener extends React.Component<Props> {
 
         return React.cloneElement(renderedChildren, {
             ...clickableChildrenProps,
+            "aria-invalid": this.props.error,
             disabled,
             "aria-controls": ariaControls,
             id,

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-opener.tsx
@@ -28,6 +28,10 @@ type Props = Partial<Omit<AriaProps, "aria-disabled">> & {
      */
     onClick: (e: React.SyntheticEvent) => unknown;
     /**
+     * Callback for when the opener is blurred.
+     */
+    onBlur?: (e: React.SyntheticEvent) => unknown;
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string;
@@ -74,6 +78,7 @@ class DropdownOpener extends React.Component<Props> {
             "aria-controls": ariaControls,
             "aria-haspopup": ariaHasPopUp,
             id,
+            onBlur,
         } = this.props;
         const renderedChildren = this.props.children({
             ...eventState,
@@ -103,6 +108,7 @@ class DropdownOpener extends React.Component<Props> {
             // try to get the testId from the child element
             // If it's not set, try to fallback to the parent's testId
             "data-testid": childrenTestId || testId,
+            onBlur,
         });
     }
 

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -55,6 +55,10 @@ type SelectOpenerProps = AriaProps & {
      * Test ID used for e2e testing.
      */
     testId?: string;
+    /**
+     * Called when it is blurred
+     */
+    onBlur?: (e: React.SyntheticEvent) => unknown;
 };
 
 type DefaultProps = {
@@ -133,6 +137,7 @@ export default class SelectOpener extends React.Component<
             light,
             open,
             testId,
+            onBlur,
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             onOpenChanged,
             ...sharedProps
@@ -171,6 +176,7 @@ export default class SelectOpener extends React.Component<
                 onClick={!disabled ? this.handleClick : undefined}
                 onKeyDown={!disabled ? this.handleKeyDown : undefined}
                 onKeyUp={!disabled ? this.handleKeyUp : undefined}
+                onBlur={onBlur}
             >
                 <LabelMedium style={styles.text}>
                     {/* Note(tamarab): Prevents unwanted vertical

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -137,6 +137,7 @@ export default class SelectOpener extends React.Component<
             light,
             open,
             testId,
+            "aria-required": ariaRequired,
             onBlur,
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             onOpenChanged,
@@ -168,6 +169,7 @@ export default class SelectOpener extends React.Component<
                 aria-disabled={disabled}
                 aria-expanded={open ? "true" : "false"}
                 aria-invalid={error}
+                aria-required={ariaRequired}
                 aria-haspopup="listbox"
                 data-testid={testId}
                 id={id}

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -162,6 +162,7 @@ export default class SelectOpener extends React.Component<
                 {...sharedProps}
                 aria-disabled={disabled}
                 aria-expanded={open ? "true" : "false"}
+                aria-invalid={error}
                 aria-haspopup="listbox"
                 data-testid={testId}
                 id={id}

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -304,9 +304,10 @@ const SingleSelect = (props: Props) => {
     const hasError = error || !!errorMessage;
 
     useOnMountEffect(() => {
-        // Only validate on mount if the value is not empty. This is so that fields
-        // don't render an error when they are initially empty
-        if (selectedValue) {
+        // Only validate on mount if the value is not empty and the field is not
+        // required. This is so that fields don't render an error when they are
+        //initially empty
+        if (selectedValue && !required) {
             handleValidation(selectedValue);
         }
     });
@@ -327,6 +328,10 @@ const SingleSelect = (props: Props) => {
 
         if (onToggle) {
             onToggle(opened);
+        }
+        if (!opened && required) {
+            // If closed and field is required, validate the selected value
+            handleValidation(selectedValue);
         }
     };
 

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -487,12 +487,13 @@ const SingleSelect = (props: Props) => {
         const dropdownOpener = (
             <IDProvider id={id} scope="single-select-opener">
                 {(uniqueOpenerId) => {
+                    const hasAriaRequired = ariaRequired || !!required;
                     return opener ? (
                         <DropdownOpener
                             id={uniqueOpenerId}
                             aria-controls={dropdownId}
                             aria-haspopup="listbox"
-                            aria-required={ariaRequired || !!required}
+                            aria-required={hasAriaRequired}
                             onClick={handleClick}
                             disabled={isDisabled}
                             ref={handleOpenerRef}
@@ -507,7 +508,7 @@ const SingleSelect = (props: Props) => {
                         <SelectOpener
                             {...sharedProps}
                             aria-controls={dropdownId}
-                            aria-required={ariaRequired || !!required}
+                            aria-required={hasAriaRequired}
                             disabled={isDisabled}
                             id={uniqueOpenerId}
                             error={hasError}

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -487,13 +487,11 @@ const SingleSelect = (props: Props) => {
         const dropdownOpener = (
             <IDProvider id={id} scope="single-select-opener">
                 {(uniqueOpenerId) => {
-                    const hasAriaRequired = ariaRequired || !!required;
                     return opener ? (
                         <DropdownOpener
                             id={uniqueOpenerId}
                             aria-controls={dropdownId}
                             aria-haspopup="listbox"
-                            aria-required={hasAriaRequired}
                             onClick={handleClick}
                             disabled={isDisabled}
                             ref={handleOpenerRef}
@@ -508,7 +506,6 @@ const SingleSelect = (props: Props) => {
                         <SelectOpener
                             {...sharedProps}
                             aria-controls={dropdownId}
-                            aria-required={hasAriaRequired}
                             disabled={isDisabled}
                             id={uniqueOpenerId}
                             error={hasError}

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -306,7 +306,7 @@ const SingleSelect = (props: Props) => {
     useOnMountEffect(() => {
         // Only validate on mount if the value is not empty and the field is not
         // required. This is so that fields don't render an error when they are
-        //initially empty
+        // initially empty
         if (selectedValue && !required) {
             handleValidation(selectedValue);
         }

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -300,6 +300,7 @@ const SingleSelect = (props: Props) => {
     const [errorMessage, setErrorMessage] = React.useState<
         string | null | undefined
     >(null);
+    const hasError = error || !!errorMessage;
 
     React.useEffect(() => {
         // Used to sync the `opened` state when this component acts as a controlled
@@ -477,6 +478,7 @@ const SingleSelect = (props: Props) => {
                             ref={handleOpenerRef}
                             text={menuText}
                             opened={open}
+                            error={hasError}
                         >
                             {opener}
                         </DropdownOpener>
@@ -486,7 +488,7 @@ const SingleSelect = (props: Props) => {
                             aria-controls={dropdownId}
                             disabled={isDisabled}
                             id={uniqueOpenerId}
-                            error={error}
+                            error={hasError}
                             isPlaceholder={!selectedItem}
                             light={light}
                             onOpenChanged={handleOpenChanged}

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -329,8 +329,8 @@ const SingleSelect = (props: Props) => {
         if (onToggle) {
             onToggle(opened);
         }
-        if (!opened && required) {
-            // If closed and field is required, validate the selected value
+        if (!opened && required && !selectedValue) {
+            // If closed, field is required, and no value is selected, validate
             handleValidation(selectedValue);
         }
     };
@@ -384,6 +384,7 @@ const SingleSelect = (props: Props) => {
             onToggle(false);
         }
 
+        // Validate when a value is selected
         handleValidation(newSelectedValue);
     };
 
@@ -457,9 +458,10 @@ const SingleSelect = (props: Props) => {
     };
 
     const handleOpenerBlur = () => {
-        if (!open && required) {
-            // Only validate on opener blur if the dropdown is closed. This
-            // prevents an error when the dropdown is opened without a value yet
+        if (!open && required && !selectedValue) {
+            // Only validate on opener blur if the dropdown is closed, the field
+            // is required, and no value is selected. This prevents an error when
+            // the dropdown is opened without a value yet.
             handleValidation(selectedValue);
         }
     };

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -492,6 +492,7 @@ const SingleSelect = (props: Props) => {
                             id={uniqueOpenerId}
                             aria-controls={dropdownId}
                             aria-haspopup="listbox"
+                            aria-required={ariaRequired || !!required}
                             onClick={handleClick}
                             disabled={isDisabled}
                             ref={handleOpenerRef}
@@ -506,6 +507,7 @@ const SingleSelect = (props: Props) => {
                         <SelectOpener
                             {...sharedProps}
                             aria-controls={dropdownId}
+                            aria-required={ariaRequired || !!required}
                             disabled={isDisabled}
                             id={uniqueOpenerId}
                             error={hasError}

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from "react-dom";
 
 import {
     IDProvider,
+    useOnMountEffect,
     type AriaProps,
     type StyleType,
 } from "@khanacademy/wonder-blocks-core";
@@ -302,6 +303,14 @@ const SingleSelect = (props: Props) => {
     >(null);
     const hasError = error || !!errorMessage;
 
+    useOnMountEffect(() => {
+        // Only validate on mount if the value is not empty. This is so that fields
+        // don't render an error when they are initially empty
+        if (selectedValue) {
+            handleValidation(selectedValue);
+        }
+    });
+
     React.useEffect(() => {
         // Used to sync the `opened` state when this component acts as a controlled
         if (disabled) {
@@ -353,13 +362,6 @@ const SingleSelect = (props: Props) => {
         [disabled, validate, setErrorMessage, onValidate, required],
     );
 
-    React.useEffect(() => {
-        if (!open) {
-            // Once dropdown is closed, validate the selected value
-            handleValidation(selectedValue);
-        }
-    }, [open, selectedValue, handleValidation]);
-
     const handleToggle = (newSelectedValue: string) => {
         // Call callback if selection changed.
         if (newSelectedValue !== selectedValue) {
@@ -376,6 +378,8 @@ const SingleSelect = (props: Props) => {
         if (onToggle) {
             onToggle(false);
         }
+
+        handleValidation(newSelectedValue);
     };
 
     const mapOptionItemsToDropdownItems = (
@@ -447,6 +451,14 @@ const SingleSelect = (props: Props) => {
         handleOpenChanged(!open);
     };
 
+    const handleOpenerBlur = () => {
+        if (!open && required) {
+            // Only validate on opener blur if the dropdown is closed. This
+            // prevents an error when the dropdown is opened without a value yet
+            handleValidation(selectedValue);
+        }
+    };
+
     const renderOpener = (
         isDisabled: boolean,
         dropdownId: string,
@@ -479,6 +491,7 @@ const SingleSelect = (props: Props) => {
                             text={menuText}
                             opened={open}
                             error={hasError}
+                            onBlur={handleOpenerBlur}
                         >
                             {opener}
                         </DropdownOpener>
@@ -495,6 +508,7 @@ const SingleSelect = (props: Props) => {
                             open={open}
                             ref={handleOpenerRef}
                             testId={testId}
+                            onBlur={handleOpenerBlur}
                         >
                             {menuText}
                         </SelectOpener>

--- a/packages/wonder-blocks-dropdown/src/util/constants.ts
+++ b/packages/wonder-blocks-dropdown/src/util/constants.ts
@@ -1,13 +1,12 @@
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {ComboboxLabels} from "./types";
 
-export const keyCodes = {
-    tab: 9,
-    enter: 13,
-    escape: 27,
-    space: 32,
-    up: 38,
-    down: 40,
+export const keys = {
+    escape: "Escape",
+    tab: "Tab",
+    space: "Space",
+    up: "ArrowUp",
+    down: "ArrowDown",
 } as const;
 
 export const selectDropdownStyle = {

--- a/packages/wonder-blocks-dropdown/src/util/constants.ts
+++ b/packages/wonder-blocks-dropdown/src/util/constants.ts
@@ -1,6 +1,10 @@
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {ComboboxLabels} from "./types";
 
+/**
+ * Key value mapping reference:
+ * https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
+ */
 export const keys = {
     escape: "Escape",
     tab: "Tab",

--- a/packages/wonder-blocks-dropdown/src/util/constants.ts
+++ b/packages/wonder-blocks-dropdown/src/util/constants.ts
@@ -4,7 +4,7 @@ import {ComboboxLabels} from "./types";
 export const keys = {
     escape: "Escape",
     tab: "Tab",
-    space: "Space",
+    space: " ",
     up: "ArrowUp",
     down: "ArrowDown",
 } as const;


### PR DESCRIPTION
## Summary:
- Adding validation related props to SingleSelect: `validate`, `onValidate`, `required`. (`error` prop was already supported)
- DropdownOpener and SelectOpener: Add optional `onBlur` prop and set `aria-invalid` based on `error` prop
- DropdownCore: When checking keyboard events, check what key is pressed using [event.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) instead of [event.which](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which) or [event.keyCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) which are now deprecated. Testing keyboard interactions in tests weren't triggering the correct logic since we were using deprecated fields that [user-event doesn't support anymore](https://github.com/testing-library/user-event/releases/tag/v14.0.0): 
  > Support for keyCode property on keyboard events has been removed.


Next: Will work on applying similar changes to MultiSelect and consolidating any common logic! 

Issue: WB-1782

## Test plan:
- SingleSelect docs are reviewed `?path=/docs/packages-dropdown-singleselect--docs`
- Validation works as expected in SingleSelect (see docs for more details on validation behaviour):
  -  Error `?path=/story/packages-dropdown-singleselect--error`
  - Required `?path=/story/packages-dropdown-singleselect--required`
  - Error From Validation `?path=/story/packages-dropdown-singleselect--error-from-validation`
- SingleSelect continues to work as expected (including keyboard interactions) 