### PR TITLE
LabeledField: Add a story for custom jsx for props

### DIFF
--- a/__docs__/wonder-blocks-labeled-field/labeled-field.argtypes.ts
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.argtypes.ts
@@ -13,10 +13,17 @@ export default {
             },
         },
     },
-    error: {
+    errorMessage: {
         table: {
             type: {
                 summary: "string | ReactNode",
+            },
+        },
+    },
+    required: {
+        table: {
+            type: {
+                summary: "string | boolean",
             },
         },
     },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -598,3 +598,30 @@ export const WithNonWb = {
         },
     },
 };
+
+/**
+ * Custom ReactNode elements can be used for the `label`, `description`, and
+ * `error` props. Ideally, the styling of LabeledField should not be overridden.
+ * If there is a specific use case where the styling needs to be overridden,
+ * please reach out to the Wonder Blocks team!
+ */
+export const Custom = {
+    args: {
+        label: (
+            <span>
+                <b>Label</b> <i>using</i> <u>JSX</u>
+            </span>
+        ),
+        description: (
+            <span>
+                <b>Description</b> <i>using</i> <u>JSX</u>
+            </span>
+        ),
+        field: <TextField value="" onChange={() => {}} />,
+        errorMessage: (
+            <span>
+                <b>Error</b> <i>using</i> <u>JSX</u>
+            </span>
+        ),
+    },
+};


### PR DESCRIPTION
## Summary:
The LabeledField accepts a ReactNode for the `label`, `description`, and `errorMessage` props already. This adds a story and documentation for this functionality!

Issue: WB-1785

## Test plan:
Review Custom story docs in `?path=/docs/packages-labeledfield--docs#custom`