### PR TITLE
[WB-1941.2] Add core.background and core.foreground semantic color tokens

### DIFF
--- a/.changeset/kind-cherries-report.md
+++ b/.changeset/kind-cherries-report.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tokens": minor
 ---
 
-Add `core.background` category.
+Add `core.background` and `core.foreground` categories.

--- a/.changeset/kind-cherries-report.md
+++ b/.changeset/kind-cherries-report.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add `core.background` category.

--- a/.changeset/pink-pandas-tap.md
+++ b/.changeset/pink-pandas-tap.md
@@ -1,0 +1,17 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-styles": patch
+"@khanacademy/wonder-blocks-switch": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-link": patch
+"@khanacademy/wonder-blocks-pill": patch
+"@khanacademy/wonder-blocks-tabs": patch
+---
+
+Replace call sites to use core.background instead of `action`.

--- a/.changeset/pink-pandas-tap.md
+++ b/.changeset/pink-pandas-tap.md
@@ -14,4 +14,4 @@
 "@khanacademy/wonder-blocks-tabs": patch
 ---
 
-Replace call sites to use core.background instead of `action`.
+Replace call sites to use `core.background` instead of `action`.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -112,7 +112,7 @@ const parameters = {
         container: DocsContainerWithTheme,
         toc: {
             // Useful for MDX pages like "Using color".
-            headingSelector: "h2, h3",
+            headingSelector: "h2, h3, h4",
             // Prevents including generic headings like "Stories" and "Usage".
             ignoreSelector:
                 ".docs-story h2, .docs-story h3, .sbdocs #stories, .sbdocs #usage, .sbdocs-subtitle",

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -265,6 +265,55 @@ For all type to ensure contrast for legibility. Inverse text applies for dark
 backgrounds in light mode.
 
 <Banner
+    kind="warning"
+    layout="full-width"
+    text="These tokens are deprecated and will be removed in the future. Please use the semanticColor.core.foreground tokens instead."
+/>
+
+<ColorGroup colors={semanticColor.text} group="text" />
+
+### Core
+
+Core colors are used for the most common elements in the UI. These colors are
+used for backgrounds, borders, and text. They are the foundation of our color
+system and are used to create a consistent look and feel across the product.
+
+### Border
+
+Borders define structure for elements. Generally borders for component elements
+would use `core.border.neutral.subtle`, `core.border.neutral.default` for when
+3:1 contrast is a priority (ex. form elements) and `core.border.neutral.strong`
+for 4.5:1 contrast.
+
+<View style={styles.gridCompact}>
+    <ActionColorGroup
+        category={semanticColor.core.border}
+        group="core.border"
+        includeExample={false}
+    />
+</View>
+
+### Background
+
+Background colors are used to define the background of elements. This includes
+the background of components like buttons, banners, and other elements that
+require a background color.
+
+<View style={styles.gridCompact}>
+    <ActionColorGroup
+        category={semanticColor.core.background}
+        group="core.background"
+        includeExample={false}
+    />
+</View>
+
+### Foreground
+
+Foreground colors are used to define the foreground of elements. This includes
+the text and icons that are displayed on top of the background color. This is
+important for ensuring that the text and icons are legible and accessible.
+
+<Banner
     kind="success"
     layout="full-width"
     text="Make sure to use these colors consistently to ensure readability and accessibility. This includes checking contrast ratios for text and background colors."
@@ -283,21 +332,10 @@ backgrounds in light mode.
     ]}
 />
 
-<ColorGroup colors={semanticColor.text} group="text" />
-
-### Core
-
-#### Border
-
-Borders define structure for elements. Generally borders for component elements
-would use `core.border.neutral.subtle`, `core.border.neutral.default` for when
-3:1 contrast is a priority (ex. form elements) and `core.border.neutral.strong`
-for 4.5:1 contrast.
-
 <View style={styles.gridCompact}>
     <ActionColorGroup
-        category={semanticColor.core.border}
-        group="border"
+        category={semanticColor.core.foreground}
+        group="core.foreground"
         includeExample={false}
     />
 </View>

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -267,7 +267,7 @@ backgrounds in light mode.
 <Banner
     kind="warning"
     layout="full-width"
-    text="These tokens are deprecated and will be removed in the future. Please use the semanticColor.core.foreground tokens instead."
+    text="These text tokens are deprecated and will be removed in the future. Please use the semanticColor.core.foreground tokens for text instead."
 />
 
 <ColorGroup colors={semanticColor.text} group="text" />
@@ -278,7 +278,7 @@ Core colors are used for the most common elements in the UI. These colors are
 used for backgrounds, borders, and text. They are the foundation of our color
 system and are used to create a consistent look and feel across the product.
 
-### Border
+#### Border
 
 Borders define structure for elements. Generally borders for component elements
 would use `core.border.neutral.subtle`, `core.border.neutral.default` for when
@@ -293,7 +293,7 @@ for 4.5:1 contrast.
     />
 </View>
 
-### Background
+#### Background
 
 Background colors are used to define the background of elements. This includes
 the background of components like buttons, banners, and other elements that
@@ -307,7 +307,7 @@ require a background color.
     />
 </View>
 
