### PR TITLE
[MulitSelect] Move `showOpenerLabelAsText` out of sharedProps

### DIFF
--- a/.changeset/famous-buckets-vanish.md
+++ b/.changeset/famous-buckets-vanish.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+[MultiSelect] Remove `showOpenerLabelAsText` from sharedProps that are passed to SelectOpener

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -528,6 +528,7 @@ export default class MultiSelect extends React.Component<Props, State> {
             className,
             "aria-invalid": ariaInvalid,
             "aria-required": ariaRequired,
+            showOpenerLabelAsText,
             /* eslint-enable @typescript-eslint/no-unused-vars */
             ...sharedProps
         } = this.props;

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -398,6 +398,7 @@ export default class SingleSelect extends React.Component<Props, State> {
             placeholder,
             selectedValue,
             testId,
+            showOpenerLabelAsText,
             // the following props are being included here to avoid
             // passing them down to the opener as part of sharedProps
             /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -414,7 +415,6 @@ export default class SingleSelect extends React.Component<Props, State> {
             className,
             "aria-invalid": ariaInvalid,
             "aria-required": ariaRequired,
-            showOpenerLabelAsText,
             ...sharedProps
         } = this.props;
 


### PR DESCRIPTION
## Summary:


Issue: XXX-XXXX

## Test plan:
Install the snapshot in webapp, yarn test