### PR TITLE
[WB-1937] IconButton not opening with the `Space` key (fix)

### DIFF
--- a/.changeset/sweet-pianos-end.md
+++ b/.changeset/sweet-pianos-end.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fixes an issue with the IconButton component not triggering `onClick` when the `Space` key is pressed.

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -13,6 +13,7 @@ import Pill from "@khanacademy/wonder-blocks-pill";
 import {
     border,
     semanticColor,
+    sizing,
     spacing,
 } from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
@@ -29,6 +30,9 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 
 import type {Item} from "../../packages/wonder-blocks-dropdown/src/util/types";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
+import Button from "@khanacademy/wonder-blocks-button";
 
 const actionItems: Array<Item> = [
     <ActionItem
@@ -532,5 +536,95 @@ export const CustomActionItems: StoryComponentType = {
         // Assert
         const actionMenu = await canvas.findByRole("menu");
         expect(actionMenu).toBeInTheDocument();
+    },
+};
+
+/**
+ * This example shows how to use the ActionMenu with a modal. The modal is
+ * opened when the user presses the "Open modal" action item. This could be done
+ * by pressing `Enter`/`Space` when the opener is focused.
+ *
+ * Use the keyboard to navigate to the "Open modal" action item and press
+ * `Enter` or `Space` to open the modal.
+ *
+ * Then navigate on the modal by pressing Tab and `Shift` + `Tab`.
+ */
+export const OpeningModal: StoryComponentType = {
+    name: "Opening a Modal",
+    render: function Render(args) {
+        const [opened, setOpened] = React.useState(false);
+
+        return (
+            <>
+                <ActionMenu menuText="Betsy Appleseed" {...args}>
+                    <ActionItem
+                        key="1"
+                        label="Profile"
+                        href="http://khanacademy.org/profile"
+                        target="_blank"
+                        testId="profile"
+                    />
+                    <ActionItem
+                        key="2"
+                        label="Open modal"
+                        testId="modal"
+                        onClick={() => {
+                            console.log("open modal");
+                            setOpened(true);
+                        }}
+                    />
+                </ActionMenu>
+                <ModalLauncher
+                    onClose={() => {
+                        setOpened(false);
+                    }}
+                    opened={opened}
+                    modal={({closeModal}) => (
+                        <OnePaneDialog
+                            title="Are you sure?"
+                            content="This is just a test"
+                            style={{maxHeight: "fit-content"}}
+                            footer={
+                                <View
+                                    style={{
+                                        flexDirection: "row",
+                                        gap: sizing.size_160,
+                                    }}
+                                >
+                                    <Button
+                                        kind="tertiary"
+                                        onClick={closeModal}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        color="destructive"
+                                        onClick={closeModal}
+                                    >
+                                        Delete
+                                    </Button>
+                                </View>
+                            }
+                        />
+                    )}
+                />
+            </>
+        );
+    },
+    args: {
+        opener: () => (
+            <IconButton
+                aria-label="Actions"
+                kind="tertiary"
+                actionType="neutral"
+                icon={IconMappings.dotsThreeBold}
+            />
+        ),
+    } as Partial<typeof ActionMenu>,
+    parameters: {
+        chromatic: {
+            // Disabling because this doesn't test visuals.
+            disableSnapshot: true,
+        },
     },
 };

--- a/__docs__/wonder-blocks-icon/phosphor-icon.argtypes.ts
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.argtypes.ts
@@ -22,6 +22,7 @@ import caretLeft from "@phosphor-icons/core/regular/caret-left.svg";
 import caretLeftBold from "@phosphor-icons/core/bold/caret-left-bold.svg";
 import caretRight from "@phosphor-icons/core/regular/caret-right.svg";
 import caretRightBold from "@phosphor-icons/core/bold/caret-right-bold.svg";
+import dotsThreeBold from "@phosphor-icons/core/bold/dots-three-bold.svg";
 import minusCircle from "@phosphor-icons/core/regular/minus-circle.svg";
 import minusCircleBold from "@phosphor-icons/core/bold/minus-circle-bold.svg";
 import lightbulb from "@phosphor-icons/core/regular/lightbulb.svg";
