### PR TITLE
Update monthYearOnly to use last day of month

### DIFF
--- a/.changeset/unlucky-cups-notice.md
+++ b/.changeset/unlucky-cups-notice.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": minor
+---
+
+Added useLastOfMonth to BirthdayPicker props

--- a/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
+++ b/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
@@ -140,6 +140,24 @@ export const BirthdayPickerWithYearAndMonthOnly: StoryComponentType = {
     },
 };
 
+export const BirthdayPickerWithUseLastOfMonth: StoryComponentType = {
+    args: {
+        monthYearOnly: true,
+        useLastDayOfMonth: true,
+        onChange: (date?: string | null) => {
+            // eslint-disable-next-line no-console
+            console.log("Date selected: ", date);
+        },
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "A BirthdayPicker can be configured to use the last day of the month when monthYearOnly is true. This can be useful when we want to display and collect a birthday that doesn't require the full DOB for privacy reasons, and you want to be cautious about the users age.",
+            },
+        },
+    },
+};
+
 export const BirthdayPickerVertical: StoryComponentType = {
     args: {
         style: {flexDirection: "column"},

--- a/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
+++ b/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
@@ -140,24 +140,6 @@ export const BirthdayPickerWithYearAndMonthOnly: StoryComponentType = {
     },
 };
 
-export const BirthdayPickerWithUseLastOfMonth: StoryComponentType = {
-    args: {
-        monthYearOnly: true,
-        useLastDayOfMonth: true,
-        onChange: (date?: string | null) => {
-            // eslint-disable-next-line no-console
-            console.log("Date selected: ", date);
-        },
-    },
-    parameters: {
-        docs: {
-            description: {
-                story: "A BirthdayPicker can be configured to use the last day of the month when monthYearOnly is true. This can be useful when we want to display and collect a birthday that doesn't require the full DOB for privacy reasons, and you want to be cautious about the users age.",
-            },
-        },
-    },
-};
-
 export const BirthdayPickerVertical: StoryComponentType = {
     args: {
         style: {flexDirection: "column"},

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
@@ -496,6 +496,40 @@ describe("BirthdayPicker", () => {
             // Verify that we passed the same day originally passed in.
             expect(onChange).toHaveBeenCalledWith("2018-08-17");
         });
+
+        it("onChange triggers the last day of the month when monthYearOnly and useLastOfMonth is set", async () => {
+            // Arrange
+            const onChange = jest.fn();
+
+            render(
+                <BirthdayPicker
+                    monthYearOnly={true}
+                    useLastDayOfMonth={true}
+                    onChange={onChange}
+                />,
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByTestId("birthday-picker-month"),
+            );
+            const monthOption = await screen.findByText("Aug");
+            await userEvent.click(monthOption, {
+                pointerEventsCheck: PointerEventsCheckLevel.Never,
+            });
+
+            await userEvent.click(
+                await screen.findByTestId("birthday-picker-year"),
+            );
+            const yearOption = await screen.findByText("2018");
+            await userEvent.click(yearOption, {
+                pointerEventsCheck: PointerEventsCheckLevel.Never,
+            });
+
+            // Assert
+            // Verify that we passed the first day of the month
+            expect(onChange).toHaveBeenCalledWith("2018-08-31");
+        });
     });
 
     describe("labels", () => {

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
@@ -435,7 +435,7 @@ describe("BirthdayPicker", () => {
             expect(onChange).toHaveBeenCalledTimes(1);
         });
 
-        it("onChange triggers the first day of the month when monthYearOnly is set", async () => {
+        it("onChange triggers the last day of the month when monthYearOnly is set", async () => {
             // Arrange
             const onChange = jest.fn();
 
@@ -460,10 +460,10 @@ describe("BirthdayPicker", () => {
 
             // Assert
             // Verify that we passed the first day of the month
-            expect(onChange).toHaveBeenCalledWith("2018-08-01");
+            expect(onChange).toHaveBeenCalledWith("2018-08-31");
         });
 
-        it("onChange triggers the passed-in day intact when defaultValue and monthYearOnly are set", async () => {
+        it("onChange triggers uses last of month when defaultValue and monthYearOnly are set", async () => {
             // Arrange
             const onChange = jest.fn();
 
@@ -494,40 +494,6 @@ describe("BirthdayPicker", () => {
 
             // Assert
             // Verify that we passed the same day originally passed in.
-            expect(onChange).toHaveBeenCalledWith("2018-08-17");
-        });
-
-        it("onChange triggers the last day of the month when monthYearOnly and useLastOfMonth is set", async () => {
-            // Arrange
-            const onChange = jest.fn();
-
-            render(
-                <BirthdayPicker
-                    monthYearOnly={true}
-                    useLastDayOfMonth={true}
-                    onChange={onChange}
-                />,
-            );
-
-            // Act
-            await userEvent.click(
-                await screen.findByTestId("birthday-picker-month"),
-            );
-            const monthOption = await screen.findByText("Aug");
-            await userEvent.click(monthOption, {
-                pointerEventsCheck: PointerEventsCheckLevel.Never,
-            });
-
-            await userEvent.click(
-                await screen.findByTestId("birthday-picker-year"),
-            );
-            const yearOption = await screen.findByText("2018");
-            await userEvent.click(yearOption, {
-                pointerEventsCheck: PointerEventsCheckLevel.Never,
-            });
-
-            // Assert
-            // Verify that we passed the first day of the month
             expect(onChange).toHaveBeenCalledWith("2018-08-31");
         });
     });

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -65,6 +65,11 @@ type Props = {
      * Additional styles applied to the dropdowns.
      */
     dropdownStyle?: StyleType;
+    /**
+     * Use the last day of the month as the day value instead of the first
+     * when `monthYearOnly` is true
+     */
+    useLastDayOfMonth?: boolean;
 };
 
 type State = {
@@ -175,7 +180,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
      * Calculates the initial state values based on the default value.
      */
     getStateFromDefault(): State {
-        const {defaultValue, monthYearOnly} = this.props;
+        const {defaultValue, monthYearOnly, useLastDayOfMonth} = this.props;
         const initialState: State = {
             month: null,
             day: monthYearOnly ? "1" : null,
@@ -189,9 +194,13 @@ export default class BirthdayPicker extends React.Component<Props, State> {
         // If a default value was provided then we use moment to convert it
         // into a date that we can use to populate the
         if (defaultValue) {
-            const date = moment(defaultValue);
+            let date = moment(defaultValue);
 
             if (date.isValid()) {
+                if (monthYearOnly && useLastDayOfMonth) {
+                    date = date.endOf("month");
+                }
+
                 initialState.month = String(date.month());
                 initialState.day = String(date.date());
                 initialState.year = String(date.year());
@@ -240,7 +249,10 @@ export default class BirthdayPicker extends React.Component<Props, State> {
 
         // This is a legal call to Moment, but our Moment types don't
         // recognize it.
-        const date = moment([year, month, day]);
+        let date = moment([year, month, day]);
+        if (this.props.monthYearOnly && this.props.useLastDayOfMonth) {
+            date = date.endOf("month");
+        }
 
         // If the date is in the future or is invalid then we want to show
         // an error to the user and return a null value.


### PR DESCRIPTION
## Summary:
BirthdayPicker currently use the first day of the month for the date if `monthYearOnly` prop is set to `true`. But for most use-cases developers want to use the last day of the month so that a user who is still 17, for example, is not considered 18, if their birthday is anything after the 1st of the month.

This update modifies the behavior of the component to pass the last day of the month to `onChange` if `monthYearOnly` is set to `true`.

Issue: PG-5959

## Test plan:
- Modified unit tests to prove last day of month is returned when the prop is set