### PR TITLE
[WB-1849] Rework action semantic color tokens

### DIFF
--- a/.changeset/hot-panthers-kneel.md
+++ b/.changeset/hot-panthers-kneel.md
@@ -2,4 +2,8 @@
 "@khanacademy/wonder-blocks-tokens": major
 ---
 
-Rework semanticColor actions to use a new structure. Every `action` now includes `default`, `hover` and `press` states, and each state includes `border`, `background` and `foreground` tokens.
+- Reworked semanticColor actions to use a new structure. Every `action` now includes `default`, `hover` and `press` states, and each state includes `border`, `background` and `foreground` tokens.
+
+- Renamed `primary` to `progressive`.
+
+- Added inverse categories to actions: `progressiveInverse` and  `destructiveInverse`.

--- a/.changeset/hot-panthers-kneel.md
+++ b/.changeset/hot-panthers-kneel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": major
+---
+
+Rework semanticColor actions to use a new structure. Every `action` now includes `default`, `hover` and `press` states, and each state includes `border`, `background` and `foreground` tokens.

--- a/.changeset/hot-panthers-kneel.md
+++ b/.changeset/hot-panthers-kneel.md
@@ -6,4 +6,4 @@
 
 - Renamed `primary` to `progressive`.
 
-- Added inverse categories to actions: `progressiveInverse` and  `destructiveInverse`.
+- Added more categories to actions: `filled` and  `outline`.

