### PR TITLE
WB-1797 Fix ActionItem height

### DIFF
--- a/.changeset/breezy-pandas-knock.md
+++ b/.changeset/breezy-pandas-knock.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-dropdown": patch
 ---
 
-Remove explict height for ActionItem so that it can grow as needed
+Remove explict height for ActionItem so that it can grow as needed. Also make sure an ActionItem with a single line of text has a height of 40px still.

--- a/.changeset/breezy-pandas-knock.md
+++ b/.changeset/breezy-pandas-knock.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Remove explict height for ActionItem so that it can grow as needed

--- a/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
@@ -10,6 +10,7 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import actionItemArgtypes from "./action-item.argtypes";
+import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 const defaultArgs = {
     label: "Action Item",
@@ -126,6 +127,27 @@ export const Disabled = {
 export const CustomActionItem = {
     args: {
         label: "Action Item",
+        onClick: () => {},
+        leftAccessory: (
+            <PhosphorIcon icon={IconMappings.calendar} size="medium" />
+        ),
+        rightAccessory: (
+            <PhosphorIcon icon={IconMappings.caretRight} size="medium" />
+        ),
+    },
+};
+
+/**
+ * Another example of a custom action item with a larger label
+ */
+export const CustomActionItemMultiLine = {
+    args: {
+        label: (
+            <View>
+                <LabelLarge>Title</LabelLarge>
+                <LabelMedium>Subtitle</LabelMedium>
+            </View>
+        ),
         onClick: () => {},
         leftAccessory: (
             <PhosphorIcon icon={IconMappings.calendar} size="medium" />

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -223,7 +223,6 @@ const styles = StyleSheet.create({
     },
     shared: {
         minHeight: DROPDOWN_ITEM_HEIGHT,
-        height: DROPDOWN_ITEM_HEIGHT,
     },
 
     label: {

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {CompactCell} from "@khanacademy/wonder-blocks-cell";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    semanticColor,
+    sizing,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import type {PropsFor, StyleType} from "@khanacademy/wonder-blocks-core";
@@ -223,6 +227,8 @@ const styles = StyleSheet.create({
     },
     shared: {
         minHeight: DROPDOWN_ITEM_HEIGHT,
+        // Make sure that the item is always at least as tall as 40px.
+        paddingBlock: sizing.size_125,
     },
 
     label: {


### PR DESCRIPTION
## Summary:
Addressing the styling issue where ActionItem contents can get cropped with the new Cell changes (found in https://github.com/Khan/webapp/pull/29021#pullrequestreview-2675406111). This was happening because we set [`overflow: hidden` now in CellCore](https://github.com/Khan/wonder-blocks/pull/2435/files#diff-0b4c2beea72229dd5e2a29d5053ba87703ec2c51882604d29f36995815a299d5R248-R250) to prevent the left bar indicator from overflowing when the border radius is set on a cell. 

Remove explicitly setting the height of action items so the contents don't overflow. We can inspect the current implementation and see the cell contents are overflowing the inner wrapper container

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/89410914-1805-43e0-a0d3-c626a427ab70) | ![image](https://github.com/user-attachments/assets/915da84c-cec5-4603-bce9-e2808e0cf2d1) |



Issue: WB-1797

## Test plan:
- Review Chromatic diffs
- Review Custom Action Item Multi Line story (`?path=/story/packages-dropdown-actionitem--custom-action-item-multi-line`)
- Check ActionItem use in webapp