### PR TITLE
[WB-1941.1] Add `core.border` semantic color tokens

### DIFF
--- a/.changeset/nice-tools-shake.md
+++ b/.changeset/nice-tools-shake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Adds new `semanticColor.core` category

--- a/.changeset/perfect-fishes-pump.md
+++ b/.changeset/perfect-fishes-pump.md
@@ -1,0 +1,16 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-styles": patch
+"@khanacademy/wonder-blocks-tokens": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-pill": patch
+"@khanacademy/wonder-blocks-tabs": patch
+---
+
+Replaces all existing `semanticColor.border` references to use `semanticColor.core.border`

--- a/__docs__/components/all-variants.tsx
+++ b/__docs__/components/all-variants.tsx
@@ -134,7 +134,7 @@ export function AllVariants(props: Props) {
                                             style={[
                                                 styles.cell,
                                                 {
-                                                    border: `${border.width.thin} dashed ${semanticColor.border.primary}`,
+                                                    border: `${border.width.thin} dashed ${semanticColor.core.border.neutral.subtle}`,
                                                 },
                                                 stylesProp?.cell,
                                             ]}
@@ -220,6 +220,6 @@ const styles = StyleSheet.create({
     childrenWrapper: {
         padding: sizing.size_080,
         marginBlock: sizing.size_080,
-        border: `${border.width.thin} dashed ${semanticColor.border.primary}`,
+        border: `${border.width.thin} dashed ${semanticColor.core.border.neutral.subtle}`,
     },
 });

--- a/__docs__/components/color.tsx
+++ b/__docs__/components/color.tsx
@@ -138,7 +138,7 @@ function Color({name, value, variant}: ColorProps) {
                 <View
                     style={{
                         backgroundColor: value,
-                        boxShadow: `inset 0 0 1px 0 ${semanticColor.border.primary}`,
+                        boxShadow: `inset 0 0 1px 0 ${semanticColor.core.border.neutral.subtle}`,
                         // Expand to fill the parent container
                         alignSelf: "stretch",
                         flex: 1,
@@ -219,7 +219,7 @@ const styles = StyleSheet.create({
         margin: spacing.xxxSmall_4,
         padding: spacing.xxxSmall_4,
         gap: spacing.xxxSmall_4,
-        border: `1px dashed ${semanticColor.border.subtle}`,
+        border: `1px dashed ${semanticColor.core.border.neutral.subtle}`,
     },
     item: {
         maxWidth: itemWidth,
@@ -231,13 +231,13 @@ const styles = StyleSheet.create({
         width: "100%",
 
         backgroundColor: semanticColor.surface.secondary,
-        border: `1px solid ${semanticColor.border.primary}`,
+        border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
         borderRadius: border.radius.radius_040,
     },
     pattern: {
         backgroundImage: `radial-gradient(${color.blue} 0.5px, ${color.offWhite} 0.5px)`,
         backgroundSize: `${spacing.small_12}px ${spacing.small_12}px`,
-        boxShadow: `0 0 1px 0 ${semanticColor.border.primary}`,
+        boxShadow: `0 0 1px 0 ${semanticColor.core.border.neutral.subtle}`,
     },
     thumbnail: {
         width: itemWidth,

--- a/__docs__/components/color.tsx
+++ b/__docs__/components/color.tsx
@@ -160,13 +160,22 @@ type ActionColorGroupProps = {
      * The group name to use as a prefix for the color names.
      */
     group: string;
+    /**
+     * Whether to include an example of the color.
+     * This is useful for showing how the color looks in a UI context.
+     */
+    includeExample?: boolean;
 };
 
-export function ActionColorGroup({category, group}: ActionColorGroupProps) {
+export function ActionColorGroup({
+    category,
+    group,
+    includeExample = true,
+}: ActionColorGroupProps) {
     return Object.entries(category).map(([state, colorGroup], index) => (
         <View style={styles.actionGroup} key={index}>
             <LabelLarge style={styles.capitalized}>{state}</LabelLarge>
-            <Example style={colorGroup} />
+            {includeExample && <Example style={colorGroup} />}
             <ColorGroup
                 colors={colorGroup}
                 group={group + "." + state}

--- a/__docs__/components/placeholder.tsx
+++ b/__docs__/components/placeholder.tsx
@@ -18,7 +18,7 @@ export const Placeholder = (props: Props) => {
                 backgroundColor: semanticColor.surface.secondary,
                 padding: sizing.size_120,
                 margin: sizing.size_010,
-                border: `${border.width.thin}px dashed ${semanticColor.border.subtle}`,
+                border: `${border.width.thin}px dashed ${semanticColor.core.border.neutral.subtle}`,
                 width: "100%",
                 alignItems: "center",
             }}

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -285,14 +285,22 @@ backgrounds in light mode.
 
 <ColorGroup colors={semanticColor.text} group="text" />
 
-### Border
+### Core
+
+#### Border
 
 Borders define structure for elements. Generally borders for component elements
-would use `border.primary`, rows and layout elements use
-`border.subtle` and `border.strong` for when 3:1
+would use `border.neutral.default`, rows and layout elements use
+`border.neutral.subtle` and `border.neutral.strong` for when 3:1
 contrast is a priority (ex. form elements)
 
-<ColorGroup colors={semanticColor.border} group="border" />
+<View style={styles.gridCompact}>
+    <ActionColorGroup
+        category={semanticColor.core.border}
+        group="border"
+        includeExample={false}
+    />
+</View>
 
 ### Focus
 

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -290,9 +290,9 @@ backgrounds in light mode.
 #### Border
 
 Borders define structure for elements. Generally borders for component elements
-would use `border.neutral.default`, rows and layout elements use
-`border.neutral.subtle` and `border.neutral.strong` for when 3:1
-contrast is a priority (ex. form elements)
+would use `core.border.neutral.subtle`, `core.border.neutral.default` for when
+3:1 contrast is a priority (ex. form elements) and `core.border.neutral.strong`
+for 4.5:1 contrast.
 
 <View style={styles.gridCompact}>
     <ActionColorGroup

--- a/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
@@ -519,7 +519,7 @@ export const CustomRootStyle = {
                         onClick={() => {}}
                         style={[
                             {
-                                border: `1px solid ${semanticColor.border.primary}`,
+                                border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
                             },
                         ]}
                         horizontalRule={"none"}
@@ -530,7 +530,7 @@ export const CustomRootStyle = {
                         style={[
                             args.rootStyle,
                             {
-                                border: `1px solid ${semanticColor.border.primary}`,
+                                border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
                             },
                         ]}
                         horizontalRule={"none"}
@@ -541,7 +541,7 @@ export const CustomRootStyle = {
                         style={[
                             args.rootStyle,
                             {
-                                border: `1px solid ${semanticColor.border.primary}`,
+                                border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
                             },
                         ]}
                         horizontalRule={"none"}

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -348,7 +348,7 @@ const styles = StyleSheet.create({
         marginRight: spacing.large_24,
     },
     navigation: {
-        border: `1px dashed ${semanticColor.border.primary}`,
+        border: `1px dashed ${semanticColor.core.border.neutral.subtle}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
     },

--- a/__docs__/wonder-blocks-dropdown/listbox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/listbox.stories.tsx
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
         width: 360,
     },
     customListbox: {
-        border: `5px solid ${semanticColor.border.primary}`,
+        border: `5px solid ${semanticColor.core.border.neutral.subtle}`,
         width: 250,
     },
 });

--- a/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
@@ -329,7 +329,7 @@ const styles = StyleSheet.create({
     },
     title: {
         paddingBottom: spacing.xSmall_8,
-        borderBottom: `1px solid ${semanticColor.border.strong}`,
+        borderBottom: `1px solid ${semanticColor.core.border.neutral.default}`,
     },
     // Multiple choice styling
     multipleChoice: {

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -245,7 +245,7 @@ export const CustomLabel: StoryComponentType = {
         label: (
             <View
                 style={{
-                    border: `1px dashed ${semanticColor.border.strong}`,
+                    border: `1px dashed ${semanticColor.core.border.neutral.default}`,
                     padding: spacing.medium_16,
                     flexDirection: "row",
                     justifyContent: "space-between",

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -673,7 +673,7 @@ const styles = StyleSheet.create({
         marginRight: spacing.large_24,
     },
     navigation: {
-        border: `1px dashed ${semanticColor.border.primary}`,
+        border: `1px dashed ${semanticColor.core.border.neutral.subtle}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
     },
@@ -702,7 +702,7 @@ const styles = StyleSheet.create({
     },
     card: {
         background: semanticColor.surface.secondary,
-        border: `${border.width.thin} solid ${semanticColor.border.primary}`,
+        border: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
         borderRadius: border.radius.radius_040,
         width: "100%",
         height: "100%",

--- a/__docs__/wonder-blocks-pill/pill.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill.stories.tsx
@@ -240,11 +240,11 @@ export const WithStyle: StoryComponentType = () => {
         paddingRight: tokens.spacing.xxLarge_48,
 
         ":hover": {
-            outlineColor: tokens.semanticColor.border.strong,
+            outlineColor: tokens.semanticColor.core.border.neutral.default,
         },
 
         ":active": {
-            outlineColor: tokens.semanticColor.border.primary,
+            outlineColor: tokens.semanticColor.core.border.neutral.subtle,
             backgroundColor: tokens.semanticColor.surface.overlay,
         },
     };

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
         justifyContent: "space-between",
     },
     playground: {
-        border: `1px dashed ${semanticColor.border.primary}`,
+        border: `1px dashed ${semanticColor.core.border.neutral.subtle}`,
         marginTop: spacing.large_24,
         padding: spacing.large_24,
         flexDirection: "row",

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -165,7 +165,7 @@ export const HeaderWithNavigationTabsExample: StoryComponentType = {
                 display: "flex",
                 alignItems: "center",
                 flexWrap: "wrap",
-                borderBottom: `1px solid ${semanticColor.border.primary}`,
+                borderBottom: `1px solid ${semanticColor.core.border.neutral.subtle}`,
                 gap: sizing.size_240,
                 padding: `${headerVerticalSpacing} ${sizing.size_240}`,
             },

--- a/__docs__/wonder-blocks-tokens/tokens-semantic-color.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-semantic-color.mdx
@@ -52,7 +52,7 @@ import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 const styles = {
     background: semanticColor.surface.secondary,
-    border: semanticColor.border.strong,
+    border: semanticColor.core.border.neutral.default,
     color: semanticColor.text.primary,
 };
 ```

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "publish:check": "pnpm run lint:pkg-json && ./utils/publish/pre-publish-check-ci.ts",
     "publish:ci": "pnpm run publish:check && git diff --stat --exit-code HEAD && pnpm build && pnpm build:types && pnpm changeset publish",
     "start": "pnpm start:storybook",
-    "start:storybook": "storybook dev -p 6061",
+    "start:storybook": "storybook dev -p 6061 && pnpm dev",
     "test:common": "pnpm run build && pnpm run lint && pnpm run typecheck && pnpm run alex",
     "test:coverage": "pnpm run test:common && pnpm run jest --coverage",
     "test:storybook": "vitest --project=storybook",

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -359,7 +359,7 @@ const _generateStyles = (
     let firstSectionStyle: StyleType = Object.freeze({});
     let lastSectionStyle: StyleType = Object.freeze({});
 
-    const borderStyle = `1px solid ${semanticColor.border.primary}`;
+    const borderStyle = `1px solid ${semanticColor.core.border.neutral.subtle}`;
 
     if (cornerKind === "square") {
         wrapperStyle = {

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -411,7 +411,7 @@ const styles = StyleSheet.create({
     },
     // TODO(WB-1852): Remove light variant.
     focusedLight: {
-        outline: `solid ${border.width.medium} ${semanticColor.border.inverse}`,
+        outline: `solid ${border.width.medium} ${semanticColor.core.border.inverse.strong}`,
     },
     disabled: {
         color: semanticColor.action.secondary.disabled.foreground,

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -709,7 +709,7 @@ const theme = {
         color: {
             default: {
                 background: semanticColor.surface.primary,
-                border: semanticColor.border.primary,
+                border: semanticColor.core.border.neutral.subtle,
             },
         },
     },

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -1077,7 +1077,7 @@ const theme = {
         color: {
             default: {
                 background: semanticColor.surface.primary,
-                border: semanticColor.border.primary,
+                border: semanticColor.core.border.neutral.subtle,
             },
         },
     },

--- a/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
@@ -42,7 +42,7 @@ export default class SeparatorItem extends React.Component<{
 const theme = {
     separator: {
         color: {
-            border: semanticColor.border.primary,
+            border: semanticColor.core.border.neutral.subtle,
         },
     },
 };

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -195,7 +195,7 @@ const theme = {
                 foreground: semanticColor.text.inverse,
             },
             focus: {
-                border: semanticColor.border.inverse,
+                border: semanticColor.core.border.inverse.strong,
                 foreground: semanticColor.text.inverse,
             },
             press: {

--- a/packages/wonder-blocks-modal/src/themes/default.ts
+++ b/packages/wonder-blocks-modal/src/themes/default.ts
@@ -35,12 +35,12 @@ const theme = {
     },
     footer: {
         color: {
-            border: semanticColor.border.primary,
+            border: semanticColor.core.border.neutral.subtle,
         },
     },
     header: {
         color: {
-            border: semanticColor.border.primary,
+            border: semanticColor.core.border.neutral.subtle,
             secondary: semanticColor.text.secondary,
         },
         spacing: {

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -260,7 +260,7 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
         default: {
             border:
                 kind === "transparent"
-                    ? `1px solid ${semanticColor.border.primary}`
+                    ? `1px solid ${semanticColor.core.border.neutral.subtle}`
                     : "none",
             background: backgroundColor,
             foreground: textColor,

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -103,7 +103,7 @@ export default class PopoverContentCore extends React.Component<Props> {
 const styles = StyleSheet.create({
     content: {
         borderRadius: border.radius.radius_040,
-        border: `solid 1px ${semanticColor.border.primary}`,
+        border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         backgroundColor: semanticColor.surface.primary,
         // TODO(WB-1878): Use `elevation` token.
         boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,

--- a/packages/wonder-blocks-styles/src/styles/action-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/action-styles.ts
@@ -1,7 +1,7 @@
 import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {focus} from "./focus-styles";
 
-const pressColor = `color-mix(in srgb, ${semanticColor.border.strong} 55%, ${semanticColor.border.inverse})`;
+const pressColor = `color-mix(in srgb, ${semanticColor.core.border.neutral.default} 55%, ${semanticColor.core.border.inverse.strong})`;
 
 /**
  * The inverse styles for an interactive control.
@@ -15,7 +15,7 @@ export const inverse = {
     // button, as there might be some cases where the interactive element
     // already includes a border.
     ":not([aria-disabled=true])": {
-        borderColor: semanticColor.border.inverse,
+        borderColor: semanticColor.core.border.inverse.strong,
         color: semanticColor.text.inverse,
     },
 
@@ -24,7 +24,7 @@ export const inverse = {
         // Overriding borderColor only to preserve the visual integrity of the
         // button, as there might be some cases where the interactive element
         // already includes a border.
-        borderColor: semanticColor.border.inverse,
+        borderColor: semanticColor.core.border.inverse.strong,
     },
 
     // Use the global focus styles to ensure that the focus state is consistent

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
     tablist: {
         display: "flex",
         gap: sizing.size_240,
-        borderBottom: `${border.width.thin} solid ${semanticColor.border.subtle}`,
+        borderBottom: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
         // Add horizontal padding for focus outline of first/last elements
         paddingInline: sizing.size_040,
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -3,6 +3,53 @@ import {color} from "./internal/primitive-color-thunderblocks";
 
 import {semanticColor as defaultSemanticColor} from "./semantic-color";
 
+const transparent = "transparent";
+
+const core = {
+    transparent,
+    border: {
+        instructive: {
+            subtle: color.blue_60,
+            default: color.blue_40,
+            strong: color.blue_10,
+        },
+        neutral: {
+            subtle: color.gray_60,
+            default: color.gray_30,
+            strong: color.gray_10,
+        },
+        critical: {
+            subtle: color.red_60,
+            default: color.red_30,
+            strong: color.red_10,
+        },
+        success: {
+            subtle: color.green_60,
+            default: color.green_30,
+            strong: color.green_10,
+        },
+        warning: {
+            subtle: color.yellow_60,
+            default: color.yellow_40,
+            strong: color.yellow_10,
+        },
+        disabled: {
+            subtle: transparent,
+            default: color.gray_70,
+            strong: color.gray_60,
+        },
+        inverse: {
+            subtle: color.gray_60,
+            default: color.gray_90,
+            strong: color.white_100,
+        },
+    },
+};
+
+/**
+ * TODO(WB-1941): Remove border once we have migrated to the new core.border
+ * tokens.
+ */
 const border = {
     subtle: color.gray_60,
     // TODO(WB-1941): Change to the new core.border structure and use
@@ -35,58 +82,58 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
         primary: {
             progressive: {
                 default: {
-                    border: border.progressive,
+                    border: core.border.instructive.default,
                     background: color.blue_30,
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: color.blue_10,
+                    border: core.border.instructive.strong,
                     background: color.blue_10,
                     foreground: text.inverse,
                 },
                 press: {
-                    border: color.blue_10,
+                    border: core.border.instructive.strong,
                     background: color.blue_10,
                     foreground: text.inverse,
                 },
             },
             destructive: {
                 default: {
-                    border: border.destructive,
+                    border: core.border.critical.default,
                     background: color.red_20,
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: color.red_05,
+                    border: core.border.critical.strong,
                     background: color.red_05,
                     foreground: text.inverse,
                 },
                 press: {
-                    border: color.red_05,
+                    border: core.border.critical.strong,
                     background: color.red_05,
                     foreground: text.inverse,
                 },
             },
             neutral: {
                 default: {
-                    border: border.primary,
+                    border: core.border.neutral.default,
                     background: color.gray_20,
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: color.gray_05,
+                    border: core.border.neutral.strong,
                     background: color.gray_05,
                     foreground: text.inverse,
                 },
                 press: {
-                    border: color.gray_05,
+                    border: core.border.neutral.strong,
                     background: color.gray_05,
                     foreground: text.inverse,
                 },
             },
 
             disabled: {
-                border: color.gray_70,
+                border: core.transparent,
                 background: color.gray_70,
                 foreground: color.gray_50,
             },
@@ -95,58 +142,58 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
         secondary: {
             progressive: {
                 default: {
-                    border: color.blue_60,
+                    border: core.border.instructive.subtle,
                     background: color.blue_80,
                     foreground: color.blue_30,
                 },
                 hover: {
-                    border: color.blue_40,
+                    border: core.border.instructive.default,
                     background: color.blue_70,
                     foreground: color.blue_30,
                 },
                 press: {
-                    border: color.blue_40,
+                    border: core.border.instructive.default,
                     background: color.blue_70,
                     foreground: color.blue_30,
                 },
             },
             destructive: {
                 default: {
-                    border: color.red_30,
+                    border: core.border.critical.default,
                     background: color.red_90,
                     foreground: color.red_20,
                 },
                 hover: {
-                    border: color.red_10,
+                    border: core.border.critical.strong,
                     background: color.red_70,
                     foreground: color.red_10,
                 },
                 press: {
-                    border: color.red_10,
+                    border: core.border.critical.strong,
                     background: color.red_70,
                     foreground: color.red_10,
                 },
             },
             neutral: {
                 default: {
-                    border: color.gray_60,
+                    border: core.border.neutral.subtle,
                     background: color.white_100,
                     foreground: color.gray_10,
                 },
                 hover: {
-                    border: color.gray_10,
+                    border: core.border.neutral.strong,
                     background: color.white_100,
                     foreground: color.black_100,
                 },
                 press: {
-                    border: color.gray_10,
+                    border: core.border.neutral.strong,
                     background: color.white_100,
                     foreground: color.black_100,
                 },
             },
 
             disabled: {
-                border: color.gray_60,
+                border: core.border.disabled.strong,
                 background: color.gray_80,
                 foreground: color.gray_50,
             },
@@ -155,17 +202,17 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
         tertiary: {
             progressive: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: "transparent",
                     foreground: color.blue_30,
                 },
                 hover: {
-                    border: color.blue_10,
+                    border: core.border.instructive.strong,
                     background: "transparent",
                     foreground: color.blue_10,
                 },
                 press: {
-                    border: color.blue_10,
+                    border: core.border.instructive.strong,
                     background: "transparent",
                     foreground: color.blue_10,
                 },
@@ -173,41 +220,41 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
 
             destructive: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: "transparent",
                     foreground: color.red_20,
                 },
                 hover: {
-                    border: color.red_10,
+                    border: core.border.critical.strong,
                     background: "transparent",
                     foreground: color.red_10,
                 },
                 press: {
-                    border: color.red_10,
+                    border: core.border.critical.strong,
                     background: "transparent",
                     foreground: color.red_10,
                 },
             },
             neutral: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: "transparent",
                     foreground: color.gray_10,
                 },
                 hover: {
-                    border: color.gray_10,
+                    border: core.border.neutral.strong,
                     background: "transparent",
                     foreground: color.black_100,
                 },
                 press: {
-                    border: color.gray_10,
+                    border: core.border.neutral.strong,
                     background: "transparent",
                     foreground: color.black_100,
                 },
             },
 
             disabled: {
-                border: "transparent",
+                border: core.border.disabled.subtle,
                 background: "transparent",
                 foreground: color.gray_50,
             },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -186,7 +186,7 @@ export const semanticColor = {
                     foreground: text.secondary,
                 },
                 hover: {
-                    border: core.border.neutral.strong,
+                    border: core.border.neutral.default,
                     background: "transparent",
                     foreground: text.secondary,
                 },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -5,7 +5,7 @@ const transparent = "transparent";
 const core = {
     transparent,
     border: {
-        informative: {
+        instructive: {
             subtle: color.fadedBlue,
             default: color.blue,
             strong: color.activeBlue,
@@ -91,12 +91,12 @@ export const semanticColor = {
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: core.border.informative.default,
+                    border: core.border.instructive.default,
                     background: color.blue,
                     foreground: text.inverse,
                 },
                 press: {
-                    border: core.border.informative.strong,
+                    border: core.border.instructive.strong,
                     background: color.activeBlue,
                     foreground: text.inverse,
                 },
@@ -152,12 +152,12 @@ export const semanticColor = {
                     foreground: color.blue,
                 },
                 hover: {
-                    border: core.border.informative.default,
+                    border: core.border.instructive.default,
                     background: "transparent",
                     foreground: color.blue,
                 },
                 press: {
-                    border: core.border.informative.strong,
+                    border: core.border.instructive.strong,
                     background: color.fadedBlue,
                     foreground: color.activeBlue,
                 },
@@ -212,12 +212,12 @@ export const semanticColor = {
                     foreground: color.blue,
                 },
                 hover: {
-                    border: core.border.informative.default,
+                    border: core.border.instructive.default,
                     background: "transparent",
                     foreground: color.blue,
                 },
                 press: {
-                    border: core.border.informative.strong,
+                    border: core.border.instructive.strong,
                     background: "transparent",
                     foreground: color.activeBlue,
                 },
@@ -276,7 +276,7 @@ export const semanticColor = {
             placeholder: text.secondary,
         },
         checked: {
-            border: core.border.informative.default,
+            border: core.border.instructive.default,
             background: color.blue,
             foreground: text.inverse,
         },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -1,5 +1,52 @@
 import {color} from "../../tokens/color";
 
+const transparent = "transparent";
+
+const core = {
+    transparent,
+    border: {
+        informative: {
+            subtle: color.fadedBlue,
+            default: color.blue,
+            strong: color.activeBlue,
+        },
+        neutral: {
+            subtle: color.fadedOffBlack16,
+            default: color.fadedOffBlack50,
+            strong: color.fadedOffBlack72,
+        },
+        critical: {
+            subtle: color.fadedRed24,
+            default: color.red,
+            strong: color.activeRed,
+        },
+        success: {
+            subtle: color.fadedGreen24,
+            default: color.green,
+            strong: color.activeGreen,
+        },
+        warning: {
+            subtle: color.fadedGold24,
+            default: color.gold,
+            strong: color.activeGold,
+        },
+        disabled: {
+            subtle: transparent,
+            default: color.fadedOffBlack16,
+            strong: color.fadedOffBlack32,
+        },
+        inverse: {
+            subtle: color.offBlack16,
+            default: color.offBlack8,
+            strong: color.white,
+        },
+    },
+};
+
+/**
+ * TODO(WB-1941): Remove border once we have migrated to the new core.border
+ * tokens.
+ */
 const border = {
     primary: color.fadedOffBlack16,
     subtle: color.fadedOffBlack8,
@@ -26,6 +73,12 @@ const text = {
 
 export const semanticColor = {
     /**
+     * Our core colors are used for the most common elements in our UI. They
+     * are the most important colors in our system and should be used
+     * consistently across all components.
+     */
+    core,
+    /**
      * For buttons, links, and controls to communicate the presence and meaning
      * of interaction.
      */
@@ -33,34 +86,34 @@ export const semanticColor = {
         primary: {
             progressive: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: color.blue,
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: border.progressive,
+                    border: core.border.informative.default,
                     background: color.blue,
                     foreground: text.inverse,
                 },
                 press: {
-                    border: color.activeBlue,
+                    border: core.border.informative.strong,
                     background: color.activeBlue,
                     foreground: text.inverse,
                 },
             },
             destructive: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: color.red,
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: border.destructive,
+                    border: core.border.critical.default,
                     background: color.red,
                     foreground: text.inverse,
                 },
                 press: {
-                    border: color.activeRed,
+                    border: core.border.critical.strong,
                     background: color.activeRed,
                     foreground: text.inverse,
                 },
@@ -68,24 +121,24 @@ export const semanticColor = {
 
             neutral: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: color.fadedOffBlack72,
                     foreground: text.inverse,
                 },
                 hover: {
-                    border: color.fadedOffBlack72,
+                    border: core.border.neutral.default,
                     background: color.fadedOffBlack72,
                     foreground: text.inverse,
                 },
                 press: {
-                    border: color.offBlack,
+                    border: core.border.neutral.strong,
                     background: color.offBlack,
                     foreground: text.inverse,
                 },
             },
 
             disabled: {
-                border: color.fadedOffBlack32,
+                border: core.border.disabled.strong,
                 background: color.fadedOffBlack32,
                 foreground: color.offWhite,
             },
@@ -94,58 +147,58 @@ export const semanticColor = {
         secondary: {
             progressive: {
                 default: {
-                    border: border.strong,
+                    border: core.border.neutral.default,
                     background: "transparent",
                     foreground: color.blue,
                 },
                 hover: {
-                    border: border.progressive,
+                    border: core.border.informative.default,
                     background: "transparent",
                     foreground: color.blue,
                 },
                 press: {
-                    border: color.activeBlue,
+                    border: core.border.informative.strong,
                     background: color.fadedBlue,
                     foreground: color.activeBlue,
                 },
             },
             destructive: {
                 default: {
-                    border: border.strong,
+                    border: core.border.neutral.default,
                     background: "transparent",
                     foreground: color.red,
                 },
                 hover: {
-                    border: border.destructive,
+                    border: core.border.critical.default,
                     background: "transparent",
                     foreground: color.red,
                 },
                 press: {
-                    border: color.activeRed,
+                    border: core.border.critical.strong,
                     background: color.fadedRed,
                     foreground: color.activeRed,
                 },
             },
             neutral: {
                 default: {
-                    border: border.strong,
+                    border: core.border.neutral.default,
                     background: "transparent",
                     foreground: text.secondary,
                 },
                 hover: {
-                    border: color.fadedOffBlack72,
+                    border: core.border.neutral.strong,
                     background: "transparent",
                     foreground: text.secondary,
                 },
                 press: {
-                    border: color.offBlack,
+                    border: core.border.neutral.strong,
                     background: color.offBlack16,
                     foreground: text.primary,
                 },
             },
 
             disabled: {
-                border: color.fadedOffBlack32,
+                border: core.border.disabled.strong,
                 background: "transparent",
                 foreground: text.disabled,
             },
@@ -154,17 +207,17 @@ export const semanticColor = {
         tertiary: {
             progressive: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: "transparent",
                     foreground: color.blue,
                 },
                 hover: {
-                    border: border.progressive,
+                    border: core.border.informative.default,
                     background: "transparent",
                     foreground: color.blue,
                 },
                 press: {
-                    border: color.activeBlue,
+                    border: core.border.informative.strong,
                     background: "transparent",
                     foreground: color.activeBlue,
                 },
@@ -172,41 +225,41 @@ export const semanticColor = {
 
             destructive: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: "transparent",
                     foreground: color.red,
                 },
                 hover: {
-                    border: border.destructive,
+                    border: core.border.critical.default,
                     background: "transparent",
                     foreground: color.red,
                 },
                 press: {
-                    border: color.activeRed,
+                    border: core.border.critical.strong,
                     background: "transparent",
                     foreground: color.activeRed,
                 },
             },
             neutral: {
                 default: {
-                    border: "transparent",
+                    border: core.transparent,
                     background: "transparent",
                     foreground: text.secondary,
                 },
                 hover: {
-                    border: color.fadedOffBlack72,
+                    border: core.border.neutral.default,
                     background: "transparent",
                     foreground: text.secondary,
                 },
                 press: {
-                    border: color.offBlack,
+                    border: core.border.neutral.strong,
                     background: "transparent",
                     foreground: text.primary,
                 },
             },
 
             disabled: {
-                border: border.primary,
+                border: core.border.disabled.default,
                 background: "transparent",
                 foreground: text.disabled,
             },
@@ -217,24 +270,24 @@ export const semanticColor = {
      */
     input: {
         default: {
-            border: border.strong,
+            border: core.border.neutral.default,
             background: surface.primary,
             foreground: text.primary,
             placeholder: text.secondary,
         },
         checked: {
-            border: border.progressive,
+            border: core.border.informative.default,
             background: color.blue,
             foreground: text.inverse,
         },
         disabled: {
-            border: border.primary,
+            border: core.border.disabled.default,
             background: color.offWhite,
             foreground: text.secondary,
             placeholder: text.secondary,
         },
         error: {
-            border: border.destructive,
+            border: core.border.critical.default,
             background: color.fadedRed8,
             foreground: text.primary,
         },

--- a/packages/wonder-blocks-tokens/src/tokens/color.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/color.ts
@@ -75,10 +75,12 @@ export const color = {
     fadedRed16: fadedColorWithWhite(baseColors.red, 0.16),
     fadedRed8: fadedColorWithWhite(baseColors.red, 0.08),
     // Green shades
+    activeGreen: mix(baseColors.offBlack32, baseColors.green),
     fadedGreen24: fadedColorWithWhite(baseColors.green, 0.24),
     fadedGreen16: fadedColorWithWhite(baseColors.green, 0.16),
     fadedGreen8: fadedColorWithWhite(baseColors.green, 0.08),
     // Gold shades
+    activeGold: mix(baseColors.offBlack32, baseColors.gold),
     fadedGold24: fadedColorWithWhite(baseColors.gold, 0.24),
     fadedGold16: fadedColorWithWhite(baseColors.gold, 0.16),
     fadedGold8: fadedColorWithWhite(baseColors.gold, 0.08),

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -121,7 +121,7 @@ export default function Toolbar({
 const sharedStyles = StyleSheet.create({
     container: {
         background: semanticColor.surface.primary,
-        border: `1px solid ${semanticColor.border.primary}`,
+        border: `1px solid ${semanticColor.core.border.neutral.default}`,
         flex: 1,
         display: "grid",
         alignItems: "center",

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -121,7 +121,7 @@ export default function Toolbar({
 const sharedStyles = StyleSheet.create({
     container: {
         background: semanticColor.surface.primary,
-        border: `1px solid ${semanticColor.core.border.neutral.default}`,
+        border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
         flex: 1,
         display: "grid",
         alignItems: "center",

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
     content: {
         maxWidth: 472,
         borderRadius: border.radius.radius_040,
-        border: `solid 1px ${semanticColor.core.border.neutral.default}`,
+        border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         backgroundColor: semanticColor.surface.primary,
         // TODO(WB-1878): Use `elevation` token.
         boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
     content: {
         maxWidth: 472,
         borderRadius: border.radius.radius_040,
-        border: `solid 1px ${semanticColor.border.primary}`,
+        border: `solid 1px ${semanticColor.core.border.neutral.default}`,
         backgroundColor: semanticColor.surface.primary,
         // TODO(WB-1878): Use `elevation` token.
         boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,


### PR DESCRIPTION
## Summary:

- Adds new `semanticColor.core` category (in both OG and TB)
- Replaces all existing `semanticColor.border` references to use `semanticColor.core.border`


### Implementation plan:

**1. Add `core.border` semantic color tokens (CURRENT)**
2. Add `core.background` semantic color tokens
3. Add `core.foreground` semantic color tokens

Issue: https://khanacademy.atlassian.net/browse/WB-1941

## Test plan:

Verify that the snapshots look as expected and that the changes are reflected in
the documentation.

Make sure that the following mapping applies:

- `semanticColor.border.subtle` => `semanticColor.core.border.neutral.subtle`
- `semanticColor.border.primary` => `semanticColor.core.border.neutral.subtle`
- `semanticColor.border.strong` => `semanticColor.core.border.neutral.default`