### PR TITLE
WB-1847: Dropdown - Update SelectOpener to match design specs

### DIFF
--- a/.changeset/tender-points-melt.md
+++ b/.changeset/tender-points-melt.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-dropdown": minor
 ---
 
-Update styles to match design specs
+SelectOpener: Update styles to match design specs

--- a/.changeset/tender-points-melt.md
+++ b/.changeset/tender-points-melt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Update styles to match design specs

--- a/.changeset/yellow-mails-fold.md
+++ b/.changeset/yellow-mails-fold.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add `pressing` tokens to actions

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -78,17 +78,12 @@ how to use these colors depending on the context.
 For buttons, links, and controls to communicate the presence and meaning of
 interaction.
 
-<View style={styles.grid}>
-    <ColorGroup colors={semanticColor.action.primary} group="action.primary" />
-    <ColorGroup
-        colors={semanticColor.action.destructive}
-        group="action.destructive"
-    />
-    <ColorGroup
-        colors={semanticColor.action.disabled}
-        group="action.disabled"
-    />
-</View>
+<ColorGroup colors={semanticColor.action.primary} group="action.primary" />
+<ColorGroup
+    colors={semanticColor.action.destructive}
+    group="action.destructive"
+/>
+<ColorGroup colors={semanticColor.action.disabled} group="action.disabled" />
 
 ### Status
 
@@ -389,10 +384,12 @@ content is accessible to all users.
 
 For more detail, you can check the following Success Criteria documents:
 
--   <a
-    href="https://www.w3.org/WAI/WCAG22/Understanding/use-of-color">Use of Color</a>
--   <a
-    href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum">Contrast (minimum)</a>
--   <a
-    href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast">Non-text
-    Contrast (Level AA)</a>
+-   <a href="https://www.w3.org/WAI/WCAG22/Understanding/use-of-color">
+        Use of Color
+    </a>
+-   <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum">
+        Contrast (minimum)
+    </a>
+-   <a href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast">
+        Non-text Contrast (Level AA)
+    </a>

--- a/__docs__/wonder-blocks-dropdown/multi-select-variants.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select-variants.stories.tsx
@@ -94,6 +94,26 @@ const KindVariants = ({light}: {light: boolean}) => {
                             {selectItems}
                         </MultiSelect>
                     </View>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
+                            Selected
+                        </LabelMedium>
+                        <MultiSelect
+                            {...defaultProps}
+                            selectedValues={["1", "2"]}
+                            light={light}
+                        >
+                            {selectItems}
+                        </MultiSelect>
+                    </View>
                 </>
             )}
         </ThemeSwitcherContext.Consumer>
@@ -150,7 +170,7 @@ const styles = StyleSheet.create({
     },
     grid: {
         display: "grid",
-        gridTemplateColumns: "repeat(3, 250px)",
+        gridTemplateColumns: "repeat(4, 250px)",
         gap: spacing.large_24,
     },
     gridRow: {

--- a/__docs__/wonder-blocks-dropdown/single-select-variants.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select-variants.stories.tsx
@@ -105,7 +105,7 @@ const KindVariants = ({light}: {light: boolean}) => {
                         ]}
                     >
                         <LabelMedium style={light && {color: color.white}}>
-                            Value selected
+                            Selected
                         </LabelMedium>
                         <SingleSelect
                             {...defaultProps}

--- a/__docs__/wonder-blocks-dropdown/single-select-variants.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select-variants.stories.tsx
@@ -65,26 +65,6 @@ const KindVariants = ({light}: {light: boolean}) => {
                         ]}
                     >
                         <LabelMedium style={light && {color: color.white}}>
-                            Value selected
-                        </LabelMedium>
-                        <SingleSelect
-                            {...defaultProps}
-                            selectedValue="1"
-                            light={light}
-                        >
-                            {selectItems}
-                        </SingleSelect>
-                    </View>
-                    <View
-                        style={[
-                            styles.gridRow,
-                            light &&
-                                (theme === "khanmigo"
-                                    ? styles.darkKhanmigo
-                                    : styles.darkDefault),
-                        ]}
-                    >
-                        <LabelMedium style={light && {color: color.white}}>
                             Disabled
                         </LabelMedium>
                         <SingleSelect
@@ -111,7 +91,26 @@ const KindVariants = ({light}: {light: boolean}) => {
                             {...defaultProps}
                             light={light}
                             error={true}
-                            // selectedValue="1"
+                        >
+                            {selectItems}
+                        </SingleSelect>
+                    </View>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
+                            Value selected
+                        </LabelMedium>
+                        <SingleSelect
+                            {...defaultProps}
+                            selectedValue="1"
+                            light={light}
                         >
                             {selectItems}
                         </SingleSelect>

--- a/__docs__/wonder-blocks-dropdown/single-select-variants.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select-variants.stories.tsx
@@ -65,6 +65,26 @@ const KindVariants = ({light}: {light: boolean}) => {
                         ]}
                     >
                         <LabelMedium style={light && {color: color.white}}>
