### PR TITLE
Make sure that the tooltip bubble is using the same ID as the aria-describedby attribute on the anchor

### DIFF
--- a/.changeset/moody-stingrays-jog.md
+++ b/.changeset/moody-stingrays-jog.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+Fix tooltips so that they are read out by screen readers

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-anchor.test.tsx
@@ -40,7 +40,11 @@ describe("TooltipAnchor", () => {
 
         // Act
         render(
-            <TooltipAnchor anchorRef={() => {}} onActiveChanged={() => {}}>
+            <TooltipAnchor
+                anchorRef={() => {}}
+                onActiveChanged={() => {}}
+                aria-describedby="ignore-this"
+            >
                 Anchor text
             </TooltipAnchor>,
         );
@@ -72,7 +76,11 @@ describe("TooltipAnchor", () => {
         );
         removeEventListenerSpy.mockClear();
         const wrapper = render(
-            <TooltipAnchor anchorRef={() => {}} onActiveChanged={() => {}}>
+            <TooltipAnchor
+                anchorRef={() => {}}
+                onActiveChanged={() => {}}
+                aria-describedby="ignore-this"
+            >
                 Anchor text
             </TooltipAnchor>,
         );
@@ -108,6 +116,7 @@ describe("TooltipAnchor", () => {
                 forceAnchorFocusivity={true}
                 anchorRef={anchorRef}
                 onActiveChanged={() => {}}
+                aria-describedby="ignore-this"
             >
                 <View id="portal">This is the anchor</View>
             </TooltipAnchor>,
@@ -128,6 +137,7 @@ describe("TooltipAnchor", () => {
                     forceAnchorFocusivity={true}
                     anchorRef={jest.fn()}
                     onActiveChanged={() => {}}
+                    aria-describedby="ignore-this"
                 >
                     <View id="portal">This is the anchor</View>
                 </TooltipAnchor>,
@@ -147,6 +157,7 @@ describe("TooltipAnchor", () => {
                     forceAnchorFocusivity={true}
                     anchorRef={jest.fn()}
                     onActiveChanged={() => {}}
+                    aria-describedby="ignore-this"
                 >
                     <View tabIndex={-1}>This is the anchor</View>
                 </TooltipAnchor>,
@@ -168,6 +179,7 @@ describe("TooltipAnchor", () => {
                     forceAnchorFocusivity={false}
                     anchorRef={jest.fn()}
                     onActiveChanged={() => {}}
+                    aria-describedby="ignore-this"
                 >
                     <View>This is the anchor</View>
                 </TooltipAnchor>,
@@ -187,6 +199,7 @@ describe("TooltipAnchor", () => {
                     forceAnchorFocusivity={props.force}
                     anchorRef={jest.fn()}
                     onActiveChanged={() => {}}
+                    aria-describedby="ignore-this"
                 >
                     <View>This is the anchor</View>
                 </TooltipAnchor>
@@ -213,6 +226,7 @@ describe("TooltipAnchor", () => {
                     forceAnchorFocusivity={props.force}
                     anchorRef={jest.fn()}
                     onActiveChanged={() => {}}
+                    aria-describedby="ignore-this"
                 >
                     <View tabIndex={-1}>This is the anchor</View>
                 </TooltipAnchor>
@@ -254,6 +268,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -296,6 +311,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -325,6 +341,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -371,6 +388,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -412,6 +430,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -454,6 +473,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -488,6 +508,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -540,6 +561,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -581,6 +603,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -609,6 +632,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -654,6 +678,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -694,6 +719,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -734,6 +760,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -766,6 +793,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -803,7 +831,11 @@ describe("TooltipAnchor", () => {
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const spy = jest.spyOn(document, "addEventListener");
             render(
-                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                    aria-describedby="tooltip-description"
+                >
                     Anchor Text
                 </TooltipAnchor>,
             );
@@ -829,7 +861,11 @@ describe("TooltipAnchor", () => {
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const spy = jest.spyOn(document, "addEventListener");
             render(
-                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                    aria-describedby="tooltip-description"
+                >
                     Anchor Text
                 </TooltipAnchor>,
             );
@@ -860,7 +896,11 @@ describe("TooltipAnchor", () => {
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             const spy = jest.spyOn(document, "removeEventListener");
             render(
-                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                    aria-describedby="tooltip-description"
+                >
                     Anchor Text
                 </TooltipAnchor>,
             );
@@ -896,7 +936,11 @@ describe("TooltipAnchor", () => {
 
             const spy = jest.spyOn(document, "removeEventListener");
             const {unmount} = render(
-                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                    aria-describedby="tooltip-description"
+                >
                     Anchor Text
                 </TooltipAnchor>,
             );
@@ -930,6 +974,7 @@ describe("TooltipAnchor", () => {
                     onActiveChanged={(active: any) => {
                         activeState = active;
                     }}
+                    aria-describedby="tooltip-description"
                 >
                     Anchor Text
                 </TooltipAnchor>,
@@ -962,7 +1007,11 @@ describe("TooltipAnchor", () => {
             });
             const timeoutSpy = jest.spyOn(global, "setTimeout");
             render(
-                <TooltipAnchor anchorRef={jest.fn()} onActiveChanged={() => {}}>
+                <TooltipAnchor
+                    anchorRef={jest.fn()}
+                    onActiveChanged={() => {}}
+                    aria-describedby="tooltip-description"
+                >
                     Anchor Text
                 </TooltipAnchor>,
             );

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx
@@ -176,7 +176,7 @@ describe("Tooltip", () => {
             const result = await screen.findByRole("tooltip");
 
             // Assert
-            expect(result).toHaveAttribute("id", "tooltip-1");
+            expect(result).toHaveAttribute("id", "tooltip-1-aria-content");
         });
 
         describe("text-only anchor", () => {
@@ -212,8 +212,31 @@ describe("Tooltip", () => {
                 // Assert
                 expect(result).toHaveAttribute(
                     "aria-describedby",
-                    "tooltip-2-anchor-aria-content",
+                    "tooltip-2-aria-content",
                 );
+            });
+
+            test("id provided, aria-describedby id matches bubble id", async () => {
+                // Arrange
+                const ue = userEvent.setup({
+                    advanceTimers: jest.advanceTimersByTimeAsync,
+                });
+                render(
+                    <View>
+                        <Tooltip id="tooltip-2" content="Content">
+                            Anchor
+                        </Tooltip>
+                    </View>,
+                );
+
+                // Act
+                const node = await screen.findByText("Anchor");
+                await ue.hover(node);
+                await act(() => jest.runOnlyPendingTimersAsync());
+                const tooltip = await screen.findByRole("tooltip");
+
+                // Assert
+                expect(node).toHaveAttribute("aria-describedby", tooltip.id);
             });
 
             test("no id provided, attaches aria-describedby", async () => {
@@ -231,8 +254,29 @@ describe("Tooltip", () => {
                 expect(node).toHaveAttribute(
                     "aria-describedby",
                     // We don't know what the generated portion would be,
-                    expect.stringMatching(/.*-anchor-aria-content/),
+                    expect.stringMatching(/.*-aria-content/),
                 );
+            });
+
+            test("no id provided, aria-describedby id matches bubble id", async () => {
+                // Arrange
+                const ue = userEvent.setup({
+                    advanceTimers: jest.advanceTimersByTimeAsync,
+                });
+                render(
+                    <View>
+                        <Tooltip content="Content">Anchor</Tooltip>
+                    </View>,
+                );
+
+                // Act
+                const node = await screen.findByText("Anchor");
+                await ue.hover(node);
+                await act(() => jest.runOnlyPendingTimersAsync());
+                const tooltip = await screen.findByRole("tooltip");
+
+                // Assert
+                expect(node).toHaveAttribute("aria-describedby", tooltip.id);
             });
         });
 
@@ -290,8 +334,43 @@ describe("Tooltip", () => {
                 // Assert
                 expect(result).toHaveAttribute(
                     "aria-describedby",
-                    "tooltip-3-anchor-aria-content",
+                    "tooltip-3-aria-content",
                 );
+            });
+
+            test("id provided, aria-describedby id matches bubble id", async () => {
+                // Arrange
+                const ue = userEvent.setup({
+                    advanceTimers: jest.advanceTimersByTimeAsync,
+                });
+                const anchor = (
+                    <View>
+                        <View>Anchor</View>
+                    </View>
+                );
+                const ref = await new Promise((resolve: any) => {
+                    render(
+                        <View>
+                            <Tooltip
+                                id="tooltip-3"
+                                ref={resolve}
+                                content="Content"
+                            >
+                                {anchor}
+                            </Tooltip>
+                        </View>,
+                    );
+                });
+
+                // Act
+                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
+                const result = ReactDOM.findDOMNode(ref) as any;
+                await ue.hover(result);
+                await act(() => jest.runOnlyPendingTimersAsync());
+                const tooltip = await screen.findByRole("tooltip");
+
+                // Assert
+                expect(result).toHaveAttribute("aria-describedby", tooltip.id);
             });
 
             test("no id provided, attaches aria-describedby", async () => {
@@ -318,8 +397,39 @@ describe("Tooltip", () => {
                 // Assert
                 expect(result).toHaveAttribute(
                     "aria-describedby",
-                    expect.stringMatching(/.*-anchor-aria-content/),
+                    expect.stringMatching(/.*-aria-content/),
                 );
+            });
+
+            test("no id provided, aria-describedby id matches bubble id", async () => {
+                // Arrange
+                const ue = userEvent.setup({
+                    advanceTimers: jest.advanceTimersByTimeAsync,
+                });
+                const anchor = (
+                    <View>
+                        <View>Anchor</View>
+                    </View>
+                );
+                const ref = await new Promise((resolve: any) => {
+                    render(
+                        <View>
+                            <Tooltip ref={resolve} content="Content">
+                                {anchor}
+                            </Tooltip>
+                        </View>,
+                    );
+                });
+
+                // Act
+                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
+                const result = ReactDOM.findDOMNode(ref) as any;
+                await ue.hover(result);
+                await act(() => jest.runOnlyPendingTimersAsync());
+                const tooltip = await screen.findByRole("tooltip");
+
+                // Assert
+                expect(result).toHaveAttribute("aria-describedby", tooltip.id);
             });
         });
     });

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx
@@ -196,7 +196,7 @@ describe("Tooltip", () => {
                 expect(result.innerHTML).toBe("Anchor");
             });
 
-            test("id provided, attaches aria-describedby", async () => {
+            test("id provided, does not attach aria-describedby when bubble is not displayed", async () => {
                 // Arrange
                 render(
                     <View>
@@ -208,6 +208,28 @@ describe("Tooltip", () => {
 
                 // Act
                 const result = await screen.findByText("Anchor");
+
+                // Assert
+                expect(result).not.toHaveAttribute("aria-describedby");
+            });
+
+            test("id provided, attaches aria-describedby when bubble is displayed", async () => {
+                // Arrange
+                const ue = userEvent.setup({
+                    advanceTimers: jest.advanceTimersByTimeAsync,
+                });
+                render(
+                    <View>
+                        <Tooltip id="tooltip-2" content="Content">
+                            Anchor
+                        </Tooltip>
+                    </View>,
+                );
+
+                // Act
+                const result = await screen.findByText("Anchor");
+                await ue.hover(result);
+                await act(() => jest.runOnlyPendingTimersAsync());
 
                 // Assert
                 expect(result).toHaveAttribute(
@@ -239,7 +261,7 @@ describe("Tooltip", () => {
                 expect(node).toHaveAttribute("aria-describedby", tooltip.id);
             });
 
-            test("no id provided, attaches aria-describedby", async () => {
+            test("no id provided, does not aria-describedby when bubble is not visible", async () => {
                 // Arrange
                 render(
                     <View>
@@ -249,6 +271,26 @@ describe("Tooltip", () => {
                 const node = await screen.findByText("Anchor");
 
                 // Act
+
+                // Assert
+                expect(node).not.toHaveAttribute("aria-describedby");
+            });
+
+            test("no id provided, attaches aria-describedby when bubble is visible", async () => {
+                // Arrange
+                const ue = userEvent.setup({
+                    advanceTimers: jest.advanceTimersByTimeAsync,
+                });
+                render(
+                    <View>
+                        <Tooltip content="Content">Anchor</Tooltip>
+                    </View>,
+                );
+
+                // Act
+                const node = await screen.findByText("Anchor");
+                await ue.hover(node);
+                await act(() => jest.runOnlyPendingTimersAsync());
 
                 // Assert
                 expect(node).toHaveAttribute(
@@ -288,7 +330,7 @@ describe("Tooltip", () => {
                         <View>Anchor</View>
                     </View>
                 );
-                const ref = await new Promise((resolve: any) => {
+                const ref: Element = await new Promise((resolve: any) => {
                     render(
                         <View>
                             <Tooltip ref={resolve} content="Content">
@@ -299,7 +341,6 @@ describe("Tooltip", () => {
                 });
 
                 // Act
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
                 const result = ReactDOM.findDOMNode(ref) as any;
 
                 // Assert
@@ -309,9 +350,9 @@ describe("Tooltip", () => {
                 expect(result.children[0].innerHTML).toBe("Anchor");
             });
 
-            test("id provided, attaches aria-describedby", async () => {
+            test("id provided, does not attach aria-describedby when bubble is not displayed", async () => {
                 // Arrange
-                const ref = await new Promise((resolve: any) => {
+                const ref: Element = await new Promise((resolve: any) => {
                     render(
                         <View>
                             <Tooltip
@@ -328,8 +369,37 @@ describe("Tooltip", () => {
                 });
 
                 // Act
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
                 const result = ReactDOM.findDOMNode(ref) as any;
+
+                // Assert
+                expect(result).not.toHaveAttribute("aria-describedby");
+            });
+
+            test("id provided, attaches aria-describedby when bubble is displayed", async () => {
+                // Arrange
+                const ue = userEvent.setup({
+                    advanceTimers: jest.advanceTimersByTimeAsync,
+                });
+                const ref: Element = await new Promise((resolve: any) => {
+                    render(
+                        <View>
+                            <Tooltip
+                                id="tooltip-3"
+                                ref={resolve}
+                                content="Content"
+                            >
+                                <View>
+                                    <View>Anchor</View>
+                                </View>
+                            </Tooltip>
+                        </View>,
+                    );
+                });
+
+                // Act
+                const result = ReactDOM.findDOMNode(ref) as any;
+                await ue.hover(result);
+                await act(() => jest.runOnlyPendingTimersAsync());
 
                 // Assert
                 expect(result).toHaveAttribute(
@@ -348,7 +418,7 @@ describe("Tooltip", () => {
                         <View>Anchor</View>
                     </View>
                 );
-                const ref = await new Promise((resolve: any) => {
+                const ref: Element = await new Promise((resolve: any) => {
                     render(
                         <View>
                             <Tooltip
@@ -363,7 +433,6 @@ describe("Tooltip", () => {
                 });
 
                 // Act
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
                 const result = ReactDOM.findDOMNode(ref) as any;
                 await ue.hover(result);
                 await act(() => jest.runOnlyPendingTimersAsync());
@@ -373,14 +442,14 @@ describe("Tooltip", () => {
                 expect(result).toHaveAttribute("aria-describedby", tooltip.id);
             });
 
-            test("no id provided, attaches aria-describedby", async () => {
+            test("no id provided, does not attach aria-describedby when bubble is not displayed", async () => {
                 // Arrange
                 const anchor = (
                     <View>
                         <View>Anchor</View>
                     </View>
                 );
-                const ref = await new Promise((resolve: any) => {
+                const ref: Element = await new Promise((resolve: any) => {
                     render(
                         <View>
                             <Tooltip ref={resolve} content="Content">
@@ -391,8 +460,36 @@ describe("Tooltip", () => {
                 });
 
                 // Act
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
                 const result = ReactDOM.findDOMNode(ref) as any;
+
+                // Assert
+                expect(result).not.toHaveAttribute("aria-describedby");
+            });
+
+            test("no id provided, attaches aria-describedby when bubble is displayed", async () => {
+                // Arrange
+                const ue = userEvent.setup({
+                    advanceTimers: jest.advanceTimersByTimeAsync,
+                });
+                const anchor = (
+                    <View>
+                        <View>Anchor</View>
+                    </View>
+                );
+                const ref: Element = await new Promise((resolve: any) => {
+                    render(
+                        <View>
+                            <Tooltip ref={resolve} content="Content">
+                                {anchor}
+                            </Tooltip>
+                        </View>,
+                    );
+                });
+
+                // Act
+                const result = ReactDOM.findDOMNode(ref) as any;
+                await ue.hover(result);
+                await act(() => jest.runOnlyPendingTimersAsync());
 
                 // Assert
                 expect(result).toHaveAttribute(
@@ -411,7 +508,7 @@ describe("Tooltip", () => {
                         <View>Anchor</View>
                     </View>
                 );
-                const ref = await new Promise((resolve: any) => {
+                const ref: Element = await new Promise((resolve: any) => {
                     render(
                         <View>
                             <Tooltip ref={resolve} content="Content">
@@ -422,7 +519,6 @@ describe("Tooltip", () => {
                 });
 
                 // Act
-                // @ts-expect-error [FEI-5019] - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'ReactInstance | null | undefined'.
                 const result = ReactDOM.findDOMNode(ref) as any;
                 await ue.hover(result);
                 await act(() => jest.runOnlyPendingTimersAsync());

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.tsx
@@ -55,8 +55,10 @@ type Props = {
     /**
      * Required aria-describedby id.
      * This ID will reference the text in the tooltip bubble.
+     * It should only be set to `undefined` when the tooltip bubble
+     * is not visible.
      */
-    "aria-describedby": string;
+    "aria-describedby": string | undefined;
 };
 
 type DefaultProps = {

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-anchor.tsx
@@ -53,9 +53,10 @@ type Props = {
      */
     onActiveChanged: (active: boolean) => unknown;
     /**
-     * Optional unique id.
+     * Required aria-describedby id.
+     * This ID will reference the text in the tooltip bubble.
      */
-    id?: string | undefined;
+    "aria-describedby": string;
 };
 
 type DefaultProps = {
@@ -161,8 +162,6 @@ export default class TooltipAnchor
             document.removeEventListener("keyup", this._handleKeyUp);
         }
     }
-
-    static ariaContentId = "aria-content";
 
     activeStateStolen: () => void = () => {
         // Something wants the active state.
@@ -320,22 +319,12 @@ export default class TooltipAnchor
         );
     }
 
-    _renderAccessibleChildren(uniqueId: string): React.ReactNode {
+    render(): React.ReactNode {
+        const {"aria-describedby": ariaDescribedBy} = this.props;
         const anchorableChildren = this._renderAnchorableChildren();
 
         return React.cloneElement(anchorableChildren, {
-            "aria-describedby": `${uniqueId}-${TooltipAnchor.ariaContentId}`,
+            "aria-describedby": ariaDescribedBy,
         });
-    }
-
-    render(): React.ReactNode {
-        // We need to make sure we can anchor on our content.
-        // If the content is just a string, we wrap it in a Text element
-        // so as not to affect styling or layout but still have an element
-        // to anchor to.
-        if (this.props.id) {
-            return this._renderAccessibleChildren(this.props.id);
-        }
-        return this._renderAnchorableChildren();
     }
 }

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -278,7 +278,9 @@ export default class Tooltip extends React.Component<Props, State> {
                     forceAnchorFocusivity={forceAnchorFocusivity}
                     anchorRef={(r) => this._updateAnchorElement(r)}
                     onActiveChanged={(active) => this.setState({active})}
-                    aria-describedby={ariaContentId}
+                    aria-describedby={
+                        shouldBeVisible ? ariaContentId : undefined
+                    }
                 >
                     {children}
                 </TooltipAnchor>

--- a/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip.tsx
@@ -217,7 +217,7 @@ export default class Tooltip extends React.Component<Props, State> {
         }
     }
 
-    _renderPopper(bubbleId: string): React.ReactNode {
+    _renderPopper(ariaContentId: string): React.ReactNode {
         const {backgroundColor, placement} = this.props;
         return (
             <TooltipPopper
@@ -228,7 +228,7 @@ export default class Tooltip extends React.Component<Props, State> {
             >
                 {(props) => (
                     <TooltipBubble
-                        id={bubbleId}
+                        id={ariaContentId}
                         style={props.style}
                         backgroundColor={backgroundColor}
                         tailOffset={props.tailOffset}
@@ -269,6 +269,8 @@ export default class Tooltip extends React.Component<Props, State> {
         const shouldBeVisible =
             popperHost && (active || activeBubble) && shouldAnchorExist;
 
+        const ariaContentId = `${uniqueId}-aria-content`;
+
         // TODO(kevinb): update to use ReactPopper's React 16-friendly syntax
         return (
             <React.Fragment>
@@ -276,13 +278,13 @@ export default class Tooltip extends React.Component<Props, State> {
                     forceAnchorFocusivity={forceAnchorFocusivity}
                     anchorRef={(r) => this._updateAnchorElement(r)}
                     onActiveChanged={(active) => this.setState({active})}
-                    id={`${uniqueId}-anchor`}
+                    aria-describedby={ariaContentId}
                 >
                     {children}
                 </TooltipAnchor>
                 {shouldBeVisible &&
                     ReactDOM.createPortal(
-                        this._renderPopper(uniqueId),
+                        this._renderPopper(ariaContentId),
                         popperHost,
                     )}
             </React.Fragment>


### PR DESCRIPTION
## Summary:
When I migrated from the old ID generation to the new `useId`-based generation, I broke the `aria-describedby` attribute on the anchor. This caused screen readers to not read out the tooltip content when the anchor was focused.

This change updates things so that the tooltip bubble ID and the ID used in the `aria-describedby` attribute are the same.

I have also added test cases to ensure that we detect regressions.

Issue: WB-1932

## Test plan:
`pnpm test`
`pnpm typecheck`