### PR TITLE
Add toggleMode to accordion and accordion section

### DIFF
--- a/.changeset/smooth-actors-mix.md
+++ b/.changeset/smooth-actors-mix.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": minor
+---
+
+Add toggle mode and nesting functionality.

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -8,7 +8,6 @@ import {
 } from "@khanacademy/wonder-blocks-accordion";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import * as tokens from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {
@@ -21,6 +20,7 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-accordion/package.json";
 
 import AccordionArgtypes from "./accordion.argtypes";
+import type {AccordionToggleModeStatus} from "../../packages/wonder-blocks-accordion/src/components/accordion";
 
 /**
  * An accordion displays a vertically stacked list of sections, each of which
@@ -162,7 +162,9 @@ export const CaretPositions: StoryComponentType = {
             <View>
                 {/* Left-to-right */}
                 <View style={styles.sideBySide}>
-                    <View style={styles.fullWidth}>
+                    <View
+                        style={(styles.fullWidth, styles.caretExamplePadding)}
+                    >
                         <LabelLarge>
                             Caret position: end, language direction: left to
                             right
@@ -171,7 +173,6 @@ export const CaretPositions: StoryComponentType = {
                             {exampleSections}
                         </Accordion>
                     </View>
-                    <Strut size={tokens.spacing.xLarge_32} />
                     <View style={styles.fullWidth}>
                         <LabelLarge>
                             Caret position: start, language direction: left to
@@ -185,7 +186,9 @@ export const CaretPositions: StoryComponentType = {
 
                 {/* Right-to-left */}
                 <View style={[styles.sideBySide, styles.rtl]}>
-                    <View style={styles.fullWidth}>
+                    <View
+                        style={(styles.fullWidth, styles.caretExamplePadding)}
+                    >
                         <LabelLarge>
                             Caret position: end, language direction: right to
                             left
@@ -204,7 +207,7 @@ export const CaretPositions: StoryComponentType = {
                             </AccordionSection>
                         </Accordion>
                     </View>
-                    <Strut size={tokens.spacing.xLarge_32} />
+
                     <View style={styles.fullWidth}>
                         <LabelLarge>
                             Caret position: start, language direction: right to
@@ -509,8 +512,8 @@ export const LongSections: StoryComponentType = {
                                         src="/logo.svg"
                                         width="100%"
                                         alt="Wonder Blocks logo"
+                                        style={styles.imagePadding}
                                     />
-                                    <Strut size={tokens.spacing.xLarge_32} />
                                     <img
                                         src="/logo.svg"
                                         width="100%"
@@ -643,10 +646,14 @@ export const BackgroundColorExample: StoryComponentType = {
 
         return (
             <>
-                <Accordion cornerKind="rounded">{sections}</Accordion>
-                <Strut size={tokens.spacing.large_24} />
-                <Accordion cornerKind="square">{sections}</Accordion>
-                <Strut size={tokens.spacing.large_24} />
+                <Accordion cornerKind="rounded" style={styles.accordionPadding}>
+                    {sections}
+                </Accordion>
+
+                <Accordion cornerKind="square" style={styles.accordionPadding}>
+                    {sections}
+                </Accordion>
+
                 <Accordion cornerKind="rounded-per-section">
                     {sections}
                 </Accordion>
@@ -684,4 +691,177 @@ const styles = StyleSheet.create({
         width: "fit-content",
         marginBottom: tokens.spacing.medium_16,
     },
+    caretExamplePadding: {
+        paddingBlockEnd: tokens.spacing.xLarge_32,
+    },
+    imagePadding: {
+        marginBottom: tokens.spacing.xLarge_32,
+    },
+    accordionPadding: {
+        paddingBlockEnd: tokens.spacing.large_24,
+    },
 });
+
+export const WithToggleMode: StoryComponentType = {
+    render: function Render() {
+        const [toggleMode, setToggleMode] = React.useState<
+            "expand-all" | "collapse-all" | undefined
+        >("none");
+
+        const [toggleModeForNextedSection, setToggleModeForNextedSection] =
+            React.useState<"expand-all" | "collapse-all" | undefined>("none");
+
+        return (
+            <>
+                <View>
+                    <LabelLarge>Accordions with toggle all</LabelLarge>
+
+                    <View
+                        style={{
+                            maxWidth: 500,
+                            marginBlockEnd: tokens.spacing.large_24,
+                            paddingBlockStart: tokens.spacing.large_24,
+                            flexDirection: "row",
+                            gap: tokens.spacing.small_12,
+                        }}
+                    >
+                        <Button
+                            onClick={() => setToggleMode("expand-all")}
+                            disabled={toggleMode === "expand-all"}
+                        >
+                            Expand All
+                        </Button>
+                        <Button
+                            onClick={() => setToggleMode("collapse-all")}
+                            disabled={toggleMode === "collapse-all"}
+                        >
+                            Collapse All
+                        </Button>
+                    </View>
+                    <Accordion
+                        toggleMode={toggleMode}
+                        onToggleModeComplete={({
+                            anyExpanded,
+                            anyCollapsed,
+                        }: AccordionToggleModeStatus) => {
+                            // partial
+                            if (anyExpanded && anyCollapsed) {
+                                setToggleMode("none");
+                            } else if (!anyExpanded) {
+                                // all closed
+                                setToggleMode("collapse-all");
+                            } else {
+                                // all open
+                                setToggleMode("expand-all");
+                            }
+                        }}
+                    >
+                        {exampleSections}
+                    </Accordion>
+                </View>
+
+                <View>
+                    <LabelLarge>Nested Accordion Example</LabelLarge>
+
+                    <View
+                        style={{
+                            maxWidth: 500,
+                            marginBlockEnd: tokens.spacing.large_24,
+                            paddingBlockStart: tokens.spacing.large_24,
+                            flexDirection: "row",
+                            gap: tokens.spacing.small_12,
+                        }}
+                    >
+                        <Button
+                            onClick={() =>
+                                setToggleModeForNextedSection("expand-all")
+                            }
+                            disabled={
+                                toggleModeForNextedSection === "expand-all"
+                            }
+                        >
+                            Expand All
+                        </Button>
+                        <Button
+                            onClick={() =>
+                                setToggleModeForNextedSection("collapse-all")
+                            }
+                            disabled={
+                                toggleModeForNextedSection === "collapse-all"
+                            }
+                        >
+                            Collapse All
+                        </Button>
+                    </View>
+
+                    {/* Main Accordion Component */}
+                    <Accordion
+                        toggleMode={toggleModeForNextedSection}
+                        onToggleModeComplete={({
+                            anyExpanded,
+                            anyCollapsed,
+                        }: AccordionToggleModeStatus) => {
+                            // partial
+                            if (anyExpanded && anyCollapsed) {
+                                setToggleModeForNextedSection("none");
+                            } else if (!anyExpanded) {
+                                // all closed
+                                setToggleModeForNextedSection("collapse-all");
+                            } else {
+                                // all open
+                                setToggleModeForNextedSection("expand-all");
+                            }
+                        }}
+                    >
+                        <AccordionSection
+                            header="Section 1"
+                            caretPosition="start"
+                        >
+                            This is the content of section 1.
+                        </AccordionSection>
+                        <AccordionSection
+                            header="Section 2"
+                            caretPosition="start"
+                        >
+                            This is the content of section 2.
+                        </AccordionSection>
+                        <AccordionSection
+                            header="Section 3"
+                            caretPosition="start"
+                        >
+                            This is the content of section 3.
+                        </AccordionSection>
+                        <AccordionSection
+                            header={`Nested Section 1`}
+                            key={`nested-section-1`}
+                            caretPosition="start"
+                        >
+                            <AccordionSection
+                                header={`Nested Section A`}
+                                caretPosition="start"
+                                cornerKind="square"
+                                expanded={
+                                    toggleModeForNextedSection === "expand-all"
+                                }
+                                parentToggleMode={toggleModeForNextedSection}
+                            >
+                                This is content for nested section 2.
+                            </AccordionSection>
+                            <AccordionSection
+                                header={`Nested Section B`}
+                                caretPosition="start"
+                                cornerKind="square"
+                                expanded={
+                                    toggleModeForNextedSection === "expand-all"
+                                }
+                                parentToggleMode={toggleModeForNextedSection}
+                            >
+                                This is content for nested section 3.
+                            </AccordionSection>
+                        </AccordionSection>
+                    </Accordion>
+                </View>
+            </>
+        );
+    },
+};

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -708,10 +708,10 @@ const styles = StyleSheet.create({
 export const WithToggleMode: StoryComponentType = {
     render: function Render() {
         const [toggleMode, setToggleMode] =
-            React.useState<AccordionToggleMode>("none");
+            React.useState<AccordionToggleMode>("collapse-all");
 
         const [toggleModeForNextedSection, setToggleModeForNextedSection] =
-            React.useState<AccordionToggleMode>("none");
+            React.useState<AccordionToggleMode>("collapse-all");
 
         return (
             <>

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -20,7 +20,10 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-accordion/package.json";
 
 import AccordionArgtypes from "./accordion.argtypes";
-import type {AccordionToggleModeStatus} from "../../packages/wonder-blocks-accordion/src/components/accordion";
+import type {
+    AccordionToggleMode,
+    AccordionToggleModeStatus,
+} from "../../packages/wonder-blocks-accordion/src/components/accordion";
 
 /**
  * An accordion displays a vertically stacked list of sections, each of which
@@ -704,12 +707,11 @@ const styles = StyleSheet.create({
 
 export const WithToggleMode: StoryComponentType = {
     render: function Render() {
-        const [toggleMode, setToggleMode] = React.useState<
-            "expand-all" | "collapse-all" | undefined
-        >("none");
+        const [toggleMode, setToggleMode] =
+            React.useState<AccordionToggleMode>("none");
 
         const [toggleModeForNextedSection, setToggleModeForNextedSection] =
-            React.useState<"expand-all" | "collapse-all" | undefined>("none");
+            React.useState<AccordionToggleMode>("none");
 
         return (
             <>
@@ -838,6 +840,7 @@ export const WithToggleMode: StoryComponentType = {
                         >
                             <AccordionSection
                                 header={`Nested Section A`}
+                                key={`nested-section-a`}
                                 caretPosition="start"
                                 cornerKind="square"
                                 expanded={

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
@@ -706,4 +706,40 @@ describe("Accordion", () => {
             },
         );
     });
+    describe("ToggleMode uniform open/close", () => {
+        test("expands all sections when toggleMode is 'expand-all' and collapses them when 'collapse-all'", async () => {
+            // Arrange
+            const {rerender} = render(
+                <Accordion toggleMode="expand-all">
+                    <AccordionSection header="Section 1">
+                        Content 1
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Content 2
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert that both sections are open (fully expanded).
+            expect(await screen.findByText("Content 1")).toBeVisible();
+            expect(await screen.findByText("Content 2")).toBeVisible();
+
+            // Act: now re-render with toggleMode="collapse-all"
+            rerender(
+                <Accordion toggleMode="collapse-all">
+                    <AccordionSection header="Section 1">
+                        Content 1
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Content 2
+                    </AccordionSection>
+                </Accordion>,
+            );
+
+            // Assert that both sections are now collapsed.
+            expect(screen.queryByText("Content 1")).not.toBeVisible();
+            expect(screen.queryByText("Content 2")).not.toBeVisible();
+        });
+    });
 });

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -17,7 +17,7 @@ type Props = {
     // Unique ID for this section's button.
     id: string;
     // Header content.
-    header: string | React.ReactElement;
+    header: string | React.ReactElement | TemplateStringsArray;
     // Whether the caret shows up at the start or end of the header block.
     caretPosition: "start" | "end";
     // Corner roundedness type.

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -125,6 +125,12 @@ type Props = AriaProps & {
      * @ignore
      */
     isRegion?: boolean;
+    /**
+     * Whether the parent accordion is in "expand-all" or "collapse-all" mode.
+     * For internal use only.
+     * @ignore
+     */
+    parentToggleMode?: "expand-all" | "collapse-all";
 };
 
 /**
@@ -199,6 +205,7 @@ const AccordionSection = React.forwardRef(function AccordionSection(
         // Assume it's a region by default. Override this to be false
         // if we know there are more than six panels in an accordion.
         isRegion = true,
+        parentToggleMode,
         ...ariaProps
     } = props;
 
@@ -207,6 +214,12 @@ const AccordionSection = React.forwardRef(function AccordionSection(
     );
 
     const controlledMode = expanded !== undefined && onToggle;
+
+    React.useEffect(() => {
+        if (parentToggleMode) {
+            setInternalExpanded(parentToggleMode === "expand-all");
+        }
+    }, [parentToggleMode]);
 
     const uniqueSectionId = useId();
     const sectionId = id ?? uniqueSectionId;

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -12,7 +12,7 @@ import {Body} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 
 import {useId} from "react";
-import type {AccordionCornerKindType} from "./accordion";
+import type {AccordionCornerKindType, AccordionToggleMode} from "./accordion";
 import AccordionSectionHeader from "./accordion-section-header";
 
 export type TagType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
@@ -27,7 +27,7 @@ type Props = AriaProps & {
      * passed in, it will automatically be given Body typography from
      * Wonder Blocks Typography.
      */
-    children: string | React.ReactElement;
+    children: string | React.ReactNode;
     /**
      * The header for this section. If a string is passed in, it will
      * automatically be given Body typography from Wonder Blocks Typography.
@@ -130,7 +130,7 @@ type Props = AriaProps & {
      * For internal use only.
      * @ignore
      */
-    parentToggleMode?: "expand-all" | "collapse-all";
+    parentToggleMode?: AccordionToggleMode;
 };
 
 /**

--- a/packages/wonder-blocks-accordion/src/components/accordion.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion.tsx
@@ -18,6 +18,11 @@ export type AccordionToggleModeStatus = {
     anyCollapsed: boolean;
 };
 
+export type AccordionToggleMode =
+    | "expand-all"
+    | "collapse-all"
+    | "none"
+    | undefined;
 type Props = AriaProps & {
     /**
      * The unique identifier for the accordion.
@@ -157,19 +162,14 @@ const Accordion = React.forwardRef(function Accordion(
     }
     const [sectionsOpened, setSectionsOpened] = React.useState(startingArray);
 
-    // We keep a local toggle mode state that defaults to "none" unless we
-    // have an initial toggleMode prop. Whenever the parent updates the
-    // toggleMode prop, this effect synchronizes our local state to match.
-    const [internalToggleMode, setInternalToggleMode] = React.useState<
-        "expand-all" | "collapse-all" | "none"
-    >(toggleMode ?? "none");
+    const [internalToggleMode, setInternalToggleMode] =
+        React.useState<AccordionToggleMode>(toggleMode ?? "none");
 
-    // Sync internal state with prop
     React.useEffect(() => {
-        if (toggleMode !== null) {
+        if (toggleMode !== internalToggleMode) {
             setInternalToggleMode(toggleMode);
         }
-    }, [toggleMode]);
+    }, [internalToggleMode, toggleMode]);
 
     //  NOTE: It may seem like we should filter out non-collapsible sections
     //  here as they are effectively disabled. However, we should keep these


### PR DESCRIPTION
## Summary:
This PR updates the Accordion and AccordionSection so that sections can be nested and exposes an internal toggle handler. 

Updates:
- Nesting is now supported.
- The toggle handler is exposed for the consumer.
- They can programmatically control open/close states.

## Screenshots:

https://github.com/user-attachments/assets/4de6c907-8f88-47f7-afb8-3500759175b2

Issue: CLASS-11631

## Test plan: