### PR TITLE
[dropdown-refresh-fix] Re-exposes type=button on dropdown openers to prevent form submits and page refreshes.

### DIFF
--- a/.changeset/hungry-papayas-grin.md
+++ b/.changeset/hungry-papayas-grin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Re-exposes type=button on dropdown openers to prevent form submits and page refreshes.

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -85,6 +85,43 @@ describe("MultiSelect", () => {
             ).toBeInTheDocument();
         });
 
+        it("should not submit a surrounding form when clicked", async () => {
+            // Arrange
+            const submit = jest.fn();
+            const {userEvent} = doRender(
+                <form
+                    onSubmit={() => {
+                        submit();
+                    }}
+                >
+                    <MultiSelect
+                        aria-label="Choose"
+                        onChange={jest.fn()}
+                        selectedValues={["toggle_a"]}
+                        showOpenerLabelAsText={false}
+                    >
+                        <OptionItem
+                            label={<div>custom item A</div>}
+                            value="toggle_a"
+                            labelAsText="Plain Toggle A"
+                        />
+                        <OptionItem
+                            label={<div>custom item B</div>}
+                            value="toggle_b"
+                            labelAsText="Plain Toggle B"
+                        />
+                    </MultiSelect>
+                </form>,
+            );
+            const opener = await screen.findByRole("combobox");
+
+            // Act
+            await userEvent.click(opener);
+
+            // Assert
+            expect(submit).not.toHaveBeenCalled();
+        });
+
         it("closes the select on {Escape}", async () => {
             // Arrange
             const {userEvent} = doRender(uncontrolledMultiSelect);
@@ -1036,6 +1073,46 @@ describe("MultiSelect", () => {
             expect(
                 await screen.findByRole("listbox", {hidden: true}),
             ).toBeInTheDocument();
+        });
+
+        it("should not submit a surrounding form when a custom opener is clicked", async () => {
+            // Arrange
+            const submit = jest.fn();
+            const {userEvent} = doRender(
+                <form
+                    onSubmit={() => {
+                        submit();
+                    }}
+                >
+                    <MultiSelect
+                        aria-label="Choose"
+                        onChange={jest.fn()}
+                        selectedValues={["toggle_a"]}
+                        showOpenerLabelAsText={false}
+                        opener={(eventState: any) => (
+                            <button aria-label="Search" onClick={jest.fn()} />
+                        )}
+                    >
+                        <OptionItem
+                            label={<div>custom item A</div>}
+                            value="toggle_a"
+                            labelAsText="Plain Toggle A"
+                        />
+                        <OptionItem
+                            label={<div>custom item B</div>}
+                            value="toggle_b"
+                            labelAsText="Plain Toggle B"
+                        />
+                    </MultiSelect>
+                </form>,
+            );
+            const opener = await screen.findByRole("combobox");
+
+            // Act
+            await userEvent.click(opener);
+
+            // Assert
+            expect(submit).not.toHaveBeenCalled();
         });
 
         it("calls the custom onClick handler", async () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -247,6 +247,44 @@ describe("SingleSelect", () => {
                 ).toBeInTheDocument();
             });
 
+            it("should not submit a surrounding form when clicked", async () => {
+                // Arrange
+                const submit = jest.fn();
+                const {userEvent} = doRender(
+                    <form
+                        onSubmit={() => {
+                            submit();
+                        }}
+                    >
+                        <SingleSelect
+                            aria-label="Choose"
+                            placeholder="Default placeholder"
+                            onChange={jest.fn()}
+                            selectedValue="toggle_a"
+                            showOpenerLabelAsText={false}
+                        >
+                            <OptionItem
+                                label={<div>custom item A</div>}
+                                value="toggle_a"
+                                labelAsText="Plain Toggle A"
+                            />
+                            <OptionItem
+                                label={<div>custom item B</div>}
+                                value="toggle_b"
+                                labelAsText="Plain Toggle B"
+                            />
+                        </SingleSelect>
+                    </form>,
+                );
+                const opener = await screen.findByRole("combobox");
+
+                // Act
+                await userEvent.click(opener);
+
+                // Assert
+                expect(submit).not.toHaveBeenCalled();
+            });
+
             it("should focus the first item in the dropdown", async () => {
                 // Arrange
                 const {userEvent} = doRender(uncontrolledSingleSelect);
@@ -708,6 +746,47 @@ describe("SingleSelect", () => {
             expect(
                 await screen.findByRole("listbox", {hidden: true}),
             ).toBeInTheDocument();
+        });
+
+        it("should not submit a surrounding form when a custom opener is clicked", async () => {
+            // Arrange
+            const submit = jest.fn();
+            const {userEvent} = doRender(
+                <form
+                    onSubmit={() => {
+                        submit();
+                    }}
+                >
+                    <SingleSelect
+                        aria-label="Choose"
+                        placeholder="Select an option"
+                        onChange={jest.fn()}
+                        selectedValue="toggle_a"
+                        showOpenerLabelAsText={false}
+                        opener={(eventState: any) => (
+                            <button aria-label="Search">Search</button>
+                        )}
+                    >
+                        <OptionItem
+                            label={<div>custom item A</div>}
+                            value="toggle_a"
+                            labelAsText="Plain Toggle A"
+                        />
+                        <OptionItem
+                            label={<div>custom item B</div>}
+                            value="toggle_b"
+                            labelAsText="Plain Toggle B"
+                        />
+                    </SingleSelect>
+                </form>,
+            );
+            const opener = await screen.findByRole("combobox");
+
+            // Act
+            await userEvent.click(opener);
+
+            // Assert
+            expect(submit).not.toHaveBeenCalled();
         });
 
         it("calls the custom onClick handler", async () => {

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -169,6 +169,7 @@ export default class SelectOpener extends React.Component<
                 data-testid={testId}
                 id={id}
                 role="combobox"
+                /* Note(marcysutton): type=button prevents form submits on click */
                 type="button"
                 style={style}
                 onClick={!disabled ? this.handleClick : undefined}

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -169,6 +169,7 @@ export default class SelectOpener extends React.Component<
                 data-testid={testId}
                 id={id}
                 role="combobox"
+                type="button"
                 style={style}
                 onClick={!disabled ? this.handleClick : undefined}
                 onKeyDown={!disabled ? this.handleKeyDown : undefined}


### PR DESCRIPTION
## Summary:
[dropdown-refresh-fix] Restore type=button to prevent refreshes

Issue: https://khanacademy.atlassian.net/browse/WB-1875

## Test plan:

- Run unit tests - removing `type="button"` in `select-opener.tsx` will cause the new tests in this PR to fail.
- Integrate in webapp to fix test failures there: https://github.com/Khan/webapp/pull/28147