### PR TITLE
Deprecate fixtures framework

### DIFF
--- a/.changeset/clever-kids-talk.md
+++ b/.changeset/clever-kids-talk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing-core": patch
+---
+
+Deprecate fixtures framework

--- a/packages/wonder-blocks-testing-core/src/fixtures/fixtures.basic.stories.tsx
+++ b/packages/wonder-blocks-testing-core/src/fixtures/fixtures.basic.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-deprecated */
 import * as React from "react";
 
 import {fixtures} from "../index";

--- a/packages/wonder-blocks-testing-core/src/fixtures/fixtures.defaultwrapper.stories.tsx
+++ b/packages/wonder-blocks-testing-core/src/fixtures/fixtures.defaultwrapper.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-deprecated */
 import * as React from "react";
 
 import {fixtures} from "../index";

--- a/packages/wonder-blocks-testing-core/src/fixtures/fixtures.tsx
+++ b/packages/wonder-blocks-testing-core/src/fixtures/fixtures.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-deprecated */
 import * as React from "react";
 import {action} from "@storybook/addon-actions";
 
@@ -12,6 +13,9 @@ import type {FixtureFn, FixtureProps} from "./types";
  * @param {React.ComponentType<any>} Component The component we want to create
  * stories for.
  * @returns {FixtureFn<TProps>} A function to create a CSF compatible story.
+ *
+ * @deprecated Use CSFv3 style stories instead. This API was for migration
+ * from our old fixtures framework and will be removed in a future release.
  */
 export const fixtures = <
     TComponent extends React.ComponentType<any>,

--- a/packages/wonder-blocks-testing-core/src/fixtures/types.ts
+++ b/packages/wonder-blocks-testing-core/src/fixtures/types.ts
@@ -2,6 +2,8 @@ import * as React from "react";
 
 /**
  * Options injected to the function that returns the fixture props.
+ * @deprecated Use CSFv3 style stories instead. This API was for migration
+ * from our old fixtures framework and will be removed in a future release.
  */
 export type GetPropsOptions = {
     /**
@@ -16,12 +18,22 @@ export type GetPropsOptions = {
     logHandler: (name: string) => (...args: Array<any>) => void;
 };
 
+/**
+ * The props for a fixture.
+ *
+ * This can be either a static object or a function that returns an object.
+ *
+ * @deprecated Use CSFv3 style stories instead. This API was for migration
+ * from our old fixtures framework and will be removed in a future release.
+ */
 export type FixtureProps<TProps extends object> =
     | Readonly<TProps>
     | ((options: Readonly<GetPropsOptions>) => Readonly<TProps>);
 
 /**
  * A function for defining a fixture.
+ * @deprecated Use CSFv3 style stories instead. This API was for migration
+ * from our old fixtures framework and will be removed in a future release.
  */
 export type FixtureFn<TProps extends object> = (
     /**


### PR DESCRIPTION
## Summary:
This marks the fixtures framework as deprecated. The fixtures framework is not
intended to be used for new code, but that is happening in Webapp.

I am hoping that showing the deprecated strikethrough will discourage folks from more new use so we can move towards removing this and not maintaining it anymore.

I do not believe webapp currently lints against deprecated code use, so this should not create any new errors in webapp when it gets updated.

Issue: FEI-5273

## Test plan:
`pnpm typecheck`
`pnpm lint`