### PR TITLE
[WB-1852.1] IconButton: Remove `light` variant

### DIFF
--- a/.changeset/beige-fireants-divide.md
+++ b/.changeset/beige-fireants-divide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": major
+---
+
+Remove `light` variant, and replace it with `actionStyles.inverse` for one-off cases

--- a/.changeset/long-cougars-enjoy.md
+++ b/.changeset/long-cougars-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-styles": minor
+---
+
+Adds a new `actionStyles` file to include styles for interactive elements

--- a/.changeset/twenty-shoes-sleep.md
+++ b/.changeset/twenty-shoes-sleep.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Update dismiss button (CloseButton) to use `actionStyles.inverse` instead of the now deprecated `IconButton.light` variant"

--- a/__docs__/wonder-blocks-icon-button/icon-button-variants.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button-variants.stories.tsx
@@ -6,7 +6,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
@@ -28,31 +28,13 @@ const sizes: ("xsmall" | "small" | "medium" | "large")[] = [
     "large",
 ];
 
-const KindVariants = ({
-    kind,
-    light,
-}: {
-    kind: "primary" | "secondary" | "tertiary";
-    light: boolean;
-}) => {
+const KindVariants = ({kind}: {kind: "primary" | "secondary" | "tertiary"}) => {
     return (
         <ThemeSwitcherContext.Consumer>
             {(theme) => (
                 <>
-                    <View
-                        style={[
-                            styles.gridCol,
-                            light &&
-                                (theme === "khanmigo"
-                                    ? styles.darkKhanmigo
-                                    : styles.darkDefault),
-                        ]}
-                    >
-                        <LabelMedium
-                            style={light && {color: semanticColor.text.inverse}}
-                        >
-                            {kind}-default
-                        </LabelMedium>
+                    <View style={[styles.gridCol]}>
+                        <LabelMedium>{kind}-default</LabelMedium>
                         <View style={[styles.iconButtons]}>
                             {sizes.map((size) => (
                                 <IconButton
@@ -60,7 +42,6 @@ const KindVariants = ({
                                     icon={paperPlaneIcon}
                                     onClick={action("clicked")}
                                     kind={kind}
-                                    light={light}
                                     actionType="progressive"
                                     size={size}
                                     key={size}
@@ -68,20 +49,8 @@ const KindVariants = ({
                             ))}
                         </View>
                     </View>
-                    <View
-                        style={[
-                            styles.gridCol,
-                            light &&
-                                (theme === "khanmigo"
-                                    ? styles.darkKhanmigo
-                                    : styles.darkDefault),
-                        ]}
-                    >
-                        <LabelMedium
-                            style={light && {color: semanticColor.text.inverse}}
-                        >
-                            {kind}-destructive
-                        </LabelMedium>
+                    <View style={[styles.gridCol]}>
+                        <LabelMedium>{kind}-destructive</LabelMedium>
                         <View style={[styles.iconButtons]}>
                             {sizes.map((size) => (
                                 <IconButton
@@ -89,7 +58,6 @@ const KindVariants = ({
                                     icon={paperPlaneIcon}
                                     onClick={action("clicked")}
                                     kind={kind}
-                                    light={light}
                                     actionType="destructive"
                                     size={size}
                                     key={size}
@@ -97,20 +65,8 @@ const KindVariants = ({
                             ))}
                         </View>
                     </View>
-                    <View
-                        style={[
-                            styles.gridCol,
-                            light &&
-                                (theme === "khanmigo"
-                                    ? styles.darkKhanmigo
-                                    : styles.darkDefault),
-                        ]}
-                    >
-                        <LabelMedium
-                            style={light && {color: semanticColor.text.inverse}}
-                        >
-                            {kind}-disabled
-                        </LabelMedium>
+                    <View style={[styles.gridCol]}>
+                        <LabelMedium>{kind}-disabled</LabelMedium>
                         <View style={[styles.iconButtons]}>
                             {sizes.map((size) => (
                                 <IconButton
@@ -118,7 +74,6 @@ const KindVariants = ({
                                     icon={paperPlaneIcon}
                                     onClick={action("clicked")}
                                     kind={kind}
-                                    light={light}
                                     disabled={true}
                                     size={size}
                                     key={size}
@@ -136,10 +91,9 @@ const VariantsByTheme = ({themeName = "Default"}: {themeName?: string}) => (
     <View style={{marginBottom: spacing.large_24}}>
         <HeadingLarge>{themeName} theme</HeadingLarge>
         <View style={styles.grid}>
-            <KindVariants kind="primary" light={false} />
-            <KindVariants kind="secondary" light={false} />
-            <KindVariants kind="tertiary" light={false} />
-            <KindVariants kind="primary" light={true} />
+            <KindVariants kind="primary" />
+            <KindVariants kind="secondary" />
+            <KindVariants kind="tertiary" />
         </View>
     </View>
 );
@@ -185,12 +139,6 @@ export const PressFocus: StoryComponentType = {
 };
 
 const styles = StyleSheet.create({
-    darkDefault: {
-        backgroundColor: semanticColor.surface.inverse,
-    },
-    darkKhanmigo: {
-        backgroundColor: semanticColor.khanmigo.primary,
-    },
     grid: {
         display: "grid",
         gridTemplateColumns: "repeat(3, 250px)",

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -16,7 +16,7 @@ import {MemoryRouter, Route, Switch} from "react-router";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-icon-button/package.json";
@@ -29,8 +29,7 @@ import TextField from "../../packages/wonder-blocks-form/src/components/text-fie
  * To use, supply an `onClick` function, a Phosphor icon asset (see the
  * `Icon>PhosphorIcon` section) and an `aria-label` to describe the button
  * functionality. Optionally specify href (URL), clientSideNav, color (Wonder
- * Blocks Blue or Red), kind ("primary", "secondary", or "tertiary"), light
- * (whether the IconButton will be rendered on a dark background), disabled ,
+ * Blocks Blue or Red), kind ("primary", "secondary", or "tertiary"), disabled,
  * test ID, and custom styling.
  *
  * The size of an `IconButton` is based on how the `size` prop is defined (see
@@ -229,59 +228,6 @@ export const WithActionType: StoryComponentType = {
 };
 
 /**
- * An `IconButton` on a dark background. Only the primary kind is allowed to have
- * the `light` prop set to true.
- */
-export const Light: StoryComponentType = {
-    render: () => {
-        return (
-            <View style={[styles.dark, styles.row]}>
-                <IconButton
-                    icon={magnifyingGlass}
-                    aria-label="search"
-                    light={true}
-                    onClick={(e) => console.log("Click!")}
-                />
-                <IconButton
-                    actionType="destructive"
-                    icon={magnifyingGlass}
-                    aria-label="search"
-                    light={true}
-                    onClick={(e) => console.log("Click!")}
-                />
-            </View>
-        );
-    },
-};
-
-/**
- * This is a disabled icon button with the `light` prop set to true.
- */
-export const DisabledLight: StoryComponentType = {
-    render: () => {
-        return (
-            <View style={[styles.dark, styles.row]}>
-                <IconButton
-                    disabled={true}
-                    icon={magnifyingGlass}
-                    aria-label="search"
-                    light={true}
-                    onClick={(e) => console.log("Click!")}
-                />
-                <IconButton
-                    actionType="destructive"
-                    disabled={true}
-                    icon={magnifyingGlass}
-                    aria-label="search"
-                    light={true}
-                    onClick={(e) => console.log("Click!")}
-                />
-            </View>
-        );
-    },
-};
-
-/**
  * This example has an `href` prop in addition to the `onClick` prop. `href` takes a URL or path,
  * and clicking the icon button will result in a navigation to the specified page. Note that
  * `onClick` is not required if `href` is defined. The `target="_blank"` prop will cause the href
@@ -396,10 +342,6 @@ export const SubmittingForms: StoryComponentType = {
 };
 
 const styles = StyleSheet.create({
-    dark: {
-        backgroundColor: semanticColor.surface.inverse,
-        padding: spacing.medium_16,
-    },
     arrowsWrapper: {
         flexDirection: "row",
         justifyContent: "space-between",

--- a/__docs__/wonder-blocks-styles/action-styles-variants.stories.tsx
+++ b/__docs__/wonder-blocks-styles/action-styles-variants.stories.tsx
@@ -52,12 +52,18 @@ export default {
                                 icon={info}
                                 style={actionStyles.inverse}
                             />
+                            <IconButton
+                                kind="primary"
+                                disabled
+                                icon={info}
+                                style={actionStyles.inverse}
+                            />
                         </View>
                     ),
                 },
             },
             {
-                name: "Using Clickable",
+                name: "Using Clickable (no border set)",
                 props: {
                     children: (
                         <Clickable
@@ -70,7 +76,7 @@ export default {
                 },
             },
             {
-                name: "Using Clickable with initial border",
+                name: "Using Clickable with border",
                 props: {
                     children: (
                         <Clickable

--- a/__docs__/wonder-blocks-styles/action-styles-variants.stories.tsx
+++ b/__docs__/wonder-blocks-styles/action-styles-variants.stories.tsx
@@ -100,6 +100,9 @@ export default {
                         <StyledButton
                             style={[
                                 {
+                                    // NOTE: Swapping the colors is intentional
+                                    // here to show the inverse version of the
+                                    // button.
                                     border: `1px solid ${semanticColor.status.success.background}`,
                                     backgroundColor:
                                         semanticColor.status.success.foreground,

--- a/__docs__/wonder-blocks-styles/action-styles-variants.stories.tsx
+++ b/__docs__/wonder-blocks-styles/action-styles-variants.stories.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react";
+import info from "@phosphor-icons/core/regular/info.svg";
+import {ScenariosLayout} from "../components/scenarios-layout";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {
+    border,
+    semanticColor,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {actionStyles} from "@khanacademy/wonder-blocks-styles";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+
+const StyledButton = addStyle("button");
+
+/**
+ * The following stories are used to generate the pseudo states for these
+ * stories. This is only used for visual testing in Chromatic.
+ */
+export default {
+    title: "Packages / Styles / Action Styles / Action Styles - All Variants",
+    parameters: {
+        docs: {
+            autodocs: false,
+        },
+    },
+    render: () => {
+        const scenarios = [
+            {
+                name: "Using IconButton",
+                props: {
+                    children: (
+                        <View
+                            style={{
+                                flexDirection: "row",
+                                gap: spacing.medium_16,
+                            }}
+                        >
+                            <IconButton
+                                kind="primary"
+                                icon={info}
+                                style={actionStyles.inverse}
+                            />
+                            <IconButton
+                                kind="secondary"
+                                icon={info}
+                                style={actionStyles.inverse}
+                            />
+                            <IconButton
+                                kind="tertiary"
+                                icon={info}
+                                style={actionStyles.inverse}
+                            />
+                        </View>
+                    ),
+                },
+            },
+            {
+                name: "Using Clickable",
+                props: {
+                    children: (
+                        <Clickable
+                            onClick={() => {}}
+                            style={actionStyles.inverse}
+                        >
+                            {() => "Clickable component"}
+                        </Clickable>
+                    ),
+                },
+            },
+            {
+                name: "Using Clickable with initial border",
+                props: {
+                    children: (
+                        <Clickable
+                            onClick={() => {}}
+                            style={[
+                                {
+                                    border: `${border.width.thick}px solid`,
+                                },
+                                actionStyles.inverse,
+                            ]}
+                        >
+                            {() => "Clickable component"}
+                        </Clickable>
+                    ),
+                },
+            },
+            {
+                name: "Using an HTML element",
+                props: {
+                    children: (
+                        <StyledButton
+                            style={[
+                                {
+                                    border: `1px solid ${semanticColor.status.success.background}`,
+                                    backgroundColor:
+                                        semanticColor.status.success.foreground,
+                                    color: semanticColor.status.success
+                                        .background,
+                                },
+                                actionStyles.inverse,
+                            ]}
+                        >
+                            Custom button
+                        </StyledButton>
+                    ),
+                },
+            },
+        ];
+
+        return (
+            <ScenariosLayout scenarios={scenarios}>
+                {(props) => (
+                    <View
+                        {...props}
+                        style={{
+                            background: semanticColor.surface.inverse,
+                            padding: spacing.medium_16,
+                            gap: spacing.medium_16,
+                        }}
+                    />
+                )}
+            </ScenariosLayout>
+        );
+    },
+    tags: ["!autodocs"],
+} as Meta;
+
+type StoryComponentType = StoryObj<any>;
+
+export const Default: StoryComponentType = {};
+
+export const Hover: StoryComponentType = {
+    parameters: {pseudo: {hover: true}},
+};
+
+export const Focus: StoryComponentType = {
+    parameters: {pseudo: {focusVisible: true}},
+};
+
+export const HoverFocus: StoryComponentType = {
+    name: "Hover + Focus",
+    parameters: {pseudo: {hover: true, focusVisible: true}},
+};
+
+export const Press: StoryComponentType = {
+    parameters: {pseudo: {active: true}},
+};
+
+export const PressFocus: StoryComponentType = {
+    name: "Press + Focus",
+    parameters: {pseudo: {active: true, focusVisible: true}},
+};

--- a/__docs__/wonder-blocks-styles/action-styles.stories.tsx
+++ b/__docs__/wonder-blocks-styles/action-styles.stories.tsx
@@ -70,6 +70,12 @@ export const InverseOutline: Story = {
                     icon={info}
                     style={actionStyles.inverse}
                 />
+                <IconButton
+                    kind="primary"
+                    disabled
+                    icon={info}
+                    style={actionStyles.inverse}
+                />
 
                 <Clickable onClick={() => {}} style={actionStyles.inverse}>
                     {() => "Clickable component"}

--- a/__docs__/wonder-blocks-styles/action-styles.stories.tsx
+++ b/__docs__/wonder-blocks-styles/action-styles.stories.tsx
@@ -1,0 +1,136 @@
+import * as React from "react";
+import {Meta, StoryObj} from "@storybook/react";
+import info from "@phosphor-icons/core/regular/info.svg";
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-styles/package.json";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {actionStyles} from "@khanacademy/wonder-blocks-styles";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import Button from "@khanacademy/wonder-blocks-button";
+import Link from "@khanacademy/wonder-blocks-link";
+
+/**
+ * Styles that can be used to create reusable states for interactive elements.
+ *
+ * NOTE: We recommend using existing Wonder Blocks interactive components (e.g.
+ * `Button`, `IconButton`, `Link` etc.). These styles are meant to be used
+ * as a last resort when our components do not meet your needs.
+ *
+ * ### Usage
+ *
+ * ```tsx
+ * import {actionStyles} from "@khanacademy/wonder-blocks-styles";
+ *
+ * <StyledButton style={actionStyles.inverse}>
+ *      Custom button
+ * </StyledButton>
+ * ```
+ */
+export default {
+    title: "Packages / Styles / Action Styles",
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+    },
+} as Meta<any>;
+
+type Story = StoryObj<any>;
+
+const StyledButton = addStyle("button");
+
+/**
+ * A global focus style that can be applied to interactive elements.
+ *
+ * This style injects a combination of `outline` and `box-shadow` to indicate
+ * the element is focused. This is used for accessibility purposes as it allows
+ * the element to present a focus state on Windows High Contrast mode.
+ *
+ * In the example below, the focus style is applied to an `IconButton` component
+ * and to a `button` element.
+ */
+export const InverseOutline: Story = {
+    name: "inverse",
+    render: () => {
+        return (
+            <>
+                <IconButton
+                    kind="primary"
+                    icon={info}
+                    style={actionStyles.inverse}
+                />
+                <IconButton
+                    kind="secondary"
+                    icon={info}
+                    style={actionStyles.inverse}
+                />
+                <IconButton
+                    kind="tertiary"
+                    icon={info}
+                    style={actionStyles.inverse}
+                />
+                <Button kind="primary" style={actionStyles.inverse}>
+                    Primary button
+                </Button>
+                <Button kind="secondary" style={actionStyles.inverse}>
+                    secondary button
+                </Button>
+                <Button kind="tertiary" style={actionStyles.inverse}>
+                    tertiary button
+                </Button>
+                <Link href="#ss" style={actionStyles.inverse}>
+                    Arr link
+                </Link>
+
+                <Clickable onClick={() => {}} style={actionStyles.inverse}>
+                    {() => "Clickable component"}
+                </Clickable>
+
+                <StyledButton
+                    style={[
+                        {
+                            border: `1px solid ${semanticColor.status.success.background}`,
+                            backgroundColor:
+                                semanticColor.status.success.foreground,
+                            color: semanticColor.status.success.background,
+                        },
+                        actionStyles.inverse,
+                    ]}
+                >
+                    Custom button
+                </StyledButton>
+            </>
+        );
+    },
+    decorators: [
+        (Story) => (
+            <View
+                style={{
+                    gap: spacing.medium_16,
+                    padding: spacing.medium_16,
+                    flexDirection: "row",
+                    placeItems: "center",
+                    display: "grid",
+                    gridTemplateColumns: "repeat(3, 1fr)",
+                }}
+            >
+                <Story />
+            </View>
+        ),
+    ],
+    parameters: {
+        backgrounds: {
+            default: "darkBlue",
+        },
+        chromatic: {
+            // Disabling because this is already covered by the All variants
+            // stories.
+            disableSnapshot: true,
+        },
+    },
+};

--- a/__docs__/wonder-blocks-styles/action-styles.stories.tsx
+++ b/__docs__/wonder-blocks-styles/action-styles.stories.tsx
@@ -8,8 +8,6 @@ import {actionStyles} from "@khanacademy/wonder-blocks-styles";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
-import Button from "@khanacademy/wonder-blocks-button";
-import Link from "@khanacademy/wonder-blocks-link";
 
 /**
  * Styles that can be used to create reusable states for interactive elements.
@@ -45,14 +43,12 @@ type Story = StoryObj<any>;
 const StyledButton = addStyle("button");
 
 /**
- * A global focus style that can be applied to interactive elements.
+ * A style that can be applied to interactive elements on inverse backgrounds.
  *
- * This style injects a combination of `outline` and `box-shadow` to indicate
- * the element is focused. This is used for accessibility purposes as it allows
- * the element to present a focus state on Windows High Contrast mode.
+ * This is used for special cases where the element is on a dark background.
  *
- * In the example below, the focus style is applied to an `IconButton` component
- * and to a `button` element.
+ * In the example below, the `inverse` style is applied to WB components along
+ * with a `button` element.
  */
 export const InverseOutline: Story = {
     name: "inverse",
@@ -74,18 +70,6 @@ export const InverseOutline: Story = {
                     icon={info}
                     style={actionStyles.inverse}
                 />
-                <Button kind="primary" style={actionStyles.inverse}>
-                    Primary button
-                </Button>
-                <Button kind="secondary" style={actionStyles.inverse}>
-                    secondary button
-                </Button>
-                <Button kind="tertiary" style={actionStyles.inverse}>
-                    tertiary button
-                </Button>
-                <Link href="#ss" style={actionStyles.inverse}>
-                    Arr link
-                </Link>
 
                 <Clickable onClick={() => {}} style={actionStyles.inverse}>
                     {() => "Clickable component"}

--- a/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
@@ -40,7 +40,6 @@ export const leftContentMappings: Mappings = {
     dismissButton: (
         <IconButton aria-label="Dismiss" icon={xIcon} kind="tertiary" />
     ),
-    lightButton: <IconButton aria-label="Dismiss" icon={xIcon} light={true} />,
     hintButton: (
         <IconButton aria-label="Hint" icon={lightbulb} kind="primary" />
     ),

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
@@ -5,7 +5,6 @@ import {userEvent} from "@testing-library/user-event";
 import {MemoryRouter, Route, Switch} from "react-router-dom";
 import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
-import expectRenderError from "../../../../../utils/testing/expect-render-error";
 import {IconButton} from "../icon-button";
 
 describe("IconButton", () => {
@@ -39,19 +38,6 @@ describe("IconButton", () => {
 
         // Assert
         expect(icon.innerHTML).toEqual(expect.stringContaining("mask-image"));
-    });
-
-    test("throw an error for if light and not primary", async () => {
-        expectRenderError(
-            <IconButton
-                icon={magnifyingGlassIcon}
-                aria-label="search"
-                kind="secondary"
-                light={true}
-                onClick={() => void 0}
-            />,
-            "Light is only supported for primary IconButtons",
-        );
     });
 
     test("client-side navigation", async () => {

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -95,7 +95,6 @@ const IconButtonCore: React.ForwardRefExoticComponent<
         href,
         icon,
         kind = "primary",
-        light = false,
         size = "medium",
         skipClientNav,
         style,
@@ -110,7 +109,6 @@ const IconButtonCore: React.ForwardRefExoticComponent<
             actionType,
             !!disabled,
             kind,
-            light,
             size,
             theme,
             themeName,
@@ -194,34 +192,19 @@ const sharedStyles = StyleSheet.create({
 
 const styles: Record<string, any> = {};
 
-type ActionType =
-    | "progressive"
-    | "destructive"
-    | "disabled"
-    // TODO(WB-1852): Remove light variants.
-    | "progressiveLight"
-    | "destructiveLight"
-    | "disabledLight";
+type ActionType = "progressive" | "destructive" | "disabled";
 
 function getStylesByKind(
     actionType: IconButtonActionType = "progressive",
     disabled: boolean,
     kind: Kind,
-    light: boolean,
     theme: IconButtonThemeContract,
 ) {
-    let actionTypeOrDisabled: ActionType = disabled ? "disabled" : actionType;
+    const actionTypeOrDisabled: ActionType = disabled ? "disabled" : actionType;
 
     const themeVariant = theme.color[kind][actionTypeOrDisabled];
 
     if (kind === "primary") {
-        // NOTE: Primary is the only kind that supports light variants.
-        if (light) {
-            actionTypeOrDisabled = `${actionTypeOrDisabled}Light`;
-        }
-
-        const themeVariant = theme.color[kind][actionTypeOrDisabled];
-
         return {
             default: {
                 borderColor: themeVariant.default.border,
@@ -246,7 +229,6 @@ function getStylesByKind(
             disabled: {
                 background: themeVariant.default.background,
                 color: themeVariant.default.foreground,
-                borderColor: themeVariant.default.border,
             },
         };
     }
@@ -273,7 +255,6 @@ function getStylesByKind(
             disabled: {
                 background: themeVariant.default.background,
                 color: themeVariant.default.foreground,
-                borderColor: themeVariant.focus.border,
             },
         };
     }
@@ -291,31 +272,20 @@ const _generateStyles = (
     actionType: IconButtonActionType = "progressive",
     disabled: boolean,
     kind: Kind,
-    light: boolean,
     size: IconButtonSize,
     theme: IconButtonThemeContract,
     themeName: string,
 ) => {
-    const buttonType = `${actionType}-d_${disabled}-${kind}-l_${light}-${size}-${themeName}`;
+    const buttonType = `${actionType}-d_${disabled}-${kind}-${size}-${themeName}`;
     if (styles[buttonType]) {
         return styles[buttonType];
-    }
-
-    if (light && kind !== "primary") {
-        throw new Error("Light is only supported for primary IconButtons");
     }
 
     const pixelsForSize = targetPixelsForSize(size);
 
     // Override styles for each kind of button. This is useful for merging
     // pseudo-classes properly.
-    const kindOverrides = getStylesByKind(
-        actionType,
-        disabled,
-        kind,
-        light,
-        theme,
-    );
+    const kindOverrides = getStylesByKind(actionType, disabled, kind, theme);
 
     const disabledStatesStyles = kindOverrides.disabled;
 

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -41,10 +41,6 @@ export type SharedProps = Partial<Omit<AriaProps, "aria-disabled">> & {
      */
     kind?: "primary" | "secondary" | "tertiary";
     /**
-     * Whether the icon button is on a dark/colored background.
-     */
-    light?: boolean;
-    /**
      * Whether the icon button is disabled.
      */
     disabled?: boolean;
@@ -192,7 +188,6 @@ export const IconButton: React.ForwardRefExoticComponent<
         disabled = false,
         href,
         kind = "primary",
-        light = false,
         size = "medium",
         skipClientNav,
         tabIndex,
@@ -228,7 +223,6 @@ export const IconButton: React.ForwardRefExoticComponent<
                 disabled={disabled}
                 href={href}
                 kind={kind}
-                light={light}
                 ref={ref}
                 skipClientNav={skipClientNav}
                 size={size}

--- a/packages/wonder-blocks-icon-button/src/themes/default.ts
+++ b/packages/wonder-blocks-icon-button/src/themes/default.ts
@@ -1,25 +1,10 @@
-import {border, color, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 const disabledStates = {
     // NOTE: This is a special case for the button
     border: semanticColor.action.primary.disabled.border,
     background: "transparent",
     foreground: semanticColor.action.secondary.disabled.foreground,
-};
-
-// TODO(WB-1852): Remove light variants.
-const disabledLightStates = {
-    border: color.white50,
-    background: "transparent",
-    foreground: color.white50,
-};
-
-const focusOutline = {
-    border: semanticColor.focus.outer,
-};
-
-const focusOutlineLight = {
-    border: semanticColor.border.inverse,
 };
 
 /**
@@ -37,7 +22,10 @@ const baseColorStates = {
             border: "transparent",
             background: "transparent",
         },
-        focus: focusOutline,
+        hover: {
+            ...semanticColor.action.secondary.progressive.hover,
+            background: "transparent",
+        },
         press: {
             border: semanticColor.action.secondary.progressive.press.border,
             background: "transparent",
@@ -52,7 +40,10 @@ const baseColorStates = {
             border: "transparent",
             background: "transparent",
         },
-        focus: focusOutline,
+        hover: {
+            ...semanticColor.action.secondary.destructive.hover,
+            background: "transparent",
+        },
         press: {
             border: semanticColor.action.secondary.destructive.press.border,
             background: "transparent",
@@ -62,63 +53,14 @@ const baseColorStates = {
     },
     disabled: {
         default: disabledStates,
-        focus: focusOutline,
         hover: disabledStates,
         press: disabledStates,
-    },
-    // TODO(WB-1852): Remove light variants.
-    disabledLight: {
-        default: disabledLightStates,
-        focus: focusOutlineLight,
-        hover: disabledLightStates,
-        press: disabledLightStates,
     },
 };
 
 const theme = {
     color: {
-        primary: {
-            ...baseColorStates,
-            // Only primary supports the light variants.
-            // TODO(WB-1852): Remove light variants.
-            progressiveLight: {
-                default: {
-                    border: semanticColor.border.inverse,
-                    background: "transparent",
-                    foreground: semanticColor.text.inverse,
-                },
-                hover: {
-                    border: semanticColor.border.inverse,
-                    background: "transparent",
-                    foreground: semanticColor.text.inverse,
-                },
-                focus: focusOutlineLight,
-                press: {
-                    border: color.fadedBlue,
-                    background: "transparent",
-                    foreground: color.fadedBlue,
-                },
-            },
-            // TODO(WB-1852): Remove light variants.
-            destructiveLight: {
-                default: {
-                    border: semanticColor.border.inverse,
-                    background: "transparent",
-                    foreground: semanticColor.text.inverse,
-                },
-                hover: {
-                    border: semanticColor.border.inverse,
-                    background: "transparent",
-                    foreground: semanticColor.text.inverse,
-                },
-                focus: focusOutlineLight,
-                press: {
-                    border: color.fadedRed,
-                    background: "transparent",
-                    foreground: color.fadedRed,
-                },
-            },
-        },
+        primary: baseColorStates,
 
         // secondary
         secondary: {
@@ -147,20 +89,12 @@ const theme = {
                     ...baseColorStates.progressive.default,
                     foreground: semanticColor.icon.primary,
                 },
-                hover: {
-                    ...baseColorStates.progressive.hover,
-                    background: "transparent",
-                },
             },
             destructive: {
                 ...baseColorStates.destructive,
                 default: {
                     ...baseColorStates.destructive.default,
                     foreground: semanticColor.icon.primary,
-                },
-                hover: {
-                    ...baseColorStates.destructive.hover,
-                    background: "transparent",
                 },
             },
         },

--- a/packages/wonder-blocks-icon-button/src/themes/khanmigo.ts
+++ b/packages/wonder-blocks-icon-button/src/themes/khanmigo.ts
@@ -1,21 +1,9 @@
 import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
-import {border, color, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import defaultTheme from "./default";
 
 const primaryState = {
     hover: {foreground: semanticColor.khanmigo.primary},
-};
-
-const primaryLightState = {
-    hover: {
-        background: semanticColor.surface.primary,
-        foreground: semanticColor.khanmigo.primary,
-    },
-    press: {
-        border: "transparent",
-        background: color.white64,
-        foreground: semanticColor.khanmigo.primary,
-    },
 };
 
 const actionType = semanticColor.action.primary;
@@ -29,8 +17,6 @@ const theme = mergeTheme(defaultTheme, {
             // NOTE: These are shared by action type
             progressive: primaryState,
             destructive: primaryState,
-            progressiveLight: primaryLightState,
-            destructiveLight: primaryLightState,
         },
 
         secondary: {

--- a/packages/wonder-blocks-modal/src/components/close-button.tsx
+++ b/packages/wonder-blocks-modal/src/components/close-button.tsx
@@ -52,7 +52,6 @@ export default class CloseButton extends React.Component<Props> {
                             aria-label="Close modal"
                             onClick={onClick || closeModal}
                             kind={light ? "primary" : "tertiary"}
-                            light={light}
                             style={style}
                             testId={testId}
                         />

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -7,7 +7,7 @@ import {
     useScopedTheme,
     useStyles,
 } from "@khanacademy/wonder-blocks-theming";
-import {focusStyles} from "@khanacademy/wonder-blocks-styles";
+import {actionStyles, focusStyles} from "@khanacademy/wonder-blocks-styles";
 import ModalContent from "./modal-content";
 import ModalHeader from "./modal-header";
 import ModalFooter from "./modal-footer";
@@ -126,16 +126,21 @@ export default function ModalPanel({
 
     const mainContent = renderMainContent();
 
+    const isInverse = !light;
+
     return (
         <View
-            style={[styles.wrapper, !light && styles.dark, style]}
+            style={[styles.wrapper, isInverse && styles.dark, style]}
             testId={testId && `${testId}-panel`}
         >
             {closeButtonVisible && (
                 <CloseButton
-                    light={!light}
+                    light={isInverse}
                     onClick={onClose}
-                    style={styles.closeButton}
+                    style={[
+                        styles.closeButton,
+                        isInverse && actionStyles.inverse,
+                    ]}
                     testId={testId && `${testId}-close`}
                 />
             )}

--- a/packages/wonder-blocks-popover/package.json
+++ b/packages/wonder-blocks-popover/package.json
@@ -20,6 +20,7 @@
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon-button": "workspace:*",
     "@khanacademy/wonder-blocks-modal": "workspace:*",
+    "@khanacademy/wonder-blocks-styles": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
     "@khanacademy/wonder-blocks-tooltip": "workspace:*",
     "@khanacademy/wonder-blocks-typography": "workspace:*"

--- a/packages/wonder-blocks-popover/src/components/close-button.tsx
+++ b/packages/wonder-blocks-popover/src/components/close-button.tsx
@@ -49,7 +49,6 @@ export default class CloseButton extends React.Component<Props> {
                             aria-label={ariaLabel}
                             onClick={close}
                             kind={light ? "primary" : "tertiary"}
-                            light={light}
                             style={style}
                             testId={testId}
                         />

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -5,6 +5,7 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 
+import {actionStyles} from "@khanacademy/wonder-blocks-styles";
 import CloseButton from "./close-button";
 
 type Props = AriaProps & {
@@ -82,7 +83,10 @@ export default class PopoverContentCore extends React.Component<Props> {
                     <CloseButton
                         aria-label={closeButtonLabel}
                         light={closeButtonLight}
-                        style={styles.closeButton}
+                        style={[
+                            styles.closeButton,
+                            closeButtonLight && actionStyles.inverse,
+                        ]}
                         testId={`${testId || "popover"}-close-btn`}
                     />
                 )}

--- a/packages/wonder-blocks-popover/tsconfig-build.json
+++ b/packages/wonder-blocks-popover/tsconfig-build.json
@@ -10,6 +10,7 @@
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-modal/tsconfig-build.json"},
+        {"path": "../wonder-blocks-styles/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-tooltip/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},

--- a/packages/wonder-blocks-styles/src/index.ts
+++ b/packages/wonder-blocks-styles/src/index.ts
@@ -1,3 +1,4 @@
+import * as actionStyles from "./styles/action-styles";
 import * as focusStyles from "./styles/focus-styles";
 
-export {focusStyles};
+export {actionStyles, focusStyles};

--- a/packages/wonder-blocks-styles/src/styles/action-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/action-styles.ts
@@ -4,9 +4,9 @@ import {focus} from "./focus-styles";
 const pressColor = `color-mix(in srgb, ${semanticColor.border.strong} 85%, ${semanticColor.border.inverse})`;
 
 /**
- * The inverse button styles.
+ * The inverse styles for an interactive control.
  *
- * This is used for special cases where the button is on a dark background.
+ * This is used for special cases where the element is on a dark background.
  *
  * NOTE: This will be deprecated in the future.
  */

--- a/packages/wonder-blocks-styles/src/styles/action-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/action-styles.ts
@@ -1,7 +1,7 @@
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {focus} from "./focus-styles";
 
-const pressColor = `color-mix(in srgb, ${semanticColor.border.strong} 85%, ${semanticColor.border.inverse})`;
+const pressColor = `color-mix(in srgb, ${semanticColor.border.strong} 55%, ${semanticColor.border.inverse})`;
 
 /**
  * The inverse styles for an interactive control.
@@ -32,7 +32,6 @@ export const inverse = {
 
     ":active:not([aria-disabled=true])": {
         borderRadius: spacing.xSmall_8,
-        color: pressColor,
         // This is a slightly darker color than the inverse color.
         borderColor: pressColor,
     },

--- a/packages/wonder-blocks-styles/src/styles/action-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/action-styles.ts
@@ -1,0 +1,37 @@
+import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {focus} from "./focus-styles";
+
+const pressColor = `color-mix(in srgb, ${semanticColor.border.strong} 85%, ${semanticColor.border.inverse})`;
+
+/**
+ * The inverse button styles.
+ *
+ * This is used for special cases where the button is on a dark background.
+ *
+ * NOTE: This will be deprecated in the future.
+ */
+export const inverse = {
+    // Overriding borderColor only to preserve the visual integrity of the
+    // button, as there might be some cases where the interactive element
+    // already includes a border.
+    borderColor: semanticColor.border.inverse,
+    color: semanticColor.text.inverse,
+
+    ":hover:not([aria-disabled=true])": {
+        color: semanticColor.text.inverse,
+        // Overriding borderColor only to preserve the visual integrity of the
+        // button, as there might be some cases where the interactive element
+        // already includes a border.
+        borderColor: semanticColor.border.inverse,
+    },
+
+    // Use the global focus styles to ensure that the focus state is consistent
+    ...focus,
+
+    ":active:not([aria-disabled=true])": {
+        borderRadius: spacing.xSmall_8,
+        color: pressColor,
+        // This is a slightly darker color than the inverse color.
+        borderColor: pressColor,
+    },
+};

--- a/packages/wonder-blocks-styles/src/styles/action-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/action-styles.ts
@@ -11,11 +11,13 @@ const pressColor = `color-mix(in srgb, ${semanticColor.border.strong} 85%, ${sem
  * NOTE: This will be deprecated in the future.
  */
 export const inverse = {
-    // Overriding borderColor only to preserve the visual integrity of the
-    // button, as there might be some cases where the interactive element
-    // already includes a border.
-    borderColor: semanticColor.border.inverse,
-    color: semanticColor.text.inverse,
+    ":not([aria-disabled=true])": {
+        // Overriding borderColor only to preserve the visual integrity of the
+        // button, as there might be some cases where the interactive element
+        // already includes a border.
+        borderColor: semanticColor.border.inverse,
+        color: semanticColor.text.inverse,
+    },
 
     ":hover:not([aria-disabled=true])": {
         color: semanticColor.text.inverse,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1054,6 +1054,9 @@ importers:
       '@khanacademy/wonder-blocks-modal':
         specifier: workspace:*
         version: link:../wonder-blocks-modal
+      '@khanacademy/wonder-blocks-styles':
+        specifier: workspace:*
+        version: link:../wonder-blocks-styles
       '@khanacademy/wonder-blocks-tokens':
         specifier: workspace:*
         version: link:../wonder-blocks-tokens


### PR DESCRIPTION
## Summary:

This PR removes the `light` variant from the IconButton component and replaces
it with a new `actionStyles.inverse` style. This change is part of a larger
effort to standardize the styling of interactive elements across WB. The `light`
variant was previously used in the `Popover` and `Moda`l components. The new
`actionStyles.inverse` style provides a way to apply almost the same styling as
the `light` variant, but allow us to avoid having to maintain a separate `light`
variant in the IconButton component (which won't be supported in Thunder
Blocks and new styles).

Key changes:

- Styles: Added a new `actionStyles.inverse` style to apply to interactive
(action) components.
- IconButton: Removed the `light` variant and replaced it with
`actionStyles.inverse`.
- Modal and Popover: Updated dismiss button (CloseButton) to use
`actionStyles.inverse` instead of the now deprecated `IconButton.light` variant.

Issue: WB-1852

## Test plan:

### IconButton

Navigate to the `IconButton` docs and verify that all the dark stories are no
longer present. Also verify that the "All variant" snapshots remove the `light`
variant.

- /?path=/docs/packages-iconbutton--docs
- /?path=/story/packages-iconbutton-all-variants--default


### Popover and Modal

Verify that the `Popover` and `Modal` components are still working as expected
and that the dismiss button (CloseButton) is using the new
`actionStyles.inverse` style.

- Popover: /?path=/docs/packages-popover-popovercontent--docs#with%20illustration
- Modal: /?path=/story/packages-modal-building-blocks-modalheader--dark&globals=viewport:desktop;

### Styles

Verify that the new `actionStyles.inverse` style is working as expected in the
`ActionStyles` docs.

- /?path=/docs/packages-styles-action-styles--docs