### PR TITLE
Tabs: Styling

### DIFF
--- a/.changeset/dirty-pens-share.md
+++ b/.changeset/dirty-pens-share.md
@@ -1,0 +1,13 @@
+---
+"@khanacademy/wonder-blocks-tabs": minor
+---
+
+Tabs:
+
+- Add styling
+- Add support for `styles` prop
+- Add `animated` prop for enabling transition animations for the selected tab
+
+NavigationTabs:
+
+- Refactored current tab indicator logic to work with Tabs

--- a/__docs__/components/placeholder.tsx
+++ b/__docs__/components/placeholder.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+
+type Props = {
+    children: React.ReactNode;
+};
+
+/**
+ * Component that renders a placeholder block. It is useful for visualizing
+ * layouts.
+ */
+export const Placeholder = (props: Props) => {
+    const {children} = props;
+    return (
+        <View
+            style={{
+                backgroundColor: semanticColor.surface.secondary,
+                padding: sizing.size_120,
+                margin: sizing.size_010,
+                border: `${border.width.thin}px dashed ${semanticColor.border.subtle}`,
+                width: "100%",
+                alignItems: "center",
+            }}
+        >
+            {children}
+        </View>
+    );
+};

--- a/__docs__/wonder-blocks-tabs/tab-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tab-variants.stories.tsx
@@ -6,6 +6,7 @@ import {AllVariants} from "../components/all-variants";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 const StyledDiv = addStyle("div");
 
@@ -24,8 +25,7 @@ const generateRows = (rtl: boolean = false) => [
                     style={{
                         display: "flex",
                         alignItems: "center",
-                        // TODO: Update to use spacing tokens
-                        gap: "4px",
+                        gap: sizing.size_040,
                     }}
                 >
                     <PhosphorIcon icon={IconMappings.cookie} />

--- a/__docs__/wonder-blocks-tabs/tab-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tab-variants.stories.tsx
@@ -1,0 +1,114 @@
+import type {Meta, StoryObj} from "@storybook/react";
+import * as React from "react";
+
+import {Tab} from "@khanacademy/wonder-blocks-tabs";
+import {AllVariants} from "../components/all-variants";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
+
+const StyledDiv = addStyle("div");
+
+const generateRows = (rtl: boolean = false) => [
+    {
+        name: "Default",
+        props: {
+            children: "Tab",
+        },
+    },
+    {
+        name: "With Icons",
+        props: {
+            children: (
+                <StyledDiv
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        // TODO: Update to use spacing tokens
+                        gap: "4px",
+                    }}
+                >
+                    <PhosphorIcon icon={IconMappings.cookie} />
+                    Tab
+                    <PhosphorIcon icon={IconMappings.iceCream} />
+                </StyledDiv>
+            ),
+            ariaLabel: "Tab with icons",
+        },
+    },
+    {
+        name: "Icon Only",
+        props: {
+            children: (
+                <PhosphorIcon icon={IconMappings.iceCream} size="medium" />
+            ),
+            ariaLabel: "Tab with icon",
+        },
+    },
+];
+
+const rows = generateRows();
+const rtlRows = generateRows(true);
+
+const columns = [
+    {
+        name: "Default",
+        props: {},
+    },
+    {
+        name: "Selected",
+        props: {
+            selected: true,
+        },
+    },
+];
+
+type Story = StoryObj<typeof Tab>;
+
+/**
+ * The following stories are used to generate the pseudo states for the Switch
+ * component. This is only used for visual testing in Chromatic.
+ */
+const meta = {
+    title: "Packages / Tabs / Tabs / Subcomponents /Tab - All Variants",
+    component: Tab,
+    render: (args) => (
+        <>
+            <AllVariants rows={rows} columns={columns}>
+                {(props) => <Tab {...args} {...props} />}
+            </AllVariants>
+            <div dir="rtl">
+                <AllVariants rows={rtlRows} columns={columns}>
+                    {(props) => <Tab {...args} {...props} />}
+                </AllVariants>
+            </div>
+        </>
+    ),
+    args: {},
+    tags: ["!autodocs"],
+} satisfies Meta<typeof Tab>;
+
+export default meta;
+
+export const Default: Story = {};
+
+export const Hover: Story = {
+    parameters: {pseudo: {hover: true}},
+};
+
+export const Focus: Story = {
+    parameters: {pseudo: {focusVisible: true}},
+};
+
+export const HoverFocus: Story = {
+    name: "Hover + Focus",
+    parameters: {pseudo: {hover: true, focusVisible: true}},
+};
+
+export const Press: Story = {
+    parameters: {pseudo: {hover: true, active: true}},
+};
+
+export const PressFocus: Story = {
+    parameters: {pseudo: {focusVisible: true, active: true}},
+};

--- a/__docs__/wonder-blocks-tabs/tab-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tab-variants.stories.tsx
@@ -7,6 +7,7 @@ import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {rtlText} from "../components/text-for-testing";
 
 const StyledDiv = addStyle("div");
 
@@ -14,7 +15,7 @@ const generateRows = (rtl: boolean = false) => [
     {
         name: "Default",
         props: {
-            children: "Tab",
+            children: rtl ? rtlText : "Tab",
         },
     },
     {
@@ -29,7 +30,7 @@ const generateRows = (rtl: boolean = false) => [
                     }}
                 >
                     <PhosphorIcon icon={IconMappings.cookie} />
-                    Tab
+                    {rtl ? rtlText : "Tab"}
                     <PhosphorIcon icon={IconMappings.iceCream} />
                 </StyledDiv>
             ),
