### PR TITLE
[WB-1911] Popover: Remove "emphasized" and "color" variants

### DIFF
--- a/.changeset/pretty-candles-pretend.md
+++ b/.changeset/pretty-candles-pretend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-popover": major
+---
+
+Remove `emphasized` variant from `PopoverContent` and `color` prop from `PopoverContentCore` as these are not currently used and no longer recommended

--- a/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
@@ -2,15 +2,10 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import type {Meta, StoryObj} from "@storybook/react";
-import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {
-    Body,
-    HeadingSmall,
-    LabelLarge,
-} from "@khanacademy/wonder-blocks-typography";
+import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 
 import {PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
 import packageConfig from "../../packages/wonder-blocks-popover/package.json";
@@ -101,7 +96,9 @@ export const WithIcon: StoryComponentType = {
 const ClickableDetailCellWrapper = ClickableDetailCell as React.ElementType;
 
 /**
- * Using DetailCell as the content
+ * Popovers can also benefit from other Wonder Blocks components. In this
+ * example, we are using the `DetailCell` component embedded as part of the
+ * popover contents.
  */
 export const WithDetailCell: StoryComponentType = {
     args: {
@@ -110,76 +107,4 @@ export const WithDetailCell: StoryComponentType = {
         style: styles.popoverWithCell,
     },
     render: (args) => <PopoverContentCore {...args} />,
-};
-
-WithDetailCell.parameters = {
-    docs: {
-        description: {
-            story: "Popovers can also benefit from other Wonder Blocks components. In this example, we are using the DetailCell component embedded as part of the popover contents.",
-        },
-    },
-};
-
-/**
- * Dark custom popover
- */
-const CustomPopoverContent = (
-    <>
-        <HeadingSmall>Custom popover title</HeadingSmall>
-        <View style={styles.row}>
-            <Clickable style={styles.action} onClick={close} id="btn-1">
-                {() => (
-                    <>
-                        <PhosphorIcon
-                            icon={IconMappings.pencilSimple}
-                            color={semanticColor.status.warning.foreground}
-                            size="large"
-                        />
-                        <LabelLarge>Option 1</LabelLarge>
-                    </>
-                )}
-            </Clickable>
-            <Clickable style={styles.action} onClick={close} id="btn-2">
-                {() => (
-                    <>
-                        <PhosphorIcon
-                            icon={IconMappings.pencilSimple}
-                            color={semanticColor.status.success.foreground}
-                            size="large"
-                        />
-                        <LabelLarge>Option 2</LabelLarge>
-                    </>
-                )}
-            </Clickable>
-            <Clickable style={styles.action} onClick={close} id="btn-3">
-                {() => (
-                    <>
-                        <PhosphorIcon
-                            icon={IconMappings.pencilSimple}
-                            color={semanticColor.status.notice.foreground}
-                            size="large"
-                        />
-                        <LabelLarge>Option 3</LabelLarge>
-                    </>
-                )}
-            </Clickable>
-        </View>
-    </>
-);
-
-export const Dark: StoryComponentType = {
-    args: {
-        children: CustomPopoverContent,
-        color: "darkBlue",
-        style: styles.customPopover,
-    },
-    render: (args) => <PopoverContentCore {...args} />,
-};
-
-Dark.parameters = {
-    docs: {
-        description: {
-            story: "This component provides a flexible variant that can be used for example, for our Confidence Prompt in test prep and popovers that don't fit into other categories. If you want to use a different background, you can set `color` as part of `PopoverContentCore`.",
-        },
-    },
 };

--- a/__docs__/wonder-blocks-popover/popover-content.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.argtypes.tsx
@@ -153,8 +153,4 @@ export default {
         options: Object.keys(ImageMappings) as Array<React.ReactNode>,
         mapping: ImageMappings,
     },
-    emphasized: {
-        description: `When true, changes the popover dialog background to blue; otherwise, the popover dialog background is not modified. It can be used only with Text-only popovers. It cannot be used with icon or image.`,
-        control: {type: "boolean"},
-    },
 } satisfies ArgTypes;

--- a/__docs__/wonder-blocks-popover/popover-content.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.stories.tsx
@@ -2,10 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {PopoverContent} from "@khanacademy/wonder-blocks-popover";
 import packageConfig from "../../packages/wonder-blocks-popover/package.json";
@@ -66,32 +63,6 @@ export const Default: StoryComponentType = {
 };
 
 Default.storyName = "Default (text)";
-
-/**
- * Text-only variant with added emphasis.
- * **NOTE:** When using this variant, make sure to apply the `light`
- * prop to each button
- */
-export const Emphasized: StoryComponentType = {
-    args: {
-        title: "Popover with emphasis",
-        content:
-            "Some content for the popover. Note that the action buttons are using the light version.",
-        emphasized: true,
-        actions: (
-            <>
-                <Button light={true} kind="secondary">
-                    Previous
-                </Button>
-                <Strut size={spacing.medium_16} />
-                <Button light={true} kind="primary">
-                    Next
-                </Button>
-            </>
-        ),
-    },
-    render: (args) => <PopoverContent {...args} />,
-};
 
 /**
  * Decorate the popover with an illustrated icon. You need to pass an `icon`

--- a/__docs__/wonder-blocks-popover/popover.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover.argtypes.tsx
@@ -5,7 +5,6 @@ import {Default, WithIcon, WithIllustration} from "./popover-content.stories";
 import {
     WithIcon as CoreWithIcon,
     WithDetailCell as CoreWithDetailCell,
-    Dark as CoreDark,
 } from "./popover-content-core.stories";
 
 // NOTE: Casting to any to avoid type errors.
@@ -14,7 +13,6 @@ const WithIconWrapper = WithIcon as any;
 const WithIllustrationWrapper = WithIllustration as any;
 const CoreWithIconWrapper = CoreWithIcon as any;
 const CoreWithDetailCellWrapper = CoreWithDetailCell as any;
-const CoreDarkWrapper = CoreDark as any;
 
 // NOTE: We have to use the `render` method to fix a bug in Storybook where
 // reusable stories don't render properly with CSF v3.
@@ -29,7 +27,6 @@ export const ContentMappings = {
     coreWithCell: CoreWithDetailCellWrapper.render({
         ...CoreWithDetailCell.args,
     }),
-    coreDark: CoreDarkWrapper.render({...CoreDark.args}),
 };
 
 export default {

--- a/__docs__/wonder-blocks-popover/popover.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover.argtypes.tsx
@@ -1,12 +1,7 @@
 import * as React from "react";
 
 // Reusable stories
-import {
-    Default,
-    Emphasized,
-    WithIcon,
-    WithIllustration,
-} from "./popover-content.stories";
+import {Default, WithIcon, WithIllustration} from "./popover-content.stories";
 import {
     WithIcon as CoreWithIcon,
     WithDetailCell as CoreWithDetailCell,
@@ -15,7 +10,6 @@ import {
 
 // NOTE: Casting to any to avoid type errors.
 const DefaultWrapper = Default as any;
-const EmphasizedWrapper = Emphasized as any;
 const WithIconWrapper = WithIcon as any;
 const WithIllustrationWrapper = WithIllustration as any;
 const CoreWithIconWrapper = CoreWithIcon as any;
@@ -27,7 +21,6 @@ const CoreDarkWrapper = CoreDark as any;
 // See https://github.com/storybookjs/storybook/issues/15954#issuecomment-1835905271
 export const ContentMappings = {
     withTextOnly: DefaultWrapper.render({...Default.args}),
-    withEmphasis: EmphasizedWrapper.render({...Emphasized.args}),
     withIcon: WithIconWrapper.render({...WithIcon.args}),
     withIllustration: WithIllustrationWrapper.render({
         ...WithIllustration.args,

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -182,7 +182,7 @@ TriggerElement.parameters = {
                 Popover to control when and/or from where to open the popover
                 dialog.\n` +
                 `- For this example, if you use the \`image\` prop, make sure
-                to avoid using \`icon\` and/or \`emphasized\` at the same time.
+                to avoid using \`icon\` at the same time.
                 Doing so will throw an error.\n` +
                 `- This example uses the \`dismissEnabled\` prop. This means
                 that the user can close the Popover by pressing \`Esc\` or

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-content.typestest.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-content.typestest.tsx
@@ -18,21 +18,3 @@ import PopoverContent from "../popover-content";
     icon="close"
     image={<img src="domokun.jpg" alt="domokun" />}
 />;
-
-<PopoverContent title="Title" content="Content" emphasized={true} />;
-
-// @ts-expect-error `emphasized` cannot be used with `icon`
-<PopoverContent
-    title="Title"
-    content="Content"
-    icon="close"
-    emphasized={true}
-/>;
-
-// @ts-expect-error `emphasized` cannot be used with `img`
-<PopoverContent
-    title="Title"
-    content="Content"
-    image={<img src="domokun.jpg" alt="domokun" />}
-    emphasized={true}
-/>;

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-dialog.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-dialog.test.tsx
@@ -9,26 +9,6 @@ import PopoverContentCore from "../popover-content-core";
 jest.mock("@khanacademy/wonder-blocks-tooltip");
 
 describe("PopoverDialog", () => {
-    it("should update the tail color to match the content's color", () => {
-        // Arrange
-        const tooltipTailSpy = jest.spyOn(Tooltip, "TooltipTail");
-
-        // Act
-        render(
-            <PopoverDialog showTail={true} placement="top" onUpdate={jest.fn()}>
-                <PopoverContentCore color="darkBlue">
-                    popover content
-                </PopoverContentCore>
-            </PopoverDialog>,
-        );
-
-        // Assert
-        expect(tooltipTailSpy).toHaveBeenCalledWith(
-            expect.objectContaining({color: "darkBlue"}),
-            {},
-        );
-    });
-
     it("should call onUpdate if placement is changed", () => {
         // Arrange
         const onUpdateMock = jest.fn();
@@ -48,7 +28,7 @@ describe("PopoverDialog", () => {
         rerender(<UnderTest placement="bottom" />);
 
         // Assert
-        expect(onUpdateMock).toBeCalledWith("bottom");
+        expect(onUpdateMock).toHaveBeenCalledWith("bottom");
     });
 
     it("should not call onUpdate if placement remains the same", () => {
@@ -71,7 +51,7 @@ describe("PopoverDialog", () => {
         rerender(<UnderTest placement="top" />);
 
         // Assert
-        expect(onUpdateMock).not.toBeCalled();
+        expect(onUpdateMock).not.toHaveBeenCalled();
     });
 
     it("should not render a tail if showTail is false", () => {

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -105,18 +105,6 @@ const styles = StyleSheet.create({
         overflow: "hidden",
         justifyContent: "center",
     },
-    /**
-     * Theming
-     */
-    blue: {
-        backgroundColor: semanticColor.surface.emphasis,
-        color: semanticColor.text.inverse,
-    },
-
-    darkBlue: {
-        backgroundColor: semanticColor.surface.inverse,
-        color: semanticColor.text.inverse,
-    },
 
     /**
      * elements

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -25,11 +25,6 @@ type Props = AriaProps & {
      */
     closeButtonVisible?: boolean;
     /**
-     * Whether we should use the default light color scheme or switch to a
-     * different color scheme.
-     */
-    color: "blue" | "darkBlue" | "white";
-    /**
      * Custom styles applied to the content container
      */
     style?: StyleType;
@@ -40,7 +35,6 @@ type Props = AriaProps & {
 };
 
 type DefaultProps = {
-    color: Props["color"];
     closeButtonLight: Props["closeButtonLight"];
     closeButtonVisible: Props["closeButtonVisible"];
 };
@@ -63,7 +57,6 @@ type DefaultProps = {
  */
 export default class PopoverContentCore extends React.Component<Props> {
     static defaultProps: DefaultProps = {
-        color: "white",
         closeButtonLight: false,
         closeButtonVisible: false,
     };
@@ -75,7 +68,6 @@ export default class PopoverContentCore extends React.Component<Props> {
             closeButtonLight,
             closeButtonLabel,
             closeButtonVisible,
-            color,
             style,
             testId,
         } = this.props;
@@ -83,17 +75,13 @@ export default class PopoverContentCore extends React.Component<Props> {
         return (
             <View
                 testId={testId}
-                style={[
-                    styles.content,
-                    color !== "white" && styles[color],
-                    style,
-                ]}
+                style={[styles.content, style]}
                 aria-label={ariaLabel}
             >
                 {closeButtonVisible && (
                     <CloseButton
                         aria-label={closeButtonLabel}
-                        light={closeButtonLight || color !== "white"}
+                        light={closeButtonLight}
                         style={styles.closeButton}
                         testId={`${testId || "popover"}-close-btn`}
                     />

--- a/packages/wonder-blocks-popover/src/components/popover-content.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content.tsx
@@ -55,43 +55,28 @@ type CommonProps = AriaProps & {
     uniqueId?: string;
 };
 
-type Props =
-    | (CommonProps & {
-          /**
-           * Decorate the popover with an illustrated icon. It cannot be used at the
-           * same time with image.
-           */
-          icon?:
-              | string
-              | React.ReactElement<React.ComponentProps<"img">>
-              | React.ReactElement<React.ComponentProps<"svg">>;
-          /**
-           * Alt text for the icon. This prop is only used if the `icon` prop
-           * is passed a url (instead of a svg or img element).
-           */
-          iconAlt?: string;
-          /**
-           * Decorate the popover with a full-bleed illustration. It cannot be used at
-           * the same time with icon.
-           */
-          image?:
-              | React.ReactElement<React.ComponentProps<"img">>
-              | React.ReactElement<React.ComponentProps<"svg">>;
-
-          emphasized?: never;
-      })
-    | (CommonProps & {
-          /**
-           * When true, changes the popover dialog background to blue; otherwise, the
-           * popover dialog background is not modified. It can be used only with
-           * Text-only popovers. It cannot be used with icon or image.
-           */
-          emphasized?: boolean;
-
-          icon?: never;
-          iconAlt?: never;
-          image?: never;
-      });
+type Props = CommonProps & {
+    /**
+     * Decorate the popover with an illustrated icon. It cannot be used at the
+     * same time with image.
+     */
+    icon?:
+        | string
+        | React.ReactElement<React.ComponentProps<"img">>
+        | React.ReactElement<React.ComponentProps<"svg">>;
+    /**
+     * Alt text for the icon. This prop is only used if the `icon` prop
+     * is passed a url (instead of a svg or img element).
+     */
+    iconAlt?: string;
+    /**
+     * Decorate the popover with a full-bleed illustration. It cannot be used at
+     * the same time with icon.
+     */
+    image?:
+        | React.ReactElement<React.ComponentProps<"img">>
+        | React.ReactElement<React.ComponentProps<"svg">>;
+};
 
 type DefaultProps = {
     closeButtonVisible: Props["closeButtonVisible"];
@@ -219,7 +204,6 @@ export default class PopoverContent extends React.Component<Props> {
             closeButtonLabel,
             closeButtonVisible,
             content,
-            emphasized = undefined,
             icon,
             image,
             style,
@@ -236,7 +220,6 @@ export default class PopoverContent extends React.Component<Props> {
 
                     return (
                         <PopoverContentCore
-                            color={emphasized ? "blue" : "white"}
                             closeButtonLight={image && placement === "top"}
                             closeButtonLabel={closeButtonLabel}
                             closeButtonVisible={closeButtonVisible}

--- a/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
@@ -84,9 +84,7 @@ export default class PopoverDialog extends React.Component<Props> {
         const contentProps = children.props as any;
 
         // extract the background color from the popover content
-        const color: keyof typeof tokens.color = contentProps.emphasized
-            ? "blue"
-            : contentProps.color;
+        const color: keyof typeof tokens.color = contentProps.color;
 
         return (
             <React.Fragment>


### PR DESCRIPTION
## Summary:

Removed the `emphasized` props from `PopoverContent` and `color` prop from
`PopoverContentCore` as these are not currently used and no longer recommended.

Issue: https://khanacademy.atlassian.net/browse/WB-1911

## Test plan:

Navigate to the Popover docs and verify that the `emphasized` and `dark` stories
are no longer present.

`/?path=/docs/packages-popover-popovercontentcore--docs`
`/?path=/docs/packages-popover-popovercontent--docs`