### PR TITLE
Fix bug in popover child tab indices

### DIFF
--- a/.changeset/rude-mice-serve.md
+++ b/.changeset/rude-mice-serve.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+---
+
+Fixes bug where `focus-manager` overrides all tab indices within popover

--- a/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.tsx
@@ -177,4 +177,50 @@ describe("FocusManager", () => {
         // Assert
         expect(focusableElementInside).toHaveAttribute("tabIndex", "-1");
     });
+
+    it("should keep the original focusability of the internal elements when tabindex is set explicitly", async () => {
+        // Arrange
+        const externalNodes = (
+            <div>
+                <button>Open popover</button>
+            </div>
+        );
+        render(externalNodes);
+
+        // get the anchor reference to be able pass it to the FocusManager
+        const anchorElementNode = await screen.findByRole("button", {
+            name: "Open popover",
+        });
+
+        render(
+            <FocusManager anchorElement={anchorElementNode}>
+                <div>
+                    <button tabIndex={0}>first focusable element inside</button>
+                    <button tabIndex={-1}>
+                        second focusable element inside
+                    </button>
+                    <button>third focusable element inside</button>
+                </div>
+            </FocusManager>,
+        );
+
+        // Act
+        // focus on the previous element before the popover (anchor element)
+        anchorElementNode.focus();
+
+        const firstFocusableElementInside = await screen.findByText(
+            "first focusable element inside",
+        );
+        const secondFocusableElementInside = await screen.findByText(
+            "second focusable element inside",
+        );
+        const thirdFocusableElementInside = await screen.findByText(
+            "third focusable element inside",
+        );
+
+        // Assert
+        expect(firstFocusableElementInside).toHaveAttribute("tabIndex", "0"); // explicit set to 0
+        expect(secondFocusableElementInside).toHaveAttribute("tabIndex", "-1"); // explicit set to -1
+        expect(thirdFocusableElementInside).toHaveAttribute("tabIndex", "0"); // not set, should default to 0
+    });
 });

--- a/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/focus-manager.test.tsx
@@ -178,7 +178,7 @@ describe("FocusManager", () => {
         expect(focusableElementInside).toHaveAttribute("tabIndex", "-1");
     });
 
-    it("should keep the original focusability of the internal elements when tabindex is set explicitly", async () => {
+    it("changeFocusabilityInsidePopover(true) should keep the original tabindex when explicitly set to 0", async () => {
         // Arrange
         const externalNodes = (
             <div>
@@ -196,10 +196,6 @@ describe("FocusManager", () => {
             <FocusManager anchorElement={anchorElementNode}>
                 <div>
                     <button tabIndex={0}>first focusable element inside</button>
-                    <button tabIndex={-1}>
-                        second focusable element inside
-                    </button>
-                    <button>third focusable element inside</button>
                 </div>
             </FocusManager>,
         );
@@ -211,16 +207,78 @@ describe("FocusManager", () => {
         const firstFocusableElementInside = await screen.findByText(
             "first focusable element inside",
         );
-        const secondFocusableElementInside = await screen.findByText(
-            "second focusable element inside",
+
+        // Assert
+        expect(firstFocusableElementInside).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("changeFocusabilityInsidePopover(true) should keep the original tabindex when explicitly set to -1", async () => {
+        // Arrange
+        const externalNodes = (
+            <div>
+                <button>Open popover</button>
+            </div>
         );
-        const thirdFocusableElementInside = await screen.findByText(
-            "third focusable element inside",
+        render(externalNodes);
+
+        // get the anchor reference to be able pass it to the FocusManager
+        const anchorElementNode = await screen.findByRole("button", {
+            name: "Open popover",
+        });
+
+        render(
+            <FocusManager anchorElement={anchorElementNode}>
+                <div>
+                    <button tabIndex={-1}>
+                        {"first focusable(...?) element inside"}
+                    </button>
+                </div>
+            </FocusManager>,
+        );
+
+        // Act
+        // focus on the previous element before the popover (anchor element)
+        anchorElementNode.focus();
+
+        const firstFocusableElementInside = await screen.findByText(
+            "first focusable(...?) element inside",
         );
 
         // Assert
-        expect(firstFocusableElementInside).toHaveAttribute("tabIndex", "0"); // explicit set to 0
-        expect(secondFocusableElementInside).toHaveAttribute("tabIndex", "-1"); // explicit set to -1
-        expect(thirdFocusableElementInside).toHaveAttribute("tabIndex", "0"); // not set, should default to 0
+        expect(firstFocusableElementInside).toHaveAttribute("tabIndex", "-1");
+    });
+
+    it("changeFocusabilityInsidePopover(true) should add tabindex of 0 when not set", async () => {
+        // Arrange
+        const externalNodes = (
+            <div>
+                <button>Open popover</button>
+            </div>
+        );
+        render(externalNodes);
+
+        // get the anchor reference to be able pass it to the FocusManager
+        const anchorElementNode = await screen.findByRole("button", {
+            name: "Open popover",
+        });
+
+        render(
+            <FocusManager anchorElement={anchorElementNode}>
+                <div>
+                    <button>first focusable element inside</button>
+                </div>
+            </FocusManager>,
+        );
+
+        // Act
+        // focus on the previous element before the popover (anchor element)
+        anchorElementNode.focus();
+
+        const firstFocusableElementInside = await screen.findByText(
+            "first focusable element inside",
+        );
+
+        // Assert
+        expect(firstFocusableElementInside).toHaveAttribute("tabIndex", "0");
     });
 });

--- a/packages/wonder-blocks-popover/src/components/focus-manager.tsx
+++ b/packages/wonder-blocks-popover/src/components/focus-manager.tsx
@@ -275,11 +275,14 @@ export default class FocusManager extends React.Component<Props> {
      * reaches to the last focusable element within the document.
      */
     changeFocusabilityInsidePopover = (enabled = true) => {
-        const tabIndex = enabled ? "0" : "-1";
-
         // Enable/disable focusability for all the focusable elements inside the
         // popover.
         this.elementsThatCanBeFocusableInsidePopover.forEach((element) => {
+            // If enabled, use the original tabIndex value; otherwise, set it to
+            // -1 to prevent the element from being focused.
+            const tabIndex = enabled
+                ? element.getAttribute("tabIndex") ?? "0"
+                : "-1";
             element.setAttribute("tabIndex", tabIndex);
         });
     };


### PR DESCRIPTION
`focus-manager.tsx` is overriding tabindex settings on all of its children. Anything that needs to implement roving focus and restrict tabbing, like a `radiogroup`, is not possible since tabindex is always reset to 0 when focus is inside of the popover.

This fixes that issue by allowing the original tabindex to remain when internal focus is not disabled.