### PR TITLE
Enable View to accept all tag names

### DIFF
--- a/.changeset/angry-boxes-own.md
+++ b/.changeset/angry-boxes-own.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Enables View to accept all tag names

--- a/packages/wonder-blocks-core/src/components/__tests__/__snapshots__/view.test.tsx.snap
+++ b/packages/wonder-blocks-core/src/components/__tests__/__snapshots__/view.test.tsx.snap
@@ -27,6 +27,15 @@ exports[`View Should set the tag to be div 1`] = `
 </div>
 `;
 
+exports[`View Should set the tag to be main 1`] = `
+<div>
+  <main
+    class=""
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0;"
+  />
+</div>
+`;
+
 exports[`View Should set the tag to be nav 1`] = `
 <div>
   <nav

--- a/packages/wonder-blocks-core/src/components/__tests__/view.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/view.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable testing-library/no-node-access */
+/* eslint-disable testing-library/no-container */
 import * as React from "react";
 import {render} from "@testing-library/react";
 
@@ -9,17 +11,11 @@ describe("View", () => {
         const view = <View tag="section" />;
         const {container} = render(view);
 
-        // Assert
-        expect(container).toMatchSnapshot();
-    });
-
-    it("Should set the tag to be section", () => {
-        // Arrage, Act
-        const view = <View tag="section" />;
-        const {container} = render(view);
+        const section = container.querySelector("section");
 
         // Assert
         expect(container).toMatchSnapshot();
+        expect(section).toBeDefined();
     });
 
     it("Should set the tag to be article", () => {
@@ -27,8 +23,11 @@ describe("View", () => {
         const view = <View tag="article" />;
         const {container} = render(view);
 
+        const article = container.querySelector("article");
+
         // Assert
         expect(container).toMatchSnapshot();
+        expect(article).toBeDefined();
     });
 
     it("Should set the tag to be aside", () => {
@@ -36,8 +35,11 @@ describe("View", () => {
         const view = <View tag="aside" />;
         const {container} = render(view);
 
+        const aside = container.querySelector("aside");
+
         // Assert
         expect(container).toMatchSnapshot();
+        expect(aside).toBeDefined();
     });
 
     it("Should set the tag to be nav", () => {
@@ -45,8 +47,23 @@ describe("View", () => {
         const view = <View tag="nav" />;
         const {container} = render(view);
 
+        const nav = container.querySelector("nav");
+
         // Assert
         expect(container).toMatchSnapshot();
+        expect(nav).toBeDefined();
+    });
+
+    it("Should set the tag to be main", () => {
+        // Arrage, Act
+        const view = <View tag="main" />;
+        const {container} = render(view);
+
+        const main = container.querySelector("main");
+
+        // Assert
+        expect(container).toMatchSnapshot();
+        expect(main).toBeDefined();
     });
 
     it("Should set the tag to be div", () => {
@@ -54,7 +71,10 @@ describe("View", () => {
         const view = <View />;
         const {container} = render(view);
 
+        const div = container.querySelector("div");
+
         // Assert
         expect(container).toMatchSnapshot();
+        expect(div).toBeDefined();
     });
 });

--- a/packages/wonder-blocks-core/src/components/view.tsx
+++ b/packages/wonder-blocks-core/src/components/view.tsx
@@ -25,19 +25,12 @@ const styles = StyleSheet.create({
     },
 });
 
-type ValidViewTags = "div" | "article" | "aside" | "nav" | "section";
 type Props = TextViewSharedProps & {
     /**
      * The HTML tag to render.
      */
-    tag?: ValidViewTags;
+    tag?: keyof JSX.IntrinsicElements;
 };
-
-const StyledDiv = addStyle("div", styles.default);
-const StyledArticle = addStyle("article", styles.default);
-const StyledAside = addStyle("aside", styles.default);
-const StyledNav = addStyle("nav", styles.default);
-const StyledSection = addStyle("section", styles.default);
 
 /**
  * View is a building block for constructing other components. `View` roughly
@@ -76,27 +69,8 @@ const View: React.ForwardRefExoticComponent<
         "data-testid": testId,
     } as const;
 
-    switch (tag) {
-        case "article":
-            return <StyledArticle {...commonProps} ref={ref} />;
-        case "aside":
-            return <StyledAside {...commonProps} ref={ref} />;
-        case "nav":
-            return <StyledNav {...commonProps} ref={ref} />;
-        case "section":
-            return <StyledSection {...commonProps} ref={ref} />;
-        case "div":
-            return (
-                <StyledDiv
-                    {...commonProps}
-                    ref={ref as React.Ref<HTMLDivElement>}
-                />
-            );
-        default:
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            tag as never;
-            throw Error(`${tag} is not an allowed value for the 'tag' prop`);
-    }
+    const StyledTag = addStyle(tag, styles.default);
+    return <StyledTag {...commonProps} ref={ref} />;
 });
 
 export default View;


### PR DESCRIPTION
Enables View to accept all React-compatible tag names.

This will allow Views to accept `main` and `header`, for instance.

Tests added.
