### PR TITLE
[routeradapterupdate] Rework the catch all path error

### DIFF
--- a/.changeset/good-ladybugs-add.md
+++ b/.changeset/good-ladybugs-add.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing-core": minor
+---
+
+Improve error messaging for the router test harness adapter

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/__snapshots__/router.test.tsx.snap
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/__snapshots__/router.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Router.adapter with full config including path should throw if the path does not match the location 1`] = `"The configured path must match the configured location or your harnessed component will not render."`;
+exports[`Router.adapter with full config including path should throw if the path does not match the location 1`] = `"The current location '/math/calculator' does not match the configured path '/something/else/entirely'. Did you provide the correct configured location, '/math/calculator', or did the routing lead to a different place than you expected?"`;
 
-exports[`Router.adapter with location config including path should throw if the path does not match the location 1`] = `"The configured path must match the configured location or your harnessed component will not render."`;
+exports[`Router.adapter with location config including path should throw if the path does not match the location 1`] = `"The current location '/math/calculator' does not match the configured path '/something/else/entirely'. Did you provide the correct configured location, '/math/calculator', or did the routing lead to a different place than you expected?"`;

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
@@ -127,10 +127,10 @@ const MaybeWithRoute = ({
                 path="*"
                 render={() => {
                     throw new Error(
-                        `The current location ${actualLocation.pathname} ` +
-                            `does not match the configured path ${path}. ` +
+                        `The current location '${actualLocation.pathname}' ` +
+                            `does not match the configured path '${path}'. ` +
                             `Did you provide the correct configured ` +
-                            `location, ${configuredLocation}, or did the ` +
+                            `location, '${configuredLocation}', or did the ` +
                             `routing lead to a different place than you ` +
                             `expected?`,
                     );
@@ -235,7 +235,7 @@ export const adapter: TestHarnessAdapter<Config> = (
         <MemoryRouter {...routerProps}>
             <MaybeWithRoute
                 path={config.path}
-                configLocation={config.initialEntries[config.initialIndex ?? 0]}
+                configLocation={entries[config.initialIndex ?? 0]}
             >
                 {children}
             </MaybeWithRoute>

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 
-import {StaticRouter, MemoryRouter, Route, Switch} from "react-router-dom";
+import {
+    StaticRouter,
+    MemoryRouter,
+    Route,
+    Switch,
+    useLocation,
+} from "react-router-dom";
 
 import type {LocationDescriptor} from "history";
 import type {TestHarnessAdapter} from "../types";
@@ -13,90 +19,101 @@ type MemoryRouterProps = JSX.LibraryManagedAttributes<
 /**
  * Configuration for the withLocation test harness adapter.
  */
-type Config = // The initial location to use.
-
-        | Readonly<
-              | {
-                    /**
-                     * See MemoryRouter prop for initialEntries.
-                     */
-                    initialEntries: MemoryRouterProps["initialEntries"];
-                    /**
-                     * See MemoryRouter prop for initialIndex.
-                     */
-                    initialIndex?: MemoryRouterProps["initialIndex"];
-                    /**
-                     * See MemoryRouter prop for getUserConfirmation.
-                     */
-                    getUserConfirmation?: MemoryRouterProps["getUserConfirmation"];
-                    /**
-                     * A path match to use.
-                     *
-                     * When this is specified, the harnessed component will be
-                     * rendered inside a `Route` handler with this path.
-                     *
-                     * If the path matches the location, then the route will
-                     * render the component.
-                     *
-                     * If the path does not match the location, then the route
-                     * will not render the component.
-                     */
-                    path?: string;
-                }
-              | {
-                    /**
-                     * The location to use.
-                     */
-                    location: LocationDescriptor;
-                    /**
-                     * Force the use of a StaticRouter, instead of MemoryRouter.
-                     */
-                    forceStatic: true;
-                    /**
-                     * A path match to use.
-                     *
-                     * When this is specified, the harnessed component will be
-                     * rendered inside a `Route` handler with this path.
-                     *
-                     * If the path matches the location, then the route will
-                     * render the component.
-                     *
-                     * If the path does not match the location, then the route
-                     * will not render the component.
-                     */
-                    path?: string;
-                }
-              | {
-                    /**
-                     * The initial location to use.
-                     */
-                    location: LocationDescriptor;
-                    /**
-                     * A path match to use.
-                     *
-                     * When this is specified, the harnessed component will be
-                     * rendered inside a `Route` handler with this path.
-                     *
-                     * If the path matches the location, then the route will
-                     * render the component.
-                     *
-                     * If the path does not match the location, then the route
-                     * will not render the component.
-                     */
-                    path?: string;
-                }
-          >
-        | string;
+type Config =
+    | Readonly<
+          | {
+                /**
+                 * See MemoryRouter prop for initialEntries.
+                 */
+                initialEntries: MemoryRouterProps["initialEntries"];
+                /**
+                 * See MemoryRouter prop for initialIndex.
+                 */
+                initialIndex?: MemoryRouterProps["initialIndex"];
+                /**
+                 * See MemoryRouter prop for getUserConfirmation.
+                 */
+                getUserConfirmation?: MemoryRouterProps["getUserConfirmation"];
+                /**
+                 * A path match to use.
+                 *
+                 * When this is specified, the harnessed component will be
+                 * rendered inside a `Route` handler with this path.
+                 *
+                 * If the path matches the location, then the route will
+                 * render the component.
+                 *
+                 * If the path does not match the location, then the route
+                 * will not render the component.
+                 */
+                path?: string;
+            }
+          | {
+                /**
+                 * The location to use.
+                 */
+                location: LocationDescriptor;
+                /**
+                 * Force the use of a StaticRouter, instead of MemoryRouter.
+                 */
+                forceStatic: true;
+                /**
+                 * A path match to use.
+                 *
+                 * When this is specified, the harnessed component will be
+                 * rendered inside a `Route` handler with this path.
+                 *
+                 * If the path matches the location, then the route will
+                 * render the component.
+                 *
+                 * If the path does not match the location, then the route
+                 * will not render the component.
+                 */
+                path?: string;
+            }
+          | {
+                /**
+                 * The initial location to use.
+                 */
+                location: LocationDescriptor;
+                /**
+                 * A path match to use.
+                 *
+                 * When this is specified, the harnessed component will be
+                 * rendered inside a `Route` handler with this path.
+                 *
+                 * If the path matches the location, then the route will
+                 * render the component.
+                 *
+                 * If the path does not match the location, then the route
+                 * will not render the component.
+                 */
+                path?: string;
+            }
+      >
+    // The initial location to use.
+    | string;
 
 /**
  * The default configuration for this adapter.
  */
 export const defaultConfig = {location: "/"} as const;
 
-const maybeWithRoute = (
-    children: React.ReactNode,
-    path?: string | null,
-): React.ReactElement => {
+const MaybeWithRoute = ({
+    children,
+    path,
+    configLocation,
+}: {
+    children: React.ReactNode;
+    path: string | null | undefined;
+    configLocation: LocationDescriptor;
+}): React.ReactElement => {
+    const actualLocation = useLocation();
+    const configuredLocation =
+        typeof configLocation === "string"
+            ? configLocation
+            : configLocation.pathname;
+
     if (path == null) {
         return <>{children}</>;
     }
@@ -110,7 +127,12 @@ const maybeWithRoute = (
                 path="*"
                 render={() => {
                     throw new Error(
-                        "The configured path must match the configured location or your harnessed component will not render.",
+                        `The current location ${actualLocation.pathname} ` +
+                            `does not match the configured path ${path}. ` +
+                            `Did you provide the correct configured ` +
+                            `location, ${configuredLocation}, or did the ` +
+                            `routing lead to a different place than you ` +
+                            `expected?`,
                     );
                 }}
             />
@@ -139,8 +161,6 @@ export const adapter: TestHarnessAdapter<Config> = (
         };
     }
 
-    // Wrap children with the various contexts and routes, as per the config.
-    const wrappedWithRoute = maybeWithRoute(children, config.path);
     if ("forceStatic" in config && config.forceStatic) {
         /**
          * There may be times (SSR testing comes to mind) where we will be
@@ -148,7 +168,12 @@ export const adapter: TestHarnessAdapter<Config> = (
          */
         return (
             <StaticRouter location={config.location} context={{}}>
-                {wrappedWithRoute}
+                <MaybeWithRoute
+                    path={config.path}
+                    configLocation={config.location}
+                >
+                    {children}
+                </MaybeWithRoute>
             </StaticRouter>
         );
     }
@@ -164,7 +189,12 @@ export const adapter: TestHarnessAdapter<Config> = (
     if ("location" in config && config.location !== undefined) {
         return (
             <MemoryRouter initialEntries={[config.location]}>
-                {wrappedWithRoute}
+                <MaybeWithRoute
+                    path={config.path}
+                    configLocation={config.location}
+                >
+                    {children}
+                </MaybeWithRoute>
             </MemoryRouter>
         );
     }
@@ -201,5 +231,14 @@ export const adapter: TestHarnessAdapter<Config> = (
         routerProps.getUserConfirmation = config.getUserConfirmation;
     }
 
-    return <MemoryRouter {...routerProps}>{wrappedWithRoute}</MemoryRouter>;
+    return (
+        <MemoryRouter {...routerProps}>
+            <MaybeWithRoute
+                path={config.path}
+                configLocation={config.initialEntries[config.initialIndex ?? 0]}
+            >
+                {children}
+            </MaybeWithRoute>
+        </MemoryRouter>
+    );
 };


### PR DESCRIPTION
## Summary:
This update is intended to make the error case when using path matching be more informative, and less confusing. The intention is to give a clearer signal to the developer about why things didn't work as they expected.

Made this a minor update because:
- Though it could potentially be considered a breaking change, it is only changing the error message thrown in the fail condition, which folks shouldn't be relying on anyway.
- It's a bit more than a patch fix, imho.

Issue: WB-XXXX

## Test plan:
`pnpm jest packages/wonder-blocks-testing-core`