### PR TITLE
[🔥AUDIT🔥] Tokens: Rename action tokens: `filled` -> `primary`, `outlined` -> `secondary`.

### DIFF
--- a/.changeset/gorgeous-wolves-vanish.md
+++ b/.changeset/gorgeous-wolves-vanish.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": major
+---
+
+Rename action tokens: `filled` -> `primary`, `outlined` -> `secondary`.

--- a/.changeset/silent-jobs-itch.md
+++ b/.changeset/silent-jobs-itch.md
@@ -1,0 +1,12 @@
+---
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-switch": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-pill": patch
+---
+
+Rename action tokens: `filled` -> `primary`, `outlined` -> `secondary`.

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -85,7 +85,7 @@ how to use these colors depending on the context.
 For buttons, links, and controls to communicate the presence and meaning of
 interaction.
 
-#### Filled
+#### Primary
 
 Communicates strong emphasis and primary actions.
 
@@ -93,8 +93,8 @@ Communicates strong emphasis and primary actions.
 
 <View style={styles.gridCompact}>
     <ActionColorGroup
-        category={semanticColor.action.filled.progressive}
-        group="action.filled.progressive"
+        category={semanticColor.action.primary.progressive}
+        group="action.primary.progressive"
     />
 </View>
 
@@ -102,12 +102,12 @@ Communicates strong emphasis and primary actions.
 
 <View style={styles.gridCompact}>
     <ActionColorGroup
-        category={semanticColor.action.filled.destructive}
-        group="action.filled.destructive"
+        category={semanticColor.action.primary.destructive}
+        group="action.primary.destructive"
     />
 </View>
 
-#### Outlined
+#### Secondary
 
 Communicates secondary actions and less emphasis.
 
@@ -115,8 +115,8 @@ Communicates secondary actions and less emphasis.
 
 <View style={styles.gridCompact}>
     <ActionColorGroup
-        category={semanticColor.action.outlined.progressive}
-        group="action.outlined.progressive"
+        category={semanticColor.action.secondary.progressive}
+        group="action.secondary.progressive"
     />
 </View>
 
@@ -124,8 +124,8 @@ Communicates secondary actions and less emphasis.
 
 <View style={styles.gridCompact}>
     <ActionColorGroup
-        category={semanticColor.action.outlined.destructive}
-        group="action.outlined.destructive"
+        category={semanticColor.action.secondary.destructive}
+        group="action.secondary.destructive"
     />
 </View>
 

