### PR TITLE
Supporting Badge with Tooltip

### DIFF
--- a/.changeset/cold-apes-yawn.md
+++ b/.changeset/cold-apes-yawn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-badge": patch
+---
+
+Include focus styling for Badge so it is used when badges are interactive when used with tooltips

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
+import {StyleSheet} from "aphrodite";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 import {
@@ -321,13 +322,13 @@ export const AllBadgesScenarios: StoryComponentType = {
                 }}
             >
                 <Heading>Badges</Heading>
-                <View style={{gap: sizing.size_240, flexDirection: "row"}}>
+                <View style={styles.badgesContainer}>
                     {badges.map((badge, index) => (
                         <View key={index}>{badge}</View>
                     ))}
                 </View>
                 <Heading>Badges with Tooltip</Heading>
-                <View style={{gap: sizing.size_240, flexDirection: "row"}}>
+                <View style={styles.badgesContainer}>
                     {badges.map((badge, index) => (
                         <Tooltip
                             content="Tooltip"
@@ -335,7 +336,7 @@ export const AllBadgesScenarios: StoryComponentType = {
                             key={index}
                             placement="bottom"
                         >
-                            {badge}
+                            {React.cloneElement(badge, {role: "button"})}
                         </Tooltip>
                     ))}
                 </View>
@@ -343,3 +344,10 @@ export const AllBadgesScenarios: StoryComponentType = {
         );
     },
 };
+
+const styles = StyleSheet.create({
+    badgesContainer: {
+        gap: sizing.size_240,
+        flexDirection: "row",
+    },
+});

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -11,7 +11,11 @@ import {
 } from "@khanacademy/wonder-blocks-badge";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {commonStates, StateSheet} from "../components/state-sheet";
