### PR TITLE
IconButton: Update tertiary color to use icon.primary

### DIFF
--- a/.changeset/fast-mails-appear.md
+++ b/.changeset/fast-mails-appear.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": patch
+---
+
+Fix IconButton theme to use semanticColor.icon tokens

--- a/.changeset/large-islands-burn.md
+++ b/.changeset/large-islands-burn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update semanticColor.icon.primary to use the new a11y-friendly offBlack72 primitive color

--- a/packages/wonder-blocks-icon-button/src/themes/default.ts
+++ b/packages/wonder-blocks-icon-button/src/themes/default.ts
@@ -134,7 +134,7 @@ const theme = {
                 ...baseColorStates.destructive,
                 default: {
                     ...baseColorStates.destructive.default,
-                    foreground: semanticColor.text.primary,
+                    foreground: semanticColor.icon.secondary,
                 },
             },
         },
@@ -145,14 +145,22 @@ const theme = {
                 ...baseColorStates.progressive,
                 default: {
                     ...baseColorStates.progressive.default,
-                    foreground: semanticColor.text.secondary,
+                    foreground: semanticColor.icon.primary,
+                },
+                hover: {
+                    ...baseColorStates.progressive.default,
+                    background: "transparent",
                 },
             },
             destructive: {
                 ...baseColorStates.destructive,
                 default: {
                     ...baseColorStates.destructive.default,
-                    foreground: semanticColor.text.secondary,
+                    foreground: semanticColor.icon.primary,
+                },
+                hover: {
+                    ...baseColorStates.destructive.default,
+                    background: "transparent",
                 },
             },
         },

--- a/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
@@ -161,7 +161,7 @@ export const semanticColor = {
      * Default icon colors that change in context (like actions).
      */
     icon: {
-        primary: color.fadedOffBlack64,
+        primary: color.fadedOffBlack72,
         secondary: color.offBlack,
         inverse: color.white,
         action: color.blue,


### PR DESCRIPTION
## Summary:

- IconButton: Updated the `IconButton` theme to use `semanticColor.icon.primary`
for the tertiary color. Also fixed the `hover` state to use a transparent background.

- Tokens: Update `icon.primary` to use `offBlack72` for consistency with `text.secondary`.

This is done following up on the changes made in `semanticColor` tokens in
previous PRs.

The `icon.primary` change was done after checking with design: https://khanacademy.slack.com/archives/C07CA2YR0BZ/p1738612644306129?thread_ts=1738357739.268909&cid=C07CA2YR0BZ

Issue: "none"

## Test plan:

Verify that the colors are updated in the `IconButton` component.