--- a/__docs__/components/color.tsx
+++ b/__docs__/components/color.tsx
@@ -5,7 +5,6 @@ import {StyleType, View} from "@khanacademy/wonder-blocks-core";
 import {
     Caption,
     Footnote,
-    LabelLarge,
     LabelSmall,
 } from "@khanacademy/wonder-blocks-typography";
 import {
@@ -17,6 +16,8 @@ import {
 } from "@khanacademy/wonder-blocks-tokens";
 import {getTokenName} from "./tokens-util";
 
+type Variant = "primitive" | "semantic" | "compact";
+
 type Props = {
     /**
      * A dictionary of colors to display.
@@ -25,7 +26,7 @@ type Props = {
     /**
      * The type of color group to display.
      */
-    variant: "primitive" | "semantic";
+    variant: Variant;
     /**
      * The group name to use as a prefix for the color names.
      */
@@ -59,15 +60,12 @@ export function ColorGroup({
 type ColorProps = {
     name: string;
     value: string;
-    variant: "primitive" | "semantic";
+    variant: Variant;
 };
 
 function Color({name, value, variant}: ColorProps) {
-    const TypographyComponent =
-        variant === "semantic" ? LabelLarge : LabelSmall;
-
     return (
-        <View style={styles.item}>
+        <View style={[styles.item, styles[variant + "Item"]]}>
             <View
                 style={[
                     styles.thumbnail,
@@ -82,17 +80,23 @@ function Color({name, value, variant}: ColorProps) {
                         // Expand to fill the parent container
                         alignSelf: "stretch",
                         flex: 1,
+                        padding: spacing.medium_16,
                     }}
                 />
             </View>
-            <View>
-                <TypographyComponent style={{fontWeight: font.weight.bold}}>
+            <View style={styles.info}>
+                <LabelSmall
+                    style={{
+                        fontWeight: font.weight.bold,
+                    }}
+                >
                     {name}
-                </TypographyComponent>
-                {variant === "semantic" ? (
+                </LabelSmall>
+                {variant !== "primitive" ? (
                     <>
                         <Caption>
-                            Primitive: <em>{getTokenName(color, value)}</em>
+                            Primitive:{" "}
+                            <em>{getTokenName(color, value) || value}</em>
                         </Caption>
                         <LabelSmall>
                             Value:{" "}
@@ -107,6 +111,9 @@ function Color({name, value, variant}: ColorProps) {
     );
 }
 
+const itemWidth = 200;
+const itemHeight = 120;
+
 const styles = StyleSheet.create({
     group: {
         flexDirection: "row",
@@ -114,19 +121,33 @@ const styles = StyleSheet.create({
         marginBlock: spacing.large_24,
     },
     item: {
-        marginBlockEnd: spacing.medium_16,
+        maxWidth: itemWidth,
+        overflowWrap: "break-word",
+    },
+    compactItem: {
+        flexDirection: "row",
+        gap: spacing.xSmall_8,
+        maxWidth: "unset",
     },
     pattern: {
         backgroundImage: `radial-gradient(${color.blue} 0.5px, ${color.offWhite} 0.5px)`,
         backgroundSize: `${spacing.small_12}px ${spacing.small_12}px`,
+        boxShadow: `0 0 1px 0 ${semanticColor.border.primary}`,
     },
     thumbnail: {
-        width: 200,
-        height: 160,
+        width: itemWidth,
+        height: itemHeight,
     },
     primitiveThumbnail: {
         width: 160,
         height: spacing.xxxLarge_64,
+    },
+    compactThumbnail: {
+        width: spacing.xxxLarge_64,
+        height: spacing.xxxLarge_64,
+    },
+    info: {
+        paddingInlineEnd: spacing.medium_16,
     },
     code: {
         alignSelf: "flex-start",

--- a/__docs__/components/color.tsx
+++ b/__docs__/components/color.tsx
@@ -5,6 +5,7 @@ import {StyleType, View} from "@khanacademy/wonder-blocks-core";
 import {
     Caption,
     Footnote,
+    LabelLarge,
     LabelSmall,
 } from "@khanacademy/wonder-blocks-typography";
 import {
@@ -64,6 +65,64 @@ type ColorProps = {
 };
 
 function Color({name, value, variant}: ColorProps) {
+    function renderInfo() {
+        if (variant === "compact") {
+            const tokenName = name.toString().split(".");
+            return (
+                <View style={styles.card}>
+                    <LabelLarge style={styles.capitalized}>
+                        {tokenName.at(tokenName.length - 1)}
+                    </LabelLarge>
+                    <LabelSmall
+                        style={{
+                            fontStyle: "italic",
+                        }}
+                    >
+                        {name}
+                    </LabelSmall>
+
+                    <Footnote>
+                        Primitive:{" "}
+                        <em>{getTokenName(color, value) || value}</em>
+                    </Footnote>
+                </View>
+            );
+        }
+
+        if (variant === "primitive") {
+            return (
+                <>
+                    <LabelSmall
+                        style={{
+                            fontWeight: font.weight.bold,
+                        }}
+                    >
+                        {name}
+                    </LabelSmall>
+                    <Footnote style={styles.code}>{value}</Footnote>
+                </>
+            );
+        }
+
+        return (
+            <>
+                <LabelSmall
+                    style={{
+                        fontWeight: font.weight.bold,
+                    }}
+                >
+                    {name}
+                </LabelSmall>
+                <Caption>
+                    Primitive: <em>{getTokenName(color, value) || value}</em>
+                </Caption>
+                <LabelSmall>
+                    Value: <Footnote style={styles.code}>{value}</Footnote>
+                </LabelSmall>
+            </>
+        );
+    }
+
     return (
         <View style={[styles.item, styles[variant + "Item"]]}>
             <View
@@ -80,34 +139,58 @@ function Color({name, value, variant}: ColorProps) {
                         // Expand to fill the parent container
                         alignSelf: "stretch",
                         flex: 1,
-                        padding: spacing.medium_16,
                     }}
                 />
             </View>
-            <View style={styles.info}>
-                <LabelSmall
-                    style={{
-                        fontWeight: font.weight.bold,
-                    }}
-                >
-                    {name}
-                </LabelSmall>
-                {variant !== "primitive" ? (
-                    <>
-                        <Caption>
-                            Primitive:{" "}
-                            <em>{getTokenName(color, value) || value}</em>
-                        </Caption>
-                        <LabelSmall>
-                            Value:{" "}
-                            <Footnote style={styles.code}>{value}</Footnote>
-                        </LabelSmall>
-                    </>
-                ) : (
-                    <Footnote style={styles.code}>{value}</Footnote>
-                )}
-            </View>
+
+            <View style={styles.info}>{renderInfo()}</View>
         </View>
+    );
+}
+
+type ActionColorGroupProps = {
+    /**
+     * A dictionary of colors to display.
+     */
+    category: Record<string, Record<string, string>>;
+    /**
+     * The group name to use as a prefix for the color names.
+     */
+    group: string;
+};
+
+export function ActionColorGroup({category, group}: ActionColorGroupProps) {
+    return Object.entries(category).map(([state, colorGroup]) => (
+        <View style={styles.actionGroup}>
+            <LabelLarge style={styles.capitalized}>{state}</LabelLarge>
+            <Example style={colorGroup} />
+            <ColorGroup
+                colors={colorGroup}
+                group={group + "." + state}
+                variant="compact"
+            />
+        </View>
+    ));
+}
+
+function Example({style}: {style?: any}) {
+    return (
+        <>
+            <View
+                style={{
+                    marginBlock: spacing.xSmall_8,
+                    marginInline: spacing.medium_16,
+                    padding: spacing.medium_16,
+                    backgroundColor: style.background,
+                    color: style.foreground,
+                    outline: `4px solid ${style.border}`,
+                    outlineOffset: 3,
+                    textAlign: "center",
+                }}
+            >
+                Some Text
+            </View>
+        </>
     );
 }
 
@@ -118,16 +201,26 @@ const styles = StyleSheet.create({
     group: {
         flexDirection: "row",
         flexWrap: "wrap",
-        marginBlock: spacing.large_24,
+        marginBlock: spacing.medium_16,
+    },
+    actionGroup: {
+        margin: spacing.xxxSmall_4,
+        padding: spacing.xxxSmall_4,
+        gap: spacing.xxxSmall_4,
+        border: `1px dashed ${semanticColor.border.subtle}`,
     },
     item: {
         maxWidth: itemWidth,
         overflowWrap: "break-word",
     },
     compactItem: {
-        flexDirection: "row",
-        gap: spacing.xSmall_8,
-        maxWidth: "unset",
+        marginBlockEnd: spacing.xSmall_8,
+        maxWidth: "100%",
+        width: "100%",
+
+        backgroundColor: semanticColor.surface.secondary,
+        border: `1px solid ${semanticColor.border.primary}`,
+        borderRadius: border.radius.medium_4,
     },
     pattern: {
         backgroundImage: `radial-gradient(${color.blue} 0.5px, ${color.offWhite} 0.5px)`,
@@ -143,11 +236,15 @@ const styles = StyleSheet.create({
         height: spacing.xxxLarge_64,
     },
     compactThumbnail: {
-        width: spacing.xxxLarge_64,
+        justifyContent: "space-between",
+        width: "100%",
         height: spacing.xxxLarge_64,
     },
     info: {
         paddingInlineEnd: spacing.medium_16,
+    },
+    card: {
+        paddingInline: spacing.xSmall_8,
     },
     code: {
         alignSelf: "flex-start",
@@ -157,5 +254,8 @@ const styles = StyleSheet.create({
         border: `1px solid ${color.offBlack16}`,
         padding: spacing.xxxxSmall_2,
         borderRadius: border.radius.medium_4,
+    },
+    capitalized: {
+        textTransform: "capitalize",
     },
 });

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -5,8 +5,9 @@ import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
 import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
-import {ColorGroup} from "./components/color";
+import {ColorGroup, ActionColorGroup} from "./components/color";
 
 <Meta
     title="Foundations / Using color"
@@ -32,9 +33,11 @@ export const styles = StyleSheet.create({
         display: "grid",
         gridTemplateColumns: "repeat(3, minmax(100px, auto))",
     },
+
     banner: {
         marginBottom: spacing.xLarge_32,
     },
+
 });
 
 # Color
@@ -82,89 +85,49 @@ how to use these colors depending on the context.
 For buttons, links, and controls to communicate the presence and meaning of
 interaction.
 
+#### Filled
+
+Communicates strong emphasis and primary actions.
+
+##### Progressive
+
+<View style={styles.gridCompact}>
+    <ActionColorGroup
+        category={semanticColor.action.filled.progressive}
+        group="action.filled.progressive"
+    />
+</View>
+
+##### Destructive
+
+<View style={styles.gridCompact}>
+    <ActionColorGroup
+        category={semanticColor.action.filled.destructive}
+        group="action.filled.destructive"
+    />
+</View>
+
+#### Outlined
+
+Communicates secondary actions and less emphasis.
+
 #### Progressive
 
-<ColorGroup
-    colors={semanticColor.action.progressive.default}
-    group="action.progressive.default"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-<ColorGroup
-    colors={semanticColor.action.progressive.hover}
-    group="action.progressive.hover"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-<ColorGroup
-    colors={semanticColor.action.progressive.press}
-    group="action.progressive.press"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-
-#### Progressive inverse
-
-<ColorGroup
-    colors={semanticColor.action.progressiveInverse.default}
-    group="action.progressiveInverse.default"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-<ColorGroup
-    colors={semanticColor.action.progressiveInverse.hover}
-    group="action.progressiveInverse.hover"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-<ColorGroup
-    colors={semanticColor.action.progressiveInverse.press}
-    group="action.progressiveInverse.press"
-    variant="compact"
-    style={styles.gridCompact}
-/>
+<View style={styles.gridCompact}>
+    <ActionColorGroup
+        category={semanticColor.action.outlined.progressive}
+        group="action.outlined.progressive"
+    />
+</View>
 
 #### Destructive
 
-<ColorGroup
-    colors={semanticColor.action.destructive.default}
-    group="action.destructive.default"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-<ColorGroup
-    colors={semanticColor.action.destructive.hover}
-    group="action.destructive.hover"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-<ColorGroup
-    colors={semanticColor.action.destructive.press}
-    group="action.destructive.press"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-
-#### Destructive inverse
-
-<ColorGroup
-    colors={semanticColor.action.destructiveInverse.default}
-    group="action.destructiveInverse.default"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-<ColorGroup
-    colors={semanticColor.action.destructiveInverse.hover}
-    group="action.destructiveInverse.hover"
-    variant="compact"
-    style={styles.gridCompact}
-/>
-<ColorGroup
-    colors={semanticColor.action.destructiveInverse.press}
-    group="action.destructiveInverse.press"
-    variant="compact"
-    style={styles.gridCompact}
-/>
+<View style={styles.gridCompact}>
+    <ActionColorGroup
+        category={semanticColor.action.outlined.destructive}
+        group="action.outlined.destructive"
+    />
+</View>
 
 #### Disabled
 

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -28,6 +28,10 @@ export const styles = StyleSheet.create({
         display: "grid",
         gridTemplateColumns: "repeat(auto-fill, 160px)",
     },
+    gridCompact: {
+        display: "grid",
+        gridTemplateColumns: "repeat(3, minmax(100px, auto))",
+    },
     banner: {
         marginBottom: spacing.xLarge_32,
     },
@@ -78,17 +82,98 @@ how to use these colors depending on the context.
 For buttons, links, and controls to communicate the presence and meaning of
 interaction.
 
-<View style={styles.grid}>
-    <ColorGroup colors={semanticColor.action.primary} group="action.primary" />
-    <ColorGroup
-        colors={semanticColor.action.destructive}
-        group="action.destructive"
-    />
-    <ColorGroup
-        colors={semanticColor.action.disabled}
-        group="action.disabled"
-    />
-</View>
+#### Progressive
+
+<ColorGroup
+    colors={semanticColor.action.progressive.default}
+    group="action.progressive.default"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+<ColorGroup
+    colors={semanticColor.action.progressive.hover}
+    group="action.progressive.hover"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+<ColorGroup
+    colors={semanticColor.action.progressive.press}
+    group="action.progressive.press"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+
+#### Progressive inverse
+
+<ColorGroup
+    colors={semanticColor.action.progressiveInverse.default}
+    group="action.progressiveInverse.default"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+<ColorGroup
+    colors={semanticColor.action.progressiveInverse.hover}
+    group="action.progressiveInverse.hover"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+<ColorGroup
+    colors={semanticColor.action.progressiveInverse.press}
+    group="action.progressiveInverse.press"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+
+#### Destructive
+
+<ColorGroup
+    colors={semanticColor.action.destructive.default}
+    group="action.destructive.default"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+<ColorGroup
+    colors={semanticColor.action.destructive.hover}
+    group="action.destructive.hover"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+<ColorGroup
+    colors={semanticColor.action.destructive.press}
+    group="action.destructive.press"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+
+#### Destructive inverse
+
+<ColorGroup
+    colors={semanticColor.action.destructiveInverse.default}
+    group="action.destructiveInverse.default"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+<ColorGroup
+    colors={semanticColor.action.destructiveInverse.hover}
+    group="action.destructiveInverse.hover"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+<ColorGroup
+    colors={semanticColor.action.destructiveInverse.press}
+    group="action.destructiveInverse.press"
+    variant="compact"
+    style={styles.gridCompact}
+/>
+
+#### Disabled
+
+<ColorGroup
+    colors={semanticColor.action.disabled}
+    group="action.disabled"
+    variant="compact"
+    style={styles.gridCompact}
+/>
 
 ### Status
 
@@ -389,10 +474,12 @@ content is accessible to all users.
 
 For more detail, you can check the following Success Criteria documents:
 
--   <a
-    href="https://www.w3.org/WAI/WCAG22/Understanding/use-of-color">Use of Color</a>
--   <a
-    href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum">Contrast (minimum)</a>
--   <a
-    href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast">Non-text
-    Contrast (Level AA)</a>
+-   <a href="https://www.w3.org/WAI/WCAG22/Understanding/use-of-color">
+        Use of Color
+    </a>
+-   <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum">
+        Contrast (minimum)
+    </a>
+-   <a href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast">
+        Non-text Contrast (Level AA)
+    </a>

--- a/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
@@ -1,18 +1,87 @@
 import {color} from "./color";
 
+const border = {
+    primary: color.fadedOffBlack16,
+    subtle: color.fadedOffBlack8,
+    strong: color.fadedOffBlack50,
+    inverse: color.white,
+};
+
 export const semanticColor = {
     /**
      * For buttons, links, and controls to communicate the presence and meaning
      * of interaction.
      */
     action: {
-        primary: {
-            default: color.blue,
-            active: color.activeBlue,
+        // For primary actions
+        progressive: {
+            default: {
+                border: "transparent",
+                background: color.blue,
+                foreground: color.white,
+            },
+            hover: {
+                border: color.blue,
+                background: color.blue,
+                foreground: color.white,
+            },
+            press: {
+                border: color.activeBlue,
+                background: color.activeBlue,
+                foreground: color.white,
+            },
+        },
+        // Inverse is meant for use on secondary controls.
+        progressiveInverse: {
+            default: {
+                border: border.strong,
+                background: color.white,
+                foreground: color.blue,
+            },
+            hover: {
+                border: color.blue,
+                background: color.white,
+                foreground: color.blue,
+            },
+            press: {
+                border: color.activeBlue,
+                background: color.fadedBlue,
+                foreground: color.activeBlue,
+            },
         },
         destructive: {
-            default: color.red,
-            active: color.activeRed,
+            default: {
+                border: "transparent",
+                background: color.red,
+                foreground: color.white,
+            },
+            hover: {
+                border: color.red,
+                background: color.white,
+                foreground: color.red,
+            },
+            press: {
+                border: color.activeRed,
+                background: color.activeRed,
+                foreground: color.white,
+            },
+        },
+        destructiveInverse: {
+            default: {
+                border: border.strong,
+                background: color.white,
+                foreground: color.red,
+            },
+            hover: {
+                border: color.red,
+                background: color.white,
+                foreground: color.red,
+            },
+            press: {
+                border: color.activeRed,
+                background: color.fadedRed,
+                foreground: color.activeRed,
+            },
         },
         disabled: {
             default: color.fadedOffBlack32,
@@ -71,12 +140,7 @@ export const semanticColor = {
      * elements would use -Primary, rows and layout elements use -Subtle and
      * -Strong for when 3:1 contrast is a priority (ex. form elements)
      */
-    border: {
-        primary: color.fadedOffBlack16,
-        subtle: color.fadedOffBlack8,
-        strong: color.fadedOffBlack50,
-        inverse: color.white,
-    },
+    border: border,
     /**
      * Default icon colors that change in context (like actions).
      */

--- a/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
@@ -13,74 +13,80 @@ export const semanticColor = {
      * of interaction.
      */
     action: {
-        // For primary actions
-        progressive: {
-            default: {
-                border: "transparent",
-                background: color.blue,
-                foreground: color.white,
+        // Filled buttons are meant for primary actions.
+        filled: {
+            progressive: {
+                default: {
+                    border: "transparent",
+                    background: color.blue,
+                    foreground: color.white,
+                },
+                hover: {
+                    border: color.blue,
+                    background: color.blue,
+                    foreground: color.white,
+                },
+                press: {
+                    border: color.activeBlue,
+                    background: color.activeBlue,
+                    foreground: color.white,
+                },
             },
-            hover: {
-                border: color.blue,
-                background: color.blue,
-                foreground: color.white,
-            },
-            press: {
-                border: color.activeBlue,
-                background: color.activeBlue,
-                foreground: color.white,
-            },
-        },
-        // Inverse is meant for use on secondary controls.
-        progressiveInverse: {
-            default: {
-                border: border.strong,
-                background: color.white,
-                foreground: color.blue,
-            },
-            hover: {
-                border: color.blue,
-                background: color.white,
-                foreground: color.blue,
-            },
-            press: {
-                border: color.activeBlue,
-                background: color.fadedBlue,
-                foreground: color.activeBlue,
-            },
-        },
-        destructive: {
-            default: {
-                border: "transparent",
-                background: color.red,
-                foreground: color.white,
-            },
-            hover: {
-                border: color.red,
-                background: color.white,
-                foreground: color.red,
-            },
-            press: {
-                border: color.activeRed,
-                background: color.activeRed,
-                foreground: color.white,
+            destructive: {
+                default: {
+                    border: "transparent",
+                    background: color.red,
+                    foreground: color.white,
+                },
+                hover: {
+                    border: color.red,
+                    background: color.red,
+                    foreground: color.white,
+                },
+                press: {
+                    border: color.activeRed,
+                    background: color.activeRed,
+                    foreground: color.white,
+                },
             },
         },
-        destructiveInverse: {
-            default: {
-                border: border.strong,
-                background: color.white,
-                foreground: color.red,
+
+        // Outlined is meant for use on secondary controls, or controls over
+        // white/transparent backgrounds.
+        outlined: {
+            progressive: {
+                default: {
+                    border: border.strong,
+                    background: color.white,
+                    foreground: color.blue,
+                },
+                hover: {
+                    border: color.blue,
+                    background: color.white,
+                    foreground: color.blue,
+                },
+                press: {
+                    border: color.activeBlue,
+                    background: color.fadedBlue,
+                    foreground: color.activeBlue,
+                },
             },
-            hover: {
-                border: color.red,
-                background: color.white,
-                foreground: color.red,
-            },
-            press: {
-                border: color.activeRed,
-                background: color.fadedRed,
-                foreground: color.activeRed,
+            destructive: {
+                default: {
+                    border: border.strong,
+                    background: color.white,
+                    foreground: color.red,
+                },
+                hover: {
+                    border: color.red,
+                    background: color.white,
+                    foreground: color.red,
+                },
+                press: {
+                    border: color.activeRed,
+                    background: color.fadedRed,
+                    foreground: color.activeRed,
+                },
             },
         },
         disabled: {


### PR DESCRIPTION
## Summary:

Reworked `semanticColor` actions to use a new structure. Every `action` now
includes `default`, `hover` and `press` states, and each state includes
`border`, `background` and `foreground` tokens.

By doing this change, we'll offer a more consistent and predictable styling
direction for our interactive components.

Issue: https://khanacademy.atlassian.net/browse/WB-1849

## Test plan:

Navigate to `/?path=/docs/foundations-using-color--docs` and check that the
`Action` section includes all the new tokens and the structure is readable and
makes sense.