### PR TITLE
Add `StatusBadge` component

### DIFF
--- a/.changeset/early-worms-relate.md
+++ b/.changeset/early-worms-relate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-badge": minor
+---
+
+Add `StatusBadge` component

--- a/__docs__/wonder-blocks-badge/_overview_.mdx
+++ b/__docs__/wonder-blocks-badge/_overview_.mdx
@@ -1,0 +1,26 @@
+import {Meta, Canvas} from "@storybook/blocks";
+import * as StatusBadgeStories from "./status-badge.stories";
+import * as BadgeStories from "./badge.stories";
+
+<Meta
+    title="Packages / Badge / Overview"
+/>
+
+# Badges
+
+Badges are visual indicators used to display concise information, such as a
+status, label, or count.
+
+The `wonder-blocks-badge` packages has several types of badges. For more details
+about each type of badge, refer to the docs for that component!
+
+## StatusBadge
+
+<Canvas of={StatusBadgeStories.Kinds} />
+
+## Custom Badges
+
+For custom badges, the `Badge` component can be used directly. The styles can be
+overridden using the `styles` prop.
+
+<Canvas of={BadgeStories.Default} />

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
-import {Badge} from "@khanacademy/wonder-blocks-badge";
+import {Badge, StatusBadge} from "@khanacademy/wonder-blocks-badge";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {commonStates, StateSheet} from "../components/state-sheet";
@@ -72,6 +72,14 @@ export const StateSheetStory: StoryComponentType = {
                 props: {},
             },
         ];