+import {
+    commonStates,
+    defaultPseudoStates,
+    StateSheet,
+} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {
     longText,
@@ -19,9 +23,10 @@ import {
 } from "../components/text-for-testing";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
+import {Heading, HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import singleColoredIcon from "../components/single-colored-icon.svg";
 import {multiColoredIcon} from "../components/icons-for-testing";
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 
 /**
  * Badges are visual indicators used to display concise information, such as
@@ -41,6 +46,15 @@ export default {
 
 type StoryComponentType = StoryObj<typeof Badge>;
 
+const statusKinds = ["info", "success", "warning", "critical"] as const;
+
+const states = [
+    commonStates.rest,
+    // Include snapshots for focus states to ensure focus styles are applied
+    // correctly. The Badge is not interactive by default, but becomes interactive
+    // when used with another component like `Tooltip`.
+    commonStates.focus,
+];
 export const StateSheetStory: StoryComponentType = {
     name: "StateSheet",
     render: () => {
@@ -78,7 +92,7 @@ export const StateSheetStory: StoryComponentType = {
         ];
 
         const statusRows = [
-            ...["info", "success", "warning", "critical"].map((kind) => ({
+            ...statusKinds.map((kind) => ({
                 name: kind,
                 props: {kind},
             })),
@@ -109,26 +123,18 @@ export const StateSheetStory: StoryComponentType = {
         return (
             <View style={{gap: sizing.size_080}}>
                 <HeadingLarge>Badge</HeadingLarge>
-                <StateSheet
-                    rows={rows}
-                    columns={columns}
-                    states={[commonStates.rest]}
-                >
+                <StateSheet rows={rows} columns={columns} states={states}>
                     {({props}) => <Badge {...props} />}
                 </StateSheet>
                 <HeadingLarge>Status Badge</HeadingLarge>
-                <StateSheet
-                    rows={statusRows}
-                    columns={columns}
-                    states={[commonStates.rest]}
-                >
+                <StateSheet rows={statusRows} columns={columns} states={states}>
                     {({props}) => <StatusBadge {...props} />}
                 </StateSheet>
                 <HeadingLarge>Gem Badge</HeadingLarge>
                 <StateSheet
                     rows={rows}
                     columns={columnsWithShowIconProp}
-                    states={[commonStates.rest]}
+                    states={states}
                 >
                     {({props}) => <GemBadge {...props} />}
                 </StateSheet>
@@ -136,20 +142,19 @@ export const StateSheetStory: StoryComponentType = {
                 <StateSheet
                     rows={rows}
                     columns={columnsWithShowIconProp}
-                    states={[commonStates.rest]}
+                    states={states}
                 >
                     {({props}) => <StreakBadge {...props} />}
                 </StateSheet>
                 <HeadingLarge>Due Badge</HeadingLarge>
-                <StateSheet
-                    rows={rows}
-                    columns={columns}
-                    states={[commonStates.rest]}
-                >
+                <StateSheet rows={rows} columns={columns} states={states}>
                     {({props}) => <DueBadge {...props} />}
                 </StateSheet>
             </View>
         );
+    },
+    parameters: {
+        pseudo: defaultPseudoStates,
     },
 };
 
@@ -276,6 +281,64 @@ export const Scenarios: StoryComponentType = {
                 <ScenariosLayout scenarios={scenarios}>
                     {(props) => <Badge {...props} />}
                 </ScenariosLayout>
+            </View>
+        );
+    },
+};
+
+export const AllBadgesScenarios: StoryComponentType = {
+    render: () => {
+        const badgesWithIcon = [
+            <Badge label="Badge" />,
+            ...statusKinds.map((kind) => (
+                <StatusBadge label="Badge" kind={kind} />
+            )),
+            <DueBadge label="Badge" />,
+        ].map((component) =>
+            React.cloneElement(component, {
+                icon: <PhosphorIcon icon={IconMappings.cookie} />,
+            }),
+        );
+
+        const badgesWithShowIcon = [
+            <GemBadge label="Badge" />,
+            <StreakBadge label="Badge" />,
+        ].map((component) =>
+            React.cloneElement(component, {
+                showIcon: true,
+            }),
+        );
+
+        const badges = [...badgesWithIcon, ...badgesWithShowIcon];
+
+        return (
+            <View
+                style={{
+                    gap: sizing.size_240,
+                    // Include end padding to ensure tooltips are included in the
+                    // snapshot
+                    paddingBlockEnd: sizing.size_880,
+                }}
+            >
+                <Heading>Badges</Heading>
+                <View style={{gap: sizing.size_240, flexDirection: "row"}}>
+                    {badges.map((badge, index) => (
+                        <View key={index}>{badge}</View>
+                    ))}
+                </View>
+                <Heading>Badges with Tooltip</Heading>
+                <View style={{gap: sizing.size_240, flexDirection: "row"}}>
+                    {badges.map((badge, index) => (
+                        <Tooltip
+                            content="Tooltip"
+                            opened={true}
+                            key={index}
+                            placement="bottom"
+                        >
+                            {badge}
+                        </Tooltip>
+                    ))}
+                </View>
             </View>
         );
     },

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -92,12 +92,10 @@ export const StateSheetStory: StoryComponentType = {
             },
         ];
 
-        const statusRows = [
-            ...statusKinds.map((kind) => ({
-                name: kind,
-                props: {kind},
-            })),
-        ];
+        const statusRows = statusKinds.map((kind) => ({
+            name: kind,
+            props: {kind},
+        }));
 
         const columnsWithShowIconProp = [
             {

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -230,6 +230,9 @@ export const Tag: StoryComponentType = {
  * `Badge`. This is so that it is interactive and the tooltip contents can be
  * read out properly via the `aria-describedby` attribute on the `Badge` added
  * by the Tooltip component.
+ *
+ * Note: The `Tooltip` component also sets the `tabIndex` of the `Badge` so that
+ * it is focusable.
  */
 export const BadgeWithTooltip: StoryComponentType = {
     render: (args) => {

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -10,6 +10,7 @@ import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes, {iconArgType} from "./badge.argtypes";
 import {multiColoredIcon} from "../components/icons-for-testing";
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 
 export default {
     title: "Packages / Badge / Badge",
@@ -221,5 +222,34 @@ export const Tag: StoryComponentType = {
         label: "Badge",
         icon: "cookie",
         tag: "strong",
+    },
+};
+
+/**
+ * When using a `Badge` with a `Tooltip`, make sure to add `role="button"` on the
+ * `Badge`. This is so that it is interactive and the tooltip contents can be
+ * read out properly via the `aria-describedby` attribute on the `Badge` added
+ * by the Tooltip component.
+ */
+export const BadgeWithTooltip: StoryComponentType = {
+    render: (args) => {
+        return (
+            <Tooltip content="This is a tooltip" opened={true}>
+                <Badge
+                    {...args}
+                    label={args.label || ""}
+                    icon={
+                        args.icon ? (
+                            <PhosphorIcon icon={args.icon} />
+                        ) : undefined
+                    }
+                    role="button"
+                />
+            </Tooltip>
+        );
+    },
+    args: {
+        label: "Badge",
+        icon: "cookie",
     },
 };

--- a/packages/wonder-blocks-badge/package.json
+++ b/packages/wonder-blocks-badge/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
+    "@khanacademy/wonder-blocks-styles": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },

--- a/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {StatusBadge} from "../status-badge";
 import {GemBadge} from "../gem-badge";
 import {StreakBadge} from "../streak-badge";
@@ -89,6 +91,22 @@ describe("Badge types", () => {
 
                     // Assert
                     expect(badge).toHaveAttribute("role", "button");
+                });
+
+                it("should be focusable when used with a tooltip and it has the role=button", async () => {
+                    // Arrange
+                    render(
+                        <Tooltip content="Tooltip content">
+                            <Component role="button" label="Badge label" />
+                        </Tooltip>,
+                    );
+                    const badge = screen.getByText("Badge label");
+
+                    // Act
+                    await userEvent.tab();
+
+                    // Assert
+                    expect(badge).toHaveFocus();
                 });
             });
         });

