### PR TITLE
[WB-1890] Link: Remove `visitable` prop

### DIFF
--- a/.changeset/rude-bobcats-tap.md
+++ b/.changeset/rude-bobcats-tap.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-link": major
+---
+
+Removes the `visitable` prop as it is not used. Also, removed as per design recommendation for privacy purposes.

--- a/__docs__/wonder-blocks-link/link-variants.stories.tsx
+++ b/__docs__/wonder-blocks-link/link-variants.stories.tsx
@@ -51,10 +51,6 @@ const columns = [
             target: "_blank",
         },
     },
-    {
-        name: "Visitable",
-        props: {visitable: true},
-    },
 ];
 
 const themes: Array<string> = ["default", "dark", "rtl"];

--- a/__docs__/wonder-blocks-link/link.argtypes.tsx
+++ b/__docs__/wonder-blocks-link/link.argtypes.tsx
@@ -63,15 +63,6 @@ export default {
         },
     },
 
-    visitable: {
-        control: {type: "boolean"},
-        description:
-            "Whether the link should change color once it's visited. Secondary or primary (light) links are not allowed to be visitable.",
-        table: {
-            type: {summary: "boolean"},
-        },
-    },
-
     rel: {
         control: {type: "text"},
         description: `Specifies the type of relationship between the current

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -51,43 +51,12 @@ export const Default: StoryComponentType = {
 };
 
 /**
- * This is a visitable link. It changes color after it has been clicked on to
- * indicate that it's been visited before. This link's `visitable` prop is set
- * to true. It links to the top of the page.
- */
-export const Visitable: StoryComponentType = {
-    render: () => (
-        <Link href="#link" visitable={true}>
-            The quick brown fox jumps over the lazy dog.
-        </Link>
-    ),
-};
-
-/**
  * Minimal link usage on a dark background. This link has its `light` prop set
  * to true. It links to the top of the page.
  */
 export const LightPrimary: StoryComponentType = {
     render: () => (
         <Link href="#link" light={true}>
-            The quick brown fox jumps over the lazy dog.
-        </Link>
-    ),
-    parameters: {
-        backgrounds: {
-            default: "darkBlue",
-        },
-    },
-};
-
-/**
- * This is a visitable link on a dark background. It changes color after it has
- * been clicked on to indicate that it's been visited before. This link's
- * `visitable` prop is set to true. It links to the top of the page.
- */
-export const LightVisitable: StoryComponentType = {
-    render: () => (
-        <Link href="#link" light={true} visitable={true}>
             The quick brown fox jumps over the lazy dog.
         </Link>
     ),
@@ -304,27 +273,14 @@ export const Inline: StoryComponentType = {
             This is an inline{" "}
             <Link href="#link" inline={true}>
                 regular link
-            </Link>{" "}
-            and an inline{" "}
+            </Link>
+            . In this sentence, there is also an inline{" "}
             <Link
                 href="https://www.procatinator.com/"
                 inline={true}
                 target="_blank"
             >
                 external link
-            </Link>
-            , and this is an inline{" "}
-            <Link href="#link" visitable={true} inline={true}>
-                Visitable link
-            </Link>{" "}
-            and an inline{" "}
-            <Link
-                href="https://www.procatinator.com/"
-                visitable={true}
-                inline={true}
-                target="_blank"
-            >
-                external Visitable link
             </Link>
             .
         </Body>
@@ -352,8 +308,8 @@ export const InlineLight: StoryComponentType = {
             This is an inline{" "}
             <Link href="#link" inline={true} light={true}>
                 regular link
-            </Link>{" "}
-            and an{" "}
+            </Link>
+            . In this sentence, there is also an inline{" "}
             <Link
                 href="https://cat-bounce.com/"
                 inline={true}
@@ -361,20 +317,6 @@ export const InlineLight: StoryComponentType = {
                 target="_blank"
             >
                 external link
-            </Link>
-            , whereas this is an inline{" "}
-            <Link href="#link" visitable={true} inline={true} light={true}>
-                Visitable link
-            </Link>{" "}
-            and an{" "}
-            <Link
-                href="https://cat-bounce.com/"
-                visitable={true}
-                inline={true}
-                light={true}
-                target="_blank"
-            >
-                external Visitable link
             </Link>
             .
         </Body>

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -5,7 +5,6 @@ import {__RouterContext} from "react-router";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {
-    mix,
     color,
     spacing,
     semanticColor,
@@ -44,7 +43,6 @@ const LinkCore = React.forwardRef(function LinkCore(
             href,
             inline = false,
             light = false,
-            visitable = false,
             pressed,
             style,
             testId,
@@ -55,7 +53,7 @@ const LinkCore = React.forwardRef(function LinkCore(
             ...restProps
         } = props;
 
-        const linkStyles = _generateStyles(inline, light, visitable);
+        const linkStyles = _generateStyles(inline, light);
 
         const defaultStyles = [
             sharedStyles.shared,
@@ -175,9 +173,6 @@ const sharedStyles = StyleSheet.create({
 
 const action = semanticColor.action.outlined.progressive;
 
-// NOTE: This color is only used here.
-const pink = "#fa50ae";
-
 /**
  * TODO(WB-1862): Move this to a shared theme file.
  */
@@ -198,12 +193,6 @@ const theme = {
             press: {
                 foreground: action.press.foreground,
             },
-            restVisited: {
-                foreground: color.purple,
-            },
-            pressVisited: {
-                foreground: mix(color.offBlack32, color.purple),
-            },
         },
         // Over dark backgrounds
         inverse: {
@@ -220,48 +209,22 @@ const theme = {
             press: {
                 foreground: color.fadedBlue,
             },
-            restVisited: {
-                foreground: pink,
-            },
-            pressVisited: {
-                foreground: mix(color.white50, pink),
-            },
         },
     },
 };
 
-const _generateStyles = (
-    inline: boolean,
-    light: boolean,
-    visitable: boolean,
-) => {
-    const buttonType = `${inline.toString()}-${light.toString()}-${visitable.toString()}`;
+const _generateStyles = (inline: boolean, light: boolean) => {
+    const buttonType = `${inline.toString()}-${light.toString()}`;
     if (styles[buttonType]) {
         return styles[buttonType];
     }
 
     const variant = light ? theme.color.inverse : theme.color.default;
 
-    const restVisited = visitable
-        ? {
-              ":visited": {
-                  color: variant.restVisited.foreground,
-              },
-          }
-        : Object.freeze({});
-    const pressVisited = visitable
-        ? {
-              ":visited": {
-                  color: variant.pressVisited.foreground,
-              },
-          }
-        : Object.freeze({});
-
     const focusStyling = {
         color: variant.focus.foreground,
         outline: `${border.width.hairline}px solid ${variant.focus.border}`,
         borderRadius: border.radius.small_3,
-        ...restVisited,
     };
 
     const pressStyling = {
@@ -270,13 +233,11 @@ const _generateStyles = (
         // TODO(WB-1521): Update the underline offset to be 4px after
         // the Link audit.
         // textUnderlineOffset: 4,
-        ...pressVisited,
     };
 
     const newStyles: StyleDeclaration = {
         rest: {
             color: variant.rest.foreground,
-            ...restVisited,
             ":hover": {
                 // TODO(WB-1521): Update text decoration to the 1px dashed
                 // underline after the Link audit.
@@ -286,7 +247,6 @@ const _generateStyles = (
                 // TODO(WB-1521): Update the underline offset to be 4px after
                 // the Link audit.
                 // textUnderlineOffset: 4,
-                ...restVisited,
             },
             // Focus styles only show up with keyboard navigation.
             // Mouse users don't see focus styles.

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -32,11 +32,6 @@ type CommonProps = AriaProps & {
      */
     light?: boolean;
     /**
-     * Whether the link should change color once it's visited.
-     * secondary or primary (light) links are not allowed to be visitable.
-     */
-    visitable?: boolean;
-    /**
      * Specifies the type of relationship between the current document and the
      * linked document. Should only be used when `href` is specified. This
      * defaults to "noopener noreferrer" when `target="_blank"`, but can be
@@ -194,7 +189,6 @@ const Link = React.forwardRef(function Link(
         target = undefined,
         inline = false,
         light = false,
-        visitable = false,
         ...sharedProps
     } = props;
 
@@ -229,7 +223,6 @@ const Link = React.forwardRef(function Link(
                                 tabIndex={tabIndex}
                                 inline={inline}
                                 light={light}
-                                visitable={visitable}
                                 ref={ref}
                             >
                                 {children}
@@ -262,7 +255,6 @@ const Link = React.forwardRef(function Link(
                                 tabIndex={tabIndex}
                                 inline={inline}
                                 light={light}
-                                visitable={visitable}
                                 ref={ref}
                             >
                                 {children}


### PR DESCRIPTION
## Summary:

Removed the `visitable` prop as it is not used in `webapp` (only 1 call site).
Also removed as per design recommendation for privacy purposes.

Confluence: https://khanacademy.atlassian.net/wiki/spaces/WB/pages/3769925723/Token+usage+in+Wonder+Blocks+components?focusedCommentId=3782017071

Issue: WB-1890

## Test plan:

Verify that the `Visitable` example in the `Link` storybook is no longer available.