### PR TITLE
Export ActionTrigger type for Banner

### DIFF
--- a/.changeset/mighty-chairs-roll.md
+++ b/.changeset/mighty-chairs-roll.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": major
+---
+
+Export ActionTrigger type

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -42,7 +42,7 @@ type ActionTriggerCustom = {
     node: React.ReactNode;
 };
 
-export type ActionTrigger =
+type ActionTrigger =
     | ActionTriggerWithButton
     | ActionTriggerWithLink
     | ActionTriggerCustom;
@@ -106,7 +106,7 @@ type Props = {
      *
      * The ActionTrigger must have either an onClick or an href field, or both.
      */
-    actions?: Array<ActionTrigger>;
+    actions?: ReadonlyArray<ActionTrigger>;
     /**
      * If present, dismiss button is on right side. If not, no button appears.
      */

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -42,7 +42,7 @@ type ActionTriggerCustom = {
     node: React.ReactNode;
 };
 
-type ActionTrigger =
+export type ActionTrigger =
     | ActionTriggerWithButton
     | ActionTriggerWithLink
     | ActionTriggerCustom;

--- a/packages/wonder-blocks-banner/src/index.ts
+++ b/packages/wonder-blocks-banner/src/index.ts
@@ -1,4 +1,3 @@
 import Banner from "./components/banner";
 
 export default Banner;
-export type {ActionTrigger} from "./components/banner";

--- a/packages/wonder-blocks-banner/src/index.ts
+++ b/packages/wonder-blocks-banner/src/index.ts
@@ -1,3 +1,4 @@
 import Banner from "./components/banner";
 
 export default Banner;
+export type {ActionTrigger} from "./components/banner";


### PR DESCRIPTION
## Summary:
Typescript doesn't seem to infer action types correctly when passing a memoized array to the Banner component.
Exporting the ActionTrigger type should allow us to properly define the type.