### PR TITLE
[WB-1814.9] Refactor Clickable and Pill to use semantic colors

### DIFF
--- a/.changeset/friendly-weeks-drum.md
+++ b/.changeset/friendly-weeks-drum.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-pill": patch
+---
+
+- Migrate to `semanticColor`.
+- Update background from 16% to 8%.
+- Update focus outline to always be `blue` (using global focus color).

--- a/.changeset/shaggy-windows-rescue.md
+++ b/.changeset/shaggy-windows-rescue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-clickable": patch
+---
+
+Migrate Clickable to `semanticColor`

--- a/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
@@ -4,51 +4,51 @@ import {StyleSheet} from "aphrodite";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
+const actionCategory = semanticColor.action.outlined.progressive;
+
 const styles = StyleSheet.create({
-    resting: {
-        boxShadow: `inset 0px 0px 1px 1px ${color.purple}`,
+    rest: {
+        border: `1px solid ${actionCategory.default.border}`,
         padding: spacing.xSmall_8,
     },
-    hovered: {
+    hover: {
         textDecoration: "underline",
-        backgroundColor: color.blue,
-        color: color.white,
+        borderColor: actionCategory.hover.border,
+        backgroundColor: actionCategory.hover.background,
+        color: actionCategory.hover.foreground,
     },
-    pressed: {
-        color: color.darkBlue,
+    press: {
+        background: actionCategory.press.background,
+        borderColor: actionCategory.press.border,
+        color: actionCategory.press.foreground,
     },
-    focused: {
-        outline: `solid 4px ${color.purple}`,
+    focus: {
+        outline: `solid 1px ${semanticColor.border.focus}`,
+        outlineOffset: spacing.xxxxSmall_2,
     },
     panel: {
         padding: spacing.medium_16,
-        boxShadow: `inset 0px 0px 0 1px ${color.offBlack8}`,
+        // TODO(WB-1878): Use elevation token.
+        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,
     },
 });
 
 export default {
     title: "Packages / Clickable / Clickable / Accessibility",
     component: Clickable,
-
-    // Disables chromatic testing for these stories.
     parameters: {
-        previewTabs: {
-            canvas: {
-                hidden: true,
-            },
-        },
-
-        viewMode: "docs",
-
+        // Disables chromatic testing for these stories.
         chromatic: {
             disableSnapshot: true,
         },
     },
+    // Include these stories in the Docs tab, but hide them from the sidebar.
+    tags: ["autodocs", "!dev"],
 };
 
 export const Labeling = {
@@ -58,9 +58,7 @@ export const Labeling = {
                 onClick={() => {}}
                 aria-label="More information about this subject"
             >
-                {({hovered, focused, pressed}) => (
-                    <PhosphorIcon icon={IconMappings.info} />
-                )}
+                {() => <PhosphorIcon icon={IconMappings.info} />}
             </Clickable>
         </View>
     ),
@@ -73,9 +71,7 @@ export const DisabledState = {
             onClick={(e) => console.log("Hello, world!")}
             disabled={true}
         >
-            {({hovered, focused, pressed}) =>
-                "This is a disabled clickable element"
-            }
+            {() => "This is a disabled clickable element"}
         </Clickable>
     ),
 
@@ -89,10 +85,10 @@ export const KeyboardNavigation = {
                 {({hovered, focused, pressed}) => (
                     <View
                         style={[
-                            styles.resting,
-                            hovered && styles.hovered,
-                            focused && styles.focused,
-                            pressed && styles.pressed,
+                            styles.rest,
+                            hovered && styles.hover,
+                            focused && styles.focus,
+                            pressed && styles.press,
                         ]}
                     >
                         <Body>Open School Info</Body>

--- a/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View, addStyle} from "@khanacademy/wonder-blocks-core";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import packageConfig from "../../packages/wonder-blocks-clickable/package.json";
@@ -52,9 +52,9 @@ export const Default: StoryComponentType = (args: any) => {
                     <View
                         style={[
                             styles.clickable,
-                            hovered && styles.hovered,
-                            focused && styles.focused,
-                            pressed && styles.pressed,
+                            hovered && styles.hover,
+                            focused && styles.focus,
+                            pressed && styles.press,
                         ]}
                         {...childrenProps}
                     >
@@ -92,9 +92,9 @@ export const WrappingButton: StoryComponentType = (args: any) => {
                         style={[
                             styles.clickable,
                             styles.newButton,
-                            hovered && styles.hovered,
-                            focused && styles.focused,
-                            pressed && styles.pressed,
+                            hovered && styles.hover,
+                            focused && styles.focus,
+                            pressed && styles.press,
                         ]}
                         {...childrenProps}
                     >
@@ -125,9 +125,9 @@ export const WithTabIndex: StoryComponentType = () => {
                     <View
                         style={[
                             styles.clickable,
-                            hovered && styles.hovered,
-                            focused && styles.focused,
-                            pressed && styles.pressed,
+                            hovered && styles.hover,
+                            focused && styles.focus,
+                            pressed && styles.press,
                         ]}
                         {...childrenProps}
                     >
@@ -156,6 +156,8 @@ WithTabIndex.parameters = {
     },
 };
 
+const actionCategory = semanticColor.action.outlined.progressive;
+
 const styles = StyleSheet.create({
     clickable: {
         cursor: "pointer",
@@ -164,18 +166,19 @@ const styles = StyleSheet.create({
     },
     newButton: {
         border: "none",
-        backgroundColor: color.white,
+        backgroundColor: actionCategory.default.background,
         width: "100%",
     },
-    hovered: {
+    hover: {
         textDecoration: "underline",
-        backgroundColor: color.blue,
-        color: color.white,
+        backgroundColor: actionCategory.hover.background,
+        color: actionCategory.hover.foreground,
     },
-    pressed: {
-        backgroundColor: color.darkBlue,
+    press: {
+        backgroundColor: actionCategory.press.background,
     },
-    focused: {
-        outline: `solid 4px ${color.purple}`,
+    focus: {
+        outline: `solid 1px ${semanticColor.border.focus}`,
+        outlineOffset: spacing.xxxxSmall_2,
     },
 });

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -4,7 +4,7 @@ import {MemoryRouter, Route, Switch} from "react-router-dom";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
@@ -305,6 +305,8 @@ Ref.parameters = {
     },
 };
 
+const progressive = semanticColor.action.outlined.progressive;
+
 const styles = StyleSheet.create({
     clickable: {
         borderWidth: 1,
@@ -312,21 +314,21 @@ const styles = StyleSheet.create({
     },
     hovered: {
         textDecoration: "underline",
-        backgroundColor: color.teal,
+        backgroundColor: progressive.hover.background,
     },
     pressed: {
-        color: color.blue,
+        color: progressive.press.foreground,
     },
     focused: {
-        outline: `solid 4px ${color.purple}`,
+        outline: `solid 4px ${semanticColor.border.focus}`,
     },
     centerText: {
         gap: spacing.medium_16,
         textAlign: "center",
     },
     dark: {
-        backgroundColor: color.darkBlue,
-        color: color.white,
+        backgroundColor: semanticColor.surface.inverse,
+        color: semanticColor.text.inverse,
         padding: spacing.xSmall_8,
     },
     row: {
@@ -337,13 +339,13 @@ const styles = StyleSheet.create({
         marginRight: spacing.large_24,
     },
     navigation: {
-        border: `1px dashed ${color.purple}`,
+        border: `1px dashed ${semanticColor.border.primary}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
     },
     disabled: {
-        color: color.white,
-        backgroundColor: color.offBlack64,
+        color: semanticColor.text.inverse,
+        backgroundColor: semanticColor.surface.overlay,
     },
     button: {
         maxWidth: 150,

--- a/__docs__/wonder-blocks-pill/pill-variants.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill-variants.stories.tsx
@@ -1,0 +1,95 @@
+import type {Meta, StoryObj} from "@storybook/react";
+import * as React from "react";
+
+import {StyleSheet} from "aphrodite";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import Pill from "@khanacademy/wonder-blocks-pill";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {AllVariants} from "../components/all-variants";
+import {PillKind} from "../../packages/wonder-blocks-pill/src/components/pill";
+
+const rows = [
+    {name: "Static", props: {}},
+    {name: "Clickable", props: {onClick: () => {}}},
+];
+
+const columns = [
+    {
+        name: "Small",
+        props: {size: "small"},
+    },
+    {
+        name: "Medium",
+        props: {size: "medium"},
+    },
+    {
+        name: "Large",
+        props: {size: "large"},
+    },
+];
+
+type Story = StoryObj<typeof Pill>;
+
+const kinds: Array<PillKind> = [
+    "neutral",
+    "accent",
+    "info",
+    "success",
+    "warning",
+    "critical",
+    "transparent",
+];
+
+/**
+ * The following stories are used to generate the pseudo states for the Switch
+ * component. This is only used for visual testing in Chromatic.
+ */
+const meta = {
+    title: "Packages / Pill / Pill - All Variants",
+    component: Pill,
+    render: (args) => (
+        <AllVariants rows={rows} columns={columns}>
+            {(props) => (
+                <View style={styles.container}>
+                    {kinds.map((kind) => (
+                        <Pill {...args} {...props} kind={kind}>
+                            {kind}, {props.size}
+                        </Pill>
+                    ))}
+                </View>
+            )}
+        </AllVariants>
+    ),
+    args: {
+        children: "This is some text!",
+    },
+    tags: ["!autodocs"],
+} satisfies Meta<typeof Pill>;
+
+export default meta;
+
+export const Default: Story = {};
+
+export const Hover: Story = {
+    parameters: {pseudo: {hover: true}},
+};
+
+export const Focus: Story = {
+    parameters: {pseudo: {focusVisible: true}},
+};
+
+export const HoverFocus: Story = {
+    name: "Hover + Focus",
+    parameters: {pseudo: {hover: true, focusVisible: true}},
+};
+
+export const Active: Story = {
+    parameters: {pseudo: {hover: true, active: true}},
+};
+
+const styles = StyleSheet.create({
+    container: {
+        gap: spacing.medium_16,
+    },
+});

--- a/__docs__/wonder-blocks-pill/pill-variants.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill-variants.stories.tsx
@@ -32,13 +32,13 @@ const columns = [
 type Story = StoryObj<typeof Pill>;
 
 const kinds: Array<PillKind> = [
+    "transparent",
     "neutral",
     "accent",
     "info",
     "success",
     "warning",
     "critical",
-    "transparent",
 ];
 
 /**

--- a/__docs__/wonder-blocks-pill/pill.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill.stories.tsx
@@ -33,6 +33,10 @@ export default {
                 version={packageConfig.version}
             />
         ),
+        chromatic: {
+            // These stories are being tested in pill-variants.stories.tsx
+            disableSnapshot: true,
+        },
     },
     argTypes: PillArgtypes,
 } as Meta<typeof Pill>;
@@ -108,6 +112,8 @@ Inline.parameters = {
             if necessary.`,
         },
     },
+    // This story presents some context that is not present in the other stories
+    chromatic: {disableSnapshot: false},
 };
 
 /**
@@ -204,153 +210,6 @@ export const Variants: StoryComponentType = {
     },
 };
 
-// Test visual styles
-// TODO(WB-1810, somewhatabstract): These aren't working. I got some passing
-// locally by calling `.focus()` directly on the elements as well as via
-// fireEvent, but it was super duper flaky and never passed first time.
-// Variants.play = async ({canvasElement}) => {
-//     const canvas = within(canvasElement);
-
-//     // Define non-clickable pills
-//     const neutralSmall = canvas.getByTestId("neutral-small-test-id");
-//     const accentSmall = canvas.getByTestId("accent-small-test-id");
-//     const infoSmall = canvas.getByTestId("info-small-test-id");
-//     const successSmall = canvas.getByTestId("success-small-test-id");
-//     const warningSmall = canvas.getByTestId("warning-small-test-id");
-//     const criticalSmall = canvas.getByTestId("critical-small-test-id");
-//     const neutralMedium = canvas.getByTestId("neutral-medium-test-id");
-//     const neutralLarge = canvas.getByTestId("neutral-large-test-id");
-//     const accentLarge = canvas.getByTestId("accent-large-test-id");
-//     const infoLarge = canvas.getByTestId("info-large-test-id");
-//     const successLarge = canvas.getByTestId("success-large-test-id");
-//     const warningLarge = canvas.getByTestId("warning-large-test-id");
-//     const criticalLarge = canvas.getByTestId("critical-large-test-id");
-
-//     // Test non-clickable pill styles
-//     await expect(neutralSmall).toHaveStyle({
-//         backgroundColor: tokens.color.offBlack8,
-//         color: tokens.color.offBlack,
-//         fontSize: 12,
-//     });
-
-//     await expect(accentSmall).toHaveStyle({
-//         backgroundColor: tokens.color.blue,
-//         color: tokens.color.white,
-//         fontSize: 12,
-//     });
-
-//     await expect(infoSmall).toHaveStyle({
-//         backgroundColor: tokens.color.fadedBlue16,
-//         color: tokens.color.offBlack,
-//         fontSize: 12,
-//     });
-
-//     await expect(successSmall).toHaveStyle({
-//         backgroundColor: tokens.color.fadedGreen16,
-//         color: tokens.color.offBlack,
-//         fontSize: 12,
-//     });
-
-//     await expect(warningSmall).toHaveStyle({
-//         backgroundColor: tokens.color.fadedGold16,
-//         color: tokens.color.offBlack,
-//         fontSize: 12,
-//     });
-
-//     await expect(criticalSmall).toHaveStyle({
-//         backgroundColor: tokens.color.fadedRed16,
-//         color: tokens.color.offBlack,
-//         fontSize: 12,
-//     });
-
-//     await expect(neutralMedium).toHaveStyle({
-//         backgroundColor: tokens.color.offBlack8,
-//         color: tokens.color.offBlack,
-//         fontSize: 14,
-//     });
-
-//     await expect(neutralLarge).toHaveStyle({
-//         backgroundColor: tokens.color.offBlack8,
-//         color: tokens.color.offBlack,
-//         fontSize: 16,
-//     });
-
-//     await expect(accentLarge).toHaveStyle({
-//         backgroundColor: tokens.color.blue,
-//         color: tokens.color.white,
-//         fontSize: 16,
-//     });
-
-//     await expect(infoLarge).toHaveStyle({
-//         backgroundColor: tokens.color.fadedBlue16,
-//         color: tokens.color.offBlack,
-//         fontSize: 16,
-//     });
-
-//     await expect(successLarge).toHaveStyle({
-//         backgroundColor: tokens.color.fadedGreen16,
-//         color: tokens.color.offBlack,
-//         fontSize: 16,
-//     });
-
-//     await expect(warningLarge).toHaveStyle({
-//         backgroundColor: tokens.color.fadedGold16,
-//         color: tokens.color.offBlack,
-//         fontSize: 16,
-//     });
-
-//     await expect(criticalLarge).toHaveStyle({
-//         backgroundColor: tokens.color.fadedRed16,
-//         color: tokens.color.offBlack,
-//         fontSize: 16,
-//     });
-
-//     // Define clickable pills
-//     // const neutralMediumClickable = canvas.getByTestId(
-//     //     "neutral-medium-clickable-test-id",
-//     // );
-//     // const accentMediumClickable = canvas.getByTestId(
-//     //     "accent-medium-clickable-test-id",
-//     // );
-//     // const infoMediumClickable = canvas.getByTestId(
-//     //     "info-medium-clickable-test-id",
-//     // );
-//     // const successMediumClickable = canvas.getByTestId(
-//     //     "success-medium-clickable-test-id",
-//     // );
-//     // const warningMediumClickable = canvas.getByTestId(
-//     //     "warning-medium-clickable-test-id",
-//     // );
-//     // const criticalMediumClickable = canvas.getByTestId(
-//     //     "critical-medium-clickable-test-id",
-//     // );
-
-//     // Test clickable pill styles
-//     // await fireEvent.focus(neutralMediumClickable);
-//     // let computedStyle = getComputedStyle(neutralMediumClickable, ":hover");
-//     // await expect(computedStyle.outline).toBe("rgb(24, 101, 242) solid 2px");
-
-//     // await userEvent.tab();
-//     // computedStyle = getComputedStyle(accentMediumClickable, ":hover");
-//     // await expect(computedStyle.outline).toBe("rgb(24, 101, 242) solid 2px");
-
-//     // await userEvent.tab();
-//     // computedStyle = getComputedStyle(infoMediumClickable, ":hover");
-//     // await expect(computedStyle.outline).toBe("rgb(24, 101, 242) solid 2px");
-
-//     // await userEvent.tab();
-//     // computedStyle = getComputedStyle(successMediumClickable, ":hover");
-//     // await expect(computedStyle.outline).toBe("rgb(24, 101, 242) solid 2px");
-
-//     // await userEvent.tab();
-//     // computedStyle = getComputedStyle(warningMediumClickable, ":hover");
-//     // await expect(computedStyle.outline).toBe("rgb(24, 101, 242) solid 2px");
-
-//     // await userEvent.tab();
-//     // computedStyle = getComputedStyle(criticalMediumClickable, ":hover");
-//     // await expect(computedStyle.outline).toBe("rgb(217, 41, 22) solid 2px");
-// };
-
 export const WithTypography: StoryComponentType = () => (
     <Pill size="large">
         <BodySerif>
@@ -369,6 +228,7 @@ WithTypography.parameters = {
                 the text, as is shown here.`,
         },
     },
+    chromatic: {disableSnapshot: false},
 };
 
 export const WithStyle: StoryComponentType = () => {
@@ -411,6 +271,7 @@ WithStyle.parameters = {
                 it new color.`,
         },
     },
+    chromatic: {disableSnapshot: false},
 };
 
 export const InList: StoryComponentType = () => {

--- a/__docs__/wonder-blocks-pill/pill.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill.stories.tsx
@@ -233,18 +233,18 @@ WithTypography.parameters = {
 
 export const WithStyle: StoryComponentType = () => {
     const customStyle = {
-        backgroundColor: tokens.color.offBlack,
-        color: tokens.color.white,
+        backgroundColor: tokens.semanticColor.surface.inverse,
+        color: tokens.semanticColor.text.inverse,
         paddingLeft: tokens.spacing.xxLarge_48,
         paddingRight: tokens.spacing.xxLarge_48,
 
         ":hover": {
-            outlineColor: tokens.color.offBlack,
+            outlineColor: tokens.semanticColor.border.strong,
         },
 
         ":active": {
-            outlineColor: tokens.color.offBlack64,
-            backgroundColor: tokens.color.offBlack64,
+            outlineColor: tokens.semanticColor.border.primary,
+            backgroundColor: tokens.semanticColor.surface.overlay,
         },
     };
 

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -5,7 +5,7 @@ import {__RouterContext} from "react-router";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import {color} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 import getClickableBehavior from "../util/get-clickable-behavior";
 import type {ClickableRole, ClickableState} from "./clickable-behavior";
@@ -410,20 +410,23 @@ const styles = StyleSheet.create({
     },
     focused: {
         ":focus": {
-            outline: `solid 2px ${color.blue}`,
+            // TODO(WB-1856): Verify if we can set global focus styles
+            outline: `solid ${border.width.thin}px ${semanticColor.border.focus}`,
         },
     },
+    // TODO(WB-1852): Remove light variant.
     focusedLight: {
-        outline: `solid 2px ${color.white}`,
+        outline: `solid ${border.width.thin}px ${semanticColor.border.inverse}`,
     },
     disabled: {
-        color: color.offBlack32,
+        color: semanticColor.text.disabled,
         cursor: "not-allowed",
         ":focus": {
             outline: "none",
         },
         ":focus-visible": {
-            outline: `solid 2px ${color.blue}`,
+            // TODO(WB-1856): Verify if we can set global focus styles
+            outline: `solid ${border.width.thin}px ${semanticColor.border.focus}`,
         },
     },
 });

--- a/packages/wonder-blocks-pill/src/components/__tests__/pill.test.tsx
+++ b/packages/wonder-blocks-pill/src/components/__tests__/pill.test.tsx
@@ -2,8 +2,6 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
-import * as tokens from "@khanacademy/wonder-blocks-tokens";
-
 import Pill from "../pill";
 
 describe("Pill", () => {
@@ -149,32 +147,4 @@ describe("Pill", () => {
         // Assert
         expect(await screen.findByText("Hello, world!")).toBeInTheDocument();
     });
-
-    test.each`
-        kind             | color
-        ${"neutral"}     | ${tokens.color.offBlack8}
-        ${"accent"}      | ${tokens.color.blue}
-        ${"info"}        | ${tokens.color.fadedBlue16}
-        ${"success"}     | ${tokens.color.fadedGreen16}
-        ${"warning"}     | ${tokens.color.fadedGold16}
-        ${"critical"}    | ${tokens.color.fadedRed16}
-        ${"transparent"} | ${"transparent"}
-    `(
-        "renders the correct background color for $kind kind",
-        async ({kind, color}) => {
-            // Arrange, Act
-            render(
-                <Pill kind={kind} testId="pill-test-id">
-                    Hello, world!
-                </Pill>,
-            );
-
-            const pill = await screen.findByTestId("pill-test-id");
-
-            // Assert
-            expect(pill).toHaveStyle({
-                backgroundColor: color,
-            });
-        },
-    );
 });

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -15,6 +15,8 @@ import type {ClickableRole} from "@khanacademy/wonder-blocks-clickable";
 import * as tokens from "@khanacademy/wonder-blocks-tokens";
 import type {Typography} from "@khanacademy/wonder-blocks-typography";
 
+const {semanticColor} = tokens;
+
 export type PillKind =
     | "neutral"
     | "accent"
@@ -218,67 +220,82 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
 
     switch (kind) {
         case "accent":
-            backgroundColor = tokens.color.blue;
+            backgroundColor = semanticColor.status.notice.foreground;
             break;
         case "info":
-            backgroundColor = tokens.color.fadedBlue16;
+            backgroundColor = semanticColor.status.notice.background;
             break;
         case "success":
-            backgroundColor = tokens.color.fadedGreen16;
+            backgroundColor = semanticColor.status.success.background;
             break;
         case "warning":
-            backgroundColor = tokens.color.fadedGold16;
+            backgroundColor = semanticColor.status.warning.background;
             break;
         case "critical":
-            backgroundColor = tokens.color.fadedRed16;
+            backgroundColor = semanticColor.status.critical.background;
             break;
         case "transparent":
             backgroundColor = "transparent";
             break;
         case "neutral":
         default:
-            backgroundColor = tokens.color.offBlack8;
+            backgroundColor = semanticColor.status.neutral.background;
     }
 
-    const activeColor =
-        kind === "neutral" || kind === "transparent"
-            ? tokens.color.offBlack16
-            : mix(tokens.color.offBlack32, backgroundColor);
+    const pressColor =
+        kind === "transparent"
+            ? semanticColor.status.neutral.background
+            : // NOTE(WB-1880): This will be simplified once we split this into Badge and Pill.
+              mix(tokens.color.offBlack32, backgroundColor);
 
     const textColor =
-        kind === "accent" ? tokens.color.white : tokens.color.offBlack;
-    const outlineColor =
-        kind === "critical" ? tokens.color.red : tokens.color.blue;
-    const activeOutlineColor =
-        kind === "critical" ? tokens.color.activeRed : tokens.color.activeBlue;
+        kind === "accent"
+            ? semanticColor.text.inverse
+            : semanticColor.text.primary;
 
-    const outline =
-        kind === "transparent"
-            ? `1px solid ${tokens.color.offBlack16}`
-            : "none";
+    const theme = {
+        default: {
+            border:
+                kind === "transparent"
+                    ? `1px solid ${semanticColor.border.primary}`
+                    : "none",
+            background: backgroundColor,
+            foreground: textColor,
+        },
+        focus: {
+            border: semanticColor.border.focus,
+        },
+        hover: {
+            border: semanticColor.border.focus,
+        },
+        press: {
+            border: semanticColor.action.filled.progressive.press.border,
+            background: pressColor,
+        },
+    };
 
     const colorStyles: StyleDeclaration = {
         pill: {
-            backgroundColor: backgroundColor,
-            outline,
-            color: textColor,
+            backgroundColor: theme.default.background,
+            outline: theme.default.border,
+            color: theme.default.foreground,
             alignItems: "center",
             justifyContent: "center",
         },
         clickableWrapper: {
-            outline,
+            outline: theme.default.border,
 
             ":hover": {
-                outline: `2px solid ${outlineColor}`,
+                outline: `2px solid ${theme.hover.border}`,
                 outlineOffset: tokens.spacing.xxxxSmall_2,
             },
             ":active": {
-                backgroundColor: activeColor,
-                outline: `2px solid ${activeOutlineColor}`,
+                backgroundColor: theme.press.background,
+                outline: `2px solid ${theme.press.border}`,
                 outlineOffset: tokens.spacing.xxxxSmall_2,
             },
             ":focus-visible": {
-                outline: `2px solid ${outlineColor}`,
+                outline: `2px solid ${theme.focus.border}`,
                 outlineOffset: tokens.spacing.xxxxSmall_2,
             },
         },


### PR DESCRIPTION
## Summary:

- Migrate Clickable and Pill to use semantic colors
- Add `All Variants` story to Pill

### Implementation plan:

1. #2439
2. #2440
3. #2441
4. #2446
5. #2449
6. #2464
7. #2468
8. #2470
9. Clickable, Pill (current PR)
10. Dropdown

Issue: WB-1814

## Test plan:

Navigate to the `Clickable` and `Pill` stories in Storybook and verify that the
colors are correct.