### PR TITLE
Add validation props to MultiSelect and share logic with SingleSelect

### DIFF
--- a/.changeset/thin-gifts-tickle.md
+++ b/.changeset/thin-gifts-tickle.md
@@ -1,0 +1,10 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+# MultiSelect
+
+- Add `required`, `validate`, and `onValidate` props to support validation.
+- Set `aria-required` on the opener if the `required` prop is `true` or
+`aria-required` is set
+- Share validation logic with SingleSelect

--- a/.changeset/thin-gifts-tickle.md
+++ b/.changeset/thin-gifts-tickle.md
@@ -5,6 +5,5 @@
 # MultiSelect
 
 - Add `required`, `validate`, and `onValidate` props to support validation.
-- Set `aria-required` on the opener if the `required` prop is `true` or
-`aria-required` is set
+- Set `aria-invalid` on the opener if it is in an error state
 - Share validation logic with SingleSelect

--- a/__docs__/wonder-blocks-dropdown/multi-select.argtypes.ts
+++ b/__docs__/wonder-blocks-dropdown/multi-select.argtypes.ts
@@ -12,6 +12,7 @@ const argTypes: ArgTypes = {
         table: {
             type: {summary: "Array<string>"},
         },
+        control: {type: "object"},
     },
     labels: {
         control: {type: "object"},

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -271,36 +271,11 @@ export const CustomStylesOpened: StoryComponentType = {
     ],
 };
 
