### PR TITLE
[internal] Use Chromatic modes

### DIFF
--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,0 +1,18 @@
+export const allModes = {
+    // Responsive modes
+    small: {
+        viewport: "small",
+    },
+    medium: {
+        viewport: "medium",
+    },
+    large: {
+        viewport: "large",
+    },
+    chromebook: {
+        viewport: "chromebook",
+    },
+    wide: {
+        viewport: "wide",
+    },
+};

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -41,6 +41,13 @@ const wbViewports = {
             height: "768px",
         },
     },
+    wide: {
+        name: "Wide",
+        styles: {
+            width: "1700px",
+            height: "900px",
+        },
+    },
 };
 
 const parameters = {
@@ -125,11 +132,11 @@ const withLanguageDirection: Decorator = (Story, context) => {
             <div dir="rtl">
                 <Story />
             </div>
-        )
+        );
     } else {
-        return <Story />
+        return <Story />;
     }
-}
+};
 
 /**
  * Wraps a story with styling that simulates [zoom](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom).
@@ -141,21 +148,18 @@ const withLanguageDirection: Decorator = (Story, context) => {
 const withZoom: Decorator = (Story, context) => {
     if (context.globals.zoom) {
         return (
-            <div style={{ zoom: context.globals.zoom }}>
+            <div style={{zoom: context.globals.zoom}}>
                 <Story />
             </div>
-        )
+        );
     }
-    return <Story />
-}
+    return <Story />;
+};
 
 /**
  * Injects the Live Region Announcer for various components
  */
-const withAnnouncer: Decorator = (
-    Story,
-    {parameters: {addBodyClass}},
-) => {
+const withAnnouncer: Decorator = (Story, {parameters: {addBodyClass}}) => {
     // Allow stories to specify a CSS body class
     if (addBodyClass) {
         document.body.classList.add(addBodyClass);
@@ -164,20 +168,23 @@ const withAnnouncer: Decorator = (
         // initialize Announcer on load to render Live Regions earlier
         initAnnouncer();
         return () => {
-          if (addBodyClass) {
-            // Remove body class when changing stories
-            document.body.classList.remove(addBodyClass);
-          }
+            if (addBodyClass) {
+                // Remove body class when changing stories
+                document.body.classList.remove(addBodyClass);
+            }
         };
-      }, [addBodyClass]);
-    return (
-        <Story />
-    );
+    }, [addBodyClass]);
+    return <Story />;
 };
 
 const preview: Preview = {
     parameters,
-    decorators: [withThemeSwitcher, withLanguageDirection, withZoom, withAnnouncer],
+    decorators: [
+        withThemeSwitcher,
+        withLanguageDirection,
+        withZoom,
+        withAnnouncer,
+    ],
     globalTypes: {
         // Allow the user to select a theme from the toolbar.
         theme: {
@@ -244,7 +251,7 @@ const preview: Preview = {
                     },
                 ],
             },
-        }
+        },
     },
 
     tags: ["autodocs"],

--- a/__docs__/wonder-blocks-button/button-variants.stories.tsx
+++ b/__docs__/wonder-blocks-button/button-variants.stories.tsx
@@ -4,6 +4,8 @@ import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg";
+import {allModes} from "../../.storybook/modes";
+
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {ThemeSwitcherContext} from "@khanacademy/wonder-blocks-theming";
 import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -21,7 +23,9 @@ export default {
             // NOTE: This is required to prevent Chromatic from cutting off the
             // dark background in screenshots (accounts for all the space taken
             // by the variants).
-            viewports: [1700],
+            modes: {
+                wide: allModes.wide,
+            },
         },
     },
     tags: ["!autodocs"],

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -18,6 +18,7 @@ import {
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 import modalDialogArgtypes from "./modal-dialog.argtypes";
+import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -84,7 +85,11 @@ export default {
             defaultViewport: "desktop",
         },
         chromatic: {
-            viewports: [320, 640, 1024],
+            modes: {
+                small: allModes.small,
+                medium: allModes.medium,
+                large: allModes.large,
+            },
         },
     },
     // Make the following props null in the control panel

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -16,6 +16,7 @@ import {
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
 import ComponentInfo from "../components/component-info";
+import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -136,7 +137,11 @@ export default {
             defaultViewport: "desktop",
         },
         chromatic: {
-            viewports: [320, 640, 1024],
+            modes: {
+                small: allModes.small,
+                medium: allModes.medium,
+                large: allModes.large,
+            },
         },
     },
     argTypes: {

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -19,6 +19,7 @@ import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
 import ComponentInfo from "../components/component-info";
 import ModalHeaderArgtypes from "./modal-header.argtypes";
+import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -165,7 +166,11 @@ export default {
             defaultViewport: "desktop",
         },
         chromatic: {
-            viewports: [320, 640, 1024],
+            modes: {
+                small: allModes.small,
+                medium: allModes.medium,
+                large: allModes.large,
+            },
         },
     },
     argTypes: ModalHeaderArgtypes,

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -31,6 +31,7 @@ import type {ModalElement} from "../../packages/wonder-blocks-modal/src/util/typ
 import ModalLauncherArgTypes from "./modal-launcher.argtypes";
 
 import ComponentInfo from "../components/component-info";
+import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -109,7 +110,11 @@ export default {
             defaultViewport: "desktop",
         },
         chromatic: {
-            viewports: [320, 640, 1024],
+            modes: {
+                small: allModes.small,
+                medium: allModes.medium,
+                large: allModes.large,
+            },
         },
     },
     argTypes: ModalLauncherArgTypes,

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -21,6 +21,7 @@ import {
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 import ComponentInfo from "../components/component-info";
 import modalPanelArgtypes from "./modal-panel.argtypes";
+import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -148,7 +149,11 @@ export default {
             defaultViewport: "desktop",
         },
         chromatic: {
-            viewports: [320, 640, 1024],
+            modes: {
+                small: allModes.small,
+                medium: allModes.medium,
+                large: allModes.large,
+            },
         },
     },
     argTypes: modalPanelArgtypes,

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -19,6 +19,7 @@ import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
 import ComponentInfo from "../components/component-info";
 import OnePaneDialogArgTypes from "./one-pane-dialog.argtypes";
+import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -75,7 +76,11 @@ export default {
             defaultViewport: "desktop",
         },
         chromatic: {
-            viewports: [320, 640, 1024],
+            modes: {
+                small: allModes.small,
+                medium: allModes.medium,
+                large: allModes.large,
+            },
         },
     },
     argTypes: OnePaneDialogArgTypes,

--- a/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
@@ -13,6 +13,7 @@ import ToolbarArgtypes, {
     leftContentMappings,
     rightContentMappings,
 } from "./toolbar.argtypes";
+import {allModes} from "../../.storybook/modes";
 
 type StoryComponentType = StoryObj<typeof Toolbar>;
 
@@ -183,7 +184,11 @@ Responsive.parameters = {
     },
     chromatic: {
         // Test responsiveness of the toolbar.
-        viewports: [320, 768, 1024],
+        modes: {
+            small: allModes.small,
+            medium: allModes.medium,
+            large: allModes.large,
+        },
     },
 };
 


### PR DESCRIPTION
## Summary:

Experimenting with the Chromatic modes feature as `viewports` was deprecated in
favor of `modes`.

This will help unlock the ability to use Chromatic modes with the ThunderBlocks
theme.

Issue: "none"

## Test plan:

TBD