### PR TITLE
Switch to pnpm catalogs

### DIFF
--- a/.changeset/hot-wasps-hug.md
+++ b/.changeset/hot-wasps-hug.md
@@ -1,0 +1,34 @@
+---
+"@khanacademy/wonder-blocks-progress-spinner": patch
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-labeled-field": patch
+"@khanacademy/wonder-blocks-search-field": patch
+"@khanacademy/wonder-blocks-testing-core": patch
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-typography": patch
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-testing": patch
+"@khanacademy/wonder-blocks-theming": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-banner": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-layout": patch
+"@khanacademy/wonder-blocks-switch": patch
+"@khanacademy/wonder-blocks-timing": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-data": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-icon": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-pill": patch
+---
+
+Use pnpm catalog to pin dependency versions across packages

--- a/package.json
+++ b/package.json
@@ -129,25 +129,23 @@
     "vitest": "^3.0.4"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
-    "@khanacademy/wonder-stuff-core": "^1.5.4",
-    "@phosphor-icons/core": "^2.0.2",
-    "@popperjs/core": "^2.11.8",
-    "aphrodite": "^1.2.5",
-    "moment": "2.29.4",
-    "node-fetch": "^2.6.7",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-popper": "^2.3.0",
-    "react-router": "5.3.4",
-    "react-router-dom": "5.3.4",
-    "react-window": "^1.8.11"
+    "@babel/runtime": "catalog:",
+    "@khanacademy/wonder-stuff-core": "catalog:",
+    "@phosphor-icons/core": "catalog:",
+    "@popperjs/core": "catalog:",
+    "aphrodite": "catalog:",
+    "moment": "catalog:",
+    "node-fetch": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-popper": "catalog:",
+    "react-router": "catalog:",
+    "react-router-dom": "catalog:",
+    "react-window": "catalog:"
   },
   "resolutions": {
     "@types/react": "18",
-    "@types/react-dom": "18",
-    "strip-ansi": "6.0.1",
-    "strip-ansi-explanation": "There's an issue with strip-ansi v7 which causes conflicts with the Khan/changeset-per-package action"
+    "@types/react-dom": "18"
   },
   "packageManager": "pnpm@10.1.0+sha512.c89847b0667ddab50396bbbd008a2a43cf3b581efd59cf5d9aa8923ea1fb4b8106c041d540d08acb095037594d73ebc51e1ec89ee40c88b30b8a66c0fae0ac1b"
 }

--- a/packages/wonder-blocks-accordion/package.json
+++ b/packages/wonder-blocks-accordion/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
@@ -25,9 +25,9 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-banner/package.json
+++ b/packages/wonder-blocks-banner/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-button": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
@@ -26,9 +26,9 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-birthday-picker/package.json
+++ b/packages/wonder-blocks-birthday-picker/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-dropdown": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
@@ -23,10 +23,10 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "moment": "^2.24.0",
-    "react": "18.2.0"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "moment": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-breadcrumbs/package.json
+++ b/packages/wonder-blocks-breadcrumbs/package.json
@@ -16,13 +16,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
@@ -26,10 +26,10 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-router": "5.3.4",
-    "react-router-dom": "5.3.4"
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-router": "catalog:",
+    "react-router-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-cell/package.json
+++ b/packages/wonder-blocks-cell/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-layout": "workspace:*",
@@ -22,8 +22,8 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -16,16 +16,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-router": "5.3.4",
-    "react-router-dom": "5.3.4"
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-router": "catalog:",
+    "react-router-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -14,14 +14,14 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5"
+    "@babel/runtime": "catalog:"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-router": "5.3.4",
-    "react-router-dom": "5.3.4"
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-router": "catalog:",
+    "react-router-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",

