### PR TITLE
[WB-1874] Remove `kind` prop now that `secondary` kind is being deprecated

### DIFF
--- a/.changeset/cool-tomatoes-run.md
+++ b/.changeset/cool-tomatoes-run.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": patch
+---
+
+Remove `kind="primary"` from Link instance"

--- a/.changeset/moody-pianos-return.md
+++ b/.changeset/moody-pianos-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-link": major
+---
+
+Remove `kind` prop as the `secondary` variant is now dropped.

--- a/__docs__/wonder-blocks-link/link-variants.stories.tsx
+++ b/__docs__/wonder-blocks-link/link-variants.stories.tsx
@@ -27,10 +27,6 @@ const columns = [
         props: {},
     },
     {
-        name: "Secondary",
-        props: {kind: "secondary"},
-    },
-    {
         name: "Visitable",
         props: {visitable: true},
     },

--- a/__docs__/wonder-blocks-link/link.argtypes.tsx
+++ b/__docs__/wonder-blocks-link/link.argtypes.tsx
@@ -55,17 +55,6 @@ export default {
         type: {name: "boolean", required: false},
     },
 
-    kind: {
-        control: {type: "select"},
-        description:
-            "Kind of Link. Note: Secondary light Links are not supported.",
-        options: ["primary", "secondary"],
-        table: {
-            type: {summary: `"primary" | "secondary"`},
-        },
-        type: {name: "enum", value: ["primary", "secondary"], required: false},
-    },
-
     light: {
         control: {type: "boolean"},
         description: "Whether the button is on a dark/colored background.",

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -40,24 +40,13 @@ export default {
 type StoryComponentType = StoryObj<typeof Link>;
 
 /**
- * By default the link is a `primary` link.
+ * By default the link uses a blue color.
  */
 export const Default: StoryComponentType = {
     args: {
         href: "/",
         children: "The quick brown fox jumps over the lazy dog.",
     },
-};
-
-/**
- * This is a `secondary` link. This links to the top of the page.
- */
-export const Secondary: StoryComponentType = {
-    render: () => (
-        <Link href="#" kind="secondary">
-            The quick brown fox jumps over the lazy dog.
-        </Link>
-    ),
 };
 
 /**
@@ -117,14 +106,7 @@ export const OpensInANewTab: StoryComponentType = {
     render: () => (
         <View>
             <Link href="https://cat-bounce.com/" target="_blank">
-                This is a Primary link that opens in a new tab
-            </Link>
-            <Link
-                href="https://cat-bounce.com/"
-                kind="secondary"
-                target="_blank"
-            >
-                This is a Secondary link that opens in a new tab
+                This is a link that opens in a new tab
             </Link>
         </View>
     ),
@@ -154,7 +136,6 @@ export const StartAndEndIcons: StoryComponentType = {
                     endIcon={
                         <PhosphorIcon icon={IconMappings.magnifyingGlassBold} />
                     }
-                    kind="secondary"
                     style={styles.standaloneLinkWrapper}
                 >
                     This link has an end icon
@@ -176,7 +157,6 @@ export const StartAndEndIcons: StoryComponentType = {
                     endIcon={
                         <PhosphorIcon icon={IconMappings.caretRightBold} />
                     }
-                    kind="secondary"
                     style={styles.standaloneLinkWrapper}
                 >
                     This link has a start icon and an end icon
@@ -322,7 +302,7 @@ export const Inline: StoryComponentType = {
         <Body>
             This is an inline{" "}
             <Link href="#" inline={true}>
-                Primary link
+                link
             </Link>{" "}
             and an inline{" "}
             <Link
@@ -330,24 +310,11 @@ export const Inline: StoryComponentType = {
                 inline={true}
                 target="_blank"
             >
-                external Primary link
-            </Link>
-            , whereas this is an inline{" "}
-            <Link href="#" kind="secondary" inline={true}>
-                Secondary link
-            </Link>
-            , and an inline{" "}
-            <Link
-                href="https://www.procatinator.com/"
-                kind="secondary"
-                inline={true}
-                target="_blank"
-            >
-                external Secondary link
+                external link
             </Link>
             , and this is an inline{" "}
             <Link href="#" visitable={true} inline={true}>
-                Visitable link (Primary only)
+                Visitable link
             </Link>{" "}
             and an inline{" "}
             <Link
@@ -356,7 +323,7 @@ export const Inline: StoryComponentType = {
                 inline={true}
                 target="_blank"
             >
-                external Visitable link (Primary only)
+                external Visitable link
             </Link>
             .
         </Body>

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -215,7 +215,6 @@ const Banner = (props: Props): React.ReactElement => {
                 return (
                     <View style={styles.action} key={action.title}>
                         <Link
-                            kind="primary"
                             href={action.href}
                             onClick={handleClick}
                             aria-label={action.ariaLabel ?? action.title}

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -37,7 +37,6 @@ const LinkCore = React.forwardRef(function LinkCore(
             hovered, // eslint-disable-line @typescript-eslint/no-unused-vars
             href,
             inline = false,
-            kind = "primary",
             light = false,
             visitable = false,
             pressed,
@@ -50,7 +49,7 @@ const LinkCore = React.forwardRef(function LinkCore(
             ...restProps
         } = props;
 
-        const linkStyles = _generateStyles(inline, kind, light, visitable);
+        const linkStyles = _generateStyles(inline, light, visitable);
 
         const defaultStyles = [
             sharedStyles.shared,
@@ -170,24 +169,15 @@ const sharedStyles = StyleSheet.create({
 
 const _generateStyles = (
     inline: boolean,
-    kind: "primary" | "secondary",
     light: boolean,
     visitable: boolean,
 ) => {
-    const buttonType = `${kind}-${inline.toString()}-${light.toString()}-${visitable.toString()}`;
+    const buttonType = `${inline.toString()}-${light.toString()}-${visitable.toString()}`;
     if (styles[buttonType]) {
         return styles[buttonType];
     }
 
-    if (kind === "secondary" && light) {
-        throw new Error("Secondary Light links are not supported");
-    }
-
-    if (visitable && kind !== "primary") {
-        throw new Error("Only primary link is visitable");
-    }
-
-    const {blue, purple, white, offBlack, offBlack32, offBlack64} = color;
+    const {blue, purple, white, offBlack, offBlack32} = color;
 
     // NOTE: This color is only used here.
     const pink = "#fa50ae";
@@ -202,16 +192,10 @@ const _generateStyles = (
     const activeDefaultPrimary = color.activeBlue;
 
     const primaryDefaultTextColor = light ? white : blue;
-    const secondaryDefaultTextColor = inline ? offBlack : offBlack64;
-    const defaultTextColor =
-        kind === "primary"
-            ? primaryDefaultTextColor
-            : secondaryDefaultTextColor;
+    const defaultTextColor = primaryDefaultTextColor;
 
     const primaryActiveColor = light ? fadedBlue : activeDefaultPrimary;
-    const secondaryActiveColor = inline ? activeDefaultPrimary : offBlack;
-    const activeColor =
-        kind === "primary" ? primaryActiveColor : secondaryActiveColor;
+    const activeColor = primaryActiveColor;
 
     const defaultVisited = visitable
         ? {

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -28,10 +28,6 @@ type CommonProps = AriaProps & {
      */
     inline?: boolean;
     /**
-     * Kind of Link. Note: Secondary light Links are not supported.
-     */
-    kind?: "primary" | "secondary";
-    /**
      * Whether the button is on a dark/colored background.
      */
     light?: boolean;
@@ -197,7 +193,6 @@ const Link = React.forwardRef(function Link(
         onKeyUp,
         target = undefined,
         inline = false,
-        kind = "primary",
         light = false,
         visitable = false,
         ...sharedProps
@@ -233,7 +228,6 @@ const Link = React.forwardRef(function Link(
                                 target={target}
                                 tabIndex={tabIndex}
                                 inline={inline}
-                                kind={kind}
                                 light={light}
                                 visitable={visitable}
                                 ref={ref}
@@ -267,7 +261,6 @@ const Link = React.forwardRef(function Link(
                                 target={target}
                                 tabIndex={tabIndex}
                                 inline={inline}
-                                kind={kind}
                                 light={light}
                                 visitable={visitable}
                                 ref={ref}


### PR DESCRIPTION
## Summary:

Now that we are moving to Polaris, we’ve noticed that the Link.secondary variant
is not used very often (~0.2% of total Link usage). We are going to remove it to
simplify the styling of Links and consolidate on a more consistent pattern
across our sites.

This PR removes the `kind` prop from the Link component and updates the
documentation to reflect this change.

Also removes the `kind="primary"` from the Link instance in `Banner` component.


Issue: WB-1874

## Test plan:

Navigate to `/?path=/docs/packages-link--docs` and verify that the Link
component does not have the `kind` prop anymore.

Also navigate to `/?path=/story/packages-link-link-all-variants--default` and
verify that the "kind" variants are not available anymore. Only "default" and
"inline".