### PR TITLE
Tabs: Implement props and features

### DIFF
--- a/.changeset/twenty-pans-film.md
+++ b/.changeset/twenty-pans-film.md
@@ -1,0 +1,11 @@
+---
+"@khanacademy/wonder-blocks-tabs": minor
+---
+
+Tabs
+
+- Added `id` and `testId`  props
+- Cache previously visited tab panels. This is so tabs are only mounted when
+they are selected the first time. Re-visiting a tab doesn't re-mount the panel
+- Support ARIA props in items in the `tabs` prop
+- Support a render function for a tab's label in the `tabs` prop

--- a/__docs__/wonder-blocks-tabs/tabs.argtypes.ts
+++ b/__docs__/wonder-blocks-tabs/tabs.argtypes.ts
@@ -5,7 +5,7 @@ export default {
         table: {
             type: {
                 summary: "Array<TabItem>",
-                detail: "type TabItem = {|\n\tid: string,\n\tlabel: React.ReactNode,\n\tpanel: React.ReactNode\n|}",
+                detail: "type TabItem = {\n\tid: string,\n\tlabel: React.ReactNode,\n\tpanel: React.ReactNode\n} & AriaProps",
             },
         },
     },

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
+import {action} from "@storybook/addon-actions";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 import {Tab, TabItem, Tabs} from "@khanacademy/wonder-blocks-tabs";
@@ -233,8 +234,7 @@ export const TabLabelRenderFunction: StoryComponentType = {
 
 const PanelExample = ({label}: {label: string}) => {
     React.useEffect(() => {
-        // eslint-disable-next-line no-console -- logging for testing purposes
-        console.log(`Panel ${label} mounted`);
+        action(`Panel mounted`)(label);
     }, [label]);
 
     return <div>{label}</div>;
@@ -244,10 +244,10 @@ const PanelExample = ({label}: {label: string}) => {
  * The tab panels are cached and only mounted once a tab is selected to prevent
  * unnecessary mounting/unmounting of tab panel contents.
  *
- * In this example, the panels contain components that print out a message
- * whenever it is mounted. Notice that a panel is only mounted when it is
- * selected the first time. Visiting a tab that has already been selected will
- * not cause the tab panel to be mounted again.
+ * In this example, the panels contain components that print out a message in
+ * the Storybook actions panel whenever it is mounted. Notice that a panel is
+ * only mounted when it is selected the first time. Visiting a tab that has
+ * already been selected will not cause the tab panel to be mounted again.
  */
 export const PanelCaching: StoryComponentType = {
     args: {

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -184,6 +184,10 @@ export const WithFocusableContent: StoryComponentType = {
  * provides the tab props that should be applied to the `Tab` component.
  * You will also need to set a `key` on the root element of the render function
  * since the tabs are rendered in a loop.
+ *
+ * This story demonstrates how to use a render function to wrap a `Tab`
+ * component in a `Tooltip` and a `Popover`. Please test the accessibility for
+ * your use case, especially focus management and keyboard interactions!
  */
 export const TabLabelRenderFunction: StoryComponentType = {
     args: {

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
-import {TabItem, Tabs} from "@khanacademy/wonder-blocks-tabs";
+import {Tab, TabItem, Tabs} from "@khanacademy/wonder-blocks-tabs";
 import argTypes from "./tabs.argtypes";
 import Button from "@khanacademy/wonder-blocks-button";
 import Link from "@khanacademy/wonder-blocks-link";
 import {TextField} from "@khanacademy/wonder-blocks-form";
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
+import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
 
 const tabs: TabItem[] = [
     {label: "Tab 1", id: "tab-1", panel: <div>Tab contents 1</div>},
@@ -172,5 +174,55 @@ export const WithFocusableContent: StoryComponentType = {
             // Disabling because this doesn't test anything visual.
             disableSnapshot: true,
         },
+    },
+};
+
+/**
+ * For specific use cases where the underlying tab element is wrapped
+ * by another component (like a `Tooltip` or `Popover`), a render function
+ * can be used with the `Tab` component instead. The render function
+ * provides the tab props that should be applied to the `Tab` component.
+ * You will also need to set a `key` on the root element of the render function
+ * since the tabs are rendered in a loop.
+ */
+export const TabLabelRenderFunction: StoryComponentType = {
+    args: {
+        tabs: [
+            {
+                label(tabProps) {
+                    return (
+                        <Tooltip
+                            content="Tooltip"
+                            opened={true}
+                            key={tabProps.id}
+                        >
+                            <Tab {...tabProps}>Tab with a tooltip on it</Tab>
+                        </Tooltip>
+                    );
+                },
+                id: "tab-1",
+                panel: <div>Tab contents 1</div>,
+            },
+            {
+                label(tabProps) {
+                    return (
+                        <Popover
+                            content={
+                                <PopoverContent
+                                    title="Title"
+                                    content="The popover content."
+                                />
+                            }
+                            opened={true}
+                            key={tabProps.id}
+                        >
+                            <Tab {...tabProps}>Tab With a Popover on it</Tab>
+                        </Popover>
+                    );
+                },
+                id: "tab-2",
+                panel: <div>Tab contents 2</div>,
+            },
+        ],
     },
 };

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -226,3 +226,49 @@ export const TabLabelRenderFunction: StoryComponentType = {
         ],
     },
 };
+
+const PanelExample = ({label}: {label: string}) => {
+    React.useEffect(() => {
+        // eslint-disable-next-line no-console -- logging for testing purposes
+        console.log(`Panel ${label} mounted`);
+    }, [label]);
+
+    return <div>{label}</div>;
+};
+
+/**
+ * The tab panels are cached and only mounted once a tab is selected to prevent
+ * unnecessary mounting/unmounting of tab panel contents.
+ *
+ * In this example, the panels contain components that print out a message
+ * whenever it is mounted. Notice that a panel is only mounted when it is
+ * selected the first time. Visiting a tab that has already been selected will
+ * not cause the tab panel to be mounted again.
+ */
+export const PanelCaching: StoryComponentType = {
+    args: {
+        tabs: [
+            {
+                label: "Tab 1",
+                id: "tab-1",
+                panel: <PanelExample label="Tab 1" />,
+            },
+            {
+                label: "Tab 2",
+                id: "tab-2",
+                panel: <PanelExample label="Tab 2" />,
+            },
+            {
+                label: "Tab 3",
+                id: "tab-3",
+                panel: <PanelExample label="Tab 3" />,
+            },
+        ],
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
+};

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab-panel.test.tsx
@@ -92,6 +92,22 @@ describe("TabPanel", () => {
             // Assert
             expect(tabPanel).toHaveAttribute("id", id);
         });
+
+        it("should set the testId for the tab panel", async () => {
+            // Arrange
+            const testId = "test-id";
+            render(
+                <TabPanel {...props} testId={testId} active={true}>
+                    TabPanel
+                </TabPanel>,
+            );
+
+            // Act
+            const tabPanel = await screen.findByRole("tabpanel");
+
+            // Assert
+            expect(tabPanel).toHaveAttribute("data-testid", testId);
+        });
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
@@ -196,6 +196,22 @@ describe("Tab", () => {
                 // Assert
                 expect(tab).not.toHaveAttribute("aria-selected");
             });
+
+            it("should set aria attributes when provided", async () => {
+                // Arrange
+                const ariaLabel = "Specific aria label";
+                render(
+                    <Tab {...props} aria-label={ariaLabel}>
+                        Label
+                    </Tab>,
+                );
+
+                // Act
+                const tab = await screen.findByRole("tab");
+
+                // Assert
+                expect(tab).toHaveAttribute("aria-label", ariaLabel);
+            });
         });
 
         describe("Focus", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
@@ -74,6 +74,22 @@ describe("Tab", () => {
             // Assert
             expect(tab).toHaveAttribute("id", id);
         });
+
+        it("should set the testId for the tab", async () => {
+            // Arrange
+            const testId = "test-id";
+            render(
+                <Tab {...props} testId={testId}>
+                    Tab
+                </Tab>,
+            );
+
+            // Act
+            const tab = await screen.findByRole("tab");
+
+            // Assert
+            expect(tab).toHaveAttribute("data-testid", testId);
+        });
     });
 
     describe("Event Handlers", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
@@ -63,6 +63,20 @@ describe("Tablist", () => {
         });
     });
 
+    describe("Props", () => {
+        it("should use the provided id", async () => {
+            // Arrange
+            const id = "id";
+            render(<Tablist id={id}>Tablist</Tablist>);
+
+            // Act
+            const tablist = await screen.findByRole("tablist");
+
+            // Assert
+            expect(tablist).toHaveAttribute("id", id);
+        });
+    });
+
     describe("Accessibility", () => {
         describe("axe", () => {
             it("should have no a11y violations", async () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tablist.test.tsx
@@ -75,6 +75,18 @@ describe("Tablist", () => {
             // Assert
             expect(tablist).toHaveAttribute("id", id);
         });
+
+        it("should set the testId for the tablist", async () => {
+            // Arrange
+            const testId = "test-id";
+            render(<Tablist testId={testId}>Tablist</Tablist>);
+
+            // Act
+            const tablist = await screen.findByRole("tablist");
+
+            // Assert
+            expect(tablist).toHaveAttribute("data-testid", testId);
+        });
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -391,6 +391,32 @@ describe("Tabs", () => {
                     ariaLabelledby,
                 );
             });
+
+            it("should use aria attributes from the tab items", async () => {
+                // Arrange
+                const ariaLabel = "Specific aria label";
+                render(
+                    <Tabs
+                        tabs={[
+                            {
+                                label: "Tab 1",
+                                id: "tab-1",
+                                "aria-label": ariaLabel,
+                                panel: "Content",
+                            },
+                        ]}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                        aria-label="Tabs Example"
+                    />,
+                );
+
+                // Act
+                const tab = await screen.findByRole("tab", {name: ariaLabel});
+
+                // Assert
+                expect(tab).toHaveAttribute("aria-label", ariaLabel);
+            });
         });
 
         describe("Keyboard Navigation", () => {

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -182,7 +182,7 @@ describe("Tabs", () => {
                 );
 
                 // Assert
-                // eslint-disable-next-line testing-library/no-node-access -- check the root element
+                // eslint-disable-next-line testing-library/no-node-access -- checking the root element
                 expect(container.firstChild).toHaveAttribute("id", id);
             });
 
@@ -219,7 +219,7 @@ describe("Tabs", () => {
                 );
 
                 // Assert
-                // eslint-disable-next-line testing-library/no-node-access -- check the root element
+                // eslint-disable-next-line testing-library/no-node-access -- checking the root element
                 expect(container.firstChild).toHaveAttribute("id");
             });
 
@@ -239,6 +239,87 @@ describe("Tabs", () => {
 
                 // Assert
                 expect(tablist.id).toEndWith("-tablist");
+            });
+        });
+
+        describe("testId", () => {
+            it("should set the testId for the root element", async () => {
+                // Arrange
+                const testId = "test-id";
+                // Act
+                const {container} = render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        testId={testId}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Assert
+                // eslint-disable-next-line testing-library/no-node-access -- checking the root element
+                expect(container.firstChild).toHaveAttribute(
+                    "data-testid",
+                    testId,
+                );
+            });
+
+            it("should set the testId for the tablist element", async () => {
+                // Arrange
+                const testId = "test-id";
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        testId={testId}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tablist = await screen.findByRole("tablist");
+
+                // Assert
+                expect(tablist).toHaveAttribute(
+                    "data-testid",
+                    `${testId}-tablist`,
+                );
+            });
+
+            it("should not set the testId for the root element if no testId is provided", () => {
+                // Arrange
+                const {container} = render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Assert
+                // eslint-disable-next-line testing-library/no-node-access -- checking the root element
+                expect(container.firstChild).not.toHaveAttribute("data-testid");
+            });
+
+            it("should not set the testId for the tablist element if no testId is provided", () => {
+                // Arrange
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tablist = screen.getByRole("tablist");
+
+                // Assert
+                expect(tablist).not.toHaveAttribute("data-testid");
             });
         });
 
@@ -279,6 +360,99 @@ describe("Tabs", () => {
 
                 // Assert
                 expect(tabPanel).toHaveAttribute("id", `${id}-panel`);
+            });
+        });
+
+        describe("tab item test ids", () => {
+            it("should set the testId for the tab element", () => {
+                // Arrange
+                const testId = "test-id";
+                render(
+                    <Tabs
+                        tabs={[
+                            {
+                                id: "tab-id",
+                                label: "Label",
+                                panel: "Panel",
+                                testId,
+                            },
+                        ]}
+                        selectedTabId={"tab-id"}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tab = screen.getByRole("tab", {name: "Label"});
+
+                // Assert
+                expect(tab).toHaveAttribute("data-testid", `${testId}-tab`);
+            });
+
+            it("should set the testId for the tab panel element", () => {
+                // Arrange
+                const testId = "test-id";
+                render(
+                    <Tabs
+                        tabs={[
+                            {
+                                id: "tab-id",
+                                label: "Label",
+                                panel: "Panel",
+                                testId,
+                            },
+                        ]}
+                        selectedTabId={"tab-id"}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tabPanel = screen.getByRole("tabpanel", {name: "Label"});
+
+                // Assert
+                expect(tabPanel).toHaveAttribute(
+                    "data-testid",
+                    `${testId}-panel`,
+                );
+            });
+
+            it("should not set the testId for the tab element if no testId is provided", () => {
+                // Arrange
+                render(
+                    <Tabs
+                        tabs={[{id: "tab-id", label: "Label", panel: "Panel"}]}
+                        selectedTabId={"tab-id"}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tab = screen.getByRole("tab", {name: "Label"});
+
+                // Assert
+                expect(tab).not.toHaveAttribute("data-testid");
+            });
+
+            it("should not set the testId for the tab panel element if no testId is provided", () => {
+                // Arrange
+                render(
+                    <Tabs
+                        tabs={[{id: "tab-id", label: "Label", panel: "Panel"}]}
+                        selectedTabId={"tab-id"}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tabPanel = screen.getByRole("tabpanel", {name: "Label"});
+
+                // Assert
+                expect(tabPanel).not.toHaveAttribute("data-testid");
             });
         });
     });

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -1675,4 +1675,78 @@ describe("Tabs", () => {
             });
         });
     });