--- a/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
@@ -9,7 +9,7 @@ import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
-const actionCategory = semanticColor.action.outlined.progressive;
+const actionCategory = semanticColor.action.secondary.progressive;
 
 const styles = StyleSheet.create({
     rest: {

--- a/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
@@ -156,7 +156,7 @@ WithTabIndex.parameters = {
     },
 };
 
-const actionCategory = semanticColor.action.outlined.progressive;
+const actionCategory = semanticColor.action.secondary.progressive;
 
 const styles = StyleSheet.create({
     clickable: {

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -305,7 +305,7 @@ Ref.parameters = {
     },
 };
 
-const progressive = semanticColor.action.outlined.progressive;
+const progressive = semanticColor.action.secondary.progressive;
 
 const styles = StyleSheet.create({
     clickable: {

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -176,11 +176,11 @@ const styles = StyleSheet.create({
         zIndex: 1,
 
         ":active": {
-            outline: `2px solid ${semanticColor.action.outlined.progressive.press.border}`,
+            outline: `2px solid ${semanticColor.action.secondary.progressive.press.border}`,
         },
 
         ":hover": {
-            outline: `2px solid ${semanticColor.action.outlined.progressive.hover.border}`,
+            outline: `2px solid ${semanticColor.action.secondary.progressive.hover.border}`,
         },
 
         ":focus-visible": {

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -359,7 +359,7 @@ export const _generateStyles = (
 
     let newStyles: Record<string, CSSProperties> = {};
     if (kind === "primary") {
-        const themeColorAction = theme.color.filled[colorToAction];
+        const themeColorAction = theme.color.primary[colorToAction];
 
         const sharedFocusHoverStyling = {
             outlineOffset: theme.border.offset.primary,
@@ -406,7 +406,7 @@ export const _generateStyles = (
             },
         };
     } else if (kind === "secondary") {
-        const themeColorAction = theme.color.outlined[colorToAction];
+        const themeColorAction = theme.color.secondary[colorToAction];
 
         const sharedFocusHoverStyling = {
             background: themeColorAction.hover.background,

--- a/packages/wonder-blocks-button/src/themes/default.ts
+++ b/packages/wonder-blocks-button/src/themes/default.ts
@@ -20,10 +20,10 @@ const theme = {
         /**
          * Primary
          */
-        filled: {
+        primary: {
             // kind=primary / color=default / light=false
             progressive: {
-                ...semanticColor.action.filled.progressive,
+                ...semanticColor.action.primary.progressive,
                 focus: focusOutline,
                 disabled: {
                     background: semanticColor.action.disabled.default,
@@ -35,29 +35,29 @@ const theme = {
             // NOTE: These colors will be removed from WB as soon as we remove the
             // light variant.
             progressiveLight: {
-                ...semanticColor.action.outlined.progressive,
+                ...semanticColor.action.secondary.progressive,
                 focus: focusOutlineLight,
                 hover: {
-                    ...semanticColor.action.outlined.progressive.hover,
+                    ...semanticColor.action.secondary.progressive.hover,
                     border: semanticColor.border.inverse,
                 },
                 press: {
-                    ...semanticColor.action.outlined.progressive.press,
-                    border: semanticColor.action.outlined.progressive.press
+                    ...semanticColor.action.secondary.progressive.press,
+                    border: semanticColor.action.secondary.progressive.press
                         .background,
                 },
                 disabled: {
                     background:
-                        semanticColor.action.outlined.progressive.press
+                        semanticColor.action.secondary.progressive.press
                             .background,
                     foreground:
-                        semanticColor.action.outlined.progressive.default
+                        semanticColor.action.secondary.progressive.default
                             .foreground,
                 },
             },
             // kind=primary / color=destructive / light=false
             destructive: {
-                ...semanticColor.action.filled.destructive,
+                ...semanticColor.action.primary.destructive,
                 focus: focusOutline,
                 disabled: {
                     background: semanticColor.action.disabled.default,
@@ -68,23 +68,23 @@ const theme = {
             // NOTE: These colors will be removed from WB as soon as we remove the
             // light variant.
             destructiveLight: {
-                ...semanticColor.action.outlined.destructive,
+                ...semanticColor.action.secondary.destructive,
                 focus: focusOutlineLight,
                 hover: {
-                    ...semanticColor.action.outlined.progressive.hover,
+                    ...semanticColor.action.secondary.progressive.hover,
                     border: semanticColor.border.inverse,
                 },
                 press: {
-                    ...semanticColor.action.outlined.destructive.press,
-                    border: semanticColor.action.outlined.destructive.press
+                    ...semanticColor.action.secondary.destructive.press,
+                    border: semanticColor.action.secondary.destructive.press
                         .background,
                 },
                 disabled: {
                     background:
-                        semanticColor.action.outlined.destructive.press
+                        semanticColor.action.secondary.destructive.press
                             .background,
                     foreground:
-                        semanticColor.action.outlined.destructive.default
+                        semanticColor.action.secondary.destructive.default
                             .foreground,
                 },
             },
@@ -95,18 +95,18 @@ const theme = {
          *
          * Outlined buttons
          */
-        outlined: {
+        secondary: {
             // kind=secondary / color=default / light=false
             progressive: {
-                ...semanticColor.action.outlined.progressive,
+                ...semanticColor.action.secondary.progressive,
                 default: {
-                    ...semanticColor.action.outlined.progressive.default,
+                    ...semanticColor.action.secondary.progressive.default,
                     // NOTE: This is a special case for the secondary button
                     background: "transparent",
                 },
                 focus: focusOutline,
                 hover: {
-                    ...semanticColor.action.outlined.progressive.hover,
+                    ...semanticColor.action.secondary.progressive.hover,
                     // NOTE: This is a special case for the secondary button
                     background: "transparent",
                     icon: "transparent",
@@ -114,7 +114,7 @@ const theme = {
                 disabled: {
                     border: semanticColor.action.disabled.default,
                     background:
-                        semanticColor.action.outlined.progressive.press
+                        semanticColor.action.secondary.progressive.press
                             .background,
                     foreground: semanticColor.text.disabled,
                 },
@@ -139,15 +139,15 @@ const theme = {
                 press: {
                     border: tokens.color.fadedBlue,
                     background:
-                        semanticColor.action.filled.progressive.press
+                        semanticColor.action.primary.progressive.press
                             .background,
                     foreground: semanticColor.text.inverse,
                 },
                 disabled: {
-                    border: semanticColor.action.outlined.progressive.press
+                    border: semanticColor.action.secondary.progressive.press
                         .background,
                     background:
-                        semanticColor.action.outlined.progressive.press
+                        semanticColor.action.secondary.progressive.press
                             .background,
                     // NOTE: Using primitive token, but this will go away once
                     // we remove the light variant.
@@ -156,10 +156,10 @@ const theme = {
             },
             // kind=secondary / color=destructive / light=false
             destructive: {
-                ...semanticColor.action.outlined.destructive,
+                ...semanticColor.action.secondary.destructive,
                 focus: focusOutline,
                 hover: {
-                    ...semanticColor.action.outlined.destructive.hover,
+                    ...semanticColor.action.secondary.destructive.hover,
                     // NOTE: This is a special case for the secondary button
                     background: "transparent",
                     icon: "transparent",
@@ -167,7 +167,7 @@ const theme = {
                 disabled: {
                     border: semanticColor.action.disabled.default,
                     background:
-                        semanticColor.action.outlined.destructive.press
+                        semanticColor.action.secondary.destructive.press
                             .background,
                     foreground: semanticColor.text.disabled,
                 },
@@ -192,15 +192,15 @@ const theme = {
                 press: {
                     border: tokens.color.fadedRed,
                     background:
-                        semanticColor.action.filled.destructive.press
+                        semanticColor.action.primary.destructive.press
                             .background,
                     foreground: semanticColor.text.inverse,
                 },
                 disabled: {
-                    border: semanticColor.action.outlined.destructive.press
+                    border: semanticColor.action.secondary.destructive.press
                         .background,
                     background:
-                        semanticColor.action.outlined.destructive.press
+                        semanticColor.action.secondary.destructive.press
                             .background,
                     foreground: tokens.color.white50,
                 },
@@ -217,17 +217,17 @@ const theme = {
                 default: {
                     background: "transparent",
                     foreground:
-                        semanticColor.action.outlined.progressive.default
+                        semanticColor.action.secondary.progressive.default
                             .foreground,
                 },
                 focus: focusOutline,
                 hover: {
-                    border: semanticColor.action.outlined.progressive.hover
+                    border: semanticColor.action.secondary.progressive.hover
                         .border,
                 },
                 press: {
                     foreground:
-                        semanticColor.action.outlined.progressive.press
+                        semanticColor.action.secondary.progressive.press
                             .foreground,
                 },
                 disabled: {
@@ -262,17 +262,17 @@ const theme = {
                 default: {
                     background: "transparent",
                     foreground:
-                        semanticColor.action.outlined.destructive.default
+                        semanticColor.action.secondary.destructive.default
                             .foreground,
                 },
                 focus: focusOutline,
                 hover: {
-                    border: semanticColor.action.outlined.destructive.hover
+                    border: semanticColor.action.secondary.destructive.hover
                         .border,
                 },
                 press: {
                     foreground:
-                        semanticColor.action.outlined.destructive.press
+                        semanticColor.action.secondary.destructive.press
                             .foreground,
                 },
                 disabled: {

--- a/packages/wonder-blocks-button/src/themes/khanmigo.ts
+++ b/packages/wonder-blocks-button/src/themes/khanmigo.ts
@@ -9,7 +9,7 @@ const secondaryBgColor = tokens.color.offWhite;
  */
 const theme = mergeTheme(defaultTheme, {
     color: {
-        outlined: {
+        secondary: {
             progressive: {
                 default: {
                     border: tokens.color.fadedBlue,
@@ -19,8 +19,8 @@ const theme = mergeTheme(defaultTheme, {
                     background: secondaryBgColor,
                     icon: tokens.color.fadedBlue16,
                     foreground:
-                        tokens.semanticColor.action.outlined.progressive.default
-                            .foreground,
+                        tokens.semanticColor.action.secondary.progressive
+                            .default.foreground,
                 },
                 press: {
                     background: tokens.color.fadedBlue8,
@@ -35,8 +35,8 @@ const theme = mergeTheme(defaultTheme, {
                     background: secondaryBgColor,
                     icon: tokens.color.fadedRed16,
                     foreground:
-                        tokens.semanticColor.action.outlined.destructive.default
-                            .foreground,
+                        tokens.semanticColor.action.secondary.destructive
+                            .default.foreground,
                 },
                 press: {
                     background: tokens.color.fadedRed8,

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -174,20 +174,18 @@ export default class ActionItem extends React.Component<ActionProps> {
 }
 
 // TODO(WB-1868): Move this to a shared theme file.
+const actionType = semanticColor.action.primary.progressive;
+
 const theme = {
     actionItem: {
         color: {
             hover: {
-                background:
-                    semanticColor.action.filled.progressive.hover.background,
-                foreground:
-                    semanticColor.action.filled.progressive.hover.foreground,
+                background: actionType.hover.background,
+                foreground: actionType.hover.foreground,
             },
             press: {
-                background:
-                    semanticColor.action.filled.progressive.press.background,
-                foreground:
-                    semanticColor.action.filled.progressive.press.foreground,
+                background: actionType.press.background,
+                foreground: actionType.press.foreground,
             },
         },
     },

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -109,7 +109,7 @@ const theme = {
             default: {
                 background: "none",
                 foreground:
-                    semanticColor.action.outlined.progressive.default
+                    semanticColor.action.secondary.progressive.default
                         .foreground,
             },
             disabled: {
@@ -118,7 +118,7 @@ const theme = {
             },
             press: {
                 foreground:
-                    semanticColor.action.outlined.progressive.press.foreground,
+                    semanticColor.action.secondary.progressive.press.foreground,
             },
         },
     },

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -310,6 +310,8 @@ const focusedStyle = {
 };
 
 // TODO(WB-1868): Move this to a theme file.
+const actionType = semanticColor.action.primary.progressive;
+
 const theme = {
     optionItem: {
         color: {
@@ -318,16 +320,12 @@ const theme = {
                 foreground: semanticColor.text.primary,
             },
             hover: {
-                background:
-                    semanticColor.action.filled.progressive.hover.background,
-                foreground:
-                    semanticColor.action.filled.progressive.hover.foreground,
+                background: actionType.hover.background,
+                foreground: actionType.hover.foreground,
             },
             press: {
-                background:
-                    semanticColor.action.filled.progressive.press.background,
-                foreground:
-                    semanticColor.action.filled.progressive.press.foreground,
+                background: actionType.press.background,
+                foreground: actionType.press.foreground,
             },
             disabled: {
                 background: "transparent",
@@ -339,21 +337,19 @@ const theme = {
         color: {
             hover: {
                 background:
-                    semanticColor.action.outlined.progressive.hover.background,
+                    semanticColor.action.secondary.progressive.hover.background,
                 foreground:
-                    semanticColor.action.outlined.progressive.hover.foreground,
+                    semanticColor.action.secondary.progressive.hover.foreground,
             },
             press: {
                 // NOTE: The checkbox press state uses white as the background
                 background: semanticColor.surface.primary,
                 foreground:
-                    semanticColor.action.outlined.progressive.press.foreground,
+                    semanticColor.action.secondary.progressive.press.foreground,
             },
             selected: {
-                background:
-                    semanticColor.action.filled.progressive.default.background,
-                foreground:
-                    semanticColor.action.filled.progressive.default.foreground,
+                background: actionType.default.background,
+                foreground: actionType.default.foreground,
             },
         },
     },

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -269,10 +269,10 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
 
     // The color is based on the action color.
     const actionType = error ? "destructive" : "progressive";
-    // NOTE: We are using the outlined action type for all the non-resting
+    // NOTE: We are using the secondary action type for all the non-resting
     // states as the opener is a bit different from a regular button in its
     // resting/default state.
-    const action = semanticColor.action.outlined[actionType];
+    const action = semanticColor.action.secondary[actionType];
 
     // TODO(WB-1868): Address outlineOffset to include hover and focus states
     const sharedOutlineStyling = {
@@ -295,7 +295,7 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
         color: placeholder
             ? error
                 ? semanticColor.text.secondary
-                : semanticColor.action.outlined.progressive.press.foreground
+                : semanticColor.action.secondary.progressive.press.foreground
             : semanticColor.text.primary,
         outlineColor: action.press.border,
         ...sharedOutlineStyling,

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -174,7 +174,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
 
     const isCheckedOrIndeterminate = checked || checked == null;
     const actionType = error ? "destructive" : "progressive";
-    const styleType = isCheckedOrIndeterminate ? "filled" : "outlined";
+    const styleType = isCheckedOrIndeterminate ? "primary" : "secondary";
 
     const colorAction = semanticColor.action[styleType][actionType];
 

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -103,9 +103,9 @@ const _generateStyles = (checked: Checked, error: boolean) => {
         return styles[styleKey];
     }
     const actionType = error ? "destructive" : "progressive";
-    // NOTE: Radio buttons use the outlined style regardless of the checked
+    // NOTE: Radio buttons use the secondary style regardless of the checked
     // state.
-    const colorAction = semanticColor.action.outlined[actionType];
+    const colorAction = semanticColor.action.secondary[actionType];
 
     // The different states that the component can be in.
     const states = {

--- a/packages/wonder-blocks-icon-button/src/themes/default.ts
+++ b/packages/wonder-blocks-icon-button/src/themes/default.ts
@@ -28,35 +28,35 @@ const focusOutlineLight = {
  * will apply the same styles as Button.
  */
 const baseColorStates = {
-    ...semanticColor.action.outlined,
+    ...semanticColor.action.secondary,
     progressive: {
-        ...semanticColor.action.outlined.progressive,
+        ...semanticColor.action.secondary.progressive,
         default: {
-            ...semanticColor.action.outlined.progressive.default,
+            ...semanticColor.action.secondary.progressive.default,
             border: "transparent",
             background: "transparent",
         },
         focus: focusOutline,
         press: {
-            border: semanticColor.action.outlined.progressive.press.border,
+            border: semanticColor.action.secondary.progressive.press.border,
             background: "transparent",
             foreground:
-                semanticColor.action.outlined.progressive.press.foreground,
+                semanticColor.action.secondary.progressive.press.foreground,
         },
     },
     destructive: {
-        ...semanticColor.action.outlined.destructive,
+        ...semanticColor.action.secondary.destructive,
         default: {
-            ...semanticColor.action.outlined.destructive.default,
+            ...semanticColor.action.secondary.destructive.default,
             border: "transparent",
             background: "transparent",
         },
         focus: focusOutline,
         press: {
-            border: semanticColor.action.outlined.destructive.press.border,
+            border: semanticColor.action.secondary.destructive.press.border,
             background: "transparent",
             foreground:
-                semanticColor.action.outlined.destructive.press.foreground,
+                semanticColor.action.secondary.destructive.press.foreground,
         },
     },
     disabled: {

--- a/packages/wonder-blocks-icon-button/src/themes/khanmigo.ts
+++ b/packages/wonder-blocks-icon-button/src/themes/khanmigo.ts
@@ -18,6 +18,8 @@ const primaryLightState = {
     },
 };
 
+const actionType = semanticColor.action.primary;
+
 /**
  * The overrides for the Khanmigo theme.
  */
@@ -33,23 +35,23 @@ const theme = mergeTheme(defaultTheme, {
 
         secondary: {
             progressive: {
-                hover: semanticColor.action.filled.progressive.hover,
-                press: semanticColor.action.filled.progressive.press,
+                hover: actionType.progressive.hover,
+                press: actionType.progressive.press,
             },
             destructive: {
-                hover: semanticColor.action.filled.destructive.hover,
-                press: semanticColor.action.filled.destructive.press,
+                hover: actionType.destructive.hover,
+                press: actionType.destructive.press,
             },
         },
 
         tertiary: {
             progressive: {
-                hover: semanticColor.action.filled.progressive.hover,
-                press: semanticColor.action.filled.progressive.press,
+                hover: actionType.progressive.hover,
+                press: actionType.progressive.press,
             },
             destructive: {
-                hover: semanticColor.action.filled.destructive.hover,
-                press: semanticColor.action.filled.destructive.press,
+                hover: actionType.destructive.hover,
+                press: actionType.destructive.press,
             },
         },
     },

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -171,7 +171,7 @@ const sharedStyles = StyleSheet.create({
     },
 });
 
-const action = semanticColor.action.outlined.progressive;
+const action = semanticColor.action.secondary.progressive;
 
 /**
  * TODO(WB-1862): Move this to a shared theme file.

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -266,10 +266,10 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
             border: semanticColor.focus.outer,
         },
         hover: {
-            border: semanticColor.action.filled.progressive.hover.border,
+            border: semanticColor.action.primary.progressive.hover.border,
         },
         press: {
-            border: semanticColor.action.filled.progressive.press.border,
+            border: semanticColor.action.primary.progressive.press.border,
             background: pressColor,
         },
     };

--- a/packages/wonder-blocks-switch/src/themes/default.ts
+++ b/packages/wonder-blocks-switch/src/themes/default.ts
@@ -6,7 +6,7 @@ import {
 } from "@khanacademy/wonder-blocks-tokens";
 
 // The color of the switch is based on the action color.
-const action = semanticColor.action.outlined.progressive;
+const action = semanticColor.action.secondary.progressive;
 
 const theme = {
     color: {

--- a/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
@@ -13,8 +13,7 @@ export const semanticColor = {
      * of interaction.
      */
     action: {
-        // Filled buttons are meant for primary actions.
-        filled: {
+        primary: {
             progressive: {
                 default: {
                     border: "transparent",
@@ -51,9 +50,7 @@ export const semanticColor = {
             },
         },
 
-        // Outlined is meant for use on secondary controls, or controls over
-        // white/transparent backgrounds.
-        outlined: {
+        secondary: {
             progressive: {
                 default: {
                     border: border.strong,


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

This is so we can have a more consistent naming convention for our action tokens
(also defined in Figma). This change is backwards compatible, as we are just
renaming the tokens.



Issue: "none"

## Test plan:

Navigate to the `foundations > Using color` section in the docs and verify that
the action tokens are now named `primary` and `secondary` instead of `filled`
and `outlined`.