### PR TITLE
Tabs: Set up keyboard navigation and activationMode prop

### DIFF
--- a/.changeset/breezy-bulldogs-yawn.md
+++ b/.changeset/breezy-bulldogs-yawn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tabs": minor
+---
+
+Tabs: Add keyboard navigation support and `activationMode` prop.

--- a/.changeset/little-laws-flash.md
+++ b/.changeset/little-laws-flash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Add focus utilities: `findFocusableNodes` and `isFocusable`

--- a/.changeset/loud-lamps-deny.md
+++ b/.changeset/loud-lamps-deny.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-core": minor
+---
+
+Add constants for `ArrowLeft`, `ArrowRight`, `Home`, and `End` keys

--- a/__docs__/wonder-blocks-tabs/tabs.accessibility.mdx
+++ b/__docs__/wonder-blocks-tabs/tabs.accessibility.mdx
@@ -32,3 +32,31 @@ associated element with `role=tabpanel`
 the associated element with `role=tab`
 - `aria-label` or `aria-labelledby` is set on the `tablist` element using the
 `Tabs` component props
+
+### Keyboard Navigation
+
+The following keyboard interactions are implemented:
+- `Tab`
+    - When focus moves into the `Tabs` component, the active tab is focused
+    - When a tab is focused, pressing `Tab` will:
+        - move focus to the tab panel if there are no focusable elements in the
+        active tab panel, or
+        - move focus to the first element in the tabpanel that is focusable
+- `Left Arrow`
+    - When focus is on a tab element, the `Left Arrow` will move focus to the
+    previous tab
+    - If focus is on the first tab, focus is moved to the last tab
+    - If `activationMode=automatic`, the newly focused tab is also activated
+- `Right Arrow`
+    - When focus is on a tab element, the `Right Arrow` will move focus to the
+    next tab
+    - If focus is on the last tab, focus is moved to the first tab
+    - If `activationMode=automatic`, the newly focused tab is also activated
+- `Home`
+    - When focus is on a tab element, the `Home` key will move focus to the first
+    tab
+    - If `activationMode=automatic`, the newly focused tab is also activated
+- `End`
+    - When focus is on a tab element, the `End` key will move focus to the last
+    tab
+    - If `activationMode=automatic`, the newly focused tab is also activated

--- a/__docs__/wonder-blocks-tabs/tabs.argtypes.ts
+++ b/__docs__/wonder-blocks-tabs/tabs.argtypes.ts
@@ -29,4 +29,11 @@ export default {
             category: "Accessibility",
         },
     },
+    activationMode: {
+        table: {
+            type: {
+                summary: '"manual" | "automatic"',
+            },
+        },
+    },
 } satisfies ArgTypes;

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -4,6 +4,9 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 import {TabItem, Tabs} from "@khanacademy/wonder-blocks-tabs";
 import argTypes from "./tabs.argtypes";