@@ -74,6 +75,7 @@ export const IconMappings = {
     checkBold,
     checkCircle,
     checkCircleBold,
+    dotsThreeBold,
     x,
     xBold,
     xCircle,

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-menu.test.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable max-lines */
 import * as React from "react";
+import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 import {render, screen} from "@testing-library/react";
 import {PointerEventsCheckLevel, userEvent} from "@testing-library/user-event";
+
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
 
 import ActionItem from "../action-item";
 import OptionItem from "../option-item";
@@ -439,6 +442,71 @@ describe("ActionMenu", () => {
 
             // Act
             await userEvent.click(await screen.findByLabelText("Search"));
+
+            // Assert
+            expect(
+                await screen.findByRole("menu", {hidden: true}),
+            ).toBeInTheDocument();
+        });
+
+        it.each([{key: "{Enter}"}, {key: " "}])(
+            "should open the menu when pressing $key",
+            async ({key}) => {
+                // Arrange
+                render(
+                    <ActionMenu
+                        menuText=""
+                        testId="openTest"
+                        onChange={onChange}
+                        selectedValues={[]}
+                        opener={() => (
+                            <IconButton
+                                aria-label="Search"
+                                icon={magnifyingGlassIcon}
+                                onClick={jest.fn()}
+                            />
+                        )}
+                    >
+                        <ActionItem label="Action" onClick={onClick} />
+                    </ActionMenu>,
+                );
+
+                await userEvent.tab();
+
+                // Act
+                await userEvent.keyboard(key);
+
+                // Assert
+                expect(
+                    await screen.findByRole("menu", {hidden: true}),
+                ).toBeInTheDocument();
+            },
+        );
+
+        it("opens the menu when pressing {Space}", async () => {
+            // Arrange
+            render(
+                <ActionMenu
+                    menuText=""
+                    testId="openTest"
+                    onChange={onChange}
+                    selectedValues={[]}
+                    opener={() => (
+                        <IconButton
+                            aria-label="Search"
+                            icon={magnifyingGlassIcon}
+                            onClick={jest.fn()}
+                        />
+                    )}
+                >
+                    <ActionItem label="Action" onClick={onClick} />
+                </ActionMenu>,
+            );
+
+            await userEvent.tab();
+
+            // Act
+            await userEvent.keyboard(" ");
 
             // Assert
             expect(

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button.test.tsx
@@ -277,15 +277,11 @@ describe("IconButton", () => {
             // the default behavior of the button.
             // eslint-disable-next-line testing-library/prefer-user-event
             fireEvent.keyDown(button, {
-                key: "Space",
-                code: "Space",
-                charCode: 32,
+                key: " ",
             });
             // eslint-disable-next-line testing-library/prefer-user-event
             fireEvent.keyUp(button, {
-                key: "Space",
-                code: "Space",
-                charCode: 32,
+                key: " ",
             });
 
             // Assert
@@ -314,8 +310,6 @@ describe("IconButton", () => {
             // eslint-disable-next-line testing-library/prefer-user-event
             fireEvent.keyDown(button, {
                 key: "Enter",
-                code: "Enter",
-                charCode: 13,
             });
             // NOTE: We need to trigger multiple events to simulate the browser
             // behavior of pressing Enter on a button. By default, browsers will
@@ -324,14 +318,10 @@ describe("IconButton", () => {
             // eslint-disable-next-line testing-library/prefer-user-event
             fireEvent.keyDown(button, {
                 key: "Enter",
-                code: "Enter",
-                charCode: 13,
             });
             // eslint-disable-next-line testing-library/prefer-user-event
             fireEvent.keyUp(button, {
                 key: "Enter",
-                code: "Enter",
-                charCode: 13,
             });
 
             // Assert

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import type {PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+import {keys} from "@khanacademy/wonder-blocks-core";
 import {Link} from "react-router-dom-v5-compat";
 import IconButtonCore from "./icon-button-core";
 import ThemedIconButton from "../themes/themed-icon-button";
@@ -202,14 +203,14 @@ export const IconButton: React.ForwardRefExoticComponent<
         // Prevent default behavior for space and enter keys on
         // buttons. We let the browser handle the default behavior
         // for links, which is to activate the link on `Enter`.
-        if (!href && (keyCode === "Enter" || keyCode === "Space")) {
+        if (!href && (keyCode === keys.enter || keyCode === keys.space)) {
             e.preventDefault();
         }
     }
 
     function handleKeyUp(e: React.KeyboardEvent) {
         const keyCode = e.key;
-        if (!href && (keyCode === "Enter" || keyCode === "Space")) {
+        if (!href && (keyCode === keys.enter || keyCode === keys.space)) {
             if (sharedProps.onClick) {
                 sharedProps.onClick(e);
             }

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -198,12 +198,13 @@ export const IconButton: React.ForwardRefExoticComponent<
         ...sharedProps
     } = props;
 
-    function handleKeyDown({key, preventDefault}: React.KeyboardEvent) {
+    function handleKeyDown(e: React.KeyboardEvent) {
+        const key = e.key;
         // Prevent default behavior for space and enter keys on
         // buttons. We let the browser handle the default behavior
         // for links, which is to activate the link on `Enter`.
         if (!href && (key === keys.enter || key === keys.space)) {
-            preventDefault();
+            e.preventDefault();
         }
     }
 

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -198,19 +198,18 @@ export const IconButton: React.ForwardRefExoticComponent<
         ...sharedProps
     } = props;
 
-    function handleKeyDown(e: React.KeyboardEvent) {
-        const keyCode = e.key;
+    function handleKeyDown({key, preventDefault}: React.KeyboardEvent) {
         // Prevent default behavior for space and enter keys on
         // buttons. We let the browser handle the default behavior
         // for links, which is to activate the link on `Enter`.
-        if (!href && (keyCode === keys.enter || keyCode === keys.space)) {
-            e.preventDefault();
+        if (!href && (key === keys.enter || key === keys.space)) {
+            preventDefault();
         }
     }
 
     function handleKeyUp(e: React.KeyboardEvent) {
-        const keyCode = e.key;
-        if (!href && (keyCode === keys.enter || keyCode === keys.space)) {
+        const key = e.key;
+        if (!href && (key === keys.enter || key === keys.space)) {
             if (sharedProps.onClick) {
                 sharedProps.onClick(e);
             }


### PR DESCRIPTION
## Summary:
- Fixes an issue with the IconButton component not triggering `onClick` when the
 `Space` key is pressed.
- Adds a story to demonstrate the issue and the fix.

Issue: https://khanacademy.atlassian.net/browse/WB-1937

## Test plan:

Navigate to `?path=/story/packages-dropdown-actionmenu--opening-modal&globals=viewport:desktop`

- Open the ActionMenu using the `Space` key.
- Verify that the ActionMenu opens as expected.
- Navigate to the "Open modal" action item by using the arrow keys.
- Press the `Space` key to open the modal.
- Verify that the modal opens as expected.
- Tab through the Modal dialog and verify that the focus is trapped within the modal.
- Press the `Escape` key to close the modal.