+
+    describe("Performance", () => {
+        it("should not mount tab panels that are not visited", () => {
+            // Arrange
+            const secondPanelOnMount = jest.fn();
+            const SecondPanel = () => {
+                React.useEffect(() => {
+                    secondPanelOnMount();
+                }, []);
+                return <div>Panel 2</div>;
+            };
+
+            // Act
+            render(
+                <ControlledTabs
+                    tabs={[
+                        {
+                            id: "tab-1",
+                            label: "Tab 1",
+                            panel: "Panel 1",
+                        },
+                        {
+                            id: "tab-2",
+                            label: "Tab 2",
+                            panel: <SecondPanel />,
+                        },
+                    ]}
+                    selectedTabId={"tab-1"}
+                />,
+            );
+
+            // Assert
+            // Since the first tab is selected, the second panel should not have been mounted
+            expect(secondPanelOnMount).not.toHaveBeenCalled();
+        });
+
+        it("should not remount tabs that have been visited", async () => {
+            // Arrange
+            const firstPanelOnMount = jest.fn();
+            const FirstPanel = () => {
+                React.useEffect(() => {
+                    firstPanelOnMount();
+                }, []);
+                return <div>Panel 1</div>;
+            };
+            render(
+                <ControlledTabs
+                    tabs={[
+                        {
+                            id: "tab-1",
+                            label: "Tab 1",
+                            panel: <FirstPanel />,
+                        },
+                        {
+                            id: "tab-2",
+                            label: "Tab 2",
+                            panel: "Panel 2",
+                        },
+                    ]}
+                    selectedTabId={"tab-1"}
+                />,
+            );
+
+            // Act
+            // Change tabs and then go back to the first tab
+            const tab2 = screen.getByRole("tab", {name: "Tab 2"});
+            await userEvent.click(tab2);
+            const tab1 = screen.getByRole("tab", {name: "Tab 1"});
+            await userEvent.click(tab1);
+
+            // Assert
+            expect(firstPanelOnMount).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -4,6 +4,7 @@ import {render, screen, within} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {PropsFor} from "@khanacademy/wonder-blocks-core";
 import {TabItem, Tabs} from "../tabs";
+import {Tab} from "../tab";
 
 describe("Tabs", () => {
     const tabs: TabItem[] = [
@@ -453,6 +454,77 @@ describe("Tabs", () => {
 
                 // Assert
                 expect(tabPanel).not.toHaveAttribute("data-testid");
+            });
+        });
+
+        describe("tabs", () => {
+            describe("label prop render function", () => {
+                it("should render the tab label using the render function", () => {
+                    // Arrange
+                    render(
+                        <Tabs
+                            aria-label={tabsAriaLabel}
+                            tabs={[
+                                {
+                                    id: "tab-1",
+                                    label: (tabProps) => (
+                                        <div
+                                            key={tabProps.id}
+                                            data-testid="tab-wrapper"
+                                        >
+                                            <Tab {...tabProps}>Label</Tab>
+                                        </div>
+                                    ),
+                                    panel: "Panel",
+                                },
+                            ]}
+                            selectedTabId="tab-1"
+                            onTabSelected={jest.fn()}
+                        />,
+                    );
+
+                    // Act
+                    const tabWrapper = screen.getByTestId("tab-wrapper");
+
+                    // Assert
+                    expect(tabWrapper).toBeInTheDocument();
+                });
+
+                it("should pass the tab props to the render function", () => {
+                    // Arrange
+                    const labelRenderFn = jest.fn();
+
+                    // Act
+                    render(
+                        <Tabs
+                            aria-label={tabsAriaLabel}
+                            tabs={[
+                                {
+                                    id: "tab-1",
+                                    label: labelRenderFn,
+                                    panel: "Panel",
+                                    "aria-label": "Tab 1 Aria Label",
+                                    testId: "tab-1-test-id",
+                                },
+                            ]}
+                            selectedTabId="tab-1"
+                            onTabSelected={jest.fn()}
+                        />,
+                    );
+
+                    // Assert
+                    expect(labelRenderFn).toHaveBeenCalledExactlyOnceWith({
+                        id: "tab-1-tab",
+                        testId: "tab-1-test-id-tab",
+                        key: "tab-1",
+                        selected: true,
+                        "aria-controls": "tab-1-panel",
+                        "aria-label": "Tab 1 Aria Label",
+                        onClick: expect.any(Function),
+                        onKeyDown: expect.any(Function),
+                        ref: expect.any(Function),
+                    });
+                });
             });
         });
     });

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -164,6 +164,125 @@ describe("Tabs", () => {
         expect(ref.current).toBe(container.firstChild);
     });
 
+    describe("Props", () => {
+        describe("id", () => {
+            it("should use the provided id for the root element", async () => {
+                // Arrange
+                const id = "id";
+
+                // Act
+                const {container} = render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        id={id}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Assert
+                // eslint-disable-next-line testing-library/no-node-access -- check the root element
+                expect(container.firstChild).toHaveAttribute("id", id);
+            });
+
+            it("should use the provided id for the tablist element", async () => {
+                // Arrange
+                const id = "id";
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        id={id}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tablist = await screen.findByRole("tablist");
+
+                // Assert
+                expect(tablist).toHaveAttribute("id", `${id}-tablist`);
+            });
+
+            it("should autogenerate an id for the root element if no id is provided", async () => {
+                // Arrange
+                // Act
+                const {container} = render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Assert
+                // eslint-disable-next-line testing-library/no-node-access -- check the root element
+                expect(container.firstChild).toHaveAttribute("id");
+            });
+
+            it("should autogenerate an id for the tablist element if no id is provided", async () => {
+                // Arrange
+                render(
+                    <Tabs
+                        tabs={tabs}
+                        selectedTabId={tabs[0].id}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tablist = await screen.findByRole("tablist");
+
+                // Assert
+                expect(tablist.id).toEndWith("-tablist");
+            });
+        });
+
+        describe("tab item ids", () => {
+            it("should use the tab item id for the tab element", () => {
+                // Arrange
+                const id = "tab-id";
+                render(
+                    <Tabs
+                        tabs={[{id, label: "Label", panel: "Panel"}]}
+                        selectedTabId={id}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tab = screen.getByRole("tab", {name: "Label"});
+
+                // Assert
+                expect(tab).toHaveAttribute("id", `${id}-tab`);
+            });
+
+            it("should use the tab item id for the tab panel element", () => {
+                // Arrange
+                const id = "tab-id";
+                render(
+                    <Tabs
+                        tabs={[{id, label: "Label", panel: "Panel"}]}
+                        selectedTabId={id}
+                        onTabSelected={jest.fn()}
+                        aria-label={tabsAriaLabel}
+                    />,
+                );
+
+                // Act
+                const tabPanel = screen.getByRole("tabpanel", {name: "Label"});
+
+                // Assert
+                expect(tabPanel).toHaveAttribute("id", `${id}-panel`);
+            });
+        });
+    });
+
     describe("Event Handlers", () => {
         it("should call the onTabSelected handler with the tab id when a tab is clicked", async () => {
             // Arrange

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -12,6 +12,10 @@ type Props = {
      */
     id: string;
     /**
+     * Optional test ID for e2e testing.
+     */
+    testId?: string;
+    /**
      * The id of the associated element with role="tab".
      */
     "aria-labelledby": string;
@@ -33,6 +37,7 @@ export const TabPanel = (props: Props) => {
         id,
         "aria-labelledby": ariaLabelledby,
         active = false,
+        testId,
     } = props;
 
     const ref = React.useRef<HTMLDivElement>(null);
@@ -57,6 +62,7 @@ export const TabPanel = (props: Props) => {
             tabIndex={hasFocusableElement ? undefined : 0}
             // Only show the tab panel if it is active
             hidden={!active}
+            data-testid={testId}
         >
             {children}
         </StyledDiv>

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -1,6 +1,7 @@
+import {AriaProps} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
-type Props = {
+type Props = AriaProps & {
     /**
      * The contents of the tab label.
      */
@@ -42,9 +43,12 @@ export const Tab = React.forwardRef(function Tab(
         "aria-controls": ariaControls,
         selected,
         onKeyDown,
+        // Should only include aria related props
+        ...otherProps
     } = props;
     return (
         <button
+            {...otherProps}
             role="tab"
             onClick={onClick}
             ref={ref}

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -15,6 +15,10 @@ type Props = AriaProps & {
      */
     id: string;
     /**
+     * Optional test ID for e2e testing.
+     */
+    testId?: string;
+    /**
      * The id of the panel that the tab controls.
      */
     "aria-controls": string;
@@ -43,6 +47,7 @@ export const Tab = React.forwardRef(function Tab(
         "aria-controls": ariaControls,
         selected,
         onKeyDown,
+        testId,
         // Should only include aria related props
         ...otherProps
     } = props;
@@ -59,6 +64,7 @@ export const Tab = React.forwardRef(function Tab(
             // between tabs using the arrow keys
             tabIndex={selected ? 0 : -1}
             onKeyDown={onKeyDown}
+            data-testid={testId}
         >
             {children}
         </button>

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -9,6 +9,10 @@ type Props = {
      */
     id?: string;
     /**
+     * Optional test ID for e2e testing.
+     */
+    testId?: string;
+    /**
      * The contents of the tablist.
      */
     children: React.ReactNode;
@@ -43,6 +47,7 @@ export const Tablist = React.forwardRef(function Tablist(
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledby,
         onBlur,
+        testId,
     } = props;
 
     return (
@@ -54,6 +59,7 @@ export const Tablist = React.forwardRef(function Tablist(
             aria-label={ariaLabel}
             aria-labelledby={ariaLabelledby}
             onBlur={onBlur}
+            data-testid={testId}
         >
             {children}
         </StyledDiv>

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -5,6 +5,10 @@ import * as React from "react";
 
 type Props = {
     /**
+     * The id of the tablist.
+     */
+    id?: string;
+    /**
      * The contents of the tablist.
      */
     children: React.ReactNode;
@@ -34,6 +38,7 @@ export const Tablist = React.forwardRef(function Tablist(
     ref: React.ForwardedRef<HTMLDivElement>,
 ) {
     const {
+        id,
         children,
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledby,
@@ -42,6 +47,7 @@ export const Tablist = React.forwardRef(function Tablist(
 
     return (
         <StyledDiv
+            id={id}
             role="tablist"
             style={styles.tablist}
             ref={ref}

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -143,13 +143,28 @@ export const Tabs = React.forwardRef(function Tabs(
         testId,
     } = props;
 
+    /**
+     * The id of the tab that is currently focused.
+     */
     const focusedTabId = React.useRef(selectedTabId);
 
     const tabRefs = React.useRef<{[key: string]: HTMLButtonElement | null}>({});
 
+    /**
+     * Element ids
+     */
     const generatedUniqueId = React.useId();
     const uniqueId = id ?? generatedUniqueId;
     const tablistId = `${uniqueId}-tablist`;
+
+    /**
+     * Keep track of tabs that have been visited to avoid unnecessary mounting/
+     * unmounting of tab panels when we switch tabs. We won't mount any tab
+     * panel contents that aren't visited, and we won't remount tabs that have
+     * been visited already.
+     */
+    const visitedTabsRef = React.useRef(new Set<string>());
+    visitedTabsRef.current.add(selectedTabId);
 
     React.useEffect(() => {
         focusedTabId.current = selectedTabId;
@@ -283,7 +298,12 @@ export const Tabs = React.forwardRef(function Tabs(
                         active={selectedTabId === tab.id}
                         testId={tab.testId && getTabPanelId(tab.testId)}
                     >
-                        {selectedTabId === tab.id && tab.panel}
+                        {/* Tab panel contents are rendered if the tab has
+                        been previously visited. This prevents unnecessary
+                        re-mounting of tab panel contents when switching tabs.
+                        Note that TabPanel will only display the contents if it
+                        is the active panel. */}
+                        {visitedTabsRef.current.has(tab.id) && tab.panel}
                     </TabPanel>
                 );
             })}

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import {keys} from "@khanacademy/wonder-blocks-core";
+import {AriaProps, keys} from "@khanacademy/wonder-blocks-core";
 import {TabPanel} from "./tab-panel";
 import {Tab} from "./tab";
 import {Tablist} from "./tablist";
 
-export type TabItem = {
+export type TabItem = AriaProps & {
     /**
      * A unique id for the tab.
      */
@@ -195,21 +195,28 @@ export const Tabs = React.forwardRef(function Tabs(
                 onBlur={handleTablistBlur}
             >
                 {tabs.map((tab) => {
+                    const {
+                        id,
+                        label,
+                        panel: _,
+                        ...otherProps // Should only include aria related props
+                    } = tab;
                     return (
                         <Tab
-                            key={tab.id}
+                            {...otherProps}
+                            key={id}
                             onClick={() => {
-                                onTabSelected(tab.id);
+                                onTabSelected(id);
                             }}
-                            id={getTabId(tab.id)}
-                            aria-controls={getTabPanelId(tab.id)}
-                            selected={tab.id === selectedTabId}
+                            id={getTabId(id)}
+                            aria-controls={getTabPanelId(id)}
+                            selected={id === selectedTabId}
                             onKeyDown={handleKeyDown}
                             ref={(element) => {
                                 tabRefs.current[tab.id] = element;
                             }}
                         >
-                            {tab.label}
+                            {label}
                         </Tab>
                     );
                 })}

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -24,6 +24,14 @@ export type TabItem = AriaProps & {
      * The contents of the panel associated with the tab.
      */
     panel: React.ReactNode;
+    /**
+     * Optional test ID for e2e testing.
+     *
+     * Here is how the test id is used for the different elements in the component:
+     * - The tab will have a testId formatted as `${testId}-tab`
+     * - The associated tab panel will have a testId formatted as `${testId}-panel`
+     */
+    testId?: string;
 };
 
 /**
@@ -63,6 +71,18 @@ type Props = {
      * - The associated tab panel will have an id formatted as `${id}-panel`
      */
     id?: string;
+    /**
+     * Optional test ID for e2e testing. Here is how the test id is used for the
+     * different elements in the component:
+     * - The root will have a testId formatted as `${testId}`
+     * - The tablist will have a testId formatted as `${testId}-tablist`
+     *
+     * If you need to apply a testId to a specific tab or tab panel, add the
+     * test id to the tab item in the `tabs` prop:
+     * - The tab will have a testId formatted as `${testId}-tab`
+     * - The associated tab panel will have a testId formatted as `${testId}-panel`
+     */
+    testId?: string;
     /**
      * The tabs to render. The Tabs component will wire up the tab and panel
      * attributes for accessibility.
@@ -120,6 +140,7 @@ export const Tabs = React.forwardRef(function Tabs(
         "aria-labelledby": ariaLabelledby,
         activationMode = "manual",
         id,
+        testId,
     } = props;
 
     const focusedTabId = React.useRef(selectedTabId);
@@ -216,18 +237,20 @@ export const Tabs = React.forwardRef(function Tabs(
     }, [selectedTabId]);
 
     return (
-        <div ref={ref} id={uniqueId}>
+        <div ref={ref} id={uniqueId} data-testid={testId}>
             <Tablist
                 aria-label={ariaLabel}
                 aria-labelledby={ariaLabelledby}
                 onBlur={handleTablistBlur}
                 id={tablistId}
+                testId={testId && `${testId}-tablist`}
             >
                 {tabs.map((tab) => {
                     const {
                         id,
                         label,
                         panel: _,
+                        testId: tabTestId,
                         ...otherProps // Should only include aria related props
                     } = tab;
                     return (
@@ -238,6 +261,7 @@ export const Tabs = React.forwardRef(function Tabs(
                                 onTabSelected(id);
                             }}
                             id={getTabId(id)}
+                            testId={tabTestId && getTabId(tabTestId)}
                             aria-controls={getTabPanelId(id)}
                             selected={id === selectedTabId}
                             onKeyDown={handleKeyDown}
@@ -257,6 +281,7 @@ export const Tabs = React.forwardRef(function Tabs(
                         id={getTabPanelId(tab.id)}
                         aria-labelledby={getTabId(tab.id)}
                         active={selectedTabId === tab.id}
+                        testId={tab.testId && getTabPanelId(tab.testId)}
                     >
                         {selectedTabId === tab.id && tab.panel}
                     </TabPanel>

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -7,6 +7,13 @@ import {Tablist} from "./tablist";
 export type TabItem = AriaProps & {
     /**
      * A unique id for the tab.
+     *
+     * Here is how the id is used for the different elements in the component:
+     * - The tab will have an id formatted as `${id}-tab`
+     * - The associated tab panel will have an id formatted as `${id}-panel`
+     *
+     * It is also used to communicate the id of the selected tab via the
+     * `selectedTabId` and `onTabSelected` props.
      */
     id: string;
     /**
@@ -42,6 +49,21 @@ type AriaLabelOrAriaLabelledby =
 
 type Props = {
     /**
+     * A unique id to use as the base of the ids for the elements within the
+     * component. If the `id` prop is not provided, a base unique id will be
+     * auto-generated.
+     *
+     * Here is how the id is used for the different elements in the component:
+     * - The root will have an id of `${id}`
+     * - The tablist will have an id formatted as ${id}-tablist
+     *
+     * If you need to apply an id to a specific tab or tab panel, the `id` for
+     * the tab item in the `tabs` prop will be used:
+     * - The tab will have an id formatted as `${id}-tab`
+     * - The associated tab panel will have an id formatted as `${id}-panel`
+     */
+    id?: string;
+    /**
      * The tabs to render. The Tabs component will wire up the tab and panel
      * attributes for accessibility.
      */
@@ -69,7 +91,7 @@ type Props = {
  * Returns the id of the tab.
  */
 function getTabId(tabId: string) {
-    return `${tabId}__tab`;
+    return `${tabId}-tab`;
 }
 
 /**
@@ -77,7 +99,7 @@ function getTabId(tabId: string) {
  */
 
 function getTabPanelId(tabId: string) {
-    return `${tabId}__panel`;
+    return `${tabId}-panel`;
 }
 
 /**
@@ -97,10 +119,16 @@ export const Tabs = React.forwardRef(function Tabs(
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledby,
         activationMode = "manual",
+        id,
     } = props;
 
     const focusedTabId = React.useRef(selectedTabId);
+
     const tabRefs = React.useRef<{[key: string]: HTMLButtonElement | null}>({});
+
+    const generatedUniqueId = React.useId();
+    const uniqueId = id ?? generatedUniqueId;
+    const tablistId = `${uniqueId}-tablist`;
 
     React.useEffect(() => {
         focusedTabId.current = selectedTabId;
@@ -188,11 +216,12 @@ export const Tabs = React.forwardRef(function Tabs(
     }, [selectedTabId]);
 
     return (
-        <div ref={ref}>
+        <div ref={ref} id={uniqueId}>
             <Tablist
                 aria-label={ariaLabel}
                 aria-labelledby={ariaLabelledby}
                 onBlur={handleTablistBlur}
+                id={tablistId}
             >
                 {tabs.map((tab) => {
                     const {

--- a/packages/wonder-blocks-tabs/src/index.ts
+++ b/packages/wonder-blocks-tabs/src/index.ts
@@ -1,5 +1,5 @@
 export {NavigationTabs} from "./components/navigation-tabs";
 export {NavigationTabItem} from "./components/navigation-tab-item";
 export {Tabs} from "./components/tabs";
-export type {TabItem} from "./components/tabs";
+export type {TabItem, TabRenderProps} from "./components/tabs";
 export {Tab} from "./components/tab";


### PR DESCRIPTION
## Summary:
- Implement remaining props (id, testId, aria props for Tab component)
- Support render function for the tab label
- Cache tab panel contents so it is only mounted once a tab is selected. Revisiting a tab panel doesn't cause it to re-mount

Issue: WB-1907

## Test plan:
- Props work as expected
- Tab Label Render Function renders properly (`?path=/story/packages-tabs-tabs-tabs--tab-label-render-function`)
  - Note: This story shows how the render function can be used for the tab label. WB-1901 is for investigating tabs more with popover/tooltip components and a11y considerations
- Panel Caching story behaves as expected (see docs for this story for more details) (`?path=/story/packages-tabs-tabs-tabs--panel-caching`)

## Implementation Plan
- Set up base component https://github.com/Khan/wonder-blocks/pull/2528
- Keyboard interactions https://github.com/Khan/wonder-blocks/pull/2536
- Remaining props https://github.com/Khan/wonder-blocks/pull/2542
- Styles

Follow up tasks when time permits: WB-1901 (Investigating tabs with tooltip/popovers. This use case is not too common right now afaik so it can be done as a follow up after the initial release!)