### PR TITLE
[WB-1871] IconButton: Rename `color` prop to `actionType`

### DIFF
--- a/.changeset/hot-days-cross.md
+++ b/.changeset/hot-days-cross.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": major
+---
+
+Rename `color` prop to `actionType`. Also rename the `default` value to `progressive`.

--- a/__docs__/wonder-blocks-icon-button/icon-button-variants.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button-variants.stories.tsx
@@ -61,7 +61,7 @@ const KindVariants = ({
                                     onClick={action("clicked")}
                                     kind={kind}
                                     light={light}
-                                    color="default"
+                                    actionType="progressive"
                                     size={size}
                                     key={size}
                                 />
@@ -90,7 +90,7 @@ const KindVariants = ({
                                     onClick={action("clicked")}
                                     kind={kind}
                                     light={light}
-                                    color="destructive"
+                                    actionType="destructive"
                                     size={size}
                                     key={size}
                                 />

--- a/__docs__/wonder-blocks-icon-button/icon-button.argtypes.ts
+++ b/__docs__/wonder-blocks-icon-button/icon-button.argtypes.ts
@@ -2,18 +2,13 @@ import type {ArgTypes} from "@storybook/react";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
 export default {
-    color: {
+    actionType: {
         control: {
             type: "select",
         },
-        description: "Color of the icon button.",
-        options: ["default", "destructive"],
         table: {
-            type: {
-                summary: `"default" | "destructive"`,
-            },
             defaultValue: {
-                summary: `"default"`,
+                summary: `"progressive"`,
             },
         },
     },
@@ -21,25 +16,18 @@ export default {
         control: {
             type: "boolean",
         },
-        description: "Whether the icon button is disabled.",
     },
     icon: {
         control: {
             type: "select",
         },
-        description: "A Phosphor icon asset (imported as a static SVG file).",
         options: IconMappings as any,
     },
     kind: {
         control: {
             type: "select",
         },
-        description: "The kind of the icon button.",
-        options: ["primary", "secondary", "tertiary"],
         table: {
-            type: {
-                summary: `"primary" | "secondary" | "tertiary"`,
-            },
             defaultValue: {
                 summary: `"primary"`,
             },
@@ -49,20 +37,13 @@ export default {
         control: {
             type: "select",
         },
-        description: "The size of the icon button.",
-        options: ["xsmall", "small", "medium", "large"],
         table: {
-            type: {
-                summary: `"xsmall" | "small" | "medium" | "large"`,
-            },
             defaultValue: {
                 summary: `"medium"`,
             },
         },
     },
     "aria-label": {
-        description:
-            "The description of this component for the screenreader to read.",
         control: {
             type: "text",
         },

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -99,7 +99,7 @@ type StoryComponentType = StoryObj<typeof IconButton>;
 export const Default: StoryComponentType = {
     args: {
         icon: magnifyingGlass,
-        color: "default",
+        actionType: "progressive",
         disabled: false,
         kind: "primary",
         size: "medium",
@@ -189,32 +189,32 @@ export const Variants: StoryComponentType = {
 };
 
 /**
- * IconButton has a `color` that is either `default` (the default, as shown
+ * IconButton has an `actionType` prop that is either `progressive` (the default, as shown
  * above) or `destructive` (as can seen below):
  */
-export const WithColor: StoryComponentType = {
-    name: "Color",
+export const WithActionType: StoryComponentType = {
+    name: "ActionType",
     render: (args) => (
         <View style={styles.row}>
             <IconButton
                 {...args}
                 icon={minusCircle}
                 onClick={() => {}}
-                color="destructive"
+                actionType="destructive"
             />
             <IconButton
                 {...args}
                 icon={minusCircle}
                 onClick={() => {}}
                 kind="secondary"
-                color="destructive"
+                actionType="destructive"
             />
             <IconButton
                 {...args}
                 icon={minusCircle}
                 onClick={() => {}}
                 kind="tertiary"
-                color="destructive"
+                actionType="destructive"
             />
             <IconButton
                 {...args}
@@ -222,7 +222,7 @@ export const WithColor: StoryComponentType = {
                 icon={minusCircle}
                 aria-label="search"
                 onClick={(e) => console.log("Click!")}
-                color="destructive"
+                actionType="destructive"
             />
         </View>
     ),
@@ -243,7 +243,7 @@ export const Light: StoryComponentType = {
                     onClick={(e) => console.log("Click!")}
                 />
                 <IconButton
-                    color="destructive"
+                    actionType="destructive"
                     icon={magnifyingGlass}
                     aria-label="search"
                     light={true}
@@ -269,7 +269,7 @@ export const DisabledLight: StoryComponentType = {
                     onClick={(e) => console.log("Click!")}
                 />
                 <IconButton
-                    color="destructive"
+                    actionType="destructive"
                     disabled={true}
                     icon={magnifyingGlass}
                     aria-label="search"

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -216,7 +216,7 @@ function getStylesByKind(
     if (kind === "primary") {
         // NOTE: Primary is the only kind that supports light variants.
         if (light) {
-            actionTypeOrDisabled = `${actionType}Light`;
+            actionTypeOrDisabled = `${actionTypeOrDisabled}Light`;
         }
 
         const themeVariant = theme.color[kind][actionTypeOrDisabled];

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -8,7 +8,11 @@ import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {useScopedTheme} from "@khanacademy/wonder-blocks-theming";
 
-import type {IconButtonSize, SharedProps} from "./icon-button";
+import type {
+    IconButtonActionType,
+    IconButtonSize,
+    SharedProps,
+} from "./icon-button";
 import {
     iconSizeForButtonSize,
     targetPixelsForSize,
@@ -19,15 +23,6 @@ import {
 } from "../themes/themed-icon-button";
 
 type Kind = "primary" | "secondary" | "tertiary";
-/**
- * The color/actionType of the button.
- *
- * NOTE: `default` maps to `progressive` in the theme.
- *
- * TODO(WB-1871): Rename `default` to `progressive` and change `color` to
- * `actionType`.
- */
-type ButtonColor = "default" | "destructive";
 
 /**
  * Returns the phosphor icon component based on the size. This is necessary
@@ -94,7 +89,7 @@ const IconButtonCore: React.ForwardRefExoticComponent<
     Props
 >(function IconButtonCore(props: Props, ref) {
     const {
-        color,
+        actionType,
         disabled,
         href,
         icon,
@@ -111,7 +106,7 @@ const IconButtonCore: React.ForwardRefExoticComponent<
 
     const renderInner = (router: any): React.ReactNode => {
         const buttonStyles = _generateStyles(
-            color,
+            actionType,
             !!disabled,
             kind,
             light,
@@ -207,40 +202,24 @@ type ActionType =
     | "destructiveLight"
     | "disabledLight";
 
-/**
- * Returns the action type based on the button color and disabled state.
- *
- * This is useful to determine which token variant to use for the button, which
- * is based on the theme structure.
- */
-function getActionType(buttonColor: ButtonColor, disabled: boolean) {
-    const actionType =
-        buttonColor === "destructive" ? "destructive" : "progressive";
-
-    if (disabled) {
-        return "disabled";
-    }
-
-    return actionType;
-}
-
 function getStylesByKind(
-    buttonColor: ButtonColor,
+    actionType: IconButtonActionType = "progressive",
     disabled: boolean,
     kind: Kind,
     light: boolean,
     theme: IconButtonThemeContract,
 ) {
-    let actionType: ActionType = getActionType(buttonColor, disabled);
-    const themeVariant = theme.color[kind][actionType];
+    let actionTypeOrDisabled: ActionType = disabled ? "disabled" : actionType;
+
+    const themeVariant = theme.color[kind][actionTypeOrDisabled];
 
     if (kind === "primary") {
         // NOTE: Primary is the only kind that supports light variants.
         if (light) {
-            actionType = `${actionType}Light`;
+            actionTypeOrDisabled = `${actionType}Light`;
         }
 
-        const themeVariant = theme.color[kind][actionType];
+        const themeVariant = theme.color[kind][actionTypeOrDisabled];
 
         return {
             default: {
@@ -317,7 +296,7 @@ function getStylesByKind(
 }
 
 const _generateStyles = (
-    buttonColor: ButtonColor = "default",
+    actionType: IconButtonActionType = "progressive",
     disabled: boolean,
     kind: Kind,
     light: boolean,
@@ -325,7 +304,7 @@ const _generateStyles = (
     theme: IconButtonThemeContract,
     themeName: string,
 ) => {
-    const buttonType = `${buttonColor}-d_${disabled}-${kind}-l_${light}-${size}-${themeName}`;
+    const buttonType = `${actionType}-d_${disabled}-${kind}-l_${light}-${size}-${themeName}`;
     if (styles[buttonType]) {
         return styles[buttonType];
     }
@@ -339,7 +318,7 @@ const _generateStyles = (
     // Override styles for each kind of button. This is useful for merging
     // pseudo-classes properly.
     const kindOverrides = getStylesByKind(
-        buttonColor,
+        actionType,
         disabled,
         kind,
         light,

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -8,6 +8,8 @@ import ThemedIconButton from "../themes/themed-icon-button";
 
 export type IconButtonSize = "xsmall" | "small" | "medium" | "large";
 
+export type IconButtonActionType = "progressive" | "destructive";
+
 export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
     /**
      * A unique identifier for the IconButton.
@@ -18,9 +20,15 @@ export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
      */
     icon: PhosphorIconAsset;
     /**
-     * The color of the icon button, either blue or red.
+     * The action type/category of the icon button.
+     *
+     * - `progressive` is used for actions that move the user forward in a flow.
+     * - `destructive` is used for actions that have a negative impact on the
+     *   user.
+     *
+     * Defaults to `progressive`.
      */
-    color?: "default" | "destructive";
+    actionType?: IconButtonActionType;
     /**
      * The kind of the icon button, either primary, secondary, or tertiary.
      *
@@ -180,7 +188,7 @@ export const IconButton: React.ForwardRefExoticComponent<
     SharedProps
 >(function IconButton(props: SharedProps, ref) {
     const {
-        color = "default",
+        actionType = "progressive",
         disabled = false,
         href,
         kind = "primary",
@@ -216,7 +224,7 @@ export const IconButton: React.ForwardRefExoticComponent<
         <ThemedIconButton>
             <IconButtonCore
                 {...sharedProps}
-                color={color}
+                actionType={actionType}
                 disabled={disabled}
                 href={href}
                 kind={kind}


### PR DESCRIPTION
## Summary:

We are trying to get more alignment with design, and part of that is that icon
buttons will use an `actionType` prop, which supports `progressive` and
`destructive`.

This PR includes the following API changes:

- `color` => `actionType`.
- `color=default` => `actionType=progressive`.

NOTE: `progressive` is now the default value.

Issue: https://khanacademy.atlassian.net/browse/WB-1871

## Test plan:

Navigate to the IconButton docs and verify that the prop is now `actionType`
instead of `color`.

/?path=/docs/packages-iconbutton--docs#actiontype