### PR TITLE
Tabs: Add `mountAllPanels` prop.

### DIFF
--- a/.changeset/fair-ants-hunt.md
+++ b/.changeset/fair-ants-hunt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tabs": minor
+---
+
+Tabs: Add `mountAllPanels` prop. Defaults to `false` so tab panels are only rendered if they are visited

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -315,8 +315,9 @@ export const AnimationsDisabled: StoryComponentType = {
 };
 
 /**
- * The tab panels are cached and only mounted once a tab is selected to prevent
- * unnecessary mounting/unmounting of tab panel contents.
+ * When `mountAllPanels` is `false` or not set, the tab panels are cached and
+ * only mounted once a tab is selected to prevent unnecessary mounting/unmounting
+ * of tab panel contents.
  *
  * In this example, the panels contain components that print out a message in
  * the Storybook actions panel whenever it is mounted. Notice that a panel is
@@ -325,6 +326,49 @@ export const AnimationsDisabled: StoryComponentType = {
  */
 export const PanelCaching: StoryComponentType = {
     args: {
+        tabs: [
+            {
+                label: "Tab 1",
+                id: "tab-1",
+                panel: <PanelExample label="Tab 1" />,
+            },
+            {
+                label: "Tab 2",
+                id: "tab-2",
+                panel: <PanelExample label="Tab 2" />,
+            },
+            {
+                label: "Tab 3",
+                id: "tab-3",
+                panel: <PanelExample label="Tab 3" />,
+            },
+        ],
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
+ * If you need to ensure that all tab panels are always in the DOM, you can
+ * set the `mountAllPanels` prop to `true`. By default, `mountAllPanels` is
+ * set to `false`.
+ *
+ * This is helpful for tabbed content that needs to be available in the DOM for
+ * SEO purposes.
+ *
+ * In this example, the panels contain components that print out a message in
+ * the Storybook actions panel whenever it is mounted. Notice that all panels
+ * are mounted when the component mounts. And panels are not remounted when
+ * switching tabs. When inspecting the DOM, you will also see that all the
+ * panel contents are there.
+ */
+export const MountAllPanels: StoryComponentType = {
+    args: {
+        mountAllPanels: true,
         tabs: [
             {
                 label: "Tab 1",

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -144,6 +144,18 @@ type Props = {
         tab?: StyleType;
         tabPanel?: StyleType;
     };
+
+    /**
+     * Whether to mount all tab panels when the component mounts.
+     *
+     * - When enabled, all tab panels are in the DOM. This is useful if the
+     * tab contents should be crawlable for SEO purposes.
+     * - When disabled, tab panels are only in the DOM if they've been visited.
+     * This is useful for performance so that unvisited panels are not mounted.
+     *
+     * Defaults to `false`.
+     */
+    mountAllPanels?: boolean;
 } & AriaLabelOrAriaLabelledby;
 
 /**
@@ -183,6 +195,7 @@ export const Tabs = React.forwardRef(function Tabs(
         testId,
         animated = false,
         styles: stylesProp,
+        mountAllPanels = false,
     } = props;
 
     /**
@@ -388,11 +401,14 @@ export const Tabs = React.forwardRef(function Tabs(
                         style={stylesProp?.tabPanel}
                     >
                         {/* Tab panel contents are rendered if the tab has
-                        been previously visited. This prevents unnecessary
+                        been previously visited or if mountAllPanels is enabled.
+                        If mountAllPanels is off, it prevents unnecessary
                         re-mounting of tab panel contents when switching tabs.
                         Note that TabPanel will only display the contents if it
                         is the active panel. */}
-                        {visitedTabsRef.current.has(tab.id) && tab.panel}
+                        {(mountAllPanels ||
+                            visitedTabsRef.current.has(tab.id)) &&
+                            tab.panel}
                     </TabPanel>
                 );
             })}


### PR DESCRIPTION
## Summary:

- Add `mountAllPanels` prop to `Tabs`. It defaults to `false`
- When it is false, panels are only mounted the first time it is visited. It stays mounted so it doesn't need to be remounted when it is visited again.
- When it is true, all panels are mounted when the Tabs first render. This is useful for SEO purposes if we want the unvisited tab panels to be crawlable (context: https://github.com/Khan/wonder-blocks/pull/2542#discussion_r2033952892)

Issue: WB-1923

## Test plan:
- Confirm the PanelCaching story behaves the same way as before (`[?path=/docs/packages-tabs-tabs--docs](http://localhost:6061/?path=/docs/packages-tabs-tabs--docs#panel%20caching)`)
- Confirm the new MountAllPanels story includes all tab panels in the DOM (even if they aren't visited yet) (`http://localhost:6061/?path=/docs/packages-tabs-tabs--docs#mount%20all%20panels`)
  - Confirm that screen readers only read out the panel content for the selected tab 