### PR TITLE
[WB-1914] Update wonder-blocks-tokens to use Base 10

### DIFF
--- a/.changeset/proud-elephants-wave.md
+++ b/.changeset/proud-elephants-wave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": major
+---
+
+Update sizing primitive tokens to use Base 10 rem units instead of Base 8

--- a/.changeset/proud-elephants-wave.md
+++ b/.changeset/proud-elephants-wave.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tokens": major
 ---
 
-Update sizing primitive tokens to use Base 10 rem units instead of Base 8
+Update sizing primitive tokens to use Base 10 rem units instead of Base 8 to work around minimum size bugs in browsers

--- a/.changeset/tricky-rice-promise.md
+++ b/.changeset/tricky-rice-promise.md
@@ -3,4 +3,4 @@
 "@khanacademy/wonder-blocks-tabs": minor
 ---
 
-Updates sizing tokens used internally to Base 10
+Updates sizing tokens used internally to Base 10 to handle browser minimum size issues

--- a/.changeset/tricky-rice-promise.md
+++ b/.changeset/tricky-rice-promise.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": minor
+"@khanacademy/wonder-blocks-tabs": minor
+---
+
+Updates sizing tokens used internally to Base 10

--- a/.changeset/tricky-rice-promise.md
+++ b/.changeset/tricky-rice-promise.md
@@ -3,4 +3,4 @@
 "@khanacademy/wonder-blocks-tabs": minor
 ---
 
-Updates sizing tokens used internally to Base 10 to handle browser minimum size issues
+Update sizing tokens used internally to Base 10 to handle browser minimum size issues

--- a/.changeset/tricky-rice-promise.md
+++ b/.changeset/tricky-rice-promise.md
@@ -1,6 +1,6 @@
 ---
-"@khanacademy/wonder-blocks-labeled-field": minor
-"@khanacademy/wonder-blocks-tabs": minor
+"@khanacademy/wonder-blocks-labeled-field": patch
+"@khanacademy/wonder-blocks-tabs": patch
 ---
 
 Update sizing tokens used internally to Base 10 to handle browser minimum size issues

--- a/__docs__/components/all-variants.tsx
+++ b/__docs__/components/all-variants.tsx
@@ -158,8 +158,8 @@ const styles = StyleSheet.create({
         padding: spacing.medium_16,
     },
     childrenWrapper: {
-        padding: sizing.size_100,
-        marginBlock: sizing.size_100,
+        padding: sizing.size_080,
+        marginBlock: sizing.size_080,
         border: `${border.width.hairline}px dashed ${semanticColor.border.primary}`,
     },
 });

