### PR TITLE
Bump TypeScript target to ES2021

### DIFF
--- a/.changeset/famous-hotels-fly.md
+++ b/.changeset/famous-hotels-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wb-dev-build-settings": minor
+---
+
+Bump TypeScript 'target' to ES2021 and remove references to 'core-js' (no longer used with swc)

--- a/build-settings/rollup.config.mjs
+++ b/build-settings/rollup.config.mjs
@@ -27,16 +27,17 @@ const createConfig = (pkgName) => {
             },
         ],
         input: `packages/${pkgName}/src/index.ts`,
-        // We're using `builtIns: "usage"` with @babel/preset-env.
-        // This results in individual modules being imported from
-        // core-js directly.  `autoExternal` doesn't know how to
-        // deal with this so we manually externalize these imports.
-        external: [/core-js/],
         plugins: [
             swc({
                 swc: {
                     swcrc: true,
                     minify: true,
+                    // We do _not_ specify "env" here (a la @babel/preset-env)
+                    // because our TypeScrip compiler "target" is set to ES2021
+                    // which is compatible with all of Khan Academy's supported
+                    // browsers _and_ will protect us against using APIs that
+                    // aren't supported in this browser list).
+                    // "env": {...}
                 },
                 exclude: "node_modules/**",
             }),

--- a/build-settings/rollup.config.mjs
+++ b/build-settings/rollup.config.mjs
@@ -33,7 +33,7 @@ const createConfig = (pkgName) => {
                     swcrc: true,
                     minify: true,
                     // We do _not_ specify "env" here (a la @babel/preset-env)
-                    // because our TypeScrip compiler "target" is set to ES2021
+                    // because our TypeScript compiler "target" is set to ES2021
                     // which is compatible with all of Khan Academy's supported
                     // browsers _and_ will protect us against using APIs that
                     // aren't supported in this browser list).

--- a/tsconfig-common.json
+++ b/tsconfig-common.json
@@ -7,7 +7,7 @@
             "./types"
         ],
         /* Language and Environment */
-        "target": "ES2016",
+        "target": "ES2021",
         "jsx": "preserve",
         /* Modules */
         // Required for dynamic imports even though we aren't using


### PR DESCRIPTION
## Summary:

This PR upgrades the TypeScript `target` to ES2021. The current minimum browser list at Khan Academy is: 
  * Chrome v128
  * Safari v15.6
  * Latest Edge
  * Latest Firefox 

All of these browsers fully support ES2021 (verified by looking through the linked features of https://caniuse.com/?search=ES2021). By bumping to ES2021 we give ourselves access to all ES2021 features without risking shipping code that is incompatible with our supported browser list.

This also cleans up the 'external' flag in our Rollup build (it referenced `@babel/preset-env which we no longer use and `core-js` is no longer a dependency of the project, further we don't use core-js because we don't need any polyfills for ES2021 support).

Related: https://github.com/Khan/perseus/pull/2511

Issue: "none"

## Test plan:

I ran `pnpm build; pnpm build:types` on `main` and on this branch and compared the `dist/` folder for each package. They were identical (ie. nothing was using `core-js` on `main` today and nothing changed). 

I ran `pnpm tsc` - no issues.