### PR TITLE
[WB-1814.6] Refactor Link to use semantic colors

### DIFF
--- a/.changeset/mighty-goats-look.md
+++ b/.changeset/mighty-goats-look.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-banner": patch
+"@khanacademy/wonder-blocks-link": patch
+---
+
+Internal `Link` refactor to use `semanticColor` tokens intead of `color`. Also moved the link colors to an object to prepare this for an upcoming theme integration"

--- a/__docs__/wonder-blocks-link/link-variants.stories.tsx
+++ b/__docs__/wonder-blocks-link/link-variants.stories.tsx
@@ -12,6 +12,8 @@ import {
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 
 import {AllVariants} from "../components/all-variants";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
 const rows = [
     {name: "Default", props: {}},
@@ -27,12 +29,35 @@ const columns = [
         props: {},
     },
     {
+        name: "startIcon",
+        props: {
+            children: "With startIcon",
+            startIcon: <PhosphorIcon icon={IconMappings.plusCircleBold} />,
+        },
+    },
+    {
+        name: "endIcon",
+        props: {
+            children: "With endIcon",
+            endIcon: <PhosphorIcon icon={IconMappings.magnifyingGlassBold} />,
+            target: "_blank",
+        },
+    },
+    {
+        name: "External",
+        props: {
+            children: "External link",
+            href: "https://www.khanacademy.org",
+            target: "_blank",
+        },
+    },
+    {
         name: "Visitable",
         props: {visitable: true},
     },
 ];
 
-const themes: Array<string> = ["default", "dark"];
+const themes: Array<string> = ["default", "dark", "rtl"];
 
 type Story = StoryObj<typeof Link>;
 
@@ -50,17 +75,16 @@ const meta = {
                     <AllVariants rows={rows} columns={columns}>
                         {(props) => (
                             <>
-                                {theme === "dark" &&
-                                props.kind === "secondary" ? null : (
-                                    <Link
-                                        {...args}
-                                        {...props}
-                                        light={theme === "dark"}
-                                        href="https://www.khanacademy.org"
-                                    >
-                                        This is a Link
-                                    </Link>
-                                )}
+                                <Link
+                                    {...args}
+                                    {...props}
+                                    light={theme === "dark"}
+                                    href="https://www.khanacademy.org"
+                                >
+                                    {theme === "rtl"
+                                        ? "هذا الرابط مكتوب باللغة العربية"
+                                        : "This is a Link"}
+                                </Link>
                             </>
                         )}
                     </AllVariants>
@@ -113,7 +137,7 @@ export const PressVisited: Story = {
 
 const styles = StyleSheet.create({
     container: {
-        maxWidth: 700,
+        maxWidth: 1000,
         gap: spacing.medium_16,
     },
     theme: {
@@ -124,6 +148,9 @@ const styles = StyleSheet.create({
     dark: {
         backgroundColor: semanticColor.surface.inverse,
         color: semanticColor.text.inverse,
+    },
+    rtl: {
+        direction: "rtl",
     },
     title: {
         textTransform: "capitalize",

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -364,7 +364,7 @@ export const InlineLight: StoryComponentType = {
             </Link>
             , whereas this is an inline{" "}
             <Link href="#link" visitable={true} inline={true} light={true}>
-                Visitable link (Primary only)
+                Visitable link
             </Link>{" "}
             and an{" "}
             <Link
@@ -374,9 +374,9 @@ export const InlineLight: StoryComponentType = {
                 light={true}
                 target="_blank"
             >
-                external Visitable link (Primary only)
+                external Visitable link
             </Link>
-            . Secondary light links are not supported.
+            .
         </Body>
     ),
     parameters: {

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -6,7 +6,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingSmall,

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -329,6 +329,13 @@ export const Inline: StoryComponentType = {
             .
         </Body>
     ),
+    parameters: {
+        chromatic: {
+            // Re-enable snapshots for this story since it shows the links in
+            // the context of paragraphs.
+            disableSnapshot: false,
+        },
+    },
 };
 
 /**
@@ -391,6 +398,13 @@ export const WithTypography: StoryComponentType = {
             </Link>
         </HeadingSmall>
     ),
+    parameters: {
+        chromatic: {
+            // Re-enable snapshots for this story since it's verifying that
+            // the styles on typography elements are applied
+            disableSnapshot: false,
+        },
+    },
 };
 
 /**

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -300,7 +300,7 @@ export const StartAndEndIcons: StoryComponentType = {
  */
 export const Inline: StoryComponentType = {
     render: () => (
-        <Body>
+        <Body style={{width: 530}}>
             This is an inline{" "}
             <Link href="#link" inline={true}>
                 regular link
@@ -335,6 +335,7 @@ export const Inline: StoryComponentType = {
             // the context of paragraphs.
             disableSnapshot: false,
         },
+        pseudo: {visited: true},
     },
 };
 
@@ -347,7 +348,7 @@ export const Inline: StoryComponentType = {
  */
 export const InlineLight: StoryComponentType = {
     render: () => (
-        <Body style={{color: semanticColor.text.inverse}}>
+        <Body style={{color: semanticColor.text.inverse, width: 530}}>
             This is an inline{" "}
             <Link href="#link" inline={true} light={true}>
                 regular link
@@ -382,6 +383,12 @@ export const InlineLight: StoryComponentType = {
         backgrounds: {
             default: "darkBlue",
         },
+        chromatic: {
+            // Re-enable snapshots for this story since it shows the links in
+            // the context of paragraphs.
+            disableSnapshot: false,
+        },
+        pseudo: {visited: true},
     },
 };
 

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -6,7 +6,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Body,
     HeadingSmall,
@@ -202,7 +202,7 @@ export const StartAndEndIcons: StoryComponentType = {
             {/* Light */}
             <View
                 style={{
-                    backgroundColor: color.darkBlue,
+                    backgroundColor: semanticColor.surface.inverse,
                     padding: spacing.large_24,
                 }}
             >
@@ -262,7 +262,7 @@ export const StartAndEndIcons: StoryComponentType = {
                 >
                     This is a multi-line link with start and end icons
                 </Link>
-                <Body style={{color: color.white}}>
+                <Body style={{color: semanticColor.text.inverse}}>
                     This is an inline{" "}
                     <Link
                         href="#link"
@@ -340,7 +340,7 @@ export const Inline: StoryComponentType = {
  */
 export const InlineLight: StoryComponentType = {
     render: () => (
-        <Body style={{color: color.white}}>
+        <Body style={{color: semanticColor.text.inverse}}>
             This is an inline{" "}
             <Link href="#link" inline={true} light={true}>
                 regular link
@@ -395,7 +395,7 @@ export const WithTypography: StoryComponentType = {
 
 /**
  * Link can take a `style` prop. Here, the Link has been given a style in which
- * the `color` field has been set to `color.red`.
+ * the `color` field has been set to `semanticColor.status.critical.foreground`.
  */
 export const WithStyle: StoryComponentType = {
     render: () => (
@@ -517,21 +517,16 @@ export const RightToLeftWithIcons: StoryComponentType = {
 };
 
 const styles = StyleSheet.create({
-    darkBackground: {
-        backgroundColor: color.darkBlue,
-        color: color.white,
-        padding: 10,
-    },
     heading: {
         marginRight: spacing.large_24,
     },
     navigation: {
-        border: `1px dashed ${color.purple}`,
+        border: `1px dashed ${semanticColor.border.primary}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
     },
     customLink: {
-        color: color.red,
+        color: semanticColor.status.critical.foreground,
     },
     row: {
         flexDirection: "row",

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -403,43 +403,14 @@ export const WithStyle: StoryComponentType = {
             This link has a style.
         </Link>
     ),
+    parameters: {
+        chromatic: {
+            // Re-enable snapshots for this story since it's verifying that
+            // custom styles are applied (one-off)
+            disableSnapshot: false,
+        },
+    },
 };
-
-export const Navigation: StoryComponentType = () => (
-    <MemoryRouter>
-        <View>
-            <View style={styles.row}>
-                <Link
-                    href="/foo"
-                    style={styles.heading}
-                    onClick={() => {
-                        // eslint-disable-next-line no-console
-                        console.log("I'm still on the same page!");
-                    }}
-                >
-                    <LabelLarge>Uses Client-side Nav</LabelLarge>
-                </Link>
-                <Link
-                    href="/iframe.html?id=link--default&viewMode=story"
-                    style={styles.heading}
-                    skipClientNav
-                >
-                    <LabelLarge>Avoids Client-side Nav</LabelLarge>
-                </Link>
-            </View>
-            <View style={styles.navigation}>
-                <Switch>
-                    <Route path="/foo">
-                        <View id="foo">
-                            The first link does client-side navigation here.
-                        </View>
-                    </Route>
-                    <Route path="*">See navigation changes here</Route>
-                </Switch>
-            </View>
-        </View>
-    </MemoryRouter>
-);
 
 /**
  * If you want to navigate to an external URL and/or reload the window, make
@@ -450,12 +421,42 @@ export const Navigation: StoryComponentType = () => (
  * documentation](/story/button-navigation-callbacks--before-nav-callbacks&viewMode=docs)
  * for details.
  */
-Navigation.parameters = {
-    docs: {
-        description: {
-            story: ``,
-        },
-    },
+export const Navigation: StoryComponentType = {
+    render: () => (
+        <MemoryRouter>
+            <View>
+                <View style={styles.row}>
+                    <Link
+                        href="/foo"
+                        style={styles.heading}
+                        onClick={() => {
+                            // eslint-disable-next-line no-console
+                            console.log("I'm still on the same page!");
+                        }}
+                    >
+                        <LabelLarge>Uses Client-side Nav</LabelLarge>
+                    </Link>
+                    <Link
+                        href="/iframe.html?id=link--default&viewMode=story"
+                        style={styles.heading}
+                        skipClientNav
+                    >
+                        <LabelLarge>Avoids Client-side Nav</LabelLarge>
+                    </Link>
+                </View>
+                <View style={styles.navigation}>
+                    <Switch>
+                        <Route path="/foo">
+                            <View id="foo">
+                                The first link does client-side navigation here.
+                            </View>
+                        </Route>
+                        <Route path="*">See navigation changes here</Route>
+                    </Switch>
+                </View>
+            </View>
+        </MemoryRouter>
+    ),
 };
 
 /**

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -4,7 +4,13 @@ import {Link} from "react-router-dom";
 import {__RouterContext} from "react-router";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import {mix, fade, color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    mix,
+    color,
+    spacing,
+    semanticColor,
+    border,
+} from "@khanacademy/wonder-blocks-tokens";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import externalLinkIcon from "@phosphor-icons/core/bold/arrow-square-out-bold.svg";
@@ -167,6 +173,63 @@ const sharedStyles = StyleSheet.create({
     },
 });
 
+const action = semanticColor.action.outlined.progressive;
+
+// NOTE: This color is only used here.
+const pink = "#fa50ae";
+
+/**
+ * TODO(WB-1862): Move this to a shared theme file.
+ */
+const theme = {
+    color: {
+        // Primary link color
+        default: {
+            rest: {
+                foreground: action.default.foreground,
+            },
+            hover: {
+                foreground: action.hover.foreground,
+            },
+            focus: {
+                border: semanticColor.border.focus,
+                foreground: action.hover.foreground,
+            },
+            press: {
+                foreground: action.press.foreground,
+            },
+            restVisited: {
+                foreground: color.purple,
+            },
+            pressVisited: {
+                foreground: mix(color.offBlack32, color.purple),
+            },
+        },
+        // Over dark backgrounds
+        inverse: {
+            rest: {
+                foreground: semanticColor.text.inverse,
+            },
+            hover: {
+                foreground: semanticColor.text.inverse,
+            },
+            focus: {
+                border: semanticColor.border.inverse,
+                foreground: semanticColor.text.inverse,
+            },
+            press: {
+                foreground: color.fadedBlue,
+            },
+            restVisited: {
+                foreground: pink,
+            },
+            pressVisited: {
+                foreground: mix(color.white50, pink),
+            },
+        },
+    },
+};
+
 const _generateStyles = (
     inline: boolean,
     light: boolean,
@@ -177,47 +240,32 @@ const _generateStyles = (
         return styles[buttonType];
     }
 
-    const {blue, purple, white, offBlack, offBlack32} = color;
-
-    // NOTE: This color is only used here.
-    const pink = "#fa50ae";
-
-    // Standard purple
-    const linkPurple = mix(fade(offBlack, 0.08), purple);
-    // Light blue
-    const fadedBlue = color.fadedBlue;
-    // Light pink
-    const activeLightVisited = mix(fade(white, 0.32), pink);
-
-    const restTextColor = light ? white : blue;
-    const pressTextColor = light ? fadedBlue : color.activeBlue;
+    const variant = light ? theme.color.inverse : theme.color.default;
 
     const restVisited = visitable
         ? {
               ":visited": {
-                  color: light ? pink : linkPurple,
+                  color: variant.restVisited.foreground,
               },
           }
         : Object.freeze({});
     const pressVisited = visitable
         ? {
               ":visited": {
-                  color: light
-                      ? activeLightVisited
-                      : mix(offBlack32, linkPurple),
+                  color: variant.pressVisited.foreground,
               },
           }
         : Object.freeze({});
 
     const focusStyling = {
-        color: restTextColor,
-        outline: `1px solid ${light ? white : blue}`,
-        borderRadius: 3,
+        color: variant.focus.foreground,
+        outline: `${border.width.hairline}px solid ${variant.focus.border}`,
+        borderRadius: border.radius.small_3,
         ...restVisited,
     };
 
     const pressStyling = {
-        color: pressTextColor,
+        color: variant.press.foreground,
         textDecoration: "underline currentcolor solid",
         // TODO(WB-1521): Update the underline offset to be 4px after
         // the Link audit.
@@ -227,14 +275,14 @@ const _generateStyles = (
 
     const newStyles: StyleDeclaration = {
         rest: {
-            color: restTextColor,
+            color: variant.rest.foreground,
             ...restVisited,
             ":hover": {
                 // TODO(WB-1521): Update text decoration to the 1px dashed
                 // underline after the Link audit.
                 // textDecoration: "underline currentcolor dashed 2px",
                 textDecoration: "underline currentcolor solid",
-                color: restTextColor,
+                color: variant.hover.foreground,
                 // TODO(WB-1521): Update the underline offset to be 4px after
                 // the Link audit.
                 // textUnderlineOffset: 4,


### PR DESCRIPTION
Next step is to refactor the `Link` component to use semantic colors.

Besides the migration, this PR also includes the following changes:

- Reworked the theme structure to make it closer to the semanticColor structure.
- Updated stories to use the new semantic colors.

### Implementation plan:

1. #2439
2. #2440
3. #2441
4. #2446
5. #2449
6. Link (current PR)
7. Modal
8. Popover, Tooltip
9. Pill
10. Clickable, Toolbar


Issue: WB-1814

## Test plan:

Verify that the Chromatic snapshots are unchanged.

URL: `/?path=/story/packages-link-link-all-variants--default`