### PR TITLE
Add GemBadge and GemIcon components

### DIFF
--- a/.changeset/khaki-actors-bow.md
+++ b/.changeset/khaki-actors-bow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-badge": minor
+---
+
+Adds `GemBadge` component

--- a/.changeset/serious-jeans-thank.md
+++ b/.changeset/serious-jeans-thank.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon": minor
+---
+
+Adds `GemIcon` custom icon component

--- a/.changeset/silly-cooks-smash.md
+++ b/.changeset/silly-cooks-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-badge": minor
+---
+
+Adds GemBadge component

--- a/.changeset/silly-cooks-smash.md
+++ b/.changeset/silly-cooks-smash.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/wonder-blocks-badge": minor
----
-
-Adds GemBadge component

--- a/__docs__/wonder-blocks-badge/_overview_.mdx
+++ b/__docs__/wonder-blocks-badge/_overview_.mdx
@@ -17,9 +17,13 @@ about each type of badge, refer to the docs for that component!
 
 ## StatusBadge
 
+A badge that represents a status.
+
 <Canvas of={StatusBadgeStories.Kinds} />
 
 ## GemBadge
+
+ A badge that represents gems.
 
 <Canvas of={GemBadgeStories.Default} />
 

--- a/__docs__/wonder-blocks-badge/_overview_.mdx
+++ b/__docs__/wonder-blocks-badge/_overview_.mdx
@@ -1,6 +1,7 @@
 import {Meta, Canvas} from "@storybook/blocks";
 import * as StatusBadgeStories from "./status-badge.stories";
 import * as BadgeStories from "./badge.stories";
+import * as GemBadgeStories from "./gem-badge.stories";
 
 <Meta
     title="Packages / Badge / Overview"
@@ -17,6 +18,10 @@ about each type of badge, refer to the docs for that component!
 ## StatusBadge
 
 <Canvas of={StatusBadgeStories.Kinds} />
+
+## GemBadge
+
+<Canvas of={GemBadgeStories.Default} />
 
 ## Custom Badges
 

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
-import {Badge, StatusBadge} from "@khanacademy/wonder-blocks-badge";
+import {Badge, GemBadge, StatusBadge} from "@khanacademy/wonder-blocks-badge";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {commonStates, StateSheet} from "../components/state-sheet";
@@ -78,6 +78,28 @@ export const StateSheetStory: StoryComponentType = {
             })),
         ];
 
