### PR TITLE
NavigationTabs stories updates

### DIFF
--- a/__docs__/wonder-blocks-tabs/navigation-tab-item-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tab-item-variants.stories.tsx
@@ -148,7 +148,7 @@ const meta = {
         <>
             <AllVariants rows={rows} columns={columns}>
                 {(props) => (
-                    <View style={styles.container}>
+                    <View style={styles.container} tag="ul">
                         <NavigationTabItem {...args} {...props} />
                     </View>
                 )}
@@ -157,7 +157,7 @@ const meta = {
                 <HeadingLarge>RTL</HeadingLarge>
                 <AllVariants rows={rtlRows} columns={columns}>
                     {(props) => (
-                        <View style={styles.container}>
+                        <View style={styles.container} tag="ul">
                             <NavigationTabItem {...args} {...props} />
                         </View>
                     )}
@@ -206,7 +206,7 @@ export const Zoom: Story = {
         <>
             <AllVariants rows={rows} columns={columns} layout="list">
                 {(props) => (
-                    <View style={styles.container}>
+                    <View style={styles.container} tag="ul">
                         <NavigationTabItem {...args} {...props} />
                     </View>
                 )}
@@ -215,7 +215,7 @@ export const Zoom: Story = {
                 <HeadingLarge>RTL</HeadingLarge>
                 <AllVariants rows={rtlRows} columns={columns} layout="list">
                     {(props) => (
-                        <View style={styles.container}>
+                        <View style={styles.container} tag="ul">
                             <NavigationTabItem {...args} {...props} />
                         </View>
                     )}

--- a/__docs__/wonder-blocks-tabs/navigation-tab-item-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tab-item-variants.stories.tsx
@@ -166,18 +166,6 @@ const meta = {
         </>
     ),
     tags: ["!autodocs"],
-    parameters: {
-        a11y: {
-            config: {
-                rules: [
-                    // Disabling warning: "List item does not have a <ul>, <ol> parent element"
-                    // This is intentional because NavigationTabs provides the ul element and it
-                    // is outside of this component
-                    {id: "listitem", enabled: false},
-                ],
-            },
-        },
-    },
 } satisfies Meta<typeof NavigationTabItem>;
 
 export default meta;

--- a/__docs__/wonder-blocks-tabs/navigation-tab-item.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tab-item.stories.tsx
@@ -4,7 +4,7 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-tabs/package.json";
 import {NavigationTabItem} from "@khanacademy/wonder-blocks-tabs";
 import Link from "@khanacademy/wonder-blocks-link";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
@@ -17,6 +17,11 @@ import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {ScenariosLayout} from "../components/scenarios-layout";
 
+const StyledUl = addStyle("ul", {
+    margin: sizing.size_0,
+    padding: sizing.size_0,
+});
+
 export default {
     title: "Packages / Tabs / NavigationTabs / NavigationTabItem",
     component: NavigationTabItem,
@@ -27,17 +32,17 @@ export default {
                 version={packageConfig.version}
             />
         ),
-        a11y: {
-            config: {
-                rules: [
-                    // Disabling warning: "List item does not have a <ul>, <ol> parent element"
-                    // This is intentional because NavigationTabs provides the ul element and it
-                    // is outside of this component
-                    {id: "listitem", enabled: false},
-                ],
-            },
-        },
     },
+    decorators: [
+        (Story) => (
+            // Wrap in a ul to address a11y warnings since NavigationTabItem
+            // renders a li element and should be used within a NavigationTabs
+            // component (which provides the ul element).
+            <StyledUl>
+                <Story />
+            </StyledUl>
+        ),
+    ],
     argTypes,
 } as Meta<typeof NavigationTabItem>;
 

--- a/__docs__/wonder-blocks-tabs/navigation-tabs-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs-variants.stories.tsx
@@ -264,7 +264,7 @@ export const Zoom: Story = {
                     // be determined because it's partially obscured by another
                     // element" since these examples can cause the horizontal
                     // scrollbar to show. Color contrast check is enabled for
-                    // other stories (including the AllVariants)
+                    // other stories (including the NavigationTabItem AllVariants)
                     {id: "color-contrast", enabled: false},
                 ],
             },

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -306,8 +306,8 @@ export const HeaderWithNavigationTabsExample: StoryComponentType = {
             <StyledDiv style={styles.pageStyle}>
                 <StyledHeader style={styles.headerStyle}>
                     <img
-                        src="/logo.svg"
-                        width="40px"
+                        src="/logo-with-text.svg"
+                        width="80px"
                         alt="Wonder Blocks logo"
                     />
                     <SingleSelect

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -245,7 +245,7 @@ export const Scenarios: StoryComponentType = {
                     // be determined because it's partially obscured by another
                     // element" since these examples can cause the horizontal
                     // scrollbar to show. Color contrast check is enabled for
-                    // other stories (including the AllVariants)
+                    // other stories (including the NavigationTabItem AllVariants)
                     {id: "color-contrast", enabled: false},
                 ],
             },


### PR DESCRIPTION
## Summary:

Minor updates to the NavigationTabs stories:
- Circling back to wrap NavigationTabItem with a `<ul>` element instead of disabling expected a11y rules ([discussed in the a11y fixes PR](https://github.com/Khan/wonder-blocks/pull/2509#discussion_r2008067305)). It was expected because the NavigationTabs component provides the `<ul>` element for it
- Use the logo with text image instead for header example (the logo asset can't be found in the deployed version, but the logo with text image should be available since we use that for the logo in Storybook)
- Update comments

Issue: WB-XXXX

## Test plan:
- Confirm the NavigationTabItem stories don't have a11y warnings using the Storybook a11y add on