### PR TITLE
[WB-1844] Button: Create separate styles for hover and focus

### DIFF
--- a/.changeset/smooth-kiwis-reflect.md
+++ b/.changeset/smooth-kiwis-reflect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-button": patch
+---
+
+Split hover and focus into separate styles. Use default outline ring color for all variants (blue)

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -361,12 +361,20 @@ export const _generateStyles = (
     if (kind === "primary") {
         const themeColorAction = theme.color.filled[colorToAction];
 
-        const focusStyling = {
-            // TODO(WB-1856): Change with global focus token
-            outlineColor: themeColorAction.hover.border,
+        const sharedFocusHoverStyling = {
             outlineOffset: theme.border.offset.primary,
             outlineStyle: "solid",
             outlineWidth: theme.border.width.focused,
+        };
+
+        const focusStyling = {
+            ...sharedFocusHoverStyling,
+            outlineColor: themeColorAction.focus.border,
+        };
+
+        const hoverStyling = {
+            ...sharedFocusHoverStyling,
+            outlineColor: themeColorAction.hover.border,
         };
 
         const activePressedStyling = {
@@ -382,9 +390,7 @@ export const _generateStyles = (
                 background: themeColorAction.default.background,
                 color: themeColorAction.default.foreground,
                 paddingInline: padding,
-                // TODO(WB-1844): Change this when we get final designs for
-                // hover.
-                [":hover:not([aria-disabled=true])" as any]: focusStyling,
+                [":hover:not([aria-disabled=true])" as any]: hoverStyling,
                 [":focus-visible:not([aria-disabled=true])" as any]:
                     focusStyling,
                 [":active:not([aria-disabled=true])" as any]:
@@ -396,21 +402,27 @@ export const _generateStyles = (
                 background: themeColorAction.disabled.background,
                 color: themeColorAction.disabled.foreground,
                 cursor: "default",
-                ":focus-visible": {
-                    ...focusStyling,
-                    outlineColor: themeColorAction.disabled.border,
-                },
+                ":focus-visible": focusStyling,
             },
         };
     } else if (kind === "secondary") {
         const themeColorAction = theme.color.outlined[colorToAction];
 
-        const focusStyling = {
+        const sharedFocusHoverStyling = {
             background: themeColorAction.hover.background,
-            outlineColor: themeColorAction.hover.border,
             outlineStyle: "solid",
             outlineOffset: theme.border.offset.secondary,
             outlineWidth: theme.border.width.focused,
+        };
+
+        const focusStyling = {
+            ...sharedFocusHoverStyling,
+            outlineColor: themeColorAction.focus.border,
+        };
+
+        const hoverStyling = {
+            ...sharedFocusHoverStyling,
+            outlineColor: themeColorAction.hover.border,
         };
 
         const activePressedStyling = {
@@ -429,9 +441,7 @@ export const _generateStyles = (
                 borderStyle: "solid",
                 borderWidth: theme.border.width.secondary,
                 paddingInline: padding,
-                // TODO(WB-1844): Change this when we get final designs for
-                // hover.
-                [":hover:not([aria-disabled=true])" as any]: focusStyling,
+                [":hover:not([aria-disabled=true])" as any]: hoverStyling,
                 [":focus-visible:not([aria-disabled=true])" as any]:
                     focusStyling,
                 [":active:not([aria-disabled=true])" as any]:
@@ -443,13 +453,7 @@ export const _generateStyles = (
                 color: themeColorAction.disabled.foreground,
                 borderColor: themeColorAction.disabled.border,
                 cursor: "default",
-                ":focus-visible": {
-                    borderColor: themeColorAction.disabled.border,
-                    outlineColor: themeColorAction.disabled.border,
-                    outlineOffset: theme.border.offset.secondary,
-                    outlineStyle: "solid",
-                    outlineWidth: theme.border.width.disabled,
-                },
+                ":focus-visible": focusStyling,
             },
             iconWrapperHovered: {
                 backgroundColor: themeColorAction.hover.icon,
@@ -462,7 +466,7 @@ export const _generateStyles = (
         const focusStyling = {
             outlineStyle: "solid",
             borderColor: "transparent",
-            outlineColor: themeColorAction.hover.border,
+            outlineColor: themeColorAction.focus.border,
             outlineWidth: theme.border.width.focused,
             borderRadius: theme.border.radius.default,
         };
@@ -493,15 +497,9 @@ export const _generateStyles = (
             disabled: {
                 color: themeColorAction.disabled.foreground,
                 cursor: "default",
-                ":focus-visible": {
-                    outlineColor: themeColorAction.disabled.border,
-                    outlineStyle: "solid",
-                    outlineWidth: theme.border.width.disabled,
-                },
+                ":focus-visible": focusStyling,
             },
-            disabledFocus: {
-                outlineColor: themeColorAction.disabled.border,
-            },
+            disabledFocus: focusStyling,
         };
     } else {
         throw new Error("Button kind not recognized");

--- a/packages/wonder-blocks-button/src/themes/default.ts
+++ b/packages/wonder-blocks-button/src/themes/default.ts
@@ -7,6 +7,14 @@ const {semanticColor} = tokens;
 // breaking with descenders.
 const textUnderlineOffset = tokens.spacing.xxxSmall_4;
 
+const focusOutline = {
+    border: semanticColor.border.focus,
+};
+
+const focusOutlineLight = {
+    border: semanticColor.border.inverse,
+};
+
 const theme = {
     color: {
         /**
@@ -16,8 +24,8 @@ const theme = {
             // kind=primary / color=default / light=false
             progressive: {
                 ...semanticColor.action.filled.progressive,
+                focus: focusOutline,
                 disabled: {
-                    border: semanticColor.action.disabled.default,
                     background: semanticColor.action.disabled.default,
                     foreground: semanticColor.action.disabled.secondary,
                 },
@@ -28,6 +36,7 @@ const theme = {
             // light variant.
             progressiveLight: {
                 ...semanticColor.action.outlined.progressive,
+                focus: focusOutlineLight,
                 hover: {
                     ...semanticColor.action.outlined.progressive.hover,
                     border: semanticColor.border.inverse,
@@ -38,8 +47,6 @@ const theme = {
                         .background,
                 },
                 disabled: {
-                    border: semanticColor.action.outlined.progressive.press
-                        .background,
                     background:
                         semanticColor.action.outlined.progressive.press
                             .background,
@@ -51,8 +58,8 @@ const theme = {
             // kind=primary / color=destructive / light=false
             destructive: {
                 ...semanticColor.action.filled.destructive,
+                focus: focusOutline,
                 disabled: {
-                    border: semanticColor.action.disabled.default,
                     background: semanticColor.action.disabled.default,
                     foreground: semanticColor.action.disabled.secondary,
                 },
@@ -62,6 +69,7 @@ const theme = {
             // light variant.
             destructiveLight: {
                 ...semanticColor.action.outlined.destructive,
+                focus: focusOutlineLight,
                 hover: {
                     ...semanticColor.action.outlined.progressive.hover,
                     border: semanticColor.border.inverse,
@@ -72,8 +80,6 @@ const theme = {
                         .background,
                 },
                 disabled: {
-                    border: semanticColor.action.outlined.destructive.press
-                        .background,
                     background:
                         semanticColor.action.outlined.destructive.press
                             .background,
@@ -98,6 +104,7 @@ const theme = {
                     // NOTE: This is a special case for the secondary button
                     background: "transparent",
                 },
+                focus: focusOutline,
                 hover: {
                     ...semanticColor.action.outlined.progressive.hover,
                     // NOTE: This is a special case for the secondary button
@@ -121,6 +128,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 hover: {
                     border: semanticColor.border.inverse,
                     background: "transparent",
@@ -149,6 +157,7 @@ const theme = {
             // kind=secondary / color=destructive / light=false
             destructive: {
                 ...semanticColor.action.outlined.destructive,
+                focus: focusOutline,
                 hover: {
                     ...semanticColor.action.outlined.destructive.hover,
                     // NOTE: This is a special case for the secondary button
@@ -172,6 +181,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 hover: {
                     border: semanticColor.border.inverse,
                     background: "transparent",
@@ -210,6 +220,7 @@ const theme = {
                         semanticColor.action.outlined.progressive.default
                             .foreground,
                 },
+                focus: focusOutline,
                 hover: {
                     border: semanticColor.action.outlined.progressive.hover
                         .border,
@@ -220,7 +231,6 @@ const theme = {
                             .foreground,
                 },
                 disabled: {
-                    border: semanticColor.action.disabled.default,
                     foreground: semanticColor.text.disabled,
                 },
             },
@@ -233,6 +243,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 hover: {
                     border: semanticColor.border.inverse,
                     background: "transparent",
@@ -243,8 +254,6 @@ const theme = {
                     foreground: tokens.color.fadedBlue,
                 },
                 disabled: {
-                    border: semanticColor.action.outlined.progressive.press
-                        .background,
                     foreground: tokens.color.white50,
                 },
             },
@@ -256,6 +265,7 @@ const theme = {
                         semanticColor.action.outlined.destructive.default
                             .foreground,
                 },
+                focus: focusOutline,
                 hover: {
                     border: semanticColor.action.outlined.destructive.hover
                         .border,
@@ -266,7 +276,6 @@ const theme = {
                             .foreground,
                 },
                 disabled: {
-                    border: semanticColor.action.disabled.default,
                     foreground: semanticColor.text.disabled,
                 },
             },
@@ -279,6 +288,7 @@ const theme = {
                     background: "transparent",
                     foreground: semanticColor.text.inverse,
                 },
+                focus: focusOutlineLight,
                 hover: {
                     border: semanticColor.border.inverse,
                     background: "transparent",
@@ -289,8 +299,6 @@ const theme = {
                     foreground: tokens.color.fadedRed,
                 },
                 disabled: {
-                    border: semanticColor.action.outlined.destructive.press
-                        .background,
                     foreground: tokens.color.white50,
                 },
             },


### PR DESCRIPTION
## Summary:

This PR aligns with the new Design aproach in Figma, were we want to define
separate styles for focus and hover states. From now on, the focus state will be
a global style, and the hover state will be a local style (replicating what we
currently have).

Figma: https://www.figma.com/design/VbVu3h2BpBhH80niq101MHHE/%F0%9F%92%A0-Main-Components?node-id=19724-1290&t=7yCkqQqjqnJeqCVc-4

Issue: WB-1844

## Test plan:

Navigate to the Button docs and check the button styles for hover and focus
states look as expected.

- hover: the button should have a different outline color based on the color
(destructive vs default).

- focus: the button should always have a blue outline (destructive, default,
disabled).