+        const columnsWithShowIconProp = [
+            {
+                name: "Label only",
+                props: {
+                    label: "Badge",
+                },
+            },
+            {
+                name: "Label with icon",
+                props: {
+                    label: "Badge",
+                    showIcon: true,
+                },
+            },
+            {
+                name: "Icon only",
+                props: {
+                    showIcon: true,
+                },
+            },
+        ];
+
         return (
             <View style={{gap: sizing.size_080}}>
                 <HeadingLarge>Badge</HeadingLarge>
@@ -95,6 +117,14 @@ export const StateSheetStory: StoryComponentType = {
                     states={[commonStates.rest]}
                 >
                     {({props}) => <StatusBadge {...props} />}
+                </StateSheet>
+                <HeadingLarge>Gem Badge</HeadingLarge>
+                <StateSheet
+                    rows={rows}
+                    columns={columnsWithShowIconProp}
+                    states={[commonStates.rest]}
+                >
+                    {({props}) => <GemBadge {...props} />}
                 </StateSheet>
             </View>
         );

--- a/__docs__/wonder-blocks-badge/badge.argtypes.ts
+++ b/__docs__/wonder-blocks-badge/badge.argtypes.ts
@@ -23,6 +23,10 @@ export const showIconArgType = {
     showIcon: {
         description: "Whether to show the icon. Defaults to `false`.",
     },
+    iconAriaLabel: {
+        description:
+            "The aria label for the icon. Required if `showIcon` is `true` and there is no `label`.",
+    },
 };
 
 export default {

--- a/__docs__/wonder-blocks-badge/badge.argtypes.ts
+++ b/__docs__/wonder-blocks-badge/badge.argtypes.ts
@@ -1,6 +1,6 @@
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
-export default {
+export const iconArgType = {
     icon: {
         control: {type: "select"},
         options: Object.keys(IconMappings),
@@ -17,6 +17,16 @@ export default {
         description:
             "The icon to display in the badge. This can be a `PhosphorIcon` or a custom icon using the `Icon` component",
     },
+};
+
+export const showIconArgType = {
+    showIcon: {
+        description: "Whether to show the icon.",
+    },
+};
+
+export default {
+    ...iconArgType,
     label: {
         // Explicitly adding label prop description since description is not
         // auto-generated due to the union type
@@ -24,5 +34,11 @@ export default {
     },
     tag: {
         control: {type: "text"},
+        description: "The HTML tag to render. Defaults to `div`.",
+        table: {
+            type: {
+                summary: "keyof JSX.IntrinsicElements",
+            },
+        },
     },
 };

--- a/__docs__/wonder-blocks-badge/badge.argtypes.ts
+++ b/__docs__/wonder-blocks-badge/badge.argtypes.ts
@@ -21,7 +21,7 @@ export const iconArgType = {
 
 export const showIconArgType = {
     showIcon: {
-        description: "Whether to show the icon.",
+        description: "Whether to show the icon. Defaults to `false`.",
     },
 };
 

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -8,13 +8,13 @@ import singleColoredIcon from "../components/single-colored-icon.svg";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
-import badgeArgtypes from "./badge.argtypes";
+import badgeArgtypes, {iconArgType} from "./badge.argtypes";
 import {multiColoredIcon} from "../components/icons-for-testing";
 
 export default {
     title: "Packages / Badge / Badge",
     component: Badge,
-    argTypes: badgeArgtypes,
+    argTypes: {...badgeArgtypes, ...iconArgType},
     parameters: {
         componentSubtitle: (
             <ComponentInfo

--- a/__docs__/wonder-blocks-badge/gem-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/gem-badge.stories.tsx
@@ -32,9 +32,7 @@ export const Default: StoryComponentType = {
     args: {
         label: "Badge",
         showIcon: true,
-        labels: {
-            iconAriaLabel: "Gems",
-        },
+        iconAriaLabel: "Gems",
     },
 };
 
@@ -55,8 +53,6 @@ export const NoIcon: StoryComponentType = {
 export const IconOnly: StoryComponentType = {
     args: {
         showIcon: true,
-        labels: {
-            iconAriaLabel: "Gems",
-        },
+        iconAriaLabel: "Gems",
     },
 };

--- a/__docs__/wonder-blocks-badge/gem-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/gem-badge.stories.tsx
@@ -48,7 +48,7 @@ export const NoIcon: StoryComponentType = {
 
 /**
  * Set `showIcon` to `true` to show the gem icon. Alt text for the gem icon can
- * be set using the `labels` prop.
+ * be set using the `iconAriaLabel` prop.
  */
 export const IconOnly: StoryComponentType = {
     args: {

--- a/__docs__/wonder-blocks-badge/gem-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/gem-badge.stories.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import {StoryObj} from "@storybook/react";
+import {GemBadge} from "@khanacademy/wonder-blocks-badge";
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-badge/package.json";
+import badgeArgTypes, {showIconArgType} from "./badge.argtypes";
+
+export default {
+    title: "Packages / Badge / GemBadge",
+    component: GemBadge,
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+        chromatic: {
+            // Disable snapshots since they're covered by the testing snapshots
+            disableSnapshot: true,
+        },
+    },
+    argTypes: {
+        ...badgeArgTypes,
+        ...showIconArgType,
+    },
+};
+
+type StoryComponentType = StoryObj<typeof GemBadge>;
+
+export const Default: StoryComponentType = {
+    args: {
+        label: "Badge",
+        showIcon: true,
+        labels: {
+            iconAriaLabel: "Gems",
+        },
+    },
+};
+
+/**
+ * Set `showIcon` to `false` to hide the gem icon.
+ */
+export const NoIcon: StoryComponentType = {
+    args: {
+        label: "Badge",
+        showIcon: false,
+    },
+};
+
+/**
+ * Set `showIcon` to `true` to show the gem icon. Alt text for the gem icon can
+ * be set using the `labels` prop.
+ */
+export const IconOnly: StoryComponentType = {
+    args: {
+        showIcon: true,
+        labels: {
+            iconAriaLabel: "Gems",
+        },
+    },
+};

--- a/__docs__/wonder-blocks-badge/status-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/status-badge.stories.tsx
@@ -9,13 +9,23 @@ import singleColoredIcon from "../components/single-colored-icon.svg";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
-import badgeArgtypes from "./badge.argtypes";
+import badgeArgtypes, {iconArgType} from "./badge.argtypes";
 import {multiColoredIcon} from "../components/icons-for-testing";
 
 export default {
     title: "Packages / Badge / StatusBadge",
     component: StatusBadge,
-    argTypes: badgeArgtypes,
+    argTypes: {
+        ...badgeArgtypes,
+        ...iconArgType,
+        kind: {
+            table: {
+                type: {
+                    summary: "info | success | warning | critical",
+                },
+            },
+        },
+    },
     parameters: {
         componentSubtitle: (
             <ComponentInfo

--- a/__docs__/wonder-blocks-icon/custom-icon-components.stories.tsx
+++ b/__docs__/wonder-blocks-icon/custom-icon-components.stories.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react";
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-icon/package.json";
+import {GemIcon} from "@khanacademy/wonder-blocks-icon";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+
+/**
+ * Custom icon components that render an inline svg. Use with the `Icon`
+ * component to display the icon.
+ */
+export default {
+    title: "Packages / Icon / Custom Icon Components",
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+        chromatic: {
+            disableSnapshot: true,
+        },
+    },
+    component: GemIcon,
+    argTypes: {
+        style: {
+            table: {
+                type: {
+                    summary: "StyleType",
+                },
+            },
+        },
+    },
+    decorators: [
+        (Story) => (
+            // Set a fixed size for the custom icons since they expand to the
+            // size of its parent container.
+            <View style={{width: sizing.size_400, height: sizing.size_400}}>
+                <Story />
+            </View>
+        ),
+    ],
+} as Meta<typeof GemIcon>;
+
+type StoryComponentType = StoryObj<typeof GemIcon>;
+
+export const AllCustomIcons: StoryComponentType = {
+    render: (args) => (
+        <View style={{gap: sizing.size_160}}>
+            <GemIcon {...args} />
+            {/* Add other custom icons here */}
+        </View>
+    ),
+    parameters: {
+        chromatic: {
+            // Include snapshots for all the custom icons
+            disableSnapshot: false,
+        },
+    },
+};
+
+/**
+ * Custom icons can be styled using the `style` prop.
+ */
+export const CustomIconsWithCustomStyle: StoryComponentType = {
+    ...AllCustomIcons,
+    args: {
+        style: {
+            backgroundColor: semanticColor.surface.secondary,
+            padding: sizing.size_040,
+            borderRadius: border.radius.radius_040,
+            border: `${border.width.thin} solid ${semanticColor.border.subtle}`,
+        },
+    },
+};
+
+/**
+ * Use the `GemIcon` component to represent gems.
+ */
+export const Gem: StoryComponentType = {
+    name: "GemIcon",
+    render: (args) => <GemIcon {...args} />,
+    args: {
+        "aria-label": "Gem",
+    },
+};

--- a/__docs__/wonder-blocks-icon/icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/icon.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {StyleSheet} from "aphrodite";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-icon/package.json";
-import {Icon} from "@khanacademy/wonder-blocks-icon";
+import {GemIcon, Icon} from "@khanacademy/wonder-blocks-icon";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
@@ -96,6 +96,10 @@ export const CompatibleElements: StoryComponentType = {
                 <Icon {...args}>{singleColoredIcon}</Icon>
                 <LabelSmall>Inline multi-colored svg</LabelSmall>
                 <Icon {...args}>{multiColoredIcon}</Icon>
+                <LabelSmall>Custom Icon Component: GemIcon</LabelSmall>
+                <Icon {...args}>
+                    <GemIcon aria-label="Gem" />
+                </Icon>
             </View>
         );
     },

--- a/packages/wonder-blocks-badge/package.json
+++ b/packages/wonder-blocks-badge/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@khanacademy/wonder-blocks-core": "workspace:*",
+    "@khanacademy/wonder-blocks-icon": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },

--- a/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
@@ -1,81 +1,82 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import {StatusBadge} from "../status-badge";
+import {GemBadge} from "../gem-badge";
 
 /**
  * Tests for props that are common to the different badge types.
  */
 describe("Badge types", () => {
-    describe.each([{name: "StatusBadge", Component: StatusBadge}])(
-        "$name",
-        ({Component}) => {
-            it("should forward the ref to the root element", () => {
+    describe.each([
+        {name: "StatusBadge", Component: StatusBadge},
+        {name: "GemBadge", Component: GemBadge},
+    ])("$name", ({Component}) => {
+        it("should forward the ref to the root element", () => {
+            // Arrange
+            const ref = React.createRef<HTMLDivElement>();
+            render(<Component ref={ref} label="Badge label" />);
+
+            // Act
+            const badge = screen.getByText("Badge label");
+
+            // Assert
+            expect(ref.current).toBe(badge);
+        });
+
+        it("should use the tag prop if provided", () => {
+            // Arrange
+            render(<Component tag={"strong"} label="Badge label" />);
+
+            // Act
+            const badge = screen.getByText("Badge label");
+
+            // Assert
+            expect(badge).toHaveProperty("tagName", "STRONG");
+        });
+
+        describe("Attributes", () => {
+            it("should set the id attribute", () => {
                 // Arrange
-                const ref = React.createRef<HTMLDivElement>();
-                render(<Component ref={ref} label="Badge label" />);
+                const id = "badge-id";
+                render(<Component id={id} label="Badge label" />);
 
                 // Act
                 const badge = screen.getByText("Badge label");
 
                 // Assert
-                expect(ref.current).toBe(badge);
+                expect(badge).toHaveAttribute("id", id);
             });
 
-            it("should use the tag prop if provided", () => {
+            it("should set the data-testid attribute", () => {
                 // Arrange
-                render(<Component tag={"strong"} label="Badge label" />);
+                const testId = "badge-testid";
+                render(<Component testId={testId} label="Badge label" />);
 
                 // Act
-                const badge = screen.getByText("Badge label");
+                const badge = screen.getByTestId(testId);
 
                 // Assert
-                expect(badge).toHaveProperty("tagName", "STRONG");
+                expect(badge).toHaveAttribute("data-testid", testId);
             });
+        });
 
-            describe("Attributes", () => {
-                it("should set the id attribute", () => {
+        describe("Accessibility", () => {
+            describe("ARIA", () => {
+                it("should use ARIA props", () => {
                     // Arrange
-                    const id = "badge-id";
-                    render(<Component id={id} label="Badge label" />);
-
-                    // Act
-                    const badge = screen.getByText("Badge label");
+                    const ariaLabel = "Example aria label";
+                    render(
+                        <Component
+                            aria-label={ariaLabel}
+                            label="Badge label"
+                        />,
+                    );
 
                     // Assert
-                    expect(badge).toHaveAttribute("id", id);
-                });
-
-                it("should set the data-testid attribute", () => {
-                    // Arrange
-                    const testId = "badge-testid";
-                    render(<Component testId={testId} label="Badge label" />);
-
-                    // Act
-                    const badge = screen.getByTestId(testId);
-
-                    // Assert
-                    expect(badge).toHaveAttribute("data-testid", testId);
+                    const badge = screen.getByLabelText(ariaLabel);
+                    expect(badge).toBeInTheDocument();
                 });
             });
-
-            describe("Accessibility", () => {
-                describe("ARIA", () => {
-                    it("should use ARIA props", () => {
-                        // Arrange
-                        const ariaLabel = "Example aria label";
-                        render(
-                            <Component
-                                aria-label={ariaLabel}
-                                label="Badge label"
-                            />,
-                        );
-
-                        // Assert
-                        const badge = screen.getByLabelText(ariaLabel);
-                        expect(badge).toBeInTheDocument();
-                    });
-                });
-            });
-        },
-    );
+        });
+    });
 });

--- a/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import {GemBadge} from "../gem-badge";
+
+describe("GemBadge", () => {
+    it("should render the label", () => {
+        // Arrange
+        const label = "Badge label";
+        render(<GemBadge label={label} />);
+
+        // Act
+        const badge = screen.getByText(label);
+
+        // Assert
+        expect(badge).toBeInTheDocument();
+    });
+
+    it("should render the icon with alt text", () => {
+        // Arrange
+        render(<GemBadge showIcon={true} labels={{iconAriaLabel: "Gems"}} />);
+
+        // Act
+        const iconElement = screen.getByRole("img", {
+            name: "Gems",
+        });
+
+        // Assert
+        expect(iconElement).toBeInTheDocument();
+    });
+
+    it("should not have an img role if showIcon is true and no alt text is provided", () => {
+        // Arrange
+        render(<GemBadge showIcon={true} />);
+
+        // Act
+        const iconElement = screen.queryByRole("img");
+
+        // Assert
+        expect(iconElement).not.toBeInTheDocument();
+    });
+
+    it("should not render anything if there is an empty label and showIcon is false", () => {
+        // Arrange
+        // Act
+        const {container} = render(<GemBadge label="" showIcon={false} />);
+
+        // Assert
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    describe("Accessibility", () => {
+        describe("axe", () => {
+            it("should not have violations", async () => {
+                // Arrange
+                // Act
+                const {container} = render(
+                    <GemBadge
+                        label="Badge label"
+                        showIcon={true}
+                        labels={{iconAriaLabel: "Gems"}}
+                    />,
+                );
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+        });
+    });
+});

--- a/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
@@ -30,7 +30,7 @@ describe("GemBadge", () => {
 
     it("should not have an img role if showIcon is true and no alt text is provided", () => {
         // Arrange
-        render(<GemBadge showIcon={true} />);
+        render(<GemBadge showIcon={true} label="Badge" />);
 
         // Act
         const iconElement = screen.queryByRole("img");
@@ -88,11 +88,11 @@ describe("GemBadge", () => {
             await expect(container).toHaveNoA11yViolations();
         });
 
-        it("should not have violations if there is no label", async () => {
+        it("should not have violations if there is no icon", async () => {
             // Arrange
             // Act
             const {container} = render(
-                <GemBadge showIcon={false} iconAriaLabel="Gem" />,
+                <GemBadge showIcon={false} label="Badge" />,
             );
 
             // Assert

--- a/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
@@ -12,7 +12,7 @@ describe("GemBadge", () => {
         const badge = screen.getByText(label);
 
         // Assert
-        expect(badge).toBeInTheDocument();
+        expect(badge).toBeVisible();
     });
 
     it("should render the icon with alt text", () => {

--- a/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
@@ -48,6 +48,17 @@ describe("GemBadge", () => {
         expect(container).toBeEmptyDOMElement();
     });
 
+    it("should not render the icon if showIcon is not set", () => {
+        // Arrange
+        render(<GemBadge label="Badge" />);
+
+        // Act
+        const iconElement = screen.queryByRole("img");
+
+        // Assert
+        expect(iconElement).not.toBeInTheDocument();
+    });
+
     describe("Accessibility", () => {
         describe("axe", () => {
             it("should not have violations", async () => {
@@ -64,6 +75,28 @@ describe("GemBadge", () => {
                 // Assert
                 await expect(container).toHaveNoA11yViolations();
             });
+        });
+
+        it("should not have violations if there is no label", async () => {
+            // Arrange
+            // Act
+            const {container} = render(
+                <GemBadge showIcon={true} iconAriaLabel="Gem" />,
+            );
+
+            // Assert
+            await expect(container).toHaveNoA11yViolations();
+        });
+
+        it("should not have violations if there is no label", async () => {
+            // Arrange
+            // Act
+            const {container} = render(
+                <GemBadge showIcon={false} iconAriaLabel="Gem" />,
+            );
+
+            // Assert
+            await expect(container).toHaveNoA11yViolations();
         });
     });
 });

--- a/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/gem-badge.test.tsx
@@ -17,7 +17,7 @@ describe("GemBadge", () => {
 
     it("should render the icon with alt text", () => {
         // Arrange
-        render(<GemBadge showIcon={true} labels={{iconAriaLabel: "Gems"}} />);
+        render(<GemBadge showIcon={true} iconAriaLabel="Gems" />);
 
         // Act
         const iconElement = screen.getByRole("img", {
@@ -57,7 +57,7 @@ describe("GemBadge", () => {
                     <GemBadge
                         label="Badge label"
                         showIcon={true}
-                        labels={{iconAriaLabel: "Gems"}}
+                        iconAriaLabel="Gems"
                     />,
                 );
 

--- a/packages/wonder-blocks-badge/src/components/badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/badge.tsx
@@ -1,59 +1,11 @@
-import {addStyle, AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
+import {BaseBadgeProps, IconLabelProps} from "../types";
 
-type IconOnly = {
-    icon: React.ReactElement;
-    label?: never;
-};
-
-type LabelOnly = {
-    icon?: never;
-    label: string;
-};
-
-type IconAndLabel = {
-    icon: React.ReactElement;
-    label: string;
-};
-
-/**
- * The props for the icon and label in the badge.
- * - Icon: The icon to display in the badge. It can be a PhosphorIcon, a custom svg,
- *   or `img` element. Considerations:
- *   - If the icon conveys meaning, set the alt text on the icon being used
- *   - If the icon is an `img` element, it may need width: 100% and height: 100%
- *     to render properly in the badge.
- * - Label: The label to display in the badge.
- */
-type IconLabelProps = IconOnly | LabelOnly | IconAndLabel;
-
-export type BadgeProps = AriaProps &
-    IconLabelProps & {
-        /**
-         * The id for the badge.
-         */
-        id?: string;
-        /**
-         * The test id for the badge.
-         */
-        testId?: string;
-        /**
-         * Custom styles for the elements in the Badge component.
-         * - `root`: Styles the root element
-         * - `icon`: Styles the icon element
-         */
-        styles?: {
-            root?: StyleType;
-            icon?: StyleType;
-        };
-        /**
-         * The HTML tag to render. Defaults to `div`.
-         */
-        tag?: keyof JSX.IntrinsicElements;
-    };
+type Props = IconLabelProps & BaseBadgeProps;
 
 const StyledSpan = addStyle("span");
 
@@ -61,8 +13,8 @@ const StyledSpan = addStyle("span");
  * Badges are visual indicators used to display concise information, such as
  * a status, label, or count.
  */
-const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(function Badge(
-    props: BadgeProps,
+const Badge = React.forwardRef<HTMLDivElement, Props>(function Badge(
+    props: Props,
     ref: React.ForwardedRef<HTMLDivElement>,
 ) {
     const {

--- a/packages/wonder-blocks-badge/src/components/gem-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/gem-badge.tsx
@@ -4,13 +4,7 @@ import {GemIcon, Icon} from "@khanacademy/wonder-blocks-icon";
 import {Badge} from "./badge";
 import {BaseBadgeProps, ShowIconProps} from "../types";
 
-type Props = {
-    /**
-     * The alt text for the gem icon.
-     */
-    iconAriaLabel?: string;
-} & BaseBadgeProps &
-    ShowIconProps;
+type Props = BaseBadgeProps & ShowIconProps;
 
 /**
  * A badge that represents gem rewards.

--- a/packages/wonder-blocks-badge/src/components/gem-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/gem-badge.tsx
@@ -6,12 +6,9 @@ import {BaseBadgeProps, ShowIconProps} from "../types";
 
 type Props = {
     /**
-     * The labels for the badge.
+     * The alt text for the gem icon.
      */
-    labels?: {
-        /** The alt text for the gem icon. */
-        iconAriaLabel?: string;
-    };
+    iconAriaLabel?: string;
 } & BaseBadgeProps &
     ShowIconProps;
 
@@ -19,7 +16,7 @@ type Props = {
  * A badge that represents gems.
  */
 const GemBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
-    const {label, showIcon, labels, ...otherProps} = props;
+    const {label, showIcon, iconAriaLabel, ...otherProps} = props;
     return (
         <Badge
             {...otherProps}
@@ -27,7 +24,7 @@ const GemBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
             icon={
                 showIcon ? (
                     <Icon>
-                        <GemIcon aria-label={labels?.iconAriaLabel || ""} />
+                        <GemIcon aria-label={iconAriaLabel} />
                     </Icon>
                 ) : undefined
             }

--- a/packages/wonder-blocks-badge/src/components/gem-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/gem-badge.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import {GemIcon, Icon} from "@khanacademy/wonder-blocks-icon";
+import {Badge} from "./badge";
+import {BaseBadgeProps, ShowIconProps} from "../types";
+
+type Props = {
+    /**
+     * The labels for the badge.
+     */
+    labels?: {
+        /** The alt text for the gem icon. */
+        iconAriaLabel?: string;
+    };
+} & BaseBadgeProps &
+    ShowIconProps;
+
+/**
+ * A badge that represents gems.
+ */
+const GemBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
+    const {label, showIcon, labels, ...otherProps} = props;
+    return (
+        <Badge
+            {...otherProps}
+            label={label || ""}
+            icon={
+                showIcon ? (
+                    <Icon>
+                        <GemIcon aria-label={labels?.iconAriaLabel || ""} />
+                    </Icon>
+                ) : undefined
+            }
+            ref={ref}
+            styles={{
+                ...otherProps.styles,
+                root: [styles.gemBadge, otherProps.styles?.root],
+            }}
+        />
+    );
+});
+
+export {GemBadge};
+
+const styles = StyleSheet.create({
+    gemBadge: {
+        // TODO(WB-1947): Replace with tokens
+        backgroundColor: "#FFE3F4",
+        border: "#FFE3F4",
+        color: "#84275E",
+    },
+});

--- a/packages/wonder-blocks-badge/src/components/gem-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/gem-badge.tsx
@@ -19,7 +19,7 @@ type Props = {
  * and icon. For more details, see the `Badge` docs.
  */
 const GemBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
-    const {label, showIcon, iconAriaLabel, ...otherProps} = props;
+    const {label, showIcon = false, iconAriaLabel, ...otherProps} = props;
     return (
         <Badge
             {...otherProps}

--- a/packages/wonder-blocks-badge/src/components/gem-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/gem-badge.tsx
@@ -13,7 +13,10 @@ type Props = {
     ShowIconProps;
 
 /**
- * A badge that represents gems.
+ * A badge that represents gem rewards.
+ *
+ * `GemBadge` uses the `Badge` component and applies the appropriate styles
+ * and icon. For more details, see the `Badge` docs.
  */
 const GemBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
     const {label, showIcon, iconAriaLabel, ...otherProps} = props;

--- a/packages/wonder-blocks-badge/src/components/status-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/status-badge.tsx
@@ -1,14 +1,16 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
-import {Badge, BadgeProps} from "./badge";
+import {Badge} from "./badge";
+import {BaseBadgeProps, IconLabelProps} from "../types";
 
 type Props = {
     /**
      * The kind of badge to display. Defaults to `info`.
      */
     kind?: "info" | "success" | "warning" | "critical";
-} & BadgeProps;
+} & BaseBadgeProps &
+    IconLabelProps;
 
 /**
  * A badge that represents a status.

--- a/packages/wonder-blocks-badge/src/index.ts
+++ b/packages/wonder-blocks-badge/src/index.ts
@@ -1,2 +1,3 @@
 export {Badge} from "./components/badge";
 export {StatusBadge} from "./components/status-badge";
+export {GemBadge} from "./components/gem-badge";

--- a/packages/wonder-blocks-badge/src/types.ts
+++ b/packages/wonder-blocks-badge/src/types.ts
@@ -46,7 +46,7 @@ type ShowIconLabelOnly = {
 
 type ShowIconAndLabel = {
     /**
-     * Whether to show the icon.
+     * Whether to show the icon. Defaults to `false`.
      */
     showIcon: boolean;
     /**

--- a/packages/wonder-blocks-badge/src/types.ts
+++ b/packages/wonder-blocks-badge/src/types.ts
@@ -1,0 +1,82 @@
+import {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
+
+type IconOnly = {
+    icon: React.ReactElement;
+    label?: never;
+};
+
+type LabelOnly = {
+    icon?: never;
+    label: string;
+};
+
+type IconAndLabel = {
+    /**
+     * The icon to display in the badge. It should be a `PhosphorIcon` or `Icon`
+     * component.
+     */
+    icon: React.ReactElement;
+    /**
+     * The label to display in the badge.
+     */
+    label: string;
+};
+
+/**
+ * The props for the icon and label in the badge.
+ * - Icon: The icon to display in the badge. It can be a PhosphorIcon, a custom svg,
+ *   or `img` element. Considerations:
+ *   - If the icon conveys meaning, set the alt text on the icon being used
+ *   - If the icon is an `img` element, it may need width: 100% and height: 100%
+ *     to render properly in the badge.
+ * - Label: The label to display in the badge.
+ */
+export type IconLabelProps = IconOnly | LabelOnly | IconAndLabel;
+
+type ShowIconOnly = {
+    showIcon: boolean;
+    label?: string;
+};
+
+type ShowIconLabelOnly = {
+    showIcon?: never;
+    label: string;
+};
+
+type ShowIconAndLabel = {
+    /**
+     * Whether to show the icon.
+     */
+    showIcon: boolean;
+    /**
+     * The label to display in the badge.
+     */
+    label: string;
+};
+
+export type ShowIconProps = ShowIconOnly | ShowIconLabelOnly | ShowIconAndLabel;
+
+export type BaseBadgeProps = AriaProps & {
+    /**
+     * The id for the badge.
+     */
+    id?: string;
+    /**
+     * The test id for the badge.
+     */
+    testId?: string;
+    /**
+     * Custom styles for the elements in the Badge component.
+     * - `root`: Styles the root element
+     * - `icon`: Styles the icon element
+     */
+    styles?: {
+        root?: StyleType;
+        icon?: StyleType;
+    };
+    /**
+     * The HTML tag to render. Defaults to `div`.
+     */
+    tag?: keyof JSX.IntrinsicElements;
+};

--- a/packages/wonder-blocks-badge/src/types.ts
+++ b/packages/wonder-blocks-badge/src/types.ts
@@ -35,13 +35,15 @@ type IconAndLabel = {
 export type IconLabelProps = IconOnly | LabelOnly | IconAndLabel;
 
 type ShowIconOnly = {
-    showIcon: boolean;
-    label?: string;
+    showIcon: true;
+    label?: never;
+    iconAriaLabel: string;
 };
 
 type ShowIconLabelOnly = {
     showIcon?: never;
     label: string;
+    iconAriaLabel?: never;
 };
 
 type ShowIconAndLabel = {
@@ -53,6 +55,10 @@ type ShowIconAndLabel = {
      * The label to display in the badge.
      */
     label: string;
+    /**
+     * Aria label for the icon.
+     */
+    iconAriaLabel?: string;
 };
 
 export type ShowIconProps = ShowIconOnly | ShowIconLabelOnly | ShowIconAndLabel;

--- a/packages/wonder-blocks-badge/tsconfig-build.json
+++ b/packages/wonder-blocks-badge/tsconfig-build.json
@@ -10,5 +10,6 @@
       {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
       {"path": "../wonder-blocks-typography/tsconfig-build.json"},
       {"path": "../wonder-blocks-styles/tsconfig-build.json"},
+      {"path": "../wonder-blocks-icon/tsconfig-build.json"},
   ]
 }

--- a/packages/wonder-blocks-icon/src/components/__tests__/custom-icon-components.test.tsx
+++ b/packages/wonder-blocks-icon/src/components/__tests__/custom-icon-components.test.tsx
@@ -1,0 +1,150 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+import {GemIcon} from "../custom-icon-components/gem-icon";
+
+describe("Custom Icon Components", () => {
+    describe.each([{name: "GemIcon", Component: GemIcon}])(
+        "${name}",
+        ({Component}) => {
+            it("should render an img role with an aria-label when provided", () => {
+                // Arrange
+                const ariaLabel = "Icon example";
+                render(<Component aria-label={ariaLabel} />);
+
+                // Act
+                const icon = screen.getByRole("img", {name: ariaLabel});
+
+                // Assert
+                expect(icon).toHaveAttribute("aria-label", ariaLabel);
+            });
+
+            it("should render an img role with an aria-labelledby when provided", () => {
+                // Arrange
+                const label = "Icon example";
+                const labelId = "id-of-label";
+                render(
+                    <div>
+                        <Component aria-labelledby={labelId} />
+                        <span id={labelId}>{label}</span>
+                    </div>,
+                );
+
+                // Act
+                const icon = screen.getByRole("img", {name: label});
+
+                // Assert
+                expect(icon).toHaveAttribute("aria-labelledby", labelId);
+            });
+
+            it("should render with aria-hidden when no aria-label or aria-labelledby is provided", () => {
+                // Arrange
+                const testId = "test-id-of-icon";
+                render(<Component testId={testId} />);
+
+                // Act
+                const icon = screen.getByTestId(testId);
+
+                // Assert
+                expect(icon).toHaveAttribute("aria-hidden", "true");
+            });
+
+            describe("Attributes", () => {
+                it("should use the id prop", () => {
+                    // Arrange
+                    const id = "id-of-icon";
+                    const testId = "test-id-of-icon";
+                    render(<Component id={id} testId={testId} />);
+
+                    // Act
+                    const icon = screen.getByTestId(testId);
+
+                    // Assert
+                    expect(icon).toHaveAttribute("id", id);
+                });
+
+                it("should use the testId prop", () => {
+                    // Arrange
+                    const testId = "test-id-of-icon";
+                    render(<Component testId={testId} />);
+
+                    // Act
+                    const icon = screen.getByTestId(testId);
+
+                    // Assert
+                    expect(icon).toHaveAttribute("data-testid", testId);
+                });
+            });
+
+            describe("Accessibility", () => {
+                describe("axe", () => {
+                    it("should not have violations when aria-label is provided", async () => {
+                        // Arrange
+                        const ariaLabel = "Icon example";
+
+                        // Act
+                        const {container} = render(
+                            <Component aria-label={ariaLabel} />,
+                        );
+
+                        // Assert
+                        await expect(container).toHaveNoA11yViolations();
+                    });
+
+                    it("should not have violations when aria-labelledby is provided", async () => {
+                        // Arrange
+                        const label = "Icon example";
+                        const labelId = "id-of-label";
+
+                        // Act
+                        const {container} = render(
+                            <div>
+                                <Component aria-labelledby={labelId} />
+                                <span id={labelId}>{label}</span>
+                            </div>,
+                        );
+
+                        // Assert
+                        await expect(container).toHaveNoA11yViolations();
+                    });
+
+                    it("should not have violations when aria-label and aria-labelledby are not provided", async () => {
+                        // Arrange
+                        // Act
+                        const {container} = render(<Component />);
+
+                        // Assert
+                        await expect(container).toHaveNoA11yViolations();
+                    });
+                });
+
+                describe("ARIA", () => {
+                    it("should accept aria props", () => {
+                        // Arrange
+                        const descriptionId = "description-id";
+                        const testId = "test-id-of-icon";
+                        render(
+                            <span>
+                                <Component
+                                    aria-describedby={descriptionId}
+                                    testId={testId}
+                                />
+                                <span id={descriptionId}>
+                                    Description of icon
+                                </span>
+                            </span>,
+                        );
+
+                        // Act
+                        const icon = screen.getByTestId(testId);
+
+                        // Assert
+                        expect(icon).toHaveAttribute(
+                            "aria-describedby",
+                            descriptionId,
+                        );
+                    });
+                });
+            });
+        },
+    );
+});

--- a/packages/wonder-blocks-icon/src/components/custom-icon-components/gem-icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/custom-icon-components/gem-icon.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
+import {CustomIconProps} from "../../types";
+import {useSvgAttributes} from "../../hooks/use-svg-attributes";
+
+const StyledSvg = addStyle("svg");
+/**
+ * A custom icon component that renders a gem icon using an inline svg. Use
+ * with the `Icon` component to display the icon.
+ */
+const GemIcon = React.forwardRef<SVGSVGElement, CustomIconProps>(
+    (props, ref) => {
+        const {
+            "aria-label": ariaLabel,
+            "aria-labelledby": ariaLabelledBy,
+            id,
+            testId,
+            style,
+            ...otherProps
+        } = props;
+
+        const attributes = useSvgAttributes({
+            "aria-label": ariaLabel,
+            "aria-labelledby": ariaLabelledBy,
+        });
+
+        return (
+            <StyledSvg
+                id={id}
+                data-testid={testId}
+                style={style}
+                ref={ref}
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                {...attributes}
+                {...otherProps}
+            >
+                {/* TODO(WB-1947): Use semantic color tokens for fill and update component docs */}
+                <path
+                    d="M1.246 5.38105L2.36444 3.66654C2.63609 3.25012 3.0934 3 3.58311 3H12.4169C12.9066 3 13.3639 3.25012 13.6356 3.66654L14.754 5.38105C15.1278 5.95411 15.0708 6.71389 14.6158 7.22195L9.08044 13.4027C8.49982 14.051 7.50018 14.051 6.91956 13.4027L1.38423 7.22195C0.929229 6.71389 0.872177 5.95411 1.246 5.38105Z"
+                    fill="#E83FA4"
+                />
+                <path
+                    d="M9.45654 7.01492L8.34027 10.0102C8.07911 10.711 8.97464 11.2595 9.48018 10.7084L12.6345 7.26989C13.0351 6.83317 12.7253 6.12858 12.1327 6.12858H10.7327C10.164 6.12858 9.65515 6.48199 9.45654 7.01492Z"
+                    fill="#F9BBE1"
+                />
+            </StyledSvg>
+        );
+    },
+);
+
+export {GemIcon};

--- a/packages/wonder-blocks-icon/src/hooks/__tests__/use-svg-attributes.test.ts
+++ b/packages/wonder-blocks-icon/src/hooks/__tests__/use-svg-attributes.test.ts
@@ -1,0 +1,48 @@
+import {useSvgAttributes} from "../use-svg-attributes";
+
+describe("useSvgAttributes", () => {
+    it("should return presentation only attributes if there is no aria-label or aria-labelledby defined", () => {
+        // Arrange
+        const props = {};
+
+        // Act
+        const attributes = useSvgAttributes(props);
+
+        // Assert
+        expect(attributes).toEqual({
+            "aria-hidden": true,
+        });
+    });
+
+    it("should return icon meaning attributes if there is an aria-label is defined", () => {
+        // Arrange
+        const props = {
+            "aria-label": "Icon example",
+        };
+
+        // Act
+        const attributes = useSvgAttributes(props);
+
+        // Assert
+        expect(attributes).toEqual({
+            "aria-label": "Icon example",
+            role: "img",
+        });
+    });
+
+    it("should return icon meaning attributes if there is aria-labelledby is defined", () => {
+        // Arrange
+        const props = {
+            "aria-labelledby": "id-of-label",
+        };
+
+        // Act
+        const attributes = useSvgAttributes(props);
+
+        // Assert
+        expect(attributes).toEqual({
+            "aria-labelledby": "id-of-label",
+            role: "img",
+        });
+    });
+});

--- a/packages/wonder-blocks-icon/src/hooks/use-svg-attributes.ts
+++ b/packages/wonder-blocks-icon/src/hooks/use-svg-attributes.ts
@@ -1,0 +1,29 @@
+/**
+ * Determines what attributes should be applied to an icon based on if there is
+ * an accessible label for the icon.
+ *
+ * @returns The attributes to apply to an svg element.
+ */
+export function useSvgAttributes(props: {
+    "aria-label"?: string;
+    "aria-labelledby"?: string;
+}) {
+    const {"aria-label": ariaLabel, "aria-labelledby": ariaLabelledBy} = props;
+
+    const presentationOnlyAttributes = {
+        "aria-hidden": true,
+    };
+
+    const iconMeaningAttributes = {
+        "aria-label": ariaLabel,
+        "aria-labelledby": ariaLabelledBy,
+        role: "img",
+    };
+
+    const attributes =
+        ariaLabel || ariaLabelledBy
+            ? iconMeaningAttributes
+            : presentationOnlyAttributes;
+
+    return attributes;
+}

--- a/packages/wonder-blocks-icon/src/index.ts
+++ b/packages/wonder-blocks-icon/src/index.ts
@@ -1,3 +1,4 @@
 export {Icon} from "./components/icon";
 export {PhosphorIcon} from "./components/phosphor-icon";
 export type {IconSize, PhosphorIconAsset} from "./types";
+export {GemIcon} from "./components/custom-icon-components/gem-icon";

--- a/packages/wonder-blocks-icon/src/types.ts
+++ b/packages/wonder-blocks-icon/src/types.ts
@@ -1,3 +1,5 @@
+import {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
+
 /**
  * All the possible icon weights.
  */
@@ -7,3 +9,36 @@ export type PhosphorIconAsset = PhosphorRegular | PhosphorBold | PhosphorFill;
  * All the possible icon weights.
  */
 export type IconSize = "small" | "medium" | "large" | "xlarge";
+
+/**
+ * Common props for custom icon components.
+ */
+export type CustomIconProps = AriaProps & {
+    /**
+     * The alternative text for the icon. If `aria-label` or `aria-labelledby`
+     * is not provided, the icon will be marked with `aria-hidden=true`..
+     */
+    "aria-label"?: string;
+
+    /**
+     * The id of the element that provides the alternative text for the icon.
+     * If `aria-label` is not provided, the icon will be marked with
+     * `aria-hidden=true`.
+     */
+    "aria-labelledby"?: string;
+
+    /**
+     * The id for the element.
+     */
+    id?: string;
+
+    /**
+     * The test id for the element.
+     */
+    testId?: string;
+
+    /**
+     * The style for the element.
+     */
+    style?: StyleType;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,6 +490,9 @@ importers:
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
+      '@khanacademy/wonder-blocks-icon':
+        specifier: workspace:*
+        version: link:../wonder-blocks-icon
       '@khanacademy/wonder-blocks-tokens':
         specifier: workspace:*
         version: link:../wonder-blocks-tokens


### PR DESCRIPTION
## Summary:
- Adds `GemBadge` component. It uses the `Badge` component with a pre-defined style and icon using the new `Icon` component
  - Since the icon is pre-defined, it accepts a `showIcon` prop instead of an `icon` prop like the `Badge` and `StatusBadge` components
  - Will be updating it to semantic color tokens in an upcoming PR
- Adds `GemIcon` custom icon component. It can be used with the `Icon` component and renders an inline svg so that we can use semantic color tokens for the fill so that the multi-colored svg is themable

GemBadge:
<img width="105" alt="Gem Badge component with a label and gem icon" src="https://github.com/user-attachments/assets/ea9a7796-8fcf-4683-8d75-b81699570a2e" />

GemIcon:
<img width="54" alt="Gem Icon component" src="https://github.com/user-attachments/assets/3c319875-056d-4f68-9993-66b4f2eab085" />

Issue: WB-1943

## Test plan:
- Review docs and components
  - Badge Overview (`?path=/docs/packages-badge-overview--docs`) 
  - GemBadge (`?path=/docs/packages-badge-gembadge--docs`)
  - Custom Icon Components (includes GemIcon) (`?path=/docs/packages-icon-custom-icon-components--docs`)