### PR TITLE
Add "active" prop to ActionItem

### DIFF
--- a/.changeset/gentle-games-study.md
+++ b/.changeset/gentle-games-study.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Adds "active" prop to ActionItem so that it can be marked `aria-current`

--- a/__docs__/wonder-blocks-dropdown/action-item.argtypes.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.argtypes.tsx
@@ -3,6 +3,7 @@ import type {ArgTypes} from "@storybook/react";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
+import type {ActionItem} from "@khanacademy/wonder-blocks-dropdown";
 
 const AccessoryMappings = {
     none: null,
@@ -111,4 +112,16 @@ export default {
         },
         type: {name: "other", required: false, value: "React.Node"},
     },
-} satisfies ArgTypes;
+    active: {
+        control: {type: "boolean"},
+        description:
+            `Optional; applies aria-current to the cell.\n\n` +
+            `This is used to indicate that the action item is currently active.`,
+        table: {
+            type: {summary: "boolean"},
+        },
+        type: {name: "boolean", required: false},
+    },
+} satisfies ArgTypes<
+    Omit<React.ComponentProps<typeof ActionItem>, "indent" | "role">
+>;

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-item.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-item.test.tsx
@@ -97,4 +97,17 @@ describe("ActionItem", () => {
         // Assert
         expect(screen.getByRole("heading")).toBeInTheDocument();
     });
+
+    it("should apply aria-current if active is true", () => {
+        // Arrange
+
+        // Act
+        render(<ActionItem label="Example" active={true} />);
+
+        // Assert
+        expect(screen.getByRole("menuitem")).toHaveAttribute(
+            "aria-current",
+            "true",
+        );
+    });
 });

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -96,6 +96,11 @@ type ActionProps = {
      * Optional right accessory to display in the `ActionItem` element.
      */
     rightAccessory?: CompactCellProps["rightAccessory"];
+
+    /**
+     * Optional; applies aria-current to the cell.
+     */
+    active?: CompactCellProps["active"];
 };
 
 type DefaultProps = {
@@ -138,6 +143,7 @@ export default class ActionItem extends React.Component<ActionProps> {
             role,
             style,
             testId,
+            active,
         } = this.props;
 
         const defaultStyle = [
@@ -173,6 +179,7 @@ export default class ActionItem extends React.Component<ActionProps> {
                 href={href}
                 target={target}
                 onClick={onClick}
+                active={active}
             />
         );
     }


### PR DESCRIPTION
Adds "active" prop to ActionItem so that the underlying link or button can get an `aria-current` value