--- a/packages/wonder-blocks-data/package.json
+++ b/packages/wonder-blocks-data/package.json
@@ -14,12 +14,12 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*"
   },
   "peerDependencies": {
-    "@khanacademy/wonder-stuff-core": "^1.5.4",
-    "react": "18.2.0"
+    "@khanacademy/wonder-stuff-core": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-cell": "workspace:*",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
@@ -30,15 +30,15 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "@popperjs/core": "^2.10.1",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-popper": "^2.0.0",
-    "react-router": "5.3.4",
-    "react-router-dom": "5.3.4",
-    "react-window": "^1.8.11"
+    "@phosphor-icons/core": "catalog:",
+    "@popperjs/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-popper": "catalog:",
+    "react-router": "catalog:",
+    "react-router-dom": "catalog:",
+    "react-window": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
@@ -25,9 +25,9 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-grid/package.json
+++ b/packages/wonder-blocks-grid/package.json
@@ -16,14 +16,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-layout": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
@@ -24,10 +24,10 @@
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-router": "5.3.4",
-    "react-router-dom": "5.3.4"
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-router": "catalog:",
+    "react-router-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-icon/package.json
+++ b/packages/wonder-blocks-icon/package.json
@@ -16,15 +16,15 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   }
 }

--- a/packages/wonder-blocks-labeled-field/package.json
+++ b/packages/wonder-blocks-labeled-field/package.json
@@ -16,16 +16,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-layout": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-layout/package.json
+++ b/packages/wonder-blocks-layout/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },
@@ -22,8 +22,8 @@
     "@khanacademy/wb-dev-build-settings": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "author": "",
   "license": "MIT"

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -16,18 +16,18 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-router": "5.3.4",
-    "react-router-dom": "5.3.4"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-router": "catalog:",
+    "react-router-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-breadcrumbs": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon-button": "workspace:*",
@@ -27,10 +27,10 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wonder-blocks-breadcrumbs": "^3.0.8",

--- a/packages/wonder-blocks-pill/package.json
+++ b/packages/wonder-blocks-pill/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-link": "workspace:*",
@@ -25,8 +25,8 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon-button": "workspace:*",
     "@khanacademy/wonder-blocks-modal": "workspace:*",
@@ -25,12 +25,12 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "@popperjs/core": "^2.10.1",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-popper": "^2.0.0"
+    "@phosphor-icons/core": "catalog:",
+    "@popperjs/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-popper": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-progress-spinner/package.json
+++ b/packages/wonder-blocks-progress-spinner/package.json
@@ -16,13 +16,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-search-field/package.json
+++ b/packages/wonder-blocks-search-field/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-form": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
@@ -25,9 +25,9 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@phosphor-icons/core": "^2.0.2",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "@phosphor-icons/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-switch/package.json
+++ b/packages/wonder-blocks-switch/package.json
@@ -16,15 +16,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
     "@khanacademy/wonder-blocks-theming": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-testing-core/package.json
