### PR TITLE
[WB-1941] Experimenting with semanticColor.core tokens (border)

### DIFF
--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -292,7 +292,23 @@ would use `border.primary`, rows and layout elements use
 `border.subtle` and `border.strong` for when 3:1
 contrast is a priority (ex. form elements)
 
-<ColorGroup colors={semanticColor.border} group="border" />
+#### Neutral
+
+<ColorGroup colors={semanticColor.border.neutral} group="border.neutral" />
+
+#### Progressive
+
+<ColorGroup
+    colors={semanticColor.border.progressive}
+    group="border.progressive"
+/>
+
+#### Destructive
+
+<ColorGroup
+    colors={semanticColor.border.destructive}
+    group="border.destructive"
+/>
 
 ### Focus
 

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -359,7 +359,7 @@ const _generateStyles = (
     let firstSectionStyle: StyleType = Object.freeze({});
     let lastSectionStyle: StyleType = Object.freeze({});
 
-    const borderStyle = `1px solid ${semanticColor.border.primary}`;
+    const borderStyle = `1px solid ${semanticColor.border.neutral.default}`;
 
     if (cornerKind === "square") {
         wrapperStyle = {

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -709,7 +709,7 @@ const theme = {
         color: {
             default: {
                 background: semanticColor.surface.primary,
-                border: semanticColor.border.primary,
+                border: semanticColor.border.neutral.default,
             },
         },
     },

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -1077,7 +1077,7 @@ const theme = {
         color: {
             default: {
                 background: semanticColor.surface.primary,
-                border: semanticColor.border.primary,
+                border: semanticColor.border.neutral.default,
             },
         },
     },

--- a/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
@@ -42,7 +42,7 @@ export default class SeparatorItem extends React.Component<{
 const theme = {
     separator: {
         color: {
-            border: semanticColor.border.primary,
+            border: semanticColor.border.neutral.default,
         },
     },
 };

--- a/packages/wonder-blocks-modal/src/themes/default.ts
+++ b/packages/wonder-blocks-modal/src/themes/default.ts
@@ -35,12 +35,12 @@ const theme = {
     },
     footer: {
         color: {
-            border: semanticColor.border.primary,
+            border: semanticColor.border.neutral.default,
         },
     },
     header: {
         color: {
-            border: semanticColor.border.primary,
+            border: semanticColor.border.neutral.default,
             secondary: semanticColor.text.secondary,
         },
         spacing: {

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -260,7 +260,7 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
         default: {
             border:
                 kind === "transparent"
-                    ? `1px solid ${semanticColor.border.primary}`
+                    ? `1px solid ${semanticColor.border.neutral.default}`
                     : "none",
             background: backgroundColor,
             foreground: textColor,

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -103,7 +103,7 @@ export default class PopoverContentCore extends React.Component<Props> {
 const styles = StyleSheet.create({
     content: {
         borderRadius: border.radius.radius_040,
-        border: `solid 1px ${semanticColor.border.primary}`,
+        border: `solid 1px ${semanticColor.border.neutral.default}`,
         backgroundColor: semanticColor.surface.primary,
         // TODO(WB-1878): Use `elevation` token.
         boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -1,13 +1,34 @@
 import {color} from "../../tokens/color";
 
-const border = {
-    primary: color.fadedOffBlack16,
-    subtle: color.fadedOffBlack8,
-    strong: color.fadedOffBlack50,
-    inverse: color.white,
-    progressive: color.blue,
-    destructive: color.red,
+const core = {
+    progressive: {
+        subtle: color.fadedBlue8,
+        default: color.blue,
+        strong: color.activeBlue,
+    },
+    destructive: {
+        subtle: color.fadedRed8,
+        default: color.red,
+        strong: color.activeRed,
+    },
+    neutral: {
+        subtle: color.fadedOffBlack8,
+        default: color.fadedOffBlack16,
+        strong: color.fadedOffBlack50,
+        // what should we do with faddedOffBlack72?
+    },
 };
+
+const border = core;
+
+// const border = {
+//     primary: color.fadedOffBlack16,
+//     subtle: color.fadedOffBlack8,
+//     strong: color.fadedOffBlack50,
+//     inverse: color.white,
+//     progressive: color.blue,
+//     destructive: color.red,
+// };
 
 const surface = {
     primary: color.white,
@@ -38,7 +59,7 @@ export const semanticColor = {
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: border.progressive,
+                    border: border.progressive.default,
                     background: color.blue,
                     foreground: text.inverse,
                 },
@@ -55,7 +76,7 @@ export const semanticColor = {
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: border.destructive,
+                    border: border.destructive.default,
                     background: color.red,
                     foreground: text.inverse,
                 },
@@ -94,51 +115,51 @@ export const semanticColor = {
         secondary: {
             progressive: {
                 default: {
-                    border: border.strong,
+                    border: border.neutral.strong,
                     background: "transparent",
                     foreground: color.blue,
                 },
                 hover: {
-                    border: border.progressive,
+                    border: border.progressive.default,
                     background: "transparent",
                     foreground: color.blue,
                 },
                 press: {
-                    border: color.activeBlue,
+                    border: border.progressive.strong,
                     background: color.fadedBlue,
                     foreground: color.activeBlue,
                 },
             },
             destructive: {
                 default: {
-                    border: border.strong,
+                    border: border.neutral.strong,
                     background: "transparent",
                     foreground: color.red,
                 },
                 hover: {
-                    border: border.destructive,
+                    border: border.destructive.default,
                     background: "transparent",
                     foreground: color.red,
                 },
                 press: {
-                    border: color.activeRed,
+                    border: border.destructive.strong,
                     background: color.fadedRed,
                     foreground: color.activeRed,
                 },
             },
             neutral: {
                 default: {
-                    border: border.strong,
+                    border: border.neutral.strong,
                     background: "transparent",
                     foreground: text.secondary,
                 },
                 hover: {
-                    border: color.fadedOffBlack72,
+                    border: border.neutral.default,
                     background: "transparent",
                     foreground: text.secondary,
                 },
                 press: {
-                    border: color.offBlack,
+                    border: border.neutral.strong,
                     background: color.offBlack16,
                     foreground: text.primary,
                 },
@@ -159,7 +180,7 @@ export const semanticColor = {
                     foreground: color.blue,
                 },
                 hover: {
-                    border: border.progressive,
+                    border: border.progressive.default,
                     background: "transparent",
                     foreground: color.blue,
                 },
@@ -177,7 +198,7 @@ export const semanticColor = {
                     foreground: color.red,
                 },
                 hover: {
-                    border: border.destructive,
+                    border: border.destructive.default,
                     background: "transparent",
                     foreground: color.red,
                 },
@@ -206,7 +227,7 @@ export const semanticColor = {
             },
 
             disabled: {
-                border: border.primary,
+                border: border.neutral.default,
                 background: "transparent",
                 foreground: text.disabled,
             },
@@ -217,24 +238,24 @@ export const semanticColor = {
      */
     input: {
         default: {
-            border: border.strong,
+            border: border.neutral.strong,
             background: surface.primary,
             foreground: text.primary,
             placeholder: text.secondary,
         },
         checked: {
-            border: border.progressive,
+            border: border.progressive.default,
             background: color.blue,
             foreground: text.inverse,
         },
         disabled: {
-            border: border.primary,
+            border: border.neutral.default,
             background: color.offWhite,
             foreground: text.secondary,
             placeholder: text.secondary,
         },
         error: {
-            border: border.destructive,
+            border: border.destructive.default,
             background: color.fadedRed8,
             foreground: text.primary,
         },

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -121,7 +121,7 @@ export default function Toolbar({
 const sharedStyles = StyleSheet.create({
     container: {
         background: semanticColor.surface.primary,
-        border: `1px solid ${semanticColor.border.primary}`,
+        border: `1px solid ${semanticColor.border.neutral.default}`,
         flex: 1,
         display: "grid",
         alignItems: "center",

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
     content: {
         maxWidth: 472,
         borderRadius: border.radius.radius_040,
-        border: `solid 1px ${semanticColor.border.primary}`,
+        border: `solid 1px ${semanticColor.border.neutral.default}`,
         backgroundColor: semanticColor.surface.primary,
         // TODO(WB-1878): Use `elevation` token.
         boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,


### PR DESCRIPTION
## Summary:

- Creates a new `semanticColor.core` category.
- Moves `border` tokens to the new category.
- Replaces border call sites to support new structure.

Issue: https://khanacademy.atlassian.net/browse/WB-1941

## Test plan:

TBD