### PR TITLE
Upgrade WB to using react-router-dom-v5-compat.

### DIFF
--- a/.changeset/blue-hairs-complain.md
+++ b/.changeset/blue-hairs-complain.md
@@ -1,0 +1,10 @@
+---
+"@khanacademy/wonder-blocks-testing-core": major
+"@khanacademy/wonder-blocks-icon-button": major
+"@khanacademy/wonder-blocks-clickable": major
+"@khanacademy/wonder-blocks-dropdown": major
+"@khanacademy/wonder-blocks-button": major
+"@khanacademy/wonder-blocks-link": major
+---
+
+Upgrade WB to using react-router-dom-v5-compat.

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 
 import type {StyleDeclaration} from "aphrodite";
 
@@ -678,22 +679,25 @@ export const PreventNavigation: StoryComponentType = {
     name: "Preventing navigation",
     render: () => (
         <MemoryRouter>
-            <View style={styles.row}>
-                <Button
-                    href="/foo"
-                    style={styles.button}
-                    onClick={(e) => {
-                        e.preventDefault();
-                    }}
-                >
-                    This button prevents navigation.
-                </Button>
-                <Switch>
-                    <Route path="/foo">
-                        <View id="foo">Hello, world!</View>
-                    </Route>
-                </Switch>
-            </View>
+            <CompatRouter>
+                <View style={styles.row}>
+                    <Button
+                        href="/foo"
+                        style={styles.button}
+                        onClick={(e) => {
+                            e.preventDefault();
+                        }}
+                    >
+                        This button prevents navigation.
+                    </Button>
+                    <Routes>
+                        <Route
+                            path="/foo"
+                            element={<View id="foo">Hello, world!</View>}
+                        />
+                    </Routes>
+                </View>
+            </CompatRouter>
         </MemoryRouter>
     ),
 };
@@ -713,19 +717,22 @@ export const WithRouter: StoryComponentType = {
     name: "Navigation with React Router",
     render: () => (
         <MemoryRouter>
-            <View style={styles.row}>
-                <Button href="/foo" style={styles.button}>
-                    Uses Client-side Nav
-                </Button>
-                <Button href="/foo" style={styles.button} skipClientNav>
-                    Avoids Client-side Nav
-                </Button>
-                <Switch>
-                    <Route path="/foo">
-                        <View id="foo">Hello, world!</View>
-                    </Route>
-                </Switch>
-            </View>
+            <CompatRouter>
+                <View style={styles.row}>
+                    <Button href="/foo" style={styles.button}>
+                        Uses Client-side Nav
+                    </Button>
+                    <Button href="/foo" style={styles.button} skipClientNav>
+                        Avoids Client-side Nav
+                    </Button>
+                    <Routes>
+                        <Route
+                            path="/foo"
+                            element={<View id="foo">Hello, world!</View>}
+                        />
+                    </Routes>
+                </View>
+            </CompatRouter>
         </MemoryRouter>
     ),
 };

--- a/__docs__/wonder-blocks-button/navigation-callbacks.mdx
+++ b/__docs__/wonder-blocks-button/navigation-callbacks.mdx
@@ -1,6 +1,7 @@
 import {Meta, Story, Canvas} from "@storybook/blocks";
-import {MemoryRouter, Route, Switch} from "react-router-dom";
-import * as NavigationCallbacksStories from './navigation-callbacks.stories';
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
+import * as NavigationCallbacksStories from "./navigation-callbacks.stories";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -18,18 +19,18 @@ passing in a URL to the `href` prop and also passing in a callback
 function to either the `onClick`, `beforeNav`, or `safeWithNav` prop.
 Which prop you choose depends on your use case.
 
-* `onClick` is guaranteed to run to completion before navigation starts,
+- `onClick` is guaranteed to run to completion before navigation starts,
   but it is not async aware, so it should only be used if all of the code
   in your callback function executes synchronously.
 
-* `beforeNav` is guaranteed to run async operations before navigation
+- `beforeNav` is guaranteed to run async operations before navigation
   starts. You must return a promise from the callback function passed in
   to this prop, and the navigation will happen after the promise
   resolves. If the promise rejects, the navigation will not occur.
   This prop should be used if it's important that the async code
   completely finishes before the next URL starts loading.
 
-* `safeWithNav` runs async code concurrently with navigation when safe,
+- `safeWithNav` runs async code concurrently with navigation when safe,
   but delays navigation until the async code is finished when
   concurrent execution is not safe. You must return a promise from the
   callback function passed in to this prop, and Wonder Blocks will run
@@ -59,95 +60,101 @@ and `safeWithNav` will still run, but navigation will not occur.
 
 export const BeforeNavCallbacks = () => (
     <MemoryRouter>
-        <View style={styles.row}>
-            <Button
-                href="/foo"
-                style={styles.button}
-                beforeNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                beforeNav, client-side nav
-            </Button>
-            <Button
-                href="/foo"
-                style={styles.button}
-                skipClientNav={true}
-                beforeNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                beforeNav, server-side nav
-            </Button>
-            <Button
-                href="https://google.com"
-                style={styles.button}
-                skipClientNav={true}
-                beforeNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                beforeNav, open URL in new tab
-            </Button>
-            <Switch>
-                <Route path="/foo">
-                    <View id="foo">Hello, world!</View>
-                </Route>
-            </Switch>
-        </View>
+        <CompatRouter>
+            <View style={styles.row}>
+                <Button
+                    href="/foo"
+                    style={styles.button}
+                    beforeNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    beforeNav, client-side nav
+                </Button>
+                <Button
+                    href="/foo"
+                    style={styles.button}
+                    skipClientNav={true}
+                    beforeNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    beforeNav, server-side nav
+                </Button>
+                <Button
+                    href="https://google.com"
+                    style={styles.button}
+                    skipClientNav={true}
+                    beforeNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    beforeNav, open URL in new tab
+                </Button>
+                <Routes>
+                    <Route
+                        path="/foo"
+                        element={<View id="foo">Hello, world!</View>}
+                    />
+                </Routes>
+            </View>
+        </CompatRouter>
     </MemoryRouter>
 );
 
 export const SafeWithNavCallbacks = () => (
     <MemoryRouter>
-        <View style={styles.row}>
-            <Button
-                href="/foo"
-                style={styles.button}
-                safeWithNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                safeWithNav, client-side nav
-            </Button>
-            <Button
-                href="/foo"
-                style={styles.button}
-                skipClientNav={true}
-                safeWithNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                safeWithNav, server-side nav
-            </Button>
-            <Button
-                href="https://google.com"
-                style={styles.button}
-                skipClientNav={true}
-                safeWithNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                safeWithNav, open URL in new tab
-            </Button>
-            <Switch>
-                <Route path="/foo">
-                    <View id="foo">Hello, world!</View>
-                </Route>
-            </Switch>
-        </View>
+        <CompatRouter>
+            <View style={styles.row}>
+                <Button
+                    href="/foo"
+                    style={styles.button}
+                    safeWithNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    safeWithNav, client-side nav
+                </Button>
+                <Button
+                    href="/foo"
+                    style={styles.button}
+                    skipClientNav={true}
+                    safeWithNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    safeWithNav, server-side nav
+                </Button>
+                <Button
+                    href="https://google.com"
+                    style={styles.button}
+                    skipClientNav={true}
+                    safeWithNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    safeWithNav, open URL in new tab
+                </Button>
+                <Routes>
+                    <Route
+                        path="/foo"
+                        element={<View id="foo">Hello, world!</View>}
+                    />
+                </Routes>
+            </View>
+        </CompatRouter>
     </MemoryRouter>
 );
 

--- a/__docs__/wonder-blocks-button/navigation-callbacks.stories.tsx
+++ b/__docs__/wonder-blocks-button/navigation-callbacks.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -8,95 +9,101 @@ import {styles} from "./button.stories";
 
 const BeforeNavCallbacks = () => (
     <MemoryRouter>
-        <View style={styles.row}>
-            <Button
-                href="/foo"
-                style={styles.button}
-                beforeNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                beforeNav, client-side nav
-            </Button>
-            <Button
-                href="/foo"
-                style={styles.button}
-                skipClientNav={true}
-                beforeNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                beforeNav, server-side nav
-            </Button>
-            <Button
-                href="https://google.com"
-                style={styles.button}
-                skipClientNav={true}
-                beforeNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                beforeNav, open URL in new tab
-            </Button>
-            <Switch>
-                <Route path="/foo">
-                    <View id="foo">Hello, world!</View>
-                </Route>
-            </Switch>
-        </View>
+        <CompatRouter>
+            <View style={styles.row}>
+                <Button
+                    href="/foo"
+                    style={styles.button}
+                    beforeNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    beforeNav, client-side nav
+                </Button>
+                <Button
+                    href="/foo"
+                    style={styles.button}
+                    skipClientNav={true}
+                    beforeNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    beforeNav, server-side nav
+                </Button>
+                <Button
+                    href="https://google.com"
+                    style={styles.button}
+                    skipClientNav={true}
+                    beforeNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    beforeNav, open URL in new tab
+                </Button>
+                <Routes>
+                    <Route
+                        path="/foo"
+                        element={<View id="foo">Hello, world!</View>}
+                    />
+                </Routes>
+            </View>
+        </CompatRouter>
     </MemoryRouter>
 );
 
 const SafeWithNavCallbacks = () => (
     <MemoryRouter>
-        <View style={styles.row}>
-            <Button
-                href="/foo"
-                style={styles.button}
-                safeWithNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                safeWithNav, client-side nav
-            </Button>
-            <Button
-                href="/foo"
-                style={styles.button}
-                skipClientNav={true}
-                safeWithNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                safeWithNav, server-side nav
-            </Button>
-            <Button
-                href="https://google.com"
-                style={styles.button}
-                skipClientNav={true}
-                safeWithNav={() =>
-                    new Promise((resolve, reject) => {
-                        setTimeout(resolve, 1000);
-                    })
-                }
-            >
-                safeWithNav, open URL in new tab
-            </Button>
-            <Switch>
-                <Route path="/foo">
-                    <View id="foo">Hello, world!</View>
-                </Route>
-            </Switch>
-        </View>
+        <CompatRouter>
+            <View style={styles.row}>
+                <Button
+                    href="/foo"
+                    style={styles.button}
+                    safeWithNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    safeWithNav, client-side nav
+                </Button>
+                <Button
+                    href="/foo"
+                    style={styles.button}
+                    skipClientNav={true}
+                    safeWithNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    safeWithNav, server-side nav
+                </Button>
+                <Button
+                    href="https://google.com"
+                    style={styles.button}
+                    skipClientNav={true}
+                    safeWithNav={() =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(resolve, 1000);
+                        })
+                    }
+                >
+                    safeWithNav, open URL in new tab
+                </Button>
+                <Routes>
+                    <Route
+                        path="/foo"
+                        element={<View id="foo">Hello, world!</View>}
+                    />
+                </Routes>
+            </View>
+        </CompatRouter>
     </MemoryRouter>
 );
 

--- a/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
@@ -185,51 +186,58 @@ export const DetailCellNavigation: StoryComponentType = {
     name: "Client-side navigation with DetailCell",
     render: () => (
         <MemoryRouter>
-            <View>
-                <DetailCell
-                    title="Data"
-                    subtitle2="Subtitle for article item"
-                    leftAccessory={
-                        <PhosphorIcon
-                            icon={IconMappings.playCircle}
-                            size="medium"
-                        />
-                    }
-                    rightAccessory={
-                        <PhosphorIcon icon={IconMappings.caretRight} />
-                    }
-                    href="/math/algebra"
-                    aria-label="Press to navigate to the article"
-                />
-                <DetailCell
-                    title="Geometry"
-                    subtitle2="Subtitle for article item"
-                    leftAccessory={
-                        <PhosphorIcon
-                            icon={IconMappings.playCircle}
-                            size="medium"
-                        />
-                    }
-                    rightAccessory={
-                        <PhosphorIcon icon={IconMappings.caretRight} />
-                    }
-                    href="/math/geometry"
-                    aria-label="Press to navigate to the article"
-                    horizontalRule="none"
-                />
-            </View>
+            <CompatRouter>
+                <View>
+                    <DetailCell
+                        title="Data"
+                        subtitle2="Subtitle for article item"
+                        leftAccessory={
+                            <PhosphorIcon
+                                icon={IconMappings.playCircle}
+                                size="medium"
+                            />
+                        }
+                        rightAccessory={
+                            <PhosphorIcon icon={IconMappings.caretRight} />
+                        }
+                        href="/math/algebra"
+                        aria-label="Press to navigate to the article"
+                    />
+                    <DetailCell
+                        title="Geometry"
+                        subtitle2="Subtitle for article item"
+                        leftAccessory={
+                            <PhosphorIcon
+                                icon={IconMappings.playCircle}
+                                size="medium"
+                            />
+                        }
+                        rightAccessory={
+                            <PhosphorIcon icon={IconMappings.caretRight} />
+                        }
+                        href="/math/geometry"
+                        aria-label="Press to navigate to the article"
+                        horizontalRule="none"
+                    />
+                </View>
 
-            <View style={styles.navigation}>
-                <Switch>
-                    <Route path="/math/algebra">
-                        Navigates to /math/algebra
-                    </Route>
-                    <Route path="/math/geometry">
-                        Navigates to /math/geometry
-                    </Route>
-                    <Route path="*">See navigation changes here</Route>
-                </Switch>
-            </View>
+                <View style={styles.navigation}>
+                    <Routes>
+                        <Route
+                            path="/math/algebra"
+                            element={<View>Navigates to /math/algebra</View>}
+                        />
+                        <Route
+                            path="/math/geometry"
+                            element={<View>Navigates to /math/geometry</View>}
+                        />
+                        <Route
+                            path="*"
+                            element={<View>See navigation changes here</View>}
+                        />
+                    </Routes>
+                </View>
+            </CompatRouter>
         </MemoryRouter>
     ),
 };