+++ b/packages/wonder-blocks-testing-core/package.json
@@ -14,16 +14,16 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5"
+    "@babel/runtime": "catalog:"
   },
   "peerDependencies": {
-    "@khanacademy/wonder-stuff-core": "^1.5.4",
+    "@khanacademy/wonder-stuff-core": "catalog:",
     "@storybook/addon-actions": "^8.5.2",
-    "aphrodite": "^1.2.5",
-    "node-fetch": "^2.6.7",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-router-dom": "5.3.4"
+    "aphrodite": "catalog:",
+    "node-fetch": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-router-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",

--- a/packages/wonder-blocks-testing/package.json
+++ b/packages/wonder-blocks-testing/package.json
@@ -14,19 +14,19 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-data": "workspace:*",
     "@khanacademy/wonder-blocks-testing-core": "workspace:*"
   },
   "peerDependencies": {
-    "@khanacademy/wonder-stuff-core": "^1.5.4",
+    "@khanacademy/wonder-stuff-core": "catalog:",
     "@storybook/addon-actions": "^8.5.2",
-    "aphrodite": "^1.2.5",
-    "node-fetch": "^2.6.7",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-router-dom": "5.3.4"
+    "aphrodite": "catalog:",
+    "node-fetch": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-router-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",

--- a/packages/wonder-blocks-theming/package.json
+++ b/packages/wonder-blocks-theming/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-timing/package.json
+++ b/packages/wonder-blocks-timing/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",

--- a/packages/wonder-blocks-toolbar/package.json
+++ b/packages/wonder-blocks-toolbar/package.json
@@ -16,14 +16,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-tooltip/package.json
+++ b/packages/wonder-blocks-tooltip/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-layout": "workspace:*",
     "@khanacademy/wonder-blocks-modal": "workspace:*",
@@ -24,11 +24,11 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
-    "@popperjs/core": "^2.10.1",
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-popper": "^2.0.0"
+    "@popperjs/core": "catalog:",
+    "aphrodite": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-popper": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-typography/package.json
+++ b/packages/wonder-blocks-typography/package.json
@@ -16,12 +16,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.24.5",
+    "@babel/runtime": "catalog:",
     "@khanacademy/wonder-blocks-core": "workspace:*"
   },
   "peerDependencies": {
-    "aphrodite": "^1.2.5",
-    "react": "18.2.0"
+    "aphrodite": "catalog:",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,54 +4,94 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@babel/runtime':
+      specifier: ^7.24.5
+      version: 7.26.7
+    '@khanacademy/wonder-stuff-core':
+      specifier: ^1.5.4
+      version: 1.5.4
+    '@phosphor-icons/core':
+      specifier: ^2.0.2
+      version: 2.1.1
+    '@popperjs/core':
+      specifier: ^2.10.1
+      version: 2.11.8
+    aphrodite:
+      specifier: ^1.2.5
+      version: 1.2.5
+    moment:
+      specifier: 2.29.4
+      version: 2.29.4
+    node-fetch:
+      specifier: ^2.6.7
+      version: 2.7.0
+    react:
+      specifier: 18.2.0
+      version: 18.2.0
+    react-dom:
+      specifier: 18.2.0
+      version: 18.2.0
+    react-popper:
+      specifier: ^2.3.0
+      version: 2.3.0
+    react-router:
+      specifier: 5.3.4
+      version: 5.3.4
+    react-router-dom:
+      specifier: 5.3.4
+      version: 5.3.4
+    react-window:
+      specifier: ^1.8.11
+      version: 1.8.11
+
 overrides:
   '@types/react': '18'
   '@types/react-dom': '18'
-  strip-ansi: 6.0.1
-  strip-ansi-explanation: There's an issue with strip-ansi v7 which causes conflicts with the Khan/changeset-per-package action
 
 importers:
 
   .:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-stuff-core':
-        specifier: ^1.5.4
+        specifier: 'catalog:'
         version: 1.5.4
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       '@popperjs/core':
-        specifier: ^2.11.8
+        specifier: 'catalog:'
         version: 2.11.8
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       moment:
-        specifier: 2.29.4
+        specifier: 'catalog:'
         version: 2.29.4
       node-fetch:
-        specifier: ^2.6.7
+        specifier: 'catalog:'
         version: 2.7.0
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
       react-popper:
-        specifier: ^2.3.0
+        specifier: 'catalog:'
         version: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-router:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-window:
-        specifier: ^1.8.11
+        specifier: 'catalog:'
         version: 1.8.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@babel/core':
@@ -327,7 +367,7 @@ importers:
   packages/wonder-blocks-accordion:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-clickable':
         specifier: workspace:*
@@ -345,13 +385,13 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -361,7 +401,7 @@ importers:
   packages/wonder-blocks-banner:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-button':
         specifier: workspace:*
@@ -385,13 +425,13 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -401,7 +441,7 @@ importers:
   packages/wonder-blocks-birthday-picker:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -422,16 +462,16 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       moment:
-        specifier: ^2.24.0
+        specifier: 'catalog:'
         version: 2.29.4
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -441,7 +481,7 @@ importers:
   packages/wonder-blocks-breadcrumbs:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -450,10 +490,10 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -463,7 +503,7 @@ importers:
   packages/wonder-blocks-button:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-clickable':
         specifier: workspace:*
@@ -487,16 +527,16 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-router:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -506,7 +546,7 @@ importers:
   packages/wonder-blocks-cell:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-clickable':
         specifier: workspace:*
@@ -524,10 +564,10 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -537,7 +577,7 @@ importers:
   packages/wonder-blocks-clickable:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -546,19 +586,19 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
       react-router:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -568,22 +608,22 @@ importers:
   packages/wonder-blocks-core:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
       react-router:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -596,16 +636,16 @@ importers:
   packages/wonder-blocks-data:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
       '@khanacademy/wonder-stuff-core':
-        specifier: ^1.5.4
+        specifier: 'catalog:'
         version: 1.5.4
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -621,7 +661,7 @@ importers:
   packages/wonder-blocks-dropdown:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-cell':
         specifier: workspace:*
@@ -657,31 +697,31 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       '@popperjs/core':
-        specifier: ^2.10.1
+        specifier: 'catalog:'
         version: 2.11.8
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
       react-popper:
-        specifier: ^2.0.0
+        specifier: 'catalog:'
         version: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-router:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-window:
-        specifier: ^1.8.11
+        specifier: 'catalog:'
         version: 1.8.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -691,7 +731,7 @@ importers:
   packages/wonder-blocks-form:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-clickable':
         specifier: workspace:*
@@ -712,13 +752,13 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -728,7 +768,7 @@ importers:
   packages/wonder-blocks-grid:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -740,10 +780,10 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -753,19 +793,19 @@ importers:
   packages/wonder-blocks-icon:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -775,7 +815,7 @@ importers:
   packages/wonder-blocks-icon-button:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-clickable':
         specifier: workspace:*
@@ -793,16 +833,16 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-router:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -812,7 +852,7 @@ importers:
   packages/wonder-blocks-labeled-field:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -827,13 +867,13 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -843,7 +883,7 @@ importers:
   packages/wonder-blocks-layout:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -852,10 +892,10 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -865,7 +905,7 @@ importers:
   packages/wonder-blocks-link:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-clickable':
         specifier: workspace:*
@@ -880,19 +920,19 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-router:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -902,7 +942,7 @@ importers:
   packages/wonder-blocks-modal:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-breadcrumbs':
         specifier: workspace:*
@@ -929,16 +969,16 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -948,7 +988,7 @@ importers:
   packages/wonder-blocks-pill:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-clickable':
         specifier: workspace:*
@@ -966,10 +1006,10 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -979,7 +1019,7 @@ importers:
   packages/wonder-blocks-popover:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -1000,22 +1040,22 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       '@popperjs/core':
-        specifier: ^2.10.1
+        specifier: 'catalog:'
         version: 2.11.8
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
       react-popper:
-        specifier: ^2.0.0
+        specifier: 'catalog:'
         version: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1025,7 +1065,7 @@ importers:
   packages/wonder-blocks-progress-spinner:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -1034,10 +1074,10 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1047,7 +1087,7 @@ importers:
   packages/wonder-blocks-search-field:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -1068,13 +1108,13 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@phosphor-icons/core':
-        specifier: ^2.0.2
+        specifier: 'catalog:'
         version: 2.1.1
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1084,7 +1124,7 @@ importers:
   packages/wonder-blocks-switch:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -1099,10 +1139,10 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1112,7 +1152,7 @@ importers:
   packages/wonder-blocks-testing:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -1124,25 +1164,25 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-testing-core
       '@khanacademy/wonder-stuff-core':
-        specifier: ^1.5.4
+        specifier: 'catalog:'
         version: 1.5.4
       '@storybook/addon-actions':
         specifier: ^8.5.2
         version: 8.5.2(storybook@8.5.2(prettier@3.4.2))
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       node-fetch:
-        specifier: ^2.6.7
+        specifier: 'catalog:'
         version: 2.7.0
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1155,28 +1195,28 @@ importers:
   packages/wonder-blocks-testing-core:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-stuff-core':
-        specifier: ^1.5.4
+        specifier: 'catalog:'
         version: 1.5.4
       '@storybook/addon-actions':
         specifier: ^8.5.2
         version: 8.5.2(storybook@8.5.2(prettier@3.4.2))
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       node-fetch:
-        specifier: ^2.6.7
+        specifier: 'catalog:'
         version: 2.7.0
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
       react-router-dom:
-        specifier: 5.3.4
+        specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1189,13 +1229,13 @@ importers:
   packages/wonder-blocks-theming:
     dependencies:
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1205,7 +1245,7 @@ importers:
   packages/wonder-blocks-timing:
     dependencies:
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1224,7 +1264,7 @@ importers:
   packages/wonder-blocks-toolbar:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -1236,10 +1276,10 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1249,7 +1289,7 @@ importers:
   packages/wonder-blocks-tooltip:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
@@ -1267,19 +1307,19 @@ importers:
         specifier: workspace:*
         version: link:../wonder-blocks-typography
       '@popperjs/core':
-        specifier: ^2.10.1
+        specifier: 'catalog:'
         version: 2.11.8
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
       react-dom:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
       react-popper:
-        specifier: ^2.0.0
+        specifier: 'catalog:'
         version: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -1289,16 +1329,16 @@ importers:
   packages/wonder-blocks-typography:
     dependencies:
       '@babel/runtime':
-        specifier: ^7.24.5
+        specifier: 'catalog:'
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
       aphrodite:
-        specifier: ^1.2.5
+        specifier: 'catalog:'
         version: 1.2.5
       react:
-        specifier: 18.2.0
+        specifier: 'catalog:'
         version: 18.2.0
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
@@ -3501,6 +3541,10 @@ packages:
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -7024,6 +7068,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
@@ -8955,7 +9003,7 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 6.0.1
+      strip-ansi: 7.1.0
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -10426,6 +10474,8 @@ snapshots:
       type-fest: 0.21.3
 
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.1.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -15037,7 +15087,7 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 6.0.1
+      strip-ansi: 7.1.0
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -15103,6 +15153,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
 
   strip-bom@3.0.0: {}
 
@@ -15887,7 +15941,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       string-width: 5.1.2
-      strip-ansi: 6.0.1
+      strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,31 @@
 packages:
-  # All WB packages
-  - 'packages/*'
-  # Required for building WB packages
-  - "build-settings"
-  # AST transforms
-  - "wb-codemod"
+    # All WB packages
+    - "packages/*"
+    # Required for building WB packages
+    - "build-settings"
+    # AST transforms
+    - "wb-codemod"
+catalog:
+    # Babel
+    "@babel/runtime": ^7.24.5
+    # Wonder Stuff
+    "@khanacademy/wonder-stuff-core": ^1.5.4
+    # Icons library
+    "@phosphor-icons/core": ^2.0.2
+    # Positioning
+    "@popperjs/core": ^2.10.1
+    react-popper: ^2.3.0
+    # Styling
+    aphrodite: ^1.2.5
+    # Dates
+    moment: 2.29.4
+    # Testing/data
+    node-fetch: ^2.6.7
+    # React
+    "react": 18.2.0
+    "react-dom": 18.2.0
+    # React Router
+    react-router: 5.3.4
+    react-router-dom: 5.3.4
+    # Virtualization
+    react-window: ^1.8.11


### PR DESCRIPTION
## Summary:

Switching to pnpm catalogs to pin dependency versions across packages.

This is helpful for ensuring that all packages are using the same version of a
dependency, and for making it easier to update dependencies across all packages.

https://pnpm.io/catalogs

Issue: "none"

## Test plan:

Verify that the builds are still passing.

Also verify that the components work as expected in Storybook.