+
+        const statusRows = [
+            ...["info", "success", "warning", "critical"].map((kind) => ({
+                name: kind,
+                props: {kind},
+            })),
+        ];
+
         return (
             <View style={{gap: sizing.size_080}}>
                 <HeadingLarge>Badge</HeadingLarge>
@@ -81,6 +89,14 @@ export const StateSheetStory: StoryComponentType = {
                     states={[commonStates.rest]}
                 >
                     {({props}) => <Badge {...props} />}
+                </StateSheet>
+                <HeadingLarge>Status Badge</HeadingLarge>
+                <StateSheet
+                    rows={statusRows}
+                    columns={columns}
+                    states={[commonStates.rest]}
+                >
+                    {({props}) => <StatusBadge {...props} />}
                 </StateSheet>
             </View>
         );

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -9,7 +9,7 @@ import {
     singleColoredIcon,
 } from "../components/icons-for-testing";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes from "./badge.argtypes";
 
@@ -125,6 +125,8 @@ export const CustomIcons: StoryComponentType = {
  * A badge can be used with custom styles. The following parts can be styled:
  * - `root`: Styles the root element
  * - `icon`: Styles the icon element
+ *
+ * Here is an example of custom styles using semantic tokens.
  */
 export const CustomStyles: StoryComponentType = {
     args: {
@@ -146,11 +148,11 @@ export const CustomStyles: StoryComponentType = {
                 }
                 styles={{
                     root: {
-                        backgroundColor: "lightblue",
-                        borderColor: "lightblue",
-                        color: "black",
+                        backgroundColor: semanticColor.surface.inverse,
+                        borderColor: semanticColor.border.inverse,
+                        color: semanticColor.text.inverse,
                     },
-                    icon: {color: "darkblue"},
+                    icon: {color: semanticColor.icon.inverse},
                 }}
             />
         );

--- a/__docs__/wonder-blocks-badge/status-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/status-badge.stories.tsx
@@ -41,6 +41,7 @@ export default {
                             key={kind}
                             {...args}
                             kind={kind}
+                            label={args.label || ""}
                             icon={
                                 args.icon ? (
                                     <PhosphorIcon
@@ -76,6 +77,7 @@ export const Default = {
     ) => (
         <StatusBadge
             {...args}
+            label={args.label || ""}
             icon={
                 args.icon ? (
                     <PhosphorIcon icon={args.icon} aria-label="Example icon" />
@@ -213,6 +215,7 @@ export const CustomStyles: StoryComponentType = {
         return (
             <StatusBadge
                 {...args}
+                label={args.label || ""}
                 icon={
                     args.icon ? (
                         <PhosphorIcon

--- a/__docs__/wonder-blocks-badge/status-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/status-badge.stories.tsx
@@ -9,7 +9,7 @@ import {
     multiColoredIcon,
     singleColoredIcon,
 } from "../components/icons-for-testing";
-import {addStyle, PropsFor, View} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes from "./badge.argtypes";
@@ -34,7 +34,7 @@ export default {
         args: Omit<PropsFor<typeof StatusBadge>, "icon"> & {icon: string},
     ) => {
         return (
-            <StyledDiv style={styles.container}>
+            <View style={styles.container}>
                 {kinds.map((kind) => {
                     return (
                         <StatusBadge
@@ -53,7 +53,7 @@ export default {
                         />
                     );
                 })}
-            </StyledDiv>
+            </View>
         );
     },
 };
@@ -64,7 +64,6 @@ type StoryComponentType = StoryObj<
     Omit<PropsFor<typeof StatusBadge>, "icon"> & {icon?: string}
 >;
 
-const StyledDiv = addStyle("div");
 const kinds = ["info", "success", "warning", "critical"] as const;
 
 export const Default = {
@@ -96,7 +95,7 @@ export const Kinds = {
     },
     render(args: Omit<PropsFor<typeof StatusBadge>, "icon"> & {icon: string}) {
         return (
-            <StyledDiv style={styles.container}>
+            <View style={styles.container}>
                 {kinds.map((kind) => {
                     const kindLabel =
                         kind.charAt(0).toUpperCase() + kind.slice(1);
@@ -114,7 +113,7 @@ export const Kinds = {
                         />
                     );
                 })}
-            </StyledDiv>
+            </View>
         );
     },
 };
@@ -152,7 +151,7 @@ export const CustomIcons: StoryComponentType = {
         return (
             <View style={{gap: sizing.size_240}}>
                 <HeadingLarge>Custom single colored svg icon</HeadingLarge>
-                <StyledDiv style={styles.container}>
+                <View style={styles.container}>
                     {kinds.map((kind) => {
                         return (
                             <StatusBadge
@@ -163,9 +162,9 @@ export const CustomIcons: StoryComponentType = {
                             />
                         );
                     })}
-                </StyledDiv>
+                </View>
                 <HeadingLarge>Custom multi-colored svg icon</HeadingLarge>
-                <StyledDiv style={styles.container}>
+                <View style={styles.container}>
                     {kinds.map((kind) => {
                         return (
                             <StatusBadge
@@ -176,9 +175,9 @@ export const CustomIcons: StoryComponentType = {
                             />
                         );
                     })}
-                </StyledDiv>
+                </View>
                 <HeadingLarge>Custom icon using img tag</HeadingLarge>
-                <StyledDiv style={styles.container}>
+                <View style={styles.container}>
                     {kinds.map((kind) => {
                         return (
                             <StatusBadge
@@ -195,7 +194,7 @@ export const CustomIcons: StoryComponentType = {
                             />
                         );
                     })}
-                </StyledDiv>
+                </View>
             </View>
         );
     },

--- a/__docs__/wonder-blocks-badge/status-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/status-badge.stories.tsx
@@ -1,0 +1,251 @@
+import * as React from "react";
+import type {StoryObj} from "@storybook/react";
+import {StyleSheet} from "aphrodite";
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-badge/package.json";
+import {StatusBadge} from "@khanacademy/wonder-blocks-badge";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {
+    multiColoredIcon,
+    singleColoredIcon,
+} from "../components/icons-for-testing";
+import {addStyle, PropsFor, View} from "@khanacademy/wonder-blocks-core";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
+import badgeArgtypes from "./badge.argtypes";
+
+export default {
+    title: "Packages / Badge / StatusBadge",
+    component: StatusBadge,
+    argTypes: badgeArgtypes,
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+        chromatic: {
+            // Disable snapshots since they're covered by the testing snapshots
+            disableSnapshot: true,
+        },
+    },
+    render: (
+        args: Omit<PropsFor<typeof StatusBadge>, "icon"> & {icon: string},
+    ) => {
+        return (
+            <StyledDiv style={styles.container}>
+                {kinds.map((kind) => {
+                    return (
+                        <StatusBadge
+                            key={kind}
+                            {...args}
+                            kind={kind}
+                            icon={
+                                args.icon ? (
+                                    <PhosphorIcon
+                                        icon={args.icon}
+                                        aria-label={"Example icon"}
+                                    />
+                                ) : undefined
+                            }
+                        />
+                    );
+                })}
+            </StyledDiv>
+        );
+    },
+};
+
+type StoryComponentType = StoryObj<
+    // Omit original icon type and replace with string so we can use the IconMapping
+    // for PhosphorIcons
+    Omit<PropsFor<typeof StatusBadge>, "icon"> & {icon?: string}
+>;
+
+const StyledDiv = addStyle("div");
+const kinds = ["info", "success", "warning", "critical"] as const;
+
+export const Default = {
+    args: {
+        label: "Badge",
+        icon: "cookie",
+    },
+    render: (
+        args: Omit<PropsFor<typeof StatusBadge>, "icon"> & {icon: string},
+    ) => (
+        <StatusBadge
+            {...args}
+            icon={
+                args.icon ? (
+                    <PhosphorIcon icon={args.icon} aria-label="Example icon" />
+                ) : undefined
+            }
+        />
+    ),
+};
+
+/**
+ * The different kinds of status badges.
+ */
+export const Kinds = {
+    args: {
+        icon: "cookie",
+    },
+    render(args: Omit<PropsFor<typeof StatusBadge>, "icon"> & {icon: string}) {
+        return (
+            <StyledDiv style={styles.container}>
+                {kinds.map((kind) => {
+                    const kindLabel =
+                        kind.charAt(0).toUpperCase() + kind.slice(1);
+                    return (
+                        <StatusBadge
+                            key={kind}
+                            kind={kind}
+                            label={kindLabel}
+                            icon={
+                                <PhosphorIcon
+                                    icon={args.icon}
+                                    aria-label="Cookie"
+                                />
+                            }
+                        />
+                    );
+                })}
+            </StyledDiv>
+        );
+    },
+};
+
+/**
+ * A badge can be used with only a label.
+ */
+export const LabelOnly: StoryComponentType = {
+    args: {
+        label: "Badge",
+    },
+};
+
+/**
+ * A badge can be used with only an icon.
+ */
+export const IconOnly: StoryComponentType = {
+    args: {
+        icon: "cookie",
+    },
+};
+
+/**
+ * A badge can be used with a custom svg. Here are some examples of custom icons:
+ * - A single colored svg icon - If the svg has `fill="currentColor"` then the
+ * icon will use the color specified by the Badge component.
+ * - A multi-colored svg icon - An svg that defines it's own fill can be used
+ * - An icon using an img tag - The `img` element should have a height and width
+ * of 100% to ensure it scales to the size of the badge icon.
+ *
+ * If the icon conveys meaning, it should have alt text.
+ */
+export const CustomIcons: StoryComponentType = {
+    render: () => {
+        return (
+            <View style={{gap: sizing.size_240}}>
+                <HeadingLarge>Custom single colored svg icon</HeadingLarge>
+                <StyledDiv style={styles.container}>
+                    {kinds.map((kind) => {
+                        return (
+                            <StatusBadge
+                                key={kind}
+                                kind={kind}
+                                icon={singleColoredIcon}
+                                label="Custom Icon"
+                            />
+                        );
+                    })}
+                </StyledDiv>
+                <HeadingLarge>Custom multi-colored svg icon</HeadingLarge>
+                <StyledDiv style={styles.container}>
+                    {kinds.map((kind) => {
+                        return (
+                            <StatusBadge
+                                key={kind}
+                                kind={kind}
+                                icon={multiColoredIcon}
+                                label="Custom Icon"
+                            />
+                        );
+                    })}
+                </StyledDiv>
+                <HeadingLarge>Custom icon using img tag</HeadingLarge>
+                <StyledDiv style={styles.container}>
+                    {kinds.map((kind) => {
+                        return (
+                            <StatusBadge
+                                key={kind}
+                                kind={kind}
+                                icon={
+                                    <img
+                                        src={"/favicon.ico"}
+                                        alt="Wonder Blocks"
+                                        style={{height: "100%", width: "100%"}}
+                                    />
+                                }
+                                label="Custom Icon"
+                            />
+                        );
+                    })}
+                </StyledDiv>
+            </View>
+        );
+    },
+};
+
+/**
+ * A badge can be used with custom styles. The following parts can be styled:
+ * - `root`: Styles the root element
+ * - `icon`: Styles the icon element
+ */
+export const CustomStyles: StoryComponentType = {
+    args: {
+        label: "Badge",
+        icon: "cookie",
+    },
+    render: (args) => {
+        return (
+            <StatusBadge
+                {...args}
+                icon={
+                    args.icon ? (
+                        <PhosphorIcon
+                            icon={args.icon}
+                            aria-label={"Example icon"}
+                        />
+                    ) : undefined
+                }
+                styles={{
+                    root: {
+                        backgroundColor: "lightblue",
+                        borderColor: "lightblue",
+                        color: "black",
+                    },
+                    icon: {color: "darkblue"},
+                }}
+            />
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Enable snapshots for this story so we can verify custom styles
+            // are applied correctly
+            disableSnapshot: false,
+        },
+    },
+};
+
+const styles = StyleSheet.create({
+    container: {
+        display: "flex",
+        flexDirection: "row",
+        gap: sizing.size_120,
+        flexWrap: "wrap",
+    },
+});

--- a/__docs__/wonder-blocks-badge/status-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/status-badge.stories.tsx
@@ -10,7 +10,7 @@ import {
     singleColoredIcon,
 } from "../components/icons-for-testing";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes from "./badge.argtypes";
 
@@ -204,6 +204,8 @@ export const CustomIcons: StoryComponentType = {
  * A badge can be used with custom styles. The following parts can be styled:
  * - `root`: Styles the root element
  * - `icon`: Styles the icon element
+ *
+ * Here is an example of custom styles using semantic tokens.
  */
 export const CustomStyles: StoryComponentType = {
     args: {
@@ -225,11 +227,11 @@ export const CustomStyles: StoryComponentType = {
                 }
                 styles={{
                     root: {
-                        backgroundColor: "lightblue",
-                        borderColor: "lightblue",
-                        color: "black",
+                        backgroundColor: semanticColor.surface.inverse,
+                        borderColor: semanticColor.border.inverse,
+                        color: semanticColor.text.inverse,
                     },
-                    icon: {color: "darkblue"},
+                    icon: {color: semanticColor.icon.inverse},
                 }}
             />
         );

--- a/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
@@ -21,6 +21,17 @@ describe("Badge types", () => {
                 expect(ref.current).toBe(badge);
             });
 
+            it("should use the tag prop if provided", () => {
+                // Arrange
+                render(<Component tag={"strong"} label="Badge label" />);
+
+                // Act
+                const badge = screen.getByText("Badge label");
+
+                // Assert
+                expect(badge).toHaveProperty("tagName", "STRONG");
+            });
+
             describe("Attributes", () => {
                 it("should set the id attribute", () => {
                     // Arrange

--- a/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import {StatusBadge} from "../status-badge";
+
+/**
+ * Tests for props that are common to the different badge types.
+ */
+describe("Badge types", () => {
+    describe.each([{name: "StatusBadge", Component: StatusBadge}])(
+        "$name",
+        ({Component}) => {
+            it("should forward the ref to the root element", () => {
+                // Arrange
+                const ref = React.createRef<HTMLDivElement>();
+                render(<Component ref={ref} label="Badge label" />);
+
+                // Act
+                const badge = screen.getByText("Badge label");
+
+                // Assert
+                expect(ref.current).toBe(badge);
+            });
+
+            describe("Attributes", () => {
+                it("should set the id attribute", () => {
+                    // Arrange
+                    const id = "badge-id";
+                    render(<Component id={id} label="Badge label" />);
+
+                    // Act
+                    const badge = screen.getByText("Badge label");
+
+                    // Assert
+                    expect(badge).toHaveAttribute("id", id);
+                });
+
+                it("should set the data-testid attribute", () => {
+                    // Arrange
+                    const testId = "badge-testid";
+                    render(<Component testId={testId} label="Badge label" />);
+
+                    // Act
+                    const badge = screen.getByTestId(testId);
+
+                    // Assert
+                    expect(badge).toHaveAttribute("data-testid", testId);
+                });
+            });
+
+            describe("Accessibility", () => {
+                describe("ARIA", () => {
+                    it("should use ARIA props", () => {
+                        // Arrange
+                        const ariaLabel = "Example aria label";
+                        render(
+                            <Component
+                                aria-label={ariaLabel}
+                                label="Badge label"
+                            />,
+                        );
+
+                        // Assert
+                        const badge = screen.getByLabelText(ariaLabel);
+                        expect(badge).toBeInTheDocument();
+                    });
+                });
+            });
+        },
+    );
+});

--- a/packages/wonder-blocks-badge/src/components/__tests__/status-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/status-badge.test.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import {StatusBadge} from "../status-badge";
+
+describe("StatusBadge", () => {
+    it("should render the label", () => {
+        // Arrange
+        const label = "Badge label";
+        render(<StatusBadge label={label} />);
+
+        // Act
+        const badge = screen.getByText(label);
+
+        // Assert
+        expect(badge).toBeInTheDocument();
+    });
+
+    it("should render the icon", () => {
+        // Arrange
+        const icon = <svg data-testid="icon-example" />;
+        render(<StatusBadge icon={icon} />);
+
+        // Act
+        const iconElement = screen.getByTestId("icon-example");
+
+        // Assert
+        expect(iconElement).toBeInTheDocument();
+    });
+
+    it("should not render anything if there is no label or icon", () => {
+        // Arrange
+        // Act
+        const {container} = render(<StatusBadge />);
+
+        // Assert
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    describe("Accessibility", () => {
+        describe("axe", () => {
+            it("should not have violations", async () => {
+                // Arrange
+                // Act
+                const {container} = render(
+                    <StatusBadge
+                        label="Badge label"
+                        icon={<img src="/" alt="Example icon" />}
+                    />,
+                );
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+        });
+    });
+});

--- a/packages/wonder-blocks-badge/src/components/__tests__/status-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/status-badge.test.tsx
@@ -27,10 +27,10 @@ describe("StatusBadge", () => {
         expect(iconElement).toBeInTheDocument();
     });
 
-    it("should not render anything if there is no label or icon", () => {
+    it("should not render anything if the label is an empty string and there is no icon", () => {
         // Arrange
         // Act
-        const {container} = render(<StatusBadge />);
+        const {container} = render(<StatusBadge label="" />);
 
         // Assert
         expect(container).toBeEmptyDOMElement();

--- a/packages/wonder-blocks-badge/src/components/status-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/status-badge.tsx
@@ -1,0 +1,138 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {Badge, BadgeProps} from "./badge";
+
+type Props = {
+    /**
+     * The kind of badge to display. Defaults to `info`.
+     */
+    kind?: "info" | "success" | "warning" | "critical";
+} & BadgeProps;
+
+/**
+ * A badge that represents a status.
+ */
+const StatusBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
+    const {kind = "info", ...otherProps} = props;
+    return (
+        <Badge
+            ref={ref}
+            {...otherProps}
+            styles={{
+                root: [getKindStyle(kind), otherProps.styles?.root],
+                icon: [getIconKindStyle(kind), otherProps.styles?.icon],
+            }}
+        />
+    );
+});
+
+export {StatusBadge};
+
+function getKindStyle(kind: Props["kind"]) {
+    switch (kind) {
+        case "info":
+            return styles.info;
+        case "success":
+            return styles.success;
+        case "warning":
+            return styles.warning;
+        case "critical":
+            return styles.critical;
+        default:
+            return {};
+    }
+}
+
+function getIconKindStyle(kind: Props["kind"]) {
+    switch (kind) {
+        case "info":
+            return styles.infoIcon;
+        case "success":
+            return styles.successIcon;
+        case "warning":
+            return styles.warningIcon;
+        case "critical":
+            return styles.criticalIcon;
+        default:
+            return {};
+    }
+}
+
+const badgeTokens = {
+    root: {
+        color: {
+            info: {
+                background: semanticColor.status.notice.background,
+                border: semanticColor.status.notice.background,
+                foreground: semanticColor.text.primary,
+            },
+            success: {
+                background: semanticColor.status.success.background,
+                border: semanticColor.status.success.background,
+                foreground: semanticColor.text.primary,
+            },
+            warning: {
+                background: semanticColor.status.warning.background,
+                border: semanticColor.status.warning.background,
+                foreground: semanticColor.text.primary,
+            },
+            critical: {
+                background: semanticColor.status.critical.background,
+                border: semanticColor.status.critical.background,
+                foreground: semanticColor.text.primary,
+            },
+        },
+    },
+    icon: {
+        color: {
+            info: {
+                foreground: semanticColor.status.notice.foreground,
+            },
+            success: {
+                foreground: semanticColor.status.success.foreground,
+            },
+            warning: {
+                foreground: semanticColor.status.warning.foreground,
+            },
+            critical: {
+                foreground: semanticColor.status.critical.foreground,
+            },
+        },
+    },
+};
+
+const styles = StyleSheet.create({
+    info: {
+        backgroundColor: badgeTokens.root.color.info.background,
+        color: badgeTokens.root.color.info.foreground,
+        borderColor: badgeTokens.root.color.info.border,
+    },
+    success: {
+        backgroundColor: badgeTokens.root.color.success.background,
+        color: badgeTokens.root.color.success.foreground,
+        borderColor: badgeTokens.root.color.success.border,
+    },
+    warning: {
+        backgroundColor: badgeTokens.root.color.warning.background,
+        color: badgeTokens.root.color.warning.foreground,
+        borderColor: badgeTokens.root.color.warning.border,
+    },
+    critical: {
+        backgroundColor: badgeTokens.root.color.critical.background,
+        color: badgeTokens.root.color.critical.foreground,
+        borderColor: badgeTokens.root.color.critical.border,
+    },
+    infoIcon: {
+        color: badgeTokens.icon.color.info.foreground,
+    },
+    successIcon: {
+        color: badgeTokens.icon.color.success.foreground,
+    },
+    warningIcon: {
+        color: badgeTokens.icon.color.warning.foreground,
+    },
+    criticalIcon: {
+        color: badgeTokens.icon.color.critical.foreground,
+    },
+});

--- a/packages/wonder-blocks-badge/src/index.ts
+++ b/packages/wonder-blocks-badge/src/index.ts
@@ -1,1 +1,2 @@
 export {Badge} from "./components/badge";
+export {StatusBadge} from "./components/status-badge";


### PR DESCRIPTION
## Summary:
- Adds `StatusBadge` component with `kind` prop. Supports `info`, `success`, `warning`, and `critical` kinds

<img width="371" alt="image" src="https://github.com/user-attachments/assets/abcd53b4-fc90-49a8-87b2-c05aacb21348" />


Issue: WB-1944

## Test plan:
- Review stories and docs for `StatusBadge` (`?path=/docs/packages-badge-statusbadge--docs`)
- Review Badge package overview docs (`?path=/docs/packages-badge-overview--docs`)