### PR TITLE
[timeouthooks.bugfix] Fix clear function on useTimeout and useInterval

### DIFF
--- a/.changeset/cool-months-travel.md
+++ b/.changeset/cool-months-travel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-timing": major
+---
+
+Fix bug with `useTimeout` and `useInterval` `clear` function where it didn't use the provided ClearPolicy

--- a/__docs__/wonder-blocks-timing/use-interval.stories.tsx
+++ b/__docs__/wonder-blocks-timing/use-interval.stories.tsx
@@ -8,6 +8,7 @@ import {
     ClearPolicy,
     SchedulePolicy,
 } from "@khanacademy/wonder-blocks-timing";
+import {Body} from "@khanacademy/wonder-blocks-typography";
 
 export default {
     title: "Packages / Timing / useInterval",
@@ -21,13 +22,23 @@ export default {
 
 export const Immediately = () => {
     const [callCount, setCallCount] = React.useState(0);
+    const [intervalSet, setIntervalSet] = React.useState(false);
     const callback = React.useCallback(() => {
         setCallCount((callCount) => callCount + 1);
     }, []);
     const interval = useInterval(callback, 1000);
+    useInterval(() => {
+        // Need to update on an interval as the returned `isSet` value is not
+        // driven by React state.
+        setIntervalSet(interval.isSet);
+    }, 100);
     return (
         <View>
-            <View>isSet = {interval.isSet.toString()}</View>
+            <Body>
+                Interval should fire every second until cleared. Setting the
+                interval again resets the interval.
+            </Body>
+            <View>isSet = {String(intervalSet)}</View>
             <View>callCount = {callCount}</View>
             <View style={{flexDirection: "row"}}>
                 <Button onClick={() => interval.set()}>Set interval</Button>
@@ -39,6 +50,7 @@ export const Immediately = () => {
 
 export const OnDemandAndResolveOnClear = () => {
     const [callCount, setCallCount] = React.useState(0);
+    const [intervalSet, setIntervalSet] = React.useState(false);
     const callback = React.useCallback(() => {
         setCallCount((callCount) => callCount + 1);
     }, []);
@@ -46,9 +58,20 @@ export const OnDemandAndResolveOnClear = () => {
         clearPolicy: ClearPolicy.Resolve,
         schedulePolicy: SchedulePolicy.OnDemand,
     });
+    useInterval(() => {
+        // Need to update on an interval as the returned `isSet` value is not
+        // driven by React state.
+        setIntervalSet(interval.isSet);
+    }, 100);
     return (
         <View>
-            <View>isSet = {interval.isSet.toString()}</View>
+            <Body>
+                Interval will not start until set is explicitly invoked.
+                Interval should fire every second until cleared. Clearing the
+                interval will invoke the interval action one more time. Setting
+                the interval again resets the interval.
+            </Body>
+            <View>isSet = {String(intervalSet)}</View>
             <View>callCount = {callCount}</View>
             <View style={{flexDirection: "row"}}>
                 <Button onClick={() => interval.set()}>Set interval</Button>

--- a/__docs__/wonder-blocks-timing/use-timeout.mdx
+++ b/__docs__/wonder-blocks-timing/use-timeout.mdx
@@ -1,4 +1,4 @@
-import * as UseTimeoutStories from './use-timeout.stories';
+import * as UseTimeoutStories from "./use-timeout.stories";
 
 import {Meta, Story, Canvas} from "@storybook/blocks";
 
@@ -33,58 +33,14 @@ called when the timeout is cleared.
 
 Notes:
 
-* Because `clear` takes a param, it's important that you don't pass it directly to an event handler,
-  e.g. `<Button onClick={clear} />` will not work as expected.
-* Calling `set` after the timeout has expired will restart the timeout.
-* Updating the second paramter, `timeoutMs`, will also restart the timeout.
-* When the component using this hooks is unmounted, the timeout will automatically be cleared.
-* Calling `set` after the timeout is set but before it expires means that the timeout will be
-  reset and will call `action`, `timeoutMs` after the most recent call to `set` was made.
+-   Because `clear` takes a param, it's important that you don't pass it directly to an event handler,
+    e.g. `<Button onClick={clear} />` will not work as expected.
+-   Calling `set` after the timeout has expired will restart the timeout.
+-   Updating the second paramter, `timeoutMs`, will also restart the timeout.
+-   When the component using this hooks is unmounted, the timeout will automatically be cleared.
+-   Calling `set` after the timeout is set but before it expires means that the timeout will be
+    reset and will call `action`, `timeoutMs` after the most recent call to `set` was made.
 
-<Canvas of={UseTimeoutStories.Immediately} />
+<Canvas sourceState="shown" of={UseTimeoutStories.Immediately} />
 
-```jsx
-const Immediately = () => {
-    const [callCount, setCallCount] = React.useState(0);
-    const callback = React.useCallback(() => {
-        setCallCount((callCount) => callCount + 1);
-    }, []);
-    const {isSet, set, clear} = useTimeout(callback, 1000);
-    return (
-        <View>
-            <View>isSet = {isSet.toString()}</View>
-            <View>callCount = {callCount}</View>
-            <View style={{flexDirection: "row"}}>
-                <Button onClick={() => set()}>Set timeout</Button>
-                <Button onClick={() => clear()}>Clear timeout</Button>
-            </View>
-        </View>
-    );
-};
-```
-
-<Canvas of={UseTimeoutStories.OnDemandAndResolveOnClear} />
-
-```jsx
-const OnDemandAndResolveOnClear = () => {
-    const [callCount, setCallCount] = React.useState(0);
-    const callback = React.useCallback(() => {
-        setCallCount((callCount) => callCount + 1);
-    }, []);
-    const {isSet, set, clear} = useTimeout(callback, 1000, {
-        clearPolicy: ClearPolicy.Resolve,
-        schedulePolicy: SchedulePolicy.OnDemand,
-    });
-    return (
-        <View>
-            <View>isSet = {isSet.toString()}</View>
-            <View>callCount = {callCount}</View>
-            <View style={{flexDirection: "row"}}>
-                <Button onClick={() => set()}>Set timeout</Button>
-                <Button onClick={() => clear()}>Clear timeout</Button>
-            </View>
-        </View>
-    );
-};
-```
-./use-timeout.stories
+<Canvas sourceState="shown" of={UseTimeoutStories.OnDemandAndResolveOnClear} />

--- a/__docs__/wonder-blocks-timing/use-timeout.stories.tsx
+++ b/__docs__/wonder-blocks-timing/use-timeout.stories.tsx
@@ -7,7 +7,8 @@ import {
     ClearPolicy,
     SchedulePolicy,
 } from "../../packages/wonder-blocks-timing/src/util/policies";
-import {useTimeout} from "@khanacademy/wonder-blocks-timing";
+import {useTimeout, useInterval} from "@khanacademy/wonder-blocks-timing";
+import {Body} from "@khanacademy/wonder-blocks-typography";
 
 export default {
     title: "Packages / Timing / useTimeout",
@@ -21,21 +22,30 @@ export default {
 
 export const Immediately = () => {
     const [callCount, setCallCount] = React.useState(0);
+    const [timeoutSet, setTimeoutSet] = React.useState(false);
     const callback = React.useCallback(() => {
+        // eslint-disable-next-line no-console
+        console.log("action called");
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const {isSet, set, clear} = useTimeout(callback, 1000);
+    const timeout = useTimeout(callback, 5000);
+    useInterval(() => {
+        // Need to update on an interval as the returned `isSet` value is not
+        // driven by React state.
+        setTimeoutSet(timeout.isSet);
+    }, 100);
     return (
         <View>
-            <View>isSet = {isSet.toString()}</View>
+            <Body>
+                Timeout should fire in 5 seconds unless set again or cleared
+            </Body>
+            <View>isSet = {String(timeoutSet)}</View>
             <View>callCount = {callCount}</View>
             <View style={{flexDirection: "row"}}>
-                <Button onClick={set}>Set timeout</Button>
+                <Button onClick={() => timeout.set()}>Set timeout</Button>
                 <Button
                     onClick={() => {
-                        if (clear) {
-                            clear();
-                        }
+                        timeout.clear();
                     }}
                 >
                     Clear timeout
@@ -47,22 +57,32 @@ export const Immediately = () => {
 
 export const OnDemandAndResolveOnClear = () => {
     const [callCount, setCallCount] = React.useState(0);
+    const [timeoutSet, setTimeoutSet] = React.useState(false);
     const callback = React.useCallback(() => {
         // eslint-disable-next-line no-console
         console.log("action called");
         setCallCount((callCount) => callCount + 1);
     }, []);
-    const {isSet, set, clear} = useTimeout(callback, 1000, {
+    const timeout = useTimeout(callback, 5000, {
         clearPolicy: ClearPolicy.Resolve,
         schedulePolicy: SchedulePolicy.OnDemand,
     });
+    useInterval(() => {
+        // Need to update on an interval as the returned `isSet` value is not
+        // driven by React state.
+        setTimeoutSet(timeout.isSet);
+    }, 100);
     return (
         <View>
-            <View>isSet = {isSet.toString()}</View>
+            <Body>
+                Timeout should fire in 5 seconds or when cleared unless set
+                again
+            </Body>
+            <View>isSet = {String(timeoutSet)}</View>
             <View>callCount = {callCount}</View>
             <View style={{flexDirection: "row"}}>
-                <Button onClick={() => set()}>Set timeout</Button>
-                <Button onClick={() => clear()}>Clear timeout</Button>
+                <Button onClick={() => timeout.set()}>Set timeout</Button>
+                <Button onClick={() => timeout.clear()}>Clear timeout</Button>
             </View>
         </View>
     );

--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-interval.test.ts
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-interval.test.ts
@@ -425,7 +425,31 @@ describe("useInterval", () => {
             expect(action).not.toHaveBeenCalled();
         });
 
-        it("should invoke the action if clear policy is ClearPolicy.Resolve", () => {
+        it("should invoke the action if clear policy is ClearPolicy.Resolve from hook options", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() =>
+                useInterval(action, 500, {
+                    clearPolicy: ClearPolicy.Resolve,
+                }),
+            );
+            act(() => {
+                result.current.set();
+            });
+
+            // Act
+            act(() => {
+                result.current.clear();
+            });
+            act(() => {
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        it("should invoke the action if clear policy is explicitly ClearPolicy.Resolve", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() => useInterval(action, 500));
@@ -445,21 +469,18 @@ describe("useInterval", () => {
             expect(action).toHaveBeenCalledTimes(1);
         });
 
-        it("should not invoke the action if clear policy is ClearPolicy.Cancel", () => {
+        it("should not invoke the action if clear policy is ClearPolicy.Cancel from hook options", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
                 useInterval(action, 500, {
-                    schedulePolicy: SchedulePolicy.Immediately,
+                    clearPolicy: ClearPolicy.Cancel,
                 }),
             );
-            act(() => {
-                result.current.set();
-            });
 
             // Act
             act(() => {
-                result.current.clear(ClearPolicy.Cancel);
+                result.current.clear();
             });
             act(() => {
                 jest.advanceTimersByTime(501);
@@ -469,7 +490,28 @@ describe("useInterval", () => {
             expect(action).not.toHaveBeenCalled();
         });
 
-        it("should not invoke the action if interval is inactive and clear policy is ClearPolicy.Resolve", () => {
+        it("should not invoke the action if clear policy is explicitly ClearPolicy.Cancel", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() =>
+                useInterval(action, 500, {
+                    clearPolicy: ClearPolicy.Cancel,
+                }),
+            );
+
+            // Act
+            act(() => {
+                result.current.clear();
+            });
+            act(() => {
+                jest.advanceTimersByTime(501);
+            });
+
+            // Assert
+            expect(action).not.toHaveBeenCalled();
+        });
+
+        it("should not invoke the action if interval is inactive and clear policy is explicitly ClearPolicy.Resolve", () => {
             // Arrange
             const action = jest.fn();
             const {result} = renderHook(() =>
@@ -491,16 +533,14 @@ describe("useInterval", () => {
         it("should not call the action on unmount if the interval is not running when the clearPolicy is ClearPolicy.Resolve", async () => {
             // Arrange
             const action = jest.fn();
-            const {result, unmount} = renderHook(() =>
+            const {unmount} = renderHook(() =>
                 useInterval(action, 500, {
+                    schedulePolicy: SchedulePolicy.OnDemand,
                     clearPolicy: ClearPolicy.Resolve,
                 }),
             );
 
             // Act
-            act(() => {
-                result.current.clear();
-            });
             act(() => {
                 unmount();
             });

--- a/packages/wonder-blocks-timing/src/hooks/__tests__/use-timeout.test.ts
+++ b/packages/wonder-blocks-timing/src/hooks/__tests__/use-timeout.test.ts
@@ -67,7 +67,7 @@ describe("useTimeout", () => {
         expect(result.current.isSet).toBe(true);
     });
 
-    it("should call the action before unmounting", () => {
+    it("should call the action before unmounting if clear policy is ClearPolicy.Resolve", () => {
         // Arrange
         const action = jest.fn();
         const {unmount} = renderHook(() =>
@@ -85,7 +85,7 @@ describe("useTimeout", () => {
         expect(action).toHaveBeenCalled();
     });
 
-    it("should call the current action", () => {
+    it("should call the current action if action is changed after setting", () => {
         // Arrange
         const action1 = jest.fn();
         const action2 = jest.fn();
@@ -362,6 +362,24 @@ describe("useTimeout", () => {
             // Act
             act(() => {
                 result.current.clear(ClearPolicy.Resolve);
+            });
+
+            // Assert
+            expect(action).toHaveBeenCalled();
+        });
+
+        it("should call the action when the timeout is cleared when passing ClearPolicy.Resolve in options", () => {
+            // Arrange
+            const action = jest.fn();
+            const {result} = renderHook(() =>
+                useTimeout(action, 1000, {
+                    clearPolicy: ClearPolicy.Resolve,
+                }),
+            );
+
+            // Act
+            act(() => {
+                result.current.clear();
             });
 
             // Assert

--- a/packages/wonder-blocks-timing/src/hooks/use-interval.ts
+++ b/packages/wonder-blocks-timing/src/hooks/use-interval.ts
@@ -31,7 +31,9 @@ import Interval from "../util/interval";
  * scheduling the interval, use `SchedulePolicy.OnDemand`.
  * @returns An `IInterval` API for interacting with the given interval. This
  * API is a no-op if called when not mounted. This means that any calls prior
- * to mounting or after unmounting will not have any effect.
+ * to mounting or after unmounting will not have any effect. This API is
+ * not reactive, so do not deconstruct the return value, but instead
+ * dereference it at the time of use.
  */
 export function useInterval(
     action: () => unknown,
@@ -87,14 +89,14 @@ export function useInterval(
             set: () => {
                 intervalRef.current?.set();
             },
-            clear: (policy?: ClearPolicy) => {
+            clear: (policy: ClearPolicy | undefined = clearPolicy) => {
                 intervalRef.current?.clear(policy);
             },
             get isSet() {
                 return intervalRef.current?.isSet ?? false;
             },
         }),
-        [],
+        [clearPolicy],
     );
 
     return externalApi;

--- a/packages/wonder-blocks-timing/src/hooks/use-timeout.ts
+++ b/packages/wonder-blocks-timing/src/hooks/use-timeout.ts
@@ -31,7 +31,9 @@ import Timeout from "../util/timeout";
  * scheduling the timeout, use `SchedulePolicy.OnDemand`.
  * @returns An `ITimeout` API for interacting with the given timeout. This
  * API is a no-op if called when not mounted. This means that any calls prior
- * to mounting or after unmounting will not have any effect.
+ * to mounting or after unmounting will not have any effect. This API is
+ * not reactive, so do not deconstruct the return value, but instead
+ * dereference it at the time of use.
  */
 export function useTimeout(
     action: () => unknown,
@@ -87,14 +89,16 @@ export function useTimeout(
             set: () => {
                 timeoutRef.current?.set();
             },
-            clear: (policy?: ClearPolicy) => {
+            clear: (policy: ClearPolicy | undefined = clearPolicy) => {
+                // Note that we default to the clear policy passed to the hook
+                // so that this works as folks might expect.
                 timeoutRef.current?.clear(policy);
             },
             get isSet() {
                 return timeoutRef.current?.isSet ?? false;
             },
         }),
-        [],
+        [clearPolicy],
     );
 
     return externalApi;


### PR DESCRIPTION
## Summary:
This fixes a bug I found in the API returned by the `useTimeout` and `useInterval` hooks. The `clear` function returned by these hooks was not properly honouring the clear policy explicitly passed to the hook options. This PR fixes that issue.

## Test plan:
`yarn test`
`yarn start:storybook` and visit the `useTimeout` and `useInterval` stories. Go to the OnDemandAndResolveOnClear story and see that clicking the Clear button will invoke the corresponding action as it should - this was not the case, previously.