### PR TITLE
LabeledField: Make sure custom required message is shown

### DIFF
--- a/.changeset/serious-cherries-wonder.md
+++ b/.changeset/serious-cherries-wonder.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": patch
+---
+
+Makes sure custom required messages passed into `LabeledField` or the `field` prop are displayed

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -3,8 +3,8 @@ import {render, screen, within} from "@testing-library/react";
 import {StyleSheet} from "aphrodite";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
-import {PropsFor, RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import userEvent from "@testing-library/user-event";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {userEvent} from "@testing-library/user-event";
 import LabeledField from "../labeled-field";
 
 const defaultOptions = {

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -3,7 +3,8 @@ import {render, screen, within} from "@testing-library/react";
 import {StyleSheet} from "aphrodite";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
-import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import userEvent from "@testing-library/user-event";
 import LabeledField from "../labeled-field";
 
 const defaultOptions = {
@@ -638,6 +639,76 @@ describe("LabeledField", () => {
                     "true",
                 );
             });
+        });
+    });
+
+    describe("Custom required message", () => {
+        it("should show the custom required message if it is set on the field", async () => {
+            // Arrange
+            const requiredMessage = "Custom required message";
+
+            const ControlledLabeledFieldWithTextField = () => {
+                const [value, setValue] = React.useState("T");
+                const [errorMessage, setErrorMessage] = React.useState<
+                    string | null
+                >();
+                return (
+                    <LabeledField
+                        field={
+                            <TextField
+                                value={value}
+                                onChange={setValue}
+                                onValidate={setErrorMessage}
+                                required="Custom required message"
+                            />
+                        }
+                        label="Label"
+                        errorMessage={errorMessage}
+                    />
+                );
+            };
+            render(<ControlledLabeledFieldWithTextField />, defaultOptions);
+            const field = await screen.findByRole("textbox");
+
+            // Act
+            await userEvent.type(field, "{backspace}");
+
+            // Assert
+            await screen.findByText(requiredMessage);
+        });
+
+        it("should show the custom required message if it is set on LabeledField", async () => {
+            // Arrange
+            const requiredMessage = "Custom required message";
+
+            const ControlledLabeledFieldWithTextField = () => {
+                const [value, setValue] = React.useState("T");
+                const [errorMessage, setErrorMessage] = React.useState<
+                    string | null
+                >();
+                return (
+                    <LabeledField
+                        field={
+                            <TextField
+                                value={value}
+                                onChange={setValue}
+                                onValidate={setErrorMessage}
+                            />
+                        }
+                        required="Custom required message"
+                        label="Label"
+                        errorMessage={errorMessage}
+                    />
+                );
+            };
+            render(<ControlledLabeledFieldWithTextField />, defaultOptions);
+            const field = await screen.findByRole("textbox");
+
+            // Act
+            await userEvent.type(field, "{backspace}");
+
+            // Assert
+            await screen.findByText(requiredMessage);
         });
     });
 });

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -659,7 +659,7 @@ describe("LabeledField", () => {
                                 value={value}
                                 onChange={setValue}
                                 onValidate={setErrorMessage}
-                                required="Custom required message"
+                                required={requiredMessage}
                             />
                         }
                         label="Label"
@@ -695,7 +695,7 @@ describe("LabeledField", () => {
                                 onValidate={setErrorMessage}
                             />
                         }
-                        required="Custom required message"
+                        required={requiredMessage}
                         label="Label"
                         errorMessage={errorMessage}
                     />

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -250,7 +250,7 @@ export default function LabeledField(props: Props) {
             ]
                 .filter(Boolean)
                 .join(" "),
-            required: isRequired,
+            required: required || field.props.required,
             error: hasError,
             testId: testId ? `${testId}-field` : undefined,
             light: isLight,


### PR DESCRIPTION
## Summary:
Makes sure custom required messages passed into `LabeledField` or the `field` prop are displayed

Issue: WB-1848

## Test plan:
Confirm in `?path=/story/packages-labeledfield--required` that the error message shows the custom required message