--- a/__docs__/components/scenarios-layout.tsx
+++ b/__docs__/components/scenarios-layout.tsx
@@ -33,11 +33,11 @@ export const ScenariosLayout = (props: Props) => {
 
 const styles = StyleSheet.create({
     container: {
-        gap: sizing.size_200,
+        gap: sizing.size_160,
         alignItems: "flex-start",
     },
     scenario: {
-        gap: sizing.size_100,
+        gap: sizing.size_080,
         maxWidth: "100%",
     },
 });

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -215,7 +215,7 @@ const AllFields = (
             style={{
                 display: "flex",
                 flexDirection: "column",
-                gap: sizing.size_300,
+                gap: sizing.size_240,
             }}
         >
             <LabeledField
@@ -467,7 +467,7 @@ export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
     const longTextWithNoBreak =
         "LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequatDuisauteiruredolorinreprehenderitinvoluptatevelitessecillumdoloreeufugiatnullapariatur";
     return (
-        <View style={{gap: sizing.size_300}}>
+        <View style={{gap: sizing.size_240}}>
             <HeadingLarge>Scenarios</HeadingLarge>
             <LabeledField
                 {...args}
@@ -628,16 +628,16 @@ export const CustomStyles = {
         required: "Custom required message",
         styles: {
             root: {
-                padding: sizing.size_100,
+                padding: sizing.size_080,
             },
             label: {
-                paddingBlockEnd: sizing.size_025,
+                paddingBlockEnd: sizing.size_020,
             },
             description: {
-                paddingBlockEnd: sizing.size_025,
+                paddingBlockEnd: sizing.size_020,
             },
             error: {
-                paddingBlockStart: sizing.size_025,
+                paddingBlockStart: sizing.size_020,
             },
         },
     },

--- a/__docs__/wonder-blocks-tabs/navigation-tab-item-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tab-item-variants.stories.tsx
@@ -224,7 +224,7 @@ export const Zoom: Story = {
 
 const styles = StyleSheet.create({
     container: {
-        gap: sizing.size_200,
+        gap: sizing.size_160,
         alignItems: "flex-start",
     },
 });

--- a/__docs__/wonder-blocks-tabs/navigation-tab-item.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tab-item.stories.tsx
@@ -82,7 +82,7 @@ export const ChildrenRenderFunction: StoryComponentType = {
                 <View
                     style={{
                         flexDirection: "row",
-                        gap: sizing.size_1000,
+                        gap: sizing.size_800,
                     }}
                 >
                     <NavigationTabItem current={true}>

--- a/__docs__/wonder-blocks-tabs/navigation-tabs-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs-variants.stories.tsx
@@ -313,6 +313,6 @@ export const Zoom: Story = {
 
 const styles = StyleSheet.create({
     container: {
-        gap: sizing.size_200,
+        gap: sizing.size_160,
     },
 });

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -137,7 +137,7 @@ export const CustomStyles: StoryComponentType = {
                 padding: sizing.size_160,
             },
             list: {
-                gap: sizing.size_320,
+                gap: sizing.size_480,
             },
         },
     },

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -134,10 +134,10 @@ export const CustomStyles: StoryComponentType = {
         children: navigationTabItems,
         styles: {
             root: {
-                padding: sizing.size_200,
+                padding: sizing.size_160,
             },
             list: {
-                gap: sizing.size_400,
+                gap: sizing.size_320,
             },
         },
     },

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -137,7 +137,7 @@ export const CustomStyles: StoryComponentType = {
                 padding: sizing.size_200,
             },
             list: {
-                gap: sizing.size_500,
+                gap: sizing.size_400,
             },
         },
     },
@@ -280,7 +280,7 @@ const StyledDiv = addStyle("div");
 export const HeaderWithNavigationTabsExample: StoryComponentType = {
     render: function HeaderExample(args) {
         // Putting styles in the component so it shows in the code snippet
-        const headerVerticalSpacing = sizing.size_150;
+        const headerVerticalSpacing = sizing.size_120;
         const styles = StyleSheet.create({
             pageStyle: {
                 backgroundColor: semanticColor.surface.secondary,
@@ -293,8 +293,8 @@ export const HeaderWithNavigationTabsExample: StoryComponentType = {
                 alignItems: "center",
                 flexWrap: "wrap",
                 borderBottom: `1px solid ${semanticColor.border.primary}`,
-                gap: sizing.size_300,
-                padding: `${headerVerticalSpacing} ${sizing.size_300}`,
+                gap: sizing.size_240,
+                padding: `${headerVerticalSpacing} ${sizing.size_240}`,
             },
             navigationTabsRoot: {
                 // set margin to negative value of header vertical spacing so

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -137,7 +137,7 @@ export const CustomStyles: StoryComponentType = {
                 padding: sizing.size_160,
             },
             list: {
-                gap: sizing.size_480,
+                gap: sizing.size_400,
             },
         },
     },

--- a/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
@@ -19,18 +19,18 @@ height, border-width, font-size, line-height, etc.
 
 Note that these values are represented in `rem` units. Using rem units allows
 the sizes to scale with the font size of the root element, which is set to
-50%/8px in our Design System. This means that the sizes will scale with the
+62.5%/10px in our Design System. This means that the sizes will scale with the
 user's browser settings.
 
 ## Usage
 
 You can use these sizes directly by importing `sizing` from the
 `wonder-blocks-tokens` package and accessing the named property like so:
-`sizing.size_200`.
+`sizing.size_160`.
 
 ```js
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
-const styles = {padding: sizing.size_200};
+const styles = {padding: sizing.size_160};
 ```
 
 ## Tokens
@@ -90,7 +90,7 @@ import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 // Now you don't need to add the unit here as it's already included in the token
 {
-    padding: `${sizing.size_200} ${sizing.size_300}`,
+    padding: `${sizing.size_160} ${sizing.size_240}`,
 }
 ```
 
@@ -98,13 +98,13 @@ The mapping of the tokens is as follows:
 
 | Spacing (old)         | Sizing (new)      |
 | --------------------- | ----------------- |
-| `spacing.xxxxSmall_2` | `sizing.size_025` |
-| `spacing.xxxSmall_4`  | `sizing.size_050` |
-| `spacing.xxSmall_6`   | `sizing.size_075` |
-| `spacing.xSmall_8`    | `sizing.size_100` |
-| `spacing.small_12`    | `sizing.size_150` |
-| `spacing.medium_16`   | `sizing.size_200` |
-| `spacing.large_24`    | `sizing.size_300` |
-| `spacing.xLarge_32`   | `sizing.size_400` |
-| `spacing.xxLarge_48`  | `sizing.size_600` |
-| `spacing.xxxLarge_64` | `sizing.size_800` |
+| `spacing.xxxxSmall_2` | `sizing.size_020` |
+| `spacing.xxxSmall_4`  | `sizing.size_040` |
+| `spacing.xxSmall_6`   | `sizing.size_060` |
+| `spacing.xSmall_8`    | `sizing.size_080` |
+| `spacing.small_12`    | `sizing.size_120` |
+| `spacing.medium_16`   | `sizing.size_160` |
+| `spacing.large_24`    | `sizing.size_240` |
+| `spacing.xLarge_32`   | `sizing.size_320` |
+| `spacing.xxLarge_48`  | `sizing.size_480` |
+| `spacing.xxxLarge_64` | `sizing.size_640` |

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -228,7 +228,7 @@ const styles = StyleSheet.create({
     shared: {
         minHeight: DROPDOWN_ITEM_HEIGHT,
         // Make sure that the item is always at least as tall as 40px.
-        paddingBlock: sizing.size_125,
+        paddingBlock: sizing.size_100,
     },
 
     label: {

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -268,21 +268,21 @@ const styles = StyleSheet.create({
         color: semanticColor.text.primary,
     },
     labelWithDescription: {
-        paddingBlockEnd: sizing.size_050,
+        paddingBlockEnd: sizing.size_040,
     },
     labelWithNoDescription: {
-        paddingBlockEnd: sizing.size_150,
+        paddingBlockEnd: sizing.size_120,
     },
     description: {
         color: semanticColor.text.secondary,
-        paddingBlockEnd: sizing.size_150,
+        paddingBlockEnd: sizing.size_120,
     },
     errorSection: {
         flexDirection: "row",
         gap: sizing.size_100,
     },
     errorSectionWithContent: {
-        paddingBlockStart: sizing.size_150,
+        paddingBlockStart: sizing.size_120,
     },
     error: {
         color: semanticColor.status.critical.foreground,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -279,7 +279,7 @@ const styles = StyleSheet.create({
     },
     errorSection: {
         flexDirection: "row",
-        gap: sizing.size_100,
+        gap: sizing.size_080,
     },
     errorSectionWithContent: {
         paddingBlockStart: sizing.size_120,

--- a/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
@@ -110,16 +110,16 @@ const styles = StyleSheet.create({
         listStyle: "none",
         display: "inline-flex",
         [":has(a:hover)" as any]: {
-            boxShadow: `inset 0 -${sizing.size_025} 0 0 ${semanticColor.action.secondary.progressive.hover.foreground}`,
+            boxShadow: `inset 0 -${sizing.size_020} 0 0 ${semanticColor.action.secondary.progressive.hover.foreground}`,
         },
         [":has(a:active)" as any]: {
-            boxShadow: `inset 0 -${sizing.size_075} 0 0 ${semanticColor.action.secondary.progressive.press.foreground}`,
+            boxShadow: `inset 0 -${sizing.size_060} 0 0 ${semanticColor.action.secondary.progressive.press.foreground}`,
         },
         paddingBlockStart: sizing.size_100,
-        paddingBlockEnd: sizing.size_225,
+        paddingBlockEnd: sizing.size_180,
         [breakpoint.mediaQuery.mdOrLarger]: {
-            paddingBlockStart: sizing.size_250,
-            paddingBlockEnd: sizing.size_300,
+            paddingBlockStart: sizing.size_200,
+            paddingBlockEnd: sizing.size_240,
         },
     },
     current: {
@@ -157,7 +157,7 @@ const styles = StyleSheet.create({
             color: semanticColor.action.secondary.progressive.default
                 .foreground,
             outline: "none",
-            boxShadow: `0 0 0 ${sizing.size_025} ${semanticColor.focus.inner}, 0 0 0 ${sizing.size_050} ${semanticColor.focus.outer}`,
+            boxShadow: `0 0 0 ${sizing.size_020} ${semanticColor.focus.inner}, 0 0 0 ${sizing.size_040} ${semanticColor.focus.outer}`,
             borderRadius: 0,
         },
     },

--- a/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
@@ -115,7 +115,7 @@ const styles = StyleSheet.create({
         [":has(a:active)" as any]: {
             boxShadow: `inset 0 -${sizing.size_060} 0 0 ${semanticColor.action.secondary.progressive.press.foreground}`,
         },
-        paddingBlockStart: sizing.size_100,
+        paddingBlockStart: sizing.size_080,
         paddingBlockEnd: sizing.size_180,
         [breakpoint.mediaQuery.mdOrLarger]: {
             paddingBlockStart: sizing.size_200,

--- a/packages/wonder-blocks-tabs/src/components/navigation-tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tabs.tsx
@@ -246,7 +246,7 @@ const styles = StyleSheet.create({
         position: "absolute",
         bottom: 0,
         left: 0,
-        height: sizing.size_050,
+        height: sizing.size_040,
         backgroundColor:
             semanticColor.action.secondary.progressive.default.foreground,
     },

--- a/packages/wonder-blocks-tabs/src/components/navigation-tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tabs.tsx
@@ -235,7 +235,7 @@ const styles = StyleSheet.create({
     },
     list: {
         // Add horizontal padding for focus outline of first/last elements
-        paddingInline: sizing.size_050,
+        paddingInline: sizing.size_040,
         paddingBlock: sizing.size_0,
         margin: sizing.size_0,
         display: "flex",

--- a/packages/wonder-blocks-tabs/src/components/navigation-tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tabs.tsx
@@ -239,7 +239,7 @@ const styles = StyleSheet.create({
         paddingBlock: sizing.size_0,
         margin: sizing.size_0,
         display: "flex",
-        gap: sizing.size_200,
+        gap: sizing.size_160,
         flexWrap: "nowrap",
     },
     currentUnderline: {

--- a/packages/wonder-blocks-tokens/src/tokens/sizing.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/sizing.ts
@@ -1,7 +1,7 @@
 /**
  * The baseline for the size tokens.
  */
-const baseline = 8;
+const baseline = 10;
 
 /**
  * Converts a number (px) to a rem value.
@@ -23,24 +23,27 @@ function pxToRem(value: number): string {
  */
 export const sizing = {
     size_0: pxToRem(0),
-    size_0125: pxToRem(1),
-    size_025: pxToRem(2),
-    size_050: pxToRem(4),
-    size_075: pxToRem(6),
-    size_100: pxToRem(8),
-    size_125: pxToRem(10),
-    size_150: pxToRem(12),
-    size_200: pxToRem(16),
-    size_225: pxToRem(18),
-    size_250: pxToRem(20),
-    size_300: pxToRem(24),
-    size_400: pxToRem(32),
-    size_500: pxToRem(40),
-    size_600: pxToRem(48),
-    size_700: pxToRem(56),
-    size_800: pxToRem(64),
-    size_900: pxToRem(72),
-    size_1000: pxToRem(80),
-    size_1100: pxToRem(88),
-    size_1200: pxToRem(96),
+    size_010: pxToRem(1),
+    size_020: pxToRem(2),
+    size_040: pxToRem(4),
+    size_060: pxToRem(6),
+    size_080: pxToRem(8),
+    size_100: pxToRem(10),
+    size_120: pxToRem(12),
+    size_140: pxToRem(14),
+    size_160: pxToRem(16),
+    size_180: pxToRem(18),
+    size_200: pxToRem(20),
+    size_240: pxToRem(24),
+    size_280: pxToRem(28),
+    size_320: pxToRem(32),
+    size_360: pxToRem(36),
+    size_400: pxToRem(40),
+    size_480: pxToRem(48),
+    size_560: pxToRem(56),
+    size_640: pxToRem(64),
+    size_720: pxToRem(72),
+    size_800: pxToRem(80),
+    size_880: pxToRem(88),
+    size_960: pxToRem(96),
 } as const;

--- a/static/sb-styles/preview.css
+++ b/static/sb-styles/preview.css
@@ -2,7 +2,7 @@
  * Overrides for the Storybook preview iframe.
  */
 html {
-    font-size: 50%;
+    font-size: 62.5%;
 }
 
 .sbdocs ul,
@@ -30,7 +30,7 @@ html {
     color: var(--color-text);
     font-family: 'Source Serif Pro', sans-serif;
     font-weight: 400;
-    margin-top: 1.5rem;
+    margin-top: 1.2rem;
 }
 
 /* Reset WB typhography colors inside docs pages */
@@ -109,11 +109,11 @@ html {
 
 /* TOC wrapper */
 .sbdocs-content+div {
-    width: 20rem;
+    width: 16rem;
 }
 
 .sbdocs-content+div>* {
-    width: 20rem;
-    padding-top: 8rem;
-    padding-bottom: 4rem;
+    width: 16rem;
+    padding-top: 6.4rem;
+    padding-bottom: 3.2rem;
 }

--- a/static/sb-styles/preview.css
+++ b/static/sb-styles/preview.css
@@ -5,6 +5,15 @@ html {
     font-size: 62.5%;
 }
 
+/* These overrides depend on a Base 10 font size */
+.sb-show-main.sb-main-padded {
+    padding: 0.8rem;
+}
+.sbdocs.sbdocs-wrapper {
+    padding: 3.2rem 20px;
+    gap: 2.4rem;
+}
+
 .sbdocs ul,
 .sbdocs li,
 .sbdocs p,
@@ -30,7 +39,7 @@ html {
     color: var(--color-text);
     font-family: 'Source Serif Pro', sans-serif;
     font-weight: 400;
-    margin-top: 1.2rem;
+    margin-top: 0.96rem;
 }
 
 /* Reset WB typhography colors inside docs pages */

--- a/static/sb-styles/vars.css
+++ b/static/sb-styles/vars.css
@@ -6,22 +6,22 @@
      * Typography
      */
     --typography-font-family: 'Source Serif Pro', sans-serif;
-    --typography-base-size: clamp(0.88rem, 3vw, 2rem);
+    --typography-base-size: clamp(1.1rem, 3vw, 2.5rem);
     --typography-base-line-height: 1.6;
-    --typography-heading-size-xxl: calc(var(--typography-base-size) * 3.75); /* 60px */
+    --typography-heading-size-xxl: calc(var(--typography-base-size) * 4.6875); /* 60px */
     --typography-heading-line-height-xxl: calc(var(--typography-heading-size-xxl) * 1.1333333);
-    --typography-heading-size-xl: calc(var(--typography-base-size) * 3); /* 48px */
+    --typography-heading-size-xl: calc(var(--typography-base-size) * 3.75); /* 48px */
     --typography-heading-line-height-xl: calc(var(--typography-heading-size-xl) * 1.125);
-    --typography-heading-size-lg: calc(var(--typography-base-size) * 2.375); /* 38px */
+    --typography-heading-size-lg: calc(var(--typography-base-size) * 2.96875); /* 38px */
     --typography-heading-line-height-lg: calc(var(--typography-heading-size-lg) * 1.1052632);
-    --typography-heading-size-md: calc(var(--typography-base-size) * 1.875); /* 30px */
+    --typography-heading-size-md: calc(var(--typography-base-size) * 2.34375); /* 30px */
     --typography-heading-line-height-md: calc(var(--typography-heading-size-md) * 1.1333333);
-    --typography-heading-size-sm: calc(var(--typography-base-size) * 1.5); /* 24px */
+    --typography-heading-size-sm: calc(var(--typography-base-size) * 1.875); /* 24px */
     --typography-heading-line-height-sm: calc(var(--typography-heading-size-sm) * 1.1666667);
-    --typography-heading-size-xs: calc(var(--typography-base-size) * 1.25); /* 20px */
+    --typography-heading-size-xs: calc(var(--typography-base-size) * 1.5625); /* 20px */
     --typography-heading-line-height-xs: calc(var(--typography-heading-size-xs) * 1.1);
-    --typography-body-size-md: calc(var(--typography-base-size) * 1.125); /* 18px */
-    --typography-body-size-sm: calc(var(--typography-base-size) * 0.9375); /* 15px */
+    --typography-body-size-md: calc(var(--typography-base-size) * 1.40625); /* 18px */
+    --typography-body-size-sm: calc(var(--typography-base-size) * 1.171875); /* 15px */
 
     /**
      * Colors

--- a/static/sb-styles/vars.css
+++ b/static/sb-styles/vars.css
@@ -6,22 +6,22 @@
      * Typography
      */
     --typography-font-family: 'Source Serif Pro', sans-serif;
-    --typography-base-size: clamp(1.1rem, 3vw, 2.5rem);
+    --typography-base-size: clamp(0.88rem, 1.5vw + 1rem, 2rem);
     --typography-base-line-height: 1.6;
-    --typography-heading-size-xxl: calc(var(--typography-base-size) * 4.6875); /* 60px */
+    --typography-heading-size-xxl: calc(var(--typography-base-size) * 3); /* 60px */
     --typography-heading-line-height-xxl: calc(var(--typography-heading-size-xxl) * 1.1333333);
-    --typography-heading-size-xl: calc(var(--typography-base-size) * 3.75); /* 48px */
+    --typography-heading-size-xl: calc(var(--typography-base-size) * 2.4); /* 48px */
     --typography-heading-line-height-xl: calc(var(--typography-heading-size-xl) * 1.125);
-    --typography-heading-size-lg: calc(var(--typography-base-size) * 2.96875); /* 38px */
+    --typography-heading-size-lg: calc(var(--typography-base-size) * 1.9); /* 38px */
     --typography-heading-line-height-lg: calc(var(--typography-heading-size-lg) * 1.1052632);
-    --typography-heading-size-md: calc(var(--typography-base-size) * 2.34375); /* 30px */
+    --typography-heading-size-md: calc(var(--typography-base-size) * 1.5); /* 30px */
     --typography-heading-line-height-md: calc(var(--typography-heading-size-md) * 1.1333333);
-    --typography-heading-size-sm: calc(var(--typography-base-size) * 1.875); /* 24px */
+    --typography-heading-size-sm: calc(var(--typography-base-size) * 1.2); /* 24px */
     --typography-heading-line-height-sm: calc(var(--typography-heading-size-sm) * 1.1666667);
-    --typography-heading-size-xs: calc(var(--typography-base-size) * 1.5625); /* 20px */
+    --typography-heading-size-xs: calc(var(--typography-base-size) * 1.0); /* 20px */
     --typography-heading-line-height-xs: calc(var(--typography-heading-size-xs) * 1.1);
-    --typography-body-size-md: calc(var(--typography-base-size) * 1.40625); /* 18px */
-    --typography-body-size-sm: calc(var(--typography-base-size) * 1.171875); /* 15px */
+    --typography-body-size-md: calc(var(--typography-base-size) * 0.9); /* 18px */
+    --typography-body-size-sm: calc(var(--typography-base-size) * 0.75); /* 15px */
 
     /**
      * Colors


### PR DESCRIPTION
## Summary:
This change updates the sizing tokens in wonder-blocks-tokens to use Base 10 rather than Base 8. We decided on this change as a team to work around some minimum issues in browsers where JavaScript returned the incorrect font-size on a page.

Issue: WB-1914

## Test plan:
1. Reference Base 10 scale in https://khanacademy.atlassian.net/wiki/spaces/WB/pages/3683483678/Sizing
2. Double-check math of values used
3. Ensure there are no lint errors with tokens used in WB
4. To-do: update usage in webapp (FEI-6229)