-const ErrorWrapper = (args: any) => {
-    const [selectedValues, setSelectedValues] = React.useState<string[]>([]);
-    const [opened, setOpened] = React.useState(false);
-    const [error, setError] = React.useState(true);
-
-    return (
-        <>
-            <LabelMedium style={{marginBottom: spacing.xSmall_8}}>
-                Select at least 2 options to clear the error!
-            </LabelMedium>
-            <MultiSelect
-                {...args}
-                error={error}
-                onChange={(values) => {
-                    setSelectedValues(values);
-                    setError(values.length < 2);
-                }}
-                onToggle={setOpened}
-                opened={opened}
-                selectedValues={selectedValues}
-            >
-                {items}
-            </MultiSelect>
-        </>
-    );
-};
-
 const ControlledMultiSelect = (args: PropsFor<typeof MultiSelect>) => {
     const [opened, setOpened] = React.useState(false);
-    const [selectedValues, setSelectedValues] = React.useState<string[]>([]);
+    const [selectedValues, setSelectedValues] = React.useState<string[]>(
+        args.selectedValues || [],
+    );
     const [errorMessage, setErrorMessage] = React.useState<
         null | string | void
     >(null);
@@ -395,9 +370,9 @@ export const Required: StoryComponentType = {
  *
  * Validation is triggered:
  * - On mount if the `value` prop is not empty and it is not required
- * - When an option is selected
+ * - When the dropdown is closed after updating the selected values
  *
- * Validation errors are cleared when a valid value is selected. The component
+ * Validation errors are cleared when the value is updated. The component
  * will set aria-invalid to "false" and call the onValidate prop with null.
  */
 export const ErrorFromValidation: StoryComponentType = {

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -129,14 +129,14 @@ const styles = StyleSheet.create({
 });
 
 const items = [
-    <OptionItem label="Mercury" value="1" key={1} />,
-    <OptionItem label="Venus" value="2" key={2} />,
-    <OptionItem label="Earth" value="3" disabled key={3} />,
-    <OptionItem label="Mars" value="4" key={4} />,
-    <OptionItem label="Jupiter" value="5" key={5} />,
-    <OptionItem label="Saturn" value="6" key={6} />,
-    <OptionItem label="Neptune" value="7" key={7} />,
-    <OptionItem label="Uranus" value="8" key={8} />,
+    <OptionItem label="Mercury" value="mercury" key={1} />,
+    <OptionItem label="Venus" value="venus" key={2} />,
+    <OptionItem label="Earth" value="earth" disabled key={3} />,
+    <OptionItem label="Mars" value="mars" key={4} />,
+    <OptionItem label="Jupiter" value="jupiter" key={5} />,
+    <OptionItem label="Saturn" value="saturn" key={6} />,
+    <OptionItem label="Neptune" value="neptune" key={7} />,
+    <OptionItem label="Uranus" value="uranus" key={8} />,
 ];
 
 const Template = (args: any) => {
@@ -289,7 +289,7 @@ const ControlledMultiSelect = (args: PropsFor<typeof MultiSelect>) => {
                 selectedValues={selectedValues}
                 onChange={setSelectedValues}
                 validate={(values) => {
-                    if (values.includes("5")) {
+                    if (values.includes("jupiter")) {
                         return "Don't pick jupiter!";
                     }
                 }}
@@ -383,6 +383,16 @@ export const ErrorFromValidation: StoryComponentType = {
                     Validation example (try picking jupiter)
                 </LabelMedium>
                 <ControlledMultiSelect {...args} id="multi-select">
+                    {items}
+                </ControlledMultiSelect>
+                <LabelMedium htmlFor="multi-select" tag="label">
+                    Validation example (on mount)
+                </LabelMedium>
+                <ControlledMultiSelect
+                    {...args}
+                    selectedValues={["jupiter"]}
+                    id="multi-select"
+                >
                     {items}
                 </ControlledMultiSelect>
             </View>

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -398,12 +398,6 @@ export const ErrorFromValidation: StoryComponentType = {
             </View>
         );
     },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -523,12 +523,6 @@ export const ErrorFromValidation: StoryComponentType = {
             </View>
         );
     },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -505,6 +505,21 @@ export const ErrorFromValidation: StoryComponentType = {
                 >
                     {items}
                 </ControlledSingleSelect>
+                <LabelSmall htmlFor="single-select" tag="label">
+                    Validation example (on mount)
+                </LabelSmall>
+                <ControlledSingleSelect
+                    {...args}
+                    id="single-select"
+                    validate={(value) => {
+                        if (value === "lemon") {
+                            return "Pick another option!";
+                        }
+                    }}
+                    selectedValue="lemon"
+                >
+                    {items}
+                </ControlledSingleSelect>
             </View>
         );
     },

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -2226,7 +2226,7 @@ describe("MultiSelect", () => {
                 },
             },
             {
-                closingMethod: "pressing Esc",
+                closingMethod: "pressing Escape",
                 closingAction: async (userEvent: UserEvent) => {
                     await userEvent.keyboard("{escape}");
                 },
@@ -2317,6 +2317,55 @@ describe("MultiSelect", () => {
                 });
             },
         );
+
+        describe("when selected values are updated and the dropdown isn't closed yet", () => {
+            it("should not call validate prop", async () => {
+                // Arrange
+                const validate = jest.fn();
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect validate={validate} />,
+                );
+                const opener = await screen.findByRole("button");
+                await userEvent.click(opener);
+                // Act
+                await userEvent.click(screen.getByText("item 1"));
+
+                // Assert
+                expect(validate).not.toHaveBeenCalled();
+            });
+
+            it("should call onValidate prop with null to clear any errors", async () => {
+                // Arrange
+                const onValidate = jest.fn();
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        validate={() => "Error"}
+                        onValidate={onValidate}
+                    />,
+                );
+                const opener = await screen.findByRole("button");
+                await userEvent.click(opener);
+                await userEvent.click(screen.getByText("item 1"));
+
+                // Assert
+                expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
+            });
+
+            it("should not be in an error state", async () => {
+                // Arrange
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect validate={() => "Error"} />,
+                );
+                const opener = await screen.findByRole("button");
+                await userEvent.click(opener);
+
+                // Act
+                await userEvent.click(screen.getByText("item 1"));
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-invalid", "false");
+            });
+        });
 
         describe("validation on mount", () => {
             it("should validate twice when first rendered if there is a selected value (once on initalization, once after mount)", () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -2098,4 +2098,57 @@ describe("MultiSelect", () => {
             expect(opener).toHaveAttribute("aria-expanded", "true");
         });
     });
+
+    describe("a11y > aria-required", () => {
+        it.each([
+            {required: "Custom required error message", ariaRequired: "true"},
+            {required: true, ariaRequired: "true"},
+            {required: false, ariaRequired: "false"},
+            {required: undefined, ariaRequired: "false"},
+        ])(
+            "should set aria-required to $ariaRequired if required is $required",
+            async ({required, ariaRequired}) => {
+                // Arrange
+                doRender(
+                    <MultiSelect
+                        onChange={jest.fn()}
+                        required={required}
+                    />,
+                );
+
+                // Act
+                const opener = await screen.findByRole("button");
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-required", ariaRequired);
+            },
+        );
+
+        it.each([
+            {required: "Custom required error message", ariaRequired: "true"},
+            {required: true, ariaRequired: "true"},
+            {required: false, ariaRequired: "false"},
+            {required: undefined, ariaRequired: "false"},
+        ])(
+            "should set aria-required to $ariaRequired if required is $required and there is a custom opener",
+            async ({required, ariaRequired}) => {
+                // Arrange
+                doRender(
+                    <MultiSelect
+                        onChange={jest.fn()}
+                        required={required}
+                        opener={() => (
+                            <button aria-label="Search" onClick={jest.fn()} />
+                        )}
+                    />,
+                );
+
+                // Act
+                const opener = await screen.findByRole("button");
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-required", ariaRequired);
+            },
+        );
+    });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -11,10 +11,12 @@ import {
 import {
     userEvent as ue,
     PointerEventsCheckLevel,
+    UserEvent,
 } from "@testing-library/user-event";
 
 import {ngettext} from "@khanacademy/wonder-blocks-i18n";
 
+import {PropsFor} from "@khanacademy/wonder-blocks-core";
 import OptionItem from "../option-item";
 import MultiSelect from "../multi-select";
 import {defaultLabels as builtinLabels} from "../../util/constants";
@@ -2110,10 +2112,7 @@ describe("MultiSelect", () => {
             async ({required, ariaRequired}) => {
                 // Arrange
                 doRender(
-                    <MultiSelect
-                        onChange={jest.fn()}
-                        required={required}
-                    />,
+                    <MultiSelect onChange={jest.fn()} required={required} />,
                 );
 
                 // Act
@@ -2161,12 +2160,7 @@ describe("MultiSelect", () => {
             "should set aria-invalid to $ariaInvalid if error is $error",
             async ({error, ariaInvalid}) => {
                 // Arrange
-                doRender(
-                    <MultiSelect
-                        onChange={jest.fn()}
-                        error={error}
-                    />,
-                );
+                doRender(<MultiSelect onChange={jest.fn()} error={error} />);
 
                 // Act
                 const opener = await screen.findByRole("button");
@@ -2201,5 +2195,635 @@ describe("MultiSelect", () => {
                 expect(opener).toHaveAttribute("aria-invalid", ariaInvalid);
             },
         );
+    });
+
+    describe("validation", () => {
+        const ControlledMultiSelect = (
+            props: Partial<PropsFor<typeof MultiSelect>>,
+        ) => {
+            const [values, setValues] = React.useState<string[] | undefined>(
+                props.selectedValues || undefined,
+            );
+            return (
+                <MultiSelect
+                    {...props}
+                    selectedValues={values}
+                    onChange={setValues}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </MultiSelect>
+            );
+        };
+        describe.each([
+            {
+                closingMethod: "clicking the opener",
+                closingAction: async (
+                    userEvent: UserEvent,
+                    opener: HTMLElement,
+                ) => {
+                    await userEvent.click(opener);
+                },
+            },
+            {
+                closingMethod: "pressing Esc",
+                closingAction: async (userEvent: UserEvent) => {
+                    await userEvent.keyboard("{escape}");
+                },
+            },
+        ])(
+            "when a value is selected and the dropdown is closed by $closingMethod",
+            ({closingAction}) => {
+                it("should call validate prop", async () => {
+                    // Arrange
+                    const validate = jest.fn();
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect validate={validate} />,
+                    );
+                    const opener = await screen.findByRole("button");
+                    await userEvent.click(opener);
+                    await userEvent.click(screen.getByText("item 1"));
+                    validate.mockClear(); // Clear any calls
+
+                    // Act
+                    await closingAction(userEvent, opener); // Close the dropdown
+
+                    // Assert
+                    expect(validate).toHaveBeenCalledExactlyOnceWith(["1"]);
+                });
+
+                it("should call onValidate prop", async () => {
+                    // Arrange
+                    const errorMessage = "error";
+                    const onValidate = jest.fn();
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            validate={() => errorMessage}
+                            onValidate={onValidate}
+                        />,
+                    );
+                    const opener = await screen.findByRole("button");
+                    await userEvent.click(opener);
+                    await userEvent.click(screen.getByText("item 1"));
+                    onValidate.mockClear(); // Clear any calls
+
+                    // Act
+                    await userEvent.click(opener); // Close the dropdown
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        errorMessage,
+                    );
+                });
+
+                it("should be in an error state when validation fails", async () => {
+                    // Arrange
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect validate={() => "Error"} />,
+                    );
+                    const opener = await screen.findByRole("button");
+                    await userEvent.click(opener);
+                    await userEvent.click(screen.getByText("item 1"));
+
+                    // Act
+                    await userEvent.click(opener); // Close the dropdown
+
+                    // Assert
+                    expect(opener).toHaveAttribute("aria-invalid", "true");
+                });
+
+                it("should be in an error state when validation fails with a custom opener", async () => {
+                    // Arrange
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            validate={() => "Error"}
+                            opener={() => (
+                                <button
+                                    aria-label="Search"
+                                    onClick={jest.fn()}
+                                />
+                            )}
+                        />,
+                    );
+                    const opener = await screen.findByLabelText("Search");
+                    await userEvent.click(opener);
+                    await userEvent.click(screen.getByText("item 1"));
+
+                    // Act
+                    await userEvent.click(opener); // Close the dropdown
+
+                    // Assert
+                    expect(opener).toHaveAttribute("aria-invalid", "true");
+                });
+            },
+        );
+
+        describe("validation on mount", () => {
+            it("should validate twice when first rendered if there is a selected value (once on initalization, once after mount)", () => {
+                // Arrange
+                const validate = jest.fn();
+                // Act
+                doRender(
+                    <ControlledMultiSelect
+                        validate={validate}
+                        selectedValues={["1"]}
+                    />,
+                );
+                // Assert
+                expect(validate.mock.calls).toStrictEqual([[["1"]], [["1"]]]);
+            });
+
+            it("should be in an error state on mount if there is an invalid selected value", async () => {
+                // Arrange
+                // Act
+                doRender(
+                    <ControlledMultiSelect
+                        validate={(values) => {
+                            if (values.includes("1")) {
+                                return "Error";
+                            }
+                        }}
+                        selectedValues={["1"]}
+                    />,
+                );
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "true",
+                );
+            });
+
+            it("should not be in an error state on mount if there is a valid selected value", async () => {
+                // Arrange
+                // Act
+                doRender(
+                    <ControlledMultiSelect
+                        validate={(values) => {
+                            if (values.includes("1")) {
+                                return "Error";
+                            }
+                        }}
+                        selectedValues={["2"]}
+                    />,
+                );
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "false",
+                );
+            });
+
+            it("should not validate on mount if there is no selected value", () => {
+                // Arrange
+                // Act
+                const validate = jest.fn();
+                doRender(
+                    <ControlledMultiSelect
+                        validate={validate}
+                        selectedValues={undefined}
+                    />,
+                );
+
+                // Assert
+                expect(validate).not.toHaveBeenCalled();
+            });
+
+            it("should not be in an error state on mount if there is no selected value", async () => {
+                // Arrange
+                // Act
+                doRender(
+                    <ControlledMultiSelect
+                        validate={() => "Error"}
+                        selectedValues={undefined}
+                    />,
+                );
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "false",
+                );
+            });
+        });
+
+        describe("interactions after there is a validation error", () => {
+            it("should still be in an error state before values are updated", async () => {
+                // Arrange
+                const errorMessage = "Error message";
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        validate={(values) =>
+                            values.includes("1") ? errorMessage : undefined
+                        }
+                        selectedValues={["1"]}
+                    />,
+                );
+
+                // Act
+                await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "true",
+                );
+            });
+
+            it("should not be in an error state once values are updated", async () => {
+                // Arrange
+                const errorMessage = "Error message";
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        validate={(values) =>
+                            values.includes("1") ? errorMessage : undefined
+                        }
+                        selectedValues={["1"]}
+                    />,
+                );
+                await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+
+                // Act
+                await userEvent.click(await screen.findByText("item 2")); // Pick a value
+
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "false",
+                );
+            });
+
+            it("should call onValidate with null once values are updated", async () => {
+                // Arrange
+                const errorMessage = "Error message";
+                const onValidate = jest.fn();
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        validate={(values) =>
+                            values.includes("1") ? errorMessage : undefined
+                        }
+                        selectedValues={["1"]}
+                        onValidate={onValidate}
+                    />,
+                );
+                await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+                onValidate.mockClear(); // Clear any calls
+
+                // Act
+                await userEvent.click(await screen.findByText("item 2")); // Pick a value
+
+                // Assert
+                expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
+            });
+        });
+
+        describe("required", () => {
+            describe("tabbing through without picking a value", () => {
+                it("should call onValidate prop", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const onValidate = jest.fn();
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            onValidate={onValidate}
+                            required={requiredMessage}
+                        />,
+                    );
+
+                    // Act
+                    await userEvent.tab(); // focus on the select
+                    await userEvent.tab(); // leave the select
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        requiredMessage,
+                    );
+                });
+
+                it("should be in an error state", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect required={requiredMessage} />,
+                    );
+                    await userEvent.tab(); // focus on the select
+
+                    // Act
+                    await userEvent.tab(); // leave the select
+
+                    // Assert
+                    expect(screen.getByRole("button")).toHaveAttribute(
+                        "aria-invalid",
+                        "true",
+                    );
+                });
+
+                it("should call onValidate prop with a custom opener", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const onValidate = jest.fn();
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            onValidate={onValidate}
+                            required={requiredMessage}
+                            opener={() => (
+                                <button
+                                    aria-label="Search"
+                                    onClick={jest.fn()}
+                                />
+                            )}
+                        />,
+                    );
+
+                    // Act
+                    await userEvent.tab(); // focus on the select
+                    await userEvent.tab(); // leave the select
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        requiredMessage,
+                    );
+                });
+
+                it("should be in an error state with a custom opener", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            opener={() => (
+                                <button
+                                    aria-label="Search"
+                                    onClick={jest.fn()}
+                                />
+                            )}
+                            required={requiredMessage}
+                        />,
+                    );
+
+                    // Act
+                    await userEvent.tab(); // focus on the select
+                    await userEvent.tab(); // leave the select
+
+                    // Assert
+                    expect(screen.getByLabelText("Search")).toHaveAttribute(
+                        "aria-invalid",
+                        "true",
+                    );
+                });
+
+                it("should not call onValidate prop if it is disabled", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const onValidate = jest.fn();
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            onValidate={onValidate}
+                            required={requiredMessage}
+                            disabled={true}
+                        />,
+                    );
+
+                    // Act
+                    await userEvent.tab(); // focus on the select
+                    await userEvent.tab(); // leave the select
+
+                    // Assert
+                    expect(onValidate).not.toHaveBeenCalled();
+                });
+
+                it("should not be in an error state if it is disabled", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            required={requiredMessage}
+                            disabled={true}
+                        />,
+                    );
+
+                    // Act
+                    await userEvent.tab(); // focus on the select
+                    await userEvent.tab(); // leave the select
+
+                    // Assert
+                    expect(screen.getByRole("button")).toHaveAttribute(
+                        "aria-invalid",
+                        "false",
+                    );
+                });
+            });
+            describe("opening and closing the dropdown without picking a value", () => {
+                it("should call the onValidate prop when it is closed", async () => {
+                    // Arrange
+                    const onValidate = jest.fn();
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            onValidate={onValidate}
+                            required={requiredMessage}
+                        />,
+                    );
+
+                    // Act
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+                    await userEvent.click(await screen.findByRole("button")); // Close the dropdown
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        requiredMessage,
+                    );
+                });
+
+                it("should be in an error state when it is closed", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect required={requiredMessage} />,
+                    );
+
+                    // Act
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+                    await userEvent.click(await screen.findByRole("button")); // Close the dropdown
+
+                    // Assert
+                    expect(await screen.findByRole("button")).toHaveAttribute(
+                        "aria-invalid",
+                        "true",
+                    );
+                });
+
+                it("should not call the onValidate prop when it is only opened", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const onValidate = jest.fn();
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            required={requiredMessage}
+                            onValidate={onValidate}
+                        />,
+                    );
+
+                    // Act
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+
+                    // Assert
+                    expect(onValidate).not.toHaveBeenCalled();
+                });
+
+                it("should not be in an error state when it is only opened", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect required={requiredMessage} />,
+                    );
+
+                    // Act
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+
+                    // Assert
+                    expect(await screen.findByRole("button")).toHaveAttribute(
+                        "aria-invalid",
+                        "false",
+                    );
+                });
+            });
+
+            describe("opening and closing the dropdown by pressing escape without picking a value", () => {
+                it("should call the onValidate prop", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const onValidate = jest.fn();
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect
+                            onValidate={onValidate}
+                            required={requiredMessage}
+                        />,
+                    );
+
+                    // Act
+                    await userEvent.tab();
+                    await userEvent.keyboard("{enter}"); // Open the dropdown
+                    await userEvent.keyboard("{escape}"); // Close the dropdown
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        requiredMessage,
+                    );
+                });
+
+                it("should be in an error state", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect required={requiredMessage} />,
+                    );
+
+                    // Act
+                    await userEvent.tab();
+                    await userEvent.keyboard("{enter}"); // Open the dropdown
+                    await userEvent.keyboard("{escape}"); // Close the dropdown
+
+                    // Assert
+                    expect(await screen.findByRole("button")).toHaveAttribute(
+                        "aria-invalid",
+                        "true",
+                    );
+                });
+            });
+
+            describe("initial render", () => {
+                it("should not call onValidate if there is no selected value on the initial render", () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const onValidate = jest.fn();
+                    // Act
+                    doRender(
+                        <ControlledMultiSelect
+                            onValidate={onValidate}
+                            required={requiredMessage}
+                        />,
+                    );
+
+                    // Assert
+                    expect(onValidate).not.toHaveBeenCalled();
+                });
+                it("should call onValidate with null if there is a selected value on the initial render", () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const onValidate = jest.fn();
+
+                    // Act
+                    doRender(
+                        <ControlledMultiSelect
+                            onValidate={onValidate}
+                            required={requiredMessage}
+                            selectedValues={["1"]}
+                        />,
+                    );
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
+                });
+            });
+
+            describe("picking a value after there was an error", () => {
+                it("should still be in an error state before a value is picked", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect required={requiredMessage} />,
+                    );
+                    await userEvent.tab();
+                    await userEvent.tab(); // Tab through the select to trigger error
+
+                    // Act
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+
+                    // Assert
+                    expect(await screen.findByRole("button")).toHaveAttribute(
+                        "aria-invalid",
+                        "true",
+                    );
+                });
+
+                it("should not be in an error state once a value is picked", async () => {
+                    // Arrange
+                    const requiredMessage = "Required field";
+                    const {userEvent} = doRender(
+                        <ControlledMultiSelect required={requiredMessage} />,
+                    );
+                    await userEvent.tab();
+                    await userEvent.tab(); // Tab through the select to trigger error
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+
+                    // Act
+                    await userEvent.click(await screen.findByText("item 1")); // Pick a value
+
+                    // Assert
+                    expect(await screen.findByRole("button")).toHaveAttribute(
+                        "aria-invalid",
+                        "false",
+                    );
+                });
+            });
+
+            it("should use the default required error message if required is set to true", async () => {
+                // Arrange
+                const onValidate = jest.fn();
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        onValidate={onValidate}
+                        required={true}
+                    />,
+                );
+
+                // Act
+                await userEvent.tab();
+                await userEvent.tab();
+
+                // Assert
+                expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                    "This field is required.",
+                );
+            });
+        });
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -2723,6 +2723,7 @@ describe("MultiSelect", () => {
                     );
                 });
             });