+                            Value selected
+                        </LabelMedium>
+                        <SingleSelect
+                            {...defaultProps}
+                            selectedValue="1"
+                            light={light}
+                        >
+                            {selectItems}
+                        </SingleSelect>
+                    </View>
+                    <View
+                        style={[
+                            styles.gridRow,
+                            light &&
+                                (theme === "khanmigo"
+                                    ? styles.darkKhanmigo
+                                    : styles.darkDefault),
+                        ]}
+                    >
+                        <LabelMedium style={light && {color: color.white}}>
                             Disabled
                         </LabelMedium>
                         <SingleSelect
@@ -91,6 +111,7 @@ const KindVariants = ({light}: {light: boolean}) => {
                             {...defaultProps}
                             light={light}
                             error={true}
+                            // selectedValue="1"
                         >
                             {selectItems}
                         </SingleSelect>
@@ -151,7 +172,7 @@ const styles = StyleSheet.create({
     },
     grid: {
         display: "grid",
-        gridTemplateColumns: "repeat(3, 250px)",
+        gridTemplateColumns: "repeat(4, 250px)",
         gap: spacing.large_24,
     },
     gridRow: {

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -608,6 +608,13 @@ export const Light: StoryComponentType = {
             </View>
         );
     },
+    parameters: {
+        chromatic: {
+            // Disabling because it is already covered in "All variants".
+            // @see single-select-variants.stories.tsx
+            disableSnapshot: true,
+        },
+    },
 };
 
 const optionItems = allCountries.map(([code, translatedName]) => (

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -150,8 +150,8 @@ export default class SelectOpener extends React.Component<
         const iconColor = light
             ? "currentColor"
             : disabled
-            ? tokens.color.offBlack32
-            : tokens.color.offBlack64;
+            ? semanticColor.action.disabled.default
+            : semanticColor.icon.primary;
 
         const style = [
             styles.shared,
@@ -229,15 +229,9 @@ const styles = StyleSheet.create({
     },
 
     caret: {
-        minWidth: 16,
+        minWidth: tokens.spacing.medium_16,
     },
 });
-
-// These values are default padding (16 and 12) minus 1, because
-// changing the borderWidth to 2 messes up the button width
-// and causes it to move a couple pixels. This fixes that.
-const adjustedPaddingLeft = tokens.spacing.medium_16 - 1;
-const adjustedPaddingRight = tokens.spacing.small_12 - 1;
 
 const stateStyles: Record<string, any> = {};
 
@@ -253,9 +247,9 @@ const _generateStyles = (
     }
 
     let newStyles: Record<string, any> = {};
-    if (light) {
-        const borderWidth = tokens.border.width.hairline;
+    const borderWidth = tokens.border.width.hairline;
 
+    if (light) {
         const focusHoverStyling = {
             borderColor: semanticColor.border.inverse,
             outlineColor: error
@@ -337,34 +331,51 @@ const _generateStyles = (
         };
     } else {
         const focusHoverStyling = {
-            borderColor: error ? tokens.color.red : tokens.color.blue,
-            borderWidth: tokens.border.width.thin,
-            paddingLeft: adjustedPaddingLeft,
-            paddingRight: adjustedPaddingRight,
+            outlineColor: error
+                ? semanticColor.status.critical.foreground
+                : semanticColor.action.primary.default,
+            // Outline sits inside the border (inset)
+            outlineOffset: -tokens.border.width.thin,
+            outlineStyle: "solid",
+            outlineWidth: tokens.border.width.thin,
         };
         const activePressedStyling = {
-            background: error ? tokens.color.fadedRed : tokens.color.fadedBlue,
-            borderColor: error ? tokens.color.red : tokens.color.activeBlue,
-            borderWidth: tokens.border.width.thin,
-            paddingLeft: adjustedPaddingLeft,
-            paddingRight: adjustedPaddingRight,
+            background: error
+                ? semanticColor.action.destructive.pressing
+                : semanticColor.action.primary.pressing,
+            color: placeholder
+                ? error
+                    ? semanticColor.text.primary
+                    : semanticColor.action.primary.active
+                : semanticColor.text.primary,
+            outlineColor: error
+                ? semanticColor.status.critical.foreground
+                : semanticColor.action.primary.active,
+            // Outline sits inside the border (inset)
+            outlineOffset: -tokens.border.width.thin,
+            outlineStyle: "solid",
+            outlineWidth: tokens.border.width.thin,
         };
         newStyles = {
             default: {
-                background: error ? tokens.color.fadedRed8 : tokens.color.white,
-                borderColor: error ? tokens.color.red : tokens.color.offBlack50,
+                background: error
+                    ? semanticColor.status.critical.background
+                    : semanticColor.surface.primary,
+                borderColor: error
+                    ? semanticColor.status.critical.foreground
+                    : semanticColor.border.strong,
                 borderWidth: tokens.border.width.hairline,
                 color: placeholder
-                    ? tokens.color.offBlack64
-                    : tokens.color.offBlack,
+                    ? semanticColor.text.secondary
+                    : semanticColor.text.primary,
                 ":hover:not([aria-disabled=true])": focusHoverStyling,
                 // Allow hover styles on non-touch devices only. This prevents an
                 // issue with hover being sticky on touch devices (e.g. mobile).
                 ["@media not (hover: hover)"]: {
                     ":hover:not([aria-disabled=true])": {
                         borderColor: error
-                            ? tokens.color.red
-                            : tokens.color.offBlack50,
+                            ? semanticColor.status.critical.foreground
+                            : semanticColor.border.strong,
                         borderWidth: tokens.border.width.hairline,
                         paddingLeft: tokens.spacing.medium_16,
                         paddingRight: tokens.spacing.small_12,
@@ -374,12 +385,15 @@ const _generateStyles = (
                 ":active:not([aria-disabled=true])": activePressedStyling,
             },
             disabled: {
-                background: tokens.color.offWhite,
-                borderColor: tokens.color.offBlack16,
-                color: tokens.color.offBlack64,
+                background: semanticColor.action.disabled.secondary,
+                borderColor: semanticColor.border.primary,
+                color: semanticColor.text.secondary,
                 cursor: "not-allowed",
                 ":focus-visible": {
-                    boxShadow: `0 0 0 1px ${tokens.color.white}, 0 0 0 3px ${tokens.color.offBlack32}`,
+                    outlineColor: semanticColor.action.disabled.default,
+                    outlineOffset: -tokens.border.width.thin,
+                    outlineStyle: "solid",
+                    outlineWidth: tokens.border.width.thin,
                 },
             },
             pressed: activePressedStyling,

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -3,7 +3,6 @@ import {StyleSheet} from "aphrodite";
 
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 
-import {mix} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
@@ -11,6 +10,8 @@ import * as tokens from "@khanacademy/wonder-blocks-tokens";
 import caretDownIcon from "@phosphor-icons/core/bold/caret-down-bold.svg";
 import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 import {OptionLabel} from "../util/types";
+
+const {semanticColor} = tokens;
 
 const StyledButton = addStyle("button");
 
@@ -146,12 +147,8 @@ export default class SelectOpener extends React.Component<
 
         const stateStyles = _generateStyles(light, isPlaceholder, error);
 
-        // The icon colors are kind of fickle. This is just logic
-        // based on the zeplin design.
         const iconColor = light
-            ? disabled || error
-                ? "currentColor"
-                : tokens.color.white
+            ? "currentColor"
             : disabled
             ? tokens.color.offBlack32
             : tokens.color.offBlack64;
@@ -204,7 +201,7 @@ const styles = StyleSheet.create({
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "space-between",
-        color: tokens.color.offBlack,
+        color: semanticColor.text.primary,
         height: DROPDOWN_ITEM_HEIGHT,
         // This asymmetry arises from the Icon on the right side, which has
         // extra padding built in. To have the component look more balanced,
@@ -257,44 +254,59 @@ const _generateStyles = (
 
     let newStyles: Record<string, any> = {};
     if (light) {
+        const borderWidth = tokens.border.width.hairline;
+
         const focusHoverStyling = {
-            borderColor: error ? tokens.color.red : tokens.color.white,
-            borderWidth: tokens.spacing.xxxxSmall_2,
-            paddingLeft: adjustedPaddingLeft,
-            paddingRight: adjustedPaddingRight,
+            borderColor: semanticColor.border.inverse,
+            outlineColor: error
+                ? semanticColor.status.critical.foreground
+                : semanticColor.action.primary.default,
+            // Provides an outline around the button to match the border width
+            outlineOffset: -(tokens.border.width.thin + borderWidth),
+            outlineStyle: "solid",
+            outlineWidth: tokens.border.width.thin,
         };
         const activePressedStyling = {
-            paddingLeft: adjustedPaddingLeft,
-            paddingRight: adjustedPaddingRight,
-            borderColor: error ? tokens.color.red : tokens.color.fadedBlue,
-            borderWidth: tokens.border.width.thin,
+            borderColor: "transparent",
+            outlineColor: error
+                ? semanticColor.status.critical.foreground
+                : semanticColor.action.primary.pressing,
+            // Provides an outline around the button to match the border width
+            outlineOffset: -(tokens.border.width.thin + borderWidth),
+            outlineStyle: "solid",
+            outlineWidth: tokens.border.width.thin,
             color: error
-                ? tokens.color.offBlack64
+                ? placeholder
+                    ? semanticColor.text.secondary
+                    : semanticColor.text.primary
                 : placeholder
-                ? mix(tokens.color.white32, tokens.color.blue)
-                : tokens.color.fadedBlue,
+                ? semanticColor.action.primary.pressing
+                : semanticColor.text.inverse,
             backgroundColor: error
-                ? tokens.color.fadedRed
-                : tokens.color.activeBlue,
+                ? semanticColor.action.destructive.pressing
+                : semanticColor.action.primary.active,
         };
         newStyles = {
             default: {
-                background: error ? tokens.color.fadedRed8 : "transparent",
-                color: error
-                    ? tokens.color.offBlack64
-                    : placeholder
-                    ? tokens.color.white50
-                    : tokens.color.white,
-                borderColor: error ? tokens.color.red : tokens.color.white50,
+                background: error
+                    ? semanticColor.status.critical.background
+                    : semanticColor.surface.primary,
+                color: placeholder
+                    ? semanticColor.text.secondary
+                    : semanticColor.text.primary,
+                borderColor: error
+                    ? semanticColor.status.critical.foreground
+                    : semanticColor.border.strong,
                 borderWidth: tokens.border.width.hairline,
                 ":hover:not([aria-disabled=true])": focusHoverStyling,
-                // Allow hover styles on non-touch devices only. This prevents an
-                // issue with hover being sticky on touch devices (e.g. mobile).
+                // Allow hover styles on non-touch devices only. This prevents
+                // an issue with hover being sticky on touch devices (e.g.
+                // mobile).
                 ["@media not (hover: hover)"]: {
                     ":hover:not([aria-disabled=true])": {
                         borderColor: error
-                            ? tokens.color.red
-                            : tokens.color.white50,
+                            ? semanticColor.status.critical.foreground
+                            : semanticColor.border.strong,
                         borderWidth: tokens.border.width.hairline,
                         paddingLeft: tokens.spacing.medium_16,
                         paddingRight: tokens.spacing.small_12,
@@ -305,11 +317,20 @@ const _generateStyles = (
             },
             disabled: {
                 background: "transparent",
-                borderColor: mix(tokens.color.white32, tokens.color.blue),
-                color: mix(tokens.color.white32, tokens.color.blue),
+                borderColor: semanticColor.border.strong,
+                color: semanticColor.text.disabled,
                 cursor: "not-allowed",
                 ":focus-visible": {
-                    boxShadow: `0 0 0 1px ${tokens.color.offBlack32}, 0 0 0 3px ${tokens.color.fadedBlue}`,
+                    outlineColor: semanticColor.action.disabled.default,
+                    // Provides a bigger outline around the button to account
+                    // for the border showing up on the button
+                    outlineOffset: -(
+                        tokens.border.width.thin +
+                        borderWidth +
+                        1
+                    ),
+                    outlineStyle: "solid",
+                    outlineWidth: tokens.border.width.thin,
                 },
             },
             pressed: activePressedStyling,

--- a/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
@@ -9,10 +9,12 @@ export const semanticColor = {
         primary: {
             default: color.blue,
             active: color.activeBlue,
+            pressing: color.fadedBlue,
         },
         destructive: {
             default: color.red,
             active: color.activeRed,
+            pressing: color.fadedRed,
         },
         disabled: {
             default: color.fadedOffBlack32,


### PR DESCRIPTION
## Summary:

The dropdown opener currently uses a darkBlue/transparent background and that
could cause accessibility issues (color contrast). These styles are not matching
the current Figma specs, which use a white background.

Also, took the opportunity to switch from `color` to `semanticColor` in most of
the cases of that component.

### Specific style changes:

- Light version: Changed from `darkBlue` to a `white` background, and also changed the `disabled` state to use disabled semantic colors instead of blue shades.
- Switched from `border` to `outline` when focused/active for better consistency across the library.
- Modified focus/active outlines to be inset (located inside the box).
- Fixed the pressed/placeholder state to use an `activeBlue` text color.

### New `semanticColor` tokens

Additionally, I've added a couple of new tokens in `semanticColor` to include
some missing colors that are defined in Figma.

https://www.figma.com/design/VbVu3h2BpBhH80niq101MHHE/%F0%9F%92%A0-Main-Components?node-id=17450-482&t=jCX4iO74AL9fsTwh-4

<img width="845" alt="Screenshot 2025-01-10 at 12 44 33 PM" src="https://github.com/user-attachments/assets/b8fefd86-d2ff-476b-83b9-9a41022ed85a" />


Issue: https://khanacademy.atlassian.net/browse/WB-1847

## Test plan:

Navigate to `/?path=/story/packages-dropdown-singleselect--light` and verify that
the SelectOpener component now has a white background.

Also verify all the variants in `/?path=/docs/packages-dropdown-singleselect-all-variants--docs`