### PR TITLE
Add `styles` prop to `LabeledField` and switch to sizing tokens

### DIFF
--- a/.changeset/gorgeous-beans-rescue.md
+++ b/.changeset/gorgeous-beans-rescue.md
@@ -1,0 +1,9 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": minor
+---
+
+LabeledField
+
+- Add `styles` prop to support custom stying for the label, description, and error elements
+- Use CSS padding instead of `<Strut>` for spacing
+- Migrated to `sizing` tokens instead of `spacing`

--- a/.changeset/selfish-goats-protect.md
+++ b/.changeset/selfish-goats-protect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": major
+---
+
+Remove `style` prop in favour of `styles` prop. Styling can be applied to the root instead using the `styles` prop

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.argtypes.ts
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.argtypes.ts
@@ -37,22 +37,11 @@ export default {
     /**
      * Visual Style
      */
-    style: {
-        table: {
-            type: {
-                summary: "StyleType",
-            },
-            category: "Visual style",
-        },
-        control: {
-            type: "null",
-        },
-    },
     styles: {
         table: {
             type: {
                 summary:
-                    "{ label?: StyleType; description?: StyleType; error?: StyleType }",
+                    "{ root?: StyleType; label?: StyleType; description?: StyleType; error?: StyleType }",
             },
             category: "Visual style",
         },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.argtypes.ts
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.argtypes.ts
@@ -48,4 +48,16 @@ export default {
             type: "null",
         },
     },
+    styles: {
+        table: {
+            type: {
+                summary:
+                    "{ label?: StyleType; description?: StyleType; error?: StyleType }",
+            },
+            category: "Visual style",
+        },
+        control: {
+            type: "null",
+        },
+    },
 };

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -613,7 +613,7 @@ export const Custom = {
 
 /**
  * Custom styles can be set for the elements in LabeledField using the `styles`
- * prop. If you need to set styles on the root element, use the `style` prop.
+ * prop.
  *
  * It is useful for specific cases where spacing between elements needs to be
  * customized. If there is a specific use case where the styling needs to be
@@ -627,14 +627,17 @@ export const CustomStyles = {
         errorMessage: "Message about the error",
         required: "Custom required message",
         styles: {
+            root: {
+                padding: sizing.size_100,
+            },
             label: {
-                paddingBottom: sizing.size_025,
+                paddingBlockEnd: sizing.size_025,
             },
             description: {
-                paddingBottom: sizing.size_025,
+                paddingBlockEnd: sizing.size_025,
             },
             error: {
-                paddingTop: sizing.size_025,
+                paddingBlockStart: sizing.size_025,
             },
         },
     },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -6,7 +6,7 @@ import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {TextArea, TextField} from "@khanacademy/wonder-blocks-form";
 import LabeledFieldArgTypes from "./labeled-field.argtypes";
 import {addStyle, PropsFor, View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     MultiSelect,
     OptionItem,
@@ -608,5 +608,34 @@ export const Custom = {
                 <b>Error</b> <i>using</i> <u>JSX</u>
             </span>
         ),
+    },
+};
+
+/**
+ * Custom styles can be set for the elements in LabeledField using the `styles`
+ * prop. If you need to set styles on the root element, use the `style` prop.
+ *
+ * It is useful for specific cases where spacing between elements needs to be
+ * customized. If there is a specific use case where the styling needs to be
+ * overridden, please reach out to the Wonder Blocks team!
+ */
+export const CustomStyles = {
+    args: {
+        field: <TextField value="" onChange={() => {}} />,
+        label: "Name",
+        description: "Helpful description text.",
+        errorMessage: "Message about the error",
+        required: "Custom required message",
+        styles: {
+            label: {
+                paddingBottom: sizing.size_025,
+            },
+            description: {
+                paddingBottom: sizing.size_025,
+            },
+            error: {
+                paddingTop: sizing.size_025,
+            },
+        },
     },
 };

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -215,7 +215,7 @@ const AllFields = (
             style={{
                 display: "flex",
                 flexDirection: "column",
-                gap: spacing.large_24,
+                gap: sizing.size_300,
             }}
         >
             <LabeledField
@@ -467,7 +467,7 @@ export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
     const longTextWithNoBreak =
         "LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequatDuisauteiruredolorinreprehenderitinvoluptatevelitessecillumdoloreeufugiatnullapariatur";
     return (
-        <View style={{gap: spacing.large_24}}>
+        <View style={{gap: sizing.size_300}}>
             <HeadingLarge>Scenarios</HeadingLarge>
             <LabeledField
                 {...args}

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {render, screen, within} from "@testing-library/react";
-import {StyleSheet} from "aphrodite";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
@@ -133,31 +132,6 @@ describe("LabeledField", () => {
         // Assert
         const error = screen.getByTestId(`${testId}-error`);
         expect(error).toBeInTheDocument();
-    });
-
-    it("stype prop applies to the LabeledField container", () => {
-        // Arrange
-        const styles = StyleSheet.create({
-            style1: {
-                flexGrow: 1,
-                background: "blue",
-            },
-        });
-
-        // Act
-        const {container} = render(
-            <LabeledField
-                field={<TextField id="tf-1" value="" onChange={() => {}} />}
-                label="Label"
-                errorMessage="Error"
-                style={styles.style1}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const labeledField = container.childNodes[0];
-        expect(labeledField).toHaveStyle("background: blue");
     });
 
     describe("Labels prop", () => {

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -3,7 +3,6 @@ import {StyleSheet} from "aphrodite";
 import WarningCircle from "@phosphor-icons/core/bold/warning-circle-bold.svg";
 
 import {View, addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -143,7 +142,13 @@ export default function LabeledField(props: Props) {
         return (
             <React.Fragment>
                 <LabelMedium
-                    style={[styles.textWordBreak, styles.label]}
+                    style={[
+                        styles.textWordBreak,
+                        styles.label,
+                        description
+                            ? styles.labelWithDescription
+                            : styles.labelWithNoDescription,
+                    ]}
                     tag="label"
                     htmlFor={fieldId}
                     testId={testId && `${testId}-label`}
@@ -152,7 +157,6 @@ export default function LabeledField(props: Props) {
                     {label}
                     {isRequired && requiredIcon}
                 </LabelMedium>
-                <Strut size={spacing.xxxSmall_4} />
             </React.Fragment>
         );
     }
@@ -171,7 +175,6 @@ export default function LabeledField(props: Props) {
                 >
                     {description}
                 </LabelSmall>
-                <Strut size={spacing.xxxSmall_4} />
             </React.Fragment>
         );
     }
@@ -242,7 +245,6 @@ export default function LabeledField(props: Props) {
         <View style={style}>
             {renderLabel()}
             {maybeRenderDescription()}
-            <Strut size={spacing.xSmall_8} />
             {renderField()}
             {maybeRenderError()}
         </View>
@@ -253,8 +255,15 @@ const styles = StyleSheet.create({
     label: {
         color: semanticColor.text.primary,
     },
+    labelWithDescription: {
+        paddingBottom: spacing.xxxSmall_4,
+    },
+    labelWithNoDescription: {
+        paddingBottom: spacing.small_12,
+    },
     description: {
         color: semanticColor.text.secondary,
+        paddingBottom: spacing.small_12,
     },
     errorSection: {
         flexDirection: "row",

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -54,14 +54,11 @@ type Props = {
      */
     errorMessage?: React.ReactNode;
     /**
-     * Custom styles for the labeled field container.
-     */
-    style?: StyleType;
-    /**
      * Custom styles for the elements of LabeledField. Useful if there are
      * specific cases where spacing between elements needs to be customized.
      */
     styles?: {
+        root?: StyleType;
         label?: StyleType;
         description?: StyleType;
         error?: StyleType;
@@ -117,7 +114,6 @@ const StyledSpan = addStyle("span");
 export default function LabeledField(props: Props) {
     const {
         field,
-        style,
         styles: stylesProp,
         label,
         id,
@@ -258,7 +254,7 @@ export default function LabeledField(props: Props) {
     }
 
     return (
-        <View style={style}>
+        <View style={stylesProp?.root}>
             {renderLabel()}
             {maybeRenderDescription()}
             {renderField()}

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import WarningCircle from "@phosphor-icons/core/bold/warning-circle-bold.svg";
 
 import {View, addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
@@ -256,21 +256,21 @@ const styles = StyleSheet.create({
         color: semanticColor.text.primary,
     },
     labelWithDescription: {
-        paddingBottom: spacing.xxxSmall_4,
+        paddingBottom: sizing.size_050,
     },
     labelWithNoDescription: {
-        paddingBottom: spacing.small_12,
+        paddingBottom: sizing.size_150,
     },
     description: {
         color: semanticColor.text.secondary,
-        paddingBottom: spacing.small_12,
+        paddingBottom: sizing.size_150,
     },
     errorSection: {
         flexDirection: "row",
-        gap: spacing.xSmall_8,
+        gap: sizing.size_100,
     },
     errorSectionWithContent: {
-        paddingTop: spacing.small_12,
+        paddingTop: sizing.size_150,
     },
     error: {
         color: semanticColor.status.critical.foreground,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -54,7 +54,7 @@ type Props = {
      */
     errorMessage?: React.ReactNode;
     /**
-     * Custom styles for the root of labeled field container.
+     * Custom styles for the labeled field container.
      */
     style?: StyleType;
     /**

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -272,21 +272,21 @@ const styles = StyleSheet.create({
         color: semanticColor.text.primary,
     },
     labelWithDescription: {
-        paddingBottom: sizing.size_050,
+        paddingBlockEnd: sizing.size_050,
     },
     labelWithNoDescription: {
-        paddingBottom: sizing.size_150,
+        paddingBlockEnd: sizing.size_150,
     },
     description: {
         color: semanticColor.text.secondary,
-        paddingBottom: sizing.size_150,
+        paddingBlockEnd: sizing.size_150,
     },
     errorSection: {
         flexDirection: "row",
         gap: sizing.size_100,
     },
     errorSectionWithContent: {
-        paddingTop: sizing.size_150,
+        paddingBlockStart: sizing.size_150,
     },
     error: {
         color: semanticColor.status.critical.foreground,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -54,9 +54,18 @@ type Props = {
      */
     errorMessage?: React.ReactNode;
     /**
-     * Custom styles for the labeled field container.
+     * Custom styles for the root of labeled field container.
      */
     style?: StyleType;
+    /**
+     * Custom styles for the elements of LabeledField. Useful if there are
+     * specific cases where spacing between elements needs to be customized.
+     */
+    styles?: {
+        label?: StyleType;
+        description?: StyleType;
+        error?: StyleType;
+    };
     /**
      * A unique id to use as the base of the ids for the elements within the component.
      * Here is how the id is used for the different elements in the component:
@@ -109,6 +118,7 @@ export default function LabeledField(props: Props) {
     const {
         field,
         style,
+        styles: stylesProp,
         label,
         id,
         required,
@@ -148,6 +158,7 @@ export default function LabeledField(props: Props) {
                         description
                             ? styles.labelWithDescription
                             : styles.labelWithNoDescription,
+                        stylesProp?.label,
                     ]}
                     tag="label"
                     htmlFor={fieldId}
@@ -169,7 +180,11 @@ export default function LabeledField(props: Props) {
         return (
             <React.Fragment>
                 <LabelSmall
-                    style={[styles.textWordBreak, styles.description]}
+                    style={[
+                        styles.textWordBreak,
+                        styles.description,
+                        stylesProp?.description,
+                    ]}
                     testId={testId && `${testId}-description`}
                     id={descriptionId}
                 >
@@ -188,6 +203,7 @@ export default function LabeledField(props: Props) {
                         errorMessage
                             ? styles.errorSectionWithContent
                             : undefined,
+                        stylesProp?.error,
                     ]}
                     id={errorId}
                     testId={testId && `${testId}-error`}


### PR DESCRIPTION
## Summary:
- Add `styles` prop to support custom stying for the label, description, and error elements
- Use CSS padding instead of `<Strut>` for spacing
- Migrated to `sizing` tokens instead of `spacing`

Issue: WB-1900

## Test plan:

- Review new Custom Styles story (`?path=/story/packages-labeledfield--custom-styles`)
- Existing styling should not be changed (no visual changes for existing stories should be detected in Chromatic, especially for `?path=/story/packages-labeledfield--scenarios`)