--- a/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/badge-types.test.tsx
@@ -79,6 +79,17 @@ describe("Badge types", () => {
                     const badge = screen.getByLabelText(ariaLabel);
                     expect(badge).toBeInTheDocument();
                 });
+
+                it("should set the role if provided", () => {
+                    // Arrange
+                    render(<Component role="button" label="Badge label" />);
+
+                    // Act
+                    const badge = screen.getByText("Badge label");
+
+                    // Assert
+                    expect(badge).toHaveAttribute("role", "button");
+                });
             });
         });
     });

--- a/packages/wonder-blocks-badge/src/components/badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/badge.tsx
@@ -3,6 +3,7 @@ import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography"
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import {BaseBadgeProps, IconLabelProps} from "../types";
 
 type Props = IconLabelProps & BaseBadgeProps;
@@ -110,6 +111,9 @@ const styles = StyleSheet.create({
         paddingBlock: badgeTokens.root.layout.paddingBlock,
         paddingInline: badgeTokens.root.layout.paddingInline,
         borderRadius: badgeTokens.root.border.radius,
+        // Include focus styles in case the badge is made interactive by using
+        // it with another component like `Tooltip`
+        ...focusStyles.focus,
     },
     defaultBadgeStyling: {
         backgroundColor: badgeTokens.root.color.background,

--- a/packages/wonder-blocks-badge/tsconfig-build.json
+++ b/packages/wonder-blocks-badge/tsconfig-build.json
@@ -11,5 +11,6 @@
       {"path": "../wonder-blocks-typography/tsconfig-build.json"},
       {"path": "../wonder-blocks-styles/tsconfig-build.json"},
       {"path": "../wonder-blocks-icon/tsconfig-build.json"},
+      {"path": "../wonder-blocks-styles/tsconfig-build.json"},
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,6 +493,9 @@ importers:
       '@khanacademy/wonder-blocks-icon':
         specifier: workspace:*
         version: link:../wonder-blocks-icon
+      '@khanacademy/wonder-blocks-styles':
+        specifier: workspace:*
+        version: link:../wonder-blocks-styles
       '@khanacademy/wonder-blocks-tokens':
         specifier: workspace:*
         version: link:../wonder-blocks-tokens


### PR DESCRIPTION
## Summary:

- Document and add examples for using Badge with Tooltips. 
- `role` needs to be set on `Badge` in order for the tooltip content to be read out by screen readers (since Tooltip sets aria-describedby on the anchor)
- Sincle the Badge would be interactive when used with a Tooltip, we use the global focus styles 

![image](https://github.com/user-attachments/assets/0c3d7139-e154-4cbb-88ae-404b9dac500b)

Issue: WB-1952

## Test plan:
`?path=/story/packages-badge-badge--badge-with-tooltip`
- The Badge should be focusable when used with a Tooltip
- The tooltip content should be read out by screen readers when the Badge is focused
  - Tested with NVDA+Chrome, NVDA+Firefox, VO+Safari. When the tooltip is open, the tooltip content is read out with the Badge label
  - Note: Created WB-1967 for broader tooltip SR improvements so that it works by default with any component without consumers having to set the role. It's also for addressing general tooltip issues like how VO doesn't always announce tooltips when it is toggled
- The Badge should use the global focus outline style 
- Docs are reviewed (`?path=/docs/packages-badge-badge--docs#badge-with-tooltip`)

`?path=/story/packages-badge-testing-snapshots--all-badges-scenarios`
- It works for all Badge types