### PR TITLE
[WB-1887] Add new sizing tokens for ThunderBlocks

### DIFF
--- a/.changeset/sharp-pens-pull.md
+++ b/.changeset/sharp-pens-pull.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add sizing primitive tokens to support the new tokens with rem units that will be used by the thunderblocks/classroom theme

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -78,7 +78,6 @@ const parameters = {
     },
     docs: {
         toc: {
-            // contentsSelector: "sbdocs-content",
             // Useful for MDX pages like "Using color".
             headingSelector: "h2, h3",
             // Prevents including generic headings like "Stories" and "Usage".
@@ -93,6 +92,10 @@ const parameters = {
     },
     viewport: {
         viewports: wbViewports,
+    },
+    // Setting the default viewport width for Chromatic
+    chromatic: {
+        viewports: [1184],
     },
 };
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -78,6 +78,7 @@ const parameters = {
     },
     docs: {
         toc: {
+            // contentsSelector: "sbdocs-content",
             // Useful for MDX pages like "Using color".
             headingSelector: "h2, h3",
             // Prevents including generic headings like "Stories" and "Usage".

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -93,10 +93,6 @@ const parameters = {
     viewport: {
         viewports: wbViewports,
     },
-    // Setting the default viewport width for Chromatic
-    chromatic: {
-        viewports: [1184],
-    },
 };
 
 const withThemeSwitcher: Decorator = (

--- a/__docs__/wonder-blocks-tokens/__overview__.mdx
+++ b/__docs__/wonder-blocks-tokens/__overview__.mdx
@@ -18,16 +18,24 @@ Design tokens are a set of key-value pairs that define the visual and behavioral
 design attributes of our components. They are the primitives that define the
 building blocks of our design system.
 
-These represent the design decisions at Khan Academy, such as:
+## Tokens
 
--   <a href="/?path=/docs/packages-tokens-border--docs">Border</a>
--   <a href="/?path=/docs/packages-tokens-semantic-color--docs">
-        Semantic Colors
-    </a>
--   <a href="/?path=/docs/packages-tokens-color--docs">Color Primitives</a>
--   <a href="/?path=/docs/packages-tokens-spacing--docs">Spacing</a>
--   <a href="/?path=/docs/packages-tokens-typography--docs">Typography</a>
--   <a href="/?path=/docs/packages-tokens-media-queries--docs">Media Queries</a>
+These represent the design decisions at Khan Academy.
+
+### Primivites
+
+- <a href="../?path=/docs/packages-tokens-border--docs">Border</a>
+- <a href="../?path=/docs/packages-tokens-color--docs">Color</a>
+- <a href="../?path=/docs/packages-tokens-sizing--docs">Sizing</a>
+- <a href="../?path=/docs/packages-tokens-spacing--docs">Spacing</a>
+- <a href="../?path=/docs/packages-tokens-typography--docs">Typography</a>
+- <a href="../?path=/docs/packages-tokens-media-queries--docs">Media Queries</a>
+
+### Semantic
+
+- <a href="../?path=/docs/packages-tokens-semantic-color--docs">
+      Semantic Colors
+  </a>
 
 ## Usage
 

--- a/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
@@ -1,0 +1,71 @@
+import {Meta, Source} from "@storybook/blocks";
+
+import TokenTable from "../components/token-table";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import * as tokens from "@khanacademy/wonder-blocks-tokens";
+
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-tokens/package.json";
+
+<Meta title="Packages / Tokens / Sizing" />
+
+# Sizing
+
+<ComponentInfo name={packageConfig.name} version={packageConfig.version} />
+
+All the available sizing values that can be used for margin, padding, width,
+height, border-width, etc.
+
+## Usage
+
+You can use these sizes directly by importing `sizing` from the
+`wonder-blocks-tokens` package and accessing the named property like so:
+`sizing.size_200`.
+
+Note that these values are represented in rem units. Using rem units allows the
+sizes to scale with the font size of the root element, which is set to 50%/8px
+in our Design System. This means that the sizes will scale with the user's
+browser settings.
+
+```js
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+const styles = {padding: spacing.size_200};
+```
+
+## Tokens
+
+<TokenTable
+    columns={[
+        {
+            label: "Token",
+            cell: (row) => <code>sizing.{row.label}</code>,
+        },
+        {
+            label: "Base unit multiplier",
+            cell: (row) => row.value.replace("rem", "x"),
+        },
+        {
+            label: "Value",
+            cell: "value",
+        },
+        {
+            label: "Pixels (equivalent)",
+            cell: (row) => parseFloat(row.value.replace("rem", "") * 8),
+        },
+        {
+            label: "Example",
+            cell: (row) => (
+                <View
+                    style={{
+                        backgroundColor: tokens.color.purple,
+                        height: row.value,
+                    }}
+                >
+                    &nbsp;
+                </View>
+            ),
+        },
+    ]}
+    tokens={tokens.sizing}
+/>

--- a/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
@@ -30,7 +30,7 @@ You can use these sizes directly by importing `sizing` from the
 
 ```js
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
-const styles = {padding: spacing.size_200};
+const styles = {padding: sizing.size_200};
 ```
 
 ## Tokens

--- a/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
@@ -81,8 +81,17 @@ easily migrate to `sizing` by replacing the following tokens:
 // Before
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
+{
+    padding: `${spacing.medium_16}px ${spacing.large_24}px`,
+}
+
 // After
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
+
+// Now you don't need to add the unit here as it's already included in the token
+{
+    padding: `${sizing.size_200} ${sizing.size_300}`,
+}
 ```
 
 The mapping of the tokens is as follows:

--- a/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
@@ -15,18 +15,18 @@ import packageConfig from "../../packages/wonder-blocks-tokens/package.json";
 <ComponentInfo name={packageConfig.name} version={packageConfig.version} />
 
 All the available sizing values that can be used for margin, padding, width,
-height, border-width, etc.
+height, border-width, font-size, line-height, etc.
+
+Note that these values are represented in `rem` units. Using rem units allows
+the sizes to scale with the font size of the root element, which is set to
+50%/8px in our Design System. This means that the sizes will scale with the
+user's browser settings.
 
 ## Usage
 
 You can use these sizes directly by importing `sizing` from the
 `wonder-blocks-tokens` package and accessing the named property like so:
 `sizing.size_200`.
-
-Note that these values are represented in rem units. Using rem units allows the
-sizes to scale with the font size of the root element, which is set to 50%/8px
-in our Design System. This means that the sizes will scale with the user's
-browser settings.
 
 ```js
 import {sizing} from "@khanacademy/wonder-blocks-tokens";

--- a/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
@@ -69,3 +69,33 @@ const styles = {padding: spacing.size_200};
     ]}
     tokens={tokens.sizing}
 />
+
+## Migrating from `spacing` to `sizing`
+
+In the past, we had a `spacing` object that contained all the sizing tokens
+define in pixels. This object has been deprecated in favor of the `sizing`
+object, which now uses `rem` units. If you were using `spacing` before, you can
+easily migrate to `sizing` by replacing the following tokens:
+
+```ts
+// Before
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+
+// After
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+```
+
+The mapping of the tokens is as follows:
+
+| Spacing (old)         | Sizing (new)      |
+| --------------------- | ----------------- |
+| `spacing.xxxxSmall_2` | `sizing.size_025` |
+| `spacing.xxxSmall_4`  | `sizing.size_050` |
+| `spacing.xxSmall_6`   | `sizing.size_075` |
+| `spacing.xSmall_8`    | `sizing.size_100` |
+| `spacing.small_12`    | `sizing.size_150` |
+| `spacing.medium_16`   | `sizing.size_200` |
+| `spacing.large_24`    | `sizing.size_300` |
+| `spacing.xLarge_32`   | `sizing.size_400` |
+| `spacing.xxLarge_48`  | `sizing.size_600` |
+| `spacing.xxxLarge_64` | `sizing.size_800` |

--- a/packages/wonder-blocks-tokens/src/index.ts
+++ b/packages/wonder-blocks-tokens/src/index.ts
@@ -2,6 +2,7 @@
 import {border} from "./tokens/border";
 import {color} from "./tokens/color";
 import {font} from "./tokens/font";
+import {sizing} from "./tokens/sizing";
 import {spacing} from "./tokens/spacing";
 
 // media queries
@@ -19,6 +20,7 @@ export {
     border,
     color,
     font,
+    sizing,
     spacing,
     /**
      * Media query breakpoints.

--- a/packages/wonder-blocks-tokens/src/tokens/sizing.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/sizing.ts
@@ -1,0 +1,44 @@
+/**
+ * The baseline for the size tokens.
+ */
+const baseline = 8;
+
+/**
+ * Converts a number (px) to a rem value.
+ */
+function convertUnitsToRem(value: number): string {
+    return `${value / baseline}rem`;
+}
+
+/**
+ * Tokens that define the sizing of elements.
+ *
+ * These tokens are multiples of 8px, the baseline for the design system.
+ *
+ * These tokens can be used for:
+ * - Margin and padding
+ * - Component sizes
+ */
+export const sizing = {
+    size_0: convertUnitsToRem(0),
+    size_0125: convertUnitsToRem(1),
+    size_025: convertUnitsToRem(2),
+    size_050: convertUnitsToRem(4),
+    size_075: convertUnitsToRem(6),
+    size_100: convertUnitsToRem(8),
+    size_125: convertUnitsToRem(10),
+    size_150: convertUnitsToRem(12),
+    size_200: convertUnitsToRem(16),
+    size_225: convertUnitsToRem(18),
+    size_250: convertUnitsToRem(20),
+    size_300: convertUnitsToRem(24),
+    size_400: convertUnitsToRem(32),
+    size_500: convertUnitsToRem(40),
+    size_600: convertUnitsToRem(48),
+    size_700: convertUnitsToRem(56),
+    size_800: convertUnitsToRem(64),
+    size_900: convertUnitsToRem(72),
+    size_1000: convertUnitsToRem(80),
+    size_1100: convertUnitsToRem(88),
+    size_1200: convertUnitsToRem(96),
+} as const;

--- a/packages/wonder-blocks-tokens/src/tokens/sizing.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/sizing.ts
@@ -6,39 +6,41 @@ const baseline = 8;
 /**
  * Converts a number (px) to a rem value.
  */
-function convertUnitsToRem(value: number): string {
+function pxToRem(value: number): string {
     return `${value / baseline}rem`;
 }
 
 /**
- * Tokens that define the sizing of elements.
+ * Tokens that define the sizing of elements. These values are expressed in
+ * `rem` units.
  *
  * These tokens are multiples of 8px, the baseline for the design system.
  *
  * These tokens can be used for:
  * - Margin and padding
  * - Component sizes
+ * - Typography
  */
 export const sizing = {
-    size_0: convertUnitsToRem(0),
-    size_0125: convertUnitsToRem(1),
-    size_025: convertUnitsToRem(2),
-    size_050: convertUnitsToRem(4),
-    size_075: convertUnitsToRem(6),
-    size_100: convertUnitsToRem(8),
-    size_125: convertUnitsToRem(10),
-    size_150: convertUnitsToRem(12),
-    size_200: convertUnitsToRem(16),
-    size_225: convertUnitsToRem(18),
-    size_250: convertUnitsToRem(20),
-    size_300: convertUnitsToRem(24),
-    size_400: convertUnitsToRem(32),
-    size_500: convertUnitsToRem(40),
-    size_600: convertUnitsToRem(48),
-    size_700: convertUnitsToRem(56),
-    size_800: convertUnitsToRem(64),
-    size_900: convertUnitsToRem(72),
-    size_1000: convertUnitsToRem(80),
-    size_1100: convertUnitsToRem(88),
-    size_1200: convertUnitsToRem(96),
+    size_0: pxToRem(0),
+    size_0125: pxToRem(1),
+    size_025: pxToRem(2),
+    size_050: pxToRem(4),
+    size_075: pxToRem(6),
+    size_100: pxToRem(8),
+    size_125: pxToRem(10),
+    size_150: pxToRem(12),
+    size_200: pxToRem(16),
+    size_225: pxToRem(18),
+    size_250: pxToRem(20),
+    size_300: pxToRem(24),
+    size_400: pxToRem(32),
+    size_500: pxToRem(40),
+    size_600: pxToRem(48),
+    size_700: pxToRem(56),
+    size_800: pxToRem(64),
+    size_900: pxToRem(72),
+    size_1000: pxToRem(80),
+    size_1100: pxToRem(88),
+    size_1200: pxToRem(96),
 } as const;

--- a/packages/wonder-blocks-tokens/src/tokens/spacing.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/spacing.ts
@@ -1,3 +1,7 @@
+/**
+ * NOTE: These tokens are going to be deprecated in favor of the new `sizing`
+ * tokens.
+ */
 export const spacing = {
     // Named
     xxxxSmall_2: 2,

--- a/static/sb-styles/preview.css
+++ b/static/sb-styles/preview.css
@@ -1,6 +1,10 @@
 /**
  * Overrides for the Storybook preview iframe.
  */
+html {
+    font-size: 50%;
+}
+
 .sbdocs ul,
 .sbdocs li,
 .sbdocs p,
@@ -59,7 +63,7 @@
 }
 
 /* only include the counter to the stories titles */
-.sb-anchor > h3::before {
+.sb-anchor>h3::before {
     counter-increment: story;
     color: var(--color-text-64);
     content: counter(story) ".";
@@ -78,4 +82,15 @@
 .sbdocs h6 {
     font-size: var(--typography-heading-size-xs);
     line-height: var(--typography-heading-line-height-xs);
+}
+
+/* TOC wrapper */
+.sbdocs-content+div {
+    width: 20rem;
+}
+
+.sbdocs-content+div>* {
+    width: 20rem;
+    padding-top: 8rem;
+    padding-bottom: 4rem;
 }

--- a/static/sb-styles/vars.css
+++ b/static/sb-styles/vars.css
@@ -6,7 +6,7 @@
      * Typography
      */
     --typography-font-family: 'Source Serif Pro', sans-serif;
-    --typography-base-size: clamp(0.88rem, 3vw, 1rem);
+    --typography-base-size: clamp(0.88rem, 3vw, 2rem);
     --typography-base-line-height: 1.6;
     --typography-heading-size-xxl: calc(var(--typography-base-size) * 3.75); /* 60px */
     --typography-heading-line-height-xxl: calc(var(--typography-heading-size-xxl) * 1.1333333);


### PR DESCRIPTION
## Summary:

Add sizing primitive tokens to support the new tokens with rem units that will
be used by the thunderblocks/classroom theme.

This is done to offer a more flexible way to define sizes in the components
that use these tokens by setting the size in rem units.

Also modified the Storybook styles to use 50%/8px as the base font size to
better match the rem units.

The tokens were defined here: https://khanacademy.atlassian.net/wiki/spaces/WB/pages/3683483678/REMs

Issue: https://khanacademy.atlassian.net/browse/WB-1887

## Test plan:

Navigate to the docs and see that the new sizing tokens are available.

/?path=/docs/packages-tokens-sizing--docs

Also verify that the font sizes in the storybook are preserved.