### PR TITLE
[WB-1902.2] IconButton: Update IconButton focus state to use box-shadow + outline for better a11y

### DIFF
--- a/.changeset/slow-cycles-visit.md
+++ b/.changeset/slow-cycles-visit.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Use `focus` styles from `wonder-blocks-styles` to match the global focus outline.

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -20,6 +20,7 @@
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
+    "@khanacademy/wonder-blocks-styles": "workspace:*",
     "@khanacademy/wonder-blocks-theming": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*"
   },

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -8,6 +8,7 @@ import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {useScopedTheme} from "@khanacademy/wonder-blocks-theming";
 
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import type {
     IconButtonActionType,
     IconButtonSize,
@@ -234,9 +235,7 @@ function getStylesByKind(
                 borderStyle: "solid",
                 borderWidth: theme.border.width.hover,
             },
-            ":focus-visible": {
-                boxShadow: light ? theme.focus.inverse : theme.focus.default,
-            },
+            ...focusStyles.focus,
             ":active": {
                 borderColor: themeVariant.press.border,
                 borderStyle: "solid",
@@ -265,9 +264,7 @@ function getStylesByKind(
                 background: themeVariant.hover.background,
                 color: themeVariant.hover.foreground,
             },
-            ":focus-visible": {
-                boxShadow: light ? theme.focus.inverse : theme.focus.default,
-            },
+            ...focusStyles.focus,
             ":active": {
                 borderColor: themeVariant.press.border,
                 background: themeVariant.press.background,

--- a/packages/wonder-blocks-icon-button/src/themes/default.ts
+++ b/packages/wonder-blocks-icon-button/src/themes/default.ts
@@ -1,9 +1,4 @@
-import {
-    border,
-    color,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, color, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 const disabledStates = {
     // NOTE: This is a special case for the button
@@ -179,11 +174,6 @@ const theme = {
         radius: {
             default: border.radius.medium_4,
         },
-    },
-
-    focus: {
-        default: `0 0 0 ${spacing.xxxxSmall_2}px ${semanticColor.focus.inner}, 0 0 0 ${spacing.xxxSmall_4}px ${semanticColor.focus.outer}`,
-        inverse: `0 0 0 ${spacing.xxxxSmall_2}px ${semanticColor.focus.outer}, 0 0 0 ${spacing.xxxSmall_4}px ${semanticColor.focus.inner}`,
     },
 };
 

--- a/packages/wonder-blocks-icon-button/tsconfig-build.json
+++ b/packages/wonder-blocks-icon-button/tsconfig-build.json
@@ -9,6 +9,7 @@
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
+        {"path": "../wonder-blocks-styles/tsconfig-build.json"},
         {"path": "../wonder-blocks-theming/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../../utils"},

--- a/packages/wonder-blocks-modal/package.json
+++ b/packages/wonder-blocks-modal/package.json
@@ -21,6 +21,7 @@
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon-button": "workspace:*",
     "@khanacademy/wonder-blocks-layout": "workspace:*",
+    "@khanacademy/wonder-blocks-styles": "workspace:*",
     "@khanacademy/wonder-blocks-theming": "workspace:*",
     "@khanacademy/wonder-blocks-timing": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -7,6 +7,7 @@ import {
     useScopedTheme,
     useStyles,
 } from "@khanacademy/wonder-blocks-theming";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import ModalContent from "./modal-content";
 import ModalHeader from "./modal-header";
 import ModalFooter from "./modal-footer";
@@ -180,11 +181,7 @@ const themedStylesFn: ThemedStylesFn<ModalDialogThemeContract> = (theme) => ({
         // programmatic focus. This is a workaround to make sure the focus
         // outline is visible when this control is focused.
         ":focus": {
-            outlineWidth: theme.root.border.width,
-            outlineColor: theme.panel.color.border,
-            outlineOffset: 1,
-            outlineStyle: "solid",
-            borderRadius: theme.root.border.radius,
+            ...focusStyles.focus[":focus-visible"],
         },
     },
 

--- a/packages/wonder-blocks-modal/src/themes/default.ts
+++ b/packages/wonder-blocks-modal/src/themes/default.ts
@@ -18,7 +18,6 @@ const theme = {
         },
         border: {
             radius: border.radius.medium_4,
-            width: border.width.thin,
         },
     },
     /**
@@ -55,9 +54,6 @@ const theme = {
         },
     },
     panel: {
-        color: {
-            border: semanticColor.focus.outer,
-        },
         spacing: {
             gap: spacing.xLarge_32,
         },

--- a/packages/wonder-blocks-modal/tsconfig-build.json
+++ b/packages/wonder-blocks-modal/tsconfig-build.json
@@ -12,6 +12,7 @@
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-layout/tsconfig-build.json"},
+        {"path": "../wonder-blocks-styles/tsconfig-build.json"},
         {"path": "../wonder-blocks-theming/tsconfig-build.json"},
         {"path": "../wonder-blocks-timing/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,9 @@ importers:
       '@khanacademy/wonder-blocks-icon':
         specifier: workspace:*
         version: link:../wonder-blocks-icon
+      '@khanacademy/wonder-blocks-styles':
+        specifier: workspace:*
+        version: link:../wonder-blocks-styles
       '@khanacademy/wonder-blocks-theming':
         specifier: workspace:*
         version: link:../wonder-blocks-theming
@@ -974,6 +977,9 @@ importers:
       '@khanacademy/wonder-blocks-layout':
         specifier: workspace:*
         version: link:../wonder-blocks-layout
+      '@khanacademy/wonder-blocks-styles':
+        specifier: workspace:*
+        version: link:../wonder-blocks-styles
       '@khanacademy/wonder-blocks-theming':
         specifier: workspace:*
         version: link:../wonder-blocks-theming


### PR DESCRIPTION
## Summary:

In #2524, we updated the IconButton focus state to use a box-shadow instead of
an outline. This change was made to improve accessibility and provide a more
modern look to the component.

Turns out that the box-shadow is not 100% accessible for all users, as it
doesn't work well on Windows High Contrast mode. This PR modifies the focus
style to use the `focus` style from `wonder-blocks-styles`, which is a
combination of a box-shadow and an outline. This should provide a more
consistent experience across different platforms and improve accessibility.

Issue: WB-1902

## Test plan:

Navigate to the IconButton component in Storybook and verify that the focus
state looks correct.

`/?path=/story/packages-iconbutton-all-variants--focus&globals=viewport:desktop;pseudo.focusVisible:!true`

Also verify that the close button in the Modal component has the correct focus
state.

`/?path=/story/packages-modal-onepanedialog--with-launcher`