### PR TITLE
[WB-1847] Dropdown: Update `SelectOpener` to match Design specs.

### DIFF
--- a/.changeset/six-jobs-promise.md
+++ b/.changeset/six-jobs-promise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Updates `SelectOpener` (internal component) from `Dropdown` to match Design specs. Also converts `color` tokens to use `semanticColor` tokens.

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -6,7 +6,11 @@ import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import * as tokens from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    semanticColor,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
 import caretDownIcon from "@phosphor-icons/core/bold/caret-down-bold.svg";
 import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 import {OptionLabel} from "../util/types";
@@ -138,8 +142,8 @@ export default class SelectOpener extends React.Component<
         const stateStyles = _generateStyles(isPlaceholder, error);
 
         const iconColor = disabled
-            ? tokens.color.offBlack32
-            : tokens.color.offBlack64;
+            ? semanticColor.action.disabled.default
+            : semanticColor.icon.primary;
 
         const style = [
             styles.shared,
@@ -189,15 +193,15 @@ const styles = StyleSheet.create({
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "space-between",
-        color: tokens.color.offBlack,
+        color: semanticColor.text.primary,
         height: DROPDOWN_ITEM_HEIGHT,
         // This asymmetry arises from the Icon on the right side, which has
         // extra padding built in. To have the component look more balanced,
         // we need to take off some paddingRight here.
-        paddingLeft: tokens.spacing.medium_16,
-        paddingRight: tokens.spacing.small_12,
+        paddingLeft: spacing.medium_16,
+        paddingRight: spacing.small_12,
         borderWidth: 0,
-        borderRadius: tokens.border.radius.medium_4,
+        borderRadius: border.radius.medium_4,
         borderStyle: "solid",
         outline: "none",
         textDecoration: "none",
@@ -209,7 +213,7 @@ const styles = StyleSheet.create({
     },
 
     text: {
-        marginRight: tokens.spacing.xSmall_8,
+        marginRight: spacing.xSmall_8,
         whiteSpace: "nowrap",
         userSelect: "none",
         overflow: "hidden",
@@ -221,12 +225,6 @@ const styles = StyleSheet.create({
     },
 });
 
-// These values are default padding (16 and 12) minus 1, because
-// changing the borderWidth to 2 messes up the button width
-// and causes it to move a couple pixels. This fixes that.
-const adjustedPaddingLeft = tokens.spacing.medium_16 - 1;
-const adjustedPaddingRight = tokens.spacing.small_12 - 1;
-
 const stateStyles: Record<string, any> = {};
 
 const _generateStyles = (placeholder: boolean, error: boolean) => {
@@ -237,53 +235,73 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
     }
 
     const focusHoverStyling = {
-        borderColor: error ? tokens.color.red : tokens.color.blue,
-        borderWidth: tokens.border.width.thin,
-        paddingLeft: adjustedPaddingLeft,
-        paddingRight: adjustedPaddingRight,
+        outlineColor: error
+            ? semanticColor.action.outlined.destructive.hover.border
+            : semanticColor.action.outlined.progressive.hover.border,
+        // Outline sits inside the border (inset)
+        outlineOffset: -border.width.thin,
+        outlineStyle: "solid",
+        outlineWidth: border.width.thin,
     };
-    const activePressedStyling = {
-        background: error ? tokens.color.fadedRed : tokens.color.fadedBlue,
-        borderColor: error ? tokens.color.red : tokens.color.activeBlue,
-        borderWidth: tokens.border.width.thin,
-        paddingLeft: adjustedPaddingLeft,
-        paddingRight: adjustedPaddingRight,
+    const pressStyling = {
+        background: error
+            ? semanticColor.action.outlined.destructive.press.background
+            : semanticColor.action.outlined.progressive.press.background,
+        color: placeholder
+            ? error
+                ? semanticColor.text.secondary
+                : semanticColor.action.outlined.progressive.press.foreground
+            : semanticColor.text.primary,
+        outlineColor: error
+            ? semanticColor.action.outlined.destructive.press.border
+            : semanticColor.action.outlined.progressive.press.border,
+        // Outline sits inside the border (inset)
+        outlineOffset: -border.width.thin,
+        outlineStyle: "solid",
+        outlineWidth: border.width.thin,
     };
 
-    const newStyles: Record<string, any> = {
+    const newStyles = {
         default: {
-            background: error ? tokens.color.fadedRed8 : tokens.color.white,
-            borderColor: error ? tokens.color.red : tokens.color.offBlack50,
-            borderWidth: tokens.border.width.hairline,
+            background: error
+                ? semanticColor.status.critical.background
+                : semanticColor.surface.primary,
+            borderColor: error
+                ? semanticColor.status.critical.foreground
+                : semanticColor.border.strong,
+            borderWidth: border.width.hairline,
             color: placeholder
-                ? tokens.color.offBlack64
-                : tokens.color.offBlack,
+                ? semanticColor.text.secondary
+                : semanticColor.text.primary,
             ":hover:not([aria-disabled=true])": focusHoverStyling,
             // Allow hover styles on non-touch devices only. This prevents an
             // issue with hover being sticky on touch devices (e.g. mobile).
             ["@media not (hover: hover)"]: {
                 ":hover:not([aria-disabled=true])": {
                     borderColor: error
-                        ? tokens.color.red
-                        : tokens.color.offBlack50,
-                    borderWidth: tokens.border.width.hairline,
-                    paddingLeft: tokens.spacing.medium_16,
-                    paddingRight: tokens.spacing.small_12,
+                        ? semanticColor.status.critical.foreground
+                        : semanticColor.border.strong,
+                    borderWidth: border.width.hairline,
+                    paddingLeft: spacing.medium_16,
+                    paddingRight: spacing.small_12,
                 },
             },
             ":focus-visible:not([aria-disabled=true])": focusHoverStyling,
-            ":active:not([aria-disabled=true])": activePressedStyling,
+            ":active:not([aria-disabled=true])": pressStyling,
         },
         disabled: {
-            background: tokens.color.offWhite,
-            borderColor: tokens.color.offBlack16,
-            color: tokens.color.offBlack64,
+            background: semanticColor.action.disabled.secondary,
+            borderColor: semanticColor.border.primary,
+            color: semanticColor.text.secondary,
             cursor: "not-allowed",
             ":focus-visible": {
-                boxShadow: `0 0 0 1px ${tokens.color.white}, 0 0 0 3px ${tokens.color.offBlack32}`,
+                outlineColor: semanticColor.action.disabled.default,
+                outlineOffset: -border.width.thin,
+                outlineStyle: "solid",
+                outlineWidth: border.width.thin,
             },
         },
-        press: activePressedStyling,
+        press: pressStyling,
     };
 
     stateStyles[styleKey] = StyleSheet.create(newStyles);


### PR DESCRIPTION
## Summary:

- Updated `SelectOpener` to match design specs.
- Also converted `color` tokens to use `semanticColor` tokens.

Figma: https://www.figma.com/design/VbVu3h2BpBhH80niq101MHHE/%F0%9F%92%A0-Main-Components?node-id=13693-11133&t=W16iu9a1X5vqz5ez-4

NOTE: The `light` version was removed on a separate PR, so those design specs are not included here anymore.

Issue: https://khanacademy.atlassian.net/browse/WB-1847

## Test plan:

Verify that the `SelectOpener` component looks as expected in the All Variants
stories.