### PR TITLE
[WB-1915.2] ActivityIconbutton: Add `label` prop

### DIFF
--- a/.changeset/nasty-impalas-sparkle.md
+++ b/.changeset/nasty-impalas-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": minor
+---
+
+Adds `label` prop to `ActivityIconButton`. Modifies the types to expect one of `aria-label` or `label`.

--- a/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
@@ -6,6 +6,8 @@ import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg"
 import {ActivityIconButton} from "@khanacademy/wonder-blocks-icon-button";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {allModes} from "../../.storybook/modes";
+import {ScenariosLayout} from "../components/scenarios-layout";
+import {longTextWithNoWordBreak} from "../components/text-for-testing";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -31,7 +33,7 @@ export default {
     },
 } as Meta;
 
-type StoryComponentType = StoryObj<typeof ActivityIconButton>;
+type Story = StoryObj<typeof ActivityIconButton>;
 
 const kinds = [
     {name: "Primary", props: {kind: "primary"}},
@@ -45,7 +47,7 @@ const actionTypes = [
     {name: "Disabled", props: {disabled: true}},
 ];
 
-export const StateSheetStory: StoryComponentType = {
+export const StateSheetStory: Story = {
     name: "StateSheet",
     render: (args) => {
         return (
@@ -67,5 +69,68 @@ export const StateSheetStory: StoryComponentType = {
     },
     parameters: {
         pseudo: defaultPseudoStates,
+    },
+};
+
+const actionTypesWithLabel = [
+    {
+        name: "Progressive",
+        props: {actionType: "progressive", label: "Send"},
+    },
+    {name: "Neutral", props: {actionType: "neutral", label: "Send"}},
+    {name: "Disabled", props: {disabled: true, label: "Send"}},
+];
+
+export const StateSheetVisibleLabelStory: Story = {
+    name: "StateSheet (Visible Label)",
+    render: (args) => {
+        return (
+            <StateSheet
+                rows={kinds}
+                columns={actionTypesWithLabel}
+                title="Kind / Action Type"
+            >
+                {({props, className, name}) => (
+                    <ActivityIconButton
+                        {...args}
+                        {...props}
+                        className={className}
+                        key={name}
+                    />
+                )}
+            </StateSheet>
+        );
+    },
+    parameters: {
+        pseudo: defaultPseudoStates,
+    },
+};
+
+/**
+ * The following story shows how the component handles specific scenarios.
+ */
+export const Scenarios: Story = {
+    render() {
+        const scenarios = [
+            {
+                name: "Long label with multiple words",
+                props: {
+                    icon: paperPlaneIcon,
+                    label: "Send with a very long text",
+                },
+            },
+            {
+                name: "Long label with no word break",
+                props: {
+                    icon: paperPlaneIcon,
+                    label: longTextWithNoWordBreak,
+                },
+            },
+        ];
+        return (
+            <ScenariosLayout scenarios={scenarios}>
+                {(props, name) => <ActivityIconButton {...props} />}
+            </ScenariosLayout>
+        );
     },
 };

--- a/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
@@ -8,6 +8,8 @@ import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {allModes} from "../../.storybook/modes";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {longTextWithNoWordBreak} from "../components/text-for-testing";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -115,21 +117,64 @@ export const Scenarios: Story = {
             {
                 name: "Long label with multiple words",
                 props: {
-                    icon: paperPlaneIcon,
-                    label: "Send with a very long text",
+                    children: (
+                        <ActivityIconButton
+                            label="Send with a very long text"
+                            icon={paperPlaneIcon}
+                        />
+                    ),
                 },
             },
             {
-                name: "Long label with no word break",
+                name: "Long label with songle word in more than two lines",
                 props: {
-                    icon: paperPlaneIcon,
-                    label: longTextWithNoWordBreak,
+                    children: (
+                        <ActivityIconButton
+                            label={longTextWithNoWordBreak}
+                            icon={paperPlaneIcon}
+                        />
+                    ),
+                },
+            },
+            {
+                name: "Long label with single word in two lines",
+                props: {
+                    children: (
+                        <ActivityIconButton
+                            label="Conversation"
+                            icon={paperPlaneIcon}
+                        />
+                    ),
+                },
+            },
+            {
+                name: "Horizontally stacked buttons",
+                props: {
+                    children: (
+                        <View
+                            style={{
+                                flexDirection: "row",
+                                background: semanticColor.surface.secondary,
+                                gap: sizing.size_160,
+                                padding: sizing.size_160,
+                            }}
+                        >
+                            <ActivityIconButton
+                                label="Label"
+                                icon={paperPlaneIcon}
+                            />
+                            <ActivityIconButton
+                                icon={paperPlaneIcon}
+                                aria-label="Send"
+                            />
+                        </View>
+                    ),
                 },
             },
         ];
         return (
             <ScenariosLayout scenarios={scenarios}>
-                {(props, name) => <ActivityIconButton {...props} />}
+                {(props) => props.children}
             </ScenariosLayout>
         );
     },

--- a/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
@@ -126,7 +126,7 @@ export const Scenarios: Story = {
                 },
             },
             {
-                name: "Long label with songle word in more than two lines",
+                name: "Long label with single word in more than two lines",
                 props: {
                     children: (
                         <ActivityIconButton

--- a/__docs__/wonder-blocks-icon-button/activity-icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button.stories.tsx
@@ -115,7 +115,6 @@ export const ActionType: StoryComponentType = {
                 >
                     {kinds.map((kind, index) => (
                         <ActivityIconButton
-                            {...args}
                             icon={IconMappings.arrowUpBold}
                             aria-label="navigate"
                             onClick={() => {}}
@@ -125,7 +124,6 @@ export const ActionType: StoryComponentType = {
                         />
                     ))}
                     <ActivityIconButton
-                        {...args}
                         disabled={true}
                         icon={IconMappings.arrowUpBold}
                         aria-label="search"
@@ -161,9 +159,10 @@ export const UsingHref: StoryComponentType = {
 };
 
 /**
- * By default, the icon buttons do not have accessible names. The `aria-label`
- * prop must be used to explain the function of the button. Remember to keep the
- * description concise but understandable.
+ * There are two ways to provide accessible names to `ActivityIconButton`. One
+ * approach is using the `aria-label` prop that can be used to explain the
+ * function of the button. Remember to keep the description concise but
+ * understandable.
  */
 export const WithAriaLabel: StoryComponentType = {
     render: () => {
@@ -178,6 +177,37 @@ export const WithAriaLabel: StoryComponentType = {
                     icon={IconMappings.caretRightBold}
                     onClick={(e) => action("clicked")(e)}
                     aria-label="Next page"
+                />
+            </View>
+        );
+    },
+};
+
+/**
+ * Another way to provide accessible names to `ActivityIconButton` is by
+ * providing a label for the button using the `label` prop. This is
+ * recommended when the button is used as a navigation item in the context
+ * of a menu, for example.
+ */
+export const WithLabel: StoryComponentType = {
+    render: () => {
+        return (
+            <View
+                style={{
+                    gap: sizing.size_160,
+                    flexDirection: "row",
+                    alignItems: "flex-start",
+                }}
+            >
+                <ActivityIconButton
+                    icon={IconMappings.check}
+                    onClick={(e) => action("clicked")(e)}
+                    label="Check"
+                />
+                <ActivityIconButton
+                    icon={IconMappings.magnifyingGlass}
+                    onClick={(e) => action("clicked")(e)}
+                    label="Search"
                 />
             </View>
         );

--- a/packages/wonder-blocks-icon-button/package.json
+++ b/packages/wonder-blocks-icon-button/package.json
@@ -30,7 +30,8 @@
     "@khanacademy/wonder-blocks-icon": "workspace:*",
     "@khanacademy/wonder-blocks-styles": "workspace:*",
     "@khanacademy/wonder-blocks-theming": "workspace:*",
-    "@khanacademy/wonder-blocks-tokens": "workspace:*"
+    "@khanacademy/wonder-blocks-tokens": "workspace:*",
+    "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
     "aphrodite": "catalog:",

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/activity-icon-button.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/activity-icon-button.test.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import {render, screen} from "@testing-library/react";
+
+import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
+
+import {ActivityIconButton} from "../activity-icon-button";
+
+/**
+ * Tests specific to the `ActivityIconButton` component.
+ *
+ * For shared tests, see `icon-button-types.test.tsx`.
+ */
+describe("ActivityIconButton", () => {
+    it("should use label to describe the button contents", async () => {
+        // Arrange
+        render(
+            <ActivityIconButton
+                label="Search"
+                icon={magnifyingGlassIcon}
+                onClick={() => {}}
+            />,
+        );
+
+        // Act
+        const button = screen.getByRole("button", {name: "Search"});
+
+        // Assert
+        expect(button).toBeInTheDocument();
+    });
+});

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/activity-icon-button.typestest.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/activity-icon-button.typestest.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
+
+import {ActivityIconButton} from "../activity-icon-button";
+
+// Valid: aria-label only
+<ActivityIconButton
+    icon={plusCircle}
+    aria-label="Add item"
+    onClick={() => {}}
+/>;
+
+// Valid: label only
+<ActivityIconButton icon={plusCircle} label="Add" onClick={() => {}} />;
+
+// @ts-expect-error - no label/aria-label set
+<ActivityIconButton icon={plusCircle} onClick={() => {}} />;
+
+// @ts-expect-error - only one of aria-label or label should be set
+<ActivityIconButton
+    icon={plusCircle}
+    aria-label="Add item"
+    label="Add"
+    onClick={() => {}}
+/>;

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-types.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-types.test.tsx
@@ -18,7 +18,7 @@ describe("IconButton types", () => {
         it("should render the icon", async () => {
             // Arrange
             render(
-                <IconButton
+                <Component
                     aria-label="Search"
                     icon={magnifyingGlassIcon}
                     onClick={() => {}}
@@ -37,7 +37,13 @@ describe("IconButton types", () => {
         it("should forward the ref to the root element", () => {
             // Arrange
             const ref = React.createRef<IconButtonRef>();
-            render(<Component icon={magnifyingGlassIcon} ref={ref} />);
+            render(
+                <Component
+                    icon={magnifyingGlassIcon}
+                    aria-label="Search"
+                    ref={ref}
+                />,
+            );
 
             // Act
             const button = screen.getByRole("button");
@@ -50,7 +56,13 @@ describe("IconButton types", () => {
             it("should set the id attribute", () => {
                 // Arrange
                 const id = "button-id";
-                render(<Component icon={magnifyingGlassIcon} id={id} />);
+                render(
+                    <Component
+                        icon={magnifyingGlassIcon}
+                        aria-label="Search"
+                        id={id}
+                    />,
+                );
 
                 // Act
                 const button = screen.getByRole("button");
@@ -63,7 +75,11 @@ describe("IconButton types", () => {
                 // Arrange
                 const testId = "badge-testid";
                 render(
-                    <Component icon={magnifyingGlassIcon} testId={testId} />,
+                    <Component
+                        icon={magnifyingGlassIcon}
+                        aria-label="Search"
+                        testId={testId}
+                    />,
                 );
 
                 // Act
@@ -79,7 +95,7 @@ describe("IconButton types", () => {
                 it("should set aria-disabled when the disabled prop is set", () => {
                     // Arrange
                     render(
-                        <IconButton
+                        <Component
                             aria-label="Search"
                             disabled={true}
                             icon={magnifyingGlassIcon}
@@ -92,6 +108,25 @@ describe("IconButton types", () => {
 
                     // Assert
                     expect(iconButton).toHaveAttribute("aria-disabled", "true");
+                });
+
+                it("should use aria-label to announce the button", () => {
+                    // Arrange
+                    render(
+                        <Component
+                            aria-label="Search"
+                            icon={magnifyingGlassIcon}
+                            onClick={() => {}}
+                        />,
+                    );
+
+                    // Act
+                    const button = screen.getByRole("button", {
+                        name: "Search",
+                    });
+
+                    // Assert
+                    expect(button).toBeInTheDocument();
                 });
             });
         });

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -239,6 +239,8 @@ const _generateStyles = (
             // layout
             flexDirection: "column",
             // Prevent the button from stretching to fill the parent
+            maxWidth: theme.label.layout.width,
+            alignSelf: "flex-start",
             justifySelf: "center",
             /**
              * States
@@ -309,14 +311,15 @@ const _generateStyles = (
          */
         label: {
             margin: 0,
-            maxWidth: theme.label.layout.width,
             textAlign: "center",
             // text clipping
             // @see https://css-tricks.com/line-clampin/#aa-the-standardized-way
             display: "-webkit-box",
             WebkitBoxOrient: "vertical",
+            // We restrict the label to a maximum of 2 lines.
             WebkitLineClamp: "2",
             overflow: "hidden",
+            wordBreak: "break-word",
         },
     } as const;
 

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -174,6 +174,8 @@ const theme = {
         },
         shadow: {
             y: {
+                // NOTE: We use px units to prevent a bug in Safari where the
+                // shadow animation flickers when using rem units.
                 rest: "6px",
                 hover: "8px",
                 press: sizing.size_0,

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -129,6 +129,7 @@ export const ActivityIconButton: React.ForwardRefExoticComponent<
                 </View>
                 {hasVisibleLabel && (
                     <BodyText
+                        tag="span"
                         size="medium"
                         weight="semi"
                         style={buttonStyles.label}
@@ -238,6 +239,7 @@ const _generateStyles = (
             color: theme.label.color[actionType],
             // layout
             flexDirection: "column",
+            gap: sizing.size_020,
             // Prevent the button from stretching to fill the parent
             maxWidth: theme.label.layout.width,
             alignSelf: "flex-start",

--- a/packages/wonder-blocks-icon-button/tsconfig-build.json
+++ b/packages/wonder-blocks-icon-button/tsconfig-build.json
@@ -12,6 +12,7 @@
         {"path": "../wonder-blocks-styles/tsconfig-build.json"},
         {"path": "../wonder-blocks-theming/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
+        {"path": "../wonder-blocks-typography/tsconfig-build.json"},
         {"path": "../../utils"},
     ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -901,6 +901,9 @@ importers:
       '@khanacademy/wonder-blocks-tokens':
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
+      '@khanacademy/wonder-blocks-typography':
+        specifier: workspace:*
+        version: link:../wonder-blocks-typography
       aphrodite:
         specifier: 'catalog:'
         version: 1.2.5


### PR DESCRIPTION
## Summary:

- Adds a `label` prop to `ActivityIconButton` to be able to use visible icon descriptions.
- Modifies the types to expect one of `aria-label` or `label`.
- Adds new docs and snapshots to cover this variant.

<img width="326" alt="Screenshot 2025-05-30 at 10 07 07 AM" src="https://github.com/user-attachments/assets/3d3176e6-4587-4e09-9360-0531667e063c" />


Issue: WB-1915

## Test plan:

- Verify that the new Label docs look correct: `/?path=/docs/packages-iconbutton-activityiconbutton--docs#with-label`
- Verify that the `label` prop is rendered correctly in the snapshots: `/?path=/story/packages-iconbutton-testing-snapshots-activityiconbutton--state-sheet-visible-label-story&globals=theme:thunderblocks`
- Verify that the Scenarios story renders the `label` prop correctly: `/?path=/story/packages-iconbutton-testing-snapshots-activityiconbutton--scenarios&globals=;theme:thunderblocks`