### PR TITLE
[WB-1644.2] Convert border and sizing tokens to CSS variables

### DIFF
--- a/.changeset/clean-ravens-happen.md
+++ b/.changeset/clean-ravens-happen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Export `border` and `sizing` as CSS variables. Map JS tokens to css var counterparts

--- a/__docs__/wonder-blocks-tokens/tokens-border.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-border.mdx
@@ -4,7 +4,7 @@ import TokenTable from "../components/token-table";
 
 import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
-import * as tokens from "@khanacademy/wonder-blocks-tokens";
+import {border, color, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 <Meta title="Packages / Tokens / Border" />
 
@@ -18,6 +18,10 @@ export const baseColumns = (kind) => [
         ),
     },
     {
+        label: "CSS Variable",
+        cell: (row) => <code>{row.css}</code>,
+    },
+    {
         label: "Value",
         cell: "value",
     },
@@ -28,7 +32,7 @@ export const baseColumns = (kind) => [
 The `border` tokens are used to define the border properties of an element. The
 border tokens are broken down into two categories: `radius` and `width`.
 
-<View style={{marginBottom: tokens.spacing.medium_16}}>
+<View style={{marginBottom: sizing.size_160}}>
     <Banner
         kind="info"
         text="We don't define border colors here, and instead we recommend you to rely on the `color` token primitives to build on top of that."
@@ -42,8 +46,8 @@ border tokens are broken down into two categories: `radius` and `width`.
 import {border} from "@khanacademy/wonder-blocks-tokens";
 const styles = {
     borderedContainer: {
-        borderRadius: border.radius.small,
-        borderWidth: border.width.small,
+        borderRadius: border.radius.radius_040,
+        borderWidth: border.width.thin,
     },
 };
 ```
@@ -60,10 +64,10 @@ const styles = {
             cell: (row) => (
                 <View
                     style={{
-                        backgroundColor: tokens.color.purple,
+                        backgroundColor: color.purple,
                         borderRadius: row.value,
-                        width: tokens.sizing.size_480,
-                        height: tokens.sizing.size_480,
+                        width: sizing.size_480,
+                        height: sizing.size_480,
                     }}
                 >
                     &nbsp;
@@ -71,7 +75,7 @@ const styles = {
             ),
         },
     ]}
-    tokens={tokens.border.radius}
+    tokens={border.radius}
 />
 
 ### Width
@@ -84,10 +88,10 @@ const styles = {
             cell: (row) => (
                 <View
                     style={{
-                        borderColor: tokens.color.purple,
+                        borderColor: color.purple,
                         borderWidth: row.value,
-                        width: tokens.sizing.size_480,
-                        height: tokens.sizing.size_480,
+                        width: sizing.size_480,
+                        height: sizing.size_480,
                     }}
                 >
                     &nbsp;
@@ -95,5 +99,5 @@ const styles = {
             ),
         },
     ]}
-    tokens={tokens.border.width}
+    tokens={border.width}
 />

--- a/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-sizing.mdx
@@ -42,6 +42,10 @@ const styles = {padding: sizing.size_160};
             cell: (row) => <code>sizing.{row.label}</code>,
         },
         {
+            label: "CSS Variable",
+            cell: (row) => <code>{row.css}</code>,
+        },
+        {
             label: "Base unit multiplier",
             cell: (row) => row.value.replace("rem", "x"),
         },

--- a/packages/wonder-blocks-tokens/src/build/generate-css-variables.ts
+++ b/packages/wonder-blocks-tokens/src/build/generate-css-variables.ts
@@ -5,7 +5,7 @@ import ancesdir from "ancesdir";
 import {THEME_DATA_ATTRIBUTE} from "@khanacademy/wonder-blocks-theming";
 import {generateTokens} from "../internal/generate-tokens";
 
-const THEMES_DIR = "../theme/color";
+const THEMES_DIR = "../theme";
 
 /**
  * Process all themes in the theme directory.
@@ -14,14 +14,22 @@ const THEMES_DIR = "../theme/color";
  * the CSS variables for each theme.
  */
 function processThemeCollection() {
-    return fs.readdirSync(path.resolve(__dirname, THEMES_DIR)).map((file) => {
-        // Remove the file extension
-        const filename = file.split(".")[0];
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const {default: themeObject} = require(`${THEMES_DIR}/${filename}`);
+    return fs
+        .readdirSync(path.resolve(__dirname, THEMES_DIR), {
+            withFileTypes: true,
+        })
+        .filter((file) => {
+            return file.isFile() && file.name.endsWith(".ts");
+        })
+        .map((file) => {
+            // Remove the file extension
+            const filename = file.name.split(".")[0];
 
-        return {name: filename, tokens: generateTokens(themeObject)};
-    });
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const {default: themeObject} = require(`${THEMES_DIR}/${filename}`);
+
+            return {name: filename, tokens: generateTokens(themeObject)};
+        });
 }
 
 /**
@@ -29,7 +37,7 @@ function processThemeCollection() {
  */
 function generateCssVariablesDefinitions() {
     return processThemeCollection()
-        .map((theme) => {
+        .map((theme, index) => {
             const cssVariables = Object.entries(theme.tokens)
                 .map(([key, value]) => `${key}: ${value};`)
                 .join("");

--- a/packages/wonder-blocks-tokens/src/index.ts
+++ b/packages/wonder-blocks-tokens/src/index.ts
@@ -1,17 +1,18 @@
 // primitive tokens
-import {border} from "./tokens/border";
 import {color} from "./tokens/color";
 import {font} from "./tokens/font";
-import {sizing} from "./tokens/sizing";
 import {spacing} from "./tokens/spacing";
 
 // media queries
 import {breakpoint} from "./tokens/media-queries";
-// semantic tokens
-import {semanticColor} from "./tokens/semantic-color";
 
 // utils
 import {mix, fade} from "./util/utils";
+
+// theme
+import theme from "./tokens/theme";
+
+const {border, semanticColor, sizing} = theme;
 
 export {
     /**

--- a/packages/wonder-blocks-tokens/src/internal/__test__/generate-tokens.test.ts
+++ b/packages/wonder-blocks-tokens/src/internal/__test__/generate-tokens.test.ts
@@ -4,8 +4,10 @@ describe("generateTokens", () => {
     it("should generate tokens", () => {
         // Arrange
         const obj = {
-            primary: "red",
-            secondary: "blue",
+            semanticColor: {
+                primary: "red",
+                secondary: "blue",
+            },
         };
 
         // Act
@@ -13,16 +15,18 @@ describe("generateTokens", () => {
 
         // Assert
         expect(cssVars).toStrictEqual({
-            "--wb-s-color-primary": "red",
-            "--wb-s-color-secondary": "blue",
+            "--wb-semanticColor-primary": "red",
+            "--wb-semanticColor-secondary": "blue",
         });
     });
 
     it("should not generate tokens in empty objects", () => {
         // Arrange
         const obj = {
-            primary: {},
-            secondary: "blue",
+            semanticColor: {
+                primary: {},
+                secondary: "blue",
+            },
         };
 
         // Act
@@ -30,7 +34,7 @@ describe("generateTokens", () => {
 
         // Assert
         expect(cssVars).toStrictEqual({
-            "--wb-s-color-secondary": "blue",
+            "--wb-semanticColor-secondary": "blue",
         });
     });
 });

--- a/packages/wonder-blocks-tokens/src/internal/generate-tokens.ts
+++ b/packages/wonder-blocks-tokens/src/internal/generate-tokens.ts
@@ -1,4 +1,4 @@
-import {CSS_VAR_COLOR_PREFIX} from "../util/constants";
+import {CSS_VAR_PREFIX} from "../util/constants";
 import {RecursivePartial} from "../util/types";
 
 /**
@@ -11,7 +11,7 @@ export function generateTokens<T>(root: T): Record<string, string> {
     const tokens = {} as Record<string, string>;
     function generateCssVariables(
         obj: T | RecursivePartial<T>,
-        prefix = CSS_VAR_COLOR_PREFIX,
+        prefix = CSS_VAR_PREFIX,
     ) {
         for (const key in obj as RecursivePartial<T>) {
             if (typeof obj[key] === "object") {

--- a/packages/wonder-blocks-tokens/src/theme/default.ts
+++ b/packages/wonder-blocks-tokens/src/theme/default.ts
@@ -1,0 +1,9 @@
+import {sizing} from "./primitive/sizing";
+import {semanticColor} from "./semantic/semantic-color";
+import {border} from "./primitive/border";
+
+export default {
+    border,
+    semanticColor,
+    sizing,
+};

--- a/packages/wonder-blocks-tokens/src/theme/primitive/border.ts
+++ b/packages/wonder-blocks-tokens/src/theme/primitive/border.ts
@@ -1,4 +1,5 @@
-import {sizing, remToPx} from "./sizing";
+import {remToPx} from "../../util/sizing-utils";
+import {sizing} from "./sizing";
 
 export const border = {
     /**

--- a/packages/wonder-blocks-tokens/src/theme/primitive/sizing.ts
+++ b/packages/wonder-blocks-tokens/src/theme/primitive/sizing.ts
@@ -1,24 +1,4 @@
-/**
- * The baseline for the size tokens.
- */
-const baseline = 10;
-
-/**
- * Converts a number (px) to a rem value.
- */
-function pxToRem(value: number): string {
-    return `${value / baseline}rem`;
-}
-
-/**
- * Converts a rem value to a number (px).
- * @param value The rem value to convert (includes the unit).
- * @returns A string with the px value.
- */
-export function remToPx(value: string): string {
-    const num = parseFloat(value);
-    return `${Math.round(num * baseline)}px`;
-}
+import {pxToRem} from "../../util/sizing-utils";
 
 /**
  * Tokens that define the sizing of elements. These values are expressed in

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -7,7 +7,7 @@ const border = {
     inverse: color.white,
 };
 
-export default {
+export const semanticColor = {
     /**
      * For buttons, links, and controls to communicate the presence and meaning
      * of interaction.

--- a/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/semantic-color.ts
@@ -1,5 +1,0 @@
-import {CSS_VAR_COLOR_PREFIX} from "../util/constants";
-import {mapValuesToCssVars} from "../internal/map-values-to-css-vars";
-import tokens from "../theme/color/default";
-
-export const semanticColor = mapValuesToCssVars(tokens, CSS_VAR_COLOR_PREFIX);

--- a/packages/wonder-blocks-tokens/src/tokens/theme.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/theme.ts
@@ -1,0 +1,5 @@
+import {CSS_VAR_PREFIX} from "../util/constants";
+import {mapValuesToCssVars} from "../internal/map-values-to-css-vars";
+import themeDefault from "../theme/default";
+
+export default mapValuesToCssVars(themeDefault, CSS_VAR_PREFIX);

--- a/packages/wonder-blocks-tokens/src/util/constants.ts
+++ b/packages/wonder-blocks-tokens/src/util/constants.ts
@@ -7,4 +7,4 @@
  * - namespace: The design token namespace (`s` for semantic tokens).
  * - token_category: The category of the design token (e.g. `color`, `size`).
  */
-export const CSS_VAR_COLOR_PREFIX = "--wb-s-color-";
+export const CSS_VAR_PREFIX = "--wb-";

--- a/packages/wonder-blocks-tokens/src/util/sizing-utils.ts
+++ b/packages/wonder-blocks-tokens/src/util/sizing-utils.ts
@@ -1,0 +1,21 @@
+/**
+ * The baseline for the size tokens.
+ */
+const baseline = 10;
+
+/**
+ * Converts a number (px) to a rem value.
+ */
+export function pxToRem(value: number): string {
+    return `${value / baseline}rem`;
+}
+
+/**
+ * Converts a rem value to a number (px).
+ * @param value The rem value to convert (includes the unit).
+ * @returns A string with the px value.
+ */
+export function remToPx(value: string): string {
+    const num = parseFloat(value);
+    return `${Math.round(num * baseline)}px`;
+}


### PR DESCRIPTION
## Summary:

This PR migrates the `border` and `sizing` tokens to internally use CSS
variables. It also updates the documentation to reflect these changes.

Also, refactored the logic for generating CSS variables by moving all those
tokens to a `theme/default.ts` file, then converting all the tokens in there to
CSS variables.

Issue: https://khanacademy.atlassian.net/browse/WB-1644

## Test plan:

Navigate to the `border` and `sizing` docs and verify that the CSS variables are now included:

- `/?path=/docs/packages-tokens-border--docs`
- `/?path=/docs/packages-tokens-sizing--docs`

Also inspect the styles in the browser and check that the CSS variables are
being used in places where `sizing` are `border` tokens are used.