### PR TITLE
Set up Tabs component

### DIFF
--- a/.changeset/twelve-pillows-lay.md
+++ b/.changeset/twelve-pillows-lay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tabs": minor
+---
+
+Adds Tabs component

--- a/__docs__/wonder-blocks-tabs/tabs.accessibility.mdx
+++ b/__docs__/wonder-blocks-tabs/tabs.accessibility.mdx
@@ -1,0 +1,34 @@
+import {Meta} from "@storybook/blocks";
+
+<Meta title="Packages / Tabs / Tabs / Accessibility" />
+
+# Accessibility for Tabs
+
+## Guidelines
+- If there is a visible label for the tabs, set the `aria-labelledby` prop to
+the id of the label. If there isn't, set the `aria-label` prop
+- Make sure the ids for the tabs are unique. They are used to associate the tabs
+and tab panels together
+
+## About the Implementation
+
+The Tabs component follows the [ARIA Authoring Practices Guide (APG) Tabs
+Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
+
+### HTML Semantics and Attributes
+
+The following semantics are used:
+- A `button` element with `role=tab` is used to control which tab panel is shown
+- An element with `role=tablist` holds a set of tab elements
+- An element with `role=tabpanel` is specified on the tab content associated with
+a tab
+
+The following attributes are implemented:
+- `aria-selected` is set to `true` on an element with `role=tab` if it is
+selected
+- `aria-controls` on the elements with `role=tab` is set to the id of the
+associated element with `role=tabpanel`
+- `aria-labelledby` on the elements with `role=tabpanel` is set to the id of
+the associated element with `role=tab`
+- `aria-label` or `aria-labelledby` is set on the `tablist` element using the
+`Tabs` component props

--- a/__docs__/wonder-blocks-tabs/tabs.argtypes.ts
+++ b/__docs__/wonder-blocks-tabs/tabs.argtypes.ts
@@ -9,4 +9,24 @@ export default {
             },
         },
     },
+    "aria-label": {
+        description:
+            "If there is no visible label for the tabs, set aria-label to a label describing the tabs. Note: Either aria-label or aria-labelledby should be provided.",
+        table: {
+            type: {
+                summary: "string",
+            },
+            category: "Accessibility",
+        },
+    },
+    "aria-labelledby": {
+        description:
+            "If the tabs have a visible label, set aria-labelledby to a value that refers to the labelling element. Note: Either aria-label or aria-labelledby should be provided.",
+        table: {
+            type: {
+                summary: "string",
+            },
+            category: "Accessibility",
+        },
+    },
 } satisfies ArgTypes;

--- a/__docs__/wonder-blocks-tabs/tabs.argtypes.ts
+++ b/__docs__/wonder-blocks-tabs/tabs.argtypes.ts
@@ -1,0 +1,12 @@
+import type {ArgTypes} from "@storybook/react";
+
+export default {
+    tabs: {
+        table: {
+            type: {
+                summary: "Array<TabItem>",
+                detail: "type TabItem = {|\n\tid: string,\n\tlabel: React.ReactNode,\n\tpanel: React.ReactNode\n|}",
+            },
+        },
+    },
+} satisfies ArgTypes;

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -26,6 +26,7 @@ export default {
     args: {
         tabs,
         selectedTabId: tabs[0].id,
+        "aria-label": "Tabs Example",
     },
     argTypes,
     render: function Controlled(args) {
@@ -35,6 +36,7 @@ export default {
 
         return (
             <Tabs
+                {...args}
                 selectedTabId={selectedTabId}
                 onTabSelected={setSelectedTabId}
                 tabs={args.tabs || tabs}

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -10,6 +10,7 @@ const tabs: TabItem[] = [
     {label: "Tab 2", id: "tab-2", panel: <div>Tab contents 2</div>},
     {label: "Tab 3", id: "tab-3", panel: <div>Tab contents 3</div>},
 ];
+
 export default {
     title: "Packages / Tabs / Tabs / Tabs",
     component: Tabs,
@@ -23,6 +24,20 @@ export default {
     },
     args: {
         tabs,
+        selectedTabId: tabs[0].id,
+    },
+    render: function Controlled(args) {
+        const [selectedTabId, setSelectedTabId] = React.useState(
+            args.selectedTabId || tabs[0].id,
+        );
+
+        return (
+            <Tabs
+                selectedTabId={selectedTabId}
+                onTabSelected={setSelectedTabId}
+                tabs={args.tabs || tabs}
+            />
+        );
     },
 } as Meta<typeof Tabs>;
 

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react";
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-form/package.json";
+import {Tabs} from "@khanacademy/wonder-blocks-tabs";
+import {TabItem} from "../../packages/wonder-blocks-tabs/src/components/tabs";
+
+const tabs: TabItem[] = [
+    {label: "Tab 1", id: "tab-1", panel: <div>Tab contents 1</div>},
+    {label: "Tab 2", id: "tab-2", panel: <div>Tab contents 2</div>},
+    {label: "Tab 3", id: "tab-3", panel: <div>Tab contents 3</div>},
+];
+export default {
+    title: "Packages / Tabs / Tabs / Tabs",
+    component: Tabs,
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+    },
+    args: {
+        tabs,
+    },
+} as Meta<typeof Tabs>;
+
+type StoryComponentType = StoryObj<typeof Tabs>;
+
+export const Default: StoryComponentType = {
+    args: {},
+};

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -4,6 +4,7 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 import {Tabs} from "@khanacademy/wonder-blocks-tabs";
 import {TabItem} from "../../packages/wonder-blocks-tabs/src/components/tabs";
+import argTypes from "./tabs.argtypes";
 
 const tabs: TabItem[] = [
     {label: "Tab 1", id: "tab-1", panel: <div>Tab contents 1</div>},
@@ -26,6 +27,7 @@ export default {
         tabs,
         selectedTabId: tabs[0].id,
     },
+    argTypes,
     render: function Controlled(args) {
         const [selectedTabId, setSelectedTabId] = React.useState(
             args.selectedTabId || tabs[0].id,

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
-import {Tabs} from "@khanacademy/wonder-blocks-tabs";
-import {TabItem} from "../../packages/wonder-blocks-tabs/src/components/tabs";
+import {TabItem, Tabs} from "@khanacademy/wonder-blocks-tabs";
 import argTypes from "./tabs.argtypes";
 
 const tabs: TabItem[] = [

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import {TabPanel} from "../tab-panel";
+
+describe("TabPanel", () => {
+    const id = "tab-panel-id";
+    const ariaLabelledby = "labelledby-id";
+
+    const props = {
+        id,
+        "aria-labelledby": ariaLabelledby,
+    };
+
+    it("should render role=tabpanel", async () => {
+        // Arrange
+        render(
+            <TabPanel id={id} aria-labelledby={ariaLabelledby}>
+                Tab panel
+            </TabPanel>,
+        );
+
+        // Act
+        const tabPanel = await screen.findByRole("tabpanel");
+
+        // Assert
+        expect(tabPanel).toBeInTheDocument();
+    });
+
+    it("should render the provided children", async () => {
+        // Arrange
+        const childrenId = "children-id";
+        render(
+            <TabPanel id={id} aria-labelledby={ariaLabelledby}>
+                <span data-testid={childrenId}>Tab panel</span>
+            </TabPanel>,
+        );
+
+        // Act
+        const children = await screen.findByTestId(childrenId);
+
+        // Assert
+        expect(children).toBeInTheDocument();
+    });
+
+    it("should forward the ref to the tab panel", async () => {
+        // Arrange
+        const ref = React.createRef<HTMLDivElement>();
+
+        // Act
+        render(
+            <TabPanel {...props} ref={ref}>
+                TabPanel
+            </TabPanel>,
+        );
+
+        // Assert
+        expect(await screen.findByRole("tabpanel")).toBe(ref.current);
+    });
+
+    describe("Props", () => {
+        it("should set the id prop for the tab panel", async () => {
+            // Arrange
+            const id = "test-id";
+            render(
+                <TabPanel {...props} id={id}>
+                    TabPanel
+                </TabPanel>,
+            );
+
+            // Act
+            const tabPanel = await screen.findByRole("tabpanel");
+
+            // Assert
+            expect(tabPanel).toHaveAttribute("id", id);
+        });
+    });
+
+    describe("Accessibility", () => {
+        describe("axe", () => {
+            it("should have no a11y violations", async () => {
+                // Arrange
+                const panelId = "panel-id";
+                const tabId = "tab-id";
+
+                // Act
+                const {container} = render(
+                    <div>
+                        <div role="tablist">
+                            <button
+                                role="tab"
+                                id={tabId}
+                                aria-controls={panelId}
+                            >
+                                Tab
+                            </button>
+                        </div>
+                        <TabPanel id={panelId} aria-labelledby={tabId}>
+                            Tab panel
+                        </TabPanel>
+                    </div>,
+                );
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+        });
+
+        describe("ARIA", () => {
+            it("should set the aria-labelledby attribute based on the prop", async () => {
+                // Arrange
+                const ariaLabelledby = "aria-labelledby-id";
+                render(
+                    <TabPanel id={id} aria-labelledby={ariaLabelledby}>
+                        Tab Panel
+                    </TabPanel>,
+                );
+
+                // Act
+                const tabPanel = await screen.findByRole("tabpanel");
+
+                // Assert
+                expect(tabPanel).toHaveAttribute(
+                    "aria-labelledby",
+                    ariaLabelledby,
+                );
+            });
+        });
+    });
+});

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
@@ -1,0 +1,180 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {Tab} from "../tab";
+
+describe("Tab", () => {
+    const id = "tab-id";
+    const ariaControlsId = "aria-controls-id";
+
+    const props = {
+        id,
+        "aria-controls": ariaControlsId,
+    };
+
+    it("should render a button element with role=tab", async () => {
+        // Arrange
+        render(
+            <Tab id={id} aria-controls={ariaControlsId}>
+                Tab
+            </Tab>,
+        );
+
+        // Act
+        const tab = await screen.findByRole("tab");
+
+        // Assert
+        expect(tab.tagName).toBe("BUTTON");
+    });
+
+    it("should render the provided children", async () => {
+        // Arrange
+        const childrenId = "children-id";
+        render(
+            <Tab id={id} aria-controls={ariaControlsId}>
+                <span data-testid={childrenId}>Tab contents</span>
+            </Tab>,
+        );
+
+        // Act
+        const children = await screen.findByTestId(childrenId);
+
+        // Assert
+        expect(children).toBeInTheDocument();
+    });
+
+    it("should forward the ref to the tab element", async () => {
+        // Arrange
+        const ref = React.createRef<HTMLButtonElement>();
+
+        // Act
+        render(
+            <Tab {...props} ref={ref}>
+                Tab
+            </Tab>,
+        );
+
+        // Assert
+        expect(await screen.findByRole("tab")).toBe(ref.current);
+    });
+
+    describe("Props", () => {
+        it("should set the id prop for the tab", async () => {
+            // Arrange
+            const id = "test-id";
+            render(
+                <Tab {...props} id={id}>
+                    Tab
+                </Tab>,
+            );
+
+            // Act
+            const tab = await screen.findByRole("tab");
+
+            // Assert
+            expect(tab).toHaveAttribute("id", id);
+        });
+    });
+
+    describe("Event Handlers", () => {
+        it("should call the onClick prop when the tab is pressed", async () => {
+            // Arrange
+            const onClick = jest.fn();
+            render(
+                <Tab {...props} onClick={onClick}>
+                    Tab
+                </Tab>,
+            );
+            const tab = await screen.findByRole("tab");
+
+            // Act
+            await userEvent.click(tab);
+
+            // Assert
+            expect(onClick).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("Accessibility", () => {
+        describe("axe", () => {
+            it("should have no a11y violations", async () => {
+                // Arrange
+                // Act
+                const {container} = render(
+                    <div>
+                        <div role="tablist">
+                            <Tab {...props}>Tab</Tab>
+                            <Tab
+                                id={id}
+                                aria-controls={ariaControlsId}
+                                selected={true}
+                            >
+                                Tab
+                            </Tab>
+                        </div>
+                        <div
+                            role="tabpanel"
+                            id={ariaControlsId}
+                            aria-labelledby={id}
+                        >
+                            Tab panel
+                        </div>
+                    </div>,
+                );
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+        });
+
+        describe("ARIA", () => {
+            it("should set the aria-controls attribute based on the prop", async () => {
+                // Arrange
+                const ariaControlsId = "test-aria-controls-id";
+                render(
+                    <Tab {...props} aria-controls={ariaControlsId}>
+                        Tab
+                    </Tab>,
+                );
+
+                // Act
+                const tab = await screen.findByRole("tab");
+
+                // Assert
+                expect(tab).toHaveAttribute("aria-controls", ariaControlsId);
+            });
+
+            it.each([
+                {selected: true, expected: "true"},
+                {selected: false, expected: "false"},
+            ])(
+                "should set aria-selected to $expected when the selected prop is set to $selected",
+                async ({selected, expected}) => {
+                    // Arrange
+                    render(
+                        <Tab {...props} selected={selected}>
+                            Tab
+                        </Tab>,
+                    );
+
+                    // Act
+                    const tab = await screen.findByRole("tab");
+
+                    // Assert
+                    expect(tab).toHaveAttribute("aria-selected", expected);
+                },
+            );
+
+            it("should not set the aria-selected attribute if the selected prop is not provided", async () => {
+                // Arrange
+                render(<Tab {...props}>Tab</Tab>);
+
+                // Act
+                const tab = await screen.findByRole("tab");
+
+                // Assert
+                expect(tab).not.toHaveAttribute("aria-selected");
+            });
+        });
+    });
+});

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import {Tablist} from "../tablist";
+
+describe("Tablist", () => {
+    it("should render role=tablist", async () => {
+        // Arrange
+        render(<Tablist>Tablist</Tablist>);
+
+        // Act
+        const tabList = await screen.findByRole("tablist");
+
+        // Assert
+        expect(tabList).toBeInTheDocument();
+    });
+
+    it("should render the provided children", async () => {
+        // Arrange
+        const childrenId = "children-id";
+        render(
+            <Tablist>
+                <span data-testid={childrenId}>Tablist</span>
+            </Tablist>,
+        );
+
+        // Act
+        const children = await screen.findByTestId(childrenId);
+
+        // Assert
+        expect(children).toBeInTheDocument();
+    });
+
+    it("should forward the ref to the tablist", async () => {
+        // Arrange
+        const ref = React.createRef<HTMLDivElement>();
+
+        // Act
+        render(<Tablist ref={ref}>Tablist</Tablist>);
+
+        // Assert
+        expect(await screen.findByRole("tablist")).toBe(ref.current);
+    });
+
+    describe("Accessibility", () => {
+        describe("axe", () => {
+            it("should have no a11y violations", async () => {
+                // Arrange
+                const panelId = "panel-id";
+                const tabId = "tab-id";
+
+                // Act
+                const {container} = render(
+                    <div>
+                        <Tablist>
+                            <button
+                                role="tab"
+                                id={tabId}
+                                aria-controls={panelId}
+                            >
+                                Tab
+                            </button>
+                        </Tablist>
+                        <div
+                            role="tabpanel"
+                            id={panelId}
+                            aria-labelledby={tabId}
+                        >
+                            Tab panel
+                        </div>
+                    </div>,
+                );
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+        });
+    });
+});

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
@@ -74,5 +74,36 @@ describe("Tablist", () => {
                 await expect(container).toHaveNoA11yViolations();
             });
         });
+
+        describe("ARIA", () => {
+            it("should set aria-label when provided", async () => {
+                // Arrange
+                const ariaLabel = "label";
+                render(<Tablist aria-label={ariaLabel}>Tablist</Tablist>);
+
+                // Act
+                const tablist = await screen.findByRole("tablist");
+
+                // Assert
+                expect(tablist).toHaveAttribute("aria-label", ariaLabel);
+            });
+
+            it("should set aria-labelledby when provided", async () => {
+                // Arrange
+                const ariaLabelledby = "labelledby";
+                render(
+                    <Tablist aria-labelledby={ariaLabelledby}>Tablist</Tablist>,
+                );
+
+                // Act
+                const tablist = await screen.findByRole("tablist");
+
+                // Assert
+                expect(tablist).toHaveAttribute(
+                    "aria-labelledby",
+                    ariaLabelledby,
+                );
+            });
+        });
     });
 });

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -1,0 +1,255 @@
+import * as React from "react";
+import {render, screen, within} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {TabItem, Tabs} from "../tabs";
+
+describe("Tabs", () => {
+    const tabs: TabItem[] = [
+        {
+            id: "tab-1",
+            label: "Tab 1",
+            panel: <div>Contents of tab 1</div>,
+        },
+        {
+            id: "tab-2",
+            label: "Tab 2",
+            panel: <div>Contents of tab 2</div>,
+        },
+        {
+            id: "tab-3",
+            label: "Tab 3",
+            panel: <div>Contents of tab 3</div>,
+        },
+    ];
+
+    it("should render the tabs in a tablist", async () => {
+        // Arrange
+        render(
+            <Tabs
+                tabs={tabs}
+                selectedTabId={tabs[0].id}
+                onTabSelected={jest.fn()}
+            />,
+        );
+        const tablist = await screen.findByRole("tablist");
+
+        // Act
+        const tabElements = await within(tablist).findAllByRole("tab");
+
+        // Assert
+        expect(tabElements).toEqual([
+            expect.objectContaining({textContent: tabs[0].label}),
+            expect.objectContaining({textContent: tabs[1].label}),
+            expect.objectContaining({textContent: tabs[2].label}),
+        ]);
+    });
+
+    it("should render the selected tab panel", () => {
+        // Arrange
+        const expectedSelectedTabPanelId = "expected-selected-tab-panel";
+        const tabs: TabItem[] = [
+            {
+                id: "tab-1",
+                label: "Tab 1",
+                panel: (
+                    <div data-testid={expectedSelectedTabPanelId}>
+                        Contents of tab 1
+                    </div>
+                ),
+            },
+            {
+                id: "tab-2",
+                label: "Tab 2",
+                panel: <div>Contents of tab 2</div>,
+            },
+            {
+                id: "tab-3",
+                label: "Tab 3",
+                panel: <div>Contents of tab 3</div>,
+            },
+        ];
+
+        // Act
+        render(
+            <Tabs
+                tabs={tabs}
+                selectedTabId={tabs[0].id}
+                onTabSelected={jest.fn()}
+            />,
+        );
+
+        // Act
+        expect(screen.getByTestId(expectedSelectedTabPanelId)).toBeVisible();
+    });
+
+    it("should not render the tab panel if it is not selected", () => {
+        // Arrange
+        const panelTestId = "panelTestId";
+        const tabs: TabItem[] = [
+            {
+                id: "tab-1",
+                label: "Tab 1",
+                panel: <div data-testid={panelTestId}>Contents of tab 1</div>,
+            },
+            {
+                id: "tab-2",
+                label: "Tab 2",
+                panel: <div>Contents of tab 2</div>,
+            },
+            {
+                id: "tab-3",
+                label: "Tab 3",
+                panel: <div>Contents of tab 3</div>,
+            },
+        ];
+        render(
+            <Tabs
+                tabs={tabs}
+                selectedTabId={tabs[1].id}
+                onTabSelected={jest.fn()}
+            />,
+        );
+
+        // Act
+        const panel = screen.queryByTestId(panelTestId);
+
+        // Assert
+        expect(panel).not.toBeInTheDocument();
+    });
+
+    it("should forward the ref to the root element", () => {
+        // Arrange
+        const ref = React.createRef<HTMLDivElement>();
+
+        // Act
+        const {container} = render(
+            <Tabs
+                tabs={tabs}
+                selectedTabId={tabs[0].id}
+                onTabSelected={jest.fn()}
+                ref={ref}
+            />,
+        );
+
+        // Assert
+        // eslint-disable-next-line testing-library/no-node-access -- check ref is on root element
+        expect(ref.current).toBe(container.firstChild);
+    });
+
+    describe("Event Handlers", () => {
+        it("should call the onTabSelected handler with the tab id when a tab is clicked", async () => {
+            // Arrange
+            const onTabSelected = jest.fn();
+
+            // Act
+            render(
+                <Tabs
+                    tabs={tabs}
+                    selectedTabId={tabs[0].id}
+                    onTabSelected={onTabSelected}
+                />,
+            );
+
+            // Act
+            const tab = screen.getByRole("tab", {name: "Tab 2"});
+            await userEvent.click(tab);
+
+            // Assert
+            expect(onTabSelected).toHaveBeenCalledExactlyOnceWith("tab-2");
+        });
+    });
+
+    describe("Accessibility", () => {
+        describe("axe", () => {
+            it("should have no a11y violations", async () => {
+                // Arrange
+                // Act
+                const {container} = render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                    />,
+                );
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+        });
+
+        describe("ARIA", () => {
+            it("should have aria-selected on the selected tab", () => {
+                // Arrange
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                    />,
+                );
+
+                // Act
+                const tab = screen.getByRole("tab", {name: "Tab 1"});
+
+                // Assert
+                expect(tab).toHaveAttribute("aria-selected", "true");
+            });
+
+            it("should have aria-selected set to false on tabs that are not selected", () => {
+                // Arrange
+                // Act
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                    />,
+                );
+
+                // Assert
+                expect(
+                    screen.getByRole("tab", {name: "Tab 2"}),
+                ).toHaveAttribute("aria-selected", "false");
+                expect(
+                    screen.getByRole("tab", {name: "Tab 3"}),
+                ).toHaveAttribute("aria-selected", "false");
+            });
+
+            it("should have aria-controls on the tab with the id of the associated tab panel", () => {
+                // Arrange
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                    />,
+                );
+                const tabPanel = screen.getByRole("tabpanel", {name: "Tab 1"});
+
+                // Act
+                const tab = screen.getByRole("tab", {name: "Tab 1"});
+
+                // Assert
+                expect(tab).toHaveAttribute("aria-controls", tabPanel.id);
+            });
+
+            it("should have aria-labelledby on the tab panel with the id of the associated tab", () => {
+                // Arrange
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                    />,
+                );
+                const tab = screen.getByRole("tab", {name: "Tab 1"});
+
+                // Act
+                const tabPanel = screen.getByRole("tabpanel", {name: "Tab 1"});
+
+                // Assert
+                expect(tabPanel).toHaveAttribute("aria-labelledby", tab.id);
+            });
+        });
+    });
+});

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -22,6 +22,8 @@ describe("Tabs", () => {
         },
     ];
 
+    const tabsAriaLabel = "Tabs Example";
+
     it("should render the tabs in a tablist", async () => {
         // Arrange
         render(
@@ -29,6 +31,7 @@ describe("Tabs", () => {
                 tabs={tabs}
                 selectedTabId={tabs[0].id}
                 onTabSelected={jest.fn()}
+                aria-label={tabsAriaLabel}
             />,
         );
         const tablist = await screen.findByRole("tablist");
@@ -75,6 +78,7 @@ describe("Tabs", () => {
                 tabs={tabs}
                 selectedTabId={tabs[0].id}
                 onTabSelected={jest.fn()}
+                aria-label={tabsAriaLabel}
             />,
         );
 
@@ -107,6 +111,7 @@ describe("Tabs", () => {
                 tabs={tabs}
                 selectedTabId={tabs[1].id}
                 onTabSelected={jest.fn()}
+                aria-label={tabsAriaLabel}
             />,
         );
 
@@ -128,6 +133,7 @@ describe("Tabs", () => {
                 selectedTabId={tabs[0].id}
                 onTabSelected={jest.fn()}
                 ref={ref}
+                aria-label={tabsAriaLabel}
             />,
         );
 
@@ -147,6 +153,7 @@ describe("Tabs", () => {
                     tabs={tabs}
                     selectedTabId={tabs[0].id}
                     onTabSelected={onTabSelected}
+                    aria-label={tabsAriaLabel}
                 />,
             );
 
@@ -161,7 +168,7 @@ describe("Tabs", () => {
 
     describe("Accessibility", () => {
         describe("axe", () => {
-            it("should have no a11y violations", async () => {
+            it("should have no a11y violations when aria-label is provided", async () => {
                 // Arrange
                 // Act
                 const {container} = render(
@@ -169,7 +176,27 @@ describe("Tabs", () => {
                         tabs={tabs}
                         selectedTabId={tabs[0].id}
                         onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
                     />,
+                );
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+
+            it("should have no a11y violations when aria-labelledby is provided", async () => {
+                // Arrange
+                // Act
+                const {container} = render(
+                    <div>
+                        <h1 id="tabs-label">Tabs Example</h1>
+                        <Tabs
+                            tabs={tabs}
+                            selectedTabId={tabs[0].id}
+                            onTabSelected={jest.fn()}
+                            aria-labelledby={"tabs-label"}
+                        />
+                    </div>,
                 );
 
                 // Assert
@@ -185,6 +212,7 @@ describe("Tabs", () => {
                         tabs={tabs}
                         selectedTabId={tabs[0].id}
                         onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
                     />,
                 );
 
@@ -203,6 +231,7 @@ describe("Tabs", () => {
                         tabs={tabs}
                         selectedTabId={tabs[0].id}
                         onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
                     />,
                 );
 
@@ -222,6 +251,7 @@ describe("Tabs", () => {
                         tabs={tabs}
                         selectedTabId={tabs[0].id}
                         onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
                     />,
                 );
                 const tabPanel = screen.getByRole("tabpanel", {name: "Tab 1"});
@@ -240,6 +270,7 @@ describe("Tabs", () => {
                         tabs={tabs}
                         selectedTabId={tabs[0].id}
                         onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
                     />,
                 );
                 const tab = screen.getByRole("tab", {name: "Tab 1"});
@@ -249,6 +280,47 @@ describe("Tabs", () => {
 
                 // Assert
                 expect(tabPanel).toHaveAttribute("aria-labelledby", tab.id);
+            });
+
+            it("should set aria-label on the tablist when provided", async () => {
+                // Arrange
+                const ariaLabel = "label";
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                        aria-label={ariaLabel}
+                    />,
+                );
+
+                // Act
+                const tablist = await screen.findByRole("tablist");
+
+                // Assert
+                expect(tablist).toHaveAttribute("aria-label", ariaLabel);
+            });
+
+            it("should set aria-labelledby on the tablist when provided", async () => {
+                // Arrange
+                const ariaLabelledby = "labelledby";
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                        aria-labelledby={ariaLabelledby}
+                    />,
+                );
+
+                // Act
+                const tablist = await screen.findByRole("tablist");
+
+                // Assert
+                expect(tablist).toHaveAttribute(
+                    "aria-labelledby",
+                    ariaLabelledby,
+                );
             });
         });
     });

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -4,7 +4,14 @@ type Props = {
     children: React.ReactNode;
 };
 
-export const TabPanel = (props: Props) => {
+export const TabPanel = React.forwardRef(function TabPanel(
+    props: Props,
+    ref: React.ForwardedRef<HTMLDivElement>,
+) {
     const {children} = props;
-    return <div role="tabpanel">{children}</div>;
-};
+    return (
+        <div ref={ref} role="tabpanel">
+            {children}
+        </div>
+    );
+});

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -2,15 +2,17 @@ import * as React from "react";
 
 type Props = {
     children: React.ReactNode;
+    id: string;
+    "aria-labelledby": string;
 };
 
 export const TabPanel = React.forwardRef(function TabPanel(
     props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-    const {children} = props;
+    const {children, id, "aria-labelledby": ariaLabelledby} = props;
     return (
-        <div ref={ref} role="tabpanel">
+        <div ref={ref} role="tabpanel" id={id} aria-labelledby={ariaLabelledby}>
             {children}
         </div>
     );

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 type Props = {
-    children: React.ReactElement;
+    children: React.ReactNode;
 };
 
 export const TabPanel = (props: Props) => {

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+type Props = {};
+
+export const TabPanel = (props: Props) => {
+    return <div>TabPanel</div>;
+};

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 
-type Props = {};
+type Props = {
+    children: React.ReactElement;
+};
 
 export const TabPanel = (props: Props) => {
-    return <div>TabPanel</div>;
+    const {children} = props;
+    return <div role="tabpanel">{children}</div>;
 };

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,11 +1,24 @@
 import * as React from "react";
 
 type Props = {
+    /**
+     * The contents of the tab panel.
+     */
     children: React.ReactNode;
+    /**
+     * A unique id for the tab panel.
+     */
     id: string;
+    /**
+     * The id of the associated element with role="tab".
+     */
     "aria-labelledby": string;
 };
 
+/**
+ * A component that has `role="tabpanel"` and is used to represent a tab panel
+ * in a tabbed interface.
+ */
 export const TabPanel = React.forwardRef(function TabPanel(
     props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -3,15 +3,31 @@ import * as React from "react";
 type Props = {
     children: React.ReactNode;
     onClick?: (event: React.MouseEvent) => unknown;
+    id: string;
+    "aria-controls": string;
+    selected?: boolean;
 };
 
 export const Tab = React.forwardRef(function Tab(
     props: Props,
     ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
-    const {children, onClick} = props;
+    const {
+        children,
+        onClick,
+        id,
+        "aria-controls": ariaControls,
+        selected,
+    } = props;
     return (
-        <button role="tab" onClick={onClick} ref={ref}>
+        <button
+            role="tab"
+            onClick={onClick}
+            ref={ref}
+            id={id}
+            aria-controls={ariaControls}
+            aria-selected={selected}
+        >
             {children}
         </button>
     );

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+type Props = {};
+
+export const Tab = (props: Props) => {
+    return <div>Tab</div>;
+};

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -5,11 +5,14 @@ type Props = {
     onClick?: (event: React.MouseEvent) => unknown;
 };
 
-export const Tab = (props: Props) => {
+export const Tab = React.forwardRef(function Tab(
+    props: Props,
+    ref: React.ForwardedRef<HTMLButtonElement>,
+) {
     const {children, onClick} = props;
     return (
-        <button role="tab" onClick={onClick}>
+        <button role="tab" onClick={onClick} ref={ref}>
             {children}
         </button>
     );
-};
+});

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -2,9 +2,14 @@ import * as React from "react";
 
 type Props = {
     children: React.ReactNode;
+    onClick?: (event: React.MouseEvent) => unknown;
 };
 
 export const Tab = (props: Props) => {
-    const {children} = props;
-    return <div role="tab">{children}</div>;
+    const {children, onClick} = props;
+    return (
+        <button role="tab" onClick={onClick}>
+            {children}
+        </button>
+    );
 };

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 
-type Props = {};
+type Props = {
+    children: React.ReactNode;
+};
 
 export const Tab = (props: Props) => {
-    return <div>Tab</div>;
+    const {children} = props;
+    return <div role="tab">{children}</div>;
 };

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -1,13 +1,32 @@
 import * as React from "react";
 
 type Props = {
+    /**
+     * The contents of the tab label.
+     */
     children: React.ReactNode;
+    /**
+     * Called when the tab is clicked.
+     */
     onClick?: (event: React.MouseEvent) => unknown;
+    /**
+     * A unique id for the tab.
+     */
     id: string;
+    /**
+     * The id of the panel that the tab controls.
+     */
     "aria-controls": string;
+    /**
+     * If the tab is currently selected.
+     */
     selected?: boolean;
 };
 
+/**
+ * A component that has `role="tab"` and is used to represent a tab in a tabbed
+ * interface.
+ */
 export const Tab = React.forwardRef(function Tab(
     props: Props,
     ref: React.ForwardedRef<HTMLButtonElement>,

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 type Props = {
-    children: React.ReactElement | Array<React.ReactElement>;
+    children: React.ReactNode;
 };
 
 const StyledDiv = addStyle("div");

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -8,6 +8,16 @@ type Props = {
      * The contents of the tablist.
      */
     children: React.ReactNode;
+    /**
+     * If there is no visible label for the tablist, set aria-label to a
+     * label describing the tablist.
+     */
+    "aria-label"?: string;
+    /**
+     * If the tablist has a visible label, set aria-labelledby to a value
+     * that refers to the labelling element.
+     */
+    "aria-labelledby"?: string;
 };
 
 const StyledDiv = addStyle("div");
@@ -19,9 +29,19 @@ export const Tablist = React.forwardRef(function Tablist(
     props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-    const {children} = props;
+    const {
+        children,
+        "aria-label": ariaLabel,
+        "aria-labelledby": ariaLabelledby,
+    } = props;
     return (
-        <StyledDiv role="tablist" style={styles.tablist} ref={ref}>
+        <StyledDiv
+            role="tablist"
+            style={styles.tablist}
+            ref={ref}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+        >
             {children}
         </StyledDiv>
     );

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -4,11 +4,17 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 type Props = {
+    /**
+     * The contents of the tablist.
+     */
     children: React.ReactNode;
 };
 
 const StyledDiv = addStyle("div");
 
+/**
+ * A component that has `role="tablist"` and is used to group tab elements.
+ */
 export const Tablist = React.forwardRef(function Tablist(
     props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+type Props = {};
+
+export const Tablist = (props: Props) => {
+    return <div>Tablist</div>;
+};

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -1,10 +1,26 @@
+import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 type Props = {
     children: React.ReactElement | Array<React.ReactElement>;
 };
 
+const StyledDiv = addStyle("div");
+
 export const Tablist = (props: Props) => {
     const {children} = props;
-    return <div role="tablist">{children}</div>;
+    return (
+        <StyledDiv role="tablist" style={styles.tablist}>
+            {children}
+        </StyledDiv>
+    );
 };
+
+const styles = StyleSheet.create({
+    tablist: {
+        display: "flex",
+        gap: sizing.size_200,
+    },
+});

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 
-type Props = {};
+type Props = {
+    children: React.ReactElement | Array<React.ReactElement>;
+};
 
 export const Tablist = (props: Props) => {
-    return <div>Tablist</div>;
+    const {children} = props;
+    return <div role="tablist">{children}</div>;
 };

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -9,14 +9,17 @@ type Props = {
 
 const StyledDiv = addStyle("div");
 
-export const Tablist = (props: Props) => {
+export const Tablist = React.forwardRef(function Tablist(
+    props: Props,
+    ref: React.ForwardedRef<HTMLDivElement>,
+) {
     const {children} = props;
     return (
-        <StyledDiv role="tablist" style={styles.tablist}>
+        <StyledDiv role="tablist" style={styles.tablist} ref={ref}>
             {children}
         </StyledDiv>
     );
-};
+});
 
 const styles = StyleSheet.create({
     tablist: {

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -15,6 +15,14 @@ type Props = {
     onTabSelected: (id: string) => unknown;
 };
 
+function getTabId(tabId: string) {
+    return `${tabId}__tab`;
+}
+
+function getTabPanelId(tabId: string) {
+    return `${tabId}__panel`;
+}
+
 export const Tabs = React.forwardRef(function Tabs(
     props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,
@@ -31,6 +39,9 @@ export const Tabs = React.forwardRef(function Tabs(
                             onClick={() => {
                                 onTabSelected(tab.id);
                             }}
+                            id={getTabId(tab.id)}
+                            aria-controls={getTabPanelId(tab.id)}
+                            selected={tab.id === selectedTabId}
                         >
                             {tab.label}
                         </Tab>
@@ -39,7 +50,11 @@ export const Tabs = React.forwardRef(function Tabs(
             </Tablist>
             {tabs.map((tab) => {
                 return (
-                    <TabPanel key={tab.id}>
+                    <TabPanel
+                        key={tab.id}
+                        id={getTabPanelId(tab.id)}
+                        aria-labelledby={getTabId(tab.id)}
+                    >
                         {selectedTabId === tab.id && tab.panel}
                     </TabPanel>
                 );

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+type Props = {};
+
+export const Tabs = (props: Props) => {
+    return <div>Tabs</div>;
+};

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -1,7 +1,30 @@
 import * as React from "react";
+import {TabPanel} from "./tab-panel";
+import {Tab} from "./tab";
+import {Tablist} from "./tablist";
 
-type Props = {};
+export type TabItem = {
+    id: string;
+    label: React.ReactNode;
+    panel: React.ReactElement;
+};
+
+type Props = {
+    tabs: Array<TabItem>;
+};
 
 export const Tabs = (props: Props) => {
-    return <div>Tabs</div>;
+    const {tabs} = props;
+    return (
+        <div>
+            <Tablist>
+                {tabs.map((tab) => {
+                    return <Tab key={tab.id}>{tab.label}</Tab>;
+                })}
+            </Tablist>
+            {tabs.map((tab) => {
+                return <TabPanel key={tab.id}>{tab.panel}</TabPanel>;
+            })}
+        </div>
+    );
 };

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -15,11 +15,14 @@ type Props = {
     onTabSelected: (id: string) => unknown;
 };
 
-export const Tabs = (props: Props) => {
+export const Tabs = React.forwardRef(function Tabs(
+    props: Props,
+    ref: React.ForwardedRef<HTMLDivElement>,
+) {
     const {tabs, selectedTabId, onTabSelected} = props;
 
     return (
-        <div>
+        <div ref={ref}>
             <Tablist>
                 {tabs.map((tab) => {
                     return (
@@ -43,4 +46,4 @@ export const Tabs = (props: Props) => {
             })}
         </div>
     );
-};
+});

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -11,19 +11,35 @@ export type TabItem = {
 
 type Props = {
     tabs: Array<TabItem>;
+    selectedTabId: string;
+    onTabSelected: (id: string) => unknown;
 };
 
 export const Tabs = (props: Props) => {
-    const {tabs} = props;
+    const {tabs, selectedTabId, onTabSelected} = props;
+
     return (
         <div>
             <Tablist>
                 {tabs.map((tab) => {
-                    return <Tab key={tab.id}>{tab.label}</Tab>;
+                    return (
+                        <Tab
+                            key={tab.id}
+                            onClick={() => {
+                                onTabSelected(tab.id);
+                            }}
+                        >
+                            {tab.label}
+                        </Tab>
+                    );
                 })}
             </Tablist>
             {tabs.map((tab) => {
-                return <TabPanel key={tab.id}>{tab.panel}</TabPanel>;
+                return (
+                    <TabPanel key={tab.id}>
+                        {selectedTabId === tab.id && tab.panel}
+                    </TabPanel>
+                );
             })}
         </div>
     );

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -18,6 +18,9 @@ export type TabItem = {
     panel: React.ReactNode;
 };
 
+/**
+ * Type to help ensure aria-label or aria-labelledby is set.
+ */
 type AriaLabelOrAriaLabelledby =
     | {
           /**

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -4,25 +4,57 @@ import {Tab} from "./tab";
 import {Tablist} from "./tablist";
 
 export type TabItem = {
+    /**
+     * A unique id for the tab.
+     */
     id: string;
+    /**
+     * The contents of the tab label.
+     */
     label: React.ReactNode;
-    panel: React.ReactElement;
+    /**
+     * The contents of the panel associated with the tab.
+     */
+    panel: React.ReactNode;
 };
 
 type Props = {
+    /**
+     * The tabs to render. The Tabs component will wire up the tab and panel
+     * attributes for accessibility.
+     */
     tabs: Array<TabItem>;
+    /**
+     * The id of the tab that is selected.
+     */
     selectedTabId: string;
+    /**
+     * Called when a tab is selected.
+     */
     onTabSelected: (id: string) => unknown;
 };
 
+/**
+ * Returns the id of the tab.
+ */
 function getTabId(tabId: string) {
     return `${tabId}__tab`;
 }
+
+/**
+ * Returns the id of the tab panel.
+ */
 
 function getTabPanelId(tabId: string) {
     return `${tabId}__panel`;
 }
 
+/**
+ * A component that uses a tabbed interface to control a specific view. The
+ * tabs have `role=”tab”` and keyboard users can change tabs using arrow keys.
+ * For a tabbed interface where the tabs are links, see the NavigationTabs
+ * component.
+ */
 export const Tabs = React.forwardRef(function Tabs(
     props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -18,6 +18,24 @@ export type TabItem = {
     panel: React.ReactNode;
 };
 
+type AriaLabelOrAriaLabelledby =
+    | {
+          /**
+           * If there is no visible label for the tabs, set aria-label to a
+           * label describing the tabs.
+           */
+          "aria-label": string;
+          "aria-labelledby"?: never;
+      }
+    | {
+          /**
+           * If the tabs have a visible label, set aria-labelledby to a value
+           * that refers to the labelling element.
+           */
+          "aria-labelledby": string;
+          "aria-label"?: never;
+      };
+
 type Props = {
     /**
      * The tabs to render. The Tabs component will wire up the tab and panel
@@ -32,7 +50,7 @@ type Props = {
      * Called when a tab is selected.
      */
     onTabSelected: (id: string) => unknown;
-};
+} & AriaLabelOrAriaLabelledby;
 
 /**
  * Returns the id of the tab.
@@ -59,11 +77,17 @@ export const Tabs = React.forwardRef(function Tabs(
     props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-    const {tabs, selectedTabId, onTabSelected} = props;
+    const {
+        tabs,
+        selectedTabId,
+        onTabSelected,
+        "aria-label": ariaLabel,
+        "aria-labelledby": ariaLabelledby,
+    } = props;
 
     return (
         <div ref={ref}>
-            <Tablist>
+            <Tablist aria-label={ariaLabel} aria-labelledby={ariaLabelledby}>
                 {tabs.map((tab) => {
                     return (
                         <Tab

--- a/packages/wonder-blocks-tabs/src/index.ts
+++ b/packages/wonder-blocks-tabs/src/index.ts
@@ -1,4 +1,5 @@
 export {NavigationTabs} from "./components/navigation-tabs";
 export {NavigationTabItem} from "./components/navigation-tab-item";
 export {Tabs} from "./components/tabs";
+export type {TabItem} from "./components/tabs";
 export {Tab} from "./components/tab";

--- a/packages/wonder-blocks-tabs/src/index.ts
+++ b/packages/wonder-blocks-tabs/src/index.ts
@@ -1,2 +1,4 @@
 export {NavigationTabs} from "./components/navigation-tabs";
 export {NavigationTabItem} from "./components/navigation-tab-item";
+export {Tabs} from "./components/tabs";
+export {Tab} from "./components/tab";


### PR DESCRIPTION
## Summary:

Set up the base Tabs component semantics and structure

Issue: WB-1073

## Test plan:
- Semantics of the Tabs component follows the [ARIA APG Tabs pattern]( https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) (uses elements with tab, tablist, and tabpanel roles)
- Review Tabs prop and a11y docs

## Implementation plan
- Set up base component
- Keyboard interactions
- Remaining props
- Styles