### PR TITLE
[FEI-6161] Update docs and examples to suggest LabeledField

### DIFF
--- a/.changeset/new-donuts-melt.md
+++ b/.changeset/new-donuts-melt.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-search-field": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Update component docs to include labelling guidelines

--- a/.changeset/witty-wolves-fry.md
+++ b/.changeset/witty-wolves-fry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Marking LabeledTextField with `@deprecated` in favour of LabeledField + TextField

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -187,7 +187,7 @@ export const Default: StoryComponentType = {
  * description, required indicator, and/or error message for the field.
  *
  * Using the field with the LabeledField component will ensure that the field
- * has the relavent accessibility attributes set.
+ * has the relevant accessibility attributes set.
  */
 export const WithLabeledField: StoryComponentType = {
     render: function LabeledFieldStory(args) {

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -39,6 +39,14 @@ type MultiSelectArgs = Partial<typeof MultiSelect>;
  * The multi select stays open until closed by the user. The onChange callback
  * happens every time there is a change in the selection of the items.
  *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
+ *
  * ### Usage
  *
  * ```tsx

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -182,6 +182,47 @@ export const Default: StoryComponentType = {
     },
 };
 
+/**
+ * The field can be used with the LabeledField component to provide a label,
+ * description, required indicator, and/or error message for the field.
+ *
+ * Using the field with the LabeledField component will ensure that the field
+ * has the relavent accessibility attributes set.
+ */
+export const WithLabeledField: StoryComponentType = {
+    render: function LabeledFieldStory(args) {
+        const [value, setValue] = React.useState(args.selectedValues || []);
+        const [errorMessage, setErrorMessage] = React.useState<
+            string | null | undefined
+        >();
+        return (
+            <LabeledField
+                label="Label"
+                field={
+                    <MultiSelect
+                        {...args}
+                        selectedValues={value}
+                        onChange={setValue}
+                        onValidate={setErrorMessage}
+                    >
+                        {optionItems}
+                    </MultiSelect>
+                }
+                description="Description"
+                required={true}
+                errorMessage={errorMessage}
+            />
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this is for documentation purposes and is
+            // covered by the LabeledField stories
+            disableSnapshot: true,
+        },
+    },
+};
+
 const ControlledWrapper = (args: any) => {
     const [selectedValues, setSelectedValues] = React.useState<Array<string>>(
         [],

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -51,6 +51,14 @@ type SingleSelectArgs = Partial<typeof SingleSelect>;
  * performance when rendering these elements and is capable of handling many
  * hundreds of items without performance problems.
  *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
+ *
  * ### Usage
  *
  * #### General usage

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -217,6 +217,47 @@ export const Default: StoryComponentType = {
 };
 
 /**
+ * The field can be used with the LabeledField component to provide a label,
+ * description, required indicator, and/or error message for the field.
+ *
+ * Using the field with the LabeledField component will ensure that the field
+ * has the relavent accessibility attributes set.
+ */
+export const WithLabeledField: StoryComponentType = {
+    render: function LabeledFieldStory(args) {
+        const [value, setValue] = React.useState(args.selectedValue || "");
+        const [errorMessage, setErrorMessage] = React.useState<
+            string | null | undefined
+        >();
+        return (
+            <LabeledField
+                label="Label"
+                field={
+                    <SingleSelect
+                        {...args}
+                        selectedValue={value}
+                        onChange={setValue}
+                        onValidate={setErrorMessage}
+                    >
+                        {optionItems}
+                    </SingleSelect>
+                }
+                description="Description"
+                required={true}
+                errorMessage={errorMessage}
+            />
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this is for documentation purposes and is
+            // covered by the LabeledField stories
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
  * Controlled SingleSelect
  */
 const ControlledOpenedWrapper = (args: any) => {

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -221,7 +221,7 @@ export const Default: StoryComponentType = {
  * description, required indicator, and/or error message for the field.
  *
  * Using the field with the LabeledField component will ensure that the field
- * has the relavent accessibility attributes set.
+ * has the relevant accessibility attributes set.
  */
 export const WithLabeledField: StoryComponentType = {
     render: function LabeledFieldStory(args) {

--- a/__docs__/wonder-blocks-form/_overview_.mdx
+++ b/__docs__/wonder-blocks-form/_overview_.mdx
@@ -49,6 +49,12 @@ user is done interacting with a field.
 button is for one field.
 - If there are errors after a form is submitted, programatically move the user's
 focus to the first field with an error.
+- Accessibility: When using a `<form>` element to wrap form fields, avoid using
+event handlers (such as key events) directly on the `<form>` element since it
+is non-interactive. To submit a form when the `Enter` key is pressed,
+include a `Button` with `type="submit"` inside the form and handle submission
+using the `onSubmit` prop on the `<form>` element. The "Enter to submit" functionality
+is handled by the browser.
 
 Here is an example of validation behaviour in a form. It validates when a
 user is done filling out a field and also shows a validation error once

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -107,7 +107,7 @@ export const Default: StoryComponentType = {
  * description, required indicator, and/or error message for the field.
  *
  * Using the field with the LabeledField component will ensure that the field
- * has the relavent accessibility attributes set.
+ * has the relevant accessibility attributes set.
  */
 export const WithLabeledField: StoryComponentType = {
     render: function LabeledFieldStory(args) {

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -18,6 +18,14 @@ import {validateEmail} from "./form-utilities";
 
 /**
  * A TextArea is an element used to accept text from the user.
+ *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
  */
 export default {
     title: "Packages / Form / TextArea",

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -103,6 +103,45 @@ export const Default: StoryComponentType = {
 };
 
 /**
+ * The field can be used with the LabeledField component to provide a label,
+ * description, required indicator, and/or error message for the field.
+ *
+ * Using the field with the LabeledField component will ensure that the field
+ * has the relavent accessibility attributes set.
+ */
+export const WithLabeledField: StoryComponentType = {
+    render: function LabeledFieldStory(args) {
+        const [value, setValue] = React.useState(args.value || "");
+        const [errorMessage, setErrorMessage] = React.useState<
+            string | null | undefined
+        >();
+        return (
+            <LabeledField
+                label="Label"
+                field={
+                    <TextArea
+                        {...args}
+                        value={value}
+                        onChange={setValue}
+                        onValidate={setErrorMessage}
+                    />
+                }
+                description="Description"
+                required={true}
+                errorMessage={errorMessage}
+            />
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this is for documentation purposes and is
+            // covered by the LabeledField stories
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
  * When setting a value and onChange props, you can use it as a controlled
  * component.
  */

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -69,7 +69,7 @@ export const Default: StoryComponentType = {
  * description, required indicator, and/or error message for the field.
  *
  * Using the field with the LabeledField component will ensure that the field
- * has the relavent accessibility attributes set.
+ * has the relevant accessibility attributes set.
  */
 export const WithLabeledField: StoryComponentType = {
     render: function LabeledFieldStory(args) {

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -19,6 +19,14 @@ import LabeledField from "../../packages/wonder-blocks-labeled-field/src/compone
 
 /**
  * A TextField is an element used to accept a single line of text from the user.
+ *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
  */
 export default {
     title: "Packages / Form / TextField",

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -10,12 +10,12 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {LabelLarge, Body} from "@khanacademy/wonder-blocks-typography";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
+import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 
 import ComponentInfo from "../components/component-info";
 import TextFieldArgTypes from "./text-field.argtypes";
 import {validateEmail, validatePhoneNumber} from "./form-utilities";
-import LabeledField from "../../packages/wonder-blocks-labeled-field/src/components/labeled-field";
 
 /**
  * A TextField is an element used to accept a single line of text from the user.
@@ -61,6 +61,45 @@ export const Default: StoryComponentType = {
         onKeyDown: () => {},
         onFocus: () => {},
         onBlur: () => {},
+    },
+};
+
+/**
+ * The field can be used with the LabeledField component to provide a label,
+ * description, required indicator, and/or error message for the field.
+ *
+ * Using the field with the LabeledField component will ensure that the field
+ * has the relavent accessibility attributes set.
+ */
+export const WithLabeledField: StoryComponentType = {
+    render: function LabeledFieldStory(args) {
+        const [value, setValue] = React.useState(args.value || "");
+        const [errorMessage, setErrorMessage] = React.useState<
+            string | null | undefined
+        >();
+        return (
+            <LabeledField
+                label="Label"
+                field={
+                    <TextField
+                        {...args}
+                        value={value}
+                        onChange={setValue}
+                        onValidate={setErrorMessage}
+                    />
+                }
+                description="Description"
+                required={true}
+                errorMessage={errorMessage}
+            />
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this is for documentation purposes and is
+            // covered by the LabeledField stories
+            disableSnapshot: true,
+        },
     },
 };
 

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -5,7 +5,7 @@ import packageConfig from "../../packages/wonder-blocks-labeled-field/package.js
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {TextArea, TextField} from "@khanacademy/wonder-blocks-form";
 import LabeledFieldArgTypes from "./labeled-field.argtypes";
-import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
+import {addStyle, PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     MultiSelect,
@@ -67,6 +67,8 @@ export const Default: StoryComponentType = {
         required: "Custom required message",
     },
 };
+
+const StyledForm = addStyle("form");
 
 const AllFields = (
     storyArgs: PropsFor<typeof LabeledField> & {
@@ -208,7 +210,14 @@ const AllFields = (
     };
 
     return (
-        <View style={{gap: spacing.large_24}}>
+        <StyledForm
+            onSubmit={handleSubmit}
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: spacing.large_24,
+            }}
+        >
             <LabeledField
                 {...args}
                 errorMessage={textFieldErrorMessage}
@@ -310,10 +319,8 @@ const AllFields = (
                 }
             />
 
-            {showSubmitButtonInStory && (
-                <Button onClick={handleSubmit}>Submit</Button>
-            )}
-        </View>
+            {showSubmitButtonInStory && <Button type="submit">Submit</Button>}
+        </StyledForm>
     );
 };
 

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -119,7 +119,7 @@ export const Default: StoryComponentType = {
  * description, required indicator, and/or error message for the field.
  *
  * Using the field with the LabeledField component will ensure that the field
- * has the relavent accessibility attributes set.
+ * has the relevant accessibility attributes set.
  */
 export const WithLabeledField: StoryComponentType = {
     render: function LabeledFieldStory(args) {

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -18,6 +18,14 @@ import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
  * `SearchField` helps users input text to search for relevant content. It is
  * commonly used in search bars and search forms.
  *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
+ *
  * ### Usage
  *
  * ```tsx

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -115,6 +115,45 @@ export const Default: StoryComponentType = {
 };
 
 /**
+ * The field can be used with the LabeledField component to provide a label,
+ * description, required indicator, and/or error message for the field.
+ *
+ * Using the field with the LabeledField component will ensure that the field
+ * has the relavent accessibility attributes set.
+ */
+export const WithLabeledField: StoryComponentType = {
+    render: function LabeledFieldStory(args) {
+        const [value, setValue] = React.useState(args.value || "");
+        const [errorMessage, setErrorMessage] = React.useState<
+            string | null | undefined
+        >();
+        return (
+            <LabeledField
+                label="Label"
+                field={
+                    <SearchField
+                        {...args}
+                        value={value}
+                        onChange={setValue}
+                        onValidate={setErrorMessage}
+                    />
+                }
+                description="Description"
+                required={true}
+                errorMessage={errorMessage}
+            />
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this is for documentation purposes and is
+            // covered by the LabeledField stories
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
  * SearchField takes a `disabled` prop, which makes it unusable. Try to avoid
  * using this if possible as it is bad for accessibility.
  */

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -213,11 +213,16 @@ type Props = AriaProps &
  * multiple options to be selected. Clients are responsible for keeping track
  * of the selected items.
  *
- * Clients are also responsible for labeling the select using `LabeledField`, or
- * an `aria-label` attribute or `aria-labelledby` on the select.
- *
  * The multi select stays open until closed by the user. The onChange callback
  * happens every time there is a change in the selection of the items.
+ *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
  *
  * ## Usage
  *

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -206,11 +206,16 @@ type Props = AriaProps &
  * The single select allows the selection of one item. Clients are responsible
  * for keeping track of the selected item in the select.
  *
- * Clients are also responsible for labeling the select using `LabeledField`, an
- * `aria-label` attribute, or `aria-labelledby`.
- *
  * The single select dropdown closes after the selection of an item. If the same
  * item is selected, there is no callback.
+ *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
  *
  * **NOTE:** If there are more than 125 items, the component automatically uses
  * [react-window](https://github.com/bvaughn/react-window) to improve

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -156,12 +156,8 @@ type State = {
 };
 
 /**
- * **DEPRECATED**: Please use `LabeledField` with `TextField` instead.
- *
  * A LabeledTextField is an element used to accept a single line of text
  * from the user paired with a label, description, and error field elements.
- *
- * @deprecated
  */
 class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
     static defaultProps: DefaultProps = {
@@ -299,8 +295,12 @@ type ExportProps = OmitConstrained<
 >;
 
 /**
+ * **DEPRECATED**: Please use `LabeledField` with `TextField` instead.
+ *
  * A LabeledTextField is an element used to accept a single line of text
  * from the user paired with a label, description, and error field elements.
+ *
+ * @deprecated
  *
  * ### Usage
  *

--- a/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/labeled-text-field.tsx
@@ -156,8 +156,12 @@ type State = {
 };
 
 /**
+ * **DEPRECATED**: Please use `LabeledField` with `TextField` instead.
+ *
  * A LabeledTextField is an element used to accept a single line of text
  * from the user paired with a label, description, and error field elements.
+ *
+ * @deprecated
  */
 class LabeledTextField extends React.Component<PropsWithForwardRef, State> {
     static defaultProps: DefaultProps = {

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -187,6 +187,17 @@ type TextAreaProps = AriaProps & {
 
 const StyledTextarea = addStyle("textarea");
 
+/**
+ * A TextArea is an element used to accept text from the user.
+ *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
+ */
 const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     function TextArea(
         props: TextAreaProps,

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -167,6 +167,14 @@ type PropsWithForwardRef = Props & WithForwardRef;
 
 /**
  * A TextField is an element used to accept a single line of text from the user.
+ *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
  */
 const TextField = (props: PropsWithForwardRef) => {
     const {

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -167,14 +167,6 @@ type PropsWithForwardRef = Props & WithForwardRef;
 
 /**
  * A TextField is an element used to accept a single line of text from the user.
- *
- * Make sure to provide a label for the field. This can be done by either:
- * - (recommended) Using the **LabeledField** component to provide a label,
- * description, and/or error message for the field
- * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
- * the field
- * - Using an `aria-label` attribute on the field
- * - Using an `aria-labelledby` attribute on the field
  */
 const TextField = (props: PropsWithForwardRef) => {
     const {
@@ -357,6 +349,13 @@ type ExportProps = OmitConstrained<
 /**
  * A TextField is an element used to accept a single line of text from the user.
  *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
  * ### Usage
  *
  * ```jsx

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -110,6 +110,14 @@ type Props = AriaProps & {
  * Search Field. A TextField with a search icon on its left side
  * and an X icon on its right side.
  *
+ * Make sure to provide a label for the field. This can be done by either:
+ * - (recommended) Using the **LabeledField** component to provide a label,
+ * description, and/or error message for the field
+ * - Using a `label` html tag with the `htmlFor` prop set to the unique id of
+ * the field
+ * - Using an `aria-label` attribute on the field
+ * - Using an `aria-labelledby` attribute on the field
+ *
  * ### Usage
  * ```jsx
  * import {SearchField} from "@khanacademy/wonder-blocks-search-field";


### PR DESCRIPTION
## Summary:
- Update component docs for TextField, TextArea, SearchField, SingleSelect and MultiSelect with guidelines for labelling, including using LabeledField. These suggestions will be shown with Intellisense
- Add stories for these fields to show it being used with LabeledField
- Add the `@deprecated` tag for the LabeledTextField component. The component docs for it were also updated to suggest using LabeledField + TextField instead
- Updated LabeledField form example to use form element with onSubmit prop. Also added docs for form guidelines around this behaviour. This shows how to avoid using event handlers on non-interactive elements (form elements)

Issue: FEI-6161

## Test plan:
- Review LabeledField section in docs for:
  - TextField (`?path=/docs/packages-form-textfield--docs#with%20labeled%20field`)
  - TextArea (`?path=/docs/packages-form-textarea--docs#with%20labeled%20field`)
  - SingleSelect (`?path=/docs/packages-dropdown-singleselect--docs#with%20labeled%20field`)
  - MultiSelect (`?path=/docs/packages-dropdown-multiselect--docs#with%20labeled%20field`)
  - SearchField (`?path=/docs/packages-searchfield--docs#with%20labeled%20field`)
- Review Form Best Practices
  - Error Validation (`?path=/docs/packages-form-overview--docs#error-validation`)
  - Ensure pressing Enter from a form field triggers form submission validation (`?path=/docs/packages-form-overview--docs#error-validation`)
- Confirm the labelling suggestions show up when the field components are used

| TextField | TextArea | SingleSelect | MultiSelect | SearchField |
|---|---|---|---|---|
| <img width="1083" alt="text-field-docs" src="https://github.com/user-attachments/assets/35c5199d-8399-47a5-bb4d-cc165f3c9a23" /> | <img width="1081" alt="text-area-docs" src="https://github.com/user-attachments/assets/0809cd0c-137a-45ee-9608-48fc16428def" /> | <img width="1133" alt="single-select-docs" src="https://github.com/user-attachments/assets/4c7a6987-eaf5-4275-bb52-bb07ffa07a2f" /> | <img width="1126" alt="multi-select-docs" src="https://github.com/user-attachments/assets/5cfe3275-4733-4d07-8d4a-3012d6cce716" /> | <img width="1125" alt="search-field-docs" src="https://github.com/user-attachments/assets/b4425d4e-49a1-4a83-80e4-78108c9daa34" /> |

- Confirm that LabeledTextField is marked as deprecated

<img width="974" alt="deprecated-labeled-text-field" src="https://github.com/user-attachments/assets/f017985f-7e1f-4699-adfa-ed624ef5e613" />