-### Foreground
+#### Foreground
 
 Foreground colors are used to define the foreground of elements. This includes
 the text and icons that are displayed on top of the background color. This is

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -192,11 +192,11 @@ const theme = {
     actionItem: {
         color: {
             hover: {
-                background: semanticColor.core.background.instructive.subtle,
+                background: actionType.hover.background,
                 foreground: actionType.hover.foreground,
             },
             press: {
-                background: semanticColor.core.background.instructive.strong,
+                background: actionType.press.background,
                 foreground: actionType.press.foreground,
             },
         },

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -192,11 +192,11 @@ const theme = {
     actionItem: {
         color: {
             hover: {
-                background: actionType.hover.background,
+                background: semanticColor.core.background.instructive.subtle,
                 foreground: actionType.hover.foreground,
             },
             press: {
-                background: actionType.press.background,
+                background: semanticColor.core.background.instructive.strong,
                 foreground: actionType.press.foreground,
             },
         },

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -324,11 +324,11 @@ const theme = {
                 foreground: semanticColor.text.primary,
             },
             hover: {
-                background: semanticColor.core.background.instructive.subtle,
+                background: actionType.hover.background,
                 foreground: actionType.hover.foreground,
             },
             press: {
-                background: semanticColor.core.background.instructive.strong,
+                background: actionType.press.background,
                 foreground: actionType.press.foreground,
             },
             disabled: {

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -324,15 +324,15 @@ const theme = {
                 foreground: semanticColor.text.primary,
             },
             hover: {
-                background: actionType.hover.background,
+                background: semanticColor.core.background.instructive.subtle,
                 foreground: actionType.hover.foreground,
             },
             press: {
-                background: actionType.press.background,
+                background: semanticColor.core.background.instructive.strong,
                 foreground: actionType.press.foreground,
             },
             disabled: {
-                background: "transparent",
+                background: semanticColor.core.background.disabled.subtle,
                 foreground: semanticColor.action.secondary.disabled.foreground,
             },
         },

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -102,19 +102,22 @@ const _generateStyles = (checked: Checked, error: boolean) => {
     // state.
     const colorAction = semanticColor.action.secondary[actionType];
 
+    const coreType = error ? "critical" : "instructive";
+    const colorCore = semanticColor.core.background[coreType];
+
     // The different states that the component can be in.
     const states = {
         // Resting state (unchecked)
         unchecked: {
             border: semanticColor.input.default.border,
-            background: colorAction.default.background,
+            background: colorCore.subtle,
         },
         checked: {
             // NOTE: This is a special case where the border is the same color
             // as the foreground. This should change as soon as we simplify the
             // existing `action` tokens.
             border: colorAction.default.foreground,
-            background: colorAction.default.background,
+            background: colorCore.subtle,
         },
         // Form validation error state
         error: {

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -60,7 +60,7 @@ const disabledChecked = {
     height: size / 2,
     width: size / 2,
     borderRadius: border.radius.radius_full,
-    backgroundColor: semanticColor.action.primary.disabled.background,
+    backgroundColor: semanticColor.core.border.disabled.strong,
 } as const;
 
 const sharedStyles = StyleSheet.create({

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -269,10 +269,10 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
             border: semanticColor.focus.outer,
         },
         hover: {
-            border: semanticColor.action.primary.progressive.hover.border,
+            border: semanticColor.core.border.instructive.default,
         },
         press: {
-            border: semanticColor.action.primary.progressive.press.border,
+            border: semanticColor.core.border.instructive.strong,
             background: pressColor,
         },
     };

--- a/packages/wonder-blocks-switch/src/themes/default.ts
+++ b/packages/wonder-blocks-switch/src/themes/default.ts
@@ -13,7 +13,7 @@ const theme = {
         bg: {
             switch: {
                 off: action.default.border,
-                disabledOff: semanticColor.action.primary.disabled.background,
+                disabledOff: semanticColor.core.border.disabled.strong,
                 // NOTE: Adding this as a primitive token b/c we don't have a
                 // semantic token for this background color
                 activeOff: color.fadedOffBlack64,

--- a/packages/wonder-blocks-switch/src/themes/default.ts
+++ b/packages/wonder-blocks-switch/src/themes/default.ts
@@ -18,7 +18,7 @@ const theme = {
                 // semantic token for this background color
                 activeOff: color.fadedOffBlack64,
                 on: action.default.foreground,
-                disabledOn: action.press.background,
+                disabledOn: semanticColor.core.border.instructive.subtle,
                 activeOn: action.press.foreground,
             },
             slider: {

--- a/packages/wonder-blocks-switch/src/themes/default.ts
+++ b/packages/wonder-blocks-switch/src/themes/default.ts
@@ -5,30 +5,28 @@ import {
     spacing,
 } from "@khanacademy/wonder-blocks-tokens";
 
-// The color of the switch is based on the action color.
-const action = semanticColor.action.secondary.progressive;
-
 const theme = {
     color: {
         bg: {
             switch: {
-                off: action.default.border,
+                off: semanticColor.core.border.neutral.default,
                 disabledOff: semanticColor.core.border.disabled.strong,
                 // NOTE: Adding this as a primitive token b/c we don't have a
                 // semantic token for this background color
                 activeOff: color.fadedOffBlack64,
-                on: action.default.foreground,
+                on: semanticColor.core.background.instructive.default,
                 disabledOn: semanticColor.core.border.instructive.subtle,
-                activeOn: action.press.foreground,
+                activeOn: semanticColor.core.background.instructive.strong,
             },
             slider: {
                 on: semanticColor.icon.inverse,
                 off: semanticColor.icon.inverse,
             },
             icon: {
-                on: action.default.foreground,
-                disabledOn: action.press.background,
-                off: action.default.border,
+                on: semanticColor.icon.action,
+                // NOTE: We use border to match the switch color.
+                disabledOn: semanticColor.core.border.instructive.subtle,
+                off: semanticColor.core.border.neutral.default,
                 disabledOff: semanticColor.icon.disabled,
             },
         },

--- a/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
@@ -111,10 +111,10 @@ const styles = StyleSheet.create({
         listStyle: "none",
         display: "inline-flex",
         [":has(a:hover)" as any]: {
-            boxShadow: `inset 0 calc(${sizing.size_020}*-1) 0 0 ${semanticColor.action.secondary.progressive.hover.foreground}`,
+            boxShadow: `inset 0 calc(${sizing.size_020}*-1) 0 0 ${semanticColor.core.border.instructive.default}`,
         },
         [":has(a:active)" as any]: {
-            boxShadow: `inset 0 calc(${sizing.size_060}*-1) 0 0 ${semanticColor.action.secondary.progressive.press.foreground}`,
+            boxShadow: `inset 0 calc(${sizing.size_060}*-1) 0 0 ${semanticColor.core.border.instructive.strong}`,
         },
         paddingBlockStart: sizing.size_080,
         paddingBlockEnd: sizing.size_180,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -76,6 +76,42 @@ const core = {
             strong: color.gray_70,
         },
     },
+
+    /**
+     * Used for text and icons.
+     */
+    foreground: {
+        instructive: {
+            subtle: color.blue_50,
+            default: color.blue_30,
+            strong: color.blue_10,
+        },
+        neutral: {
+            subtle: color.gray_20,
+            default: color.gray_10,
+            strong: color.black_100,
+        },
+        critical: {
+            subtle: color.red_50,
+            default: color.red_20,
+            strong: color.red_10,
+        },
+        success: {
+            subtle: color.green_50,
+            default: color.green_20,
+            strong: color.green_05,
+        },
+        warning: {
+            subtle: color.yellow_50,
+            default: color.yellow_10,
+            strong: color.yellow_05,
+        },
+        inverse: {
+            subtle: color.gray_60,
+            default: color.gray_90,
+            strong: color.white_100,
+        },
+    },
 };
 
 /**
@@ -176,51 +212,51 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 default: {
                     border: core.border.instructive.subtle,
                     background: core.background.instructive.subtle,
-                    foreground: color.blue_30,
+                    foreground: core.foreground.instructive.default,
                 },
                 hover: {
                     border: core.border.instructive.default,
                     background: core.background.instructive.subtle,
-                    foreground: color.blue_30,
+                    foreground: core.foreground.instructive.default,
                 },
                 press: {
                     border: core.border.instructive.default,
                     background: core.background.instructive.subtle,
-                    foreground: color.blue_30,
+                    foreground: core.foreground.instructive.default,
                 },
             },
             destructive: {
                 default: {
                     border: core.border.critical.default,
                     background: core.background.critical.subtle,
-                    foreground: color.red_20,
+                    foreground: core.foreground.critical.default,
                 },
                 hover: {
                     border: core.border.critical.strong,
                     background: core.background.critical.subtle,
-                    foreground: color.red_10,
+                    foreground: core.foreground.critical.strong,
                 },
                 press: {
                     border: core.border.critical.strong,
                     background: core.background.critical.subtle,
-                    foreground: color.red_10,
+                    foreground: core.foreground.critical.strong,
                 },
             },
             neutral: {
                 default: {
                     border: core.border.neutral.subtle,
                     background: core.background.neutral.subtle,
-                    foreground: color.gray_10,
+                    foreground: core.foreground.neutral.default,
                 },
                 hover: {
                     border: core.border.neutral.strong,
                     background: core.background.neutral.subtle,
-                    foreground: color.black_100,
+                    foreground: core.foreground.neutral.strong,
                 },
                 press: {
                     border: core.border.neutral.strong,
                     background: core.background.neutral.subtle,
-                    foreground: color.black_100,
+                    foreground: core.foreground.neutral.strong,
                 },
             },
 
@@ -236,17 +272,17 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 default: {
                     border: core.transparent,
                     background: core.transparent,
-                    foreground: color.blue_30,
+                    foreground: core.foreground.instructive.default,
                 },
                 hover: {
                     border: core.border.instructive.strong,
                     background: core.transparent,
-                    foreground: color.blue_10,
+                    foreground: core.foreground.instructive.strong,
                 },
                 press: {
                     border: core.border.instructive.strong,
                     background: core.transparent,
-                    foreground: color.blue_10,
+                    foreground: core.foreground.instructive.strong,
                 },
             },
 
@@ -254,34 +290,34 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 default: {
                     border: core.transparent,
                     background: core.transparent,
-                    foreground: color.red_20,
+                    foreground: core.foreground.critical.default,
                 },
                 hover: {
                     border: core.border.critical.strong,
                     background: core.transparent,
-                    foreground: color.red_10,
+                    foreground: core.foreground.critical.strong,
                 },
                 press: {
                     border: core.border.critical.strong,
                     background: core.transparent,
-                    foreground: color.red_10,
+                    foreground: core.foreground.critical.strong,
                 },
             },
             neutral: {
                 default: {
                     border: core.transparent,
                     background: core.transparent,
-                    foreground: color.gray_10,
+                    foreground: core.foreground.neutral.default,
                 },
                 hover: {
                     border: core.border.neutral.strong,
                     background: core.transparent,
-                    foreground: color.black_100,
+                    foreground: core.foreground.neutral.strong,
                 },
                 press: {
                     border: core.border.neutral.strong,
                     background: core.transparent,
-                    foreground: color.black_100,
+                    foreground: core.foreground.neutral.strong,
                 },
             },
 

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -139,10 +139,10 @@ const surface = {
 };
 
 const text = {
-    primary: color.black_100,
-    secondary: color.gray_20,
-    disabled: color.gray_60,
-    inverse: color.white_100,
+    primary: core.foreground.neutral.strong,
+    secondary: core.foreground.neutral.subtle,
+    disabled: core.foreground.inverse.subtle,
+    inverse: core.foreground.inverse.strong,
 };
 
 export const semanticColor = mergeTheme(defaultSemanticColor, {

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -44,6 +44,38 @@ const core = {
             strong: color.white_100,
         },
     },
+    background: {
+        instructive: {
+            subtle: color.blue_80,
+            default: color.blue_30,
+            strong: color.blue_10,
+        },
+        neutral: {
+            subtle: color.white_100,
+            default: color.gray_20,
+            strong: color.black_100,
+        },
+        critical: {
+            subtle: color.red_90,
+            default: color.red_20,
+            strong: color.red_05,
+        },
+        success: {
+            subtle: color.green_90,
+            default: color.green_30,
+            strong: color.green_10,
+        },
+        warning: {
+            subtle: color.yellow_90,
+            default: color.yellow_60,
+            strong: color.yellow_10,
+        },
+        disabled: {
+            subtle: transparent,
+            default: color.gray_80,
+            strong: color.gray_70,
+        },
+    },
 };
 
 /**
@@ -83,58 +115,58 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             progressive: {
                 default: {
                     border: core.border.instructive.default,
-                    background: color.blue_30,
+                    background: core.background.instructive.default,
                     foreground: text.inverse,
                 },
                 hover: {
                     border: core.border.instructive.strong,
-                    background: color.blue_10,
+                    background: core.background.instructive.strong,
                     foreground: text.inverse,
                 },
                 press: {
                     border: core.border.instructive.strong,
-                    background: color.blue_10,
+                    background: core.background.instructive.strong,
                     foreground: text.inverse,
                 },
             },
             destructive: {
                 default: {
                     border: core.border.critical.default,
-                    background: color.red_20,
+                    background: core.background.critical.default,
                     foreground: text.inverse,
                 },
                 hover: {
                     border: core.border.critical.strong,
-                    background: color.red_05,
+                    background: core.background.critical.strong,
                     foreground: text.inverse,
                 },
                 press: {
                     border: core.border.critical.strong,
-                    background: color.red_05,
+                    background: core.background.critical.strong,
                     foreground: text.inverse,
                 },
             },
             neutral: {
                 default: {
                     border: core.border.neutral.default,
-                    background: color.gray_20,
+                    background: core.background.neutral.default,
                     foreground: text.inverse,
                 },
                 hover: {
                     border: core.border.neutral.strong,
-                    background: color.gray_05,
+                    background: core.background.neutral.strong,
                     foreground: text.inverse,
                 },
                 press: {
                     border: core.border.neutral.strong,
-                    background: color.gray_05,
+                    background: core.background.neutral.strong,
                     foreground: text.inverse,
                 },
             },
 
             disabled: {
                 border: core.transparent,
-                background: color.gray_70,
+                background: core.background.disabled.strong,
                 foreground: color.gray_50,
             },
         },
@@ -143,58 +175,58 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             progressive: {
                 default: {
                     border: core.border.instructive.subtle,
-                    background: color.blue_80,
+                    background: core.background.instructive.subtle,
                     foreground: color.blue_30,
                 },
                 hover: {
                     border: core.border.instructive.default,
-                    background: color.blue_70,
+                    background: core.background.instructive.subtle,
                     foreground: color.blue_30,
                 },
                 press: {
                     border: core.border.instructive.default,
-                    background: color.blue_70,
+                    background: core.background.instructive.subtle,
                     foreground: color.blue_30,
                 },
             },
             destructive: {
                 default: {
                     border: core.border.critical.default,
-                    background: color.red_90,
+                    background: core.background.critical.subtle,
                     foreground: color.red_20,
                 },
                 hover: {
                     border: core.border.critical.strong,
-                    background: color.red_70,
+                    background: core.background.critical.subtle,
                     foreground: color.red_10,
                 },
                 press: {
                     border: core.border.critical.strong,
-                    background: color.red_70,
+                    background: core.background.critical.subtle,
                     foreground: color.red_10,
                 },
             },
             neutral: {
                 default: {
                     border: core.border.neutral.subtle,
-                    background: color.white_100,
+                    background: core.background.neutral.subtle,
                     foreground: color.gray_10,
                 },
                 hover: {
                     border: core.border.neutral.strong,
-                    background: color.white_100,
+                    background: core.background.neutral.subtle,
                     foreground: color.black_100,
                 },
                 press: {
                     border: core.border.neutral.strong,
-                    background: color.white_100,
+                    background: core.background.neutral.subtle,
                     foreground: color.black_100,
                 },
             },
 
             disabled: {
                 border: core.border.disabled.strong,
-                background: color.gray_80,
+                background: core.background.disabled.default,
                 foreground: color.gray_50,
             },
         },
@@ -203,17 +235,17 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             progressive: {
                 default: {
                     border: core.transparent,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.blue_30,
                 },
                 hover: {
                     border: core.border.instructive.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.blue_10,
                 },
                 press: {
                     border: core.border.instructive.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.blue_10,
                 },
             },
@@ -221,41 +253,41 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             destructive: {
                 default: {
                     border: core.transparent,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.red_20,
                 },
                 hover: {
                     border: core.border.critical.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.red_10,
                 },
                 press: {
                     border: core.border.critical.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.red_10,
                 },
             },
             neutral: {
                 default: {
                     border: core.transparent,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.gray_10,
                 },
                 hover: {
                     border: core.border.neutral.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.black_100,
                 },
                 press: {
                     border: core.border.neutral.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.black_100,
                 },
             },
 
             disabled: {
                 border: core.border.disabled.subtle,
-                background: "transparent",
+                background: core.background.disabled.subtle,
                 foreground: color.gray_50,
             },
         },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -106,6 +106,11 @@ const core = {
             default: color.yellow_10,
             strong: color.yellow_05,
         },
+        disabled: {
+            subtle: color.gray_60,
+            default: color.gray_50,
+            strong: color.gray_40,
+        },
         inverse: {
             subtle: color.gray_60,
             default: color.gray_90,
@@ -203,7 +208,7 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             disabled: {
                 border: core.transparent,
                 background: core.background.disabled.strong,
-                foreground: color.gray_50,
+                foreground: core.foreground.disabled.default,
             },
         },
 
@@ -263,7 +268,7 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             disabled: {
                 border: core.border.disabled.strong,
                 background: core.background.disabled.default,
-                foreground: color.gray_50,
+                foreground: core.foreground.disabled.default,
             },
         },
 
@@ -324,7 +329,7 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             disabled: {
                 border: core.border.disabled.subtle,
                 background: core.background.disabled.subtle,
-                foreground: color.gray_50,
+                foreground: core.foreground.disabled.subtle,
             },
         },
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -36,8 +36,8 @@ const core = {
             strong: color.fadedOffBlack32,
         },
         inverse: {
-            subtle: color.offBlack16,
-            default: color.offBlack8,
+            subtle: color.fadedOffBlack16,
+            default: color.fadedOffBlack8,
             strong: color.white,
         },
     },
@@ -137,10 +137,10 @@ const surface = {
  * tokens.
  */
 const text = {
-    primary: color.offBlack,
-    secondary: color.fadedOffBlack72,
-    disabled: color.fadedOffBlack32,
-    inverse: color.white,
+    primary: core.foreground.neutral.strong,
+    secondary: core.foreground.neutral.default,
+    disabled: core.foreground.inverse.subtle,
+    inverse: core.foreground.inverse.strong,
 };
 
 export const semanticColor = {

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -255,17 +255,17 @@ export const semanticColor = {
                 default: {
                     border: core.border.neutral.default,
                     background: core.transparent,
-                    foreground: core.foreground.neutral.subtle,
+                    foreground: core.foreground.neutral.default,
                 },
                 hover: {
                     border: core.border.neutral.default,
                     background: core.transparent,
-                    foreground: core.foreground.neutral.subtle,
+                    foreground: core.foreground.neutral.default,
                 },
                 press: {
                     border: core.border.neutral.strong,
                     background: core.background.neutral.subtle,
-                    foreground: core.foreground.neutral.default,
+                    foreground: core.foreground.neutral.strong,
                 },
             },
 
@@ -316,17 +316,17 @@ export const semanticColor = {
                 default: {
                     border: core.transparent,
                     background: core.transparent,
-                    foreground: core.foreground.neutral.subtle,
+                    foreground: core.foreground.neutral.default,
                 },
                 hover: {
                     border: core.border.neutral.default,
                     background: core.transparent,
-                    foreground: core.foreground.neutral.subtle,
+                    foreground: core.foreground.neutral.default,
                 },
                 press: {
                     border: core.border.neutral.strong,
                     background: core.transparent,
-                    foreground: core.foreground.neutral.default,
+                    foreground: core.foreground.neutral.strong,
                 },
             },
 

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -103,6 +103,11 @@ const core = {
             default: color.activeGold,
             strong: color.offBlack,
         },
+        disabled: {
+            subtle: color.fadedOffBlack16,
+            default: color.fadedOffBlack32,
+            strong: color.fadedOffBlack50,
+        },
         inverse: {
             subtle: color.fadedOffBlack32,
             default: color.offWhite,
@@ -272,7 +277,7 @@ export const semanticColor = {
             disabled: {
                 border: core.border.disabled.strong,
                 background: core.background.disabled.subtle,
-                foreground: core.foreground.inverse.subtle,
+                foreground: core.foreground.disabled.default,
             },
         },
 
@@ -333,7 +338,7 @@ export const semanticColor = {
             disabled: {
                 border: core.border.disabled.default,
                 background: core.background.disabled.subtle,
-                foreground: core.foreground.inverse.subtle,
+                foreground: core.foreground.disabled.default,
             },
         },
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -41,6 +41,38 @@ const core = {
             strong: color.white,
         },
     },
+    background: {
+        instructive: {
+            subtle: color.fadedBlue8,
+            default: color.blue,
+            strong: color.activeBlue,
+        },
+        neutral: {
+            subtle: color.fadedOffBlack8,
+            default: color.fadedOffBlack72,
+            strong: color.offBlack,
+        },
+        critical: {
+            subtle: color.fadedRed8,
+            default: color.red,
+            strong: color.activeRed,
+        },
+        success: {
+            subtle: color.fadedGreen8,
+            default: color.green,
+            strong: color.activeGreen,
+        },
+        warning: {
+            subtle: color.fadedGold8,
+            default: color.gold,
+            strong: color.activeGold,
+        },
+        disabled: {
+            subtle: transparent,
+            default: color.fadedOffBlack8,
+            strong: color.fadedOffBlack16,
+        },
+    },
 };
 
 /**
@@ -87,34 +119,34 @@ export const semanticColor = {
             progressive: {
                 default: {
                     border: core.transparent,
-                    background: color.blue,
+                    background: core.background.instructive.default,
                     foreground: text.inverse,
                 },
                 hover: {
                     border: core.border.instructive.default,
-                    background: color.blue,
+                    background: core.background.instructive.default,
                     foreground: text.inverse,
                 },
                 press: {
                     border: core.border.instructive.strong,
-                    background: color.activeBlue,
+                    background: core.background.instructive.strong,
                     foreground: text.inverse,
                 },
             },
             destructive: {
                 default: {
                     border: core.transparent,
-                    background: color.red,
+                    background: core.background.critical.default,
                     foreground: text.inverse,
                 },
                 hover: {
                     border: core.border.critical.default,
-                    background: color.red,
+                    background: core.background.critical.default,
                     foreground: text.inverse,
                 },
                 press: {
                     border: core.border.critical.strong,
-                    background: color.activeRed,
+                    background: core.background.critical.strong,
                     foreground: text.inverse,
                 },
             },
@@ -122,24 +154,24 @@ export const semanticColor = {
             neutral: {
                 default: {
                     border: core.transparent,
-                    background: color.fadedOffBlack72,
+                    background: core.background.neutral.default,
                     foreground: text.inverse,
                 },
                 hover: {
                     border: core.border.neutral.default,
-                    background: color.fadedOffBlack72,
+                    background: core.background.neutral.default,
                     foreground: text.inverse,
                 },
                 press: {
                     border: core.border.neutral.strong,
-                    background: color.offBlack,
+                    background: core.background.neutral.strong,
                     foreground: text.inverse,
                 },
             },
 
             disabled: {
                 border: core.border.disabled.strong,
-                background: color.fadedOffBlack32,
+                background: core.border.disabled.strong,
                 foreground: color.offWhite,
             },
         },
@@ -148,58 +180,58 @@ export const semanticColor = {
             progressive: {
                 default: {
                     border: core.border.neutral.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.blue,
                 },
                 hover: {
                     border: core.border.instructive.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.blue,
                 },
                 press: {
                     border: core.border.instructive.strong,
-                    background: color.fadedBlue,
+                    background: core.background.instructive.subtle,
                     foreground: color.activeBlue,
                 },
             },
             destructive: {
                 default: {
                     border: core.border.neutral.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.red,
                 },
                 hover: {
                     border: core.border.critical.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.red,
                 },
                 press: {
                     border: core.border.critical.strong,
-                    background: color.fadedRed,
+                    background: core.background.critical.subtle,
                     foreground: color.activeRed,
                 },
             },
             neutral: {
                 default: {
                     border: core.border.neutral.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: text.secondary,
                 },
                 hover: {
                     border: core.border.neutral.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: text.secondary,
                 },
                 press: {
                     border: core.border.neutral.strong,
-                    background: color.offBlack16,
+                    background: core.background.neutral.subtle,
                     foreground: text.primary,
                 },
             },
 
             disabled: {
                 border: core.border.disabled.strong,
-                background: "transparent",
+                background: core.background.disabled.subtle,
                 foreground: text.disabled,
             },
         },
@@ -208,17 +240,17 @@ export const semanticColor = {
             progressive: {
                 default: {
                     border: core.transparent,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.blue,
                 },
                 hover: {
                     border: core.border.instructive.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.blue,
                 },
                 press: {
                     border: core.border.instructive.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.activeBlue,
                 },
             },
@@ -226,41 +258,41 @@ export const semanticColor = {
             destructive: {
                 default: {
                     border: core.transparent,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.red,
                 },
                 hover: {
                     border: core.border.critical.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.red,
                 },
                 press: {
                     border: core.border.critical.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: color.activeRed,
                 },
             },
             neutral: {
                 default: {
                     border: core.transparent,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: text.secondary,
                 },
                 hover: {
                     border: core.border.neutral.default,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: text.secondary,
                 },
                 press: {
                     border: core.border.neutral.strong,
-                    background: "transparent",
+                    background: core.transparent,
                     foreground: text.primary,
                 },
             },
 
             disabled: {
                 border: core.border.disabled.default,
-                background: "transparent",
+                background: core.background.disabled.subtle,
                 foreground: text.disabled,
             },
         },
@@ -277,7 +309,7 @@ export const semanticColor = {
         },
         checked: {
             border: core.border.instructive.default,
-            background: color.blue,
+            background: core.background.instructive.default,
             foreground: text.inverse,
         },
         disabled: {
@@ -288,7 +320,7 @@ export const semanticColor = {
         },
         error: {
             border: core.border.critical.default,
-            background: color.fadedRed8,
+            background: core.background.critical.subtle,
             foreground: text.primary,
         },
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -73,6 +73,42 @@ const core = {
             strong: color.fadedOffBlack16,
         },
     },
+
+    /**
+     * Used for text and icons.
+     */
+    foreground: {
+        instructive: {
+            subtle: color.blue,
+            default: color.activeBlue,
+            strong: color.offBlack,
+        },
+        neutral: {
+            subtle: color.fadedOffBlack64,
+            default: color.fadedOffBlack72,
+            strong: color.offBlack,
+        },
+        critical: {
+            subtle: color.red,
+            default: color.activeRed,
+            strong: color.offBlack,
+        },
+        success: {
+            subtle: color.green,
+            default: color.activeGreen,
+            strong: color.offBlack,
+        },
+        warning: {
+            subtle: color.gold,
+            default: color.activeGold,
+            strong: color.offBlack,
+        },
+        inverse: {
+            subtle: color.fadedOffBlack32,
+            default: color.offWhite,
+            strong: color.white,
+        },
+    },
 };
 
 /**
@@ -96,6 +132,10 @@ const surface = {
     overlay: color.offBlack64,
 };
 
+/**
+ * TODO(WB-1941): Remove text once we have migrated to the new core.foreground
+ * tokens.
+ */
 const text = {
     primary: color.offBlack,
     secondary: color.fadedOffBlack72,
@@ -120,34 +160,34 @@ export const semanticColor = {
                 default: {
                     border: core.transparent,
                     background: core.background.instructive.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 hover: {
                     border: core.border.instructive.default,
                     background: core.background.instructive.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 press: {
                     border: core.border.instructive.strong,
                     background: core.background.instructive.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
             },
             destructive: {
                 default: {
                     border: core.transparent,
                     background: core.background.critical.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 hover: {
                     border: core.border.critical.default,
                     background: core.background.critical.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 press: {
                     border: core.border.critical.strong,
                     background: core.background.critical.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
             },
 
@@ -155,24 +195,24 @@ export const semanticColor = {
                 default: {
                     border: core.transparent,
                     background: core.background.neutral.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 hover: {
                     border: core.border.neutral.default,
                     background: core.background.neutral.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 press: {
                     border: core.border.neutral.strong,
                     background: core.background.neutral.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
             },
 
             disabled: {
                 border: core.border.disabled.strong,
                 background: core.border.disabled.strong,
-                foreground: color.offWhite,
+                foreground: core.foreground.inverse.default,
             },
         },
 
@@ -181,58 +221,58 @@ export const semanticColor = {
                 default: {
                     border: core.border.neutral.default,
                     background: core.transparent,
-                    foreground: color.blue,
+                    foreground: core.foreground.instructive.subtle,
                 },
                 hover: {
                     border: core.border.instructive.default,
                     background: core.transparent,
-                    foreground: color.blue,
+                    foreground: core.foreground.instructive.subtle,
                 },
                 press: {
                     border: core.border.instructive.strong,
                     background: core.background.instructive.subtle,
-                    foreground: color.activeBlue,
+                    foreground: core.foreground.instructive.default,
                 },
             },
             destructive: {
                 default: {
                     border: core.border.neutral.default,
                     background: core.transparent,
-                    foreground: color.red,
+                    foreground: core.foreground.critical.subtle,
                 },
                 hover: {
                     border: core.border.critical.default,
                     background: core.transparent,
-                    foreground: color.red,
+                    foreground: core.foreground.critical.subtle,
                 },
                 press: {
                     border: core.border.critical.strong,
                     background: core.background.critical.subtle,
-                    foreground: color.activeRed,
+                    foreground: core.foreground.critical.default,
                 },
             },
             neutral: {
                 default: {
                     border: core.border.neutral.default,
                     background: core.transparent,
-                    foreground: text.secondary,
+                    foreground: core.foreground.neutral.subtle,
                 },
                 hover: {
                     border: core.border.neutral.default,
                     background: core.transparent,
-                    foreground: text.secondary,
+                    foreground: core.foreground.neutral.subtle,
                 },
                 press: {
                     border: core.border.neutral.strong,
                     background: core.background.neutral.subtle,
-                    foreground: text.primary,
+                    foreground: core.foreground.neutral.default,
                 },
             },
 
             disabled: {
                 border: core.border.disabled.strong,
                 background: core.background.disabled.subtle,
-                foreground: text.disabled,
+                foreground: core.foreground.inverse.subtle,
             },
         },
 
@@ -241,17 +281,17 @@ export const semanticColor = {
                 default: {
                     border: core.transparent,
                     background: core.transparent,
-                    foreground: color.blue,
+                    foreground: core.foreground.instructive.subtle,
                 },
                 hover: {
                     border: core.border.instructive.default,
                     background: core.transparent,
-                    foreground: color.blue,
+                    foreground: core.foreground.instructive.subtle,
                 },
                 press: {
                     border: core.border.instructive.strong,
                     background: core.transparent,
-                    foreground: color.activeBlue,
+                    foreground: core.foreground.instructive.default,
                 },
             },
 
@@ -259,41 +299,41 @@ export const semanticColor = {
                 default: {
                     border: core.transparent,
                     background: core.transparent,
-                    foreground: color.red,
+                    foreground: core.foreground.critical.subtle,
                 },
                 hover: {
                     border: core.border.critical.default,
                     background: core.transparent,
-                    foreground: color.red,
+                    foreground: core.foreground.critical.subtle,
                 },
                 press: {
                     border: core.border.critical.strong,
                     background: core.transparent,
-                    foreground: color.activeRed,
+                    foreground: core.foreground.critical.default,
                 },
             },
             neutral: {
                 default: {
                     border: core.transparent,
                     background: core.transparent,
-                    foreground: text.secondary,
+                    foreground: core.foreground.neutral.subtle,
                 },
                 hover: {
                     border: core.border.neutral.default,
                     background: core.transparent,
-                    foreground: text.secondary,
+                    foreground: core.foreground.neutral.subtle,
                 },
                 press: {
                     border: core.border.neutral.strong,
                     background: core.transparent,
-                    foreground: text.primary,
+                    foreground: core.foreground.neutral.default,
                 },
             },
 
             disabled: {
                 border: core.border.disabled.default,
                 background: core.background.disabled.subtle,
-                foreground: text.disabled,
+                foreground: core.foreground.inverse.subtle,
             },
         },
     },
@@ -304,24 +344,24 @@ export const semanticColor = {
         default: {
             border: core.border.neutral.default,
             background: surface.primary,
-            foreground: text.primary,
-            placeholder: text.secondary,
+            foreground: core.foreground.neutral.strong,
+            placeholder: core.foreground.neutral.default,
         },
         checked: {
             border: core.border.instructive.default,
             background: core.background.instructive.default,
-            foreground: text.inverse,
+            foreground: core.foreground.inverse.strong,
         },
         disabled: {
             border: core.border.disabled.default,
             background: color.offWhite,
-            foreground: text.secondary,
-            placeholder: text.secondary,
+            foreground: core.foreground.neutral.default,
+            placeholder: core.foreground.neutral.default,
         },
         error: {
             border: core.border.critical.default,
             background: core.background.critical.subtle,
-            foreground: text.primary,
+            foreground: core.foreground.neutral.strong,
         },
     },
     /**
@@ -330,24 +370,24 @@ export const semanticColor = {
      */
     status: {
         critical: {
-            background: color.fadedRed8,
-            foreground: color.red,
+            background: core.background.critical.subtle,
+            foreground: core.foreground.critical.subtle,
         },
         warning: {
-            background: color.fadedGold8,
-            foreground: color.gold,
+            background: core.background.warning.subtle,
+            foreground: core.foreground.warning.subtle,
         },
         success: {
-            background: color.fadedGreen8,
-            foreground: color.green,
+            background: core.background.success.subtle,
+            foreground: core.foreground.success.subtle,
         },
         notice: {
-            background: color.fadedBlue8,
-            foreground: color.blue,
+            background: core.background.instructive.subtle,
+            foreground: core.foreground.instructive.subtle,
         },
         neutral: {
-            background: color.fadedOffBlack8,
-            foreground: text.primary,
+            background: core.background.neutral.subtle,
+            foreground: core.foreground.neutral.strong,
         },
     },
     /**

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -36,8 +36,8 @@ const core = {
             strong: color.fadedOffBlack32,
         },
         inverse: {
-            subtle: color.fadedOffBlack16,
-            default: color.fadedOffBlack8,
+            subtle: color.offBlack16,
+            default: color.offBlack8,
             strong: color.white,
         },
     },
@@ -64,8 +64,8 @@ const core = {
         },
         warning: {
             subtle: color.fadedGold8,
-            default: color.gold,
-            strong: color.activeGold,
+            default: color.fadedGold24,
+            strong: color.gold,
         },
         disabled: {
             subtle: transparent,


### PR DESCRIPTION
## Summary:

- Replaced some `action` call sites with `core.background` tokens.
- Added `core.background` and `core.foreground` tokens in `OG` and `TB`.
- Updated `press` action states to use `core.subtle` (`fadedBlue8`) instead of `fadedBlue`.

### Implementation plan:

1. #2613
**2. Add `core.background` and `core.foreground` semantic color tokens (CURRENT)**

Issue: WB-1941

## Test plan:

Verify that the Chromatic snapshots look as expected.

Note that `Button`, `IconButton`, `Action/OptionItem` and `Checkbox`/`Radio` will change as we changed the press background color.

https://khanacademy.slack.com/archives/C07CA2YR0BZ/p1747931528405019