### PR TITLE
Tabs: Fix keyboard navigation for right-to-left

### DIFF
--- a/.changeset/late-carpets-jam.md
+++ b/.changeset/late-carpets-jam.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tabs": patch
+---
+
+Tabs: Fix keyboard navigation for right-to-left

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -447,3 +447,28 @@ export const CustomStyles: StoryComponentType = {
         ],
     },
 };
+
+/**
+ * If an ancestor element of the `Tabs` component has `dir="rtl"`, the
+ * keyboard arrow navigation will be reversed:
+ * - `{ArrowRight}` will move focus to the previous tab
+ * - `{ArrowLeft}` will move focus to the next tab
+ *
+ * `{Home}` continues to move focus to the first tab. `{End}` continues to move
+ * focus to the last tab.
+ */
+export const RightToLeft: StoryComponentType = {
+    args: {
+        tabs: generateTabs(3, "Tab", false),
+        selectedTabId: "tab-1",
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test anything visual.
+            disableSnapshot: true,
+        },
+    },
+    globals: {
+        direction: "rtl",
+    },
+};

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -1752,8 +1752,24 @@ describe("Tabs", () => {
                     render(
                         <div dir="rtl">
                             <ControlledTabs
-                                tabs={tabs}
-                                selectedTabId={tabs[1].id}
+                                tabs={[
+                                    {
+                                        id: "tab-1",
+                                        label: "Tab 1",
+                                        panel: <div>Contents of tab 1</div>,
+                                    },
+                                    {
+                                        id: "tab-2",
+                                        label: "Tab 2",
+                                        panel: <div>Contents of tab 2</div>,
+                                    },
+                                    {
+                                        id: "tab-3",
+                                        label: "Tab 3",
+                                        panel: <div>Contents of tab 3</div>,
+                                    },
+                                ]}
+                                selectedTabId={"tab-2"}
                             />
                         </div>,
                     );
@@ -1773,8 +1789,24 @@ describe("Tabs", () => {
                     render(
                         <div dir="rtl">
                             <ControlledTabs
-                                tabs={tabs}
-                                selectedTabId={tabs[1].id}
+                                tabs={[
+                                    {
+                                        id: "tab-1",
+                                        label: "Tab 1",
+                                        panel: <div>Contents of tab 1</div>,
+                                    },
+                                    {
+                                        id: "tab-2",
+                                        label: "Tab 2",
+                                        panel: <div>Contents of tab 2</div>,
+                                    },
+                                    {
+                                        id: "tab-3",
+                                        label: "Tab 3",
+                                        panel: <div>Contents of tab 3</div>,
+                                    },
+                                ]}
+                                selectedTabId={"tab-2"}
                             />
                         </div>,
                     );
@@ -1794,8 +1826,24 @@ describe("Tabs", () => {
                     render(
                         <div dir="rtl">
                             <ControlledTabs
-                                tabs={tabs}
-                                selectedTabId={tabs[1].id}
+                                tabs={[
+                                    {
+                                        id: "tab-1",
+                                        label: "Tab 1",
+                                        panel: <div>Contents of tab 1</div>,
+                                    },
+                                    {
+                                        id: "tab-2",
+                                        label: "Tab 2",
+                                        panel: <div>Contents of tab 2</div>,
+                                    },
+                                    {
+                                        id: "tab-3",
+                                        label: "Tab 3",
+                                        panel: <div>Contents of tab 3</div>,
+                                    },
+                                ]}
+                                selectedTabId={"tab-2"}
                             />
                         </div>,
                     );
@@ -1815,8 +1863,24 @@ describe("Tabs", () => {
                     render(
                         <div dir="rtl">
                             <ControlledTabs
-                                tabs={tabs}
-                                selectedTabId={tabs[1].id}
+                                tabs={[
+                                    {
+                                        id: "tab-1",
+                                        label: "Tab 1",
+                                        panel: <div>Contents of tab 1</div>,
+                                    },
+                                    {
+                                        id: "tab-2",
+                                        label: "Tab 2",
+                                        panel: <div>Contents of tab 2</div>,
+                                    },
+                                    {
+                                        id: "tab-3",
+                                        label: "Tab 3",
+                                        panel: <div>Contents of tab 3</div>,
+                                    },
+                                ]}
+                                selectedTabId={"tab-2"}
                             />
                         </div>,
                     );

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tabs.test.tsx
@@ -1745,6 +1745,92 @@ describe("Tabs", () => {
                     expect(tab2b).toHaveFocus();
                 });
             });
+
+            describe("RTL", () => {
+                it("should focus on the previous tab when the right arrow key is pressed and it is in RTL mode", async () => {
+                    // Arrange
+                    render(
+                        <div dir="rtl">
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />
+                        </div>,
+                    );
+                    await userEvent.tab();
+
+                    // Act
+                    await userEvent.keyboard("{ArrowRight}");
+
+                    // Assert
+                    expect(
+                        screen.getByRole("tab", {name: "Tab 1"}),
+                    ).toHaveFocus();
+                });
+
+                it("should focus on the next tab when the left arrow key is pressed and it is in RTL mode", async () => {
+                    // Arrange
+                    render(
+                        <div dir="rtl">
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />
+                        </div>,
+                    );
+                    await userEvent.tab();
+
+                    // Act
+                    await userEvent.keyboard("{ArrowLeft}");
+
+                    // Assert
+                    expect(
+                        screen.getByRole("tab", {name: "Tab 3"}),
+                    ).toHaveFocus();
+                });
+
+                it("should focus on the first tab when the home key is pressed and it is in RTL mode", async () => {
+                    // Arrange
+                    render(
+                        <div dir="rtl">
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />
+                        </div>,
+                    );
+                    await userEvent.tab();
+
+                    // Act
+                    await userEvent.keyboard("{Home}");
+
+                    // Assert
+                    expect(
+                        screen.getByRole("tab", {name: "Tab 1"}),
+                    ).toHaveFocus();
+                });
+
+                it("should focus on the last tab when the end key is pressed and it is in RTL mode", async () => {
+                    // Arrange
+                    render(
+                        <div dir="rtl">
+                            <ControlledTabs
+                                tabs={tabs}
+                                selectedTabId={tabs[1].id}
+                            />
+                        </div>,
+                    );
+                    await userEvent.tab();
+
+                    // Act
+                    await userEvent.keyboard("{End}");
+
+                    // Assert
+                    expect(
+                        screen.getByRole("tab", {name: "Tab 3"}),
+                    ).toHaveFocus();
+                });
+            });
         });
     });
 

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -110,7 +110,7 @@ export const styles = StyleSheet.create({
             position: "absolute",
             left: 0,
             right: 0,
-            bottom: `-${bottomSpacing}`,
+            bottom: `calc(${bottomSpacing} * -1)`,
         },
         // Only apply hover styles to tabs that are not selected
         [":hover:not([aria-selected='true'])" as any]: {

--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -291,16 +291,22 @@ export const Tabs = React.forwardRef(function Tabs(
             const currentIndex = tabs.findIndex(
                 (tab) => tab.id === focusedTabId.current,
             );
+            const element = event.currentTarget;
+            const isRtl = !!element.closest("[dir=rtl]");
 
             switch (event.key) {
-                case keys.left: {
+                case isRtl && keys.right:
+                case !isRtl && keys.left: {
+                    // Select previous tab
                     event.preventDefault();
                     const prevIndex =
                         (currentIndex - 1 + tabs.length) % tabs.length;
                     handleKeyInteraction(tabs[prevIndex].id);
                     break;
                 }
-                case keys.right: {
+                case isRtl && keys.left:
+                case !isRtl && keys.right: {
+                    // Select next tab
                     event.preventDefault();
                     const nextIndex = (currentIndex + 1) % tabs.length;
                     handleKeyInteraction(tabs[nextIndex].id);


### PR DESCRIPTION
## Summary:

We now check if an ancestor element has `dir=rtl` to determine what the left and right arrow keys do within the Tabs component. In RTL mode:
- The right arrow will move the focus to the tab on the right (which is the previous tab)
- The left arrow will move the focus to the tab on the left (which is the next tab)
- The `Home` and `End` keys continue to move the focus to the first and last tabs

Issue: WB-1933

## Test plan:
Confirm that the keyboard behaviour in RTL and LTR work as expected (`?path=/story/packages-tabs-tabs--right-to-left`)