+
             describe("opening and closing the dropdown without picking a value", () => {
                 it("should call the onValidate prop when it is closed", async () => {
                     // Arrange

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -2473,6 +2473,44 @@ describe("MultiSelect", () => {
                 // Assert
                 expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
             });
+
+            it("should still be in an error state if an invalid value is unselected and selected again", async () => {
+                // Arrange
+                const errorMessage = "Error message";
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        validate={(values) =>
+                            values.includes("1") ? errorMessage : undefined
+                        }
+                        selectedValues={["1"]}
+                        testId="multi-select"
+                    />,
+                );
+                // Open the dropdown
+                await userEvent.click(await screen.findByRole("button"));
+                // Need to find item text within the listbox since the item text is also used on the opener
+                const listbox = await screen.findByRole("listbox", {
+                    hidden: true,
+                });
+                // Unselect the invalid value
+                await userEvent.click(
+                    await within(listbox).findByText("item 1"),
+                );
+                // Select the invalid value again
+                await userEvent.click(
+                    await within(listbox).findByText("item 1"),
+                );
+
+                // Act
+                // Close the dropdown
+                await userEvent.click(await screen.findByRole("button"));
+
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "true",
+                );
+            });
         });
 
         describe("required", () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -2912,5 +2912,107 @@ describe("MultiSelect", () => {
                 );
             });
         });
+
+        describe("validate and required props", () => {
+            it("should be in an error state if validate succeeds and required is set to true", async () => {
+                // Arrange
+                const requiredMessage = "Required field";
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        required={requiredMessage}
+                        validate={() => {}}
+                        selectedValues={["1"]}
+                    />,
+                );
+                // Open the dropdown
+                await userEvent.click(await screen.findByRole("button"));
+
+                // Unselect selected option
+                const listbox = await screen.findByRole("listbox", {
+                    hidden: true,
+                });
+                await userEvent.click(
+                    await within(listbox).findByText("item 1"),
+                );
+
+                // Act
+                // Close the dropdown
+                await userEvent.click(await screen.findByRole("button"));
+
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "true",
+                );
+            });
+
+            it("should call the onValidate prop with null and the required error message if validate succeeds and required is set to true", async () => {
+                // Arrange
+                const onValidate = jest.fn();
+                const requiredMessage = "Required field";
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        onValidate={onValidate}
+                        required={requiredMessage}
+                        validate={() => {}}
+                        selectedValues={["1"]}
+                    />,
+                );
+                // Open the dropdown
+                await userEvent.click(await screen.findByRole("button"));
+
+                // Unselect selected option
+                const listbox = await screen.findByRole("listbox", {
+                    hidden: true,
+                });
+                await userEvent.click(
+                    await within(listbox).findByText("item 1"),
+                );
+                onValidate.mockClear(); // Clear the mock
+
+                // Act
+                // Close the dropdown
+                await userEvent.click(await screen.findByRole("button"));
+
+                // Assert
+                expect(onValidate.mock.calls).toStrictEqual([
+                    [null], // onValidate is called with null when `validate` is called, this clears any existing errors
+                    [requiredMessage], // onValidate is called with the required error message if it is required
+                ]);
+            });
+
+            it("should call the onValidate prop with the validate error message", async () => {
+                // Arrange
+                const errorMessage = "Error message";
+                const onValidate = jest.fn();
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        onValidate={onValidate}
+                        validate={() => errorMessage}
+                        required={true}
+                        selectedValues={["1"]}
+                    />,
+                );
+                // Open the dropdown
+                await userEvent.click(await screen.findByRole("button"));
+                // Unselect selected option
+                const listbox = await screen.findByRole("listbox", {
+                    hidden: true,
+                });
+                await userEvent.click(
+                    await within(listbox).findByText("item 1"),
+                );
+                onValidate.mockClear(); // Clear the mock
+
+                // Act
+                // Close the dropdown
+                await userEvent.click(await screen.findByRole("button"));
+
+                // Assert
+                expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                    errorMessage,
+                );
+            });
+        });
     });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -2151,4 +2151,55 @@ describe("MultiSelect", () => {
             },
         );
     });
+
+    describe("a11y > aria-invalid", () => {
+        it.each([
+            {error: true, ariaInvalid: "true"},
+            {error: false, ariaInvalid: "false"},
+            {error: undefined, ariaInvalid: "false"},
+        ])(
+            "should set aria-invalid to $ariaInvalid if error is $error",
+            async ({error, ariaInvalid}) => {
+                // Arrange
+                doRender(
+                    <MultiSelect
+                        onChange={jest.fn()}
+                        error={error}
+                    />,
+                );
+
+                // Act
+                const opener = await screen.findByRole("button");
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-invalid", ariaInvalid);
+            },
+        );
+
+        it.each([
+            {error: true, ariaInvalid: "true"},
+            {error: false, ariaInvalid: "false"},
+            {error: undefined, ariaInvalid: "false"},
+        ])(
+            "should set aria-invalid to $ariaInvalid if error is $error and there is a custom opener",
+            async ({error, ariaInvalid}) => {
+                // Arrange
+                doRender(
+                    <MultiSelect
+                        onChange={jest.fn()}
+                        error={error}
+                        opener={() => (
+                            <button aria-label="Search" onClick={jest.fn()} />
+                        )}
+                    />,
+                );
+
+                // Act
+                const opener = await screen.findByRole("button");
+
+                // Assert
+                expect(opener).toHaveAttribute("aria-invalid", ariaInvalid);
+            },
+        );
+    });
 });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -2101,56 +2101,6 @@ describe("MultiSelect", () => {
         });
     });
 
