### PR TITLE
[birthday-picker-combobox] Add labels to birthday picker

### DIFF
--- a/.changeset/mighty-mangos-hammer.md
+++ b/.changeset/mighty-mangos-hammer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": minor
+---
+
+Exposes aria-label attributes on each field with values from the labels prop.

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
@@ -183,34 +183,63 @@ describe("BirthdayPicker", () => {
             expect(await screen.findByRole("alert")).toBeInTheDocument();
         });
 
-        // NOTE(john): After upgrading to user-event v14 this test no longer
-        // works. the findByRole("listbox") is not finding the listbox. Juan
-        // and I tried all sorts of options, but none work. Hopefully this
-        // can be fixed once we upgrade to React 18?
-        it.skip.each(["day", "month", "year"])(
-            "%s > renders the listbox as invalid with an invalid default value",
-            async (fragment) => {
-                // Arrange
-                const defaultValue = "2021-02-31";
+        describe.each(["day", "month", "year"])(
+            "$fragment",
+            (fragment: string) => {
+                it("%s > renders the listbox as invalid with an invalid default value", async () => {
+                    // Arrange
+                    const defaultValue = "2021-02-31";
 
-                render(
-                    <BirthdayPicker
-                        defaultValue={defaultValue}
-                        onChange={() => {}}
-                    />,
-                );
+                    render(
+                        <BirthdayPicker
+                            defaultValue={defaultValue}
+                            onChange={() => {}}
+                        />,
+                    );
 
-                const button = await screen.findByTestId(
-                    `birthday-picker-${fragment}`,
-                );
-                await userEvent.click(button);
+                    const button = await screen.findByTestId(
+                        `birthday-picker-${fragment}`,
+                    );
+                    await userEvent.click(button);
 
-                // Act
-                // wait for the listbox (options list) to appear
-                const listbox = await screen.findByRole("listbox");
+                    // Act
+                    // wait for the listbox (options list) to appear
+                    const listbox = await screen.findByRole("listbox", {
+                        hidden: true,
+                    });
 
-                // Assert
-                expect(listbox).toHaveAttribute("aria-invalid", "true");
+                    // Assert
+                    expect(listbox).toHaveAttribute("aria-invalid", "true");
+                });
+
+                it("$s > labels the opener", async () => {
+                    // Arrange
+                    const defaultValue = "2021-02-31";
+                    const testLabels: Labels = {
+                        month: "Mois",
+                        day: "Jour",
+                        year: "Année",
+                        errorMessage: "There was an error",
+                    };
+
+                    render(
+                        <BirthdayPicker
+                            defaultValue={defaultValue}
+                            onChange={() => {}}
+                            labels={testLabels}
+                        />,
+                    );
+
+                    // Act
+                    const button = await screen.findByTestId(
+                        `birthday-picker-${fragment}`,
+                    );
+
+                    // Assert
+                    expect(button).toHaveAccessibleName(
+                        testLabels[fragment as keyof Labels],
+                    );
+                });
             },
         );
     });

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -306,6 +306,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
         const minWidth = this.getMonthYearWidth(monthYearOnly);
         return (
             <SingleSelect
+                aria-label={this.labels.month}
                 aria-invalid={!!this.state.error}
                 error={!!this.state.error}
                 disabled={disabled}
@@ -336,6 +337,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
             <>
                 <Strut size={spacing.xSmall_8} />
                 <SingleSelect
+                    aria-label={this.labels.day}
                     aria-invalid={!!this.state.error}
                     error={!!this.state.error}
                     disabled={disabled}
@@ -377,6 +379,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
 
         return (
             <SingleSelect
+                aria-label={this.labels.year}
                 aria-invalid={!!this.state.error}
                 error={!!this.state.error}
                 disabled={disabled}


### PR DESCRIPTION
## Summary:
Updating Birthday Picker to use aria-labels for accessible names. The label placeholders were not applied in this way after WB Dropdowns were changed to use `role="combobox"`.

Issue: https://khanacademy.atlassian.net/browse/WB-1872

## Test plan: