### PR TITLE
Tooling: Move Storybook reusable components to __docs__ to optimize Turbosnap

### DIFF
--- a/__docs__/components/component-info.tsx
+++ b/__docs__/components/component-info.tsx
@@ -1,31 +1,26 @@
 import * as React from "react";
 
+import githubLogo from "@phosphor-icons/core/fill/github-logo-fill.svg";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Caption} from "@khanacademy/wonder-blocks-typography";
-import githubLogo from "@phosphor-icons/core/fill/github-logo-fill.svg";
 
 type Props = {
     /**
      * The package name.
      */
-    name: string,
+    name: string;
     /**
      * The latest stable version.
      */
-    version: string
+    version: string;
 };
 
 /**
  * An internal component that displays the package name and version. It also
  * includes a link to the Github repo.
  */
-const ComponentInfo: React.FC<Props> = (
-    {
-        name,
-        version,
-    },
-): React.ReactElement => {
+function ComponentInfo({name, version}: Props): React.ReactElement {
     const packageFolder = name.split("/")?.[1];
     return (
         <View
@@ -50,6 +45,6 @@ const ComponentInfo: React.FC<Props> = (
             </Button>
         </View>
     );
-};
+}
 
 export default ComponentInfo;

--- a/__docs__/components/token-table.tsx
+++ b/__docs__/components/token-table.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {addStyle, View} from "@khanacademy/wonder-blocks-core";
-import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 const StyledTable = addStyle("table");

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -12,7 +12,7 @@ import {Strut} from "@khanacademy/wonder-blocks-layout";
 import * as tokens from "@khanacademy/wonder-blocks-tokens";
 import {HeadingSmall, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-accordion/package.json";
 
 import AccordionSectionArgtypes from "./accordion-section.argtypes";

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -17,7 +17,7 @@ import {
     SingleSelect,
 } from "@khanacademy/wonder-blocks-dropdown";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-accordion/package.json";
 
 import AccordionArgtypes from "./accordion.argtypes";

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -12,7 +12,7 @@ import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Banner from "@khanacademy/wonder-blocks-banner";
 
 import BannerArgTypes from "./banner.argtypes";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-banner/package.json";
 import crownIcon from "../wonder-blocks-icon/icons/crown.svg";
 

--- a/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
+++ b/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
@@ -6,7 +6,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import packageConfig from "../../packages/wonder-blocks-birthday-picker/package.json";
 import BirthdayPicker from "@khanacademy/wonder-blocks-birthday-picker";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 import ArgTypes from "./birthday-picker.argtypes";
 

--- a/__docs__/wonder-blocks-breadcrumbs/breadcrumbs.stories.tsx
+++ b/__docs__/wonder-blocks-breadcrumbs/breadcrumbs.stories.tsx
@@ -8,7 +8,7 @@ import {
     BreadcrumbsItem,
 } from "@khanacademy/wonder-blocks-breadcrumbs";
 import packageConfig from "../../packages/wonder-blocks-breadcrumbs/package.json";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 import BreadcrumbsArgTypes from "./breadcrumbs.argtypes";
 

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -22,7 +22,7 @@ import {
 
 import Button from "@khanacademy/wonder-blocks-button";
 import packageConfig from "../../packages/wonder-blocks-button/package.json";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 import ButtonArgTypes from "./button.argtypes";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";

--- a/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
@@ -10,7 +10,7 @@ import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import packageConfig from "../../packages/wonder-blocks-cell/package.json";
 import {CompactCell} from "@khanacademy/wonder-blocks-cell";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import CompactCellArgTypes, {AccessoryMappings} from "./compact-cell.argtypes";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 

--- a/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
@@ -10,7 +10,7 @@ import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
 import packageConfig from "../../packages/wonder-blocks-cell/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import DetailCellArgTypes from "./detail-cell.argtypes";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 

--- a/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
@@ -8,7 +8,7 @@ import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import packageConfig from "../../packages/wonder-blocks-clickable/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import argTypes from "./clickable-behavior.argtypes";
 
 const ClickableBehavior = getClickableBehavior();

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -10,7 +10,7 @@ import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import packageConfig from "../../packages/wonder-blocks-clickable/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import argTypes from "./clickable.argtypes";
 import Button from "@khanacademy/wonder-blocks-button";
 

--- a/__docs__/wonder-blocks-core/initial-fallback.stories.tsx
+++ b/__docs__/wonder-blocks-core/initial-fallback.stories.tsx
@@ -5,7 +5,7 @@ import {Body} from "@khanacademy/wonder-blocks-typography";
 import {View, InitialFallback} from "@khanacademy/wonder-blocks-core";
 import packageConfig from "../../packages/wonder-blocks-core/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 type StoryComponentType = StoryObj<typeof InitialFallback>;
 

--- a/__docs__/wonder-blocks-core/view.stories.tsx
+++ b/__docs__/wonder-blocks-core/view.stories.tsx
@@ -11,7 +11,7 @@ import {
 import {View} from "@khanacademy/wonder-blocks-core";
 import packageConfig from "../../packages/wonder-blocks-core/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import viewArgTypes from "./view.argtypes";
 
 export default {

--- a/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
@@ -6,7 +6,7 @@ import {ActionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import actionItemArgtypes from "./action-item.argtypes";

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -21,7 +21,7 @@ import {
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import actionMenuArgtypes from "./action-menu.argtypes";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 
 import type {Item} from "../../packages/wonder-blocks-dropdown/src/util/types";

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -18,7 +18,7 @@ import argTypes from "./combobox.argtypes";
 
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 const items = [
     <OptionItem label="Banana" value="banana" key={0} />,

--- a/__docs__/wonder-blocks-dropdown/listbox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/listbox.stories.tsx
@@ -10,7 +10,7 @@ import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {allProfilesWithPictures} from "./option-item-examples";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 
 const items = [

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -14,7 +14,7 @@ import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import type {Labels} from "@khanacademy/wonder-blocks-dropdown";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 import multiSelectArgtypes from "./multi-select.argtypes";
 import {defaultLabels} from "../../packages/wonder-blocks-dropdown/src/util/constants";

--- a/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
@@ -6,7 +6,7 @@ import {OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import optionItemArgtypes, {AccessoryMappings} from "./option-item.argtypes";

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -29,7 +29,7 @@ import {
 import type {SingleSelectLabels} from "@khanacademy/wonder-blocks-dropdown";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import singleSelectArgtypes from "./single-select.argtypes";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {defaultLabels} from "../../packages/wonder-blocks-dropdown/src/util/constants";

--- a/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
@@ -9,7 +9,7 @@ import {LabelLarge, LabelXSmall} from "@khanacademy/wonder-blocks-typography";
 import {Choice, CheckboxGroup} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 export default {
     title: "Packages / Form / CheckboxGroup",

--- a/__docs__/wonder-blocks-form/checkbox.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox.stories.tsx
@@ -8,7 +8,7 @@ import {Checkbox, CheckboxGroup, Choice} from "@khanacademy/wonder-blocks-form";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import Strut from "../../packages/wonder-blocks-layout/src/components/strut";
 
 export default {

--- a/__docs__/wonder-blocks-form/choice.stories.tsx
+++ b/__docs__/wonder-blocks-form/choice.stories.tsx
@@ -12,7 +12,7 @@ import {
     RadioGroup,
 } from "@khanacademy/wonder-blocks-form";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 
 export default {

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -11,7 +11,7 @@ import Link from "@khanacademy/wonder-blocks-link";
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import LabeledTextFieldArgTypes from "./labeled-text-field.argtypes";
 
 /**

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -9,7 +9,7 @@ import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {Choice, RadioGroup} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 export default {
     title: "Packages / Form / RadioGroup",

--- a/__docs__/wonder-blocks-form/radio.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 
 import Radio from "../../packages/wonder-blocks-form/src/components/radio";

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -5,7 +5,7 @@ import {StyleSheet} from "aphrodite";
 import {TextArea} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import Button from "@khanacademy/wonder-blocks-button";
 import {LabelSmall, LabelLarge} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -16,7 +16,7 @@ import {
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TextFieldArgTypes from "./text-field.argtypes";
 import {validateEmail, validatePhoneNumber} from "./form-utilities";
 

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -18,7 +18,7 @@ import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-icon-button/package.json";
 import IconButtonArgtypes from "./icon-button.argtypes";
 import TextField from "../../packages/wonder-blocks-form/src/components/text-field";

--- a/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
@@ -18,7 +18,7 @@ import {
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import * as tokens from "@khanacademy/wonder-blocks-tokens";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-icon/package.json";
 import PhosphorIconArgtypes, {IconMappings} from "./phosphor-icon.argtypes";
 

--- a/__docs__/wonder-blocks-layout/media-layout.stories.tsx
+++ b/__docs__/wonder-blocks-layout/media-layout.stories.tsx
@@ -19,7 +19,7 @@ import {
     MediaLayoutContext,
 } from "@khanacademy/wonder-blocks-layout";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-layout/package.json";
 
 export default {

--- a/__docs__/wonder-blocks-layout/spring.stories.tsx
+++ b/__docs__/wonder-blocks-layout/spring.stories.tsx
@@ -9,7 +9,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {Spring, Strut} from "@khanacademy/wonder-blocks-layout";
 import packageConfig from "../../packages/wonder-blocks-layout/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 type StoryComponentType = StoryObj<typeof Spring>;
 

--- a/__docs__/wonder-blocks-layout/strut.stories.tsx
+++ b/__docs__/wonder-blocks-layout/strut.stories.tsx
@@ -9,7 +9,7 @@ import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import packageConfig from "../../packages/wonder-blocks-layout/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 export default {
     title: "Packages / Layout / Strut",

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -20,7 +20,7 @@ import {
 import Link from "@khanacademy/wonder-blocks-link";
 import packageConfig from "../../packages/wonder-blocks-link/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import LinkArgTypes from "./link.argtypes";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -15,7 +15,7 @@ import {
     ModalPanel,
 } from "@khanacademy/wonder-blocks-modal";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 import modalDialogArgtypes from "./modal-dialog.argtypes";
 

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -15,7 +15,7 @@ import {
 } from "@khanacademy/wonder-blocks-modal";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 const customViewports = {
     phone: {

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from "@khanacademy/wonder-blocks-modal";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import ModalHeaderArgtypes from "./modal-header.argtypes";
 
 const customViewports = {

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -30,7 +30,7 @@ import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 import type {ModalElement} from "../../packages/wonder-blocks-modal/src/util/types";
 import ModalLauncherArgTypes from "./modal-launcher.argtypes";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 const customViewports = {
     phone: {

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -15,7 +15,7 @@ import {
     ModalFooter,
 } from "@khanacademy/wonder-blocks-modal";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import modalPanelArgtypes from "./modal-panel.argtypes";
 
 const customViewports = {

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -17,7 +17,7 @@ import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import OnePaneDialogArgTypes from "./one-pane-dialog.argtypes";
 
 const customViewports = {

--- a/__docs__/wonder-blocks-pill/pill.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill.stories.tsx
@@ -18,7 +18,7 @@ import type {
     PillSize,
 } from "../../packages/wonder-blocks-pill/src/components/pill";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-search-field/package.json";
 
 import PillArgtypes from "./pill.argtypes";

--- a/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
@@ -14,7 +14,7 @@ import {
 
 import {PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
 import packageConfig from "../../packages/wonder-blocks-popover/package.json";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
 // NOTE: We are reusing an existing Cell SB Story to test how Popovers can be

--- a/__docs__/wonder-blocks-popover/popover-content.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.stories.tsx
@@ -10,7 +10,7 @@ import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {PopoverContent} from "@khanacademy/wonder-blocks-popover";
 import packageConfig from "../../packages/wonder-blocks-popover/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import PopoverContentArgtypes from "./popover-content.argtypes";
 
 export default {

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -12,7 +12,7 @@ import type {Placement} from "@khanacademy/wonder-blocks-tooltip";
 import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
 import packageConfig from "../../packages/wonder-blocks-popover/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import PopoverArgtypes, {ContentMappings} from "./popover.argtypes";
 
 /**

--- a/__docs__/wonder-blocks-progress-spinner/circular-spinner.stories.tsx
+++ b/__docs__/wonder-blocks-progress-spinner/circular-spinner.stories.tsx
@@ -7,7 +7,7 @@ import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {CircularSpinner} from "@khanacademy/wonder-blocks-progress-spinner";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-progress-spinner/package.json";
 
 export default {

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -10,7 +10,7 @@ import {LabelLarge, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-search-field/package.json";
 import SearchFieldArgtypes from "./search-field.argtypes";
 

--- a/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
@@ -10,7 +10,7 @@ import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import packageConfig from "../../packages/wonder-blocks-switch/package.json";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 import SwitchArgtypes from "./switch.argtypes";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";

--- a/__docs__/wonder-blocks-switch/switch.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch.stories.tsx
@@ -12,7 +12,7 @@ import * as tokens from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import packageConfig from "../../packages/wonder-blocks-switch/package.json";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 import SwitchArgtypes from "./switch.argtypes";
 

--- a/__docs__/wonder-blocks-timing/with-action-scheduler.mdx
+++ b/__docs__/wonder-blocks-timing/with-action-scheduler.mdx
@@ -9,7 +9,7 @@ import {
     MyGoodComponentWithScheduler,
     MyNaughtyComponent,
 } from "./with-action-scheduler-examples";
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 <Meta of={WithActionSchedulerStories} />
 

--- a/__docs__/wonder-blocks-tokens/__overview__.mdx
+++ b/__docs__/wonder-blocks-tokens/__overview__.mdx
@@ -1,6 +1,6 @@
 import {Meta, Source} from "@storybook/blocks";
 
-import TokenTable from "../../.storybook/components/token-table";
+import TokenTable from "../components/token-table";
 
 import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -21,7 +21,9 @@ building blocks of our design system.
 These represent the design decisions at Khan Academy, such as:
 
 -   <a href="/?path=/docs/packages-tokens-border--docs">Border</a>
--   <a href="/?path=/docs/packages-tokens-semantic-color--docs">Semantic Colors</a>
+-   <a href="/?path=/docs/packages-tokens-semantic-color--docs">
+        Semantic Colors
+    </a>
 -   <a href="/?path=/docs/packages-tokens-color--docs">Color Primitives</a>
 -   <a href="/?path=/docs/packages-tokens-spacing--docs">Spacing</a>
 -   <a href="/?path=/docs/packages-tokens-typography--docs">Typography</a>

--- a/__docs__/wonder-blocks-tokens/tokens-border.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-border.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/blocks";
 
-import TokenTable from "../../.storybook/components/token-table";
+import TokenTable from "../components/token-table";
 
 import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";

--- a/__docs__/wonder-blocks-tokens/tokens-color.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-color.mdx
@@ -1,12 +1,12 @@
 import {Meta, Source} from "@storybook/blocks";
 
-import TokenTable from "../../.storybook/components/token-table";
+import TokenTable from "../components/token-table";
 
 import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as tokens from "@khanacademy/wonder-blocks-tokens";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-tokens/package.json";
 
 <Meta title="Packages / Tokens / Color" />

--- a/__docs__/wonder-blocks-tokens/tokens-font.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-font.mdx
@@ -4,7 +4,7 @@ import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as tokens from "@khanacademy/wonder-blocks-tokens";
 
-import TokenTable from "../../.storybook/components/token-table";
+import TokenTable from "../components/token-table";
 
 <Meta title="Packages / Tokens / Typography" />
 

--- a/__docs__/wonder-blocks-tokens/tokens-media-queries.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-media-queries.mdx
@@ -1,11 +1,11 @@
 import {Meta, Source} from "@storybook/blocks";
 
-import TokenTable from "../../.storybook/components/token-table";
+import TokenTable from "../components/token-table";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as tokens from "@khanacademy/wonder-blocks-tokens";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-tokens/package.json";
 
 <Meta title="Packages / Tokens / Media Query Breakpoints" />
@@ -29,8 +29,8 @@ You can use mediaQuery conditions by importing `breakpoint` from the
 import {breakpoint} from "@khanacademy/wonder-blocks-tokens";
 const styles = {
     [breakpoint.mediaQuery.sm]: {
-        flexDirection: "column"
-    }
+        flexDirection: "column",
+    },
 };
 ```
 
@@ -46,8 +46,8 @@ a string to add the `px` unit like so:
 import {breakpoint} from "@khanacademy/wonder-blocks-tokens";
 const styles = {
     element: {
-        maxWidth: `${breakpoint.width.lg}px`
-    }
+        maxWidth: `${breakpoint.width.lg}px`,
+    },
 };
 ```
 

--- a/__docs__/wonder-blocks-tokens/tokens-semantic-color.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-semantic-color.mdx
@@ -1,12 +1,12 @@
 import {Meta, Source} from "@storybook/blocks";
 
-import TokenTable from "../../.storybook/components/token-table";
+import TokenTable from "../components/token-table";
 
 import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-tokens/package.json";
 
 import {flattenNestedTokens} from "../components/tokens-util";

--- a/__docs__/wonder-blocks-tokens/tokens-spacing.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-spacing.mdx
@@ -1,11 +1,11 @@
 import {Meta, Source} from "@storybook/blocks";
 
-import TokenTable from "../../.storybook/components/token-table";
+import TokenTable from "../components/token-table";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as tokens from "@khanacademy/wonder-blocks-tokens";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-tokens/package.json";
 
 <Meta title="Packages / Tokens / Spacing" />

--- a/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
@@ -8,7 +8,7 @@ import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import Toolbar from "@khanacademy/wonder-blocks-toolbar";
 import packageConfig from "../../packages/wonder-blocks-toolbar/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import ToolbarArgtypes, {
     leftContentMappings,
     rightContentMappings,

--- a/__docs__/wonder-blocks-tooltip/tooltip-content.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip-content.stories.tsx
@@ -5,7 +5,7 @@ import {Body, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
 import packageConfig from "../../packages/wonder-blocks-tooltip/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 
 type StoryComponentType = StoryObj<typeof TooltipContent>;
 

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -19,7 +19,7 @@ import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import packageConfig from "../../packages/wonder-blocks-tooltip/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TooltipArgTypes from "./tooltip.argtypes";
 
 type StoryComponentType = StoryObj<typeof Tooltip>;

--- a/__docs__/wonder-blocks-typography/body-monospace.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body-monospace.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {BodyMonospace} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/body-serif-block.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body-serif-block.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {BodySerifBlock} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/body-serif.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body-serif.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {BodySerif} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/body.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {Body} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/caption.stories.tsx
+++ b/__docs__/wonder-blocks-typography/caption.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {Caption} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/footnote.stories.tsx
+++ b/__docs__/wonder-blocks-typography/footnote.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {Footnote} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/heading-large.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading-large.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/heading-medium.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading-medium.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/heading-small.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading-small.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/heading-xsmall.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading-xsmall.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {HeadingXSmall} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/label-large.stories.tsx
+++ b/__docs__/wonder-blocks-typography/label-large.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/label-medium.stories.tsx
+++ b/__docs__/wonder-blocks-typography/label-medium.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/label-small.stories.tsx
+++ b/__docs__/wonder-blocks-typography/label-small.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/label-xsmall.stories.tsx
+++ b/__docs__/wonder-blocks-typography/label-xsmall.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {LabelXSmall} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/tagline.stories.tsx
+++ b/__docs__/wonder-blocks-typography/tagline.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {Tagline} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/title.stories.tsx
+++ b/__docs__/wonder-blocks-typography/title.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 import {Title} from "@khanacademy/wonder-blocks-typography";

--- a/__docs__/wonder-blocks-typography/typography.stories.tsx
+++ b/__docs__/wonder-blocks-typography/typography.stories.tsx
@@ -25,7 +25,7 @@ import {
 } from "@khanacademy/wonder-blocks-typography";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
-import ComponentInfo from "../../.storybook/components/component-info";
+import ComponentInfo from "../components/component-info";
 import TypographyArgTypes from "./typography.argtypes";
 
 // NOTE: Only for testing purposes.


### PR DESCRIPTION
## Summary:

While investigating the performance of Chromatic/Turbosnap, I found that
chromatic was disabling Turbosnap of the storybook stories in a lot of builds
because apparently we were making changing changes in files inside the
`.storybook` folder. This is not the case as those builds didn't include changes
in such files, but this made me realize that we could optimize the performance
of Turbosnap by moving the reusable components from the `.storybook` folder to
the `__docs__` folder.

Issue: XXX-XXXX

## Test plan:

Verify that Storybook still works as expected and check the Chromatic build to
see if Turbosnap is enabled for the stories that were previously disabled.