+import Button from "@khanacademy/wonder-blocks-button";
+import Link from "@khanacademy/wonder-blocks-link";
+import {TextField} from "@khanacademy/wonder-blocks-form";
 
 const tabs: TabItem[] = [
     {label: "Tab 1", id: "tab-1", panel: <div>Tab contents 1</div>},
@@ -91,10 +94,41 @@ export const AutomaticActivation: StoryComponentType = {
  */
 export const WithFocusablePanelContent: StoryComponentType = {
     args: {
+        selectedTabId: "tab-wb-button",
         tabs: [
             {
+                label: "Content with WB Button",
+                id: "tab-wb-button",
+                panel: (
+                    <div>
+                        Tab contents with button{" "}
+                        <Button>Focusable Button</Button>
+                    </div>
+                ),
+            },
+            {
+                label: "Content with WB Link",
+                id: "tab-wb-link",
+                panel: (
+                    <div>
+                        Tab contents with link{" "}
+                        <Link href="#link">Focusable Link</Link>
+                    </div>
+                ),
+            },
+            {
+                label: "Content with WB TextField",
+                id: "tab-wb-textfield",
+                panel: (
+                    <div>
+                        Tab contents with WB TextField{" "}
+                        <TextField value="" onChange={() => {}} />
+                    </div>
+                ),
+            },
+            {
                 label: "Content with button",
-                id: "tab-1",
+                id: "tab-button",
                 panel: (
                     <div>
                         Tab contents with button{" "}
@@ -104,7 +138,7 @@ export const WithFocusablePanelContent: StoryComponentType = {
             },
             {
                 label: "Content with link",
-                id: "tab-2",
+                id: "tab-link",
                 panel: (
                     <div>
                         Tab contents with link{" "}
@@ -114,7 +148,7 @@ export const WithFocusablePanelContent: StoryComponentType = {
             },
             {
                 label: "Content with input",
-                id: "tab-3",
+                id: "tab-input",
                 panel: (
                     <div>
                         Tab contents with input <input type="text" />
@@ -123,7 +157,7 @@ export const WithFocusablePanelContent: StoryComponentType = {
             },
             {
                 label: "Content with no focusable elements",
-                id: "tab-4",
+                id: "tab-no-focusable-elements",
                 panel: <div>No focusable elements. Tab panel is focusable</div>,
             },
         ],

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -49,3 +49,44 @@ type StoryComponentType = StoryObj<typeof Tabs>;
 export const Default: StoryComponentType = {
     args: {},
 };
+
+export const WithFocusablePanelContent: StoryComponentType = {
+    args: {
+        tabs: [
+            {
+                label: "Content with button",
+                id: "tab-1",
+                panel: (
+                    <div>
+                        Tab contents with button{" "}
+                        <button>Focusable Button</button>
+                    </div>
+                ),
+            },
+            {
+                label: "Content with link",
+                id: "tab-2",
+                panel: (
+                    <div>
+                        Tab contents with link{" "}
+                        <a href="#link">Focusable Link</a>
+                    </div>
+                ),
+            },
+            {
+                label: "Content with input",
+                id: "tab-3",
+                panel: (
+                    <div>
+                        Tab contents with input <input type="text" />
+                    </div>
+                ),
+            },
+            {
+                label: "Content with no focusable elements",
+                id: "tab-4",
+                panel: <div>No focusable elements. Tab panel is focusable</div>,
+            },
+        ],
+    },
+};

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -85,9 +85,9 @@ export const AutomaticActivation: StoryComponentType = {
 
 /**
  * When a tab panel has focusable elements, pressing `Tab` from the tablist
- * will move focus to the first focusable element in the tab. If there are no
- * focusable elements in the active panel, the tabpanel will be focused on
- * instead.
+ * will move focus to the first focusable element in the tab panel. If there
+ * are no focusable elements in the active tab panel, the tab panel will be
+ * focused instead.
  */
 export const WithFocusablePanelContent: StoryComponentType = {
     args: {

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -92,7 +92,7 @@ export const AutomaticActivation: StoryComponentType = {
  * are no focusable elements in the active tab panel, the tab panel will be
  * focused instead.
  */
-export const WithFocusablePanelContent: StoryComponentType = {
+export const WithFocusableContent: StoryComponentType = {
     args: {
         selectedTabId: "tab-wb-button",
         tabs: [
@@ -122,7 +122,11 @@ export const WithFocusablePanelContent: StoryComponentType = {
                 panel: (
                     <div>
                         Tab contents with WB TextField{" "}
-                        <TextField value="" onChange={() => {}} />
+                        <TextField
+                            value=""
+                            onChange={() => {}}
+                            aria-label="Focusable TextField"
+                        />
                     </div>
                 ),
             },
@@ -151,7 +155,8 @@ export const WithFocusablePanelContent: StoryComponentType = {
                 id: "tab-input",
                 panel: (
                     <div>
-                        Tab contents with input <input type="text" />
+                        Tab contents with input{" "}
+                        <input type="text" aria-label="Focusable input" />
                     </div>
                 ),
             },

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -50,6 +50,45 @@ export const Default: StoryComponentType = {
     args: {},
 };
 
+/**
+ * When `activationMode` is set to `manual`, the tab will only be activated
+ * via keyboard when a tab receives focus and is selected by pressing `Space`
+ * or `Enter`.
+ */
+export const ManualActivation: StoryComponentType = {
+    args: {
+        activationMode: "manual",
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
+ * When `activationMode` is set to `automatic`, the tab will be activated via
+ * keyboard when a tab receives focus.
+ */
+export const AutomaticActivation: StoryComponentType = {
+    args: {
+        activationMode: "automatic",
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
+ * When a tab panel has focusable elements, pressing `Tab` from the tablist
+ * will move focus to the first focusable element in the tab. If there are no
+ * focusable elements in the active panel, the tabpanel will be focused on
+ * instead.
+ */
 export const WithFocusablePanelContent: StoryComponentType = {
     args: {
         tabs: [
@@ -88,5 +127,11 @@ export const WithFocusablePanelContent: StoryComponentType = {
                 panel: <div>No focusable elements. Tab panel is focusable</div>,
             },
         ],
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
     },
 };

--- a/packages/wonder-blocks-core/src/util/__tests__/focus.test.tsx
+++ b/packages/wonder-blocks-core/src/util/__tests__/focus.test.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import {isFocusable} from "../focus";
+
+describe("isFocusable", () => {
+    it("should mark a button as focusable", () => {
+        // Arrange
+        render(<button>Open popover</button>);
+
+        // Act
+        const result = isFocusable(screen.getByRole("button"));
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("should mark a div as non-focusable", () => {
+        // Arrange
+        render(<div>placeholder</div>);
+
+        // Act
+        const result = isFocusable(screen.getByText("placeholder"));
+
+        // Assert
+        expect(result).toBe(false);
+    });
+
+    it("should mark a div with tabIndex greater than -1 as focusable", () => {
+        // Arrange
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- Explicitly testing this case
+        render(<div tabIndex={0}>placeholder</div>);
+
+        // Act
+        const result = isFocusable(screen.getByText("placeholder"));
+
+        // Assert
+        expect(result).toBe(true);
+    });
+});

--- a/packages/wonder-blocks-core/src/util/focus.ts
+++ b/packages/wonder-blocks-core/src/util/focus.ts
@@ -1,0 +1,20 @@
+/**
+ * List of elements that can be focused
+ * @see https://www.w3.org/TR/html5/editing.html#can-be-focused
+ */
+const FOCUSABLE_ELEMENTS =
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+export function findFocusableNodes(
+    root: HTMLElement | Document,
+): Array<HTMLElement> {
+    return Array.from(root.querySelectorAll(FOCUSABLE_ELEMENTS));
+}
+
+/**
+ * Checks if an element is focusable
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
+ */
+export function isFocusable(element: HTMLElement): boolean {
+    return element.matches(FOCUSABLE_ELEMENTS);
+}

--- a/packages/wonder-blocks-core/src/util/keys.ts
+++ b/packages/wonder-blocks-core/src/util/keys.ts
@@ -9,4 +9,8 @@ export const keys = {
     space: " ",
     up: "ArrowUp",
     down: "ArrowDown",
+    left: "ArrowLeft",
+    right: "ArrowRight",
+    home: "Home",
+    end: "End",
 } as const;

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
@@ -199,6 +199,62 @@ describe("TabPanel", () => {
                     expect(tabPanel).not.toHaveFocus();
                 },
             );
+
+            it.each([
+                {
+                    element: (
+                        <a
+                            href="#link"
+                            data-testid="expected-focusable-element"
+                        >
+                            Link Example
+                        </a>
+                    ),
+                    label: "Link",
+                },
+                {
+                    element: (
+                        <input
+                            type="text"
+                            data-testid="expected-focusable-element"
+                        />
+                    ),
+                    label: "Input",
+                },
+                {
+                    element: (
+                        <button data-testid="expected-focusable-element">
+                            Button
+                        </button>
+                    ),
+                    label: "Button",
+                },
+                {
+                    element: (
+                        <textarea data-testid="expected-focusable-element" />
+                    ),
+                    label: "Textarea",
+                },
+            ])(
+                "should focus on the expected focusable element if there is a focusable element in the panel ($label)",
+                async ({element}) => {
+                    // Arrange
+                    render(
+                        <TabPanel {...props} active={true}>
+                            {element}
+                        </TabPanel>,
+                    );
+                    const expectedFocusableElement = await screen.findByTestId(
+                        "expected-focusable-element",
+                    );
+
+                    // Act
+                    await userEvent.tab();
+
+                    // Assert
+                    expect(expectedFocusableElement).toHaveFocus();
+                },
+            );
         });
     });
 });

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {TabPanel} from "../tab-panel";
 
 describe("TabPanel", () => {
@@ -43,23 +44,6 @@ describe("TabPanel", () => {
 
         // Assert
         expect(children).toBeInTheDocument();
-    });
-
-    it("should forward the ref to the tab panel", async () => {
-        // Arrange
-        const ref = React.createRef<HTMLDivElement>();
-
-        // Act
-        render(
-            <TabPanel {...props} ref={ref}>
-                TabPanel
-            </TabPanel>,
-        );
-
-        // Assert
-        expect(await screen.findByRole("tabpanel", {hidden: true})).toBe(
-            ref.current,
-        );
     });
 
     it("should not be visible if active is false", async () => {
@@ -161,6 +145,60 @@ describe("TabPanel", () => {
                     ariaLabelledby,
                 );
             });
+        });
+
+        describe("Focus", () => {
+            it("should be focusable if there are no focusable elements in the panel", async () => {
+                // Arrange
+                render(
+                    <TabPanel {...props} active={true}>
+                        No focusable elements
+                    </TabPanel>,
+                );
+                const tabPanel = await screen.findByRole("tabpanel");
+
+                // Act
+                await userEvent.tab();
+
+                // Assert
+                expect(tabPanel).toHaveFocus();
+            });
+
+            it.each([
+                {
+                    element: <a href="#link">Link Example</a>,
+                    label: "Link",
+                },
+                {
+                    element: <input type="text" />,
+                    label: "Input",
+                },
+                {
+                    element: <button>Button</button>,
+                    label: "Button",
+                },
+                {
+                    element: <textarea />,
+                    label: "Textarea",
+                },
+            ])(
+                "should not be focusable if there is a focusable element in the panel ($label)",
+                async ({element}) => {
+                    // Arrange
+                    render(
+                        <TabPanel {...props} active={true}>
+                            {element}
+                        </TabPanel>,
+                    );
+                    const tabPanel = await screen.findByRole("tabpanel");
+
+                    // Act
+                    await userEvent.tab();
+
+                    // Assert
+                    expect(tabPanel).not.toHaveFocus();
+                },
+            );
         });
     });
 });

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
@@ -20,7 +20,10 @@ describe("TabPanel", () => {
         );
 
         // Act
-        const tabPanel = await screen.findByRole("tabpanel");
+        const tabPanel = await screen.findByRole("tabpanel", {
+            // We expect the tab panel to be hidden if it is not active
+            hidden: true,
+        });
 
         // Assert
         expect(tabPanel).toBeInTheDocument();
@@ -54,7 +57,37 @@ describe("TabPanel", () => {
         );
 
         // Assert
-        expect(await screen.findByRole("tabpanel")).toBe(ref.current);
+        expect(await screen.findByRole("tabpanel", {hidden: true})).toBe(
+            ref.current,
+        );
+    });
+
+    it("should not be visible if active is false", async () => {
+        // Arrange
+        render(
+            <TabPanel {...props} active={false}>
+                TabPanel
+            </TabPanel>,
+        );
+        // Act
+        const tabPanel = await screen.findByRole("tabpanel", {hidden: true});
+
+        // Assert
+        expect(tabPanel).not.toBeVisible();
+    });
+
+    it("should be visible if active is true", async () => {
+        // Arrange
+        render(
+            <TabPanel {...props} active={true}>
+                TabPanel
+            </TabPanel>,
+        );
+        // Act
+        const tabPanel = await screen.findByRole("tabpanel");
+
+        // Assert
+        expect(tabPanel).toBeVisible();
     });
 
     describe("Props", () => {
@@ -68,7 +101,9 @@ describe("TabPanel", () => {
             );
 
             // Act
-            const tabPanel = await screen.findByRole("tabpanel");
+            const tabPanel = await screen.findByRole("tabpanel", {
+                hidden: true,
+            });
 
             // Assert
             expect(tabPanel).toHaveAttribute("id", id);
@@ -116,7 +151,9 @@ describe("TabPanel", () => {
                 );
 
                 // Act
-                const tabPanel = await screen.findByRole("tabpanel");
+                const tabPanel = await screen.findByRole("tabpanel", {
+                    hidden: true,
+                });
 
                 // Assert
                 expect(tabPanel).toHaveAttribute(

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
@@ -93,6 +93,27 @@ describe("Tab", () => {
             // Assert
             expect(onClick).toHaveBeenCalledOnce();
         });
+
+        it("should call onKeyDown when a key is pressed", async () => {
+            // Arrange
+            const onKeyDown = jest.fn();
+            render(
+                <Tab {...props} onKeyDown={onKeyDown} selected={true}>
+                    Tab
+                </Tab>,
+            );
+            await userEvent.tab();
+
+            // Act
+            await userEvent.keyboard("{Enter}");
+
+            // Assert
+            expect(onKeyDown).toHaveBeenCalledExactlyOnceWith(
+                expect.objectContaining({
+                    key: "Enter",
+                }),
+            );
+        });
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
@@ -176,5 +176,39 @@ describe("Tab", () => {
                 expect(tab).not.toHaveAttribute("aria-selected");
             });
         });
+
+        describe("Focus", () => {
+            it("should be focusable if it is selected", async () => {
+                // Arrange
+                render(
+                    <Tab {...props} selected={true}>
+                        Tab
+                    </Tab>,
+                );
+                const tab = await screen.findByRole("tab");
+
+                // Act
+                await userEvent.keyboard("{tab}");
+
+                // Assert
+                expect(tab).toHaveFocus();
+            });
+
+            it("should not be focusable if it is not selected", async () => {
+                // Arrange
+                render(
+                    <Tab {...props} selected={false}>
+                        Tab
+                    </Tab>,
+                );
+                const tab = await screen.findByRole("tab");
+
+                // Act
+                await userEvent.keyboard("{tab}");
+
+                // Assert
+                expect(tab).not.toHaveFocus();
+            });
+        });
     });
 });

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
@@ -209,7 +209,7 @@ describe("Tab", () => {
                 const tab = await screen.findByRole("tab");
 
                 // Act
-                await userEvent.keyboard("{tab}");
+                await userEvent.tab();
 
                 // Assert
                 expect(tab).toHaveFocus();
@@ -225,7 +225,7 @@ describe("Tab", () => {
                 const tab = await screen.findByRole("tab");
 
                 // Act
-                await userEvent.keyboard("{tab}");
+                await userEvent.tab();
 
                 // Assert
                 expect(tab).not.toHaveFocus();

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
@@ -42,29 +42,6 @@ describe("Tablist", () => {
         expect(await screen.findByRole("tablist")).toBe(ref.current);
     });
 
-    describe("Event handlers", () => {
-        it("should call onKeyDown when a key is pressed", async () => {
-            // Arrange
-            const onKeyDown = jest.fn();
-            render(
-                <Tablist onKeyDown={onKeyDown}>
-                    <button role="tab">Tab</button>
-                </Tablist>,
-            );
-            await userEvent.tab();
-
-            // Act
-            await userEvent.keyboard("{enter}");
-
-            // Assert
-            expect(onKeyDown).toHaveBeenCalledExactlyOnceWith(
-                expect.objectContaining({
-                    key: "Enter",
-                }),
-            );
-        });
-    });
-
     describe("Accessibility", () => {
         describe("axe", () => {
             it("should have no a11y violations", async () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import {Tablist} from "../tablist";
 
 describe("Tablist", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {Tablist} from "../tablist";
 
 describe("Tablist", () => {
@@ -39,6 +40,29 @@ describe("Tablist", () => {
 
         // Assert
         expect(await screen.findByRole("tablist")).toBe(ref.current);
+    });
+
+    describe("Event handlers", () => {
+        it("should call onKeyDown when a key is pressed", async () => {
+            // Arrange
+            const onKeyDown = jest.fn();
+            render(
+                <Tablist onKeyDown={onKeyDown}>
+                    <button role="tab">Tab</button>
+                </Tablist>,
+            );
+            await userEvent.tab();
+
+            // Act
+            await userEvent.keyboard("{enter}");
+
+            // Assert
+            expect(onKeyDown).toHaveBeenCalledExactlyOnceWith(
+                expect.objectContaining({
+                    key: "Enter",
+                }),
+            );
+        });
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {Tablist} from "../tablist";
 
 describe("Tablist", () => {
@@ -39,6 +40,27 @@ describe("Tablist", () => {
 
         // Assert
         expect(await screen.findByRole("tablist")).toBe(ref.current);
+    });
+
+    describe("Event Handlers", () => {
+        describe("onBlur", () => {
+            it("should call the handler when the tablist is blurred", async () => {
+                // Arrange
+                const onBlur = jest.fn();
+                render(
+                    <Tablist onBlur={onBlur}>
+                        <button role="tab">Tab</button>
+                    </Tablist>,
+                );
+                await userEvent.tab(); // Focus on the tab
+
+                // Act
+                await userEvent.tab(); // Move focus out of the tablist
+
+                // Assert
+                expect(onBlur).toHaveBeenCalledTimes(1);
+            });
+        });
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -188,6 +188,53 @@ describe("Tabs", () => {
         });
     });
 
+    describe("Interactions", () => {
+        describe("Selecting a tab", () => {
+            it("should focus on the selected tab when a tab is clicked", async () => {
+                // Arrange
+                render(
+                    <ControlledTabs tabs={tabs} selectedTabId={tabs[0].id} />,
+                );
+
+                // Act
+                await userEvent.click(screen.getByRole("tab", {name: "Tab 2"}));
+
+                // Assert
+                expect(screen.getByRole("tab", {name: "Tab 2"})).toHaveFocus();
+            });
+
+            it("should select the tab when a tab is clicked", async () => {
+                // Arrange
+                render(
+                    <ControlledTabs tabs={tabs} selectedTabId={tabs[0].id} />,
+                );
+
+                // Act
+                await userEvent.click(screen.getByRole("tab", {name: "Tab 2"}));
+
+                // Assert
+                expect(
+                    screen.getByRole("tab", {name: "Tab 2"}),
+                ).toHaveAttribute("aria-selected", "true");
+            });
+
+            it("should change the tab panel content when a tab is clicked", async () => {
+                // Arrange
+                render(
+                    <ControlledTabs tabs={tabs} selectedTabId={tabs[0].id} />,
+                );
+
+                // Act
+                await userEvent.click(screen.getByRole("tab", {name: "Tab 2"}));
+
+                // Assert
+                expect(
+                    screen.getByText("Contents of tab 2"),
+                ).toBeInTheDocument();
+            });
+        });
+    });
+
     describe("Accessibility", () => {
         describe("axe", () => {
             it("should have no a11y violations when aria-label is provided", async () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -1256,6 +1256,59 @@ describe("Tabs", () => {
                     });
                 });
             });
+
+            describe("Multiple Tabs instances", () => {
+                it("should only focus on tabs within the same instance when an arrow key is pressed", async () => {
+                    // Arrange
+                    render(
+                        <div>
+                            <ControlledTabs
+                                // First set of tabs are post fixed with "a" and
+                                // will have the same ids as the second set of tabs
+                                tabs={[
+                                    {
+                                        label: "Tab 1a",
+                                        id: "tab-1",
+                                        panel: "Panel 1a",
+                                    },
+                                    {
+                                        label: "Tab 2a",
+                                        id: "tab-2",
+                                        panel: "Panel 2a",
+                                    },
+                                ]}
+                                selectedTabId={"tab-1"}
+                            />
+                            <ControlledTabs
+                                // Second set of tabs are post fixed with "b" and
+                                // will have the same ids as the first set of tabs
+                                tabs={[
+                                    {
+                                        label: "Tab 1b",
+                                        id: "tab-1",
+                                        panel: "Panel 1b",
+                                    },
+                                    {
+                                        label: "Tab 2b",
+                                        id: "tab-2",
+                                        panel: "Panel 2b",
+                                    },
+                                ]}
+                                selectedTabId={"tab-1"}
+                            />
+                        </div>,
+                    );
+                    const tab1b = screen.getByRole("tab", {name: "Tab 1b"});
+                    const tab2b = screen.getByRole("tab", {name: "Tab 2b"});
+                    tab1b.focus(); // Focus on the second set of tabs
+
+                    // Act
+                    await userEvent.keyboard("{ArrowRight}");
+
+                    // Assert
+                    expect(tab2b).toHaveFocus();
+                });
+            });
         });
     });
 });

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -394,18 +394,76 @@ describe("Tabs", () => {
         });
 
         describe("Keyboard Navigation", () => {
-            it("should focus on the active tab when the tab key is pressed", async () => {
-                // Arrange
-                render(
-                    <ControlledTabs tabs={tabs} selectedTabId={tabs[1].id} />,
-                );
-                const tab = screen.getByRole("tab", {name: "Tab 2"});
+            describe("Tab key", () => {
+                it("should focus on the active tab when the tab key is pressed", async () => {
+                    // Arrange
+                    render(
+                        <ControlledTabs
+                            tabs={tabs}
+                            selectedTabId={tabs[1].id}
+                        />,
+                    );
+                    const tab = screen.getByRole("tab", {name: "Tab 2"});
 
-                // Act
-                await userEvent.keyboard("{Tab}");
+                    // Act
+                    await userEvent.keyboard("{Tab}");
 
-                // Assert
-                expect(tab).toHaveFocus();
+                    // Assert
+                    expect(tab).toHaveFocus();
+                });
+
+                it("should focus on the tabpanel if there are no focusable elements in the tabpanel", async () => {
+                    // Arrange
+                    render(
+                        <ControlledTabs
+                            tabs={tabs}
+                            selectedTabId={tabs[1].id}
+                        />,
+                    );
+                    const tabPanel = screen.getByRole("tabpanel", {
+                        name: "Tab 2",
+                    });
+                    await userEvent.keyboard("{Tab}"); // tab to get to the active tab
+
+                    // Act
+                    await userEvent.keyboard("{Tab}"); // tab to leave the tablist
+
+                    // Assert
+                    expect(tabPanel).toHaveFocus();
+                });
+
+                it("should focus on the first focusable element in the tabpanel if there is one", async () => {
+                    // Arrange
+                    render(
+                        <ControlledTabs
+                            tabs={[
+                                {
+                                    id: "tab-1",
+                                    label: "Tab 1",
+                                    panel: (
+                                        <div>
+                                            With button <button>Button</button>
+                                        </div>
+                                    ),
+                                },
+                                {
+                                    id: "tab-2",
+                                    label: "Tab 2",
+                                    panel: <div>No focusable elements</div>,
+                                },
+                            ]}
+                            selectedTabId={tabs[0].id}
+                        />,
+                    );
+                    const button = screen.getByRole("button", {name: "Button"});
+                    await userEvent.keyboard("{Tab}"); // tab to get to the active tab
+
+                    // Act
+                    await userEvent.keyboard("{Tab}"); // tab to leave the tablist
+
+                    // Assert
+                    expect(button).toHaveFocus();
+                });
             });
 
             describe("Activation Mode: Manual", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -406,7 +406,7 @@ describe("Tabs", () => {
                     const tab = screen.getByRole("tab", {name: "Tab 2"});
 
                     // Act
-                    await userEvent.keyboard("{Tab}");
+                    await userEvent.tab();
 
                     // Assert
                     expect(tab).toHaveFocus();
@@ -423,10 +423,10 @@ describe("Tabs", () => {
                     const tabPanel = screen.getByRole("tabpanel", {
                         name: "Tab 2",
                     });
-                    await userEvent.keyboard("{Tab}"); // tab to get to the active tab
+                    await userEvent.tab(); // tab to get to the active tab
 
                     // Act
-                    await userEvent.keyboard("{Tab}"); // tab to leave the tablist
+                    await userEvent.tab(); // tab to leave the tablist
 
                     // Assert
                     expect(tabPanel).toHaveFocus();
@@ -456,10 +456,10 @@ describe("Tabs", () => {
                         />,
                     );
                     const button = screen.getByRole("button", {name: "Button"});
-                    await userEvent.keyboard("{Tab}"); // tab to get to the active tab
+                    await userEvent.tab(); // tab to get to the active tab
 
                     // Act
-                    await userEvent.keyboard("{Tab}"); // tab to leave the tablist
+                    await userEvent.tab(); // tab to leave the tablist
 
                     // Assert
                     expect(button).toHaveFocus();
@@ -521,7 +521,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[0].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -540,7 +540,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[0].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -559,7 +559,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[0].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -580,7 +580,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[2].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -599,7 +599,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[2].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -618,7 +618,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[2].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -639,7 +639,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[1].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -658,7 +658,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[1].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -677,7 +677,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[1].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -698,7 +698,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[0].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -717,7 +717,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[0].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -736,7 +736,7 @@ describe("Tabs", () => {
                                 selectedTabId={tabs[0].id}
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -941,7 +941,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -961,7 +961,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -981,7 +981,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -1003,7 +1003,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -1023,7 +1023,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -1043,7 +1043,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowRight}");
@@ -1065,7 +1065,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -1085,7 +1085,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -1105,7 +1105,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -1127,7 +1127,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -1147,7 +1147,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");
@@ -1167,7 +1167,7 @@ describe("Tabs", () => {
                                 activationMode="automatic"
                             />,
                         );
-                        await userEvent.keyboard("{Tab}");
+                        await userEvent.tab();
 
                         // Act
                         await userEvent.keyboard("{ArrowLeft}");

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -464,6 +464,51 @@ describe("Tabs", () => {
                     // Assert
                     expect(button).toHaveFocus();
                 });
+
+                it("should focus on the selected tab when focus is back to the tablist after changing the focused tab without selecting it", async () => {
+                    // Arrange
+                    render(
+                        <ControlledTabs
+                            tabs={tabs}
+                            selectedTabId={tabs[0].id}
+                        />,
+                    );
+                    await userEvent.tab(); // focus on the active tab
+                    await userEvent.keyboard("{ArrowRight}"); // move focus to the next tab without selecting it
+                    await userEvent.tab(); // move focus out of the tablist
+
+                    // Act
+                    await userEvent.keyboard("{Shift>}{Tab}"); // move focus back to the tablist
+
+                    // Assert
+                    // Selected tab should be focused
+                    expect(
+                        screen.getByRole("tab", {name: "Tab 1"}),
+                    ).toHaveFocus();
+                });
+
+                it("should continue to focus on the correct tab when focus is moved from the tablist without selecting a tab", async () => {
+                    // Arrange
+                    render(
+                        <ControlledTabs
+                            tabs={tabs}
+                            selectedTabId={tabs[0].id}
+                        />,
+                    );
+                    await userEvent.tab(); // focus on the active tab
+                    await userEvent.keyboard("{ArrowRight}"); // move focus to the next tab without selecting it
+                    await userEvent.tab(); // move focus out of the tablist
+                    await userEvent.keyboard("{Shift>}{Tab}"); // move focus back to the tablist
+
+                    // Act
+                    await userEvent.keyboard("{ArrowRight}"); // move focus to the next tab
+
+                    // Assert
+                    // Next tab should be focused
+                    expect(
+                        screen.getByRole("tab", {name: "Tab 2"}),
+                    ).toHaveFocus();
+                });
             });
 
             describe("Activation Mode: Manual", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable max-lines */
 import * as React from "react";
 import {render, screen, within} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import {PropsFor} from "@khanacademy/wonder-blocks-core";
 import {TabItem, Tabs} from "../tabs";
 
 describe("Tabs", () => {
@@ -23,6 +25,26 @@ describe("Tabs", () => {
     ];
 
     const tabsAriaLabel = "Tabs Example";
+
+    const ControlledTabs = (
+        props: Omit<
+            PropsFor<typeof Tabs>,
+            "onTabSelected" | "aria-label" | "aria-labelledby"
+        >,
+    ) => {
+        const [selectedTabId, setSelectedTabId] = React.useState(
+            props.selectedTabId,
+        );
+
+        return (
+            <Tabs
+                {...props}
+                aria-label={tabsAriaLabel}
+                selectedTabId={selectedTabId}
+                onTabSelected={setSelectedTabId}
+            />
+        );
+    };
 
     it("should render the tabs in a tablist", async () => {
         // Arrange
@@ -321,6 +343,813 @@ describe("Tabs", () => {
                     "aria-labelledby",
                     ariaLabelledby,
                 );
+            });
+        });
+
+        describe("Keyboard Navigation", () => {
+            it("should focus on the active tab when the tab key is pressed", async () => {
+                // Arrange
+                render(
+                    <ControlledTabs tabs={tabs} selectedTabId={tabs[1].id} />,
+                );
+                const tab = screen.getByRole("tab", {name: "Tab 2"});
+
+                // Act
+                await userEvent.keyboard("{Tab}");
+
+                // Assert
+                expect(tab).toHaveFocus();
+            });
+
+            describe("Activation Mode: Manual", () => {
+                describe("Right arrow key", () => {
+                    it("should focus on the next tab when the right arrow key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 2"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should not change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 2"}),
+                        ).toHaveAttribute("aria-selected", "false");
+                    });
+
+                    it("should not change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.queryByText("Contents of tab 2"),
+                        ).not.toBeInTheDocument();
+                    });
+                });
+
+                describe("Right arrow key when the last tab is active", () => {
+                    it("should focus on the first tab when the right arrow key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[2].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should not change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[2].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveAttribute("aria-selected", "false");
+                    });
+
+                    it("should not change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[2].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.queryByText("Contents of tab 1"),
+                        ).not.toBeInTheDocument();
+                    });
+                });
+
+                describe("Left arrow key", () => {
+                    it("should focus on the previous tab when the left arrow key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should not change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveAttribute("aria-selected", "false");
+                    });
+
+                    it("should not change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.queryByText("Contents of tab 1"),
+                        ).not.toBeInTheDocument();
+                    });
+                });
+
+                describe("Left arrow key when the first tab is active", () => {
+                    it("should focus on the last tab when the left arrow key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 3"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should not change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 3"}),
+                        ).toHaveAttribute("aria-selected", "false");
+                    });
+
+                    it("should not change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.queryByText("Contents of tab 3"),
+                        ).not.toBeInTheDocument();
+                    });
+                });
+
+                describe("Home key", () => {
+                    it("should focus on the first tab when the home key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+                        // Act
+                        await userEvent.keyboard("{Home}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should not change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+
+                        // Act
+                        await userEvent.keyboard("{Home}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveAttribute("aria-selected", "false");
+                    });
+
+                    it("should not change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+
+                        // Act
+                        await userEvent.keyboard("{Home}");
+
+                        // Assert
+                        expect(
+                            screen.queryByText("Contents of tab 1"),
+                        ).not.toBeInTheDocument();
+                    });
+                });
+
+                describe("End key", () => {
+                    it("should focus on the last tab when the end key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+                        // Act
+                        await userEvent.keyboard("{End}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 3"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should not change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+
+                        // Act
+                        await userEvent.keyboard("{End}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 3"}),
+                        ).toHaveAttribute("aria-selected", "false");
+                    });
+
+                    it("should not change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+
+                        // Act
+                        await userEvent.keyboard("{End}");
+
+                        // Assert
+                        expect(
+                            screen.queryByText("Contents of tab 3"),
+                        ).not.toBeInTheDocument();
+                    });
+                });
+
+                describe.each([
+                    {key: "{Enter}", label: "Enter"},
+                    {key: " ", label: "Space"},
+                ])("$label key to activate tab", ({key}) => {
+                    it("should keep focus on the tab when it's activated", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Act
+                        await userEvent.keyboard(key);
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Act
+                        await userEvent.keyboard(key);
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveAttribute("aria-selected", "true");
+                    });
+
+                    it("should change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />,
+                        );
+                        await userEvent.tab();
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Act
+                        await userEvent.keyboard(key);
+
+                        // Assert
+                        expect(
+                            screen.getByText("Contents of tab 1"),
+                        ).toBeInTheDocument();
+                    });
+                });
+            });
+
+            describe("Activation Mode: Automatic", () => {
+                describe("Right arrow key", () => {
+                    it("should focus on the next tab when the right arrow key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 2"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 2"}),
+                        ).toHaveAttribute("aria-selected", "true");
+                    });
+
+                    it("should change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByText("Contents of tab 2"),
+                        ).toBeInTheDocument();
+                    });
+                });
+
+                describe("Right arrow key when the last tab is active", () => {
+                    it("should focus on the first tab when the right arrow key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[2].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[2].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveAttribute("aria-selected", "true");
+                    });
+
+                    it("should change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[2].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowRight}");
+
+                        // Assert
+                        expect(
+                            screen.getByText("Contents of tab 1"),
+                        ).toBeInTheDocument();
+                    });
+                });
+
+                describe("Left arrow key", () => {
+                    it("should focus on the previous tab when the left arrow key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveAttribute("aria-selected", "true");
+                    });
+
+                    it("should change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByText("Contents of tab 1"),
+                        ).toBeInTheDocument();
+                    });
+                });
+
+                describe("Left arrow key when the first tab is active", () => {
+                    it("should focus on the last tab when the left arrow key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 3"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 3"}),
+                        ).toHaveAttribute("aria-selected", "true");
+                    });
+
+                    it("should change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[0].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.keyboard("{Tab}");
+
+                        // Act
+                        await userEvent.keyboard("{ArrowLeft}");
+
+                        // Assert
+                        expect(
+                            screen.getByText("Contents of tab 3"),
+                        ).toBeInTheDocument();
+                    });
+                });
+
+                describe("Home key", () => {
+                    it("should focus on the first tab when the home key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.tab();
+                        // Act
+                        await userEvent.keyboard("{Home}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.tab();
+
+                        // Act
+                        await userEvent.keyboard("{Home}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 1"}),
+                        ).toHaveAttribute("aria-selected", "true");
+                    });
+
+                    it("should change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.tab();
+
+                        // Act
+                        await userEvent.keyboard("{Home}");
+
+                        // Assert
+                        expect(
+                            screen.getByText("Contents of tab 1"),
+                        ).toBeInTheDocument();
+                    });
+                });
+
+                describe("End key", () => {
+                    it("should focus on the last tab when the end key is pressed", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.tab();
+                        // Act
+                        await userEvent.keyboard("{End}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 3"}),
+                        ).toHaveFocus();
+                    });
+
+                    it("should change the selected tab", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.tab();
+
+                        // Act
+                        await userEvent.keyboard("{End}");
+
+                        // Assert
+                        expect(
+                            screen.getByRole("tab", {name: "Tab 3"}),
+                        ).toHaveAttribute("aria-selected", "true");
+                    });
+
+                    it("should change the tab panel content", async () => {
+                        // Arrange
+                        render(
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                                activationMode="automatic"
+                            />,
+                        );
+                        await userEvent.tab();
+
+                        // Act
+                        await userEvent.keyboard("{End}");
+
+                        // Assert
+                        expect(
+                            screen.getByText("Contents of tab 3"),
+                        ).toBeInTheDocument();
+                    });
+                });
             });
         });
     });

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -40,6 +40,8 @@ export const TabPanel = (props: Props) => {
     const [hasFocusableElement, setHasFocusableElement] = React.useState(false);
 
     React.useEffect(() => {
+        // Whenever tab panel contents change, determine if the panel has a
+        // focusable element
         if (ref.current) {
             setHasFocusableElement(findFocusableNodes(ref.current).length > 0);
         }
@@ -52,6 +54,8 @@ export const TabPanel = (props: Props) => {
             id={id}
             aria-labelledby={ariaLabelledby}
             style={!active && styles.hidden}
+            // If the tab panel doesn't have focusable elements, it should be
+            // focusable so that it is included in the tab sequence of the page
             tabIndex={hasFocusableElement ? undefined : 0}
         >
             {children}

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {StyleSheet} from "aphrodite";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {findFocusableNodes} from "../../../wonder-blocks-core/src/util/focus";
 

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -56,6 +56,7 @@ export const TabPanel = (props: Props) => {
             // If the tab panel doesn't have focusable elements, it should be
             // focusable so that it is included in the tab sequence of the page
             tabIndex={hasFocusableElement ? undefined : 0}
+            // Only show the tab panel if it is active
             hidden={!active}
         >
             {children}

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -53,18 +53,12 @@ export const TabPanel = (props: Props) => {
             role="tabpanel"
             id={id}
             aria-labelledby={ariaLabelledby}
-            style={!active && styles.hidden}
             // If the tab panel doesn't have focusable elements, it should be
             // focusable so that it is included in the tab sequence of the page
             tabIndex={hasFocusableElement ? undefined : 0}
+            hidden={!active}
         >
             {children}
         </StyledDiv>
     );
 };
-
-const styles = StyleSheet.create({
-    hidden: {
-        display: "none",
-    },
-});

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 
 type Props = {
     /**
@@ -13,8 +15,14 @@ type Props = {
      * The id of the associated element with role="tab".
      */
     "aria-labelledby": string;
+
+    /**
+     * Whether the tab panel is active.
+     */
+    active?: boolean;
 };
 
+const StyledDiv = addStyle("div");
 /**
  * A component that has `role="tabpanel"` and is used to represent a tab panel
  * in a tabbed interface.
@@ -23,10 +31,27 @@ export const TabPanel = React.forwardRef(function TabPanel(
     props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-    const {children, id, "aria-labelledby": ariaLabelledby} = props;
+    const {
+        children,
+        id,
+        "aria-labelledby": ariaLabelledby,
+        active = false,
+    } = props;
     return (
-        <div ref={ref} role="tabpanel" id={id} aria-labelledby={ariaLabelledby}>
+        <StyledDiv
+            ref={ref}
+            role="tabpanel"
+            id={id}
+            aria-labelledby={ariaLabelledby}
+            style={!active && styles.hidden}
+        >
             {children}
-        </div>
+        </StyledDiv>
     );
+});
+
+const styles = StyleSheet.create({
+    hidden: {
+        display: "none",
+    },
 });

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {findFocusableNodes} from "../../../wonder-blocks-core/src/util/focus";
 
 type Props = {
     /**
@@ -27,16 +28,23 @@ const StyledDiv = addStyle("div");
  * A component that has `role="tabpanel"` and is used to represent a tab panel
  * in a tabbed interface.
  */
-export const TabPanel = React.forwardRef(function TabPanel(
-    props: Props,
-    ref: React.ForwardedRef<HTMLDivElement>,
-) {
+export const TabPanel = (props: Props) => {
     const {
         children,
         id,
         "aria-labelledby": ariaLabelledby,
         active = false,
     } = props;
+
+    const ref = React.useRef<HTMLDivElement>(null);
+    const [hasFocusableElement, setHasFocusableElement] = React.useState(false);
+
+    React.useEffect(() => {
+        if (ref.current) {
+            setHasFocusableElement(findFocusableNodes(ref.current).length > 0);
+        }
+    }, [active, ref, children]);
+
     return (
         <StyledDiv
             ref={ref}
@@ -44,11 +52,12 @@ export const TabPanel = React.forwardRef(function TabPanel(
             id={id}
             aria-labelledby={ariaLabelledby}
             style={!active && styles.hidden}
+            tabIndex={hasFocusableElement ? undefined : 0}
         >
             {children}
         </StyledDiv>
     );
-});
+};
 
 const styles = StyleSheet.create({
     hidden: {

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -46,6 +46,7 @@ export const Tab = React.forwardRef(function Tab(
             id={id}
             aria-controls={ariaControls}
             aria-selected={selected}
+            tabIndex={selected ? 0 : -1}
         >
             {children}
         </button>

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -51,6 +51,8 @@ export const Tab = React.forwardRef(function Tab(
             id={id}
             aria-controls={ariaControls}
             aria-selected={selected}
+            // Only the selected tab is focusable since keyboard users will navigate
+            // between tabs using the arrow keys
             tabIndex={selected ? 0 : -1}
             onKeyDown={onKeyDown}
         >

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -21,6 +21,10 @@ type Props = {
      * If the tab is currently selected.
      */
     selected?: boolean;
+    /**
+     * Called when a key is pressed on the tab.
+     */
+    onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 };
 
 /**
@@ -37,6 +41,7 @@ export const Tab = React.forwardRef(function Tab(
         id,
         "aria-controls": ariaControls,
         selected,
+        onKeyDown,
     } = props;
     return (
         <button
@@ -47,6 +52,7 @@ export const Tab = React.forwardRef(function Tab(
             aria-controls={ariaControls}
             aria-selected={selected}
             tabIndex={selected ? 0 : -1}
+            onKeyDown={onKeyDown}
         >
             {children}
         </button>

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -18,10 +18,6 @@ type Props = {
      * that refers to the labelling element.
      */
     "aria-labelledby"?: string;
-    /**
-     * Called when a key is pressed on the tablist.
-     */
-    onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 };
 
 const StyledDiv = addStyle("div");
@@ -37,7 +33,6 @@ export const Tablist = React.forwardRef(function Tablist(
         children,
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledby,
-        onKeyDown,
     } = props;
 
     return (
@@ -47,8 +42,6 @@ export const Tablist = React.forwardRef(function Tablist(
             ref={ref}
             aria-label={ariaLabel}
             aria-labelledby={ariaLabelledby}
-            onKeyDown={onKeyDown}
-            tabIndex={-1}
         >
             {children}
         </StyledDiv>

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -18,6 +18,10 @@ type Props = {
      * that refers to the labelling element.
      */
     "aria-labelledby"?: string;
+    /**
+     * Called when a key is pressed on the tablist.
+     */
+    onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 };
 
 const StyledDiv = addStyle("div");
@@ -33,7 +37,9 @@ export const Tablist = React.forwardRef(function Tablist(
         children,
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledby,
+        onKeyDown,
     } = props;
+
     return (
         <StyledDiv
             role="tablist"
@@ -41,6 +47,8 @@ export const Tablist = React.forwardRef(function Tablist(
             ref={ref}
             aria-label={ariaLabel}
             aria-labelledby={ariaLabelledby}
+            onKeyDown={onKeyDown}
+            tabIndex={-1}
         >
             {children}
         </StyledDiv>

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -18,6 +18,10 @@ type Props = {
      * that refers to the labelling element.
      */
     "aria-labelledby"?: string;
+    /**
+     * Called when focus moves out of the tablist.
+     */
+    onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void;
 };
 
 const StyledDiv = addStyle("div");
@@ -33,6 +37,7 @@ export const Tablist = React.forwardRef(function Tablist(
         children,
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledby,
+        onBlur,
     } = props;
 
     return (
@@ -42,6 +47,7 @@ export const Tablist = React.forwardRef(function Tablist(
             ref={ref}
             aria-label={ariaLabel}
             aria-labelledby={ariaLabelledby}
+            onBlur={onBlur}
         >
             {children}
         </StyledDiv>

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -131,7 +131,7 @@ export const Tabs = React.forwardRef(function Tabs(
         }
     };
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
         const currentIndex = tabs.findIndex(
             (tab) => tab.id === focusId.current,
         );
@@ -167,11 +167,7 @@ export const Tabs = React.forwardRef(function Tabs(
 
     return (
         <div ref={ref}>
-            <Tablist
-                aria-label={ariaLabel}
-                aria-labelledby={ariaLabelledby}
-                onKeyDown={handleKeyDown}
-            >
+            <Tablist aria-label={ariaLabel} aria-labelledby={ariaLabelledby}>
                 {tabs.map((tab) => {
                     return (
                         <Tab
@@ -182,6 +178,7 @@ export const Tabs = React.forwardRef(function Tabs(
                             id={getTabId(tab.id)}
                             aria-controls={getTabPanelId(tab.id)}
                             selected={tab.id === selectedTabId}
+                            onKeyDown={handleKeyDown}
                         >
                             {tab.label}
                         </Tab>

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -100,6 +100,7 @@ export const Tabs = React.forwardRef(function Tabs(
     } = props;
 
     const focusedTabId = React.useRef(selectedTabId);
+    const tabRefs = React.useRef<{[key: string]: HTMLButtonElement | null}>({});
 
     React.useEffect(() => {
         focusedTabId.current = selectedTabId;
@@ -118,7 +119,7 @@ export const Tabs = React.forwardRef(function Tabs(
     const handleKeyInteraction = React.useCallback(
         (tabId: string) => {
             // Move focus to the tab
-            const tabElement = document.getElementById(getTabId(tabId));
+            const tabElement = tabRefs.current[tabId];
             tabElement?.focus();
 
             switch (activationMode) {
@@ -194,6 +195,9 @@ export const Tabs = React.forwardRef(function Tabs(
                             aria-controls={getTabPanelId(tab.id)}
                             selected={tab.id === selectedTabId}
                             onKeyDown={handleKeyDown}
+                            ref={(element) => {
+                                tabRefs.current[tab.id] = element;
+                            }}
                         >
                             {tab.label}
                         </Tab>

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -191,6 +191,7 @@ export const Tabs = React.forwardRef(function Tabs(
                         key={tab.id}
                         id={getTabPanelId(tab.id)}
                         aria-labelledby={getTabId(tab.id)}
+                        active={selectedTabId === tab.id}
                     >
                         {selectedTabId === tab.id && tab.panel}
                     </TabPanel>

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -55,7 +55,8 @@ type Props = {
      */
     onTabSelected: (id: string) => unknown;
     /**
-     * The mode of activation for the tabs for keyboard navigation.
+     * The mode of activation for the tabs for keyboard navigation. Defaults to
+     * `manual`.
      *
      * - If `manual`, the tab will only be activated when a tab receives focus
      * and is selected by pressing `Space` or `Enter`.

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -99,10 +99,10 @@ export const Tabs = React.forwardRef(function Tabs(
         activationMode = "manual",
     } = props;
 
-    const focusId = React.useRef(selectedTabId);
+    const focusedId = React.useRef(selectedTabId);
 
     React.useEffect(() => {
-        focusId.current = selectedTabId;
+        focusedId.current = selectedTabId;
     }, [selectedTabId]);
 
     const selectTab = (tabId: string) => {
@@ -121,11 +121,12 @@ export const Tabs = React.forwardRef(function Tabs(
             case "manual": {
                 // Only update which tab is focused since we aren't activating
                 // the tab yet
-                focusId.current = tabId;
+                focusedId.current = tabId;
                 break;
             }
             case "automatic": {
-                // Activate the tab
+                // Activate the tab. When selectedTabId is updated, focus will
+                // be moved to the selected tab
                 selectTab(tabId);
                 break;
             }
@@ -134,33 +135,37 @@ export const Tabs = React.forwardRef(function Tabs(
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
         const currentIndex = tabs.findIndex(
-            (tab) => tab.id === focusId.current,
+            (tab) => tab.id === focusedId.current,
         );
 
         switch (event.key) {
-            case keys.left:
+            case keys.left: {
                 event.preventDefault();
                 const prevIndex =
                     (currentIndex - 1 + tabs.length) % tabs.length;
                 handleKeyInteraction(tabs[prevIndex].id);
                 break;
-            case keys.right:
+            }
+            case keys.right: {
                 event.preventDefault();
                 const nextIndex = (currentIndex + 1) % tabs.length;
                 handleKeyInteraction(tabs[nextIndex].id);
                 break;
-            case keys.home:
+            }
+            case keys.home: {
                 event.preventDefault();
                 handleKeyInteraction(tabs[0].id);
                 break;
-            case keys.end:
+            }
+            case keys.end: {
                 event.preventDefault();
                 handleKeyInteraction(tabs[tabs.length - 1].id);
                 break;
+            }
             case keys.enter:
             case keys.space: {
                 event.preventDefault();
-                selectTab(focusId.current);
+                selectTab(focusedId.current);
                 break;
             }
         }

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -99,10 +99,10 @@ export const Tabs = React.forwardRef(function Tabs(
         activationMode = "manual",
     } = props;
 
-    const focusedId = React.useRef(selectedTabId);
+    const focusedTabId = React.useRef(selectedTabId);
 
     React.useEffect(() => {
-        focusedId.current = selectedTabId;
+        focusedTabId.current = selectedTabId;
     }, [selectedTabId]);
 
     const selectTab = React.useCallback(
@@ -125,7 +125,7 @@ export const Tabs = React.forwardRef(function Tabs(
                 case "manual": {
                     // Only update which tab is focused since we aren't activating
                     // the tab yet
-                    focusedId.current = tabId;
+                    focusedTabId.current = tabId;
                     break;
                 }
                 case "automatic": {
@@ -136,13 +136,13 @@ export const Tabs = React.forwardRef(function Tabs(
                 }
             }
         },
-        [activationMode, selectTab, focusedId],
+        [activationMode, selectTab, focusedTabId],
     );
 
     const handleKeyDown = React.useCallback(
         (event: React.KeyboardEvent<HTMLButtonElement>) => {
             const currentIndex = tabs.findIndex(
-                (tab) => tab.id === focusedId.current,
+                (tab) => tab.id === focusedTabId.current,
             );
 
             switch (event.key) {
@@ -172,12 +172,12 @@ export const Tabs = React.forwardRef(function Tabs(
                 case keys.enter:
                 case keys.space: {
                     event.preventDefault();
-                    selectTab(focusedId.current);
+                    selectTab(focusedTabId.current);
                     break;
                 }
             }
         },
-        [handleKeyInteraction, selectTab, tabs, focusedId],
+        [handleKeyInteraction, selectTab, tabs, focusedTabId],
     );
 
     return (

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -105,71 +105,80 @@ export const Tabs = React.forwardRef(function Tabs(
         focusedId.current = selectedTabId;
     }, [selectedTabId]);
 
-    const selectTab = (tabId: string) => {
-        if (tabId !== selectedTabId) {
-            // Select the tab only if it's not already selected
-            onTabSelected(tabId);
-        }
-    };
+    const selectTab = React.useCallback(
+        (tabId: string) => {
+            if (tabId !== selectedTabId) {
+                // Select the tab only if it's not already selected
+                onTabSelected(tabId);
+            }
+        },
+        [onTabSelected, selectedTabId],
+    );
 
-    const handleKeyInteraction = (tabId: string) => {
-        // Move focus to the tab
-        const tabElement = document.getElementById(getTabId(tabId));
-        tabElement?.focus();
+    const handleKeyInteraction = React.useCallback(
+        (tabId: string) => {
+            // Move focus to the tab
+            const tabElement = document.getElementById(getTabId(tabId));
+            tabElement?.focus();
 
-        switch (activationMode) {
-            case "manual": {
-                // Only update which tab is focused since we aren't activating
-                // the tab yet
-                focusedId.current = tabId;
-                break;
+            switch (activationMode) {
+                case "manual": {
+                    // Only update which tab is focused since we aren't activating
+                    // the tab yet
+                    focusedId.current = tabId;
+                    break;
+                }
+                case "automatic": {
+                    // Activate the tab. When selectedTabId is updated, focus will
+                    // be moved to the selected tab
+                    selectTab(tabId);
+                    break;
+                }
             }
-            case "automatic": {
-                // Activate the tab. When selectedTabId is updated, focus will
-                // be moved to the selected tab
-                selectTab(tabId);
-                break;
-            }
-        }
-    };
+        },
+        [activationMode, selectTab, focusedId],
+    );
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-        const currentIndex = tabs.findIndex(
-            (tab) => tab.id === focusedId.current,
-        );
+    const handleKeyDown = React.useCallback(
+        (event: React.KeyboardEvent<HTMLButtonElement>) => {
+            const currentIndex = tabs.findIndex(
+                (tab) => tab.id === focusedId.current,
+            );
 
-        switch (event.key) {
-            case keys.left: {
-                event.preventDefault();
-                const prevIndex =
-                    (currentIndex - 1 + tabs.length) % tabs.length;
-                handleKeyInteraction(tabs[prevIndex].id);
-                break;
+            switch (event.key) {
+                case keys.left: {
+                    event.preventDefault();
+                    const prevIndex =
+                        (currentIndex - 1 + tabs.length) % tabs.length;
+                    handleKeyInteraction(tabs[prevIndex].id);
+                    break;
+                }
+                case keys.right: {
+                    event.preventDefault();
+                    const nextIndex = (currentIndex + 1) % tabs.length;
+                    handleKeyInteraction(tabs[nextIndex].id);
+                    break;
+                }
+                case keys.home: {
+                    event.preventDefault();
+                    handleKeyInteraction(tabs[0].id);
+                    break;
+                }
+                case keys.end: {
+                    event.preventDefault();
+                    handleKeyInteraction(tabs[tabs.length - 1].id);
+                    break;
+                }
+                case keys.enter:
+                case keys.space: {
+                    event.preventDefault();
+                    selectTab(focusedId.current);
+                    break;
+                }
             }
-            case keys.right: {
-                event.preventDefault();
-                const nextIndex = (currentIndex + 1) % tabs.length;
-                handleKeyInteraction(tabs[nextIndex].id);
-                break;
-            }
-            case keys.home: {
-                event.preventDefault();
-                handleKeyInteraction(tabs[0].id);
-                break;
-            }
-            case keys.end: {
-                event.preventDefault();
-                handleKeyInteraction(tabs[tabs.length - 1].id);
-                break;
-            }
-            case keys.enter:
-            case keys.space: {
-                event.preventDefault();
-                selectTab(focusedId.current);
-                break;
-            }
-        }
-    };
+        },
+        [handleKeyInteraction, selectTab, tabs, focusedId],
+    );
 
     return (
         <div ref={ref}>

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -181,9 +181,19 @@ export const Tabs = React.forwardRef(function Tabs(
         [handleKeyInteraction, selectTab, tabs, focusedTabId],
     );
 
+    const handleTablistBlur = React.useCallback(() => {
+        // When tablist loses focus, set the focused tab to the selected tab to
+        // reset it
+        focusedTabId.current = selectedTabId;
+    }, [selectedTabId]);
+
     return (
         <div ref={ref}>
-            <Tablist aria-label={ariaLabel} aria-labelledby={ariaLabelledby}>
+            <Tablist
+                aria-label={ariaLabel}
+                aria-labelledby={ariaLabelledby}
+                onBlur={handleTablistBlur}
+            >
                 {tabs.map((tab) => {
                     return (
                         <Tab

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import {keys} from "@khanacademy/wonder-blocks-core";
 import {TabPanel} from "./tab-panel";
 import {Tab} from "./tab";
 import {Tablist} from "./tablist";
@@ -88,9 +89,47 @@ export const Tabs = React.forwardRef(function Tabs(
         "aria-labelledby": ariaLabelledby,
     } = props;
 
+    const selectTab = (tabId: string) => {
+        // Move focus to the tab
+        const tabElement = document.getElementById(getTabId(tabId));
+        tabElement?.focus();
+        // Select the tab
+        onTabSelected(tabId);
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        const currentIndex = tabs.findIndex((tab) => tab.id === selectedTabId);
+
+        switch (event.key) {
+            case keys.left:
+                event.preventDefault();
+                const prevIndex =
+                    (currentIndex - 1 + tabs.length) % tabs.length;
+                selectTab(tabs[prevIndex].id);
+                break;
+            case keys.right:
+                event.preventDefault();
+                const nextIndex = (currentIndex + 1) % tabs.length;
+                selectTab(tabs[nextIndex].id);
+                break;
+            case keys.home:
+                event.preventDefault();
+                selectTab(tabs[0].id);
+                break;
+            case keys.end:
+                event.preventDefault();
+                selectTab(tabs[tabs.length - 1].id);
+                break;
+        }
+    };
+
     return (
         <div ref={ref}>
-            <Tablist aria-label={ariaLabel} aria-labelledby={ariaLabelledby}>
+            <Tablist
+                aria-label={ariaLabel}
+                aria-labelledby={ariaLabelledby}
+                onKeyDown={handleKeyDown}
+            >
                 {tabs.map((tab) => {
                     return (
                         <Tab


### PR DESCRIPTION
## Summary:

### Tabs:
Implement the focus management and keyboard interactions from the [ARIA APG Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)
- Add keyboard support for Tabs (left arrow, right arrow, home, and end keys)
- Add `activationMode` prop to choose between manual and automatic activation (defaults to `manual`)
- Make the tabpanel focusable if there are no focusable elements in it
- Make only the active tab focusable

### Core:
- Copy focus utilities to core so more components can use them
- Add more key constants for keyboard events


Issue: WB-1909

## Test plan:

- Test the keyboard interactions and focus management in the following stories:
  - `?path=/story/packages-tabs-tabs-tabs--manual-activation`
  - `?path=/story/packages-tabs-tabs-tabs--automatic-activation`
  - `?path=/story/packages-tabs-tabs-tabs--with-focusable-panel-content`
- Also test with screen readers
- Review a11y docs `?path=/docs/packages-tabs-tabs-accessibility--docs`

## Implementation plan
- Set up base component https://github.com/Khan/wonder-blocks/pull/2528
- Keyboard interactions https://github.com/Khan/wonder-blocks/pull/2536
- Remaining props
- Styles