--- a/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable-behavior.stories.tsx
@@ -15,7 +15,7 @@ const ClickableBehavior = getClickableBehavior();
 
 export default {
     title: "Packages / Clickable / ClickableBehavior",
-    component: ClickableBehavior,
+    component: ClickableBehavior as unknown,
     argTypes: argTypes,
     args: {
         disabled: false,

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -204,42 +205,50 @@ Disabled.parameters = {
 
 export const ClientSideNavigation: StoryComponentType = () => (
     <MemoryRouter>
-        <View>
-            <View style={styles.row}>
-                <Clickable
-                    href="/foo"
-                    style={styles.heading}
-                    onClick={() => {
-                        // eslint-disable-next-line no-console
-                        console.log("I'm still on the same page!");
-                    }}
-                >
-                    {(eventState) => (
-                        <LabelLarge>Uses Client-side Nav</LabelLarge>
-                    )}
-                </Clickable>
-                <Clickable
-                    href="/iframe.html?id=clickable-clickable--default&viewMode=story"
-                    style={styles.heading}
-                    skipClientNav
-                >
-                    {(eventState) => (
-                        <LabelLarge>Avoids Client-side Nav</LabelLarge>
-                    )}
-                </Clickable>
+        <CompatRouter>
+            <View>
+                <View style={styles.row}>
+                    <Clickable
+                        href="/foo"
+                        style={styles.heading}
+                        onClick={() => {
+                            // eslint-disable-next-line no-console
+                            console.log("I'm still on the same page!");
+                        }}
+                    >
+                        {(eventState) => (
+                            <LabelLarge>Uses Client-side Nav</LabelLarge>
+                        )}
+                    </Clickable>
+                    <Clickable
+                        href="/iframe.html?id=clickable-clickable--default&viewMode=story"
+                        style={styles.heading}
+                        skipClientNav
+                    >
+                        {(eventState) => (
+                            <LabelLarge>Avoids Client-side Nav</LabelLarge>
+                        )}
+                    </Clickable>
+                </View>
+                <View style={styles.navigation}>
+                    <Routes>
+                        <Route
+                            path="/foo"
+                            element={
+                                <View id="foo">
+                                    The first clickable element does client-side
+                                    navigation here.
+                                </View>
+                            }
+                        />
+                        <Route
+                            path="*"
+                            element={<View>See navigation changes here</View>}
+                        />
+                    </Routes>
+                </View>
             </View>
-            <View style={styles.navigation}>
-                <Switch>
-                    <Route path="/foo">
-                        <View id="foo">
-                            The first clickable element does client-side
-                            navigation here.
-                        </View>
-                    </Route>
-                    <Route path="*">See navigation changes here</Route>
-                </Switch>
-            </View>
-        </View>
+        </CompatRouter>
     </MemoryRouter>
 );
 

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 import * as React from "react";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import {StyleSheet} from "aphrodite";
 import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
@@ -12,7 +14,6 @@ import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 import magnifyingGlassBold from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 import minusCircle from "@phosphor-icons/core/regular/minus-circle.svg";
 
-import {MemoryRouter, Route, Switch} from "react-router";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
@@ -309,27 +310,30 @@ export const WithRouter: StoryComponentType = {
     name: "Navigation with React Router",
     render: () => (
         <MemoryRouter>
-            <View style={styles.row}>
-                <IconButton
-                    href="/foo"
-                    icon={caretRight}
-                    onClick={() => console.log("Click!")}
-                    aria-label="Navigate to /foo using React Router"
-                />
-                <IconButton
-                    href="https://www.khanacademy.org"
-                    target="_blank"
-                    icon={externalLinkIcon}
-                    onClick={() => console.log("Click!")}
-                    aria-label="Skip client navigation"
-                    skipClientNav
-                />
-                <Switch>
-                    <Route path="/foo">
-                        <View id="foo">Hello, world!</View>
-                    </Route>
-                </Switch>
-            </View>
+            <CompatRouter>
+                <View style={styles.row}>
+                    <IconButton
+                        href="/foo"
+                        icon={caretRight}
+                        onClick={() => console.log("Click!")}
+                        aria-label="Navigate to /foo using React Router"
+                    />
+                    <IconButton
+                        href="https://www.khanacademy.org"
+                        target="_blank"
+                        icon={externalLinkIcon}
+                        onClick={() => console.log("Click!")}
+                        aria-label="Skip client navigation"
+                        skipClientNav
+                    />
+                    <Routes>
+                        <Route
+                            path="/foo"
+                            element={<View id="foo">Hello, world!</View>}
+                        />
+                    </Routes>
+                </View>
+            </CompatRouter>
         </MemoryRouter>
     ),
 };

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -387,37 +388,48 @@ export const WithStyle: StoryComponentType = {
 export const Navigation: StoryComponentType = {
     render: () => (
         <MemoryRouter>
-            <View>
-                <View style={styles.row}>
-                    <Link
-                        href="/foo"
-                        style={styles.heading}
-                        onClick={() => {
-                            // eslint-disable-next-line no-console
-                            console.log("I'm still on the same page!");
-                        }}
-                    >
-                        <LabelLarge>Uses Client-side Nav</LabelLarge>
-                    </Link>
-                    <Link
-                        href="/iframe.html?id=link--default&viewMode=story"
-                        style={styles.heading}
-                        skipClientNav
-                    >
-                        <LabelLarge>Avoids Client-side Nav</LabelLarge>
-                    </Link>
+            <CompatRouter>
+                <View>
+                    <View style={styles.row}>
+                        <Link
+                            href="/foo"
+                            style={styles.heading}
+                            onClick={() => {
+                                // eslint-disable-next-line no-console
+                                console.log("I'm still on the same page!");
+                            }}
+                        >
+                            <LabelLarge>Uses Client-side Nav</LabelLarge>
+                        </Link>
+                        <Link
+                            href="/iframe.html?id=link--default&viewMode=story"
+                            style={styles.heading}
+                            skipClientNav
+                        >
+                            <LabelLarge>Avoids Client-side Nav</LabelLarge>
+                        </Link>
+                    </View>
+                    <View style={styles.navigation}>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={
+                                    <View id="foo">
+                                        The first link does client-side
+                                        navigation here.
+                                    </View>
+                                }
+                            />
+                            <Route
+                                path="*"
+                                element={
+                                    <View>See navigation changes here</View>
+                                }
+                            />
+                        </Routes>
+                    </View>
                 </View>
-                <View style={styles.navigation}>
-                    <Switch>
-                        <Route path="/foo">
-                            <View id="foo">
-                                The first link does client-side navigation here.
-                            </View>
-                        </Route>
-                        <Route path="*">See navigation changes here</Route>
-                    </Switch>
-                </View>
-            </View>
+            </CompatRouter>
         </MemoryRouter>
     ),
 };

--- a/consistency-tests/__tests__/clickables.test.tsx
+++ b/consistency-tests/__tests__/clickables.test.tsx
@@ -6,6 +6,7 @@
  */
 import * as React from "react";
 import {MemoryRouter} from "react-router-dom";
+import {CompatRouter} from "react-router-dom-v5-compat";
 import {render, screen} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
@@ -95,7 +96,9 @@ describe.each`
         // Arrange
         render(
             <MemoryRouter>
-                <Component href="#">Click me</Component>
+                <CompatRouter>
+                    <Component href="#">Click me</Component>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -133,7 +136,9 @@ describe.each`
         // Arrange
         render(
             <MemoryRouter>
-                <Component onClick={() => {}}>Click me</Component>
+                <CompatRouter>
+                    <Component onClick={() => {}}>Click me</Component>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -149,7 +154,9 @@ describe.each`
         const clickHandler = jest.fn();
         render(
             <MemoryRouter>
-                <Component onClick={clickHandler}>Click me</Component>
+                <CompatRouter>
+                    <Component onClick={clickHandler}>Click me</Component>
+                </CompatRouter>
             </MemoryRouter>,
         );
 

--- a/consistency-tests/__tests__/ref-forwarded.test.tsx
+++ b/consistency-tests/__tests__/ref-forwarded.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {render, waitFor} from "@testing-library/react";
-import {MemoryRouter, Link as ReactRouterLink} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter} from "react-router-dom-v5-compat";
 import * as ReactDOM from "react-dom";
 
 import plus from "@phosphor-icons/core/regular/plus.svg";
@@ -169,14 +170,16 @@ describe("Link", () => {
     // Link element) if it uses a router and uses client navigation.
     test("forwards ref to react-router-dom Link which is an HTMLAnchorElement", () => {
         // Arrange
-        const ref: React.RefObject<typeof ReactRouterLink> = React.createRef();
+        const ref: any = React.createRef();
 
         // Act
         render(
             <MemoryRouter>
-                <Link href="/foo" skipClientNav={false} ref={ref}>
-                    Click me!
-                </Link>
+                <CompatRouter>
+                    <Link href="/foo" skipClientNav={false} ref={ref}>
+                        Click me!
+                    </Link>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -271,14 +274,16 @@ describe("Button", () => {
     // Link element) if it uses a router and uses client navigation.
     test("forwards ref to react-router-dom Link which is an HTMLAnchorElement", () => {
         // Arrange
-        const ref: React.RefObject<typeof ReactRouterLink> = React.createRef();
+        const ref: any = React.createRef();
 
         // Act
         render(
             <MemoryRouter>
-                <Link href="/foo" skipClientNav={false} ref={ref}>
-                    Click me!
-                </Link>
+                <CompatRouter>
+                    <Link href="/foo" skipClientNav={false} ref={ref}>
+                        Click me!
+                    </Link>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -324,18 +329,20 @@ describe("IconButton", () => {
     // Link element) if it uses a router and uses client navigation.
     test("forwards ref to react-router-dom Link which is an HTMLAnchorElement", () => {
         // Arrange
-        const ref: React.RefObject<typeof ReactRouterLink> = React.createRef();
+        const ref: any = React.createRef();
 
         // Act
         render(
             <MemoryRouter>
-                <IconButton
-                    href="/foo"
-                    skipClientNav={false}
-                    ref={ref}
-                    icon={plus}
-                />
-                ,
+                <CompatRouter>
+                    <IconButton
+                        href="/foo"
+                        skipClientNav={false}
+                        ref={ref}
+                        icon={plus}
+                    />
+                    ,
+                </CompatRouter>
             </MemoryRouter>,
         );
 

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "react-popper": "catalog:",
     "react-router": "catalog:",
     "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:",
     "react-window": "catalog:"
   },
   "resolutions": {

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -29,7 +29,8 @@
     "aphrodite": "catalog:",
     "react": "catalog:",
     "react-router": "catalog:",
-    "react-router-dom": "catalog:"
+    "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-button/src/components/__tests__/button.test.tsx
+++ b/packages/wonder-blocks-button/src/components/__tests__/button.test.tsx
@@ -5,7 +5,8 @@
  * (button-with-icon.test.tsx) since this one is already too long.
  */
 import * as React from "react";
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import {render, screen, waitFor} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
@@ -29,14 +30,17 @@ describe("Button", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Button href="/foo">Click me!</Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button href="/foo">Click me!</Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -52,16 +56,19 @@ describe("Button", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Button href="/foo" beforeNav={() => Promise.reject()}>
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button href="/foo" beforeNav={() => Promise.reject()}>
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -78,20 +85,23 @@ describe("Button", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        beforeNav={() => Promise.reject()}
-                        safeWithNav={safeWithNavMock}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            beforeNav={() => Promise.reject()}
+                            safeWithNav={safeWithNavMock}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -107,16 +117,19 @@ describe("Button", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Button href="/foo" beforeNav={() => Promise.resolve()}>
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button href="/foo" beforeNav={() => Promise.resolve()}>
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -136,20 +149,23 @@ describe("Button", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        beforeNav={() => Promise.resolve()}
-                        safeWithNav={safeWithNavMock}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                            safeWithNav={safeWithNavMock}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -169,16 +185,19 @@ describe("Button", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Button href="/foo" beforeNav={() => Promise.resolve()}>
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button href="/foo" beforeNav={() => Promise.resolve()}>
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -196,20 +215,23 @@ describe("Button", () => {
         jest.spyOn(window.location, "assign");
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        safeWithNav={() => Promise.resolve()}
-                        skipClientNav={true}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            safeWithNav={() => Promise.resolve()}
+                            skipClientNav={true}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -227,20 +249,23 @@ describe("Button", () => {
         jest.spyOn(window.location, "assign");
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        safeWithNav={() => Promise.resolve()}
-                        skipClientNav={true}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            safeWithNav={() => Promise.resolve()}
+                            skipClientNav={true}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -257,21 +282,24 @@ describe("Button", () => {
         jest.spyOn(window.location, "assign");
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        beforeNav={() => Promise.resolve()}
-                        safeWithNav={() => Promise.resolve()}
-                        skipClientNav={true}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                            safeWithNav={() => Promise.resolve()}
+                            skipClientNav={true}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -290,20 +318,23 @@ describe("Button", () => {
         jest.spyOn(window.location, "assign");
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        safeWithNav={() => Promise.reject()}
-                        skipClientNav={true}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            safeWithNav={() => Promise.reject()}
+                            skipClientNav={true}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -321,7 +352,7 @@ describe("Button", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
+                <CompatRouter>
                     <Button
                         href="/foo"
                         safeWithNav={safeWithNavMock}
@@ -329,12 +360,13 @@ describe("Button", () => {
                     >
                         Click me!
                     </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                    <Routes>
+                        <Route
+                            path="/foo"
+                            element={<div id="foo">Hello, world!</div>}
+                        />
+                    </Routes>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -353,21 +385,24 @@ describe("Button", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        beforeNav={() => Promise.resolve()}
-                        safeWithNav={safeWithNavMock}
-                        skipClientNav={false}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                            safeWithNav={safeWithNavMock}
+                            skipClientNav={false}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -387,14 +422,17 @@ describe("Button", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Button href="/unknown">Click me!</Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button href="/unknown">Click me!</Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -410,16 +448,19 @@ describe("Button", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Button href="/foo" skipClientNav>
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button href="/foo" skipClientNav>
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -435,16 +476,19 @@ describe("Button", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Button href="/foo" disabled={true}>
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button href="/foo" disabled={true}>
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -461,20 +505,23 @@ describe("Button", () => {
         const beforeNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        disabled={true}
-                        beforeNav={beforeNavMock}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            disabled={true}
+                            beforeNav={beforeNavMock}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -491,20 +538,23 @@ describe("Button", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Button
-                        href="/foo"
-                        disabled={true}
-                        safeWithNav={safeWithNavMock}
-                    >
-                        Click me!
-                    </Button>
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Button
+                            href="/foo"
+                            disabled={true}
+                            safeWithNav={safeWithNavMock}
+                        >
+                            Click me!
+                        </Button>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -552,14 +602,17 @@ describe("Button", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Button href="/foo">Click me!</Button>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Button href="/foo">Click me!</Button>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -577,14 +630,17 @@ describe("Button", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Button href="/foo">Click me!</Button>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Button href="/foo">Click me!</Button>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -602,16 +658,22 @@ describe("Button", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Button href="/foo" beforeNav={() => Promise.reject()}>
-                            Click me!
-                        </Button>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Button
+                                href="/foo"
+                                beforeNav={() => Promise.reject()}
+                            >
+                                Click me!
+                            </Button>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -627,16 +689,22 @@ describe("Button", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Button href="/foo" beforeNav={() => Promise.resolve()}>
-                            Click me!
-                        </Button>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Button
+                                href="/foo"
+                                beforeNav={() => Promise.resolve()}
+                            >
+                                Click me!
+                            </Button>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -657,20 +725,23 @@ describe("Button", () => {
             jest.spyOn(window.location, "assign");
             render(
                 <MemoryRouter>
-                    <div>
-                        <Button
-                            href="/foo"
-                            safeWithNav={() => Promise.resolve()}
-                            skipClientNav={true}
-                        >
-                            Click me!
-                        </Button>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Button
+                                href="/foo"
+                                safeWithNav={() => Promise.resolve()}
+                                skipClientNav={true}
+                            >
+                                Click me!
+                            </Button>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -687,20 +758,23 @@ describe("Button", () => {
             jest.spyOn(window.location, "assign");
             render(
                 <MemoryRouter>
-                    <div>
-                        <Button
-                            href="/foo"
-                            safeWithNav={() => Promise.reject()}
-                            skipClientNav={true}
-                        >
-                            Click me!
-                        </Button>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Button
+                                href="/foo"
+                                safeWithNav={() => Promise.reject()}
+                                skipClientNav={true}
+                            >
+                                Click me!
+                            </Button>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -720,20 +794,23 @@ describe("Button", () => {
             const safeWithNavMock = jest.fn();
             render(
                 <MemoryRouter>
-                    <div>
-                        <Button
-                            href="/foo"
-                            safeWithNav={safeWithNavMock}
-                            skipClientNav={false}
-                        >
-                            Click me!
-                        </Button>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Button
+                                href="/foo"
+                                safeWithNav={safeWithNavMock}
+                                skipClientNav={false}
+                            >
+                                Click me!
+                            </Button>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -238,7 +238,7 @@ const themedSharedStyles: ThemedStylesFn<ButtonThemeContract> = (theme) => ({
         border: "none",
         borderRadius: theme.border.radius.default,
         cursor: "pointer",
-        //outline: "none",
+        outline: "none",
         textDecoration: "none",
         boxSizing: "border-box",
         // This removes the 300ms click delay on mobile browsers by indicating that

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {CSSProperties, StyleSheet} from "aphrodite";
-import {Link} from "react-router-dom";
-import {__RouterContext} from "react-router";
+import {Link, useInRouterContext} from "react-router-dom-v5-compat";
 
 import {LabelLarge, LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
@@ -36,202 +35,191 @@ const ButtonCore: React.ForwardRefExoticComponent<
 >(function ButtonCore(props: Props, ref) {
     const {theme, themeName} = useScopedTheme(ButtonThemeContext);
     const sharedStyles = useStyles(themedSharedStyles, theme);
+    const inRouterContext = useInRouterContext();
 
-    const renderInner = (router: any): React.ReactNode => {
-        const {
-            children,
-            skipClientNav,
-            color,
-            disabled: disabledProp,
-            focused,
-            hovered,
-            href = undefined,
-            kind = "primary",
-            labelStyle,
-            light = false,
-            pressed,
-            size = "medium",
-            style,
-            testId,
-            type = undefined,
-            spinner,
-            startIcon,
-            endIcon,
-            id,
-            waiting: _,
-            ...restProps
-        } = props;
+    const {
+        children,
+        skipClientNav,
+        color,
+        disabled: disabledProp,
+        focused,
+        hovered,
+        href = undefined,
+        kind = "primary",
+        labelStyle,
+        light = false,
+        pressed,
+        size = "medium",
+        style,
+        testId,
+        type = undefined,
+        spinner,
+        startIcon,
+        endIcon,
+        id,
+        waiting: _,
+        ...restProps
+    } = props;
 
-        const buttonStyles = _generateStyles(
-            color,
-            kind,
-            light,
-            size,
-            theme,
-            themeName,
-        );
-
-        const disabled = spinner || disabledProp;
-
-        const defaultStyle = [
-            sharedStyles.shared,
-            disabled && sharedStyles.disabled,
-            startIcon && sharedStyles.withStartIcon,
-            endIcon && sharedStyles.withEndIcon,
-            buttonStyles.default,
-            disabled && buttonStyles.disabled,
-            // apply focus effect only to default and secondary buttons
-            kind !== "tertiary" &&
-                !disabled &&
-                (pressed
-                    ? buttonStyles.pressed
-                    : focused && buttonStyles.focused),
-            kind === "tertiary" &&
-                !pressed &&
-                focused && [
-                    buttonStyles.focused,
-                    disabled && buttonStyles.disabledFocus,
-                ],
-            size === "small" && sharedStyles.small,
-            size === "large" && sharedStyles.large,
-        ];
-
-        const commonProps = {
-            "data-testid": testId,
-            id: id,
-            role: "button",
-            style: [defaultStyle, style],
-            ...restProps,
-        } as const;
-
-        const Label = size === "small" ? LabelSmall : LabelLarge;
-
-        const label = (
-            <Label
-                style={[
-                    sharedStyles.text,
-                    size === "small" && sharedStyles.smallText,
-                    size === "large" && sharedStyles.largeText,
-                    labelStyle,
-                    spinner && sharedStyles.hiddenText,
-                    kind === "tertiary" && sharedStyles.textWithFocus,
-                    // apply press/hover effects on the label
-                    kind === "tertiary" &&
-                        !disabled &&
-                        (pressed
-                            ? [buttonStyles.hover, buttonStyles.active]
-                            : hovered && buttonStyles.hover),
-                ]}
-                testId={testId ? `${testId}-inner-label` : undefined}
-            >
-                {children}
-            </Label>
-        );
-
-        const sizeMapping = {
-            medium: "small",
-            small: "xsmall",
-            large: "medium",
-        } as const;
-
-        // We have to use `medium` for both md and lg buttons so we can fit the
-        // icons in large buttons.
-        const iconSize = size === "small" ? "small" : "medium";
-
-        const contents = (
-            <React.Fragment>
-                {startIcon && (
-                    <View
-                        // The start icon doesn't have the circle around it
-                        // in the Khanmigo theme, but we wrap it with
-                        // iconWrapper anyway to give it the same spacing
-                        // as the end icon so the button is symmetrical.
-                        style={sharedStyles.iconWrapper}
-                    >
-                        <ButtonIcon
-                            size={iconSize}
-                            icon={startIcon}
-                            style={[
-                                sharedStyles.startIcon,
-                                kind === "tertiary" &&
-                                    sharedStyles.tertiaryStartIcon,
-                            ]}
-                            testId={testId ? `${testId}-start-icon` : undefined}
-                        />
-                    </View>
-                )}
-                {label}
-                {spinner && (
-                    <CircularSpinner
-                        style={sharedStyles.spinner}
-                        size={sizeMapping[size]}
-                        light={kind === "primary"}
-                        testId={`${testId || "button"}-spinner`}
-                    />
-                )}
-                {endIcon && (
-                    <View
-                        testId={
-                            testId ? `${testId}-end-icon-wrapper` : undefined
-                        }
-                        style={[
-                            styles.endIcon,
-                            sharedStyles.iconWrapper,
-                            sharedStyles.endIconWrapper,
-                            kind === "tertiary" &&
-                                sharedStyles.endIconWrapperTertiary,
-                            (focused || hovered) &&
-                                kind !== "primary" &&
-                                buttonStyles.iconWrapperHovered,
-                        ]}
-                    >
-                        <ButtonIcon
-                            size={iconSize}
-                            icon={endIcon}
-                            testId={testId ? `${testId}-end-icon` : undefined}
-                        />
-                    </View>
-                )}
-            </React.Fragment>
-        );
-
-        if (href && !disabled) {
-            return router && !skipClientNav && isClientSideUrl(href) ? (
-                <StyledLink
-                    {...commonProps}
-                    to={href}
-                    ref={ref as React.Ref<typeof Link>}
-                >
-                    {contents}
-                </StyledLink>
-            ) : (
-                <StyledA
-                    {...commonProps}
-                    href={href}
-                    ref={ref as React.Ref<HTMLAnchorElement>}
-                >
-                    {contents}
-                </StyledA>
-            );
-        } else {
-            return (
-                <StyledButton
-                    type={type || "button"}
-                    {...commonProps}
-                    aria-disabled={disabled}
-                    ref={ref as React.Ref<HTMLButtonElement>}
-                >
-                    {contents}
-                </StyledButton>
-            );
-        }
-    };
-
-    return (
-        <__RouterContext.Consumer>
-            {(router) => renderInner(router)}
-        </__RouterContext.Consumer>
+    const buttonStyles = _generateStyles(
+        color,
+        kind,
+        light,
+        size,
+        theme,
+        themeName,
     );
+
+    const disabled = spinner || disabledProp;
+
+    const defaultStyle = [
+        sharedStyles.shared,
+        disabled && sharedStyles.disabled,
+        startIcon && sharedStyles.withStartIcon,
+        endIcon && sharedStyles.withEndIcon,
+        buttonStyles.default,
+        disabled && buttonStyles.disabled,
+        // apply focus effect only to default and secondary buttons
+        kind !== "tertiary" &&
+            !disabled &&
+            (pressed ? buttonStyles.pressed : focused && buttonStyles.focused),
+        kind === "tertiary" &&
+            !pressed &&
+            focused && [
+                buttonStyles.focused,
+                disabled && buttonStyles.disabledFocus,
+            ],
+        size === "small" && sharedStyles.small,
+        size === "large" && sharedStyles.large,
+    ];
+
+    const commonProps = {
+        "data-testid": testId,
+        id: id,
+        role: "button",
+        style: [defaultStyle, style],
+        ...restProps,
+    } as const;
+
+    const Label = size === "small" ? LabelSmall : LabelLarge;
+
+    const label = (
+        <Label
+            style={[
+                sharedStyles.text,
+                size === "small" && sharedStyles.smallText,
+                size === "large" && sharedStyles.largeText,
+                labelStyle,
+                spinner && sharedStyles.hiddenText,
+                kind === "tertiary" && sharedStyles.textWithFocus,
+                // apply press/hover effects on the label
+                kind === "tertiary" &&
+                    !disabled &&
+                    (pressed
+                        ? [buttonStyles.hover, buttonStyles.active]
+                        : hovered && buttonStyles.hover),
+            ]}
+            testId={testId ? `${testId}-inner-label` : undefined}
+        >
+            {children}
+        </Label>
+    );
+
+    const sizeMapping = {
+        medium: "small",
+        small: "xsmall",
+        large: "medium",
+    } as const;
+
+    // We have to use `medium` for both md and lg buttons so we can fit the
+    // icons in large buttons.
+    const iconSize = size === "small" ? "small" : "medium";
+
+    const contents = (
+        <React.Fragment>
+            {startIcon && (
+                <View
+                    // The start icon doesn't have the circle around it
+                    // in the Khanmigo theme, but we wrap it with
+                    // iconWrapper anyway to give it the same spacing
+                    // as the end icon so the button is symmetrical.
+                    style={sharedStyles.iconWrapper}
+                >
+                    <ButtonIcon
+                        size={iconSize}
+                        icon={startIcon}
+                        style={[
+                            sharedStyles.startIcon,
+                            kind === "tertiary" &&
+                                sharedStyles.tertiaryStartIcon,
+                        ]}
+                        testId={testId ? `${testId}-start-icon` : undefined}
+                    />
+                </View>
+            )}
+            {label}
+            {spinner && (
+                <CircularSpinner
+                    style={sharedStyles.spinner}
+                    size={sizeMapping[size]}
+                    light={kind === "primary"}
+                    testId={`${testId || "button"}-spinner`}
+                />
+            )}
+            {endIcon && (
+                <View
+                    testId={testId ? `${testId}-end-icon-wrapper` : undefined}
+                    style={[
+                        styles.endIcon,
+                        sharedStyles.iconWrapper,
+                        sharedStyles.endIconWrapper,
+                        kind === "tertiary" &&
+                            sharedStyles.endIconWrapperTertiary,
+                        (focused || hovered) &&
+                            kind !== "primary" &&
+                            buttonStyles.iconWrapperHovered,
+                    ]}
+                >
+                    <ButtonIcon
+                        size={iconSize}
+                        icon={endIcon}
+                        testId={testId ? `${testId}-end-icon` : undefined}
+                    />
+                </View>
+            )}
+        </React.Fragment>
+    );
+
+    if (href && !disabled) {
+        return inRouterContext && !skipClientNav && isClientSideUrl(href) ? (
+            <StyledLink
+                {...commonProps}
+                to={href}
+                ref={ref as React.Ref<typeof Link>}
+            >
+                {contents}
+            </StyledLink>
+        ) : (
+            <StyledA
+                {...commonProps}
+                href={href}
+                ref={ref as React.Ref<HTMLAnchorElement>}
+            >
+                {contents}
+            </StyledA>
+        );
+    } else {
+        return (
+            <StyledButton
+                type={type || "button"}
+                {...commonProps}
+                aria-disabled={disabled}
+                ref={ref as React.Ref<HTMLButtonElement>}
+            >
+                {contents}
+            </StyledButton>
+        );
+    }
 });
 
 export default ButtonCore;

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -238,7 +238,7 @@ const themedSharedStyles: ThemedStylesFn<ButtonThemeContract> = (theme) => ({
         border: "none",
         borderRadius: theme.border.radius.default,
         cursor: "pointer",
-        outline: "none",
+        //outline: "none",
         textDecoration: "none",
         boxSizing: "border-box",
         // This removes the 300ms click delay on mobile browsers by indicating that

--- a/packages/wonder-blocks-button/src/components/button.tsx
+++ b/packages/wonder-blocks-button/src/components/button.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {__RouterContext} from "react-router";
 
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 import type {
@@ -8,7 +7,7 @@ import type {
 } from "@khanacademy/wonder-blocks-clickable";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
-import {Link} from "react-router-dom";
+import {Link, useInRouterContext} from "react-router-dom-v5-compat";
 import ButtonCore from "./button-core";
 import ThemedButton from "../themes/themed-button";
 
@@ -230,11 +229,13 @@ const Button: React.ForwardRefExoticComponent<
         ...sharedButtonCoreProps
     } = props;
 
-    const renderClickableBehavior = (router: any): React.ReactNode => {
+    const RenderClickableBehavior = (props: Props) => {
+        const inRouterContext = useInRouterContext();
+
         const ClickableBehavior = getClickableBehavior(
             href,
             skipClientNav,
-            router,
+            inRouterContext,
         );
 
         const renderProp = (
@@ -299,9 +300,7 @@ const Button: React.ForwardRefExoticComponent<
 
     return (
         <ThemedButton>
-            <__RouterContext.Consumer>
-                {(router) => renderClickableBehavior(router)}
-            </__RouterContext.Consumer>
+            <RenderClickableBehavior {...props} />
         </ThemedButton>
     );
 });

--- a/packages/wonder-blocks-button/src/components/button.tsx
+++ b/packages/wonder-blocks-button/src/components/button.tsx
@@ -229,20 +229,20 @@ const Button: React.ForwardRefExoticComponent<
         ...sharedButtonCoreProps
     } = props;
 
-    const RenderClickableBehavior = (props: Props) => {
-        const inRouterContext = useInRouterContext();
+    const inRouterContext = useInRouterContext();
 
-        const ClickableBehavior = getClickableBehavior(
-            href,
-            skipClientNav,
-            inRouterContext,
-        );
+    const ClickableBehavior = getClickableBehavior(
+        href,
+        skipClientNav,
+        inRouterContext,
+    );
 
-        const renderProp = (
-            state: ClickableState,
-            restChildProps: ChildrenProps,
-        ) => {
-            return (
+    const renderProp = (
+        state: ClickableState,
+        restChildProps: ChildrenProps,
+    ) => {
+        return (
+            <ThemedButton>
                 <ButtonCore
                     {...sharedButtonCoreProps}
                     {...state}
@@ -262,47 +262,41 @@ const Button: React.ForwardRefExoticComponent<
                 >
                     {children}
                 </ButtonCore>
-            );
-        };
-
-        if (beforeNav) {
-            return (
-                <ClickableBehavior
-                    disabled={spinner || disabled}
-                    href={href}
-                    role="button"
-                    type={type}
-                    onClick={onClick}
-                    beforeNav={beforeNav}
-                    safeWithNav={safeWithNav}
-                    rel={rel}
-                >
-                    {renderProp}
-                </ClickableBehavior>
-            );
-        } else {
-            return (
-                <ClickableBehavior
-                    disabled={spinner || disabled}
-                    href={href}
-                    role="button"
-                    type={type}
-                    onClick={onClick}
-                    safeWithNav={safeWithNav}
-                    target={target}
-                    rel={rel}
-                >
-                    {renderProp}
-                </ClickableBehavior>
-            );
-        }
+            </ThemedButton>
+        );
     };
 
-    return (
-        <ThemedButton>
-            <RenderClickableBehavior {...props} />
-        </ThemedButton>
-    );
+    if (beforeNav) {
+        return (
+            <ClickableBehavior
+                disabled={spinner || disabled}
+                href={href}
+                role="button"
+                type={type}
+                onClick={onClick}
+                beforeNav={beforeNav}
+                safeWithNav={safeWithNav}
+                rel={rel}
+            >
+                {renderProp}
+            </ClickableBehavior>
+        );
+    } else {
+        return (
+            <ClickableBehavior
+                disabled={spinner || disabled}
+                href={href}
+                role="button"
+                type={type}
+                onClick={onClick}
+                safeWithNav={safeWithNav}
+                target={target}
+                rel={rel}
+            >
+                {renderProp}
+            </ClickableBehavior>
+        );
+    }
 });
 
 export default Button;

--- a/packages/wonder-blocks-clickable/package.json
+++ b/packages/wonder-blocks-clickable/package.json
@@ -25,7 +25,8 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-router": "catalog:",
-    "react-router-dom": "catalog:"
+    "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.tsx
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable-behavior.test.tsx
@@ -2,7 +2,8 @@
 /* eslint-disable max-lines */
 import * as React from "react";
 import {render, screen, fireEvent, waitFor} from "@testing-library/react";
-import {MemoryRouter, Switch, Route} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import {userEvent} from "@testing-library/user-event";
 import {keys} from "@khanacademy/wonder-blocks-core";
 
@@ -901,27 +902,32 @@ describe("ClickableBehavior", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <ClickableBehaviorWithRouter
-                            href="/foo"
-                            onClick={(e: any) => {}}
-                            role="checkbox"
-                        >
-                            {(state: any, childrenProps: any) => {
-                                // The base element here doesn't matter in this testing
-                                // environment, but the simulated events in the test are in
-                                // line with what browsers do for this element.
-                                return (
-                                    <button {...childrenProps}>label</button>
-                                );
-                            }}
-                        </ClickableBehaviorWithRouter>
-                        <Switch>
-                            <Route path="/foo">
-                                <div>Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <ClickableBehaviorWithRouter
+                                href="/foo"
+                                onClick={(e: any) => {}}
+                                role="checkbox"
+                            >
+                                {(state: any, childrenProps: any) => {
+                                    // The base element here doesn't matter in this testing
+                                    // environment, but the simulated events in the test are in
+                                    // line with what browsers do for this element.
+                                    return (
+                                        <button {...childrenProps}>
+                                            label
+                                        </button>
+                                    );
+                                }}
+                            </ClickableBehaviorWithRouter>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div>Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -939,32 +945,35 @@ describe("ClickableBehavior", () => {
                 // Arrange
                 render(
                     <MemoryRouter>
-                        <div>
-                            <ClickableBehaviorWithRouter
-                                href="/foo"
-                                onClick={(e: any) => {}}
-                                role="checkbox"
-                                beforeNav={() => Promise.resolve()}
-                            >
-                                {(state: any, childrenProps: any) => {
-                                    // The base element here doesn't matter in this testing
-                                    // environment, but the simulated events in the test are in
-                                    // line with what browsers do for this element.
-                                    return (
-                                        <button {...childrenProps}>
-                                            {state.waiting
-                                                ? "waiting"
-                                                : "label"}
-                                        </button>
-                                    );
-                                }}
-                            </ClickableBehaviorWithRouter>
-                            <Switch>
-                                <Route path="/foo">
-                                    <div>Hello, world!</div>
-                                </Route>
-                            </Switch>
-                        </div>
+                        <CompatRouter>
+                            <div>
+                                <ClickableBehaviorWithRouter
+                                    href="/foo"
+                                    onClick={(e: any) => {}}
+                                    role="checkbox"
+                                    beforeNav={() => Promise.resolve()}
+                                >
+                                    {(state: any, childrenProps: any) => {
+                                        // The base element here doesn't matter in this testing
+                                        // environment, but the simulated events in the test are in
+                                        // line with what browsers do for this element.
+                                        return (
+                                            <button {...childrenProps}>
+                                                {state.waiting
+                                                    ? "waiting"
+                                                    : "label"}
+                                            </button>
+                                        );
+                                    }}
+                                </ClickableBehaviorWithRouter>
+                                <Routes>
+                                    <Route
+                                        path="/foo"
+                                        element={<div>Hello, world!</div>}
+                                    />
+                                </Routes>
+                            </div>
+                        </CompatRouter>
                     </MemoryRouter>,
                 );
 
@@ -985,32 +994,35 @@ describe("ClickableBehavior", () => {
                 // Arrange
                 render(
                     <MemoryRouter>
-                        <div>
-                            <ClickableBehaviorWithRouter
-                                href="/foo"
-                                onClick={(e: any) => {}}
-                                role="checkbox"
-                                beforeNav={() => Promise.resolve()}
-                            >
-                                {(state: any, childrenProps: any) => {
-                                    // The base element here doesn't matter in this testing
-                                    // environment, but the simulated events in the test are in
-                                    // line with what browsers do for this element.
-                                    return (
-                                        <button {...childrenProps}>
-                                            {state.waiting
-                                                ? "waiting"
-                                                : "label"}
-                                        </button>
-                                    );
-                                }}
-                            </ClickableBehaviorWithRouter>
-                            <Switch>
-                                <Route path="/foo">
-                                    <div>Hello, world!</div>
-                                </Route>
-                            </Switch>
-                        </div>
+                        <CompatRouter>
+                            <div>
+                                <ClickableBehaviorWithRouter
+                                    href="/foo"
+                                    onClick={(e: any) => {}}
+                                    role="checkbox"
+                                    beforeNav={() => Promise.resolve()}
+                                >
+                                    {(state: any, childrenProps: any) => {
+                                        // The base element here doesn't matter in this testing
+                                        // environment, but the simulated events in the test are in
+                                        // line with what browsers do for this element.
+                                        return (
+                                            <button {...childrenProps}>
+                                                {state.waiting
+                                                    ? "waiting"
+                                                    : "label"}
+                                            </button>
+                                        );
+                                    }}
+                                </ClickableBehaviorWithRouter>
+                                <Routes>
+                                    <Route
+                                        path="/foo"
+                                        element={<div>Hello, world!</div>}
+                                    />
+                                </Routes>
+                            </div>
+                        </CompatRouter>
                     </MemoryRouter>,
                 );
 
@@ -1025,30 +1037,33 @@ describe("ClickableBehavior", () => {
                 // Arrange
                 render(
                     <MemoryRouter>
-                        <div>
-                            <ClickableBehaviorWithRouter
-                                href="/foo"
-                                onClick={(e: any) => {}}
-                                role="checkbox"
-                                beforeNav={() => Promise.reject()}
-                            >
-                                {(state: any, childrenProps: any) => {
-                                    // The base element here doesn't matter in this testing
-                                    // environment, but the simulated events in the test are in
-                                    // line with what browsers do for this element.
-                                    return (
-                                        <button {...childrenProps}>
-                                            label
-                                        </button>
-                                    );
-                                }}
-                            </ClickableBehaviorWithRouter>
-                            <Switch>
-                                <Route path="/foo">
-                                    <div>Hello, world!</div>
-                                </Route>
-                            </Switch>
-                        </div>
+                        <CompatRouter>
+                            <div>
+                                <ClickableBehaviorWithRouter
+                                    href="/foo"
+                                    onClick={(e: any) => {}}
+                                    role="checkbox"
+                                    beforeNav={() => Promise.reject()}
+                                >
+                                    {(state: any, childrenProps: any) => {
+                                        // The base element here doesn't matter in this testing
+                                        // environment, but the simulated events in the test are in
+                                        // line with what browsers do for this element.
+                                        return (
+                                            <button {...childrenProps}>
+                                                label
+                                            </button>
+                                        );
+                                    }}
+                                </ClickableBehaviorWithRouter>
+                                <Routes>
+                                    <Route
+                                        path="/foo"
+                                        element={<div>Hello, world!</div>}
+                                    />
+                                </Routes>
+                            </div>
+                        </CompatRouter>
                     </MemoryRouter>,
                 );
 
@@ -1066,33 +1081,36 @@ describe("ClickableBehavior", () => {
                 const safeWithNavMock = jest.fn();
                 render(
                     <MemoryRouter>
-                        <div>
-                            <ClickableBehaviorWithRouter
-                                href="/foo"
-                                onClick={(e: any) => {}}
-                                role="checkbox"
-                                beforeNav={() => Promise.resolve()}
-                                safeWithNav={safeWithNavMock}
-                            >
-                                {(state: any, childrenProps: any) => {
-                                    // The base element here doesn't matter in this testing
-                                    // environment, but the simulated events in the test are in
-                                    // line with what browsers do for this element.
-                                    return (
-                                        <button {...childrenProps}>
-                                            {state.waiting
-                                                ? "waiting"
-                                                : "label"}
-                                        </button>
-                                    );
-                                }}
-                            </ClickableBehaviorWithRouter>
-                            <Switch>
-                                <Route path="/foo">
-                                    <div>Hello, world!</div>
-                                </Route>
-                            </Switch>
-                        </div>
+                        <CompatRouter>
+                            <div>
+                                <ClickableBehaviorWithRouter
+                                    href="/foo"
+                                    onClick={(e: any) => {}}
+                                    role="checkbox"
+                                    beforeNav={() => Promise.resolve()}
+                                    safeWithNav={safeWithNavMock}
+                                >
+                                    {(state: any, childrenProps: any) => {
+                                        // The base element here doesn't matter in this testing
+                                        // environment, but the simulated events in the test are in
+                                        // line with what browsers do for this element.
+                                        return (
+                                            <button {...childrenProps}>
+                                                {state.waiting
+                                                    ? "waiting"
+                                                    : "label"}
+                                            </button>
+                                        );
+                                    }}
+                                </ClickableBehaviorWithRouter>
+                                <Routes>
+                                    <Route
+                                        path="/foo"
+                                        element={<div>Hello, world!</div>}
+                                    />
+                                </Routes>
+                            </div>
+                        </CompatRouter>
                     </MemoryRouter>,
                 );
 
@@ -1110,28 +1128,33 @@ describe("ClickableBehavior", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <ClickableBehaviorWithRouter
-                            href="/foo"
-                            onClick={(e: any) => {}}
-                            role="checkbox"
-                            safeWithNav={() => Promise.resolve()}
-                        >
-                            {(state: any, childrenProps: any) => {
-                                // The base element here doesn't matter in this testing
-                                // environment, but the simulated events in the test are in
-                                // line with what browsers do for this element.
-                                return (
-                                    <button {...childrenProps}>label</button>
-                                );
-                            }}
-                        </ClickableBehaviorWithRouter>
-                        <Switch>
-                            <Route path="/foo">
-                                <div>Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <ClickableBehaviorWithRouter
+                                href="/foo"
+                                onClick={(e: any) => {}}
+                                role="checkbox"
+                                safeWithNav={() => Promise.resolve()}
+                            >
+                                {(state: any, childrenProps: any) => {
+                                    // The base element here doesn't matter in this testing
+                                    // environment, but the simulated events in the test are in
+                                    // line with what browsers do for this element.
+                                    return (
+                                        <button {...childrenProps}>
+                                            label
+                                        </button>
+                                    );
+                                }}
+                            </ClickableBehaviorWithRouter>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div>Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -1148,27 +1171,32 @@ describe("ClickableBehavior", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <ClickableBehaviorWithRouter
-                            href="/foo"
-                            onClick={(e: any) => e.preventDefault()}
-                            role="checkbox"
-                        >
-                            {(state: any, childrenProps: any) => {
-                                // The base element here doesn't matter in this testing
-                                // environment, but the simulated events in the test are in
-                                // line with what browsers do for this element.
-                                return (
-                                    <button {...childrenProps}>label</button>
-                                );
-                            }}
-                        </ClickableBehaviorWithRouter>
-                        <Switch>
-                            <Route path="/foo">
-                                <div>Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <ClickableBehaviorWithRouter
+                                href="/foo"
+                                onClick={(e: any) => e.preventDefault()}
+                                role="checkbox"
+                            >
+                                {(state: any, childrenProps: any) => {
+                                    // The base element here doesn't matter in this testing
+                                    // environment, but the simulated events in the test are in
+                                    // line with what browsers do for this element.
+                                    return (
+                                        <button {...childrenProps}>
+                                            label
+                                        </button>
+                                    );
+                                }}
+                            </ClickableBehaviorWithRouter>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div>Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -1284,23 +1312,25 @@ describe("ClickableBehavior", () => {
             // Arrange
             render(
                 <MemoryRouter initialEntries={["/"]}>
-                    <ClickableBehavior
-                        disabled={false}
-                        href="https://www.khanacademy.org"
-                        role="link"
-                        target="_blank"
-                    >
-                        {(state: any, childrenProps: any) => {
-                            return (
-                                <a
-                                    href="https://www.khanacademy.org"
-                                    {...childrenProps}
-                                >
-                                    Label
-                                </a>
-                            );
-                        }}
-                    </ClickableBehavior>
+                    <CompatRouter>
+                        <ClickableBehavior
+                            disabled={false}
+                            href="https://www.khanacademy.org"
+                            role="link"
+                            target="_blank"
+                        >
+                            {(state: any, childrenProps: any) => {
+                                return (
+                                    <a
+                                        href="https://www.khanacademy.org"
+                                        {...childrenProps}
+                                    >
+                                        Label
+                                    </a>
+                                );
+                            }}
+                        </ClickableBehavior>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -1320,24 +1350,26 @@ describe("ClickableBehavior", () => {
             const safeWithNavMock = jest.fn().mockResolvedValue();
             render(
                 <MemoryRouter initialEntries={["/"]}>
-                    <ClickableBehavior
-                        disabled={false}
-                        href="https://www.khanacademy.org"
-                        role="link"
-                        target="_blank"
-                        safeWithNav={safeWithNavMock}
-                    >
-                        {(state: any, childrenProps: any) => {
-                            return (
-                                <a
-                                    href="https://www.khanacademy.org"
-                                    {...childrenProps}
-                                >
-                                    Label
-                                </a>
-                            );
-                        }}
-                    </ClickableBehavior>
+                    <CompatRouter>
+                        <ClickableBehavior
+                            disabled={false}
+                            href="https://www.khanacademy.org"
+                            role="link"
+                            target="_blank"
+                            safeWithNav={safeWithNavMock}
+                        >
+                            {(state: any, childrenProps: any) => {
+                                return (
+                                    <a
+                                        href="https://www.khanacademy.org"
+                                        {...childrenProps}
+                                    >
+                                        Label
+                                    </a>
+                                );
+                            }}
+                        </ClickableBehavior>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -1357,24 +1389,26 @@ describe("ClickableBehavior", () => {
             const safeWithNavMock = jest.fn().mockResolvedValue();
             render(
                 <MemoryRouter initialEntries={["/"]}>
-                    <ClickableBehavior
-                        disabled={false}
-                        href="https://www.khanacademy.org"
-                        role="link"
-                        target="_blank"
-                        safeWithNav={safeWithNavMock}
-                    >
-                        {(state: any, childrenProps: any) => {
-                            return (
-                                <a
-                                    href="https://www.khanacademy.org"
-                                    {...childrenProps}
-                                >
-                                    Label
-                                </a>
-                            );
-                        }}
-                    </ClickableBehavior>
+                    <CompatRouter>
+                        <ClickableBehavior
+                            disabled={false}
+                            href="https://www.khanacademy.org"
+                            role="link"
+                            target="_blank"
+                            safeWithNav={safeWithNavMock}
+                        >
+                            {(state: any, childrenProps: any) => {
+                                return (
+                                    <a
+                                        href="https://www.khanacademy.org"
+                                        {...childrenProps}
+                                    >
+                                        Label
+                                    </a>
+                                );
+                            }}
+                        </ClickableBehavior>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 

--- a/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.tsx
+++ b/packages/wonder-blocks-clickable/src/components/__tests__/clickable.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import {render, screen, fireEvent, waitFor} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
@@ -18,16 +19,19 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <View>
-                    <Clickable testId="button" href="/foo">
-                        {(eventState: any) => <h1>Click Me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <View>Hello, world!</View>
-                        </Route>
-                    </Switch>
-                </View>
+                <CompatRouter>
+                    <View>
+                        <Clickable testId="button" href="/foo">
+                            {(eventState: any) => <h1>Click Me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </View>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -42,16 +46,19 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <View>
-                    <Clickable testId="button" href="/unknown">
-                        {(eventState: any) => <h1>Click Me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <View>Hello, world!</View>
-                        </Route>
-                    </Switch>
-                </View>
+                <CompatRouter>
+                    <View>
+                        <Clickable testId="button" href="/unknown">
+                            {(eventState: any) => <h1>Click Me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </View>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -66,16 +73,19 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <View>
-                    <Clickable testId="button" href="/foo" skipClientNav>
-                        {(eventState: any) => <h1>Click Me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <View>Hello, world!</View>
-                        </Route>
-                    </Switch>
-                </View>
+                <CompatRouter>
+                    <View>
+                        <Clickable testId="button" href="/foo" skipClientNav>
+                            {(eventState: any) => <h1>Click Me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </View>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -90,16 +100,19 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <View>
-                    <Clickable testId="button" href="/foo" disabled={true}>
-                        {(eventState: any) => <h1>Click Me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <View>Hello, world!</View>
-                        </Route>
-                    </Switch>
-                </View>
+                <CompatRouter>
+                    <View>
+                        <Clickable testId="button" href="/foo" disabled={true}>
+                            {(eventState: any) => <h1>Click Me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </View>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -146,20 +159,23 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        beforeNav={() => Promise.reject()}
-                    >
-                        {() => <span>Click me!</span>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            beforeNav={() => Promise.reject()}
+                        >
+                            {() => <span>Click me!</span>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -175,21 +191,24 @@ describe("Clickable", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        beforeNav={() => Promise.reject()}
-                        safeWithNav={safeWithNavMock}
-                    >
-                        {() => <span>Click me!</span>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            beforeNav={() => Promise.reject()}
+                            safeWithNav={safeWithNavMock}
+                        >
+                            {() => <span>Click me!</span>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -204,20 +223,23 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        beforeNav={() => Promise.resolve()}
-                    >
-                        {() => <span>Click me!</span>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                        >
+                            {() => <span>Click me!</span>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -237,21 +259,24 @@ describe("Clickable", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        beforeNav={() => Promise.resolve()}
-                        safeWithNav={safeWithNavMock}
-                    >
-                        {() => <span>Click me!</span>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                            safeWithNav={safeWithNavMock}
+                        >
+                            {() => <span>Click me!</span>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -268,21 +293,24 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        safeWithNav={() => Promise.resolve()}
-                        skipClientNav={true}
-                    >
-                        {() => <h1>Click me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            safeWithNav={() => Promise.resolve()}
+                            skipClientNav={true}
+                        >
+                            {() => <h1>Click me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -299,22 +327,25 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        beforeNav={() => Promise.resolve()}
-                        safeWithNav={() => Promise.resolve()}
-                        skipClientNav={true}
-                    >
-                        {() => <h1>Click me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                            safeWithNav={() => Promise.resolve()}
+                            skipClientNav={true}
+                        >
+                            {() => <h1>Click me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -331,21 +362,24 @@ describe("Clickable", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        safeWithNav={() => Promise.reject()}
-                        skipClientNav={true}
-                    >
-                        {() => <h1>Click me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            safeWithNav={() => Promise.reject()}
+                            skipClientNav={true}
+                        >
+                            {() => <h1>Click me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -363,21 +397,24 @@ describe("Clickable", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        safeWithNav={safeWithNavMock}
-                        skipClientNav={false}
-                    >
-                        {() => <h1>Click me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            safeWithNav={safeWithNavMock}
+                            skipClientNav={false}
+                        >
+                            {() => <h1>Click me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -397,22 +434,25 @@ describe("Clickable", () => {
         const safeWithNavMock = jest.fn();
         render(
             <MemoryRouter>
-                <div>
-                    <Clickable
-                        testId="button"
-                        href="/foo"
-                        beforeNav={() => Promise.resolve()}
-                        safeWithNav={safeWithNavMock}
-                        skipClientNav={false}
-                    >
-                        {() => <h1>Click me!</h1>}
-                    </Clickable>
-                    <Switch>
-                        <Route path="/foo">
-                            <div>Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <Clickable
+                            testId="button"
+                            href="/foo"
+                            beforeNav={() => Promise.resolve()}
+                            safeWithNav={safeWithNavMock}
+                            skipClientNav={false}
+                        >
+                            {() => <h1>Click me!</h1>}
+                        </Clickable>
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<View>Hello, world!</View>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {keys} from "@khanacademy/wonder-blocks-core";
+import {NavigateFunction} from "react-router-dom-v5-compat";
 
 // NOTE: Potentially add to this as more cases come up.
 export type ClickableRole =
@@ -102,10 +103,10 @@ type CommonProps = Readonly<{
      */
     safeWithNav?: () => Promise<unknown>;
     /**
-     * Passed in by withRouter HOC.
+     * Passed in by an HOC in get-clickable-behavior.tsx.
      * @ignore
      */
-    history?: any;
+    navigate?: NavigateFunction;
     /**
      * A role that encapsulates how the clickable component should behave, which
      * affects which keyboard actions trigger the component. For example, a
@@ -354,7 +355,7 @@ export default class ClickableBehavior extends React.Component<
     navigateOrReset(shouldNavigate: boolean) {
         if (shouldNavigate) {
             const {
-                history,
+                navigate,
                 href,
                 skipClientNav,
                 target = undefined,
@@ -363,8 +364,8 @@ export default class ClickableBehavior extends React.Component<
                 if (target === "_blank") {
                     window.open(href, "_blank");
                     this.setState({waiting: false});
-                } else if (history && !skipClientNav) {
-                    history.push(href);
+                } else if (navigate && !skipClientNav) {
+                    navigate(href);
                     this.setState({waiting: false});
                 } else {
                     window.location.assign(href);
@@ -381,9 +382,9 @@ export default class ClickableBehavior extends React.Component<
         safeWithNav: () => Promise<unknown>,
         shouldNavigate: boolean,
     ): Promise<void> {
-        const {skipClientNav, history} = this.props;
+        const {skipClientNav, navigate} = this.props;
 
-        if ((history && !skipClientNav) || this.props.target === "_blank") {
+        if ((navigate && !skipClientNav) || this.props.target === "_blank") {
             // client-side nav
             safeWithNav();
 

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {Link} from "react-router-dom";
+import {Link} from "react-router-dom-v5-compat";
 import {__RouterContext} from "react-router";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {Link} from "react-router-dom-v5-compat";
-import {__RouterContext} from "react-router";
+import {Link, useInRouterContext} from "react-router-dom-v5-compat";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
@@ -215,14 +214,20 @@ const Clickable = React.forwardRef(function Clickable(
 ) {
     const getCorrectTag: (
         clickableState: ClickableState,
-        router: any,
+        inRouterContext: boolean,
         commonProps: {
             [key: string]: any;
         },
-    ) => React.ReactElement = (clickableState, router, commonProps) => {
+    ) => React.ReactElement = (
+        clickableState,
+        inRouterContext,
+        commonProps,
+    ) => {
         const activeHref = props.href && !props.disabled;
         const useClient =
-            router && !props.skipClientNav && isClientSideUrl(props.href || "");
+            inRouterContext &&
+            !props.skipClientNav &&
+            isClientSideUrl(props.href || "");
 
         // NOTE: checking this.props.href here is redundant, but TypeScript
         // needs it to refine this.props.href to a string.
@@ -266,9 +271,8 @@ const Clickable = React.forwardRef(function Clickable(
         }
     };
 
-    const renderClickableBehavior: (router: any) => React.ReactNode = (
-        router: any,
-    ) => {
+    const RenderClickableBehavior = (props: Props) => {
+        const inRouterContext = useInRouterContext();
         const {
             href,
             onClick,
@@ -292,7 +296,7 @@ const Clickable = React.forwardRef(function Clickable(
         const ClickableBehavior = getClickableBehavior(
             href,
             skipClientNav,
-            router,
+            inRouterContext,
         );
 
         const getStyle = (state: ClickableState): StyleType => [
@@ -321,7 +325,7 @@ const Clickable = React.forwardRef(function Clickable(
                     tabIndex={tabIndex}
                 >
                     {(state, childrenProps) =>
-                        getCorrectTag(state, router, {
+                        getCorrectTag(state, inRouterContext, {
                             ...restProps,
                             "data-testid": testId,
                             style: getStyle(state),
@@ -346,7 +350,7 @@ const Clickable = React.forwardRef(function Clickable(
                     tabIndex={tabIndex}
                 >
                     {(state, childrenProps) =>
-                        getCorrectTag(state, router, {
+                        getCorrectTag(state, inRouterContext, {
                             ...restProps,
                             "data-testid": testId,
                             style: getStyle(state),
@@ -358,11 +362,7 @@ const Clickable = React.forwardRef(function Clickable(
         }
     };
 
-    return (
-        <__RouterContext.Consumer>
-            {(router) => renderClickableBehavior(router)}
-        </__RouterContext.Consumer>
-    );
+    return <RenderClickableBehavior {...props} />;
 });
 
 Clickable.defaultProps = {

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -271,98 +271,94 @@ const Clickable = React.forwardRef(function Clickable(
         }
     };
 
-    const RenderClickableBehavior = (props: Props) => {
-        const inRouterContext = useInRouterContext();
-        const {
-            href,
-            onClick,
-            skipClientNav,
-            beforeNav = undefined,
-            safeWithNav = undefined,
-            style,
-            target = undefined,
-            testId,
-            onFocus,
-            onKeyDown,
-            onKeyUp,
-            onMouseDown,
-            onMouseUp,
-            hideDefaultFocusRing,
-            light,
-            disabled,
-            tabIndex,
-            ...restProps
-        } = props;
-        const ClickableBehavior = getClickableBehavior(
-            href,
-            skipClientNav,
-            inRouterContext,
+    const inRouterContext = useInRouterContext();
+    const {
+        href,
+        onClick,
+        skipClientNav,
+        beforeNav = undefined,
+        safeWithNav = undefined,
+        style,
+        target = undefined,
+        testId,
+        onFocus,
+        onKeyDown,
+        onKeyUp,
+        onMouseDown,
+        onMouseUp,
+        hideDefaultFocusRing,
+        light,
+        disabled,
+        tabIndex,
+        ...restProps
+    } = props;
+    const ClickableBehavior = getClickableBehavior(
+        href,
+        skipClientNav,
+        inRouterContext,
+    );
+
+    const getStyle = (state: ClickableState): StyleType => [
+        styles.reset,
+        styles.link,
+        !hideDefaultFocusRing &&
+            state.focused &&
+            (light ? styles.focusedLight : styles.focused),
+        disabled && styles.disabled,
+        style,
+    ];
+
+    if (beforeNav) {
+        return (
+            <ClickableBehavior
+                href={href}
+                onClick={onClick}
+                beforeNav={beforeNav}
+                safeWithNav={safeWithNav}
+                onFocus={onFocus}
+                onKeyDown={onKeyDown}
+                onKeyUp={onKeyUp}
+                onMouseDown={onMouseDown}
+                onMouseUp={onMouseUp}
+                disabled={disabled}
+                tabIndex={tabIndex}
+            >
+                {(state, childrenProps) =>
+                    getCorrectTag(state, inRouterContext, {
+                        ...restProps,
+                        "data-testid": testId,
+                        style: getStyle(state),
+                        ...childrenProps,
+                    })
+                }
+            </ClickableBehavior>
         );
-
-        const getStyle = (state: ClickableState): StyleType => [
-            styles.reset,
-            styles.link,
-            !hideDefaultFocusRing &&
-                state.focused &&
-                (light ? styles.focusedLight : styles.focused),
-            disabled && styles.disabled,
-            style,
-        ];
-
-        if (beforeNav) {
-            return (
-                <ClickableBehavior
-                    href={href}
-                    onClick={onClick}
-                    beforeNav={beforeNav}
-                    safeWithNav={safeWithNav}
-                    onFocus={onFocus}
-                    onKeyDown={onKeyDown}
-                    onKeyUp={onKeyUp}
-                    onMouseDown={onMouseDown}
-                    onMouseUp={onMouseUp}
-                    disabled={disabled}
-                    tabIndex={tabIndex}
-                >
-                    {(state, childrenProps) =>
-                        getCorrectTag(state, inRouterContext, {
-                            ...restProps,
-                            "data-testid": testId,
-                            style: getStyle(state),
-                            ...childrenProps,
-                        })
-                    }
-                </ClickableBehavior>
-            );
-        } else {
-            return (
-                <ClickableBehavior
-                    href={href}
-                    onClick={onClick}
-                    safeWithNav={safeWithNav}
-                    onFocus={onFocus}
-                    onKeyDown={onKeyDown}
-                    onKeyUp={onKeyUp}
-                    onMouseDown={onMouseDown}
-                    onMouseUp={onMouseUp}
-                    target={target}
-                    disabled={disabled}
-                    tabIndex={tabIndex}
-                >
-                    {(state, childrenProps) =>
-                        getCorrectTag(state, inRouterContext, {
-                            ...restProps,
-                            "data-testid": testId,
-                            style: getStyle(state),
-                            ...childrenProps,
-                        })
-                    }
-                </ClickableBehavior>
-            );
-        }
-    };
-
-    return <RenderClickableBehavior {...props} />;
+    } else {
+        return (
+            <ClickableBehavior
+                href={href}
+                onClick={onClick}
+                safeWithNav={safeWithNav}
+                onFocus={onFocus}
+                onKeyDown={onKeyDown}
+                onKeyUp={onKeyUp}
+                onMouseDown={onMouseDown}
+                onMouseUp={onMouseUp}
+                target={target}
+                disabled={disabled}
+                tabIndex={tabIndex}
+            >
+                {(state, childrenProps) =>
+                    getCorrectTag(state, inRouterContext, {
+                        ...restProps,
+                        "data-testid": testId,
+                        style: getStyle(state),
+                        ...childrenProps,
+                    })
+                }
+            </ClickableBehavior>
+        );
+    }
 });
 
 Clickable.defaultProps = {

--- a/packages/wonder-blocks-clickable/src/util/__tests__/get-clickable-behavior.test.tsx
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/get-clickable-behavior.test.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-import {MemoryRouter} from "react-router-dom";
 import ClickableBehavior from "../../components/clickable-behavior";
 import getClickableBehavior from "../get-clickable-behavior";
 
@@ -23,11 +21,15 @@ describe("getClickableBehavior", () => {
             // Arrange
             const url = "http://google.com";
             const skipClientNav = undefined;
-            const router = <MemoryRouter />;
+            const inRouterContext = true;
             const expectation = ClickableBehavior;
 
             // Act
-            const result = getClickableBehavior(url, skipClientNav, router);
+            const result = getClickableBehavior(
+                url,
+                skipClientNav,
+                inRouterContext,
+            );
 
             // Assert
             expect(result).toBe(expectation);
@@ -39,14 +41,14 @@ describe("getClickableBehavior", () => {
                     // Arrange
                     const url = "/prep/lsat";
                     const skipClientNav = undefined;
-                    const router = undefined;
+                    const inRouterContext = false;
                     const expectation = ClickableBehavior;
 
                     // Act
                     const result = getClickableBehavior(
                         url,
                         skipClientNav,
-                        router,
+                        inRouterContext,
                     );
 
                     // Assert
@@ -57,14 +59,14 @@ describe("getClickableBehavior", () => {
                     // Arrange
                     const url = "/prep/lsat";
                     const skipClientNav = undefined;
-                    const router = <MemoryRouter />;
+                    const inRouterContext = true;
                     const expectation = "withRouter(ClickableBehavior)";
 
                     // Act
                     const result = getClickableBehavior(
                         url,
                         skipClientNav,
-                        router,
+                        inRouterContext,
                     );
 
                     // Assert
@@ -76,11 +78,15 @@ describe("getClickableBehavior", () => {
                 // Arrange
                 const url = "/prep/lsat";
                 const skipClientNav = false;
-                const router = <MemoryRouter />;
+                const inRouterContext = true;
                 const expectation = "withRouter(ClickableBehavior)";
 
                 // Act
-                const result = getClickableBehavior(url, skipClientNav, router);
+                const result = getClickableBehavior(
+                    url,
+                    skipClientNav,
+                    inRouterContext,
+                );
 
                 // Assert
                 expect((result as any).displayName).toBe(expectation);
@@ -90,11 +96,15 @@ describe("getClickableBehavior", () => {
                 // Arrange
                 const url = "/prep/lsat";
                 const skipClientNav = true;
-                const router = <MemoryRouter />;
+                const inRouterContext = true;
                 const expectation = ClickableBehavior;
 
                 // Act
-                const result = getClickableBehavior(url, skipClientNav, router);
+                const result = getClickableBehavior(
+                    url,
+                    skipClientNav,
+                    inRouterContext,
+                );
 
                 // Assert
                 expect(result).toBe(expectation);

--- a/packages/wonder-blocks-clickable/src/util/__tests__/get-clickable-behavior.test.tsx
+++ b/packages/wonder-blocks-clickable/src/util/__tests__/get-clickable-behavior.test.tsx
@@ -68,7 +68,7 @@ describe("getClickableBehavior", () => {
                     );
 
                     // Assert
-                    expect(result.displayName).toBe(expectation);
+                    expect((result as any).displayName).toBe(expectation);
                 });
             });
 
@@ -83,7 +83,7 @@ describe("getClickableBehavior", () => {
                 const result = getClickableBehavior(url, skipClientNav, router);
 
                 // Assert
-                expect(result.displayName).toBe(expectation);
+                expect((result as any).displayName).toBe(expectation);
             });
 
             test("skipClientNav is true, returns ClickableBehavior", () => {

--- a/packages/wonder-blocks-clickable/src/util/get-clickable-behavior.tsx
+++ b/packages/wonder-blocks-clickable/src/util/get-clickable-behavior.tsx
@@ -9,14 +9,24 @@
  * See https://reacttraining.com/react-router/web/guides/basic-components.
  */
 import * as React from "react";
-import {withRouter} from "react-router-dom";
-
-import {PropsFor} from "@khanacademy/wonder-blocks-core";
+import {useNavigate} from "react-router-dom-v5-compat";
 
 import ClickableBehavior from "../components/clickable-behavior";
 import {isClientSideUrl} from "./is-client-side-url";
 
-// @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'typeof ClickableBehavior' is not assignable to parameter of type 'ComponentType<RouteComponentProps<any, StaticContext, unknown>>'.
+// Create a wrapper component that uses useNavigate
+function withRouter(Component: typeof ClickableBehavior) {
+    function WithRouterWrapper(
+        props: Omit<React.ComponentProps<typeof ClickableBehavior>, "navigate">,
+    ) {
+        const navigate = useNavigate();
+        // @ts-expect-error Ignoring the type mismatch
+        return <Component {...props} navigate={navigate} />;
+    }
+    WithRouterWrapper.displayName = "withRouter(ClickableBehavior)";
+    return WithRouterWrapper;
+}
+
 const ClickableBehaviorWithRouter = withRouter(ClickableBehavior);
 
 export default function getClickableBehavior(
@@ -32,15 +42,10 @@ export default function getClickableBehavior(
      * router object added to the React context object by react-router-dom.
      */
     router?: any,
-): React.ComponentType<PropsFor<typeof ClickableBehavior>> {
+): typeof ClickableBehavior {
     if (router && skipClientNav !== true && href && isClientSideUrl(href)) {
-        // We cast to `any` here since the type of ClickableBehaviorWithRouter
-        // is slightly different from the return type of this function.
-        // TODO(WB-1037): Always return the wrapped version once all routes have
-        // been ported to the app-shell in webapp.
-        return ClickableBehaviorWithRouter as any;
+        return ClickableBehaviorWithRouter as unknown as typeof ClickableBehavior;
     }
 
-    // @ts-expect-error [FEI-5019] - TS2322 - Type 'typeof ClickableBehavior' is not assignable to type 'ComponentType<Pick<Props, "children" | "href" | "tabIndex" | "role" | "target" | "type" | "rel" | "onKeyDown" | "onKeyUp" | "onClick" | "history" | "skipClientNav" | "safeWithNav" | "beforeNav"> & InexactPartial<...> & InexactPartial<...>>'.
     return ClickableBehavior;
 }

--- a/packages/wonder-blocks-clickable/src/util/get-clickable-behavior.tsx
+++ b/packages/wonder-blocks-clickable/src/util/get-clickable-behavior.tsx
@@ -39,11 +39,16 @@ export default function getClickableBehavior(
      */
     skipClientNav?: boolean,
     /**
-     * router object added to the React context object by react-router-dom.
+     * Whether we're in a react-router context.
      */
-    router?: any,
+    inRouterContext?: boolean,
 ): typeof ClickableBehavior {
-    if (router && skipClientNav !== true && href && isClientSideUrl(href)) {
+    if (
+        inRouterContext &&
+        skipClientNav !== true &&
+        href &&
+        isClientSideUrl(href)
+    ) {
         return ClickableBehaviorWithRouter as unknown as typeof ClickableBehavior;
     }
 

--- a/packages/wonder-blocks-core/package.json
+++ b/packages/wonder-blocks-core/package.json
@@ -21,7 +21,8 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-router": "catalog:",
-    "react-router-dom": "catalog:"
+    "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -39,6 +39,7 @@
     "react-popper": "catalog:",
     "react-router": "catalog:",
     "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:",
     "react-window": "catalog:"
   },
   "devDependencies": {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-item.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-item.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import * as ReactRouterDOM from "react-router-dom";
+import * as ReactRouterDOMV5Compat from "react-router-dom-v5-compat";
 
 import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -39,14 +40,18 @@ describe("ActionItem", () => {
         expect(document.querySelectorAll("a")).toHaveLength(1);
     });
 
-    it("should render a Link if there's a router", () => {
+    // NOTE(john): After upgrading to React Router v6, the Link component
+    // appears to not be mockable, it's an object instead of a function.
+    it.skip("should render a Link if there's a router", () => {
         // Arrange
-        const linkSpy = jest.spyOn(ReactRouterDOM, "Link");
+        const linkSpy = jest.spyOn(ReactRouterDOMV5Compat, "Link");
 
         // Act
         render(
             <ReactRouterDOM.MemoryRouter>
-                <ActionItem href="/foo" label="Example" />
+                <ReactRouterDOMV5Compat.CompatRouter>
+                    <ActionItem href="/foo" label="Example" />
+                </ReactRouterDOMV5Compat.CompatRouter>
             </ReactRouterDOM.MemoryRouter>,
         );
 

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -28,7 +28,8 @@
     "aphrodite": "catalog:",
     "react": "catalog:",
     "react-router": "catalog:",
-    "react-router-dom": "catalog:"
+    "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import {fireEvent, render, screen} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import {IconButton} from "../icon-button";
@@ -44,19 +45,22 @@ describe("IconButton", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <IconButton
-                        icon={magnifyingGlassIcon}
-                        aria-label="search"
-                        testId="icon-button"
-                        href="/foo"
-                    />
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <IconButton
+                            icon={magnifyingGlassIcon}
+                            aria-label="search"
+                            testId="icon-button"
+                            href="/foo"
+                        />
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -71,19 +75,22 @@ describe("IconButton", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <IconButton
-                        icon={magnifyingGlassIcon}
-                        aria-label="search"
-                        testId="icon-button"
-                        href="/unknown"
-                    />
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <IconButton
+                            icon={magnifyingGlassIcon}
+                            aria-label="search"
+                            testId="icon-button"
+                            href="/unknown"
+                        />
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -98,20 +105,23 @@ describe("IconButton", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <div>
-                    <IconButton
-                        icon={magnifyingGlassIcon}
-                        aria-label="search"
-                        testId="icon-button"
-                        href="/foo"
-                        skipClientNav
-                    />
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <IconButton
+                            icon={magnifyingGlassIcon}
+                            aria-label="search"
+                            testId="icon-button"
+                            href="/foo"
+                            skipClientNav
+                        />
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -125,20 +135,23 @@ describe("IconButton", () => {
     test("disallow navigation when href and disabled are both set", async () => {
         render(
             <MemoryRouter>
-                <div>
-                    <IconButton
-                        icon={magnifyingGlassIcon}
-                        aria-label="search"
-                        testId="icon-button"
-                        href="/foo"
-                        disabled={true}
-                    />
-                    <Switch>
-                        <Route path="/foo">
-                            <div id="foo">Hello, world!</div>
-                        </Route>
-                    </Switch>
-                </div>
+                <CompatRouter>
+                    <div>
+                        <IconButton
+                            icon={magnifyingGlassIcon}
+                            aria-label="search"
+                            testId="icon-button"
+                            href="/foo"
+                            disabled={true}
+                        />
+                        <Routes>
+                            <Route
+                                path="/foo"
+                                element={<div id="foo">Hello, world!</div>}
+                            />
+                        </Routes>
+                    </div>
+                </CompatRouter>
             </MemoryRouter>,
         );
 
@@ -208,7 +221,9 @@ describe("IconButton", () => {
         // Arrange
         render(
             <MemoryRouter>
-                <IconButton icon={magnifyingGlassIcon} href="#" />,
+                <CompatRouter>
+                    <IconButton icon={magnifyingGlassIcon} href="#" />,
+                </CompatRouter>
             </MemoryRouter>,
         );
 

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-core.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {Link} from "react-router-dom";
-import {__RouterContext} from "react-router";
+import {Link, useInRouterContext} from "react-router-dom-v5-compat";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
@@ -103,69 +102,62 @@ const IconButtonCore: React.ForwardRefExoticComponent<
         ...restProps
     } = props;
     const {theme, themeName} = useScopedTheme(IconButtonThemeContext);
+    const inRouterContext = useInRouterContext();
 
-    const renderInner = (router: any): React.ReactNode => {
-        const buttonStyles = _generateStyles(
-            actionType,
-            !!disabled,
-            kind,
-            size,
-            theme,
-            themeName,
-        );
-
-        const defaultStyle = [
-            sharedStyles.shared,
-            buttonStyles.default,
-            disabled && buttonStyles.disabled,
-        ];
-
-        const child = <IconChooser size={size} icon={icon} />;
-
-        const commonProps = {
-            "data-testid": testId,
-            style: [defaultStyle, style],
-            ...restProps,
-        } as const;
-
-        if (href && !disabled) {
-            return router && !skipClientNav && isClientSideUrl(href) ? (
-                <StyledLink
-                    {...commonProps}
-                    to={href}
-                    ref={ref as React.Ref<typeof Link>}
-                >
-                    {child}
-                </StyledLink>
-            ) : (
-                <StyledA
-                    {...commonProps}
-                    href={href}
-                    ref={ref as React.Ref<HTMLAnchorElement>}
-                >
-                    {child}
-                </StyledA>
-            );
-        } else {
-            return (
-                <StyledButton
-                    type={type}
-                    {...commonProps}
-                    onClick={disabled ? undefined : restProps.onClick}
-                    aria-disabled={disabled}
-                    ref={ref as React.Ref<HTMLButtonElement>}
-                >
-                    {child}
-                </StyledButton>
-            );
-        }
-    };
-
-    return (
-        <__RouterContext.Consumer>
-            {(router) => renderInner(router)}
-        </__RouterContext.Consumer>
+    const buttonStyles = _generateStyles(
+        actionType,
+        !!disabled,
+        kind,
+        size,
+        theme,
+        themeName,
     );
+
+    const defaultStyle = [
+        sharedStyles.shared,
+        buttonStyles.default,
+        disabled && buttonStyles.disabled,
+    ];
+
+    const child = <IconChooser size={size} icon={icon} />;
+
+    const commonProps = {
+        "data-testid": testId,
+        style: [defaultStyle, style],
+        ...restProps,
+    } as const;
+
+    if (href && !disabled) {
+        return inRouterContext && !skipClientNav && isClientSideUrl(href) ? (
+            <StyledLink
+                {...commonProps}
+                to={href}
+                ref={ref as React.Ref<typeof Link>}
+            >
+                {child}
+            </StyledLink>
+        ) : (
+            <StyledA
+                {...commonProps}
+                href={href}
+                ref={ref as React.Ref<HTMLAnchorElement>}
+            >
+                {child}
+            </StyledA>
+        );
+    } else {
+        return (
+            <StyledButton
+                type={type}
+                {...commonProps}
+                onClick={disabled ? undefined : restProps.onClick}
+                aria-disabled={disabled}
+                ref={ref as React.Ref<HTMLButtonElement>}
+            >
+                {child}
+            </StyledButton>
+        );
+    }
 });
 
 export default IconButtonCore;

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import type {PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import {Link} from "react-router-dom";
+import {Link} from "react-router-dom-v5-compat";
 import IconButtonCore from "./icon-button-core";
 import ThemedIconButton from "../themes/themed-icon-button";
 

--- a/packages/wonder-blocks-link/package.json
+++ b/packages/wonder-blocks-link/package.json
@@ -27,7 +27,8 @@
     "aphrodite": "catalog:",
     "react": "catalog:",
     "react-router": "catalog:",
-    "react-router-dom": "catalog:"
+    "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*"

--- a/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import {MemoryRouter, Route, Switch} from "react-router-dom";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
@@ -29,14 +30,17 @@ describe("Link", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Link href="/foo">Click me!</Link>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Link href="/foo">Click me!</Link>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -54,14 +58,17 @@ describe("Link", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Link href="/">Click me!</Link>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Link href="/">Click me!</Link>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -80,16 +87,22 @@ describe("Link", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Link href="/foo" beforeNav={() => Promise.resolve()}>
-                            Click me!
-                        </Link>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Link
+                                href="/foo"
+                                beforeNav={() => Promise.resolve()}
+                            >
+                                Click me!
+                            </Link>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -108,16 +121,22 @@ describe("Link", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Link href="/foo" beforeNav={() => Promise.resolve()}>
-                            Click me!
-                        </Link>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Link
+                                href="/foo"
+                                beforeNav={() => Promise.resolve()}
+                            >
+                                Click me!
+                            </Link>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -133,16 +152,22 @@ describe("Link", () => {
             // Arrange
             render(
                 <MemoryRouter>
-                    <div>
-                        <Link href="/foo" beforeNav={() => Promise.reject()}>
-                            Click me!
-                        </Link>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Link
+                                href="/foo"
+                                beforeNav={() => Promise.reject()}
+                            >
+                                Click me!
+                            </Link>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -159,20 +184,23 @@ describe("Link", () => {
             const safeWithNavMock = jest.fn();
             render(
                 <MemoryRouter>
-                    <div>
-                        <Link
-                            href="/foo"
-                            beforeNav={() => Promise.resolve()}
-                            safeWithNav={safeWithNavMock}
-                        >
-                            Click me!
-                        </Link>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Link
+                                href="/foo"
+                                beforeNav={() => Promise.resolve()}
+                                safeWithNav={safeWithNavMock}
+                            >
+                                Click me!
+                            </Link>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 
@@ -194,20 +222,23 @@ describe("Link", () => {
             const safeWithNavMock = jest.fn();
             render(
                 <MemoryRouter>
-                    <div>
-                        <Link
-                            href="/foo"
-                            beforeNav={() => Promise.resolve()}
-                            safeWithNav={safeWithNavMock}
-                        >
-                            Click me!
-                        </Link>
-                        <Switch>
-                            <Route path="/foo">
-                                <div id="foo">Hello, world!</div>
-                            </Route>
-                        </Switch>
-                    </div>
+                    <CompatRouter>
+                        <div>
+                            <Link
+                                href="/foo"
+                                beforeNav={() => Promise.resolve()}
+                                safeWithNav={safeWithNavMock}
+                            >
+                                Click me!
+                            </Link>
+                            <Routes>
+                                <Route
+                                    path="/foo"
+                                    element={<div id="foo">Hello, world!</div>}
+                                />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
                 </MemoryRouter>,
             );
 

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {Link} from "react-router-dom";
-import {__RouterContext} from "react-router";
+import {Link, useInRouterContext} from "react-router-dom-v5-compat";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {
@@ -34,116 +33,107 @@ const LinkCore = React.forwardRef(function LinkCore(
     props: Props,
     ref: React.ForwardedRef<typeof Link | HTMLAnchorElement>,
 ) {
-    const renderInner = (router: any): React.ReactNode => {
-        const {
-            children,
-            skipClientNav,
-            focused,
-            hovered, // eslint-disable-line @typescript-eslint/no-unused-vars
-            href,
-            inline = false,
-            light = false,
-            pressed,
-            style,
-            testId,
-            waiting: _,
-            target,
-            startIcon,
-            endIcon,
-            ...restProps
-        } = props;
+    const inRouterContext = useInRouterContext();
 
-        const linkStyles = _generateStyles(inline, light);
+    const {
+        children,
+        skipClientNav,
+        focused,
+        hovered, // eslint-disable-line @typescript-eslint/no-unused-vars
+        href,
+        inline = false,
+        light = false,
+        pressed,
+        style,
+        testId,
+        waiting: _,
+        target,
+        startIcon,
+        endIcon,
+        ...restProps
+    } = props;
 
-        const defaultStyles = [
-            sharedStyles.shared,
-            linkStyles.rest,
-            inline && linkStyles.restInline,
-            // focused is preserved to allow for programmatic focus.
-            !pressed && focused && linkStyles.focus,
-        ];
+    const linkStyles = _generateStyles(inline, light);
 
-        const commonProps = {
-            "data-testid": testId,
-            style: [defaultStyles, style],
-            target,
-            ...restProps,
-        } as const;
+    const defaultStyles = [
+        sharedStyles.shared,
+        linkStyles.rest,
+        inline && linkStyles.restInline,
+        // focused is preserved to allow for programmatic focus.
+        !pressed && focused && linkStyles.focus,
+    ];
 
-        const linkUrl = new URL(href, window.location.origin);
+    const commonProps = {
+        "data-testid": testId,
+        style: [defaultStyles, style],
+        target,
+        ...restProps,
+    } as const;
 
-        const isExternalLink = linkUrl.origin !== window.location.origin;
+    const linkUrl = new URL(href, window.location.origin);
 
-        const externalIcon = (
-            <PhosphorIcon
-                icon={externalLinkIcon}
-                size="small"
-                style={[linkContentStyles.endIcon, linkContentStyles.centered]}
-                testId="external-icon"
-            />
-        );
+    const isExternalLink = linkUrl.origin !== window.location.origin;
 
-        let startIconElement;
-        let endIconElement;
+    const externalIcon = (
+        <PhosphorIcon
+            icon={externalLinkIcon}
+            size="small"
+            style={[linkContentStyles.endIcon, linkContentStyles.centered]}
+            testId="external-icon"
+        />
+    );
 
-        if (startIcon) {
-            startIconElement = React.cloneElement(startIcon, {
-                style: [
-                    linkContentStyles.startIcon,
-                    linkContentStyles.centered,
-                ],
-                testId: "start-icon",
-                "aria-hidden": "true",
-                ...startIcon.props,
-            } as Partial<
-                React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>
-            >);
-        }
+    let startIconElement;
+    let endIconElement;
 
-        if (endIcon) {
-            endIconElement = React.cloneElement(endIcon, {
-                style: [linkContentStyles.endIcon, linkContentStyles.centered],
-                testId: "end-icon",
-                "aria-hidden": "true",
-                ...endIcon.props,
-            } as Partial<
-                React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>
-            >);
-        }
+    if (startIcon) {
+        startIconElement = React.cloneElement(startIcon, {
+            style: [linkContentStyles.startIcon, linkContentStyles.centered],
+            testId: "start-icon",
+            "aria-hidden": "true",
+            ...startIcon.props,
+        } as Partial<
+            React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>
+        >);
+    }
 
-        const linkContent = (
-            <>
-                {startIcon && startIconElement}
-                {children}
-                {endIcon
-                    ? endIconElement
-                    : isExternalLink && target === "_blank" && externalIcon}
-            </>
-        );
+    if (endIcon) {
+        endIconElement = React.cloneElement(endIcon, {
+            style: [linkContentStyles.endIcon, linkContentStyles.centered],
+            testId: "end-icon",
+            "aria-hidden": "true",
+            ...endIcon.props,
+        } as Partial<
+            React.ReactElement<React.ComponentProps<typeof PhosphorIcon>>
+        >);
+    }
 
-        return router && !skipClientNav && isClientSideUrl(href) ? (
-            <StyledLink
-                {...commonProps}
-                to={href}
-                ref={ref as React.ForwardedRef<typeof Link>}
-            >
-                {linkContent}
-            </StyledLink>
-        ) : (
-            <StyledA
-                {...commonProps}
-                href={href}
-                ref={ref as React.ForwardedRef<HTMLAnchorElement>}
-            >
-                {linkContent}
-            </StyledA>
-        );
-    };
+    const linkContent = (
+        <>
+            {startIcon && startIconElement}
+            {children}
+            {endIcon
+                ? endIconElement
+                : isExternalLink && target === "_blank" && externalIcon}
+        </>
+    );
 
-    return (
-        <__RouterContext.Consumer>
-            {(router) => renderInner(router)}
-        </__RouterContext.Consumer>
+    return inRouterContext && !skipClientNav && isClientSideUrl(href) ? (
+        <StyledLink
+            {...commonProps}
+            to={href}
+            ref={ref as React.ForwardedRef<typeof Link>}
+        >
+            {linkContent}
+        </StyledLink>
+    ) : (
+        <StyledA
+            {...commonProps}
+            href={href}
+            ref={ref as React.ForwardedRef<HTMLAnchorElement>}
+        >
+            {linkContent}
+        </StyledA>
     );
 });
 

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
-import {__RouterContext} from "react-router";
-import {Link as ReactRouterLink} from "react-router-dom";
+import {
+    Link as ReactRouterLink,
+    useInRouterContext,
+} from "react-router-dom-v5-compat";
 import {getClickableBehavior} from "@khanacademy/wonder-blocks-clickable";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
@@ -192,85 +194,79 @@ const Link = React.forwardRef(function Link(
         ...sharedProps
     } = props;
 
-    const renderClickableBehavior = (router: any): React.ReactNode => {
-        const ClickableBehavior = getClickableBehavior(
-            href,
-            skipClientNav,
-            router,
-        );
+    const inRouterContext = useInRouterContext();
 
-        if (beforeNav) {
-            return (
-                <ClickableBehavior
-                    disabled={false}
-                    href={href}
-                    role="link"
-                    onClick={onClick}
-                    beforeNav={beforeNav}
-                    safeWithNav={safeWithNav}
-                    onKeyDown={onKeyDown}
-                    onKeyUp={onKeyUp}
-                >
-                    {(state, {...childrenProps}) => {
-                        return (
-                            <LinkCore
-                                {...sharedProps}
-                                {...state}
-                                {...childrenProps}
-                                skipClientNav={skipClientNav}
-                                href={href}
-                                target={target}
-                                tabIndex={tabIndex}
-                                inline={inline}
-                                light={light}
-                                ref={ref}
-                            >
-                                {children}
-                            </LinkCore>
-                        );
-                    }}
-                </ClickableBehavior>
-            );
-        } else {
-            return (
-                <ClickableBehavior
-                    disabled={false}
-                    href={href}
-                    role="link"
-                    onClick={onClick}
-                    safeWithNav={safeWithNav}
-                    target={target}
-                    onKeyDown={onKeyDown}
-                    onKeyUp={onKeyUp}
-                >
-                    {(state, {...childrenProps}) => {
-                        return (
-                            <LinkCore
-                                {...sharedProps}
-                                {...state}
-                                {...childrenProps}
-                                skipClientNav={skipClientNav}
-                                href={href}
-                                target={target}
-                                tabIndex={tabIndex}
-                                inline={inline}
-                                light={light}
-                                ref={ref}
-                            >
-                                {children}
-                            </LinkCore>
-                        );
-                    }}
-                </ClickableBehavior>
-            );
-        }
-    };
-
-    return (
-        <__RouterContext.Consumer>
-            {(router) => renderClickableBehavior(router)}
-        </__RouterContext.Consumer>
+    const ClickableBehavior = getClickableBehavior(
+        href,
+        skipClientNav,
+        inRouterContext,
     );
+
+    if (beforeNav) {
+        return (
+            <ClickableBehavior
+                disabled={false}
+                href={href}
+                role="link"
+                onClick={onClick}
+                beforeNav={beforeNav}
+                safeWithNav={safeWithNav}
+                onKeyDown={onKeyDown}
+                onKeyUp={onKeyUp}
+            >
+                {(state, {...childrenProps}) => {
+                    return (
+                        <LinkCore
+                            {...sharedProps}
+                            {...state}
+                            {...childrenProps}
+                            skipClientNav={skipClientNav}
+                            href={href}
+                            target={target}
+                            tabIndex={tabIndex}
+                            inline={inline}
+                            light={light}
+                            ref={ref}
+                        >
+                            {children}
+                        </LinkCore>
+                    );
+                }}
+            </ClickableBehavior>
+        );
+    } else {
+        return (
+            <ClickableBehavior
+                disabled={false}
+                href={href}
+                role="link"
+                onClick={onClick}
+                safeWithNav={safeWithNav}
+                target={target}
+                onKeyDown={onKeyDown}
+                onKeyUp={onKeyUp}
+            >
+                {(state, {...childrenProps}) => {
+                    return (
+                        <LinkCore
+                            {...sharedProps}
+                            {...state}
+                            {...childrenProps}
+                            skipClientNav={skipClientNav}
+                            href={href}
+                            target={target}
+                            tabIndex={tabIndex}
+                            inline={inline}
+                            light={light}
+                            ref={ref}
+                        >
+                            {children}
+                        </LinkCore>
+                    );
+                }}
+            </ClickableBehavior>
+        );
+    }
 });
 
 export default Link;

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import {render, screen, waitFor} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
+import {MemoryRouter} from "react-router-dom";
+import {CompatRouter} from "react-router-dom-v5-compat";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
@@ -295,33 +297,39 @@ describe("ModalLauncher", () => {
             };
 
             return (
-                <View>
-                    <Button>Top of page (should not receive focus)</Button>
-                    <Button
-                        testId="launcher-button"
-                        onClick={() => handleOpen()}
-                    >
-                        Open modal
-                    </Button>
-                    <ModalLauncher
-                        onClose={() => handleClose()}
-                        opened={opened}
-                        modal={({closeModal}: any) => (
-                            <OnePaneDialog
-                                title="Regular modal"
-                                content={<View>Hello World</View>}
-                                footer={
-                                    <Button
-                                        testId="modal-close-button"
-                                        onClick={closeModal}
-                                    >
-                                        Close Modal
-                                    </Button>
-                                }
+                <MemoryRouter>
+                    <CompatRouter>
+                        <View>
+                            <Button>
+                                Top of page (should not receive focus)
+                            </Button>
+                            <Button
+                                testId="launcher-button"
+                                onClick={() => handleOpen()}
+                            >
+                                Open modal
+                            </Button>
+                            <ModalLauncher
+                                onClose={() => handleClose()}
+                                opened={opened}
+                                modal={({closeModal}: any) => (
+                                    <OnePaneDialog
+                                        title="Regular modal"
+                                        content={<View>Hello World</View>}
+                                        footer={
+                                            <Button
+                                                testId="modal-close-button"
+                                                onClick={closeModal}
+                                            >
+                                                Close Modal
+                                            </Button>
+                                        }
+                                    />
+                                )}
                             />
-                        )}
-                    />
-                </View>
+                        </View>
+                    </CompatRouter>
+                </MemoryRouter>
             );
         };
 

--- a/packages/wonder-blocks-testing-core/package.json
+++ b/packages/wonder-blocks-testing-core/package.json
@@ -23,7 +23,8 @@
     "node-fetch": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-router-dom": "catalog:"
+    "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",

--- a/packages/wonder-blocks-testing-core/src/__tests__/render-hook-static.test.ts
+++ b/packages/wonder-blocks-testing-core/src/__tests__/render-hook-static.test.ts
@@ -1,4 +1,4 @@
-import {useLocation} from "react-router-dom";
+import {useLocation} from "react-router-dom-v5-compat";
 
 import {hookHarness} from "../harness/hook-harness";
 import {renderHookStatic} from "../render-hook-static";

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.test.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {withRouter, Prompt} from "react-router-dom";
+import {useLocation, useNavigate} from "react-router-dom-v5-compat";
 import {render} from "@testing-library/react";
 import * as Router from "../router";
 
@@ -27,50 +27,47 @@ describe("Router.adapter", () => {
     `("with $type config", ({config}: any) => {
         it("should allow navigation", () => {
             // Arrange
-            const historyListen = jest.fn();
-            const HistoryListener = withRouter(
-                ({history}: any): React.ReactElement | null => {
-                    React.useEffect(
-                        () => history.listen(historyListen),
-                        [history],
-                    );
-                    if (history.location.pathname === "/math") {
-                        history.push("/math/calculator");
-                    }
-                    return null;
-                },
-            );
+            const navigateListen = jest.fn();
+            const NavigateListener = (): React.ReactElement | null => {
+                const navigate = useNavigate();
+                const location = useLocation();
+                React.useEffect(() => navigateListen(location), [location]);
+                if (location.pathname === "/math") {
+                    navigate("/math/calculator");
+                }
+                return null;
+            };
 
             // Act
-            render(Router.adapter(<HistoryListener />, config));
+            render(Router.adapter(<NavigateListener />, config));
 
             // Assert
-            expect(historyListen).not.toHaveBeenCalled();
+            expect(navigateListen).toHaveBeenCalledOnce();
+            expect(navigateListen).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    pathname: "/math",
+                }),
+            );
         });
 
-        it("should have default route match of root /", () => {
+        it("should have default route match of /math", () => {
             // Arrange
-            const matchCatcherFn = jest.fn();
-            const MatchCatcher = withRouter(
-                ({match, history}: any): React.ReactElement | null => {
-                    React.useEffect(() => {
-                        if (history.location.pathname === "/math") {
-                            history.push("/math/calculator");
-                        }
-                        matchCatcherFn(match);
-                    }, [match, history]);
-                    return null;
-                },
-            );
+            const locationCatcherFn = jest.fn();
+            const LocationCatcher = (): React.ReactElement | null => {
+                const location = useLocation();
+                React.useEffect(() => {
+                    locationCatcherFn(location);
+                }, [location]);
+                return null;
+            };
 
             // Act
-            render(Router.adapter(<MatchCatcher />, config));
+            render(Router.adapter(<LocationCatcher />, config));
 
             // Assert
-            expect(matchCatcherFn).toHaveBeenLastCalledWith(
+            expect(locationCatcherFn).toHaveBeenLastCalledWith(
                 expect.objectContaining({
-                    path: "/",
-                    url: "/",
+                    pathname: "/math",
                 }),
             );
         });
@@ -83,25 +80,22 @@ describe("Router.adapter", () => {
     `("with $type config including path", ({config}: any) => {
         it("should include routing for the given path", () => {
             // Arrange
-            const matchCatcherFn = jest.fn();
-            const MatchCatcher = withRouter(
-                ({match}: any): React.ReactElement | null => {
-                    React.useEffect(() => {
-                        matchCatcherFn(match);
-                    }, [match]);
-                    return null;
-                },
-            );
+            const locationCatcherFn = jest.fn();
+            const LocationCatcher = (): React.ReactElement | null => {
+                const location = useLocation();
+                React.useEffect(() => {
+                    locationCatcherFn(location);
+                }, [location]);
+                return null;
+            };
 
             // Act
-            render(Router.adapter(<MatchCatcher />, config));
+            render(Router.adapter(<LocationCatcher />, config));
 
             // Assert
-            expect(matchCatcherFn).toHaveBeenLastCalledWith(
+            expect(locationCatcherFn).toHaveBeenLastCalledWith(
                 expect.objectContaining({
-                    isExact: true,
-                    path: "/math/*",
-                    url: "/math/calculator",
+                    pathname: "/math/calculator",
                 }),
             );
         });
@@ -128,76 +122,76 @@ describe("Router.adapter", () => {
     describe("with forceStatic", () => {
         it("should not navigate", () => {
             // Arrange
-            const historyListen = jest.fn();
-            const HistoryListener = withRouter(
-                ({history}: any): React.ReactElement | null => {
-                    React.useEffect(
-                        () => history.listen(historyListen),
-                        [history],
-                    );
-                    if (history.location.pathname === "/math") {
-                        history.push("/math/calculator");
-                    }
-                    return null;
-                },
-            );
+            const navigateListen = jest.fn();
+            const NavigateListener = (): React.ReactElement | null => {
+                const navigate = useNavigate();
+                const location = useLocation();
+                React.useEffect(() => navigateListen(location), [location]);
+                if (location.pathname === "/math") {
+                    navigate("/math/calculator");
+                }
+                return null;
+            };
 
             // Act
             render(
-                Router.adapter(<HistoryListener />, {
+                Router.adapter(<NavigateListener />, {
                     location: "/math",
                     forceStatic: true,
                 }),
             );
 
             // Assert
-            expect(historyListen).not.toHaveBeenCalled();
+            expect(navigateListen).toHaveBeenCalledOnce();
+            expect(navigateListen).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    pathname: "/math",
+                }),
+            );
         });
     });
 
     describe("with initialEntries", () => {
         it("should use the defaultConfig location if initialEntries is empty", () => {
             // Arrange
-            const matchCatcherFn = jest.fn();
-            const MatchCatcher = withRouter(
-                ({match, history}: any): React.ReactElement | null => {
-                    React.useEffect(() => {
-                        matchCatcherFn(match);
-                    }, [match, history]);
-                    return null;
-                },
-            );
+            const locationCatcherFn = jest.fn();
+            const LocationCatcher = (): React.ReactElement | null => {
+                const location = useLocation();
+                React.useEffect(() => {
+                    locationCatcherFn(location);
+                }, [location]);
+                return null;
+            };
 
             // Act
             render(
-                Router.adapter(<MatchCatcher />, {
+                Router.adapter(<LocationCatcher />, {
                     initialEntries: [],
                 }),
             );
 
             // Assert
-            expect(matchCatcherFn).toHaveBeenLastCalledWith(
+            expect(locationCatcherFn).toHaveBeenLastCalledWith(
                 expect.objectContaining({
-                    url: Router.defaultConfig.location,
+                    pathname: Router.defaultConfig.location,
                 }),
             );
         });
 
         it("should set initialIndex prop on MemoryRouter if given in configuration", () => {
             // Arrange
-            const matchCatcherFn = jest.fn();
-            const MatchCatcher = withRouter(
-                ({match}: any): React.ReactElement | null => {
-                    React.useEffect(() => {
-                        matchCatcherFn(match);
-                    }, [match]);
-                    return null;
-                },
-            );
+            const locationCatcherFn = jest.fn();
+            const LocationCatcher = (): React.ReactElement | null => {
+                const location = useLocation();
+                React.useEffect(() => {
+                    locationCatcherFn(location);
+                }, [location]);
+                return null;
+            };
 
             // Act
             render(
-                Router.adapter(<MatchCatcher />, {
+                Router.adapter(<LocationCatcher />, {
                     initialEntries: ["/location/old", "/location/current"],
                     initialIndex: 1,
                     path: "/location/*",
@@ -205,47 +199,10 @@ describe("Router.adapter", () => {
             );
 
             // Assert
-            expect(matchCatcherFn).toHaveBeenLastCalledWith(
+            expect(locationCatcherFn).toHaveBeenLastCalledWith(
                 expect.objectContaining({
-                    url: "/location/current",
+                    pathname: "/location/current",
                 }),
-            );
-        });
-
-        it("should set getUserConfirmation prop on MemoryRouter if given in configuration", () => {
-            // Arrange
-            const getUserConfirmationSpy = jest
-                .fn()
-                .mockImplementation((message: any, cb: any) => {
-                    cb(true);
-                });
-            const matchCatcherFn = jest.fn();
-            const MatchCatcher = withRouter(
-                ({match, history}: any): React.ReactElement => {
-                    React.useEffect(() => {
-                        if (history.location.pathname === "/location/old") {
-                            // Fire off a location change.
-                            history.goForward();
-                        }
-                        matchCatcherFn(match);
-                    }, [match, history]);
-                    return <Prompt message="Are you sure?" />;
-                },
-            );
-
-            // Act
-            render(
-                Router.adapter(<MatchCatcher />, {
-                    initialEntries: ["/location/old", "/location/current"],
-                    getUserConfirmation: getUserConfirmationSpy,
-                    path: "/location/*",
-                }),
-            );
-
-            // Assert
-            expect(getUserConfirmationSpy).toHaveBeenCalledWith(
-                "Are you sure?",
-                expect.any(Function),
             );
         });
     });

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.test.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import {Redirect, useLocation as useLocationV5} from "react-router-dom";
 import {useLocation, useNavigate} from "react-router-dom-v5-compat";
 import {render} from "@testing-library/react";
 import * as Router from "../router";
@@ -138,6 +139,36 @@ describe("Router.adapter", () => {
                 Router.adapter(<NavigateListener />, {
                     location: "/math",
                     forceStatic: true,
+                }),
+            );
+
+            // Assert
+            expect(navigateListen).toHaveBeenCalledOnce();
+            expect(navigateListen).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    pathname: "/math",
+                }),
+            );
+        });
+
+        it("should support turning off the CompatRouter", () => {
+            // Arrange
+            const navigateListen = jest.fn();
+            const NavigateListener = (): React.ReactElement | null => {
+                const location = useLocationV5();
+                React.useEffect(() => navigateListen(location), [location]);
+                if (location.pathname === "/math") {
+                    return <Redirect to="/math/calculator" />;
+                }
+                return null;
+            };
+
+            // Act
+            render(
+                Router.adapter(<NavigateListener />, {
+                    location: "/math",
+                    forceStatic: true,
+                    disableCompatRouter: true,
                 }),
             );
 

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
@@ -1,12 +1,7 @@
 import * as React from "react";
 
-import {StaticRouter, MemoryRouter} from "react-router-dom";
-import {
-    CompatRouter,
-    Route,
-    Routes,
-    useLocation,
-} from "react-router-dom-v5-compat";
+import {StaticRouter, MemoryRouter, Switch, Route} from "react-router-dom";
+import {CompatRouter, useLocation} from "react-router-dom-v5-compat";
 
 import type {LocationDescriptor} from "history";
 import type {TestHarnessAdapter} from "../types";
@@ -126,11 +121,16 @@ const MaybeWithRoute = ({
         throw new Error(errorMessage);
     };
 
+    // NOTE(john): We want to use a Switch here because we want to ensure that
+    // we're still rendering RRv5-style routes. If we were to use Routes here
+    // then we would be rendering RRv6-style routes and that would break any
+    // usage of RRv5-style APIs happening inside the component we're testing.
+    // When we fully adopt v6, we can (and must) switch to using Routes.
     return (
-        <Routes>
-            <Route path={path} element={<>{children}</>} />
-            <Route path="*" element={<ErrorElement />} />
-        </Routes>
+        <Switch>
+            <Route path={path} render={() => <>{children}</>} />
+            <Route path="*" component={ErrorElement} />
+        </Switch>
     );
 };
 

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
@@ -159,17 +159,19 @@ export const adapter: TestHarnessAdapter<Config> = (
         /**
          * There may be times (SSR testing comes to mind) where we will be
          * really strict about not permitting client-side navigation events.
+         *
+         * NOTE(john): We don't have a CompatRouter here as it uses useLayoutEffect
+         * which causes issues in our test enviornment. Namely, that it generates
+         * a warning about the use of useLayoutEffect, which causes an error.
          */
         return (
             <StaticRouter location={config.location} context={{}}>
-                <CompatRouter>
-                    <MaybeWithRoute
-                        path={config.path}
-                        configLocation={config.location}
-                    >
-                        {children}
-                    </MaybeWithRoute>
-                </CompatRouter>
+                <MaybeWithRoute
+                    path={config.path}
+                    configLocation={config.location}
+                >
+                    {children}
+                </MaybeWithRoute>
             </StaticRouter>
         );
     }

--- a/packages/wonder-blocks-testing/package.json
+++ b/packages/wonder-blocks-testing/package.json
@@ -26,7 +26,8 @@
     "node-fetch": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-router-dom": "catalog:"
+    "react-router-dom": "catalog:",
+    "react-router-dom-v5-compat": "catalog:"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
@@ -621,6 +624,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
@@ -646,6 +652,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
@@ -744,6 +753,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
       react-window:
         specifier: 'catalog:'
         version: 1.8.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -871,6 +883,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
@@ -961,6 +976,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
@@ -1255,6 +1273,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
@@ -1289,6 +1310,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     react-router-dom:
       specifier: 5.3.4
       version: 5.3.4
+    react-router-dom-v5-compat:
+      specifier: ^6.30.0
+      version: 6.30.0
     react-window:
       specifier: ^1.8.11
       version: 1.8.11
@@ -90,6 +93,9 @@ importers:
       react-router-dom:
         specifier: 'catalog:'
         version: 5.3.4(react@18.2.0)
+      react-router-dom-v5-compat:
+        specifier: 'catalog:'
+        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
       react-window:
         specifier: 'catalog:'
         version: 1.8.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -405,7 +411,7 @@ importers:
         version: 7.26.7
       '@khanacademy/wonder-blocks-core':
         specifier: ^9.0.0
-        version: 9.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 9.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@6.30.0(react@18.2.0))(react@18.2.0)
       aphrodite:
         specifier: 'catalog:'
         version: 1.2.5
@@ -2674,6 +2680,10 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
+
   '@rollup/plugin-babel@6.0.4':
     resolution: {integrity: sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==}
     engines: {node: '>=14.0.0'}
@@ -4937,6 +4947,9 @@ packages:
   history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
 
+  history@5.3.0:
+    resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
@@ -6639,6 +6652,14 @@ packages:
     resolution: {integrity: sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom-v5-compat@6.30.0:
+    resolution: {integrity: sha512-MAVRASbdQ3+ZOTPPjAa7jKcF0F9LkHWKB/iib3hf+jzzIazL4GEpMDDdTswCsqRQNU+zNnT3qD0WiNbzJ6ncPw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+      react-router-dom: 4 || 5
+
   react-router-dom@5.3.4:
     resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
     peerDependencies:
@@ -6648,6 +6669,12 @@ packages:
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
     peerDependencies:
       react: '>=15'
+
+  react-router@6.30.0:
+    resolution: {integrity: sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
 
   react-window@1.8.11:
     resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==}
@@ -9307,13 +9334,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@khanacademy/wonder-blocks-core@9.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-core@9.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@6.30.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.26.7
       aphrodite: 1.2.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 5.3.4(react@18.2.0)
+      react-router: 6.30.0(react@18.2.0)
       react-router-dom: 5.3.4(react@18.2.0)
 
   '@khanacademy/wonder-stuff-core@1.5.4': {}
@@ -9465,6 +9492,8 @@ snapshots:
   '@polka/url@1.0.0-next.28': {}
 
   '@popperjs/core@2.11.8': {}
+
+  '@remix-run/router@1.23.0': {}
 
   '@rollup/plugin-babel@6.0.4(@babel/core@7.26.7)(@types/babel__core@7.20.5)(rollup@2.79.2)':
     dependencies:
@@ -12168,6 +12197,10 @@ snapshots:
       tiny-warning: 1.0.3
       value-equal: 1.0.1
 
+  history@5.3.0:
+    dependencies:
+      '@babel/runtime': 7.26.7
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
@@ -14533,6 +14566,15 @@ snapshots:
 
   react-refresh@0.16.0: {}
 
+  react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      history: 5.3.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 6.30.0(react@18.2.0)
+      react-router-dom: 5.3.4(react@18.2.0)
+
   react-router-dom@5.3.4(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.26.7
@@ -14556,6 +14598,11 @@ snapshots:
       react-is: 16.13.1
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
+
+  react-router@6.30.0(react@18.2.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.2.0
 
   react-window@1.8.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,5 +27,6 @@ catalog:
     # React Router
     react-router: 5.3.4
     react-router-dom: 5.3.4
+    react-router-dom-v5-compat: ^6.30.0
     # Virtualization
     react-window: ^1.8.11


### PR DESCRIPTION
## Summary:

This goes along with this PR: https://github.com/Khan/webapp/pull/31190 it switches all of the components that do routing over to using react-router-dom v5 + react-router-dom-v5-compat, enabling them to work in both v5 and v6 while we're in this transitory period.

Issue: FEI-6356

## Test plan:
I've confirmed that all tests are passing. I've also confirmed that they worked in-product, see the other PR for more details.