### PR TITLE
[WB-1856] Focus: Define general pattern for focus indicators in all components

### DIFF
--- a/.changeset/chilled-otters-hang.md
+++ b/.changeset/chilled-otters-hang.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tokens": major
 ---
 
-Rename `semanticColor.border.focus` to `semanticColor.focus.outer`
+Rename `semanticColor.border.focus` to `semanticColor.focus.outer`, and add `focus.inner`.

--- a/.changeset/chilled-otters-hang.md
+++ b/.changeset/chilled-otters-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": major
+---
+
+Rename `semanticColor.border.focus` to `semanticColor.focus.outer`

--- a/.changeset/funny-rocks-smoke.md
+++ b/.changeset/funny-rocks-smoke.md
@@ -1,0 +1,15 @@
+---
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-switch": patch
+"@khanacademy/wonder-blocks-tokens": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-pill": patch
+---
+
+Switch to use `focus.outer` semanticColor token

--- a/__docs__/components/gallery/component-tile.tsx
+++ b/__docs__/components/gallery/component-tile.tsx
@@ -126,7 +126,7 @@ const styles = StyleSheet.create({
 
         ":focus": {
             border: `1px solid ${tokens.color.blue}`,
-            outline: `1px solid ${tokens.color.blue}`,
+            outline: `1px solid ${tokens.semanticColor.focus.outer}`,
         },
     },
     descriptionWithDetails: {

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -48,8 +48,8 @@ in our product and how these are reflected in our primitive tokens.
 
 Colors are defined into two categories:
 
--   <Link href="#semantic-colors">Semantic Colors</Link>
--   <Link href="#primitive-colors">Primitive Colors</Link>
+- <Link href="#semantic-colors">Semantic Colors</Link>
+- <Link href="#primitive-colors">Primitive Colors</Link>
 
 ## Semantic Colors
 
@@ -215,6 +215,16 @@ would use `border.primary`, rows and layout elements use
 contrast is a priority (ex. form elements)
 
 <ColorGroup colors={semanticColor.border} group="border" />
+
+### Focus
+
+For focus states on interactive elements. This is meant to be used globally for
+all interactive elements regardless of the state (disabled, error, etc).
+
+- `outer`: The outer ring of the focus state.
+- `inner`: The inner ring of the focus state.
+
+<ColorGroup colors={semanticColor.focus} group="focus" />
 
 ### Icon
 
@@ -437,12 +447,12 @@ content is accessible to all users.
 
 For more detail, you can check the following Success Criteria documents:
 
--   <a href="https://www.w3.org/WAI/WCAG22/Understanding/use-of-color">
-        Use of Color
-    </a>
--   <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum">
-        Contrast (minimum)
-    </a>
--   <a href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast">
-        Non-text Contrast (Level AA)
-    </a>
+- <a href="https://www.w3.org/WAI/WCAG22/Understanding/use-of-color">
+      Use of Color
+  </a>
+- <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum">
+      Contrast (minimum)
+  </a>
+- <a href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast">
+      Non-text Contrast (Level AA)
+  </a>

--- a/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
         color: actionCategory.press.foreground,
     },
     focus: {
-        outline: `solid 1px ${semanticColor.border.focus}`,
+        outline: `solid 1px ${semanticColor.focus.outer}`,
         outlineOffset: spacing.xxxxSmall_2,
     },
     panel: {

--- a/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
         backgroundColor: actionCategory.press.background,
     },
     focus: {
-        outline: `solid 1px ${semanticColor.border.focus}`,
+        outline: `solid 1px ${semanticColor.focus.outer}`,
         outlineOffset: spacing.xxxxSmall_2,
     },
 });

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -320,7 +320,7 @@ const styles = StyleSheet.create({
         color: progressive.press.foreground,
     },
     focused: {
-        outline: `solid 4px ${semanticColor.border.focus}`,
+        outline: `solid 4px ${semanticColor.focus.outer}`,
     },
     centerText: {
         gap: spacing.medium_16,

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -151,7 +151,7 @@ const styles = StyleSheet.create({
         padding: spacing.medium_16,
     },
     focused: {
-        outlineColor: semanticColor.border.focus,
+        outlineColor: semanticColor.focus.outer,
         outlineOffset: spacing.xxxxSmall_2,
     },
     hovered: {

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -124,7 +124,7 @@ const styles = StyleSheet.create({
         padding: spacing.medium_16,
     },
     focused: {
-        outlineColor: semanticColor.border.focus,
+        outlineColor: semanticColor.focus.outer,
         outlineOffset: spacing.xxxxSmall_2,
     },
     hovered: {

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -130,7 +130,7 @@ const styles = StyleSheet.create({
         padding: spacing.medium_16,
     },
     focused: {
-        outlineColor: semanticColor.border.focus,
+        outlineColor: semanticColor.focus.outer,
         outlineOffset: spacing.xxxxSmall_2,
     },
     hovered: {

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -180,11 +180,11 @@ const styles = StyleSheet.create({
         },
 
         ":hover": {
-            outline: `2px solid ${semanticColor.border.focus}`,
+            outline: `2px solid ${semanticColor.action.outlined.progressive.hover.border}`,
         },
 
         ":focus-visible": {
-            outline: `2px solid ${semanticColor.border.focus}`,
+            outline: `2px solid ${semanticColor.focus.outer}`,
         },
     },
     headerWrapperWithAnimation: {

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -239,8 +239,7 @@ const styles = StyleSheet.create({
         color: "inherit",
 
         ":focus-visible": {
-            // TODO(WB-1856): Verify if we can use the global focus color
-            outline: `2px solid ${semanticColor.action.disabled.default}`,
+            outline: `2px solid ${semanticColor.focus.outer}`,
         },
     },
 });

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -362,8 +362,7 @@ export const _generateStyles = (
         const themeColorAction = theme.color.filled[colorToAction];
 
         const focusStyling = {
-            // TODO(WB-1856): Change with global focus token
-            outlineColor: themeColorAction.hover.border,
+            outlineColor: themeColorAction.focus.border,
             outlineOffset: theme.border.offset.primary,
             outlineStyle: "solid",
             outlineWidth: theme.border.width.focused,
@@ -407,7 +406,7 @@ export const _generateStyles = (
 
         const focusStyling = {
             background: themeColorAction.hover.background,
-            outlineColor: themeColorAction.hover.border,
+            outlineColor: themeColorAction.focus.border,
             outlineStyle: "solid",
             outlineOffset: theme.border.offset.secondary,
             outlineWidth: theme.border.width.focused,
@@ -462,7 +461,7 @@ export const _generateStyles = (
         const focusStyling = {
             outlineStyle: "solid",
             borderColor: "transparent",
-            outlineColor: themeColorAction.hover.border,
+            outlineColor: themeColorAction.focus.border,
             outlineWidth: theme.border.width.focused,
             borderRadius: theme.border.radius.default,
         };

--- a/packages/wonder-blocks-button/src/themes/default.ts
+++ b/packages/wonder-blocks-button/src/themes/default.ts
@@ -7,6 +7,14 @@ const {semanticColor} = tokens;
 // breaking with descenders.
 const textUnderlineOffset = tokens.spacing.xxxSmall_4;
 
+const focusOutline = {
+    border: semanticColor.focus.outer,
+};
+
+const focusOutlineLight = {
+    border: semanticColor.border.inverse,
+};
+
 const theme = {
     color: {
         /**
@@ -16,6 +24,7 @@ const theme = {
             // kind=primary / color=default / light=false
             progressive: {
                 ...semanticColor.action.filled.progressive,
+                focus: focusOutline,
                 disabled: {
                     border: semanticColor.action.disabled.default,
                     background: semanticColor.action.disabled.default,
@@ -32,6 +41,7 @@ const theme = {
                     ...semanticColor.action.outlined.progressive.hover,
                     border: semanticColor.border.inverse,
                 },
+                focus: focusOutlineLight,
                 press: {
                     ...semanticColor.action.outlined.progressive.press,
                     border: semanticColor.action.outlined.progressive.press
@@ -51,6 +61,7 @@ const theme = {
             // kind=primary / color=destructive / light=false
             destructive: {
                 ...semanticColor.action.filled.destructive,
+                focus: focusOutline,
                 disabled: {
                     border: semanticColor.action.disabled.default,
                     background: semanticColor.action.disabled.default,
@@ -62,6 +73,7 @@ const theme = {
             // light variant.
             destructiveLight: {
                 ...semanticColor.action.outlined.destructive,
+                focus: focusOutlineLight,
                 hover: {
                     ...semanticColor.action.outlined.progressive.hover,
                     border: semanticColor.border.inverse,
@@ -98,6 +110,7 @@ const theme = {
                     // NOTE: This is a special case for the secondary button
                     background: "transparent",
                 },
+                focus: focusOutline,
                 hover: {
                     ...semanticColor.action.outlined.progressive.hover,
                     // NOTE: This is a special case for the secondary button
@@ -121,6 +134,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 hover: {
                     border: semanticColor.border.inverse,
                     background: "transparent",
@@ -149,6 +163,7 @@ const theme = {
             // kind=secondary / color=destructive / light=false
             destructive: {
                 ...semanticColor.action.outlined.destructive,
+                focus: focusOutline,
                 hover: {
                     ...semanticColor.action.outlined.destructive.hover,
                     // NOTE: This is a special case for the secondary button
@@ -172,6 +187,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 hover: {
                     border: semanticColor.border.inverse,
                     background: "transparent",
@@ -210,6 +226,7 @@ const theme = {
                         semanticColor.action.outlined.progressive.default
                             .foreground,
                 },
+                focus: focusOutline,
                 hover: {
                     border: semanticColor.action.outlined.progressive.hover
                         .border,
@@ -233,6 +250,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 hover: {
                     border: semanticColor.border.inverse,
                     background: "transparent",
@@ -256,6 +274,7 @@ const theme = {
                         semanticColor.action.outlined.destructive.default
                             .foreground,
                 },
+                focus: focusOutline,
                 hover: {
                     border: semanticColor.action.outlined.destructive.hover
                         .border,
@@ -279,6 +298,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 hover: {
                     border: semanticColor.border.inverse,
                     background: "transparent",

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -410,8 +410,7 @@ const styles = StyleSheet.create({
     },
     focused: {
         ":focus": {
-            // TODO(WB-1856): Verify if we can set global focus styles
-            outline: `solid ${border.width.thin}px ${semanticColor.border.focus}`,
+            outline: `solid ${border.width.thin}px ${semanticColor.focus.outer}`,
         },
     },
     // TODO(WB-1852): Remove light variant.
@@ -425,8 +424,7 @@ const styles = StyleSheet.create({
             outline: "none",
         },
         ":focus-visible": {
-            // TODO(WB-1856): Verify if we can set global focus styles
-            outline: `solid ${border.width.thin}px ${semanticColor.border.focus}`,
+            outline: `solid ${border.width.thin}px ${semanticColor.focus.outer}`,
         },
     },
 });

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -207,7 +207,7 @@ const styles = StyleSheet.create({
             // Override the default focus state for the cell element, so that it
             // can be added programmatically to the button element.
             borderRadius: spacing.xxxSmall_4,
-            outline: `${spacing.xxxxSmall_2}px solid ${semanticColor.border.focus}`,
+            outline: `${spacing.xxxxSmall_2}px solid ${semanticColor.focus.outer}`,
             outlineOffset: -spacing.xxxxSmall_2,
         },
 

--- a/packages/wonder-blocks-dropdown/src/components/combobox-multiple-selection.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox-multiple-selection.tsx
@@ -103,6 +103,6 @@ const styles = StyleSheet.create({
         paddingInlineEnd: spacing.xxxSmall_4,
     },
     pillFocused: {
-        outline: `1px solid ${semanticColor.border.focus}`,
+        outline: `1px solid ${semanticColor.focus.outer}`,
     },
 });

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -696,7 +696,7 @@ const theme = {
                 background: semanticColor.surface.primary,
             },
             focus: {
-                border: semanticColor.border.focus,
+                border: semanticColor.focus.outer,
                 background: semanticColor.surface.primary,
             },
             disabled: {

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -305,7 +305,7 @@ const focusedStyle = {
     // Override the default focus state for the cell element, so that it
     // can be added programmatically to the button element.
     borderRadius: spacing.xxxSmall_4,
-    outline: `${spacing.xxxxSmall_2}px solid ${semanticColor.border.focus}`,
+    outline: `${spacing.xxxxSmall_2}px solid ${semanticColor.focus.outer}`,
     outlineOffset: -spacing.xxxxSmall_2,
 };
 
@@ -475,7 +475,7 @@ const styles = StyleSheet.create({
     },
     itemFocused: focusedStyle,
     itemDisabled: {
-        outlineColor: semanticColor.border.focus,
+        outlineColor: semanticColor.focus.outer,
     },
     itemContainer: {
         minHeight: "unset",

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -286,6 +286,10 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
         ...sharedOutlineStyling,
         outlineColor: semanticColor.focus.outer,
     };
+    const hoverStyling = {
+        ...sharedOutlineStyling,
+        outlineColor: action.hover.border,
+    };
     const pressStyling = {
         background: action.press.background,
         color: placeholder
@@ -298,11 +302,6 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
     };
 
     const currentState = error ? states.error : states.default;
-
-    const hoverStyling = {
-        ...sharedOutlineStyling,
-        outlineColor: currentState.border,
-    };
 
     const newStyles = {
         default: {

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -274,7 +274,7 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
     // resting/default state.
     const action = semanticColor.action.outlined[actionType];
 
-    // TODO(WB-1856): Define global semantic outline tokens.
+    // TODO(WB-1868): Address outlineOffset to include hover and focus states
     const sharedOutlineStyling = {
         // Outline sits inside the border (inset)
         outlineOffset: -border.width.thin,
@@ -282,9 +282,9 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
         outlineWidth: border.width.thin,
     };
 
-    const focusHoverStyling = {
-        outlineColor: semanticColor.focus.outer,
+    const focusStyling = {
         ...sharedOutlineStyling,
+        outlineColor: semanticColor.focus.outer,
     };
     const pressStyling = {
         background: action.press.background,
@@ -299,6 +299,11 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
 
     const currentState = error ? states.error : states.default;
 
+    const hoverStyling = {
+        ...sharedOutlineStyling,
+        outlineColor: currentState.border,
+    };
+
     const newStyles = {
         default: {
             background: currentState.background,
@@ -307,7 +312,7 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
             color: placeholder
                 ? semanticColor.text.secondary
                 : currentState.foreground,
-            ":hover:not([aria-disabled=true])": focusHoverStyling,
+            ":hover:not([aria-disabled=true])": hoverStyling,
             // Allow hover styles on non-touch devices only. This prevents an
             // issue with hover being sticky on touch devices (e.g. mobile).
             ["@media not (hover: hover)"]: {
@@ -318,7 +323,7 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
                     paddingRight: spacing.small_12,
                 },
             },
-            ":focus-visible:not([aria-disabled=true])": focusHoverStyling,
+            ":focus-visible:not([aria-disabled=true])": focusStyling,
             ":active:not([aria-disabled=true])": pressStyling,
         },
         disabled: {

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -283,9 +283,7 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
     };
 
     const focusHoverStyling = {
-        // TODO(WB-1856): Use `border.focus` when we define a global pattern for
-        // focus indicators.
-        outlineColor: action.hover.border,
+        outlineColor: semanticColor.focus.outer,
         ...sharedOutlineStyling,
     };
     const pressStyling = {
@@ -329,9 +327,7 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
             color: states.disabled.foreground,
             cursor: "not-allowed",
             ":focus-visible": {
-                // TODO(WB-1856): Use `border.focus` when we define a global
-                // pattern for focus indicators.
-                outlineColor: semanticColor.action.disabled.default,
+                outlineColor: semanticColor.focus.outer,
                 ...sharedOutlineStyling,
             },
         },

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -203,8 +203,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
                 // Focus and hover have the same style. Focus style only shows
                 // up with keyboard navigation.
                 ":focus-visible": {
-                    // TODO(WB-1856): Define global pattern for focus styles
-                    outline: `${border.width.thin}px solid ${colorAction.hover.border}`,
+                    outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
                     outlineOffset: 1,
                 },
 
@@ -235,8 +234,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
                     backgroundColor: error
                         ? states.error.background
                         : colorAction.hover.background,
-                    // TODO(WB-1856): Define global pattern for focus styles
-                    outline: `${border.width.thin}px solid ${colorAction.hover.border}`,
+                    outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
                     outlineOffset: -1,
                 },
 

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -139,8 +139,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
                 // Focus and hover have the same style. Focus style only shows
                 // up with keyboard navigation.
                 ":focus-visible": {
-                    // TODO(WB-1856): Define global pattern for focus styles
-                    outline: `${border.width.thin}px solid ${colorAction.hover.border}`,
+                    outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
                     outlineOffset: 1,
                 },
 
@@ -170,8 +169,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
                     backgroundColor: error
                         ? states.error.background
                         : colorAction.hover.background,
-                    // TODO(WB-1856): Define global pattern for focus styles
-                    outline: `${border.width.thin}px solid ${colorAction.hover.border}`,
+                    outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
                     outlineOffset: -1,
                 },
 

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -358,8 +358,8 @@ const styles = StyleSheet.create({
     },
     defaultFocus: {
         ":focus-visible": {
-            borderColor: semanticColor.border.focus,
-            outline: `${border.width.hairline}px solid ${semanticColor.border.focus}`,
+            borderColor: semanticColor.focus.outer,
+            outline: `${border.width.hairline}px solid ${semanticColor.focus.outer}`,
             // Negative outline offset so it focus outline is not cropped off if
             // an ancestor element has overflow: hidden
             outlineOffset: -2,
@@ -374,8 +374,7 @@ const styles = StyleSheet.create({
         },
         cursor: "not-allowed",
         ":focus-visible": {
-            // TODO(WB-1856): Verify if we can use the global focus color
-            outline: `${border.width.thin}px solid ${semanticColor.action.disabled.default}`,
+            outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
             outlineOffset: -3,
         },
     },

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -386,8 +386,7 @@ const styles = StyleSheet.create({
             color: semanticColor.text.secondary,
         },
         ":focus-visible": {
-            // TODO(WB-1856): Verify if we can use the global focus color
-            outlineColor: states.error.border,
+            outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
             borderColor: states.error.border,
         },
     },

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -302,8 +302,8 @@ const styles = StyleSheet.create({
     },
     defaultFocus: {
         ":focus-visible": {
-            borderColor: semanticColor.border.focus,
-            outline: `${border.width.hairline}px solid ${semanticColor.border.focus}`,
+            borderColor: semanticColor.focus.outer,
+            outline: `${border.width.hairline}px solid ${semanticColor.focus.outer}`,
             // Negative outline offset so it focus outline is not cropped off if
             // an ancestor element has overflow: hidden
             outlineOffset: -2,
@@ -317,8 +317,7 @@ const styles = StyleSheet.create({
             color: semanticColor.text.secondary,
         },
         ":focus-visible": {
-            // TODO(WB-1856): Verify if we can use the global focus color
-            outlineColor: states.error.border,
+            outlineColor: semanticColor.focus.outer,
             borderColor: states.error.border,
         },
     },

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -318,7 +318,7 @@ const styles = StyleSheet.create({
         },
         ":focus-visible": {
             outlineColor: semanticColor.focus.outer,
-            borderColor: states.error.border,
+            outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
         },
     },
     disabled: {
@@ -330,8 +330,7 @@ const styles = StyleSheet.create({
         },
         cursor: "not-allowed",
         ":focus-visible": {
-            // TODO(WB-1856): Verify if we can use the global focus color
-            outline: `${border.width.thin}px solid ${semanticColor.action.disabled.default}`,
+            outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
             outlineOffset: -3,
         },
     },

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -270,7 +270,7 @@ function getStylesByKind(
             disabled: {
                 background: themeVariant.default.background,
                 color: themeVariant.default.foreground,
-                outlineColor: themeVariant.default.border,
+                outlineColor: themeVariant.focus.border,
             },
         };
     }
@@ -302,7 +302,7 @@ function getStylesByKind(
             disabled: {
                 background: themeVariant.default.background,
                 color: themeVariant.default.foreground,
-                outlineColor: themeVariant.default.border,
+                outlineColor: themeVariant.focus.border,
             },
         };
     }

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -259,7 +259,7 @@ function getStylesByKind(
                     : theme.border.width.hovered,
             },
             ":focus-visible": {
-                outlineColor: themeVariant.hover.border,
+                outlineColor: themeVariant.focus.border,
             },
             ":active": {
                 borderColor: themeVariant.press.border,
@@ -290,7 +290,7 @@ function getStylesByKind(
                 outlineWidth: theme.border.width.active,
             },
             ":focus-visible": {
-                outlineColor: themeVariant.hover.border,
+                outlineColor: themeVariant.focus.border,
             },
             ":active": {
                 borderColor: themeVariant.press.border,

--- a/packages/wonder-blocks-icon-button/src/themes/default.ts
+++ b/packages/wonder-blocks-icon-button/src/themes/default.ts
@@ -13,6 +13,14 @@ const disabledLightStates = {
     foreground: color.white50,
 };
 
+const focusOutline = {
+    border: semanticColor.focus.outer,
+};
+
+const focusOutlineLight = {
+    border: semanticColor.border.inverse,
+};
+
 /**
  * The color styles shared between all the button kinds.
  *
@@ -28,6 +36,7 @@ const baseColorStates = {
             border: "transparent",
             background: "transparent",
         },
+        focus: focusOutline,
         press: {
             border: semanticColor.action.outlined.progressive.press.border,
             background: "transparent",
@@ -42,6 +51,7 @@ const baseColorStates = {
             border: "transparent",
             background: "transparent",
         },
+        focus: focusOutline,
         press: {
             border: semanticColor.action.outlined.destructive.press.border,
             background: "transparent",
@@ -51,12 +61,14 @@ const baseColorStates = {
     },
     disabled: {
         default: disabledStates,
+        focus: focusOutline,
         hover: disabledStates,
         press: disabledStates,
     },
     // TODO(WB-1852): Remove light variants.
     disabledLight: {
         default: disabledLightStates,
+        focus: focusOutlineLight,
         hover: disabledLightStates,
         press: disabledLightStates,
     },
@@ -79,6 +91,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 press: {
                     border: color.fadedBlue,
                     background: "transparent",
@@ -97,6 +110,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 press: {
                     border: color.fadedRed,
                     background: "transparent",

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -187,7 +187,7 @@ const theme = {
                 foreground: action.hover.foreground,
             },
             focus: {
-                border: semanticColor.border.focus,
+                border: semanticColor.focus.outer,
                 foreground: action.hover.foreground,
             },
             press: {

--- a/packages/wonder-blocks-modal/src/themes/default.ts
+++ b/packages/wonder-blocks-modal/src/themes/default.ts
@@ -56,7 +56,7 @@ const theme = {
     },
     panel: {
         color: {
-            border: semanticColor.border.focus,
+            border: semanticColor.focus.outer,
         },
         spacing: {
             gap: spacing.xLarge_32,

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -263,10 +263,10 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
             foreground: textColor,
         },
         focus: {
-            border: semanticColor.border.focus,
+            border: semanticColor.focus.outer,
         },
         hover: {
-            border: semanticColor.border.focus,
+            border: semanticColor.action.filled.progressive.hover.border,
         },
         press: {
             border: semanticColor.action.filled.progressive.press.border,

--- a/packages/wonder-blocks-switch/src/themes/default.ts
+++ b/packages/wonder-blocks-switch/src/themes/default.ts
@@ -33,7 +33,7 @@ const theme = {
             },
         },
         outline: {
-            default: semanticColor.border.focus,
+            default: semanticColor.focus.outer,
         },
     },
     border: {

--- a/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
@@ -4,7 +4,6 @@ const border = {
     primary: color.fadedOffBlack16,
     subtle: color.fadedOffBlack8,
     strong: color.fadedOffBlack50,
-    focus: color.blue,
     inverse: color.white,
 };
 
@@ -148,6 +147,11 @@ export const semanticColor = {
      * -Strong for when 3:1 contrast is a priority (ex. form elements)
      */
     border: border,
+
+    focus: {
+        outer: color.blue,
+        inner: color.white,
+    },
     /**
      * Default icon colors that change in context (like actions).
      */


### PR DESCRIPTION
## Summary:

- Tokens: Renamed `border.focus` to `focus.outer` and added a new `focus.inner` token.
- Switch all components to use a new `focus.outer` semanticColor token.
- Consolidated all the interactive elements to use the same global semantic focus token. This means that `error` and `disabled` states now use the blue outline when focused.

Issue: WB-1856

## Test plan:

Verify that all components have the correct focus indicator color.