@@ -75,11 +76,19 @@ const meta = {
     render: (args) => (
         <>
             <AllVariants rows={rows} columns={columns}>
-                {(props) => <Tab {...args} {...props} />}
+                {(props) => (
+                    <div role="tablist">
+                        <Tab {...args} {...props} />
+                    </div>
+                )}
             </AllVariants>
             <div dir="rtl">
                 <AllVariants rows={rtlRows} columns={columns}>
-                    {(props) => <Tab {...args} {...props} />}
+                    {(props) => (
+                        <div role="tablist">
+                            <Tab {...args} {...props} />
+                        </div>
+                    )}
                 </AllVariants>
             </div>
         </>

--- a/__docs__/wonder-blocks-tabs/tabs-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs-variants.stories.tsx
@@ -109,6 +109,7 @@ const generateRows = (rtl: boolean = false) => [
                     ),
                     id: "tab-1",
                     panel: rtl ? rtlText : "Tab 1 Contents",
+                    "aria-label": "Tab 1",
                 },
                 {
                     label: (
@@ -119,6 +120,7 @@ const generateRows = (rtl: boolean = false) => [
                     ),
                     id: "tab-2",
                     panel: rtl ? rtlText : "Tab 2 Contents",
+                    "aria-label": "Tab 2",
                 },
             ],
             selectedTabId: "tab-1",
@@ -188,4 +190,30 @@ export const HoverFocus: Story = {
 
 export const Press: Story = {
     parameters: {pseudo: {hover: true, active: true}},
+};
+
+export const Zoom: Story = {
+    render: (args) => (
+        <>
+            <AllVariants rows={rows} columns={columns} layout="list">
+                {(props) => (
+                    <View>
+                        <Tabs {...args} {...props} />
+                    </View>
+                )}
+            </AllVariants>
+            <div dir="rtl">
+                <AllVariants rows={rtlRows} columns={columns} layout="list">
+                    {(props) => (
+                        <View>
+                            <Tabs {...args} {...props} />
+                        </View>
+                    )}
+                </AllVariants>
+            </div>
+        </>
+    ),
+    globals: {
+        zoom: "400%",
+    },
 };

--- a/__docs__/wonder-blocks-tabs/tabs-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs-variants.stories.tsx
@@ -1,0 +1,191 @@
+import type {Meta, StoryObj} from "@storybook/react";
+import * as React from "react";
+
+import {Tabs} from "@khanacademy/wonder-blocks-tabs";
+import {AllVariants} from "../components/all-variants";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {rtlText} from "../components/text-for-testing";
+
+const StyledDiv = addStyle("div");
+
+const generateRows = (rtl: boolean = false) => [
+    {
+        name: "Default",
+        props: {
+            tabs: [
+                {
+                    label: rtl ? rtlText : "Tab 1",
+                    id: "tab-1",
+                    panel: rtl ? rtlText : "Tab 1 Contents",
+                },
+                {
+                    label: rtl ? rtlText : "Tab 2",
+                    id: "tab-2",
+                    panel: rtl ? rtlText : "Tab 2 Contents",
+                },
+                {
+                    label: rtl ? rtlText : "Tab 3",
+                    id: "tab-3",
+                    panel: rtl ? rtlText : "Tab 3 Contents",
+                },
+            ],
+            selectedTabId: "tab-1",
+        },
+    },
+    {
+        name: "With Icons",
+        props: {
+            tabs: [
+                {
+                    label: (
+                        <StyledDiv
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                // TODO: Update to use spacing tokens
+                                gap: "4px",
+                            }}
+                        >
+                            <PhosphorIcon icon={IconMappings.cookie} />
+                            {rtl ? rtlText : "Tab 1"}
+                            <PhosphorIcon icon={IconMappings.iceCream} />
+                        </StyledDiv>
+                    ),
+                    id: "tab-1",
+                    panel: rtl ? rtlText : "Tab 1 Contents",
+                },
+                {
+                    label: (
+                        <StyledDiv
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                // TODO: Update to use spacing tokens
+                                gap: "4px",
+                            }}
+                        >
+                            <PhosphorIcon icon={IconMappings.cookie} />
+                            {rtl ? rtlText : "Tab 2"}
+                            <PhosphorIcon icon={IconMappings.iceCream} />
+                        </StyledDiv>
+                    ),
+                    id: "tab-2",
+                    panel: rtl ? rtlText : "Tab 2 Contents",
+                },
+                {
+                    label: (
+                        <StyledDiv
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                // TODO: Update to use spacing tokens
+                                gap: "4px",
+                            }}
+                        >
+                            <PhosphorIcon icon={IconMappings.cookie} />
+                            {rtl ? rtlText : "Tab 3"}
+                            <PhosphorIcon icon={IconMappings.iceCream} />
+                        </StyledDiv>
+                    ),
+                    id: "tab-3",
+                    panel: rtl ? rtlText : "Tab 3 Contents",
+                },
+            ],
+            selectedTabId: "tab-1",
+        },
+    },
+    {
+        name: "Icon Only",
+        props: {
+            tabs: [
+                {
+                    label: (
+                        <PhosphorIcon
+                            icon={IconMappings.iceCream}
+                            size="medium"
+                        />
+                    ),
+                    id: "tab-1",
+                    panel: rtl ? rtlText : "Tab 1 Contents",
+                },
+                {
+                    label: (
+                        <PhosphorIcon
+                            icon={IconMappings.cookie}
+                            size="medium"
+                        />
+                    ),
+                    id: "tab-2",
+                    panel: rtl ? rtlText : "Tab 2 Contents",
+                },
+            ],
+            selectedTabId: "tab-1",
+        },
+    },
+];
+
+const rows = generateRows();
+const rtlRows = generateRows(true);
+
+const columns = [
+    {
+        name: "Default",
+        props: {},
+    },
+];
+
+type Story = StoryObj<typeof Tabs>;
+
+/**
+ * The following stories are used to generate the pseudo states for the Switch
+ * component. This is only used for visual testing in Chromatic.
+ */
+const meta = {
+    title: "Packages / Tabs / Tabs / Tabs - All Variants",
+    component: Tabs,
+    render: (args) => (
+        <>
+            <AllVariants rows={rows} columns={columns}>
+                {(props) => (
+                    <View>
+                        <Tabs {...args} {...props} />
+                    </View>
+                )}
+            </AllVariants>
+            <div dir="rtl">
+                <AllVariants rows={rtlRows} columns={columns}>
+                    {(props) => (
+                        <View>
+                            <Tabs {...args} {...props} />
+                        </View>
+                    )}
+                </AllVariants>
+            </div>
+        </>
+    ),
+    args: {},
+    tags: ["!autodocs"],
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+
+export const Default: Story = {};
+
+export const Hover: Story = {
+    parameters: {pseudo: {hover: true}},
+};
+
+export const Focus: Story = {
+    parameters: {pseudo: {focusVisible: true}},
+};
+
+export const HoverFocus: Story = {
+    name: "Hover + Focus",
+    parameters: {pseudo: {hover: true, focusVisible: true}},
+};
+
+export const Press: Story = {
+    parameters: {pseudo: {hover: true, active: true}},
+};

--- a/__docs__/wonder-blocks-tabs/tabs-variants.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs-variants.stories.tsx
@@ -7,6 +7,7 @@ import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {rtlText} from "../components/text-for-testing";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 const StyledDiv = addStyle("div");
 
@@ -44,8 +45,7 @@ const generateRows = (rtl: boolean = false) => [
                             style={{
                                 display: "flex",
                                 alignItems: "center",
-                                // TODO: Update to use spacing tokens
-                                gap: "4px",
+                                gap: sizing.size_040,
                             }}
                         >
                             <PhosphorIcon icon={IconMappings.cookie} />
@@ -62,8 +62,7 @@ const generateRows = (rtl: boolean = false) => [
                             style={{
                                 display: "flex",
                                 alignItems: "center",
-                                // TODO: Update to use spacing tokens
-                                gap: "4px",
+                                gap: sizing.size_040,
                             }}
                         >
                             <PhosphorIcon icon={IconMappings.cookie} />
@@ -80,8 +79,7 @@ const generateRows = (rtl: boolean = false) => [
                             style={{
                                 display: "flex",
                                 alignItems: "center",
-                                // TODO: Update to use spacing tokens
-                                gap: "4px",
+                                gap: sizing.size_040,
                             }}
                         >
                             <PhosphorIcon icon={IconMappings.cookie} />

--- a/__docs__/wonder-blocks-tabs/tabs.accessibility.mdx
+++ b/__docs__/wonder-blocks-tabs/tabs.accessibility.mdx
@@ -9,6 +9,11 @@ import {Meta} from "@storybook/blocks";
 the id of the label. If there isn't, set the `aria-label` prop
 - Make sure the ids for the tabs are unique. They are used to associate the tabs
 and tab panels together
+- When enabling animations in the component using the `animated` prop, consider
+setting it to `false` for users who have their prefered reduced motion setting
+on. By default, animations are disabled.
+    - Note: We have an `animated` prop to enable animations so that this can be
+    configured based on both the OS and user's site settings
 
 ## About the Implementation
 

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -10,6 +10,14 @@ import Link from "@khanacademy/wonder-blocks-link";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
+import {ScenariosLayout} from "../components/scenarios-layout";
+import {
+    longText,
+    longTextWithNoWordBreak,
+} from "../components/text-for-testing";
+import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 
 const tabs: TabItem[] = [
     {label: "Tab 1", id: "tab-1", panel: <div>Tab contents 1</div>},
@@ -275,5 +283,143 @@ export const PanelCaching: StoryComponentType = {
             // Disabling because this doesn't test anything visual.
             disableSnapshot: true,
         },
+    },
+};
+
+const StyledSpan = addStyle("span");
+
+const generateTabs = (
+    count: number,
+    tabContent: string = "Tab",
+    withIcons: boolean = false,
+) => {
+    return new Array(count).fill(0).map((_, index) => ({
+        label: (
+            <StyledSpan
+                style={{display: "flex", gap: "8px", alignItems: "center"}}
+            >
+                {withIcons && <PhosphorIcon icon={IconMappings.cookie} />}
+                {`${tabContent} ${index + 1}`}
+                {withIcons && <PhosphorIcon icon={IconMappings.iceCream} />}
+            </StyledSpan>
+        ),
+        id: `tab-${index + 1}`,
+        panel: <div>Tab contents {index + 1}</div>,
+    }));
+};
+
+export const Scenarios: StoryComponentType = {
+    render: () => {
+        const scenarios = [
+            {
+                name: "Zero items",
+                props: {
+                    tabs: [],
+                },
+            },
+            {
+                name: "Many Items",
+                props: {
+                    tabs: generateTabs(30),
+                    selectedTabId: "tab-1",
+                },
+            },
+            {
+                name: "No item selected",
+                props: {
+                    tabs: generateTabs(3),
+                    selectedTabId: "",
+                },
+            },
+            {
+                name: "Long text",
+                props: {
+                    tabs: generateTabs(3, longText),
+                    selectedTabId: "tab-1",
+                },
+            },
+            {
+                name: "Long text with no word break",
+                props: {
+                    tabs: generateTabs(3, longTextWithNoWordBreak),
+                    selectedTabId: "tab-1",
+                },
+            },
+            {
+                name: "Long text (with icons)",
+                props: {
+                    tabs: generateTabs(3, longText, true),
+                    selectedTabId: "tab-1",
+                },
+            },
+            {
+                name: "Long text with no word break (with icons)",
+                props: {
+                    tabs: generateTabs(3, longTextWithNoWordBreak, true),
+                    selectedTabId: "tab-1",
+                },
+            },
+            {
+                name: "Varying lengths",
+                props: {
+                    tabs: [
+                        {
+                            label: longText,
+                            id: "tab-1",
+                            panel: <div>Tab contents 1</div>,
+                        },
+                        {
+                            label: "Short text",
+                            id: "tab-2",
+                            panel: <div>Tab contents 2</div>,
+                        },
+                        {
+                            label: longText,
+                            id: "tab-3",
+                            panel: <div>Tab contents 3</div>,
+                        },
+                        {
+                            label: "Short text",
+                            id: "tab-4",
+                            panel: <div>Tab contents 4</div>,
+                        },
+                    ],
+                    selectedTabId: "tab-1",
+                },
+            },
+            {
+                name: "With icons only",
+                props: {
+                    tabs: [
+                        {
+                            label: (
+                                <PhosphorIcon
+                                    icon={IconMappings.cookie}
+                                    size="medium"
+                                />
+                            ),
+                            id: "tab-1",
+                            panel: <div>Tab contents 1</div>,
+                        },
+                        {
+                            label: (
+                                <PhosphorIcon
+                                    icon={IconMappings.iceCream}
+                                    size="medium"
+                                />
+                            ),
+                            id: "tab-2",
+                            panel: <div>Tab contents 2</div>,
+                        },
+                    ],
+                    selectedTabId: "tab-1",
+                },
+            },
+        ];
+        return (
+            <ScenariosLayout scenarios={scenarios}>
+                {(props) => <Tabs {...props} />}
+            </ScenariosLayout>
+        );
     },
 };

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -401,10 +401,10 @@ export const CustomStyles: StoryComponentType = {
         // visual regression tests to ensure that the custom styles are applied
         // correctly.
         styles: {
-            root: {outline: "2px solid red"},
-            tablist: {backgroundColor: "lightpink"},
-            tabPanel: {backgroundColor: "lightblue"},
-            tab: {backgroundColor: "lightgray"},
+            root: {outline: "2px solid lightpink"},
+            tablist: {backgroundColor: "lavender"},
+            tabPanel: {backgroundColor: "lavenderblush"},
+            tab: {backgroundColor: "lightcyan"},
         },
         tabs: [
             {
@@ -419,13 +419,23 @@ export const CustomStyles: StoryComponentType = {
             },
             {
                 label: (
-                    <View style={{backgroundColor: "lightgreen"}}>
+                    <View
+                        style={{
+                            backgroundColor: "honeydew",
+                            fontStyle: "italic",
+                        }}
+                    >
                         Tab with custom style
                     </View>
                 ),
                 id: "tab-3",
                 panel: (
-                    <View style={{backgroundColor: "lightgreen"}}>
+                    <View
+                        style={{
+                            backgroundColor: "honeydew",
+                            fontStyle: "italic",
+                        }}
+                    >
                         Tab contents with custom style
                     </View>
                 ),
@@ -520,6 +530,7 @@ const scenarios = [
                         <PhosphorIcon
                             icon={IconMappings.cookie}
                             size="medium"
+                            aria-label="Tab 1"
                         />
                     ),
                     id: "tab-1",
@@ -530,6 +541,7 @@ const scenarios = [
                         <PhosphorIcon
                             icon={IconMappings.iceCream}
                             size="medium"
+                            aria-label="Tab 2"
                         />
                     ),
                     id: "tab-2",

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -19,15 +19,15 @@ import {
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
-import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 const Placeholder = ({children}: {children: React.ReactNode}) => {
     return (
         <View
             style={{
                 backgroundColor: semanticColor.surface.secondary,
-                padding: "12px", // TODO: Use sizing tokens
-                margin: "1px",
+                padding: sizing.size_120,
+                margin: sizing.size_010,
                 border: `${border.width.thin}px dashed ${semanticColor.border.subtle}`,
                 width: "100%",
                 alignItems: "center",
@@ -46,7 +46,11 @@ const generateTabs = (
     return new Array(count).fill(0).map((_, index) => ({
         label: (
             <View
-                style={{gap: "8px", alignItems: "center", flexDirection: "row"}}
+                style={{
+                    gap: sizing.size_080,
+                    alignItems: "center",
+                    flexDirection: "row",
+                }}
             >
                 {withIcons && <PhosphorIcon icon={IconMappings.cookie} />}
                 {`${tabContent} ${index + 1}`}

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -18,12 +18,62 @@ import {
 } from "../components/text-for-testing";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {addStyle, PropsFor} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
+import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+
+const Placeholder = ({children}: {children: React.ReactNode}) => {
+    return (
+        <View
+            style={{
+                backgroundColor: semanticColor.surface.secondary,
+                padding: "12px", // TODO: Use sizing tokens
+                margin: "1px",
+                border: `${border.width.thin}px dashed ${semanticColor.border.subtle}`,
+                width: "100%",
+                alignItems: "center",
+            }}
+        >
+            {children}
+        </View>
+    );
+};
+
+const generateTabs = (
+    count: number,
+    tabContent: string = "Tab",
+    withIcons: boolean = false,
+) => {
+    return new Array(count).fill(0).map((_, index) => ({
+        label: (
+            <View
+                style={{gap: "8px", alignItems: "center", flexDirection: "row"}}
+            >
+                {withIcons && <PhosphorIcon icon={IconMappings.cookie} />}
+                {`${tabContent} ${index + 1}`}
+                {withIcons && <PhosphorIcon icon={IconMappings.iceCream} />}
+            </View>
+        ),
+        id: `tab-${index + 1}`,
+        panel: <Placeholder>Tab contents {index + 1}</Placeholder>,
+    }));
+};
 
 const tabs: TabItem[] = [
-    {label: "Tab 1", id: "tab-1", panel: <div>Tab contents 1</div>},
-    {label: "Tab 2", id: "tab-2", panel: <div>Tab contents 2</div>},
-    {label: "Tab 3", id: "tab-3", panel: <div>Tab contents 3</div>},
+    {
+        label: "Tab 1",
+        id: "tab-1",
+        panel: <Placeholder>Tab contents 1</Placeholder>,
+    },
+    {
+        label: "Tab 2",
+        id: "tab-2",
+        panel: <Placeholder>Tab contents 2</Placeholder>,
+    },
+    {
+        label: "Tab 3",
+        id: "tab-3",
+        panel: <Placeholder>Tab contents 3</Placeholder>,
+    },
 ];
 
 function ControlledTabs(props: PropsFor<typeof Tabs>) {
@@ -92,6 +142,22 @@ export const ManualActivation: StoryComponentType = {
 export const AutomaticActivation: StoryComponentType = {
     args: {
         activationMode: "automatic",
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
+ * The tab label can be customized to include icons.
+ */
+export const WithIcons: StoryComponentType = {
+    args: {
+        tabs: generateTabs(3, "Tab", true),
+        selectedTabId: "tab-1",
     },
     parameters: {
         chromatic: {
@@ -218,7 +284,7 @@ export const TabLabelRenderFunction: StoryComponentType = {
                     );
                 },
                 id: "tab-1",
-                panel: <div>Tab contents 1</div>,
+                panel: <Placeholder>Tab contents 1</Placeholder>,
             },
             {
                 label(tabProps) {
@@ -238,7 +304,7 @@ export const TabLabelRenderFunction: StoryComponentType = {
                     );
                 },
                 id: "tab-2",
-                panel: <div>Tab contents 2</div>,
+                panel: <Placeholder>Tab contents 2</Placeholder>,
             },
         ],
     },
@@ -337,26 +403,47 @@ export const PanelCaching: StoryComponentType = {
     },
 };
 
-const StyledSpan = addStyle("span");
-
-const generateTabs = (
-    count: number,
-    tabContent: string = "Tab",
-    withIcons: boolean = false,
-) => {
-    return new Array(count).fill(0).map((_, index) => ({
-        label: (
-            <StyledSpan
-                style={{display: "flex", gap: "8px", alignItems: "center"}}
-            >
-                {withIcons && <PhosphorIcon icon={IconMappings.cookie} />}
-                {`${tabContent} ${index + 1}`}
-                {withIcons && <PhosphorIcon icon={IconMappings.iceCream} />}
-            </StyledSpan>
-        ),
-        id: `tab-${index + 1}`,
-        panel: <div>Tab contents {index + 1}</div>,
-    }));
+/**
+ * The following example shows how the `styles` prop can be used to apply
+ * custom styles to different elements in the `Tabs` component.
+ */
+export const CustomStyles: StoryComponentType = {
+    args: {
+        // These styles are for demo purposes only. We use this story in the
+        // visual regression tests to ensure that the custom styles are applied
+        // correctly.
+        styles: {
+            root: {outline: "2px solid red"},
+            tablist: {backgroundColor: "lightpink"},
+            tabPanel: {backgroundColor: "lightblue"},
+            tab: {backgroundColor: "lightgray"},
+        },
+        tabs: [
+            {
+                label: "Tab 1",
+                id: "tab-1",
+                panel: <div>Tab contents 1</div>,
+            },
+            {
+                label: "Tab 2",
+                id: "tab-2",
+                panel: <div>Tab contents 2</div>,
+            },
+            {
+                label: (
+                    <View style={{backgroundColor: "lightgreen"}}>
+                        Tab with custom style
+                    </View>
+                ),
+                id: "tab-3",
+                panel: (
+                    <View style={{backgroundColor: "lightgreen"}}>
+                        Tab contents with custom style
+                    </View>
+                ),
+            },
+        ],
+    },
 };
 
 const scenarios = [

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -19,24 +19,8 @@ import {
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-
-const Placeholder = ({children}: {children: React.ReactNode}) => {
-    return (
-        <View
-            style={{
-                backgroundColor: semanticColor.surface.secondary,
-                padding: sizing.size_120,
-                margin: sizing.size_010,
-                border: `${border.width.thin}px dashed ${semanticColor.border.subtle}`,
-                width: "100%",
-                alignItems: "center",
-            }}
-        >
-            {children}
-        </View>
-    );
-};
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {Placeholder} from "../components/placeholder";
 
 const generateTabs = (
     count: number,

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -401,7 +401,7 @@ export const CustomStyles: StoryComponentType = {
         // visual regression tests to ensure that the custom styles are applied
         // correctly.
         styles: {
-            root: {outline: "2px solid lightpink"},
+            root: {border: "2px solid lightpink"},
             tablist: {backgroundColor: "lavender"},
             tabPanel: {backgroundColor: "lavenderblush"},
             tab: {backgroundColor: "lightcyan"},

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -341,6 +341,12 @@ export const AnimationsDisabled: StoryComponentType = {
     args: {
         animated: false,
     },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
     play: async ({canvasElement}) => {
         // Arrange
         const canvas = within(canvasElement.ownerDocument.body);

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -18,8 +18,9 @@ const tabs: TabItem[] = [
 ];
 
 export default {
-    title: "Packages / Tabs / Tabs / Tabs",
+    title: "Packages / Tabs / Tabs",
     component: Tabs,
+    subcomponents: {Tab},
     parameters: {
         componentSubtitle: (
             <ComponentInfo

--- a/packages/wonder-blocks-tabs/src/components/navigation-tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tabs.tsx
@@ -2,12 +2,12 @@ import {
     addStyle,
     AriaProps,
     StyleType,
-    useOnMountEffect,
     View,
 } from "@khanacademy/wonder-blocks-core";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
+import {useTabIndicator} from "../hooks/use-tab-indicator";
 
 type Props = AriaProps & {
     /**
@@ -107,81 +107,22 @@ export const NavigationTabs = React.forwardRef(function NavigationTabs(
      */
     const listRef = React.useRef<HTMLUListElement>(null);
 
-    /**
-     * Determines if we should show the underline current indicator. We only
-     * want to show it if the list has been measured at least once after the
-     * initial aphrodite styles have loaded.
-     */
-    const indicatorIsReady = React.useRef(false);
+    const isTabActive = React.useCallback(
+        (navTabItemElement: Element): boolean => {
+            // Check the link inside the NavigationTabItem to see if it has aria-current="page"
+            return navTabItemElement.children[0]?.ariaCurrent === "page";
+        },
+        [],
+    );
 
-    /**
-     * The styles for the underline current indicator.
-     */
-    const [underlineStyle, setUnderlineStyle] = React.useState({
-        left: 0,
-        width: 0,
-    });
-
-    const updateUnderlineStyle = React.useCallback(() => {
-        if (!listRef.current) {
-            return;
-        }
-
-        // Find the active tab based on which link (child of NavigationTabItem) has
-        // the aria-current set
-        const activeTab = Array.from(listRef.current.children).find(
-            (child) => child.children[0]?.ariaCurrent,
-        );
-
-        if (activeTab) {
-            const tabRect = activeTab.getBoundingClientRect();
-            const parentRect = listRef.current.getBoundingClientRect();
-            const zoomFactor = parentRect.width / listRef.current.offsetWidth;
-
-            // When calculating, we divide by the zoom factor so the underline
-            // is proportional to the rest of the component
-            const left = (tabRect.left - parentRect.left) / zoomFactor; // Get position relative to parent
-            const width = tabRect.width / zoomFactor; // Use bounding width
-
-            setUnderlineStyle({
-                left,
-                width,
-            });
-        }
-    }, [setUnderlineStyle, listRef]);
-
-    /**
-     * On mount, set up the resize observer to watch the list element. We
-     * recalculate the underline style when the list size changes.
-     */
-    useOnMountEffect(() => {
-        // If the list ref is not set or if the ResizeObserver is not available,
-        // don't set up a resize observer. Note: ResizeObserver is supported in
-        // the browsers we support, but not in jsdom for tests
-        // https://github.com/jsdom/jsdom/issues/3368
-        if (!listRef.current || !window.ResizeObserver) {
-            return;
-        }
-        const observer = new window.ResizeObserver(([entry]) => {
-            if (entry) {
-                // Update underline style when the list size changes
-                updateUnderlineStyle();
-                if (!indicatorIsReady.current) {
-                    // Mark indicator as ready to show
-                    indicatorIsReady.current = true;
-                }
-            }
-        });
-
-        observer.observe(listRef.current);
-
-        return () => {
-            observer.disconnect();
-        };
+    const {indicatorProps, updateUnderlineStyle} = useTabIndicator({
+        animated,
+        tabsContainerRef: listRef,
+        isTabActive,
     });
 
     React.useEffect(() => {
-        // Update the underline style when children change
+        // Update the underline style when children (tabs) change
         updateUnderlineStyle();
     }, [children, updateUnderlineStyle]);
 
@@ -196,31 +137,14 @@ export const NavigationTabs = React.forwardRef(function NavigationTabs(
             {...otherProps}
         >
             {/* Wrap the contents so that any custom styles (like padding) set
-            on the root doesn't affect the positioning of the underline. */}
+            on the root doesn't affect the positioning of the underline indicator. */}
             <StyledDiv style={styles.contents}>
                 <StyledUl style={[styles.list, stylesProp?.list]} ref={listRef}>
                     {children}
                 </StyledUl>
                 {/* Underline indicator for the current tab item. It is a sibling of
-            the list so that it can slide between tab items. We only show it
-            once it is ready so that we don't show the indicator re-positioning
-            itself after aphrodite styles are first loaded in */}
-                {indicatorIsReady.current && (
-                    <View
-                        style={[
-                            {
-                                // Translate x position instead of setting the
-                                // left position so layout doesn't need to be
-                                // recalculated each time
-                                transform: `translateX(${underlineStyle.left}px)`,
-                                width: `${underlineStyle.width}px`,
-                            },
-                            styles.currentUnderline,
-                            animated && styles.underlineTransition,
-                        ]}
-                        role="presentation"
-                    />
-                )}
+            the list so that it can slide between tab items. */}
+                {<View {...indicatorProps} />}
             </StyledDiv>
         </StyledNav>
     );
@@ -241,16 +165,5 @@ const styles = StyleSheet.create({
         display: "flex",
         gap: sizing.size_160,
         flexWrap: "nowrap",
-    },
-    currentUnderline: {
-        position: "absolute",
-        bottom: 0,
-        left: 0,
-        height: sizing.size_040,
-        backgroundColor:
-            semanticColor.action.secondary.progressive.default.foreground,
-    },
-    underlineTransition: {
-        transition: "transform 0.3s ease, width 0.3s ease",
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import {findFocusableNodes} from "../../../wonder-blocks-core/src/util/focus";
 
@@ -25,6 +25,11 @@ type Props = {
      * Whether the tab panel is active.
      */
     active?: boolean;
+
+    /**
+     * Custom styles for the `TabPanel` component.
+     */
+    style?: StyleType;
 };
 
 const StyledDiv = addStyle("div");
@@ -39,6 +44,7 @@ export const TabPanel = (props: Props) => {
         "aria-labelledby": ariaLabelledby,
         active = false,
         testId,
+        style,
     } = props;
 
     const ref = React.useRef<HTMLDivElement>(null);
@@ -65,7 +71,7 @@ export const TabPanel = (props: Props) => {
             hidden={!active}
             data-testid={testId}
             // Only apply styles if it is active so it doesn't override the display: none for inactive tabs
-            style={active && styles.tabPanel}
+            style={active && [styles.tabPanel, style]}
         >
             {children}
         </StyledDiv>

--- a/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab-panel.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {StyleSheet} from "aphrodite";
 import {findFocusableNodes} from "../../../wonder-blocks-core/src/util/focus";
 
 type Props = {
@@ -63,8 +64,17 @@ export const TabPanel = (props: Props) => {
             // Only show the tab panel if it is active
             hidden={!active}
             data-testid={testId}
+            // Only apply styles if it is active so it doesn't override the display: none for inactive tabs
+            style={active && styles.tabPanel}
         >
             {children}
         </StyledDiv>
     );
 };
+
+const styles = StyleSheet.create({
+    tabPanel: {
+        // Apply flex so that panel supports rtl
+        display: "flex",
+    },
+});

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -1,5 +1,9 @@
-import {AriaProps} from "@khanacademy/wonder-blocks-core";
+import {addStyle, AriaProps} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 
 type Props = AriaProps & {
     /**
@@ -32,6 +36,8 @@ type Props = AriaProps & {
     onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 };
 
+const StyledButton = addStyle("button");
+
 /**
  * A component that has `role="tab"` and is used to represent a tab in a tabbed
  * interface.
@@ -52,7 +58,7 @@ export const Tab = React.forwardRef(function Tab(
         ...otherProps
     } = props;
     return (
-        <button
+        <StyledButton
             {...otherProps}
             role="tab"
             onClick={onClick}
@@ -65,8 +71,59 @@ export const Tab = React.forwardRef(function Tab(
             tabIndex={selected ? 0 : -1}
             onKeyDown={onKeyDown}
             data-testid={testId}
+            style={[
+                typographyStyles.Body,
+                styles.tab,
+                selected && styles.selectedTab,
+            ]}
         >
             {children}
-        </button>
+        </StyledButton>
     );
+});
+
+export const styles = StyleSheet.create({
+    tab: {
+        display: "flex",
+        alignItems: "center",
+        textWrap: "nowrap",
+        backgroundColor: "transparent",
+        border: "none",
+        margin: 0,
+        padding: 0,
+        cursor: "pointer",
+        // TODO: Update to use spacing tokens
+        marginBlockStart: "8px",
+        // TODO: Update to use spacing tokens
+        marginBlockEnd: "14px",
+        position: "relative",
+        ...focusStyles.focus,
+        ":after": {
+            content: "''",
+            position: "absolute",
+            left: 0,
+            right: 0,
+            // TODO: Update to use spacing tokens
+            bottom: "-14px",
+        },
+        ":hover": {
+            color: semanticColor.action.secondary.progressive.hover.foreground,
+            [":after" as any]: {
+                height: border.width.hairline,
+                backgroundColor:
+                    semanticColor.action.secondary.progressive.hover.foreground,
+            },
+        },
+        ":active": {
+            color: semanticColor.action.secondary.progressive.press.foreground,
+            [":after" as any]: {
+                height: border.width.thick,
+                backgroundColor:
+                    semanticColor.action.secondary.progressive.press.foreground,
+            },
+        },
+    },
+    selectedTab: {
+        color: semanticColor.action.secondary.progressive.default.foreground,
+    },
 });

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -103,6 +103,8 @@ export const styles = StyleSheet.create({
         marginBlockEnd: bottomSpacing,
         position: "relative",
         ...focusStyles.focus,
+        // Using :after styling to apply the hover/pressed underline styling
+        // instead of box-shadow because we use box-shadow for the focus outline.
         ":after": {
             content: "''",
             position: "absolute",

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -1,7 +1,7 @@
 import {addStyle, AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 
@@ -88,6 +88,7 @@ export const Tab = React.forwardRef(function Tab(
     );
 });
 
+const bottomSpacing = sizing.size_140;
 export const styles = StyleSheet.create({
     tab: {
         display: "flex",
@@ -98,10 +99,8 @@ export const styles = StyleSheet.create({
         margin: 0,
         padding: 0,
         cursor: "pointer",
-        // TODO: Update to use spacing tokens
-        marginBlockStart: "8px",
-        // TODO: Update to use spacing tokens
-        marginBlockEnd: "14px",
+        marginBlockStart: sizing.size_080,
+        marginBlockEnd: bottomSpacing,
         position: "relative",
         ...focusStyles.focus,
         ":after": {
@@ -109,8 +108,7 @@ export const styles = StyleSheet.create({
             position: "absolute",
             left: 0,
             right: 0,
-            // TODO: Update to use spacing tokens
-            bottom: "-14px",
+            bottom: `-${bottomSpacing}`,
         },
         // Only apply hover styles to tabs that are not selected
         [":hover:not([aria-selected='true'])" as any]: {

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -1,4 +1,4 @@
-import {addStyle, AriaProps} from "@khanacademy/wonder-blocks-core";
+import {addStyle, AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
@@ -34,6 +34,10 @@ type Props = AriaProps & {
      * Called when a key is pressed on the tab.
      */
     onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
+    /**
+     * Custom styles for the `Tab` component.
+     */
+    style?: StyleType;
 };
 
 const StyledButton = addStyle("button");
@@ -54,6 +58,7 @@ export const Tab = React.forwardRef(function Tab(
         selected,
         onKeyDown,
         testId,
+        style,
         // Should only include aria related props
         ...otherProps
     } = props;
@@ -75,6 +80,7 @@ export const Tab = React.forwardRef(function Tab(
                 typographyStyles.Body,
                 styles.tab,
                 selected && styles.selectedTab,
+                style,
             ]}
         >
             {children}
@@ -106,7 +112,8 @@ export const styles = StyleSheet.create({
             // TODO: Update to use spacing tokens
             bottom: "-14px",
         },
-        ":hover": {
+        // Only apply hover styles to tabs that are not selected
+        [":hover:not([aria-selected='true'])" as any]: {
             color: semanticColor.action.secondary.progressive.hover.foreground,
             [":after" as any]: {
                 height: border.width.hairline,
@@ -114,7 +121,8 @@ export const styles = StyleSheet.create({
                     semanticColor.action.secondary.progressive.hover.foreground,
             },
         },
-        ":active": {
+        // Only apply active styles to tabs that are not selected
+        [":active:not([aria-selected='true'])" as any]: {
             color: semanticColor.action.secondary.progressive.press.foreground,
             [":after" as any]: {
                 height: border.width.thick,

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -1,4 +1,4 @@
-import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
 import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
@@ -30,6 +30,10 @@ type Props = {
      * Called when focus moves out of the tablist.
      */
     onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void;
+    /**
+     * Custom styles for the `Tablist` component.
+     */
+    style?: StyleType;
 };
 
 const StyledDiv = addStyle("div");
@@ -48,13 +52,14 @@ export const Tablist = React.forwardRef(function Tablist(
         "aria-labelledby": ariaLabelledby,
         onBlur,
         testId,
+        style,
     } = props;
 
     return (
         <StyledDiv
             id={id}
             role="tablist"
-            style={styles.tablist}
+            style={[styles.tablist, style]}
             ref={ref}
             aria-label={ariaLabel}
             aria-labelledby={ariaLabelledby}
@@ -72,5 +77,7 @@ const styles = StyleSheet.create({
         // TODO: Update to use spacing tokens
         gap: "24px",
         borderBottom: `1px solid ${semanticColor.border.subtle}`,
+        // Add horizontal padding for focus outline of first/last elements
+        paddingInline: "4px", // TODO: Use sizing tokens
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -1,5 +1,5 @@
 import {addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
     tablist: {
         display: "flex",
         gap: sizing.size_240,
-        borderBottom: `1px solid ${semanticColor.border.subtle}`,
+        borderBottom: `${border.width.hairline}px solid ${semanticColor.border.subtle}`,
         // Add horizontal padding for focus outline of first/last elements
         paddingInline: sizing.size_040,
     },

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -69,7 +69,6 @@ export const Tablist = React.forwardRef(function Tablist(
 const styles = StyleSheet.create({
     tablist: {
         display: "flex",
-        overflowX: "auto",
         // TODO: Update to use spacing tokens
         gap: "24px",
         borderBottom: `1px solid ${semanticColor.border.subtle}`,

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -1,5 +1,5 @@
 import {addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -74,10 +74,9 @@ export const Tablist = React.forwardRef(function Tablist(
 const styles = StyleSheet.create({
     tablist: {
         display: "flex",
-        // TODO: Update to use spacing tokens
-        gap: "24px",
+        gap: sizing.size_240,
         borderBottom: `1px solid ${semanticColor.border.subtle}`,
         // Add horizontal padding for focus outline of first/last elements
-        paddingInline: "4px", // TODO: Use sizing tokens
+        paddingInline: sizing.size_040,
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -1,5 +1,5 @@
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -69,6 +69,9 @@ export const Tablist = React.forwardRef(function Tablist(
 const styles = StyleSheet.create({
     tablist: {
         display: "flex",
-        gap: sizing.size_200,
+        overflowX: "auto",
+        // TODO: Update to use spacing tokens
+        gap: "24px",
+        borderBottom: `1px solid ${semanticColor.border.subtle}`,
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -366,7 +366,7 @@ export const Tabs = React.forwardRef(function Tabs(
                             ref: (element) => {
                                 tabRefs.current[tab.id] = element;
                             },
-                            style: [stylesProp?.tab],
+                            style: stylesProp?.tab,
                         };
 
                         if (typeof label === "function") {

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -4,6 +4,7 @@ import {
     AriaProps,
     keys,
     PropsFor,
+    StyleType,
     View,
 } from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
@@ -127,6 +128,23 @@ type Props = {
      * `false`.
      */
     animated?: boolean;
+    /**
+     * Custom styles for the `Tabs` component.
+     * - `root`: Styles the root `div` element.
+     * - `tablist`: Styles the `tablist` element.
+     * - `tab`: Styles all `tab` elements.
+     * - `tabPanel`: Styles all the `tabpanel` elements.
+     *
+     * If styles need to be applied to specific tab or tab panel elements,
+     * consider setting the styles on the `label` and `panel` content for the
+     * `tabs` prop.
+     */
+    styles?: {
+        root?: StyleType;
+        tablist?: StyleType;
+        tab?: StyleType;
+        tabPanel?: StyleType;
+    };
 } & AriaLabelOrAriaLabelledby;
 
 /**
@@ -165,6 +183,7 @@ export const Tabs = React.forwardRef(function Tabs(
         id,
         testId,
         animated = false,
+        styles: stylesProp,
     } = props;
 
     /**
@@ -311,7 +330,7 @@ export const Tabs = React.forwardRef(function Tabs(
             ref={ref}
             id={uniqueId}
             data-testid={testId}
-            style={styles.tabs}
+            style={[styles.tabs, stylesProp?.root]}
         >
             {/* Wrap the tablist so we can set relative positioning for the tab indicator */}
             <StyledDiv style={styles.tablistWrapper}>
@@ -322,6 +341,7 @@ export const Tabs = React.forwardRef(function Tabs(
                     id={tablistId}
                     testId={testId && `${testId}-tablist`}
                     ref={tablistRef}
+                    style={stylesProp?.tablist}
                 >
                     {tabs.map((tab) => {
                         const {
@@ -346,6 +366,7 @@ export const Tabs = React.forwardRef(function Tabs(
                             ref: (element) => {
                                 tabRefs.current[tab.id] = element;
                             },
+                            style: [stylesProp?.tab],
                         };
 
                         if (typeof label === "function") {
@@ -365,6 +386,7 @@ export const Tabs = React.forwardRef(function Tabs(
                         aria-labelledby={getTabId(tab.id)}
                         active={selectedTabId === tab.id}
                         testId={tab.testId && getTabPanelId(tab.testId)}
+                        style={stylesProp?.tabPanel}
                     >
                         {/* Tab panel contents are rendered if the tab has
                         been previously visited. This prevents unnecessary

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import {AriaProps, keys, PropsFor} from "@khanacademy/wonder-blocks-core";
+import {
+    addStyle,
+    AriaProps,
+    keys,
+    PropsFor,
+} from "@khanacademy/wonder-blocks-core";
+import {StyleSheet} from "aphrodite";
 import {TabPanel} from "./tab-panel";
 import {Tab} from "./tab";
 import {Tablist} from "./tablist";
@@ -130,6 +136,7 @@ function getTabPanelId(tabId: string) {
     return `${tabId}-panel`;
 }
 
+const StyledDiv = addStyle("div");
 /**
  * A component that uses a tabbed interface to control a specific view. The
  * tabs have `role=”tab”` and keyboard users can change tabs using arrow keys.
@@ -259,8 +266,17 @@ export const Tabs = React.forwardRef(function Tabs(
         focusedTabId.current = selectedTabId;
     }, [selectedTabId]);
 
+    if (tabs.length === 0) {
+        return <React.Fragment />;
+    }
+
     return (
-        <div ref={ref} id={uniqueId} data-testid={testId}>
+        <StyledDiv
+            ref={ref}
+            id={uniqueId}
+            data-testid={testId}
+            style={styles.tabs}
+        >
             <Tablist
                 aria-label={ariaLabel}
                 aria-labelledby={ariaLabelledby}
@@ -318,6 +334,14 @@ export const Tabs = React.forwardRef(function Tabs(
                     </TabPanel>
                 );
             })}
-        </div>
+        </StyledDiv>
     );
+});
+
+const styles = StyleSheet.create({
+    tabs: {
+        display: "inline-flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+    },
 });

--- a/packages/wonder-blocks-tabs/src/hooks/use-tab-indicator.ts
+++ b/packages/wonder-blocks-tabs/src/hooks/use-tab-indicator.ts
@@ -3,7 +3,7 @@ import {
     StyleType,
     useOnMountEffect,
 } from "@khanacademy/wonder-blocks-core";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
         position: "absolute",
         bottom: 0,
         left: 0,
-        height: sizing.size_050, // TODO: update token
+        height: border.width.thick,
         backgroundColor:
             semanticColor.action.secondary.progressive.default.foreground,
     },

--- a/packages/wonder-blocks-tabs/src/hooks/use-tab-indicator.ts
+++ b/packages/wonder-blocks-tabs/src/hooks/use-tab-indicator.ts
@@ -28,6 +28,14 @@ type Props = {
      */
     isTabActive(childElement: Element): boolean;
 };
+
+/**
+ * A hook that is used to manage the underline current indicator for tabs.
+ * It returns:
+ * - `indicatorProps`: The props to apply to the underline current indicator
+ * - `updateUnderlineStyle`: A function that updates the underline style. Use
+ * this function when the component detects a change in the tabs
+ */
 export const useTabIndicator = (props: Props) => {
     const {animated, tabsContainerRef, isTabActive} = props;
 

--- a/packages/wonder-blocks-tabs/src/hooks/use-tab-indicator.ts
+++ b/packages/wonder-blocks-tabs/src/hooks/use-tab-indicator.ts
@@ -1,0 +1,141 @@
+import {
+    AriaRole,
+    StyleType,
+    useOnMountEffect,
+} from "@khanacademy/wonder-blocks-core";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+type IndicatorProps = {
+    style: StyleType;
+    role: AriaRole;
+};
+
+type Props = {
+    /**
+     * Whether to include animation.
+     */
+    animated: boolean;
+    /**
+     * Ref for the container of the tabs so we can observe when the size of the
+     * children changes. This is necessary to update the underline position.
+     */
+    tabsContainerRef: React.RefObject<HTMLElement>;
+    /**
+     * Function that determines if a tab is active. The `childElement` argument
+     * is the child element of the `tabsContainerRef` prop
+     */
+    isTabActive(childElement: Element): boolean;
+};
+export const useTabIndicator = (props: Props) => {
+    const {animated, tabsContainerRef, isTabActive} = props;
+
+    /**
+     * Determines if we should show the underline current indicator. We only
+     * want to show it if the tabs container has been measured at least once
+     * after the initial aphrodite styles have loaded.
+     */
+    const indicatorIsReady = React.useRef(false);
+
+    /**
+     * The styles for the underline current indicator.
+     */
+    const [underlineStyle, setUnderlineStyle] = React.useState({
+        left: 0,
+        width: 0,
+    });
+
+    const updateUnderlineStyle = React.useCallback(() => {
+        if (!tabsContainerRef.current) {
+            return;
+        }
+
+        // Find the active tab
+        const activeTab = Array.from(tabsContainerRef.current.children).find(
+            isTabActive,
+        );
+
+        if (activeTab) {
+            const tabRect = activeTab.getBoundingClientRect();
+            const parentRect = tabsContainerRef.current.getBoundingClientRect();
+            const zoomFactor =
+                parentRect.width / tabsContainerRef.current.offsetWidth;
+
+            // When calculating, we divide by the zoom factor so the underline
+            // is proportional to the rest of the component
+            const left = (tabRect.left - parentRect.left) / zoomFactor; // Get position relative to parent
+            const width = tabRect.width / zoomFactor; // Use bounding width
+
+            setUnderlineStyle({
+                left,
+                width,
+            });
+        }
+    }, [setUnderlineStyle, tabsContainerRef, isTabActive]);
+
+    /**
+     * On mount, set up the resize observer to watch the tabs container element.
+     * We recalculate the underline style when the tabs container size changes.
+     */
+    useOnMountEffect(() => {
+        // If the ref is not set or if the ResizeObserver is not available,
+        // don't set up a resize observer. Note: ResizeObserver is supported in
+        // the browsers we support, but not in jsdom for tests
+        // https://github.com/jsdom/jsdom/issues/3368
+        if (!tabsContainerRef.current || !window?.ResizeObserver) {
+            return;
+        }
+        const observer = new window.ResizeObserver(([entry]) => {
+            if (entry) {
+                // Update underline style when the ref size changes
+                updateUnderlineStyle();
+                if (!indicatorIsReady.current) {
+                    // Mark indicator as ready to show
+                    indicatorIsReady.current = true;
+                }
+            }
+        });
+
+        observer.observe(tabsContainerRef.current);
+
+        return () => {
+            observer.disconnect();
+        };
+    });
+
+    const indicatorProps: IndicatorProps = {
+        style: [
+            {
+                // Translate x position instead of setting the
+                // left position so layout doesn't need to be
+                // recalculated each time
+                transform: `translateX(${underlineStyle.left}px)`,
+                width: `${underlineStyle.width}px`,
+            },
+            styles.currentUnderline,
+            animated && styles.underlineTransition,
+            // We only show it once it is ready so that we don't show the
+            // indicator re-positioning itself after aphrodite styles are first
+            // loaded in the browser
+            !indicatorIsReady.current && {display: "none"},
+        ],
+        role: "presentation",
+    };
+
+    return {indicatorProps, updateUnderlineStyle};
+};
+
+const styles = StyleSheet.create({
+    currentUnderline: {
+        position: "absolute",
+        bottom: 0,
+        left: 0,
+        height: sizing.size_050, // TODO: update token
+        backgroundColor:
+            semanticColor.action.secondary.progressive.default.foreground,
+    },
+    underlineTransition: {
+        transition: "transform 0.3s ease, width 0.3s ease",
+    },
+});

--- a/packages/wonder-blocks-tabs/tsconfig-build.json
+++ b/packages/wonder-blocks-tabs/tsconfig-build.json
@@ -10,5 +10,6 @@
       {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
       {"path": "../wonder-blocks-typography/tsconfig-build.json"},
       {"path": "../wonder-blocks-link/tsconfig-build.json"},
+      {"path": "../wonder-blocks-styles/tsconfig-build.json"},
   ]
 }


### PR DESCRIPTION
## Summary:

- Implement styling for the Tabs component
- Add support for `styles` prop
- Implement the selected tab indicator animation with `animated` prop
  - Refactored NavigationTabs tab indicator logic into a hook so it can be shared


Issue: WB-1908

## Test plan:

- styles look as expected
  - Scenarios (including scrolling behaviour) (`?path=/story/packages-tabs-tabs--scenarios`)
  - Tab All Variants (`?path=/story/packages-tabs-tabs-subcomponents-tab-all-variants--default`)
  - Tabs All Variants (states + zoom) (`?path=/story/packages-tabs-tabs-tabs-all-variants--default`)
- `animated` prop works as expected (`?path=/story/packages-tabs-tabs--animated`)
- `styles` prop works as expected (`?path=/story/packages-tabs-tabs--custom-styles`)
- NavigationTabs animations continues to work as expected

## Implementation Plan
- Set up base component https://github.com/Khan/wonder-blocks/pull/2528
- Keyboard interactions https://github.com/Khan/wonder-blocks/pull/2536
- Remaining props https://github.com/Khan/wonder-blocks/pull/2542
- Styles https://github.com/Khan/wonder-blocks/pull/2545