### PR TITLE
[add-style-reorder] Adjust props for type=button bug

### DIFF
--- a/.changeset/happy-flowers-complain.md
+++ b/.changeset/happy-flowers-complain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": patch
+---
+
+Reordering props in addStyle to handle a DOM prop rendering bug in WB Dropdown

--- a/packages/wonder-blocks-core/src/util/add-style.tsx
+++ b/packages/wonder-blocks-core/src/util/add-style.tsx
@@ -42,8 +42,8 @@ export default function addStyle<
 
         return (
             <Component
-                {...otherProps}
                 ref={ref}
+                {...otherProps} // Move otherProps after ref but before style
                 className={[aphroditeClassName, className]
                     .filter(Boolean)
                     .join(" ")}


### PR DESCRIPTION
## Summary:
Adding type="button" to SelectOpener in wonder-blocks-dropdown caused a ton of errors in CellCore for some reason. This change is an attempt to fix errors caused by type="button" by correctly ordering props for DOM elements using addStyle.

The error in files using SingleSelect and MultiSelect was:

```
Error: Element type is invalid: expected a string (for built-in components) 
or a class/function (for composite components) but got: object.

Check the render method of `CellCore`.
```

Issue: https://khanacademy.atlassian.net/browse/WB-1875

## Test plan:

1. Test snapshot in webapp.