-    describe("a11y > aria-required", () => {
-        it.each([
-            {required: "Custom required error message", ariaRequired: "true"},
-            {required: true, ariaRequired: "true"},
-            {required: false, ariaRequired: "false"},
-            {required: undefined, ariaRequired: "false"},
-        ])(
-            "should set aria-required to $ariaRequired if required is $required",
-            async ({required, ariaRequired}) => {
-                // Arrange
-                doRender(
-                    <MultiSelect onChange={jest.fn()} required={required} />,
-                );
-
-                // Act
-                const opener = await screen.findByRole("button");
-
-                // Assert
-                expect(opener).toHaveAttribute("aria-required", ariaRequired);
-            },
-        );
-
-        it.each([
-            {required: "Custom required error message", ariaRequired: "true"},
-            {required: true, ariaRequired: "true"},
-            {required: false, ariaRequired: "false"},
-            {required: undefined, ariaRequired: "false"},
-        ])(
-            "should set aria-required to $ariaRequired if required is $required and there is a custom opener",
-            async ({required, ariaRequired}) => {
-                // Arrange
-                doRender(
-                    <MultiSelect
-                        onChange={jest.fn()}
-                        required={required}
-                        opener={() => (
-                            <button aria-label="Search" onClick={jest.fn()} />
-                        )}
-                    />,
-                );
-
-                // Act
-                const opener = await screen.findByRole("button");
-
-                // Assert
-                expect(opener).toHaveAttribute("aria-required", ariaRequired);
-            },
-        );
-    });
-
     describe("a11y > aria-invalid", () => {
         it.each([
             {error: true, ariaInvalid: "true"},
@@ -2195,6 +2145,54 @@ describe("MultiSelect", () => {
                 expect(opener).toHaveAttribute("aria-invalid", ariaInvalid);
             },
         );
+    });
+
+    describe("a11y > violations", () => {
+        afterEach(() => {
+            jest.useFakeTimers();
+        });
+
+        it("should not have any violations", async () => {
+            // Arrange
+            const {container} = doRender(
+                <MultiSelect onChange={jest.fn()} opened={true}>
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </MultiSelect>,
+            );
+
+            // Act
+            // Flush any pending timers before switching to real timers
+            // https://testing-library.com/docs/using-fake-timers/
+            jest.runOnlyPendingTimers();
+            // Use real timers for the jest-axe check otherwise the test will timeout
+            // https://github.com/dequelabs/axe-core/issues/3055
+            jest.useRealTimers();
+
+            // Assert
+            await expect(container).toHaveNoA11yViolations();
+        });
+
+        it("should not have any violations when it is open", async () => {
+            // Arrange
+            const {container} = doRender(
+                <MultiSelect onChange={jest.fn()} opened={true}>
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </MultiSelect>,
+            );
+
+            // Act
+            // Flush any pending timers before switching to real timers
+            // https://testing-library.com/docs/using-fake-timers/
+            jest.runOnlyPendingTimers();
+            // Use real timers for the jest-axe check otherwise the test will timeout
+            // https://github.com/dequelabs/axe-core/issues/3055
+            jest.useRealTimers();
+
+            // Assert
+            await expect(container).toHaveNoA11yViolations();
+        });
     });
 
     describe("validation", () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -2327,6 +2327,7 @@ describe("MultiSelect", () => {
                 );
                 const opener = await screen.findByRole("button");
                 await userEvent.click(opener);
+
                 // Act
                 await userEvent.click(screen.getByText("item 1"));
 
@@ -2345,6 +2346,8 @@ describe("MultiSelect", () => {
                 );
                 const opener = await screen.findByRole("button");
                 await userEvent.click(opener);
+
+                // Act
                 await userEvent.click(screen.getByText("item 1"));
 
                 // Assert
@@ -2371,6 +2374,7 @@ describe("MultiSelect", () => {
             it("should validate twice when first rendered if there is a selected value (once on initalization, once after mount)", () => {
                 // Arrange
                 const validate = jest.fn();
+
                 // Act
                 doRender(
                     <ControlledMultiSelect
@@ -2500,6 +2504,30 @@ describe("MultiSelect", () => {
                 );
             });
 
+            it("should be in an error state once closed if the new values still includes invalid values", async () => {
+                // Arrange
+                const errorMessage = "Error message";
+                const {userEvent} = doRender(
+                    <ControlledMultiSelect
+                        validate={(values) =>
+                            values.includes("1") ? errorMessage : undefined
+                        }
+                        selectedValues={["1"]}
+                    />,
+                );
+                await userEvent.click(await screen.findByRole("button")); // Open the dropdown
+                await userEvent.click(await screen.findByText("item 2")); // Pick a value
+
+                // Act
+                await userEvent.click(await screen.findByRole("button")); // Close the dropdown
+
+                // Assert
+                expect(await screen.findByRole("button")).toHaveAttribute(
+                    "aria-invalid",
+                    "true",
+                );
+            });
+
             it("should call onValidate with null once values are updated", async () => {
                 // Arrange
                 const errorMessage = "Error message";
@@ -2574,9 +2602,9 @@ describe("MultiSelect", () => {
                             required={requiredMessage}
                         />,
                     );
+                    await userEvent.tab(); // focus on the select
 
                     // Act
-                    await userEvent.tab(); // focus on the select
                     await userEvent.tab(); // leave the select
 
                     // Assert
@@ -2619,9 +2647,9 @@ describe("MultiSelect", () => {
                             )}
                         />,
                     );
+                    await userEvent.tab(); // focus on the select
 
                     // Act
-                    await userEvent.tab(); // focus on the select
                     await userEvent.tab(); // leave the select
 
                     // Assert
@@ -2644,9 +2672,9 @@ describe("MultiSelect", () => {
                             required={requiredMessage}
                         />,
                     );
+                    await userEvent.tab(); // focus on the select
 
                     // Act
-                    await userEvent.tab(); // focus on the select
                     await userEvent.tab(); // leave the select
 
                     // Assert
@@ -2667,9 +2695,9 @@ describe("MultiSelect", () => {
                             disabled={true}
                         />,
                     );
+                    await userEvent.tab(); // focus on the select
 
                     // Act
-                    await userEvent.tab(); // focus on the select
                     await userEvent.tab(); // leave the select
 
                     // Assert
@@ -2685,9 +2713,9 @@ describe("MultiSelect", () => {
                             disabled={true}
                         />,
                     );
+                    await userEvent.tab(); // focus on the select
 
                     // Act
-                    await userEvent.tab(); // focus on the select
                     await userEvent.tab(); // leave the select
 
                     // Assert
@@ -2708,9 +2736,9 @@ describe("MultiSelect", () => {
                             required={requiredMessage}
                         />,
                     );
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
 
                     // Act
-                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
                     await userEvent.click(await screen.findByRole("button")); // Close the dropdown
 
                     // Assert
@@ -2725,9 +2753,9 @@ describe("MultiSelect", () => {
                     const {userEvent} = doRender(
                         <ControlledMultiSelect required={requiredMessage} />,
                     );
+                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
 
                     // Act
-                    await userEvent.click(await screen.findByRole("button")); // Open the dropdown
                     await userEvent.click(await screen.findByRole("button")); // Close the dropdown
 
                     // Assert
@@ -2784,10 +2812,10 @@ describe("MultiSelect", () => {
                             required={requiredMessage}
                         />,
                     );
-
-                    // Act
                     await userEvent.tab();
                     await userEvent.keyboard("{enter}"); // Open the dropdown
+
+                    // Act
                     await userEvent.keyboard("{escape}"); // Close the dropdown
 
                     // Assert
@@ -2802,10 +2830,10 @@ describe("MultiSelect", () => {
                     const {userEvent} = doRender(
                         <ControlledMultiSelect required={requiredMessage} />,
                     );
-
-                    // Act
                     await userEvent.tab();
                     await userEvent.keyboard("{enter}"); // Open the dropdown
+
+                    // Act
                     await userEvent.keyboard("{escape}"); // Close the dropdown
 
                     // Assert
@@ -2851,7 +2879,7 @@ describe("MultiSelect", () => {
                 });
             });
 
-            describe("picking a value after there was an error", () => {
+            describe("interactions after there was an error", () => {
                 it("should still be in an error state before a value is picked", async () => {
                     // Arrange
                     const requiredMessage = "Required field";
@@ -2901,9 +2929,9 @@ describe("MultiSelect", () => {
                         required={true}
                     />,
                 );
+                await userEvent.tab();
 
                 // Act
-                await userEvent.tab();
                 await userEvent.tab();
 
                 // Assert
@@ -2914,7 +2942,7 @@ describe("MultiSelect", () => {
         });
 
         describe("validate and required props", () => {
-            it("should be in an error state if validate succeeds and required is set to true", async () => {
+            it("should be in an error state if validate succeeds and required is set", async () => {
                 // Arrange
                 const requiredMessage = "Required field";
                 const {userEvent} = doRender(
@@ -2946,7 +2974,7 @@ describe("MultiSelect", () => {
                 );
             });
 
-            it("should call the onValidate prop with null and the required error message if validate succeeds and required is set to true", async () => {
+            it("should call the onValidate prop with null and the required error message if validate succeeds and required is set", async () => {
                 // Arrange
                 const onValidate = jest.fn();
                 const requiredMessage = "Required field";

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -2309,6 +2309,8 @@ describe("SingleSelect", () => {
                     );
 
                     // Assert
+                    // onValidate is called with null because required validation
+                    // is triggered and clears any errors
                     expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
                 });
             });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1891,7 +1891,7 @@ describe("SingleSelect", () => {
         });
 
         describe("validation on mount", () => {
-            it("should validate on mount if there is a selected value", () => {
+            it("should validate twice when first rendered if there is a selected value (once on initalization, once after mount)", () => {
                 // Arrange
                 const validate = jest.fn();
                 // Act
@@ -1902,7 +1902,7 @@ describe("SingleSelect", () => {
                     />,
                 );
                 // Assert
-                expect(validate).toHaveBeenCalledExactlyOnceWith("1");
+                expect(validate.mock.calls).toStrictEqual([["1"], ["1"]]);
             });
 
             it("should be in an error state on mount if there is an invalid selected value", async () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -2294,8 +2294,7 @@ describe("SingleSelect", () => {
                     // Assert
                     expect(onValidate).not.toHaveBeenCalled();
                 });
-
-                it("should not call onValidate if there is a selected value on the initial render", () => {
+                it("should call onValidate with null if there is a selected value on the initial render", () => {
                     // Arrange
                     const requiredMessage = "Required field";
                     const onValidate = jest.fn();
@@ -2310,7 +2309,7 @@ describe("SingleSelect", () => {
                     );
 
                     // Assert
-                    expect(onValidate).not.toHaveBeenCalled();
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
                 });
             });
 

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -25,7 +25,7 @@ import type {
     OptionItemComponent,
     OptionItemComponentArray,
 } from "../util/types";
-import {getLabel, getSelectOpenerLabel, areArraysEqual} from "../util/helpers";
+import {getLabel, getSelectOpenerLabel} from "../util/helpers";
 import {useSelectValidation} from "../hooks/use-select-validation";
 
 export type Labels = {
@@ -322,11 +322,11 @@ const MultiSelect = (props: Props) => {
 
         // Handle validation when it is closed
         if (!opened) {
-            if (!areArraysEqual(lastSelectedValues, selectedValues)) {
-                // If there are newly selected values, trigger selection validation
+            if (lastSelectedValues !== selectedValues) {
+                // If lastSelectedValues is not the same as selectedValues, trigger selection validation
                 onSelectionValidation(selectedValues);
             } else {
-                // If there are no newly selected values, trigger closed validation
+                // If there are no changes to the selected values, trigger closed validation
                 onDropdownClosedValidation();
             }
         }

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -284,14 +284,15 @@ const MultiSelect = (props: Props) => {
     // to this element, and also to pass the reference to Popper.js.
     const [openerElement, setOpenerElement] = React.useState<HTMLElement>();
 
-    const {errorMessage, onOpenerBlurValidation} = useSelectValidation({
-        selectedValue: selectedValues,
-        disabled,
-        validate,
-        onValidate,
-        required,
-        open,
-    });
+    const {errorMessage, onOpenerBlurValidation, onDropdownClosedValidation} =
+        useSelectValidation({
+            selectedValue: selectedValues,
+            disabled,
+            validate,
+            onValidate,
+            required,
+            open,
+        });
 
     const hasError = error || !!errorMessage;
 
@@ -312,6 +313,10 @@ const MultiSelect = (props: Props) => {
 
         if (onToggle) {
             onToggle(opened);
+        }
+
+        if (!opened) {
+            onDropdownClosedValidation();
         }
     };
 

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -291,7 +291,7 @@ const MultiSelect = (props: Props) => {
         onSelectionValidation,
         onSelectedValuesChangeValidation,
     } = useSelectValidation({
-        selectedValue: selectedValues,
+        value: selectedValues,
         disabled,
         validate,
         onValidate,

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -547,14 +547,12 @@ const MultiSelect = (props: Props) => {
         const dropdownOpener = (
             <IDProvider id={id} scope="multi-select-opener">
                 {(uniqueOpenerId) => {
-                    const hasAriaRequired = ariaRequired || !!required;
                     return opener ? (
                         <DropdownOpener
                             id={uniqueOpenerId}
                             error={hasError}
                             aria-controls={dropdownId}
                             aria-haspopup="listbox"
-                            aria-required={hasAriaRequired}
                             onClick={handleClick}
                             onBlur={onOpenerBlurValidation}
                             disabled={isDisabled}
@@ -571,7 +569,6 @@ const MultiSelect = (props: Props) => {
                             disabled={isDisabled}
                             id={uniqueOpenerId}
                             aria-controls={dropdownId}
-                            aria-required={hasAriaRequired}
                             isPlaceholder={menuText === noneSelected}
                             light={light}
                             onOpenChanged={handleOpenChanged}

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -547,12 +547,14 @@ const MultiSelect = (props: Props) => {
         const dropdownOpener = (
             <IDProvider id={id} scope="multi-select-opener">
                 {(uniqueOpenerId) => {
+                    const hasAriaRequired = ariaRequired || !!required;
                     return opener ? (
                         <DropdownOpener
                             id={uniqueOpenerId}
                             error={hasError}
                             aria-controls={dropdownId}
                             aria-haspopup="listbox"
+                            aria-required={hasAriaRequired}
                             onClick={handleClick}
                             onBlur={onOpenerBlurValidation}
                             disabled={isDisabled}
@@ -569,6 +571,7 @@ const MultiSelect = (props: Props) => {
                             disabled={isDisabled}
                             id={uniqueOpenerId}
                             aria-controls={dropdownId}
+                            aria-required={hasAriaRequired}
                             isPlaceholder={menuText === noneSelected}
                             light={light}
                             onOpenChanged={handleOpenChanged}

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -284,7 +284,7 @@ const MultiSelect = (props: Props) => {
     // to this element, and also to pass the reference to Popper.js.
     const [openerElement, setOpenerElement] = React.useState<HTMLElement>();
 
-    const {errorMessage} = useSelectValidation({
+    const {errorMessage, onOpenerBlurValidation} = useSelectValidation({
         selectedValue: selectedValues,
         disabled,
         validate,
@@ -535,6 +535,7 @@ const MultiSelect = (props: Props) => {
                             aria-controls={dropdownId}
                             aria-haspopup="listbox"
                             onClick={handleClick}
+                            onBlur={onOpenerBlurValidation}
                             disabled={isDisabled}
                             ref={handleOpenerRef}
                             text={menuText}
@@ -552,6 +553,7 @@ const MultiSelect = (props: Props) => {
                             isPlaceholder={menuText === noneSelected}
                             light={light}
                             onOpenChanged={handleOpenChanged}
+                            onBlur={onOpenerBlurValidation}
                             open={open}
                             ref={handleOpenerRef}
                             testId={testId}

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -289,6 +289,7 @@ const MultiSelect = (props: Props) => {
         onOpenerBlurValidation,
         onDropdownClosedValidation,
         onSelectionValidation,
+        onSelectedValuesChangeValidation,
     } = useSelectValidation({
         selectedValue: selectedValues,
         disabled,
@@ -343,6 +344,8 @@ const MultiSelect = (props: Props) => {
             // Item was newly selected
             onChange([...selectedValues, selectedValue]);
         }
+        // Handle validation when the selected values change
+        onSelectedValuesChangeValidation();
     };
 
     const handleSelectAll = () => {

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -25,7 +25,7 @@ import type {
     OptionItemComponent,
     OptionItemComponentArray,
 } from "../util/types";
-import {getLabel, getSelectOpenerLabel} from "../util/helpers";
+import {getLabel, getSelectOpenerLabel, areArraysEqual} from "../util/helpers";
 import {useSelectValidation} from "../hooks/use-select-validation";
 
 export type Labels = {
@@ -284,15 +284,19 @@ const MultiSelect = (props: Props) => {
     // to this element, and also to pass the reference to Popper.js.
     const [openerElement, setOpenerElement] = React.useState<HTMLElement>();
 
-    const {errorMessage, onOpenerBlurValidation, onDropdownClosedValidation} =
-        useSelectValidation({
-            selectedValue: selectedValues,
-            disabled,
-            validate,
-            onValidate,
-            required,
-            open,
-        });
+    const {
+        errorMessage,
+        onOpenerBlurValidation,
+        onDropdownClosedValidation,
+        onSelectionValidation,
+    } = useSelectValidation({
+        selectedValue: selectedValues,
+        disabled,
+        validate,
+        onValidate,
+        required,
+        open,
+    });
 
     const hasError = error || !!errorMessage;
 
@@ -315,8 +319,15 @@ const MultiSelect = (props: Props) => {
             onToggle(opened);
         }
 
+        // Handle validation when it is closed
         if (!opened) {
-            onDropdownClosedValidation();
+            if (!areArraysEqual(lastSelectedValues, selectedValues)) {
+                // If there are newly selected values, trigger selection validation
+                onSelectionValidation(selectedValues);
+            } else {
+                // If there are no newly selected values, trigger closed validation
+                onDropdownClosedValidation();
+            }
         }
     };
 

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -199,7 +199,7 @@ type Props = AriaProps &
          * Use this for errors that are shown to the user while they are filling out
          * a form.
          */
-        validate?: (value: string) => string | null | void;
+        validate?: (value?: string | null) => string | null | void;
         /**
          * Called right after the field is validated.
          */
@@ -302,7 +302,7 @@ const SingleSelect = (props: Props) => {
         onDropdownClosedValidation,
         onSelectionValidation,
     } = useSelectValidation({
-        selectedValue,
+        value: selectedValue,
         disabled,
         validate,
         onValidate,

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -329,7 +329,7 @@ const SingleSelect = (props: Props) => {
             onToggle(opened);
         }
         if (!opened) {
-            // If dropdown is closed, handle dropdown closedvalidation
+            // If dropdown is closed, handle dropdown closed validation
             onDropdownClosedValidation();
         }
     };

--- a/packages/wonder-blocks-dropdown/src/hooks/__tests__/use-select-validation.test.ts
+++ b/packages/wonder-blocks-dropdown/src/hooks/__tests__/use-select-validation.test.ts
@@ -1,4 +1,4 @@
-import {act, renderHook} from "@testing-library/react-hooks";
+import {act, renderHook} from "@testing-library/react";
 import {
     SelectValidationProps,
     SelectValue,

--- a/packages/wonder-blocks-dropdown/src/hooks/__tests__/use-select-validation.test.ts
+++ b/packages/wonder-blocks-dropdown/src/hooks/__tests__/use-select-validation.test.ts
@@ -58,6 +58,7 @@ describe("useSelectValidation", () => {
                 // Assert
                 expect(result.current.errorMessage).toBe(null);
             });
+
             it.each(valueCases)(
                 "should have the errorMessage from the validate prop if value is set to %s",
                 (value) => {
@@ -135,6 +136,7 @@ describe("useSelectValidation", () => {
                 expect(validate).not.toHaveBeenCalled();
             });
         });
+
         describe("onValidate prop", () => {
             it.each(valueCases)(
                 "should call the onValidate prop once initially (only after mount) when value is `%s`",
@@ -178,7 +180,7 @@ describe("useSelectValidation", () => {
                 },
             );
 
-            it("should not call the validate prop if it is disabled", () => {
+            it("should not call the onValidate prop if it is disabled", () => {
                 // Arrange
                 const onValidate = jest.fn();
 
@@ -299,12 +301,13 @@ describe("useSelectValidation", () => {
             // Assert
             expect(result.current.errorMessage).toBe("This field is required.");
         });
+
         it.each([
             {condition: "if it is open", props: {open: true}},
             {condition: "if it is not required", props: {required: false}},
-            {condition: "if it is has a string value", props: {value: "Test"}},
+            {condition: "if it has a string value", props: {value: "Test"}},
             {
-                condition: "if it is has an array value",
+                condition: "if it has an array value",
                 props: {value: ["Test"]},
             },
         ])("should not call the onValidate prop $condition", ({props}) => {
@@ -333,9 +336,9 @@ describe("useSelectValidation", () => {
         it.each([
             {condition: "if it is open", props: {open: true}},
             {condition: "if it is not required", props: {required: false}},
-            {condition: "if it is has a string value", props: {value: "Test"}},
+            {condition: "if it has a string value", props: {value: "Test"}},
             {
-                condition: "if it is has an array value",
+                condition: "if it has an array value",
                 props: {value: ["Test"]},
             },
         ])("should not have an error message $condition", ({props}) => {
@@ -483,6 +486,7 @@ describe("useSelectValidation", () => {
             },
         );
     });
+
     describe("onSelectionValidation", () => {
         describe("validate prop", () => {
             it("should not call the validate prop if it is disabled", () => {
@@ -615,6 +619,7 @@ describe("useSelectValidation", () => {
                 });
             });
         });
+
         describe("validating a new value when it is required", () => {
             describe.each([
                 {

--- a/packages/wonder-blocks-dropdown/src/hooks/__tests__/use-select-validation.test.ts
+++ b/packages/wonder-blocks-dropdown/src/hooks/__tests__/use-select-validation.test.ts
@@ -648,7 +648,9 @@ describe("useSelectValidation", () => {
                     });
 
                     // Assert
-                    expect(result.current.errorMessage).toBe(testRequiredErrorMessage);
+                    expect(result.current.errorMessage).toBe(
+                        testRequiredErrorMessage,
+                    );
                 });
 
                 it("should set the errorMessage to the default required message if the required prop is true", () => {
@@ -666,14 +668,20 @@ describe("useSelectValidation", () => {
                     });
 
                     // Assert
-                    expect(result.current.errorMessage).toBe("This field is required.");
+                    expect(result.current.errorMessage).toBe(
+                        "This field is required.",
+                    );
                 });
 
                 it("should call onValidate with the required prop message", () => {
                     // Arrange
                     const onValidate = jest.fn();
                     const {result} = renderHook(() =>
-                        useSelectValidation<SelectValue>({value, required: testRequiredErrorMessage, onValidate}),
+                        useSelectValidation<SelectValue>({
+                            value,
+                            required: testRequiredErrorMessage,
+                            onValidate,
+                        }),
                     );
                     onValidate.mockClear(); // Clear any calls from mounting
 
@@ -683,14 +691,20 @@ describe("useSelectValidation", () => {
                     });
 
                     // Assert
-                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(testRequiredErrorMessage);
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        testRequiredErrorMessage,
+                    );
                 });
 
                 it("should call onValidate with the default required message if the required prop is true", () => {
                     // Arrange
                     const onValidate = jest.fn();
                     const {result} = renderHook(() =>
-                        useSelectValidation<SelectValue>({value, required: true, onValidate}),
+                        useSelectValidation<SelectValue>({
+                            value,
+                            required: true,
+                            onValidate,
+                        }),
                     );
                     onValidate.mockClear(); // Clear any calls from mounting
 
@@ -721,7 +735,10 @@ describe("useSelectValidation", () => {
                 it("should have a null errorMessage since the field has a value", () => {
                     // Arrange
                     const {result} = renderHook(() =>
-                        useSelectValidation<SelectValue>({value, required: testRequiredErrorMessage}),
+                        useSelectValidation<SelectValue>({
+                            value,
+                            required: testRequiredErrorMessage,
+                        }),
                     );
 
                     // Act
@@ -737,7 +754,11 @@ describe("useSelectValidation", () => {
                     // Arrange
                     const onValidate = jest.fn();
                     const {result} = renderHook(() =>
-                        useSelectValidation<SelectValue>({value, onValidate, required: testRequiredErrorMessage}),
+                        useSelectValidation<SelectValue>({
+                            value,
+                            onValidate,
+                            required: testRequiredErrorMessage,
+                        }),
                     );
                     onValidate.mockClear(); // Clear any calls from mounting
 
@@ -750,13 +771,17 @@ describe("useSelectValidation", () => {
                     expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
                 });
             });
-        })
+        });
 
         describe("validate + required", () => {
             it("should set the error message to the required error message if the validation succeeds", () => {
                 // Arrange
                 const {result} = renderHook(() =>
-                    useSelectValidation<SelectValue>({value: "Test", validate: () => {},required: testRequiredErrorMessage}),
+                    useSelectValidation<SelectValue>({
+                        value: "Test",
+                        validate: () => {},
+                        required: testRequiredErrorMessage,
+                    }),
                 );
 
                 // Act
@@ -765,13 +790,19 @@ describe("useSelectValidation", () => {
                 });
 
                 // Assert
-                expect(result.current.errorMessage).toBe(testRequiredErrorMessage);
+                expect(result.current.errorMessage).toBe(
+                    testRequiredErrorMessage,
+                );
             });
 
             it("should set the error message to the validate error message if the validation fails", () => {
                 // Arrange
                 const {result} = renderHook(() =>
-                    useSelectValidation<SelectValue>({value: "Test", validate: () => testErrorMessage,required: testRequiredErrorMessage}),
+                    useSelectValidation<SelectValue>({
+                        value: "Test",
+                        validate: () => testErrorMessage,
+                        required: testRequiredErrorMessage,
+                    }),
                 );
 
                 // Act

--- a/packages/wonder-blocks-dropdown/src/hooks/__tests__/use-select-validation.test.ts
+++ b/packages/wonder-blocks-dropdown/src/hooks/__tests__/use-select-validation.test.ts
@@ -1,0 +1,831 @@
+import {act, renderHook} from "@testing-library/react-hooks";
+import {
+    SelectValidationProps,
+    SelectValue,
+    useSelectValidation,
+} from "../use-select-validation";
+
+const emptyValueCases = ["", [], undefined, null];
+const valueCases = ["Test", ["Test"]];
+
+describe("useSelectValidation", () => {
+    const testErrorMessage = "Error message";
+    const testRequiredErrorMessage = "Required error message";
+
+    describe("Initialization", () => {
+        describe("errorMessage", () => {
+            it.each(emptyValueCases)(
+                "should have a null errorMessage if value is `%s`",
+                (value) => {
+                    // Arrange
+                    // Act
+                    const {result} = renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate: () => testErrorMessage,
+                        }),
+                    );
+
+                    // Assert
+                    expect(result.current.errorMessage).toBe(null);
+                },
+            );
+
+            it("should have a null errorMessage if value is set and there is no validate prop", () => {
+                // Arrange
+                // Act
+                const {result} = renderHook(() =>
+                    useSelectValidation({
+                        value: "Test",
+                    }),
+                );
+
+                // Assert
+                expect(result.current.errorMessage).toBe(null);
+            });
+
+            it("should have a null errorMessage if it is disabled", () => {
+                // Arrange
+                // Act
+                const {result} = renderHook(() =>
+                    useSelectValidation({
+                        value: "Test",
+                        validate: () => testErrorMessage,
+                        disabled: true,
+                    }),
+                );
+
+                // Assert
+                expect(result.current.errorMessage).toBe(null);
+            });
+            it.each(valueCases)(
+                "should have the errorMessage from the validate prop if value is set to %s",
+                (value) => {
+                    // Arrange
+                    // Act
+                    const {result} = renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate: () => testErrorMessage,
+                        }),
+                    );
+
+                    // Assert
+                    expect(result.current.errorMessage).toBe(testErrorMessage);
+                },
+            );
+        });
+
+        describe("validate prop", () => {
+            it.each(valueCases)(
+                "should call the validate prop with value (%s) twice initially (once on state initalization and once after mounting)",
+                (value) => {
+                    // Arrange
+                    const validate = jest.fn();
+
+                    // Act
+                    renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate,
+                        }),
+                    );
+
+                    // Assert
+                    expect(validate.mock.calls).toStrictEqual([
+                        [value],
+                        [value],
+                    ]);
+                },
+            );
+
+            it.each(emptyValueCases)(
+                "should not call the validate prop if value is `%s`",
+                (value) => {
+                    // Arrange
+                    const validate = jest.fn();
+
+                    // Act
+                    renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate,
+                        }),
+                    );
+
+                    // Assert
+                    expect(validate).not.toHaveBeenCalled();
+                },
+            );
+
+            it("should not call the validate prop if it is disabled", () => {
+                // Arrange
+                const validate = jest.fn();
+
+                // Act
+                renderHook(() =>
+                    useSelectValidation({
+                        value: "Test",
+                        validate,
+                        disabled: true,
+                    }),
+                );
+
+                // Assert
+                expect(validate).not.toHaveBeenCalled();
+            });
+        });
+        describe("onValidate prop", () => {
+            it.each(valueCases)(
+                "should call the onValidate prop once initially (only after mount) when value is `%s`",
+                (value) => {
+                    // Arrange
+                    const onValidate = jest.fn();
+
+                    // Act
+                    renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate: () => testErrorMessage,
+                            onValidate,
+                        }),
+                    );
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        testErrorMessage,
+                    );
+                },
+            );
+
+            it.each(emptyValueCases)(
+                "should not call the onValidate prop if value is `%s`",
+                (value) => {
+                    // Arrange
+                    const onValidate = jest.fn();
+
+                    // Act
+                    renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate: () => testErrorMessage,
+                            onValidate,
+                        }),
+                    );
+
+                    // Assert
+                    expect(onValidate).not.toHaveBeenCalled();
+                },
+            );
+
+            it("should not call the validate prop if it is disabled", () => {
+                // Arrange
+                const onValidate = jest.fn();
+
+                // Act
+                renderHook(() =>
+                    useSelectValidation({
+                        value: "Test",
+                        validate: () => testErrorMessage,
+                        onValidate,
+                        disabled: true,
+                    }),
+                );
+
+                // Assert
+                expect(onValidate).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe("onOpenerBlurValidation", () => {
+        // Since onOpenerBlurValidation handles the validation for `required`,
+        // we don't need tests checking if the validate prop is called since
+        // it works without the validate prop.
+        it.each(emptyValueCases)(
+            "should call the onValidate prop with the required prop message if the dropdown is closed, the field is required, and no value (%s) is selected",
+            (value) => {
+                // Arrange
+                const onValidate = jest.fn();
+                const {result} = renderHook(() =>
+                    useSelectValidation({
+                        value,
+                        onValidate,
+                        required: testRequiredErrorMessage,
+                        open: false,
+                    }),
+                );
+
+                // Act
+                act(() => {
+                    result.current.onOpenerBlurValidation();
+                });
+
+                // Assert
+                expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                    testRequiredErrorMessage,
+                );
+            },
+        );
+
+        it("should call the onValidate prop with the default required message if required=true, dropdown is closed, the field is required, and no value is selected", () => {
+            // Arrange
+            const onValidate = jest.fn();
+            const value = "";
+            const {result} = renderHook(() =>
+                useSelectValidation({
+                    value,
+                    onValidate,
+                    required: true,
+                    open: false,
+                }),
+            );
+
+            // Act
+            act(() => {
+                result.current.onOpenerBlurValidation();
+            });
+
+            // Assert
+            expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                "This field is required.",
+            );
+        });
+
+        it.each(emptyValueCases)(
+            "should have the errorMessage be the required prop message if the dropdown is closed, the field is required, and no value (%s) is selected",
+            (value) => {
+                // Arrange
+                const onValidate = jest.fn();
+                const {result} = renderHook(() =>
+                    useSelectValidation({
+                        value,
+                        onValidate,
+                        required: testRequiredErrorMessage,
+                        open: false,
+                    }),
+                );
+
+                // Act
+                act(() => {
+                    result.current.onOpenerBlurValidation();
+                });
+
+                // Assert
+                expect(result.current.errorMessage).toBe(
+                    testRequiredErrorMessage,
+                );
+            },
+        );
+
+        it("should have the errorMessage be the default required message if the required=true, dropdown is closed, the field is required, and no value is selected", () => {
+            // Arrange
+            const onValidate = jest.fn();
+            const value = "";
+            const {result} = renderHook(() =>
+                useSelectValidation({
+                    value,
+                    onValidate,
+                    required: true,
+                    open: false,
+                }),
+            );
+
+            // Act
+            act(() => {
+                result.current.onOpenerBlurValidation();
+            });
+
+            // Assert
+            expect(result.current.errorMessage).toBe("This field is required.");
+        });
+        it.each([
+            {condition: "if it is open", props: {open: true}},
+            {condition: "if it is not required", props: {required: false}},
+            {condition: "if it is has a string value", props: {value: "Test"}},
+            {
+                condition: "if it is has an array value",
+                props: {value: ["Test"]},
+            },
+        ])("should not call the onValidate prop $condition", ({props}) => {
+            // Arrange
+            const onValidate = jest.fn();
+            const {result} = renderHook(() =>
+                useSelectValidation({
+                    value: props.value || "",
+                    onValidate,
+                    required: true,
+                    open: false,
+                    ...props,
+                }),
+            );
+            onValidate.mockClear(); // Clear any calls from mounting
+
+            // Act
+            act(() => {
+                result.current.onOpenerBlurValidation();
+            });
+
+            // Assert
+            expect(onValidate).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            {condition: "if it is open", props: {open: true}},
+            {condition: "if it is not required", props: {required: false}},
+            {condition: "if it is has a string value", props: {value: "Test"}},
+            {
+                condition: "if it is has an array value",
+                props: {value: ["Test"]},
+            },
+        ])("should not have an error message $condition", ({props}) => {
+            // Arrange
+            const onValidate = jest.fn();
+            const {result} = renderHook(() =>
+                useSelectValidation({
+                    value: props.value || "",
+                    onValidate,
+                    required: true,
+                    open: false,
+                    ...props,
+                }),
+            );
+            onValidate.mockClear(); // Clear any calls from mounting
+
+            // Act
+            act(() => {
+                result.current.onOpenerBlurValidation();
+            });
+
+            // Assert
+            expect(result.current.errorMessage).toBe(null);
+        });
+    });
+
+    describe("onDropdownClosedValidation", () => {
+        it.each(emptyValueCases)(
+            "should call the onValidate prop with the required prop message if the field is required, and no value (%s) is selected",
+            (value) => {
+                // Arrange
+                const onValidate = jest.fn();
+                const {result} = renderHook(() =>
+                    useSelectValidation({
+                        value,
+                        onValidate,
+                        required: testRequiredErrorMessage,
+                    }),
+                );
+
+                // Act
+                act(() => {
+                    result.current.onDropdownClosedValidation();
+                });
+
+                // Assert
+                expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                    testRequiredErrorMessage,
+                );
+            },
+        );
+
+        it.each(emptyValueCases)(
+            "should have the required prop message as the errorMessage if the field is required, and no value (%s) is selected",
+            (value) => {
+                // Arrange
+                const {result} = renderHook(() =>
+                    useSelectValidation({
+                        value,
+                        required: testRequiredErrorMessage,
+                    }),
+                );
+
+                // Act
+                act(() => {
+                    result.current.onDropdownClosedValidation();
+                });
+
+                // Assert
+                expect(result.current.errorMessage).toBe(
+                    testRequiredErrorMessage,
+                );
+            },
+        );
+
+        const conditionsThatShouldNotTriggerValidation = [
+            {
+                condition: "if it is not required and value is []",
+                props: {required: false, value: []},
+            },
+            {
+                condition: "if it is not required and value is an empty string",
+                props: {required: false, value: ""},
+            },
+            {
+                condition:
+                    "if it is not required and value is set to a string value",
+                props: {required: false, value: "test"},
+            },
+            {
+                condition:
+                    "if it is not required and value is set to an array value",
+                props: {required: false, value: ["test"]},
+            },
+            {
+                condition:
+                    "if it is required and value is set to a string value",
+                props: {required: testRequiredErrorMessage, value: "test"},
+            },
+            {
+                condition:
+                    "if it is required and value is set to an array value",
+                props: {required: testRequiredErrorMessage, value: ["test"]},
+            },
+        ];
+
+        it.each(conditionsThatShouldNotTriggerValidation)(
+            "should not call the onValidate prop $condition",
+            ({props}: {props: SelectValidationProps<string | string[]>}) => {
+                // Arrange
+                const onValidate = jest.fn();
+                const {result} = renderHook(() =>
+                    useSelectValidation({
+                        ...props,
+                        onValidate,
+                    }),
+                );
+                onValidate.mockClear(); // Clear any calls from mounting
+
+                // Act
+                act(() => {
+                    result.current.onDropdownClosedValidation();
+                });
+
+                // Assert
+                expect(onValidate).not.toHaveBeenCalled();
+            },
+        );
+
+        it.each(conditionsThatShouldNotTriggerValidation)(
+            "should not have an error message $condition",
+            ({props}: {props: SelectValidationProps<string | string[]>}) => {
+                // Arrange
+                const {result} = renderHook(() =>
+                    useSelectValidation({...props}),
+                );
+
+                // Act
+                act(() => {
+                    result.current.onDropdownClosedValidation();
+                });
+
+                // Assert
+                expect(result.current.errorMessage).toBe(null);
+            },
+        );
+    });
+    describe("onSelectionValidation", () => {
+        describe("validate prop", () => {
+            it("should not call the validate prop if it is disabled", () => {
+                // Arrange
+                const validate = jest.fn();
+                const {result} = renderHook(() =>
+                    useSelectValidation<string>({
+                        value: "Test",
+                        validate,
+                        disabled: true,
+                    }),
+                );
+
+                // Act
+                act(() => {
+                    result.current.onSelectionValidation("Test2");
+                });
+
+                // Assert
+                expect(validate).not.toHaveBeenCalled();
+            });
+
+            describe.each([
+                {
+                    condition: "newValue is a string",
+                    value: "Test",
+                    newValue: "Test2",
+                },
+                {
+                    condition: "newValue is an array",
+                    value: ["Test"],
+                    newValue: ["Test", "Test2"],
+                },
+            ])("$condition", ({value, newValue}) => {
+                it("should call the validate prop with the new value", () => {
+                    // Arrange
+                    const validate = jest.fn();
+                    const {result} = renderHook(() =>
+                        useSelectValidation({value, validate}),
+                    );
+                    validate.mockClear(); // Clear any calls from mounting
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(validate).toHaveBeenCalledExactlyOnceWith(newValue);
+                });
+
+                it("should set the errorMessage to the message returned by the validate prop", () => {
+                    // Arrange
+                    const {result} = renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate: () => testErrorMessage,
+                        }),
+                    );
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(result.current.errorMessage).toBe(testErrorMessage);
+                });
+
+                it("should set the errorMessage to null if the validate prop doesn't return an error message", () => {
+                    // Arrange
+                    const {result} = renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate: () => {},
+                        }),
+                    );
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(result.current.errorMessage).toBe(null);
+                });
+
+                it("should call onValidate with the message returned by the validate prop", () => {
+                    // Arrange
+                    const onValidate = jest.fn();
+                    const {result} = renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate: () => testErrorMessage,
+                            onValidate,
+                        }),
+                    );
+                    onValidate.mockClear(); // Clear any calls from mounting
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        testErrorMessage,
+                    );
+                });
+
+                it("should call onValidate with null if the validate prop doesn't return an error message", () => {
+                    // Arrange
+                    const onValidate = jest.fn();
+                    const {result} = renderHook(() =>
+                        useSelectValidation({
+                            value,
+                            validate: () => {},
+                            onValidate,
+                        }),
+                    );
+                    onValidate.mockClear(); // Clear any calls from mounting
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
+                });
+            });
+        });
+        describe("validating a new value when it is required", () => {
+            describe.each([
+                {
+                    condition: "newValue is an empty string",
+                    value: "Test",
+                    newValue: "",
+                },
+                {
+                    condition: "newValue is null",
+                    value: "Test",
+                    newValue: null,
+                },
+                {
+                    condition: "newValue is an empty array",
+                    value: ["Test"],
+                    newValue: [] as string[],
+                },
+            ])("$condition", ({value, newValue}) => {
+                it("should set the errorMessage to the required prop message", () => {
+                    // Arrange
+                    const {result} = renderHook(() =>
+                        useSelectValidation<SelectValue>({
+                            value,
+                            required: testRequiredErrorMessage,
+                        }),
+                    );
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(result.current.errorMessage).toBe(testRequiredErrorMessage);
+                });
+
+                it("should set the errorMessage to the default required message if the required prop is true", () => {
+                    // Arrange
+                    const {result} = renderHook(() =>
+                        useSelectValidation<SelectValue>({
+                            value,
+                            required: true,
+                        }),
+                    );
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(result.current.errorMessage).toBe("This field is required.");
+                });
+
+                it("should call onValidate with the required prop message", () => {
+                    // Arrange
+                    const onValidate = jest.fn();
+                    const {result} = renderHook(() =>
+                        useSelectValidation<SelectValue>({value, required: testRequiredErrorMessage, onValidate}),
+                    );
+                    onValidate.mockClear(); // Clear any calls from mounting
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(testRequiredErrorMessage);
+                });
+
+                it("should call onValidate with the default required message if the required prop is true", () => {
+                    // Arrange
+                    const onValidate = jest.fn();
+                    const {result} = renderHook(() =>
+                        useSelectValidation<SelectValue>({value, required: true, onValidate}),
+                    );
+                    onValidate.mockClear(); // Clear any calls from mounting
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(
+                        "This field is required.",
+                    );
+                });
+            });
+
+            describe.each([
+                {
+                    condition: "newValue is a string value",
+                    value: "Test",
+                    newValue: "Test2",
+                },
+                {
+                    condition: "newValue is an array",
+                    value: ["Test"],
+                    newValue: ["Test", "Test2"],
+                },
+            ])("$condition", ({value, newValue}) => {
+                it("should have a null errorMessage since the field has a value", () => {
+                    // Arrange
+                    const {result} = renderHook(() =>
+                        useSelectValidation<SelectValue>({value, required: testRequiredErrorMessage}),
+                    );
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(result.current.errorMessage).toBe(null);
+                });
+
+                it("should call the onValidate prop with null since the field has a value", () => {
+                    // Arrange
+                    const onValidate = jest.fn();
+                    const {result} = renderHook(() =>
+                        useSelectValidation<SelectValue>({value, onValidate, required: testRequiredErrorMessage}),
+                    );
+                    onValidate.mockClear(); // Clear any calls from mounting
+
+                    // Act
+                    act(() => {
+                        result.current.onSelectionValidation(newValue);
+                    });
+
+                    // Assert
+                    expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
+                });
+            });
+        })
+
+        describe("validate + required", () => {
+            it("should set the error message to the required error message if the validation succeeds", () => {
+                // Arrange
+                const {result} = renderHook(() =>
+                    useSelectValidation<SelectValue>({value: "Test", validate: () => {},required: testRequiredErrorMessage}),
+                );
+
+                // Act
+                act(() => {
+                    result.current.onSelectionValidation("");
+                });
+
+                // Assert
+                expect(result.current.errorMessage).toBe(testRequiredErrorMessage);
+            });
+
+            it("should set the error message to the validate error message if the validation fails", () => {
+                // Arrange
+                const {result} = renderHook(() =>
+                    useSelectValidation<SelectValue>({value: "Test", validate: () => testErrorMessage,required: testRequiredErrorMessage}),
+                );
+
+                // Act
+                act(() => {
+                    result.current.onSelectionValidation("");
+                });
+
+                // Assert
+                expect(result.current.errorMessage).toBe(testErrorMessage);
+            });
+        });
+    });
+
+    describe("onSelectedValuesChangeValidation", () => {
+        it("should set the errorMessage to null", () => {
+            // Arrange
+            // Mounting with a value and validate prop returning an error message
+            // will trigger it to have an error message already
+            const {result} = renderHook(() =>
+                useSelectValidation({
+                    value: "Test",
+                    validate: () => testErrorMessage,
+                }),
+            );
+
+            // Act
+            act(() => {
+                result.current.onSelectedValuesChangeValidation();
+            });
+
+            // Assert
+            expect(result.current.errorMessage).toBe(null);
+        });
+
+        it("should call onValidate with null", () => {
+            // Arrange
+            // Mounting with a value and validate prop returning an error message
+            // will trigger it to have an error message already
+            const onValidate = jest.fn();
+            const {result} = renderHook(() =>
+                useSelectValidation({
+                    value: "Test",
+                    validate: () => testErrorMessage,
+                    onValidate,
+                }),
+            );
+            onValidate.mockClear(); // Clear any calls from mounting
+            // Act
+            act(() => {
+                result.current.onSelectedValuesChangeValidation();
+            });
+
+            // Assert
+            expect(onValidate).toHaveBeenCalledExactlyOnceWith(null);
+        });
+    });
+});

--- a/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
@@ -21,6 +21,24 @@ function hasValue<T extends SelectValue>(value?: T | null): value is T {
     return value ? value.length > 0 : false;
 }
 
+/**
+ * Hook for validation logic for select based fields. Based on the props provided,
+ * the hook will:
+ * - call the `validate` and `onValidate` props on initialization and mount
+ * - provide validation functions for specific events
+ * - these functions will call the `validate` and `onValidate` props as needed
+ *
+ * @returns {object} An object with:
+ * - `errorMessage` - The error message from validation.
+ * - `onOpenerBlurValidation` - Validation logic for when the opener is blurred
+ * - `onDropdownClosedValidation` - Validation logic for when the opener is
+ * closed
+ * - `onSelectionValidation` - Validation logic for when a user is done
+ * selecting (a) value/value(s)
+ * - `onSelectedValuesChangeValidation` - Validation logic for when selected
+ * values are updated before selection is done (ie. values are updated and
+ * dropdown isn't closed yet)
+ */
 export function useSelectValidation<T extends SelectValue>({
     value,
     disabled = false,

--- a/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
@@ -37,7 +37,9 @@ function hasValue<T extends SelectValue>(value?: T | null): value is T {
  * selecting (a) value/value(s)
  * - `onSelectedValuesChangeValidation` - Validation logic for when selected
  * values are updated before selection is done (ie. values are updated and
- * dropdown isn't closed yet)
+ * dropdown isn't closed yet). Note that this should only be called when there
+ * are multiple values that can be selected. onSelectionValidation should be
+ * used whenever the user is done selecting a value or values.
  */
 export function useSelectValidation<T extends SelectValue>({
     value,
@@ -70,7 +72,7 @@ export function useSelectValidation<T extends SelectValue>({
                     onValidate(error);
                 }
                 if (error) {
-                    // If there is an error, do not continue with required validation
+                    // If there is an error, do not continue with validation related to `required` prop
                     return;
                 }
             }
@@ -100,15 +102,19 @@ export function useSelectValidation<T extends SelectValue>({
     function onOpenerBlurValidation() {
         if (!open && required && !hasValue(value)) {
             // Only validate on opener blur if the dropdown is closed, the field
-            // is required, and no value is selected. This prevents an error when
-            // the dropdown is opened without a value yet.
+            // is required, and no value is selected. This prevents an error state
+            // when the dropdown is opened without a value yet since opening
+            // the dropdown will also trigger the blur event since focus is moved
+            // to the dropdown
             handleValidation(value);
         }
     }
 
     const onDropdownClosedValidation = () => {
         if (required && !hasValue(value)) {
-            // If closed, field is required, and no value is selected, validate
+            // If field is required, and no value is selected, validate
+            // We don't check for `!open` because `open` is not updated yet
+            // when this is called
             handleValidation(value);
         }
     };

--- a/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
@@ -1,0 +1,92 @@
+import {useOnMountEffect} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
+
+const defaultErrorMessage = "This field is required.";
+
+type SelectValidationProps = {
+    selectedValue?: string | null;
+    disabled?: boolean;
+    validate?: (value: string) => string | null | void;
+    onValidate?: (errorMessage?: string | null | undefined) => unknown;
+    required?: boolean | string;
+    open: boolean;
+};
+
+export function useSelectValidation({
+    selectedValue,
+    disabled = false,
+    validate,
+    onValidate,
+    required,
+    open,
+}: SelectValidationProps) {
+    const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+    const handleValidation = React.useCallback(
+        (value?: string | null) => {
+            // Should not handle validation if it is disabled
+            if (disabled) {
+                return;
+            }
+            if (validate && value) {
+                const error = validate(value) || null;
+                setErrorMessage(error);
+                if (onValidate) {
+                    onValidate(error);
+                }
+                if (error) {
+                    // If there is an error, do not continue with required validation
+                    return;
+                }
+            }
+            if (required) {
+                const requiredString =
+                    typeof required === "string"
+                        ? required
+                        : defaultErrorMessage;
+                const error = value ? null : requiredString;
+                setErrorMessage(error);
+                if (onValidate) {
+                    onValidate(error);
+                }
+            }
+        },
+        [disabled, validate, setErrorMessage, onValidate, required],
+    );
+
+    useOnMountEffect(() => {
+        // Only validate on mount if the value is not empty and the field is not
+        // required. This is so that fields don't render an error when they are
+        //initially empty
+        if (selectedValue && !required) {
+            handleValidation(selectedValue);
+        }
+    });
+
+    const onOpenerBlurValidation = () => {
+        if (!open && required && !selectedValue) {
+            // Only validate on opener blur if the dropdown is closed, the field
+            // is required, and no value is selected. This prevents an error when
+            // the dropdown is opened without a value yet.
+            handleValidation(selectedValue);
+        }
+    };
+
+    const onDropdownClosedValidation = () => {
+        if (required && !selectedValue) {
+            // If closed, field is required, and no value is selected, validate
+            handleValidation(selectedValue);
+        }
+    };
+
+    const onSelectionValidation = (value: string) => {
+        handleValidation(value);
+    };
+
+    return {
+        errorMessage,
+        onOpenerBlurValidation,
+        onDropdownClosedValidation,
+        onSelectionValidation,
+    };
+}

--- a/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
@@ -92,10 +92,23 @@ export function useSelectValidation<T extends SelectValue>({
         handleValidation(value);
     };
 
+    const onSelectedValuesChangeValidation = () => {
+        // When selected values change, clear the error message
+        // This is so errors aren't shown to the user while they update the
+        // selected values. Note that this should only be called when there are
+        // multiple values that can be selected. onSelectionValidation should be
+        // used whenever the user is done selecting a value or values.
+        setErrorMessage(null);
+        if (onValidate) {
+            onValidate(null);
+        }
+    };
+
     return {
         errorMessage,
         onOpenerBlurValidation,
         onDropdownClosedValidation,
         onSelectionValidation,
+        onSelectedValuesChangeValidation,
     };
 }

--- a/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
@@ -14,7 +14,7 @@ type SelectValidationProps<T extends SelectValue> = {
     validate?: (value: T) => string | null | void;
     onValidate?: (errorMessage?: string | null | undefined) => unknown;
     required?: boolean | string;
-    open: boolean;
+    open?: boolean;
 };
 
 function hasValue<T extends SelectValue>(value?: T | null): value is T {

--- a/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
@@ -45,7 +45,8 @@ export function useSelectValidation<T extends SelectValue>({
                 return;
             }
             if (validate) {
-                const error = (newValue !== undefined && validate(newValue)) || null;
+                const error =
+                    (newValue !== undefined && validate(newValue)) || null;
                 setErrorMessage(error);
                 if (onValidate) {
                     onValidate(error);

--- a/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
@@ -9,7 +9,7 @@ type MultiSelectedValues = string[];
 type SelectValue = SingleSelectedValue | MultiSelectedValues;
 
 type SelectValidationProps<T extends SelectValue> = {
-    selectedValue?: T;
+    value?: T;
     disabled?: boolean;
     validate?: (value: T) => string | null | void;
     onValidate?: (errorMessage?: string | null | undefined) => unknown;
@@ -22,7 +22,7 @@ function hasValue<T extends SelectValue>(value?: T | null): value is T {
 }
 
 export function useSelectValidation<T extends SelectValue>({
-    selectedValue,
+    value,
     disabled = false,
     validate,
     onValidate,
@@ -32,13 +32,13 @@ export function useSelectValidation<T extends SelectValue>({
     const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
 
     const handleValidation = React.useCallback(
-        (value?: T) => {
+        (newValue?: T) => {
             // Should not handle validation if it is disabled
             if (disabled) {
                 return;
             }
-            if (validate && hasValue(value)) {
-                const error = validate(value) || null;
+            if (validate && hasValue(newValue)) {
+                const error = validate(newValue) || null;
                 setErrorMessage(error);
                 if (onValidate) {
                     onValidate(error);
@@ -53,7 +53,7 @@ export function useSelectValidation<T extends SelectValue>({
                     typeof required === "string"
                         ? required
                         : defaultErrorMessage;
-                const error = hasValue(value) ? null : requiredString;
+                const error = hasValue(newValue) ? null : requiredString;
                 setErrorMessage(error);
                 if (onValidate) {
                     onValidate(error);
@@ -66,29 +66,29 @@ export function useSelectValidation<T extends SelectValue>({
     useOnMountEffect(() => {
         // Only validate on mount if the value is not empty. This is so that
         // fields don't render an error when they are initially empty
-        if (hasValue(selectedValue)) {
-            handleValidation(selectedValue);
+        if (hasValue(value)) {
+            handleValidation(value);
         }
     });
 
     function onOpenerBlurValidation() {
-        if (!open && required && !hasValue(selectedValue)) {
+        if (!open && required && !hasValue(value)) {
             // Only validate on opener blur if the dropdown is closed, the field
             // is required, and no value is selected. This prevents an error when
             // the dropdown is opened without a value yet.
-            handleValidation(selectedValue);
+            handleValidation(value);
         }
     }
 
     const onDropdownClosedValidation = () => {
-        if (required && !hasValue(selectedValue)) {
+        if (required && !hasValue(value)) {
             // If closed, field is required, and no value is selected, validate
-            handleValidation(selectedValue);
+            handleValidation(value);
         }
     };
 
-    const onSelectionValidation = (value: T) => {
-        handleValidation(value);
+    const onSelectionValidation = (newValue: T) => {
+        handleValidation(newValue);
     };
 
     const onSelectedValuesChangeValidation = () => {

--- a/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
+++ b/packages/wonder-blocks-dropdown/src/hooks/use-select-validation.tsx
@@ -64,10 +64,9 @@ export function useSelectValidation<T extends SelectValue>({
     );
 
     useOnMountEffect(() => {
-        // Only validate on mount if the value is not empty and the field is not
-        // required. This is so that fields don't render an error when they are
-        //initially empty
-        if (hasValue(selectedValue) && !required) {
+        // Only validate on mount if the value is not empty. This is so that
+        // fields don't render an error when they are initially empty
+        if (hasValue(selectedValue)) {
             handleValidation(selectedValue);
         }
     });

--- a/packages/wonder-blocks-dropdown/src/util/helpers.ts
+++ b/packages/wonder-blocks-dropdown/src/util/helpers.ts
@@ -84,3 +84,17 @@ export function getSelectOpenerLabel(
     }
     return props.label;
 }
+
+/**
+ * Determines if two arrays of strings are equal.
+ */
+export function areArraysEqual(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+
+    const sortedA = [...a].sort();
+    const sortedB = [...b].sort();
+
+    return sortedA.every((value, index) => value === sortedB[index]);
+}

--- a/packages/wonder-blocks-dropdown/src/util/helpers.ts
+++ b/packages/wonder-blocks-dropdown/src/util/helpers.ts
@@ -84,17 +84,3 @@ export function getSelectOpenerLabel(
     }
     return props.label;
 }
-
-/**
- * Determines if two arrays of strings are equal.
- */
-export function areArraysEqual(a: string[], b: string[]): boolean {
-    if (a.length !== b.length) {
-        return false;
-    }
-
-    const sortedA = [...a].sort();
-    const sortedB = [...b].sort();
-
-    return sortedA.every((value, index) => value === sortedB[index]);
-}


### PR DESCRIPTION
## Summary:
- Refactor SingleSelect validation logic to useSelectValidation hook
- Adding validation related props to MultiSelect: validate, onValidate, required. (error prop was already supported)
  - Make sure aria-invalid is set if it is in an error state

Issue: WB-1782

## Test plan:
- MultiSelect docs are reviewed `?path=/docs/packages-dropdown-multiselect--docs`
- Validation works as expected in MultiSelect (see docs for more details on validation behaviour):
  - Error (`?path=/story/packages-dropdown-multiselect--error`)
  - Required (`?path=/story/packages-dropdown-multiselect--required`)
  - Error from Validation (`?path=/story/packages-dropdown-multiselect--error-from-validation`)
- MultiSelect continues to work as expected (including keyboard interactions)
- SingleSelect continues to work as expected (including validation)