### PR TITLE
RadioGroup: Add flexible width to legend element to fill available space

### DIFF
--- a/.changeset/cold-rocks-notice.md
+++ b/.changeset/cold-rocks-notice.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Adds `width: 100%` to `legend` element to allow expanding it to fill the available space

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import {Choice, RadioGroup} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
@@ -223,6 +225,36 @@ FiltersOutFalsyChildren.parameters = {
     chromatic: {
         // The unit tests already verify that false-y children aren't rendered.
         disableSnapshot: true,
+    },
+};
+
+/**
+ * There are specific situations where you might want to use a custom label
+ * component instead of using the default `LabelMedium` component. This example
+ * demonstrates how to use a custom label component that can be passed in as a
+ * prop to the `RadioGroup` component.
+ */
+export const CustomLabel: StoryComponentType = {
+    ...Default,
+    args: {
+        style: {
+            // Adding an arbitrary width to the radio group to demonstrate how
+            // the custom label component expands to fill the available space.
+            width: 400,
+        },
+        label: (
+            <View
+                style={{
+                    border: `1px dashed ${semanticColor.border.strong}`,
+                    padding: spacing.medium_16,
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                }}
+            >
+                <LabelLarge>Pokemon</LabelLarge>
+                <LabelMedium>(optional)</LabelMedium>
+            </View>
+        ),
     },
 };
 

--- a/packages/wonder-blocks-form/src/components/group-styles.ts
+++ b/packages/wonder-blocks-form/src/components/group-styles.ts
@@ -15,6 +15,8 @@ const styles: StyleDeclaration = StyleSheet.create({
 
     legend: {
         padding: 0,
+        // Let the legend use the size defined by the parent.
+        width: "100%",
     },
 
     description: {


### PR DESCRIPTION
## Summary:

Adds `width: 100%` to `legend` element to allow expanding it to fill the
available space.

Note that this applies to both `RadioGroup` and `CheckboxGroup`.

Issue: XXX-XXXX

## Test plan:

Navigate to `/?path=/docs/packages-form-radiogroup--docs#custom%20label`.

Verify that the legend element is now full-bleed.