### PR TITLE
[WB-1776] Styles: Add wonder-blocks-styles package

### DIFF
--- a/.changeset/rotten-queens-sneeze.md
+++ b/.changeset/rotten-queens-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-styles": minor
+---
+
+Add `styles` package. Create `focusStyles` for focus indicators

--- a/__docs__/wonder-blocks-styles/styles.stories.tsx
+++ b/__docs__/wonder-blocks-styles/styles.stories.tsx
@@ -42,17 +42,23 @@ export const Focus: StoryComponentType = {
             <View
                 style={{
                     padding: spacing.medium_16,
-                    gap: spacing.medium_16,
                     flexDirection: "row",
                     placeItems: "center",
                 }}
             >
-                <IconButton
-                    kind="tertiary"
-                    icon={info}
-                    style={focusStyles.focus}
-                />
-
+                <View
+                    style={{
+                        background: semanticColor.status.success.background,
+                        padding: spacing.medium_16,
+                        gap: spacing.medium_16,
+                    }}
+                >
+                    <IconButton
+                        kind="tertiary"
+                        icon={info}
+                        style={focusStyles.focus}
+                    />
+                </View>
                 <View
                     style={{
                         background: semanticColor.surface.inverse,
@@ -78,5 +84,6 @@ export const Focus: StoryComponentType = {
                 code: JSON.stringify(focusStyles.focus, null, "\t"),
             },
         },
+        pseudo: {focusVisible: true},
     },
 };

--- a/packages/wonder-blocks-styles/src/styles/focus-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/focus-styles.ts
@@ -11,6 +11,6 @@ export const focus = {
     ":focus-visible": {
         boxShadow: `0 0 0 ${border.width.thin}px ${semanticColor.focus.inner}`,
         outline: `${border.width.thin}px solid ${semanticColor.focus.outer}`,
-        outlineOffset: -border.width.thin,
+        outlineOffset: border.width.thin,
     },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1139,6 +1139,19 @@ importers:
         specifier: workspace:*
         version: link:../../build-settings
 
+  packages/wonder-blocks-styles:
+    dependencies:
+      '@babel/runtime':
+        specifier: 'catalog:'
+        version: 7.26.7
+      '@khanacademy/wonder-blocks-tokens':
+        specifier: workspace:*
+        version: link:../wonder-blocks-tokens
+    devDependencies:
+      '@khanacademy/wb-dev-build-settings':
+        specifier: workspace:*
+        version: link:../../build-settings
+
   packages/wonder-blocks-switch:
     dependencies:
       '@babel/runtime':


### PR DESCRIPTION
## Summary:

Created the `wonder-blocks-styles` package to include the focus styles for
Wonder Blocks (more styles will come later!).

This package will be used by other Wonder Blocks packages to ensure consistent
styles across the library. Also to provide a single source of truth for focus
styles in consumer applications.


Issue: https://khanacademy.atlassian.net/browse/WB-1776

## Test plan:

Navigate to `/?path=/docs/packages-styles-overview--docs` and verify that the
overview page looks fine.

Also navigate to `/?path=/docs/wonder-blocks-styles-styles--focus-styles` and
verify that the focus styles are applied correctly in both backgrounds (light
and dark).